### PR TITLE
Change button styles (fixes #769)

### DIFF
--- a/app/src/main/res/layout-large-land/activity_login.xml
+++ b/app/src/main/res/layout-large-land/activity_login.xml
@@ -183,14 +183,14 @@
                         android:layout_height="wrap_content"
                         android:layout_marginTop="10dp"
                         android:text="@string/btn_guest_login"
-                        android:theme="@style/PrimaryFlatButton"
+                        style="@style/GreyButtons"
                         android:textSize="14sp" />
 
                     <Button
                         android:layout_width="wrap_content"
                         android:layout_gravity="center"
                         android:layout_margin="@dimen/padding_normal"
-                        android:theme="@style/PrimaryFlatButton"
+                        style="@style/GreyButtons"
                         android:id="@+id/become_member"
                         android:text="Become a member"
                         android:layout_height="wrap_content" />

--- a/app/src/main/res/layout-xlarge-land/activity_login.xml
+++ b/app/src/main/res/layout-xlarge-land/activity_login.xml
@@ -182,7 +182,8 @@
                         android:layout_marginTop="10dp"
                         android:text="@string/btn_guest_login"
                         android:textSize="14sp"
-                        android:theme="@style/PrimaryFlatButton" />
+                        style="@style/GreyButtons"
+                        />
 
                     <Button
                         android:id="@+id/become_member"
@@ -191,7 +192,8 @@
                         android:layout_gravity="center"
                         android:layout_margin="@dimen/padding_normal"
                         android:text="Become a member"
-                        android:theme="@style/PrimaryFlatButton" />
+                        style="@style/GreyButtons"
+                        />
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -187,11 +187,11 @@
 
                     <Button
                         android:id="@+id/btn_guest_login"
+                        style="@style/GreyButtons"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="10dp"
                         android:text="@string/btn_guest_login"
-                        android:theme="@style/PrimaryFlatButton"
                         android:textSize="14sp" />
 
                     <Button
@@ -201,7 +201,8 @@
                         android:layout_gravity="center"
                         android:layout_margin="@dimen/padding_normal"
                         android:text="Become a member"
-                        android:theme="@style/PrimaryFlatButton" />
+                        style="@style/GreyButtons"
+                        />
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout/alert_add_attachment.xml
+++ b/app/src/main/res/layout/alert_add_attachment.xml
@@ -47,5 +47,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/add_resources"
-        android:theme="@style/PrimaryFlatButton" />
+        style="@style/GreyButtons"
+        />
 </LinearLayout>

--- a/app/src/main/res/layout/edit_attachement.xml
+++ b/app/src/main/res/layout/edit_attachement.xml
@@ -50,7 +50,8 @@
                 android:layout_height="wrap_content"
                 android:text="Edit"
                 android:visibility="visible"
-                android:theme="@style/PrimaryFlatButton" />
+                style="@style/GreyButtons"
+                />
 
             <ImageView
                 android:id="@+id/iv_delete"

--- a/app/src/main/res/layout/edit_other_info.xml
+++ b/app/src/main/res/layout/edit_other_info.xml
@@ -25,7 +25,8 @@
             android:layout_gravity="center"
             android:text="Edit"
             android:visibility="visible"
-            android:theme="@style/PrimaryFlatButton" />
+            style="@style/GreyButtons"
+            />
 
         <ImageView
             android:id="@+id/iv_delete"

--- a/app/src/main/res/layout/fragment_achievement.xml
+++ b/app/src/main/res/layout/fragment_achievement.xml
@@ -44,7 +44,8 @@
                     android:drawableLeft="@drawable/ic_edit"
                     android:drawablePadding="@dimen/padding_normal"
                     android:text="@string/edit_achievement"
-                    android:theme="@style/AccentButton" />
+                    style="@style/GreyButtons"
+                    />
 
 
             </LinearLayout>

--- a/app/src/main/res/layout/fragment_course_detail.xml
+++ b/app/src/main/res/layout/fragment_course_detail.xml
@@ -26,14 +26,17 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Open Resource"
-                    android:theme="@style/PrimaryButton" />
+                    android:layout_marginRight="10dp"
+                    style="@style/GreyButtons"
+                    />
 
                 <Button
                     android:id="@+id/btn_resources"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Resources"
-                    android:theme="@style/PrimaryButton" />
+                    style="@style/GreyButtons"
+                    />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_course_step.xml
+++ b/app/src/main/res/layout/fragment_course_step.xml
@@ -21,14 +21,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Open Resource"
-                android:theme="@style/PrimaryButton" />
+                android:layout_marginRight="10dp"
+                style="@style/GreyButtons"
+                />
 
             <Button
                 android:id="@+id/btn_resources"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Download Resources"
-                android:theme="@style/PrimaryButton" />
+                style="@style/GreyButtons"
+                />
 
             <Button
                 android:id="@+id/btn_take_test"

--- a/app/src/main/res/layout/fragment_edit_achievement.xml
+++ b/app/src/main/res/layout/fragment_edit_achievement.xml
@@ -43,7 +43,8 @@
                     android:drawableLeft="@drawable/ic_edit"
                     android:drawablePadding="@dimen/padding_normal"
                     android:text="@string/edit_achievement"
-                    android:theme="@style/AccentButton" />
+                    style="@style/GreyButtons"
+                    />
 
 
             </LinearLayout>

--- a/app/src/main/res/layout/fragment_feedback.xml
+++ b/app/src/main/res/layout/fragment_feedback.xml
@@ -110,14 +110,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_submit"
-                android:theme="@style/PrimaryButton" />
+                style="@style/GreyButtons"
+                android:layout_marginRight="10dp"
+                />
 
             <Button
                 android:id="@+id/btn_cancel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_cancel"
-                android:theme="@style/AccentButton" />
+                style="@style/GreyButtons"
+                />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_in_active_dashboard.xml
+++ b/app/src/main/res/layout/fragment_in_active_dashboard.xml
@@ -29,7 +29,8 @@
             android:text="Submit Feedback"
             android:layout_height="wrap_content"
             android:padding="@dimen/padding_normal"
-            android:theme="@style/PrimaryButton" />
+            style="@style/GreyButtons"
+            />
     </LinearLayout>
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_library_detail.xml
+++ b/app/src/main/res/layout/fragment_library_detail.xml
@@ -46,14 +46,17 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="right"
                         android:text="@string/download"
-                        android:theme="@style/PrimaryButton" />
+                        android:layout_marginRight="10dp"
+                        style="@style/GreyButtons"
+                        />
 
                     <Button
                         android:id="@+id/btn_remove"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/btn_remove_lib"
-                        android:theme="@style/AccentButton" />
+                        style="@style/GreyButtons"
+                        />
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_my_library.xml
+++ b/app/src/main/res/layout/fragment_my_library.xml
@@ -33,14 +33,19 @@
                 android:id="@+id/btn_collections"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/collections" />
+                android:text="@string/collections"
+                android:layout_marginRight="10dp"
+                style="@style/GreyButtons"
+                />
 
             <Button
                 android:id="@+id/show_filter"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/show_filter"
-                android:theme="@style/PrimaryFlatButton" />
+                android:layout_marginRight="10dp"
+                style="@style/GreyButtons"
+                />
 
 
             <Button
@@ -49,7 +54,8 @@
                 android:layout_height="wrap_content"
                 android:text="@string/clear_tags"
                 android:textColor="@color/md_white_1000"
-                android:theme="@style/PrimaryFlatButton" />
+                style="@style/GreyButtons"
+                />
 
 
             <TextView

--- a/app/src/main/res/layout/fragment_my_meetup_detail.xml
+++ b/app/src/main/res/layout/fragment_my_meetup_detail.xml
@@ -48,8 +48,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/invite_member"
-                        android:textColor="@color/md_white_1000"
-                        android:theme="@style/PrimaryFlatButton" />
+                        android:layout_marginRight="10dp"
+                        style="@style/GreyButtons"
+                        />
 
 
                     <Button
@@ -57,7 +58,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/leave"
-                        android:theme="@style/AccentButton" />
+                        style="@style/GreyButtons"
+                        />
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_my_teams_detail.xml
+++ b/app/src/main/res/layout/fragment_my_teams_detail.xml
@@ -48,8 +48,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/invite_member"
-                        android:textColor="@color/md_white_1000"
-                        android:theme="@style/PrimaryFlatButton" />
+                        android:layout_marginRight="10dp"
+                        style="@style/GreyButtons"
+                        />
 
 
                     <Button
@@ -57,7 +58,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/leave"
-                        android:theme="@style/AccentButton" />
+                        style="@style/GreyButtons"
+                        />
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_rating.xml
+++ b/app/src/main/res/layout/fragment_rating.xml
@@ -45,14 +45,17 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/button_submit"
-            android:theme="@style/PrimaryButton" />
+            android:layout_marginRight="10dp"
+            style="@style/GreyButtons"
+            />
 
         <Button
             android:id="@+id/btn_cancel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/button_cancel"
-            android:theme="@style/AccentButton" />
+            style="@style/GreyButtons"
+            />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_take_course.xml
+++ b/app/src/main/res/layout/fragment_take_course.xml
@@ -74,7 +74,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/btn_remove_lib"
-                        android:theme="@style/AccentButton" />
+                        style="@style/GreyButtons"
+                        />
 
                     <TextView
                         android:id="@+id/previous_step"

--- a/app/src/main/res/layout/fragment_take_exam.xml
+++ b/app/src/main/res/layout/fragment_take_exam.xml
@@ -118,7 +118,8 @@
                     android:layout_margin="@dimen/padding_large"
                     android:padding="@dimen/padding_normal"
                     android:text="Submit Answer"
-                    android:theme="@style/PrimaryButton" />
+                    style="@style/GreyButtons"
+                    />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_user_information.xml
+++ b/app/src/main/res/layout/fragment_user_information.xml
@@ -209,14 +209,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_update"
-                android:theme="@style/PrimaryButton" />
+                android:layout_marginRight="10dp"
+                style="@style/GreyButtons"
+                />
 
             <Button
                 android:id="@+id/btn_cancel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_cancel"
-                android:theme="@style/AccentButton" />
+                style="@style/GreyButtons"
+                />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/row_survey.xml
+++ b/app/src/main/res/layout/row_survey.xml
@@ -66,14 +66,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Send Survey"
-                android:theme="@style/PrimaryButton" />
+                android:layout_marginRight="10dp"
+                style="@style/GreyButtons"
+                />
 
             <Button
                 android:id="@+id/start_survey"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Take Survey"
-                android:theme="@style/PrimaryButton" />
+                style="@style/GreyButtons"
+                />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -90,6 +90,13 @@
         <item name="colorAccent">@color/colorPrimary</item>
     </style>
 
+
+    <style name="GreyButtons" parent="Theme.AppCompat">
+        <item name="android:textColor">@color/md_white_1000</item>
+        <item name="android:background">@color/md_grey_500</item>
+        <item name="colorControlHighlight">@color/disable_color</item>
+    </style>
+
     <style name="Seekbar" parent="@android:style/Widget.ProgressBar.Horizontal">
         <item name="android:thumb">@drawable/white_line</item>
         <item name="tickMark">@drawable/white_line</item>


### PR DESCRIPTION
Fixes #769 

## Description

Added a new button style to create uniformity in design. Applied to all buttons of grey backgrounds, making their text white and backgrounds a darker shade of grey.

### Example

#### Changed this: 

<img width="225" alt="Screen Shot 2019-05-13 at 2 36 36 PM" src="https://user-images.githubusercontent.com/29234807/57645597-a2e07100-758c-11e9-974a-ef84639a5938.png">

#### To this:

<img width="225" alt="Screen Shot 2019-05-13 at 2 37 01 PM" src="https://user-images.githubusercontent.com/29234807/57645620-af64c980-758c-11e9-9b78-8fcd4d796dd6.png">

*Note: I have opened [another PR](https://github.com/open-learning-exchange/myplanet/pull/778) fixing the same issue using a different tactic.*
