### PR TITLE
Expands beta functionality (fixes #410)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/library/AdapterLibrary.java
+++ b/app/src/main/java/org/ole/planet/myplanet/library/AdapterLibrary.java
@@ -22,6 +22,7 @@ import org.ole.planet.myplanet.callback.OnHomeItemClickListener;
 import org.ole.planet.myplanet.callback.OnLibraryItemSelected;
 import org.ole.planet.myplanet.callback.OnRatingChangeListener;
 import org.ole.planet.myplanet.courses.AdapterCourses;
+import org.ole.planet.myplanet.utilities.Constants;
 import org.ole.planet.myplanet.utilities.Utilities;
 
 import java.util.ArrayList;
@@ -87,6 +88,7 @@ public class AdapterLibrary extends RecyclerView.Adapter<RecyclerView.ViewHolder
             ((ViewHolderLibrary) holder).rating.setText(TextUtils.isEmpty(libraryList.get(position).getAverageRating()) ? "0.0" : String.format("%.1f", Double.parseDouble(libraryList.get(position).getAverageRating())));
             displayTagCloud(((ViewHolderLibrary) holder).flexboxDrawable, position);
             holder.itemView.setOnClickListener(view -> openLibrary(libraryList.get(position)));
+
             ((ViewHolderLibrary) holder).llRating.setOnClickListener(view -> homeItemClickListener.showRatingDialog("resource", libraryList.get(position).getResource_id(), libraryList.get(position).getTitle(), ratingChangeListener));
 
             if (ratingMap.containsKey(libraryList.get(position).getResource_id())) {
@@ -129,7 +131,7 @@ public class AdapterLibrary extends RecyclerView.Adapter<RecyclerView.ViewHolder
     }
 
     class ViewHolderLibrary extends RecyclerView.ViewHolder {
-        TextView title, desc, rating, timesRated;
+        TextView title, desc, rating, timesRated, average, tv_rating;
         CheckBox checkBox;
         AppCompatRatingBar ratingBar;
         FlexboxLayout flexboxDrawable;
@@ -144,6 +146,11 @@ public class AdapterLibrary extends RecyclerView.Adapter<RecyclerView.ViewHolder
             ratingBar = itemView.findViewById(R.id.rating_bar);
             checkBox = itemView.findViewById(R.id.checkbox);
             llRating = itemView.findViewById(R.id.ll_rating);
+            llRating.setVisibility(Constants.showBetaFeature(Constants.KEY_RATING, context) ? View.VISIBLE :View.GONE );
+            average = itemView.findViewById(R.id.average);
+            average.setVisibility(Constants.showBetaFeature(Constants.KEY_RATING, context) ? View.VISIBLE :View.GONE );
+            tv_rating = itemView.findViewById(R.id.tv_rating);
+//            tv_rating.setVisibility(Constants.showBetaFeature(Constants.KEY_RATING, context) ? View.VISIBLE :View.GONE );
             checkBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override
                 public void onCheckedChanged(CompoundButton compoundButton, boolean b) {

--- a/app/src/main/java/org/ole/planet/myplanet/library/AdapterLibrary.java
+++ b/app/src/main/java/org/ole/planet/myplanet/library/AdapterLibrary.java
@@ -131,7 +131,7 @@ public class AdapterLibrary extends RecyclerView.Adapter<RecyclerView.ViewHolder
     }
 
     class ViewHolderLibrary extends RecyclerView.ViewHolder {
-        TextView title, desc, rating, timesRated, average, tv_rating;
+        TextView title, desc, rating, timesRated, average;
         CheckBox checkBox;
         AppCompatRatingBar ratingBar;
         FlexboxLayout flexboxDrawable;
@@ -149,8 +149,7 @@ public class AdapterLibrary extends RecyclerView.Adapter<RecyclerView.ViewHolder
             llRating.setVisibility(Constants.showBetaFeature(Constants.KEY_RATING, context) ? View.VISIBLE :View.GONE );
             average = itemView.findViewById(R.id.average);
             average.setVisibility(Constants.showBetaFeature(Constants.KEY_RATING, context) ? View.VISIBLE :View.GONE );
-            tv_rating = itemView.findViewById(R.id.tv_rating);
-//            tv_rating.setVisibility(Constants.showBetaFeature(Constants.KEY_RATING, context) ? View.VISIBLE :View.GONE );
+            rating.setVisibility(Constants.showBetaFeature(Constants.KEY_RATING, context) ? View.VISIBLE :View.GONE );
             checkBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override
                 public void onCheckedChanged(CompoundButton compoundButton, boolean b) {

--- a/app/src/main/java/org/ole/planet/myplanet/library/LibraryDetailFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/library/LibraryDetailFragment.java
@@ -7,6 +7,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -19,6 +20,7 @@ import org.ole.planet.myplanet.R;
 import org.ole.planet.myplanet.base.BaseContainerFragment;
 import org.ole.planet.myplanet.callback.OnRatingChangeListener;
 import org.ole.planet.myplanet.datamanager.DatabaseService;
+import org.ole.planet.myplanet.utilities.Constants;
 import org.ole.planet.myplanet.utilities.Utilities;
 
 import io.realm.Realm;
@@ -69,6 +71,9 @@ public class LibraryDetailFragment extends BaseContainerFragment implements OnRa
     }
 
     private void initView(View v) {
+        TextView average, tv_rating;
+        LinearLayout llRating;
+
         author = v.findViewById(R.id.tv_author);
         title = v.findViewById(R.id.tv_title);
         pubishedBy = v.findViewById(R.id.tv_published);
@@ -80,6 +85,12 @@ public class LibraryDetailFragment extends BaseContainerFragment implements OnRa
         type = v.findViewById(R.id.tv_type);
         download = v.findViewById(R.id.btn_download);
         remove = v.findViewById(R.id.btn_remove);
+        llRating = v.findViewById(R.id.ll_rating);
+        llRating.setVisibility(Constants.showBetaFeature(Constants.KEY_RATING, getActivity()) ? View.VISIBLE :View.GONE );
+        average = v.findViewById(R.id.average);
+        average.setVisibility(Constants.showBetaFeature(Constants.KEY_RATING, getActivity()) ? View.VISIBLE :View.GONE );
+        tv_rating = v.findViewById(R.id.tv_rating);
+        tv_rating.setVisibility(Constants.showBetaFeature(Constants.KEY_RATING, getActivity()) ? View.VISIBLE :View.GONE );
         v.findViewById(R.id.ll_rating).setOnClickListener(view -> homeItemClickListener.showRatingDialog("resource", library.getResource_id(), library.getTitle(), LibraryDetailFragment.this));
         initRatingView(v);
     }
@@ -94,7 +105,12 @@ public class LibraryDetailFragment extends BaseContainerFragment implements OnRa
         license.setText(library.getLinkToLicense());
         resource.setText(realm_myLibrary.listToString(library.getResourceFor()));
         profileDbHandler.setResourceOpenCount(library);
-        onRatingChanged();
+        try {
+            onRatingChanged();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+
         download.setVisibility(TextUtils.isEmpty(library.getResourceLocalAddress()) ? View.GONE : View.VISIBLE);
         setClickListeners();
     }

--- a/app/src/main/java/org/ole/planet/myplanet/library/MyLibraryFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/library/MyLibraryFragment.java
@@ -20,6 +20,7 @@ import org.ole.planet.myplanet.Data.realm_rating;
 import org.ole.planet.myplanet.R;
 import org.ole.planet.myplanet.base.BaseRecyclerFragment;
 import org.ole.planet.myplanet.callback.OnLibraryItemSelected;
+import org.ole.planet.myplanet.utilities.Constants;
 import org.ole.planet.myplanet.utilities.Utilities;
 
 import java.util.ArrayList;
@@ -70,6 +71,7 @@ public class MyLibraryFragment extends BaseRecyclerFragment<realm_myLibrary> imp
         config = Utilities.getCloudConfig().showClose(R.color.black_overlay);
         tvAddToLib = getView().findViewById(R.id.tv_add_to_lib);
         tvDelete = getView().findViewById(R.id.tv_delete);
+        tvDelete.setVisibility(Constants.showBetaFeature(Constants.KEY_DELETE, getActivity()) ? View.VISIBLE :View.GONE );
         etSearch = getView().findViewById(R.id.et_search);
         etTags = getView().findViewById(R.id.et_tags);
         imgSearch = getView().findViewById(R.id.img_search);

--- a/app/src/main/java/org/ole/planet/myplanet/mymeetup/MyMeetupDetailFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/mymeetup/MyMeetupDetailFragment.java
@@ -19,6 +19,7 @@ import org.ole.planet.myplanet.Data.realm_meetups;
 import org.ole.planet.myplanet.R;
 import org.ole.planet.myplanet.datamanager.DatabaseService;
 import org.ole.planet.myplanet.userprofile.UserProfileDbHandler;
+import org.ole.planet.myplanet.utilities.Constants;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ public class MyMeetupDetailFragment extends Fragment implements View.OnClickList
     String meetUpId;
     TextView title;
     Button btnLeave;
+    Button btnInvite;
     UserProfileDbHandler profileDbHandler;
     realm_UserModel user;
     ListView listUsers;
@@ -63,7 +65,10 @@ public class MyMeetupDetailFragment extends Fragment implements View.OnClickList
         listDesc = v.findViewById(R.id.list_desc);
         listUsers = v.findViewById(R.id.list_users);
         tvJoined = v.findViewById(R.id.tv_joined);
+        btnInvite = v.findViewById(R.id.btn_invite);
+        btnInvite.setVisibility(Constants.showBetaFeature(Constants.KEY_MEETUPS, getActivity()) ? View.VISIBLE :View.GONE );
         btnLeave = v.findViewById(R.id.btn_leave);
+        btnLeave.setVisibility(Constants.showBetaFeature(Constants.KEY_MEETUPS, getActivity()) ? View.VISIBLE :View.GONE );
         btnLeave.setOnClickListener(this);
         title = v.findViewById(R.id.meetup_title);
         mRealm = new DatabaseService(getActivity()).getRealmInstance();

--- a/app/src/main/java/org/ole/planet/myplanet/survey/AdapterSurvey.java
+++ b/app/src/main/java/org/ole/planet/myplanet/survey/AdapterSurvey.java
@@ -14,6 +14,7 @@ import org.ole.planet.myplanet.Data.realm_submissions;
 import org.ole.planet.myplanet.R;
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener;
 import org.ole.planet.myplanet.userprofile.AdapterMySubmission;
+import org.ole.planet.myplanet.utilities.Constants;
 
 import java.util.List;
 
@@ -80,7 +81,9 @@ public class AdapterSurvey extends RecyclerView.Adapter<RecyclerView.ViewHolder>
             noSubmission = itemView.findViewById(R.id.tv_no_submissions);
             lastSubDate = itemView.findViewById(R.id.tv_date);
             startSurvey = itemView.findViewById(R.id.start_survey);
+            startSurvey.setVisibility(Constants.showBetaFeature(Constants.KEY_SURVEY, context) ? View.VISIBLE :View.GONE );
             sendSurvey = itemView.findViewById(R.id.send_survey);
+            sendSurvey.setVisibility(Constants.showBetaFeature(Constants.KEY_SURVEY, context) ? View.VISIBLE :View.GONE );
             sendSurvey.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {

--- a/app/src/main/java/org/ole/planet/myplanet/teams/MyTeamsDetailFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/teams/MyTeamsDetailFragment.java
@@ -20,6 +20,7 @@ import org.ole.planet.myplanet.Data.realm_myTeams;
 import org.ole.planet.myplanet.R;
 import org.ole.planet.myplanet.datamanager.DatabaseService;
 import org.ole.planet.myplanet.userprofile.UserProfileDbHandler;
+import org.ole.planet.myplanet.utilities.Constants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +40,7 @@ public class MyTeamsDetailFragment extends Fragment implements View.OnClickListe
     Realm mRealm;
     realm_myTeams team;
     Button btnLeave;
+    Button btnInvite;
     ListView lvJoined, lvRequested;
     DatabaseService dbService;
 
@@ -73,12 +75,16 @@ public class MyTeamsDetailFragment extends Fragment implements View.OnClickListe
     private void initializeViews(View v) {
         btnLeave = v.findViewById(R.id.btn_leave);
         btnLeave.setOnClickListener(this);
+        btnLeave.setVisibility(Constants.showBetaFeature(Constants.KEY_MEETUPS, getActivity()) ? View.VISIBLE :View.GONE );
+        btnInvite = v.findViewById(R.id.btn_invite);
+        btnInvite.setVisibility(Constants.showBetaFeature(Constants.KEY_MEETUPS, getActivity()) ? View.VISIBLE :View.GONE );
         tvDescription = v.findViewById(R.id.description);
         tvJoined = v.findViewById(R.id.tv_joined);
         tvRequested = v.findViewById(R.id.tv_requested);
         lvJoined = v.findViewById(R.id.list_joined);
         lvRequested = v.findViewById(R.id.list_requested);
         tvTitle = v.findViewById(R.id.title);
+
     }
 
     @Override

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Constants.java
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Constants.java
@@ -23,6 +23,7 @@ public class Constants {
     public static final String KEY_SURVEY = "survey";
     public static final String KEY_MEETUPS = "meetup";
     public static final String KEY_TEAMS = "teams";
+    public static final String KEY_DELETE = "delete";
 
     static {
         shelfDataList = new ArrayList<>();
@@ -34,6 +35,10 @@ public class Constants {
         betaList = new ArrayList<>();
         betaList.add(KEY_RATING);
         betaList.add(KEY_EXAM);
+        betaList.add(KEY_TEAMS);
+        betaList.add(KEY_MEETUPS);
+        betaList.add(KEY_SURVEY);
+        betaList.add(KEY_DELETE);
     }
 
     public static class ShelfData {


### PR DESCRIPTION
Only problem with this is where I have my comment

![comment](https://user-images.githubusercontent.com/20867959/50732626-bdbd5780-114c-11e9-8bcf-36ca384fa3b7.JPG)

If uncommented, it throws exception when attempting to open library. Without it, it still shows the rating number on library.
However, the same code works on the library detail (clicking on a resource)

![rating_number](https://user-images.githubusercontent.com/20867959/50732669-6ec3f200-114d-11e9-85a6-169f486bfa97.JPG)

With only difference being that it uses `getActivity()` in contrast to `context` on the commented line
(`getActivity()` is not accepted on commented line)