### PR TITLE
Remove "make leader" option for the team leader (fixes #1892)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 843
-        versionName "0.8.43"
+        versionCode 844
+        versionName "0.8.44"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import io.realm.Realm;
 
-public class AdapterJoinedMemeber extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+public class AdapterJoinedMember extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private Context context;
     private List<RealmUserModel> list;
     private Realm mRealm;
@@ -31,7 +31,7 @@ public class AdapterJoinedMemeber extends RecyclerView.Adapter<RecyclerView.View
     private RealmUserModel currentUser;
     private String teamLeaderId;
 
-    public AdapterJoinedMemeber(Context context, List<RealmUserModel> list, Realm mRealm, String teamId) {
+    public AdapterJoinedMember(Context context, List<RealmUserModel> list, Realm mRealm, String teamId) {
         this.context = context;
         this.list = list;
         this.mRealm = mRealm;
@@ -54,32 +54,46 @@ public class AdapterJoinedMemeber extends RecyclerView.Adapter<RecyclerView.View
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         if (holder instanceof ViewHolderUser) {
             ((ViewHolderUser) holder).tvTitle.setText(list.get(position).toString());
-            ((ViewHolderUser) holder).tvDescription.setText(list.get(position).getRoleAsString() + " (" + RealmTeamLog.getVisitCount(mRealm, list.get(position).getName(), teamId) + " visits )");
+            ((ViewHolderUser) holder).tvDescription
+                    .setText(list.get(position).getRoleAsString()
+                            + " ("
+                            + RealmTeamLog.getVisitCount(mRealm, list.get(position).getName(), teamId)
+                            + " visits )");
 
+            // If the currently logged in user is the team leader
             if (this.teamLeaderId != null && this.teamLeaderId.equals(this.currentUser.getId())) {
                 ((ViewHolderUser) holder).icMore.setVisibility(View.VISIBLE);
+                // Options that will be shown when the overflow menu is clicked.
+                String[] overflowMenuOptions;
+
+
+                // If the current user/card is the logged in user/team leader
+                if (this.teamLeaderId.equals(list.get(position).getId())) {
+                    ((ViewHolderUser) holder).isLeader.setVisibility(View.VISIBLE);
+                    ((ViewHolderUser) holder).isLeader.setText("(Team Leader)");
+                    overflowMenuOptions = new String[] {context.getString(R.string.remove)};
+                } else {
+                    ((ViewHolderUser) holder).isLeader.setVisibility(View.GONE);
+                    overflowMenuOptions = new String[] {
+                            context.getString(R.string.remove),
+                            context.getString(R.string.make_leader)};
+                }
+
+                ((ViewHolderUser) holder).icMore.setOnClickListener(view -> {
+
+                    new AlertDialog.Builder(context)
+                            .setItems(overflowMenuOptions, (dialogInterface, i) -> {
+                                if (i == 0) {
+                                    reject(list.get(position), position);
+                                } else {
+                                    makeLeader(list.get(position), position);
+                                }
+                            }).setNegativeButton("Dismiss", null).show();
+                });
             } else {
                 ((ViewHolderUser) holder).icMore.setVisibility(View.GONE);
             }
 
-            if (this.teamLeaderId != null && this.teamLeaderId.equals(list.get(position).getId())) {
-                ((ViewHolderUser) holder).isLeader.setVisibility(View.VISIBLE);
-                ((ViewHolderUser) holder).isLeader.setText("(Team Leader)");
-            } else {
-                ((ViewHolderUser) holder).isLeader.setVisibility(View.GONE);
-            }
-
-            ((ViewHolderUser) holder).icMore.setOnClickListener(view -> {
-                String[] s = {context.getString(R.string.remove), context.getString(R.string.make_leader)};
-                new AlertDialog.Builder(context)
-                        .setItems(s, (dialogInterface, i) -> {
-                            if (i == 0) {
-                                reject(list.get(position), position);
-                            } else {
-                                makeLeader(list.get(position), position);
-                            }
-                        }).setNegativeButton("Dismiss", null).show();
-            });
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.java
@@ -76,24 +76,30 @@ public class AdapterJoinedMember extends RecyclerView.Adapter<RecyclerView.ViewH
                         context.getString(R.string.remove),
                         context.getString(R.string.make_leader)};
             }
+            checkUserAndShowOverflowMenu((ViewHolderUser) holder, position, overflowMenuOptions, isLoggedInUserTeamLeader);
 
-            // If the currently logged in user is the team leader, show
-            // overflow menu and all the actions available to the leader
-            if (isLoggedInUserTeamLeader) {
-                ((ViewHolderUser) holder).icMore.setVisibility(View.VISIBLE);
-                ((ViewHolderUser) holder).icMore.setOnClickListener(view -> {
-                    new AlertDialog.Builder(context)
-                            .setItems(overflowMenuOptions, (dialogInterface, i) -> {
-                                if (i == 0) {
-                                    reject(list.get(position), position);
-                                } else {
-                                    makeLeader(list.get(position), position);
-                                }
-                            }).setNegativeButton("Dismiss", null).show();
-                });
-            } else {
-                ((ViewHolderUser) holder).icMore.setVisibility(View.GONE);
-            }
+        }
+    }
+
+    private void checkUserAndShowOverflowMenu(@NonNull ViewHolderUser holder, int position, String[] overflowMenuOptions, boolean isLoggedInUserTeamLeader) {
+        /**
+         * Checks if the user that is currently logged-in is the leader
+         * of the team we are looking at and shows/hides the overflow menu accordingly.
+         */
+        if (isLoggedInUserTeamLeader) {
+            holder.icMore.setVisibility(View.VISIBLE);
+            holder.icMore.setOnClickListener(view -> {
+                new AlertDialog.Builder(context)
+                        .setItems(overflowMenuOptions, (dialogInterface, i) -> {
+                            if (i == 0) {
+                                reject(list.get(position), position);
+                            } else {
+                                makeLeader(list.get(position), position);
+                            }
+                        }).setNegativeButton("Dismiss", null).show();
+            });
+        } else {
+            holder.icMore.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.java
@@ -53,6 +53,7 @@ public class AdapterJoinedMember extends RecyclerView.Adapter<RecyclerView.ViewH
     @Override
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         if (holder instanceof ViewHolderUser) {
+            String[] overflowMenuOptions;
             ((ViewHolderUser) holder).tvTitle.setText(list.get(position).toString());
             ((ViewHolderUser) holder).tvDescription
                     .setText(list.get(position).getRoleAsString()
@@ -64,27 +65,23 @@ public class AdapterJoinedMember extends RecyclerView.Adapter<RecyclerView.ViewH
             boolean isLoggedInUserTeamLeader = this.teamLeaderId != null
                     && this.teamLeaderId.equals(this.currentUser.getId());
 
+            // If the current user card is the logged in user/team leader
+            if (this.teamLeaderId.equals(list.get(position).getId())) {
+                ((ViewHolderUser) holder).isLeader.setVisibility(View.VISIBLE);
+                ((ViewHolderUser) holder).isLeader.setText("(Team Leader)");
+                overflowMenuOptions = new String[] {context.getString(R.string.remove)};
+            } else {
+                ((ViewHolderUser) holder).isLeader.setVisibility(View.GONE);
+                overflowMenuOptions = new String[] {
+                        context.getString(R.string.remove),
+                        context.getString(R.string.make_leader)};
+            }
+
             // If the currently logged in user is the team leader, show
             // overflow menu and all the actions available to the leader
             if (isLoggedInUserTeamLeader) {
                 ((ViewHolderUser) holder).icMore.setVisibility(View.VISIBLE);
-                String[] overflowMenuOptions;
-
-
-                // If the current user card is the logged in user/team leader
-                if (this.teamLeaderId.equals(list.get(position).getId())) {
-                    ((ViewHolderUser) holder).isLeader.setVisibility(View.VISIBLE);
-                    ((ViewHolderUser) holder).isLeader.setText("(Team Leader)");
-                    overflowMenuOptions = new String[] {context.getString(R.string.remove)};
-                } else {
-                    ((ViewHolderUser) holder).isLeader.setVisibility(View.GONE);
-                    overflowMenuOptions = new String[] {
-                            context.getString(R.string.remove),
-                            context.getString(R.string.make_leader)};
-                }
-
                 ((ViewHolderUser) holder).icMore.setOnClickListener(view -> {
-
                     new AlertDialog.Builder(context)
                             .setItems(overflowMenuOptions, (dialogInterface, i) -> {
                                 if (i == 0) {
@@ -97,7 +94,6 @@ public class AdapterJoinedMember extends RecyclerView.Adapter<RecyclerView.ViewH
             } else {
                 ((ViewHolderUser) holder).icMore.setVisibility(View.GONE);
             }
-
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.java
@@ -60,14 +60,18 @@ public class AdapterJoinedMember extends RecyclerView.Adapter<RecyclerView.ViewH
                             + RealmTeamLog.getVisitCount(mRealm, list.get(position).getName(), teamId)
                             + " visits )");
 
-            // If the currently logged in user is the team leader
-            if (this.teamLeaderId != null && this.teamLeaderId.equals(this.currentUser.getId())) {
+
+            boolean isLoggedInUserTeamLeader = this.teamLeaderId != null
+                    && this.teamLeaderId.equals(this.currentUser.getId());
+
+            // If the currently logged in user is the team leader, show
+            // overflow menu and all the actions available to the leader
+            if (isLoggedInUserTeamLeader) {
                 ((ViewHolderUser) holder).icMore.setVisibility(View.VISIBLE);
-                // Options that will be shown when the overflow menu is clicked.
                 String[] overflowMenuOptions;
 
 
-                // If the current user/card is the logged in user/team leader
+                // If the current user card is the logged in user/team leader
                 if (this.teamLeaderId.equals(list.get(position).getId())) {
                     ((ViewHolderUser) holder).isLeader.setVisibility(View.VISIBLE);
                     ((ViewHolderUser) holder).isLeader.setText("(Team Leader)");

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/JoinedMemberFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/JoinedMemberFragment.java
@@ -28,7 +28,7 @@ public class JoinedMemberFragment extends BaseMemberFragment {
 
     @Override
     public RecyclerView.Adapter getAdapter() {
-        return new AdapterJoinedMemeber(getActivity(), getList(), mRealm, teamId);
+        return new AdapterJoinedMember(getActivity(), getList(), mRealm, teamId);
     }
 
     @Override

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.8.43</string>
+    <string name="app_version">0.8.44</string>
 </resources>


### PR DESCRIPTION
- Removed the "make leader" option from the team member card when the user is the leader of the displayed team.
- Fixed typo refactored "AdapterJoinedMemeber" to "AdapterJoinedMember.

![Screenshot_1594145593](https://user-images.githubusercontent.com/6264813/86824344-07497400-c05c-11ea-89b6-c2971455cfbd.png)
"