### PR TITLE
Alert Before Leaving Health Examination (fixes #1836)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 818
+        versionCode 819
         versionName "0.8.19"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 28
         versionCode 818
-        versionName "0.8.18"
+        versionName "0.8.19"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 819
-        versionName "0.8.19"
+        versionCode 820
+        versionName "0.8.20"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddExaminationActivity.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddExaminationActivity.java
@@ -263,7 +263,7 @@ public class AddExaminationActivity extends AppCompatActivity implements Compoun
         }
         mRealm.commitTransaction();
         Utilities.toast(this, "Added successfully");
-        finish();
+       finish();
     }
 
     private boolean getHasInfo() {
@@ -335,22 +335,18 @@ public class AddExaminationActivity extends AppCompatActivity implements Compoun
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
-        alertDialogBuilder.setMessage("Are you sure you want to exit? Your data will be lost.");
-        alertDialogBuilder.setPositiveButton("Yes, I want to exit. ", (dialogInterface, i) -> {
-            if (item.getItemId() == android.R.id.home)
-                finish();
-        }).setNegativeButton("Cancel", null);
-        alertDialogBuilder.show();
+        if (item.getItemId() == android.R.id.home){
+            finish();
+        }
         return super.onOptionsItemSelected(item);
     }
 
     @Override
-    public void onBackPressed() {
+    public void finish() {
         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
         alertDialogBuilder.setMessage("Are you sure you want to exit? Your data will be lost.");
         alertDialogBuilder.setPositiveButton("Yes, I want to exit. ", (dialogInterface, i) -> {
-            super.onBackPressed();
+            super.finish();
         }).setNegativeButton("Cancel", null);
         alertDialogBuilder.show();
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddExaminationActivity.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddExaminationActivity.java
@@ -5,10 +5,13 @@ import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.EditText;
+import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.android.flexbox.FlexboxLayout;
@@ -33,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
+import androidx.fragment.app.Fragment;
 import io.realm.Realm;
 
 public class AddExaminationActivity extends AppCompatActivity implements CompoundButton.OnCheckedChangeListener {
@@ -329,11 +333,15 @@ public class AddExaminationActivity extends AppCompatActivity implements Compoun
         }
     }
 
-
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == android.R.id.home)
-            finish();
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
+        alertDialogBuilder.setMessage("Are you sure you want to exit? Your data will be lost.");
+        alertDialogBuilder.setPositiveButton("Yes, I want to exit. ", (dialogInterface, i) -> {
+            if (item.getItemId() == android.R.id.home)
+                finish();
+        }).setNegativeButton("Cancel", null);
+        alertDialogBuilder.show();
         return super.onOptionsItemSelected(item);
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddExaminationActivity.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddExaminationActivity.java
@@ -346,6 +346,16 @@ public class AddExaminationActivity extends AppCompatActivity implements Compoun
     }
 
     @Override
+    public void onBackPressed() {
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
+        alertDialogBuilder.setMessage("Are you sure you want to exit? Your data will be lost.");
+        alertDialogBuilder.setPositiveButton("Yes, I want to exit. ", (dialogInterface, i) -> {
+            super.onBackPressed();
+        }).setNegativeButton("Cancel", null);
+        alertDialogBuilder.show();
+    }
+
+    @Override
     public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
         String text = compoundButton.getText().toString().trim();
         mapConditions.put(text, b);

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.8.18</string>
+    <string name="app_version">0.8.19</string>
 </resources>

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.8.19</string>
+    <string name="app_version">0.8.20</string>
 </resources>


### PR DESCRIPTION
fixes #1836 

## Description 
Before, the user would be able to exit out of the examination losing all of their data. This may lead to accidental data loss if the user does not mean to exit out of the examination. 

## Additions 
Now, the user receives an alert when exiting out of an exam asking if they are sure of this decision. 

## Screenshots
![Screen Shot 2020-06-23 at 1 15 46 AM](https://user-images.githubusercontent.com/49795308/85372621-5c7b7680-b4ef-11ea-8830-8190e2b40475.png)
