### PR TITLE
Option to Add Custom Labels (fixes #1855)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmNews.java
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmNews.java
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.model;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -132,7 +133,10 @@ public class RealmNews extends RealmObject {
     public void addLabel(String label) {
         if (!this.labels.contains(label)) {
             Utilities.log("Added");
+            Log.i("this is it", label);
+            Log.i("LABEL", "LABEL");
             this.labels.add(label);
+            Log.i("Labels", labels + "");
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmNews.java
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmNews.java
@@ -133,10 +133,7 @@ public class RealmNews extends RealmObject {
     public void addLabel(String label) {
         if (!this.labels.contains(label)) {
             Utilities.log("Added");
-            Log.i("this is it", label);
-            Log.i("LABEL", "LABEL");
             this.labels.add(label);
-            Log.i("Labels", labels + "");
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.java
@@ -140,7 +140,7 @@ public class AdapterNews extends BaseNewsAdapter {
                         Utilities.toast(context, "Label added.");
                         showChips(holder, news);
                     } else {
-                        final String[] text = new String[1];
+
                         View v = LayoutInflater.from(context).inflate(R.layout.alert_add_label, null);
 
                         AlertDialog.Builder alert = new AlertDialog.Builder(context);
@@ -148,11 +148,11 @@ public class AdapterNews extends BaseNewsAdapter {
                         final EditText title = (EditText) v.findViewById(R.id.et_label);
                         alert.setTitle("Enter Label");
                         alert.setPositiveButton("Save", (dialogInterface, i) -> {
-                            text[0] = title.getText().toString();
-                            Constants.LABELS.put(text[0], text[0]);
-                            if (!mRealm.isInTransaction() && text[0] != null) {
+                            String text = title.getText().toString();
+                            Constants.LABELS.put(text, text);
+                            if (!mRealm.isInTransaction() && text != null) {
                                 mRealm.beginTransaction();
-                                news.addLabel(Constants.LABELS.get(text[0]));
+                                news.addLabel(Constants.LABELS.get(text));
                                 mRealm.commitTransaction();
                                 Utilities.toast(context, "Label added.");
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.java
@@ -1,7 +1,10 @@
 package org.ole.planet.myplanet.ui.news;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.text.Editable;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuInflater;
 import android.view.View;
@@ -32,6 +35,7 @@ import org.ole.planet.myplanet.utilities.Utilities;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import fisk.chipcloud.ChipCloud;
 import fisk.chipcloud.ChipCloudConfig;
@@ -125,12 +129,50 @@ public class AdapterNews extends BaseNewsAdapter {
             MenuInflater inflater = menu.getMenuInflater();
             inflater.inflate(R.menu.menu_add_label, menu.getMenu());
             menu.setOnMenuItemClickListener(menuItem -> {
-                if (!mRealm.isInTransaction())
-                    mRealm.beginTransaction();
-                news.addLabel(Constants.LABELS.get(menuItem.getTitle() + ""));
-                Utilities.toast(context, "Label added.");
-                mRealm.commitTransaction();
-                showChips(holder, news);
+                String menutitle = menuItem.getTitle().toString().toLowerCase();
+                Log.i("Menu Title", menutitle);
+                    if (!menutitle.equals("other")) {
+                        if (!mRealm.isInTransaction()) {
+                            mRealm.beginTransaction();
+                        }
+                        news.addLabel(Constants.LABELS.get(menuItem.getTitle() + ""));
+                        mRealm.commitTransaction();
+                        Utilities.toast(context, "Label added.");
+                        showChips(holder, news);
+                    } else {
+                        final String[] text = new String[1];
+                        View v = LayoutInflater.from(context).inflate(R.layout.alert_add_label, null);
+
+                        AlertDialog.Builder alert = new AlertDialog.Builder(context);
+                        alert.setView(v);
+                        final EditText title = (EditText) v.findViewById(R.id.et_label);
+                        alert.setTitle("Enter Label");
+                        alert.setPositiveButton("Save", (dialogInterface, i) -> {
+                            text[0] = title.getText().toString();
+                            Constants.LABELS.put(text[0], text[0]);
+                            if (!mRealm.isInTransaction() && text[0] != null) {
+                                mRealm.beginTransaction();
+                                news.addLabel(Constants.LABELS.get(text[0]));
+                                mRealm.commitTransaction();
+                                Utilities.toast(context, "Label added.");
+
+                                showChips(holder, news);
+                            }
+
+                        });
+
+
+                        alert.setNegativeButton("Cancel", null);
+                        AlertDialog d = alert.create();
+                        d.show();
+                        Log.i("here", "now here");
+
+
+
+                    }
+
+
+
                 return false;
             });
             menu.show();

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Constants.java
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Constants.java
@@ -132,6 +132,7 @@ public class Constants {
         LABELS.put("Help Wanted", "help");
         LABELS.put("Offer", "offer");
         LABELS.put("Request for advice", "advice");
+        LABELS.put("Other", "other");
 
     }
 

--- a/app/src/main/res/layout/alert_add_label.xml
+++ b/app/src/main/res/layout/alert_add_label.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="10dp"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/et_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Label"
+        android:inputType="text" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_add_label.xml
+++ b/app/src/main/res/menu/menu_add_label.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
         android:id="@+id/help_wanted"
@@ -15,5 +16,6 @@
     <item
         android:id="@+id/request_for_advice"
         android:title="Request for advice" />
+    <item android:title="Other" />
 
 </menu>


### PR DESCRIPTION
fixes #1855 

## Description
Now the user can enter in their own idea for a label for chat messages. 

## Images
![Screen Shot 2020-06-30 at 10 53 01 PM](https://user-images.githubusercontent.com/49795308/86204376-97e7f780-bb24-11ea-9375-e99c5fd084d0.png)
![Screen Shot 2020-06-30 at 10 53 14 PM](https://user-images.githubusercontent.com/49795308/86204382-99192480-bb24-11ea-850a-5c7dd997d2eb.png)
![Screen Shot 2020-06-30 at 10 53 22 PM](https://user-images.githubusercontent.com/49795308/86204383-99b1bb00-bb24-11ea-9a0e-4323ec19bdd2.png)
