### PR TITLE
Add Units to Examination (fixes #1804)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 799
-        versionName "0.7.99"
+        versionCode 800
+        versionName "0.8.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -279,7 +279,7 @@
     <string name="button_reject">Reject</string>
     <string name="button_accept">Accept</string>
     <string name="plan">Plan</string>
-    <string name="body_temperature">Body Temperature</string>
+    <string name="body_temperature">Body Temperature (°C)</string>
     <string name="rectally">Rectally</string>
     <string name="axillary">Axillary</string>
     <string name="by_ear">By ear</string>
@@ -334,7 +334,7 @@
     <string name="examination">Examination</string>
     <string name="add_examination">Add Examination</string>
     <string name="new_patient">Next Member</string>
-    <string name="height">Height</string>
+    <string name="height">Height (cm)</string>
     <string name="width">Width</string>
     <string name="vision">Vision</string>
     <string name="hearing">Hearing</string>
@@ -350,7 +350,7 @@
     <string name="labtest">Lab Tests</string>
     <string name="referrals">Referrals</string>
     <string name="full_name">Full Name</string>
-    <string name="weight">Weight</string>
+    <string name="weight">Weight (kg)</string>
     <string name="no_records">No records found</string>
     <string name="chats">Chats</string>
     <string name="select_health_member">Select Member</string>

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.7.99</string>
+    <string name="app_version">0.8.0</string>
 </resources>


### PR DESCRIPTION
Fixes #1804 

## Description
In Planet, the user is suggested what units to use when adding an examination as seen below: 
![Screen Shot 2020-06-05 at 9 15 18 AM](https://user-images.githubusercontent.com/49795308/83895263-af8fb400-a70f-11ea-9535-f563db2574d7.png)

Now in the myPlanet application, the units should match as seen below: 
![Screen Shot 2020-06-05 at 9 30 48 AM](https://user-images.githubusercontent.com/49795308/83895326-c504de00-a70f-11ea-98a9-0964cc50da9a.png)
