### PR TITLE
Make Level More Apparent on Become a Member Screen (fixes #1812)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 812
-        versionName "0.8.12"
+        versionCode 813
+        versionName "0.8.13"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true

--- a/app/src/main/res/layout/activity_become_member.xml
+++ b/app/src/main/res/layout/activity_become_member.xml
@@ -247,8 +247,8 @@
                 <RelativeLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="5dp"
-                    android:background="@color/colorPrimary">
+                    android:padding="@dimen/padding_normal"
+                    android:background="@drawable/border">
                     <Spinner
                         android:id="@+id/spn_level"
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_become_member.xml
+++ b/app/src/main/res/layout/activity_become_member.xml
@@ -244,13 +244,18 @@
                     android:text="@string/level"
                     android:textColor="@color/md_black_1000" />
 
-                <Spinner
-                    android:id="@+id/spn_level"
+                <RelativeLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:entries="@array/level"
-                    android:padding="@dimen/padding_small" />
-
+                    android:padding="5dp"
+                    android:background="@color/colorPrimary">
+                    <Spinner
+                        android:id="@+id/spn_level"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:entries="@array/level"
+                        android:padding="@dimen/padding_small" />
+                </RelativeLayout>
             </LinearLayout>
 
 

--- a/app/src/main/res/layout/activity_become_member.xml
+++ b/app/src/main/res/layout/activity_become_member.xml
@@ -138,6 +138,7 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:orientation="vertical"
+
                     android:padding="@dimen/padding_normal">
 
                     <TextView
@@ -151,9 +152,10 @@
                     <Spinner
                         android:id="@+id/spn_lang"
                         android:layout_width="match_parent"
+                        android:background="@drawable/border"
                         android:layout_height="wrap_content"
                         android:entries="@array/language"
-                        android:padding="4dp" />
+                        android:padding="@dimen/padding_normal" />
 
                 </LinearLayout>
             </LinearLayout>
@@ -182,7 +184,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
                     android:layout_weight="1"
-                    android:background="?attr/selectableItemBackground"
+                    android:background="@drawable/border"
                     android:drawableRight="@drawable/ic_date"
                     android:gravity="center_vertical"
                     android:padding="@dimen/padding_normal"

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.8.12</string>
+    <string name="app_version">0.8.13</string>
 </resources>


### PR DESCRIPTION
fixes #1812
Changed level spinner background to primary color. Any other color can be used if this one is not suitable.
