### PR TITLE
Fix button layout (fixes #1927)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 836
-        versionName "0.8.36"
+        versionCode 837
+        versionName "0.8.37"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true

--- a/app/src/main/res/layout/activity_become_member.xml
+++ b/app/src/main/res/layout/activity_become_member.xml
@@ -267,19 +267,23 @@
                 android:layout_gravity="right">
 
                 <Button
-                    android:id="@+id/btn_submit"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="10dp"
-                    android:text="@string/become_a_member"
-                    android:theme="@style/PrimaryButton" />
-
-                <Button
                     android:id="@+id/btn_cancel"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/button_cancel"
-                    android:theme="@style/RejectButton" />
+                    android:textStyle="bold"
+                    android:textSize="@dimen/text_size_mid"
+                    style="@style/Widget.MaterialComponents.Button.TextButton"/>
+
+                <Button
+                    android:id="@+id/btn_submit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/become_a_member"
+                    android:textSize="@dimen/text_size_mid"
+                    android:theme="@style/FocusButton"/>
+
+
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_feedback.xml
+++ b/app/src/main/res/layout/fragment_feedback.xml
@@ -105,20 +105,22 @@
             android:layout_height="wrap_content"
             android:layout_gravity="right">
 
-            <Button
-                android:id="@+id/btn_submit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/button_submit"
-                android:theme="@style/PrimaryButton"
-                android:layout_marginRight="10dp"/>
 
             <Button
                 android:id="@+id/btn_cancel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/button_cancel"
-                android:theme="@style/AccentButton" />
+                android:textSize="@dimen/text_size_mid"
+                style="@style/Widget.MaterialComponents.Button.TextButton" />
+
+            <Button
+                android:id="@+id/btn_submit"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/button_submit"
+                android:textSize="@dimen/text_size_mid"
+                style="@style/Widget.MaterialComponents.Button.TextButton" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -76,7 +76,14 @@
         <item name="android:textSize">@dimen/text_size_mid</item>
     </style>
 
+<!--    Button Themes   -->
     <style name="RejectButton" parent="Theme.AppCompat">
+        <item name="colorButtonNormal">@color/colorAccent</item>
+        <item name="colorControlHighlight">@color/colorAccent</item>
+    </style>
+
+    <!--  Button that uses accent color, primarily as the most important button on the screen  -->
+    <style name="FocusButton" parent="Theme.AppCompat">
         <item name="colorButtonNormal">@color/colorAccent</item>
         <item name="colorControlHighlight">@color/colorAccent</item>
     </style>

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.8.36</string>
+    <string name="app_version">0.8.37</string>
 </resources>


### PR DESCRIPTION
Changed the layout of buttons to the color scheme used throughout the app in dialogs. Moved dismissive buttons like **Cancel** to the left.

![Screenshot_1593890419](https://user-images.githubusercontent.com/6264813/86519569-e7227680-be09-11ea-8973-0f906bef1b43.png)
![Screenshot_1593890405](https://user-images.githubusercontent.com/6264813/86519570-e853a380-be09-11ea-9b2e-d7c8d2c6334c.png)
