### PR TITLE
Drawer Opens by Default on Login (fixes #1782)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 795
-        versionName "0.7.95"
+        versionCode 796
+        versionName "0.7.96"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -109,7 +110,7 @@ public class DashboardActivity extends DashboardElementActivity implements OnHom
         navigationView.setVisibility(new UserProfileDbHandler(this).getUserModel().getShowTopbar() ? View.VISIBLE : View.GONE);
         headerResult = getAccountHeader();
         createDrawer();
-        if(getWindowManager().getDefaultDisplay().getRotation() == Surface.ROTATION_0 || getWindowManager().getDefaultDisplay().getRotation() == Surface.ROTATION_180) {
+        if(getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
             result.openDrawer();
         }//Opens drawer by default
         result.getStickyFooter().setPadding(0, 0, 0, 0); // moves logout button to the very bottom of the drawer. Without it, the "logout" button suspends a little.

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.java
@@ -106,6 +106,7 @@ public class DashboardActivity extends DashboardElementActivity implements OnHom
         navigationView.setVisibility(new UserProfileDbHandler(this).getUserModel().getShowTopbar() ? View.VISIBLE : View.GONE);
         headerResult = getAccountHeader();
         createDrawer();
+        result.openDrawer(); //Opens drawer by default
         result.getStickyFooter().setPadding(0, 0, 0, 0); // moves logout button to the very bottom of the drawer. Without it, the "logout" button suspends a little.
         result.getActionBarDrawerToggle().setDrawerIndicatorEnabled(true);
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
@@ -119,6 +120,7 @@ public class DashboardActivity extends DashboardElementActivity implements OnHom
 
         findViewById(R.id.iv_sync).setOnClickListener(view -> syncNow());
         findViewById(R.id.img_logo).setOnClickListener(view -> result.openDrawer());
+
         bellToolbar.setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.java
@@ -4,6 +4,7 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -14,11 +15,13 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.GestureDetector;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
+import android.view.Surface;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.ImageView;
@@ -77,6 +80,7 @@ public class DashboardActivity extends DashboardElementActivity implements OnHom
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+
         super.onCreate(savedInstanceState);
         checkUser();
         setContentView(R.layout.activity_dashboard);
@@ -106,7 +110,9 @@ public class DashboardActivity extends DashboardElementActivity implements OnHom
         navigationView.setVisibility(new UserProfileDbHandler(this).getUserModel().getShowTopbar() ? View.VISIBLE : View.GONE);
         headerResult = getAccountHeader();
         createDrawer();
-        result.openDrawer(); //Opens drawer by default
+        if(getWindowManager().getDefaultDisplay().getRotation() == Surface.ROTATION_0 || getWindowManager().getDefaultDisplay().getRotation() == Surface.ROTATION_180) {
+            result.openDrawer();
+        }//Opens drawer by default
         result.getStickyFooter().setPadding(0, 0, 0, 0); // moves logout button to the very bottom of the drawer. Without it, the "logout" button suspends a little.
         result.getActionBarDrawerToggle().setDrawerIndicatorEnabled(true);
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.java
@@ -80,7 +80,6 @@ public class DashboardActivity extends DashboardElementActivity implements OnHom
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-
         super.onCreate(savedInstanceState);
         checkUser();
         setContentView(R.layout.activity_dashboard);

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.7.95</string>
+    <string name="app_version">0.7.96</string>
 </resources>


### PR DESCRIPTION
Fixes #1782 

## Description 
The navigation menu opens up once by default when the user first logs in so that they know the menu is there. 
Example screenshot: 
![Screen Shot 2020-06-02 at 4 27 08 PM](https://user-images.githubusercontent.com/49795308/83579181-cd81cc80-a4f5-11ea-8795-23148894682a.png)
* works on tablets and phones without layout issues 