### PR TITLE
Create consistent design (fixes #769)

### DIFF
--- a/app/src/main/res/layout-large-land/activity_login.xml
+++ b/app/src/main/res/layout-large-land/activity_login.xml
@@ -183,6 +183,7 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
                         android:layout_margin="@dimen/padding_normal"
+                        android:background="@color/md_grey_500"
                         android:text="Become a member"
                         android:textColor="@color/md_white_1000"
                         android:theme="@style/PrimaryFlatButton" />

--- a/app/src/main/res/layout-large-land/activity_login.xml
+++ b/app/src/main/res/layout-large-land/activity_login.xml
@@ -178,13 +178,14 @@
                         android:textColor="@android:color/white" />
 
                     <Button
+                        android:id="@+id/become_member"
                         android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
                         android:layout_gravity="center"
                         android:layout_margin="@dimen/padding_normal"
-                        android:theme="@style/PrimaryFlatButton"
-                        android:id="@+id/become_member"
                         android:text="Become a member"
-                        android:layout_height="wrap_content" />
+                        android:textColor="@color/md_white_1000"
+                        android:theme="@style/PrimaryFlatButton" />
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout-xlarge-land/activity_login.xml
+++ b/app/src/main/res/layout-xlarge-land/activity_login.xml
@@ -177,13 +177,14 @@
 
 
                     <Button
+                        android:id="@+id/become_member"
                         android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
                         android:layout_gravity="center"
                         android:layout_margin="@dimen/padding_normal"
-                        android:theme="@style/PrimaryFlatButton"
-                        android:id="@+id/become_member"
                         android:text="Become a member"
-                        android:layout_height="wrap_content" />
+                        android:textColor="@color/md_white_1000"
+                        android:theme="@style/PrimaryFlatButton" />
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout-xlarge-land/activity_login.xml
+++ b/app/src/main/res/layout-xlarge-land/activity_login.xml
@@ -182,6 +182,7 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
                         android:layout_margin="@dimen/padding_normal"
+                        android:background="@color/md_grey_500"
                         android:text="Become a member"
                         android:textColor="@color/md_white_1000"
                         android:theme="@style/PrimaryFlatButton" />

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -191,6 +191,7 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
                         android:layout_margin="@dimen/padding_normal"
+                        android:background="@color/md_grey_500"
                         android:text="Become a member"
                         android:textColor="@color/md_white_1000"
                         android:theme="@style/PrimaryFlatButton" />

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -186,13 +186,14 @@
                         android:textSize="12sp" />
 
                     <Button
+                        android:id="@+id/become_member"
                         android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
                         android:layout_gravity="center"
                         android:layout_margin="@dimen/padding_normal"
-                        android:theme="@style/PrimaryFlatButton"
-                        android:id="@+id/become_member"
                         android:text="Become a member"
-                        android:layout_height="wrap_content" />
+                        android:textColor="@color/md_white_1000"
+                        android:theme="@style/PrimaryFlatButton" />
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout/alert_add_attachment.xml
+++ b/app/src/main/res/layout/alert_add_attachment.xml
@@ -46,6 +46,7 @@
         android:id="@+id/btn_add_resources"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="@color/md_grey_500"
         android:text="@string/add_resources"
         android:textColor="@color/md_white_1000"
         android:theme="@style/PrimaryFlatButton" />

--- a/app/src/main/res/layout/alert_add_attachment.xml
+++ b/app/src/main/res/layout/alert_add_attachment.xml
@@ -47,5 +47,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/add_resources"
+        android:textColor="@color/md_white_1000"
         android:theme="@style/PrimaryFlatButton" />
 </LinearLayout>

--- a/app/src/main/res/layout/edit_attachement.xml
+++ b/app/src/main/res/layout/edit_attachement.xml
@@ -46,11 +46,12 @@
             <Button
                 android:id="@+id/edit"
                 android:layout_width="wrap_content"
-                android:layout_gravity="center"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:text="Edit"
-                android:visibility="visible"
-                android:theme="@style/PrimaryFlatButton" />
+                android:textColor="@color/md_white_1000"
+                android:theme="@style/PrimaryFlatButton"
+                android:visibility="visible" />
 
             <ImageView
                 android:id="@+id/iv_delete"

--- a/app/src/main/res/layout/edit_attachement.xml
+++ b/app/src/main/res/layout/edit_attachement.xml
@@ -48,6 +48,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
+                android:background="@color/md_grey_500"
                 android:text="Edit"
                 android:textColor="@color/md_white_1000"
                 android:theme="@style/PrimaryFlatButton"

--- a/app/src/main/res/layout/edit_other_info.xml
+++ b/app/src/main/res/layout/edit_other_info.xml
@@ -24,8 +24,9 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:text="Edit"
-            android:visibility="visible"
-            android:theme="@style/PrimaryFlatButton" />
+            android:textColor="@color/md_white_1000"
+            android:theme="@style/PrimaryFlatButton"
+            android:visibility="visible" />
 
         <ImageView
             android:id="@+id/iv_delete"

--- a/app/src/main/res/layout/edit_other_info.xml
+++ b/app/src/main/res/layout/edit_other_info.xml
@@ -23,6 +23,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
+            android:background="@color/md_grey_500"
             android:text="Edit"
             android:textColor="@color/md_white_1000"
             android:theme="@style/PrimaryFlatButton"

--- a/app/src/main/res/layout/fragment_achievement.xml
+++ b/app/src/main/res/layout/fragment_achievement.xml
@@ -41,6 +41,7 @@
                     android:id="@+id/btn_edit"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:background="@color/md_grey_500"
                     android:drawableLeft="@drawable/ic_edit"
                     android:drawablePadding="@dimen/padding_normal"
                     android:text="@string/edit_achievement"

--- a/app/src/main/res/layout/fragment_achievement.xml
+++ b/app/src/main/res/layout/fragment_achievement.xml
@@ -44,6 +44,7 @@
                     android:drawableLeft="@drawable/ic_edit"
                     android:drawablePadding="@dimen/padding_normal"
                     android:text="@string/edit_achievement"
+                    android:textColor="@color/md_white_1000"
                     android:theme="@style/AccentButton" />
 
 

--- a/app/src/main/res/layout/fragment_course_detail.xml
+++ b/app/src/main/res/layout/fragment_course_detail.xml
@@ -26,6 +26,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Open Resource"
+                    android:textColor="@color/md_white_1000"
                     android:theme="@style/PrimaryButton" />
 
                 <Button
@@ -33,6 +34,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Resources"
+                    android:textColor="@color/md_white_1000"
                     android:theme="@style/PrimaryButton" />
 
             </LinearLayout>

--- a/app/src/main/res/layout/fragment_course_detail.xml
+++ b/app/src/main/res/layout/fragment_course_detail.xml
@@ -25,14 +25,17 @@
                     android:id="@+id/btn_open"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:background="@color/md_grey_500"
                     android:text="Open Resource"
                     android:textColor="@color/md_white_1000"
-                    android:theme="@style/PrimaryButton" />
+                    android:theme="@style/PrimaryButton"
+                    android:layout_marginRight="10dp"/>
 
                 <Button
                     android:id="@+id/btn_resources"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:background="@color/md_grey_500"
                     android:text="Resources"
                     android:textColor="@color/md_white_1000"
                     android:theme="@style/PrimaryButton" />

--- a/app/src/main/res/layout/fragment_course_step.xml
+++ b/app/src/main/res/layout/fragment_course_step.xml
@@ -20,14 +20,17 @@
                 android:id="@+id/btn_open"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="Open Resource"
                 android:textColor="@color/md_white_1000"
-                android:theme="@style/PrimaryButton" />
+                android:theme="@style/PrimaryButton"
+                android:layout_marginRight="10dp"/>
 
             <Button
                 android:id="@+id/btn_resources"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="Download Resources"
                 android:textColor="@color/md_white_1000"
                 android:theme="@style/PrimaryButton" />

--- a/app/src/main/res/layout/fragment_course_step.xml
+++ b/app/src/main/res/layout/fragment_course_step.xml
@@ -21,6 +21,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Open Resource"
+                android:textColor="@color/md_white_1000"
                 android:theme="@style/PrimaryButton" />
 
             <Button
@@ -28,6 +29,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Download Resources"
+                android:textColor="@color/md_white_1000"
                 android:theme="@style/PrimaryButton" />
 
             <Button

--- a/app/src/main/res/layout/fragment_edit_achievement.xml
+++ b/app/src/main/res/layout/fragment_edit_achievement.xml
@@ -43,6 +43,7 @@
                     android:drawableLeft="@drawable/ic_edit"
                     android:drawablePadding="@dimen/padding_normal"
                     android:text="@string/edit_achievement"
+                    android:textColor="@color/md_white_1000"
                     android:theme="@style/AccentButton" />
 
 
@@ -211,6 +212,7 @@
                     android:layout_height="wrap_content"
                     android:padding="@dimen/padding_normal"
                     android:text="@string/add_an_achievement"
+                    android:textColor="@color/md_white_1000"
                     android:theme="@style/PrimaryButton" />
 
                 <TextView
@@ -233,6 +235,7 @@
                     android:padding="@dimen/padding_normal"
 
                     android:text="@string/add_a_reference"
+                    android:textColor="@color/md_white_1000"
                     android:theme="@style/PrimaryButton" />
 
                 <CheckBox
@@ -254,6 +257,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/button_update"
+                        android:textColor="@color/md_white_1000"
                         android:theme="@style/PrimaryButton" />
 
                     <Button
@@ -261,6 +265,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/button_cancel"
+                        android:textColor="@color/md_white_1000"
                         android:theme="@style/AccentButton" />
 
                 </LinearLayout>

--- a/app/src/main/res/layout/fragment_edit_achievement.xml
+++ b/app/src/main/res/layout/fragment_edit_achievement.xml
@@ -40,6 +40,7 @@
                     android:id="@+id/btn_edit"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:background="@color/md_grey_500"
                     android:drawableLeft="@drawable/ic_edit"
                     android:drawablePadding="@dimen/padding_normal"
                     android:text="@string/edit_achievement"

--- a/app/src/main/res/layout/fragment_feedback.xml
+++ b/app/src/main/res/layout/fragment_feedback.xml
@@ -109,14 +109,17 @@
                 android:id="@+id/btn_submit"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="@string/button_submit"
                 android:textColor="@color/md_white_1000"
-                android:theme="@style/PrimaryButton" />
+                android:theme="@style/PrimaryButton"
+                android:layout_marginRight="10dp"/>
 
             <Button
                 android:id="@+id/btn_cancel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="@string/button_cancel"
                 android:textColor="@color/md_white_1000"
                 android:theme="@style/AccentButton" />

--- a/app/src/main/res/layout/fragment_feedback.xml
+++ b/app/src/main/res/layout/fragment_feedback.xml
@@ -110,6 +110,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_submit"
+                android:textColor="@color/md_white_1000"
                 android:theme="@style/PrimaryButton" />
 
             <Button
@@ -117,6 +118,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_cancel"
+                android:textColor="@color/md_white_1000"
                 android:theme="@style/AccentButton" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_in_active_dashboard.xml
+++ b/app/src/main/res/layout/fragment_in_active_dashboard.xml
@@ -27,6 +27,7 @@
             android:id="@+id/btn_feedback"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:background="@color/md_grey_500"
             android:padding="@dimen/padding_normal"
             android:text="Submit Feedback"
             android:textColor="@color/md_white_1000"

--- a/app/src/main/res/layout/fragment_in_active_dashboard.xml
+++ b/app/src/main/res/layout/fragment_in_active_dashboard.xml
@@ -26,9 +26,10 @@
         <Button
             android:id="@+id/btn_feedback"
             android:layout_width="wrap_content"
-            android:text="Submit Feedback"
             android:layout_height="wrap_content"
             android:padding="@dimen/padding_normal"
+            android:text="Submit Feedback"
+            android:textColor="@color/md_white_1000"
             android:theme="@style/PrimaryButton" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_library_detail.xml
+++ b/app/src/main/res/layout/fragment_library_detail.xml
@@ -45,14 +45,17 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="right"
+                        android:background="@color/md_grey_500"
                         android:text="@string/download"
                         android:textColor="@color/md_white_1000"
-                        android:theme="@style/PrimaryButton" />
+                        android:theme="@style/PrimaryButton"
+                        android:layout_marginRight="10dp"/>
 
                     <Button
                         android:id="@+id/btn_remove"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:background="@color/md_grey_500"
                         android:text="@string/btn_remove_lib"
                         android:textColor="@color/md_white_1000"
                         android:theme="@style/AccentButton" />

--- a/app/src/main/res/layout/fragment_library_detail.xml
+++ b/app/src/main/res/layout/fragment_library_detail.xml
@@ -46,6 +46,7 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="right"
                         android:text="@string/download"
+                        android:textColor="@color/md_white_1000"
                         android:theme="@style/PrimaryButton" />
 
                     <Button
@@ -53,6 +54,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/btn_remove_lib"
+                        android:textColor="@color/md_white_1000"
                         android:theme="@style/AccentButton" />
 
                 </LinearLayout>

--- a/app/src/main/res/layout/fragment_my_library.xml
+++ b/app/src/main/res/layout/fragment_my_library.xml
@@ -33,13 +33,15 @@
                 android:id="@+id/btn_collections"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/collections" />
+                android:text="@string/collections"
+                android:textColor="@color/md_white_1000" />
 
             <Button
                 android:id="@+id/show_filter"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/show_filter"
+                android:textColor="@color/md_white_1000"
                 android:theme="@style/PrimaryFlatButton" />
 
 

--- a/app/src/main/res/layout/fragment_my_library.xml
+++ b/app/src/main/res/layout/fragment_my_library.xml
@@ -33,25 +33,31 @@
                 android:id="@+id/btn_collections"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="@string/collections"
-                android:textColor="@color/md_white_1000" />
+                android:textColor="@color/md_white_1000"
+                android:layout_marginRight="10dp"/>
 
             <Button
                 android:id="@+id/show_filter"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="@string/show_filter"
                 android:textColor="@color/md_white_1000"
-                android:theme="@style/PrimaryFlatButton" />
+                android:theme="@style/PrimaryFlatButton"
+                android:layout_marginRight="10dp"/>
 
 
             <Button
                 android:id="@+id/btn_clear_tags"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="@string/clear_tags"
                 android:textColor="@color/md_white_1000"
-                android:theme="@style/PrimaryFlatButton" />
+                android:theme="@style/PrimaryFlatButton"
+                android:layout_marginRight="5dp"/>
 
 
             <TextView

--- a/app/src/main/res/layout/fragment_my_meetup_detail.xml
+++ b/app/src/main/res/layout/fragment_my_meetup_detail.xml
@@ -47,15 +47,18 @@
                         android:id="@+id/btn_invite"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:background="@color/md_grey_500"
                         android:text="@string/invite_member"
                         android:textColor="@color/md_white_1000"
-                        android:theme="@style/PrimaryFlatButton" />
+                        android:theme="@style/PrimaryFlatButton"
+                        android:layout_marginRight="10dp"/>
 
 
                     <Button
                         android:id="@+id/btn_leave"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:background="@color/md_grey_500"
                         android:text="@string/leave"
                         android:textColor="@color/md_white_1000"
                         android:theme="@style/AccentButton" />

--- a/app/src/main/res/layout/fragment_my_meetup_detail.xml
+++ b/app/src/main/res/layout/fragment_my_meetup_detail.xml
@@ -57,6 +57,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/leave"
+                        android:textColor="@color/md_white_1000"
                         android:theme="@style/AccentButton" />
 
                 </LinearLayout>

--- a/app/src/main/res/layout/fragment_my_teams_detail.xml
+++ b/app/src/main/res/layout/fragment_my_teams_detail.xml
@@ -47,15 +47,18 @@
                         android:id="@+id/btn_invite"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:background="@color/md_grey_500"
                         android:text="@string/invite_member"
                         android:textColor="@color/md_white_1000"
-                        android:theme="@style/PrimaryFlatButton" />
+                        android:theme="@style/PrimaryFlatButton"
+                        android:layout_marginRight="10dp"/>
 
 
                     <Button
                         android:id="@+id/btn_leave"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:background="@color/md_grey_500"
                         android:text="@string/leave"
                         android:textColor="@color/md_white_1000"
                         android:theme="@style/AccentButton" />

--- a/app/src/main/res/layout/fragment_my_teams_detail.xml
+++ b/app/src/main/res/layout/fragment_my_teams_detail.xml
@@ -57,6 +57,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/leave"
+                        android:textColor="@color/md_white_1000"
                         android:theme="@style/AccentButton" />
 
                 </LinearLayout>

--- a/app/src/main/res/layout/fragment_rating.xml
+++ b/app/src/main/res/layout/fragment_rating.xml
@@ -44,14 +44,17 @@
             android:id="@+id/btn_submit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:background="@color/md_grey_500"
             android:text="@string/button_submit"
             android:textColor="@color/md_white_1000"
-            android:theme="@style/PrimaryButton" />
+            android:theme="@style/PrimaryButton"
+            android:layout_marginRight="10dp"/>
 
         <Button
             android:id="@+id/btn_cancel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:background="@color/md_grey_500"
             android:text="@string/button_cancel"
             android:textColor="@color/md_white_1000"
             android:theme="@style/AccentButton" />

--- a/app/src/main/res/layout/fragment_rating.xml
+++ b/app/src/main/res/layout/fragment_rating.xml
@@ -45,6 +45,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/button_submit"
+            android:textColor="@color/md_white_1000"
             android:theme="@style/PrimaryButton" />
 
         <Button
@@ -52,6 +53,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/button_cancel"
+            android:textColor="@color/md_white_1000"
             android:theme="@style/AccentButton" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_take_course.xml
+++ b/app/src/main/res/layout/fragment_take_course.xml
@@ -73,6 +73,7 @@
                         android:id="@+id/btn_remove"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:background="@color/md_grey_500"
                         android:text="@string/btn_remove_lib"
                         android:textColor="@color/md_white_1000"
                         android:theme="@style/AccentButton" />

--- a/app/src/main/res/layout/fragment_take_course.xml
+++ b/app/src/main/res/layout/fragment_take_course.xml
@@ -74,6 +74,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/btn_remove_lib"
+                        android:textColor="@color/md_white_1000"
                         android:theme="@style/AccentButton" />
 
                     <TextView

--- a/app/src/main/res/layout/fragment_take_exam.xml
+++ b/app/src/main/res/layout/fragment_take_exam.xml
@@ -118,6 +118,7 @@
                     android:layout_margin="@dimen/padding_large"
                     android:padding="@dimen/padding_normal"
                     android:text="Submit Answer"
+                    android:textColor="@color/md_white_1000"
                     android:theme="@style/PrimaryButton" />
 
             </LinearLayout>

--- a/app/src/main/res/layout/fragment_take_exam.xml
+++ b/app/src/main/res/layout/fragment_take_exam.xml
@@ -116,6 +116,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="right"
                     android:layout_margin="@dimen/padding_large"
+                    android:background="@color/md_grey_500"
                     android:padding="@dimen/padding_normal"
                     android:text="Submit Answer"
                     android:textColor="@color/md_white_1000"

--- a/app/src/main/res/layout/fragment_user_information.xml
+++ b/app/src/main/res/layout/fragment_user_information.xml
@@ -209,6 +209,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_update"
+                android:textColor="@color/md_white_1000"
                 android:theme="@style/PrimaryButton" />
 
             <Button
@@ -216,6 +217,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_cancel"
+                android:textColor="@color/md_white_1000"
                 android:theme="@style/AccentButton" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_user_information.xml
+++ b/app/src/main/res/layout/fragment_user_information.xml
@@ -208,14 +208,17 @@
                 android:id="@+id/btn_submit"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="@string/button_update"
                 android:textColor="@color/md_white_1000"
-                android:theme="@style/PrimaryButton" />
+                android:theme="@style/PrimaryButton"
+                android:layout_marginRight="10dp"/>
 
             <Button
                 android:id="@+id/btn_cancel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="@string/button_cancel"
                 android:textColor="@color/md_white_1000"
                 android:theme="@style/AccentButton" />

--- a/app/src/main/res/layout/layout_button_primary.xml
+++ b/app/src/main/res/layout/layout_button_primary.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Button xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
     android:id="@+id/btn"
-    android:padding="@dimen/padding_normal"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:layout_margin="@dimen/padding_normal"
-    android:theme="@style/PrimaryButton"
+    android:background="@color/md_grey_500"
     android:drawablePadding="@dimen/padding_small"
-    android:layout_height="wrap_content">
+    android:padding="@dimen/padding_normal"
+    android:theme="@style/PrimaryButton">
 
 </Button>

--- a/app/src/main/res/layout/row_survey.xml
+++ b/app/src/main/res/layout/row_survey.xml
@@ -65,14 +65,17 @@
                 android:id="@+id/send_survey"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="Send Survey"
                 android:textColor="@color/md_white_1000"
-                android:theme="@style/PrimaryButton" />
+                android:theme="@style/PrimaryButton"
+                android:layout_marginRight="10dp"/>
 
             <Button
                 android:id="@+id/start_survey"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="@color/md_grey_500"
                 android:text="Take Survey"
                 android:textColor="@color/md_white_1000"
                 android:theme="@style/PrimaryButton" />

--- a/app/src/main/res/layout/row_survey.xml
+++ b/app/src/main/res/layout/row_survey.xml
@@ -66,6 +66,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Send Survey"
+                android:textColor="@color/md_white_1000"
                 android:theme="@style/PrimaryButton" />
 
             <Button
@@ -73,6 +74,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Take Survey"
+                android:textColor="@color/md_white_1000"
                 android:theme="@style/PrimaryButton" />
 
         </LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'io.realm:realm-gradle-plugin:5.2.0'
         classpath 'pl.droidsonroids.gif:android-gif-drawable:1.2.+'
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Fixes #769 

## Description
Changes the color of a button's text to white if the button has a non-white background, to create design consistency.

## An example:

#### Changes this
<img width="456" alt="Screen Shot 2019-04-30 at 4 42 29 PM" src="https://user-images.githubusercontent.com/29234807/56992064-3797a780-6b67-11e9-8326-8d2efaf84579.png">

#### To this
<img width="456" alt="Screen Shot 2019-04-30 at 4 43 47 PM" src="https://user-images.githubusercontent.com/29234807/56992081-43836980-6b67-11e9-9fc5-5b385b49bc08.png">

`Note: This inconsistency in text color occurred in many files. `



