### PR TITLE
Build/enhancements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'realm-android'
+apply plugin: 'kotlin-parcelize'
 
 android {
     compileSdkVersion 33
@@ -35,6 +35,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    buildFeatures {
+            viewBinding true
+        }
 
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'realm-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
     defaultConfig {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 889
         versionName "0.8.89"
         ndkVersion '21.3.6528147'
@@ -59,32 +59,32 @@ android {
 
 repositories {
     mavenCentral()
-    jcenter()
+    mavenCentral()
     maven { url "https://jitpack.io" }
 }
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.multidex:multidex:2.0.0'
+    implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.codehaus.jackson:jackson-mapper-asl:1.5.0'
-    implementation('com.mikepenz:materialdrawer:6.0.7@aar') {
+    implementation('com.mikepenz:materialdrawer:6.1.1@aar') {
         transitive = true
     }
-    implementation 'androidx.appcompat:appcompat:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'androidx.annotation:annotation:1.0.0'
-    implementation 'com.google.android.material:material:1.0.0'
-    implementation 'androidx.exifinterface:exifinterface:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.0'
+    implementation 'androidx.annotation:annotation:1.6.0'
+    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.6'
     implementation 'com.mikepenz:google-material-typeface:3.0.1.1.original@aar'
-    implementation 'com.mikepenz:fontawesome-typeface:5.0.6.0@aar'
-    implementation 'com.mikepenz:octicons-typeface:3.0.0.1@aar'
-    implementation 'de.hdodenhof:circleimageview:2.2.0'
+    implementation 'com.mikepenz:fontawesome-typeface:5.3.1.1@aar'
+    implementation 'com.mikepenz:octicons-typeface:3.2.0.5@aar'
+    implementation 'de.hdodenhof:circleimageview:3.1.0'
 
-    implementation 'com.mikepenz:itemanimators:1.0.2@aar'
+    implementation 'com.mikepenz:itemanimators:1.1.0@aar'
     implementation('com.github.jeancsanchez:JcPlayer:2.6.13') {
         exclude group: 'com.android.support.constraint'
     }
@@ -96,18 +96,18 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'com.squareup.retrofit2:retrofit:2.3.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'de.rtner:PBKDF2:1.1.2'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    testImplementation 'junit:junit:4.12'
-    implementation 'com.github.bumptech.glide:glide:4.7.1'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.7.1'
+    testImplementation 'junit:junit:4.13.2'
+    implementation 'com.github.bumptech.glide:glide:4.15.1'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
     implementation 'com.github.tiagohm.MarkdownView:library:0.19.0'
     implementation 'com.github.tiagohm.MarkdownView:emoji:0.19.0'
     implementation 'com.opencsv:opencsv:3.9'
-    implementation 'com.google.android.exoplayer:exoplayer:2.7.2'
-    implementation 'de.hdodenhof:circleimageview:3.0.0'
+    implementation 'com.google.android.exoplayer:exoplayer:2.18.5'
+    implementation 'de.hdodenhof:circleimageview:3.1.0'
     implementation 'org.osmdroid:osmdroid-android:6.1.0'
     implementation 'com.github.clans:fab:1.6.4'
     implementation 'com.borax12.materialdaterangepicker:library:2.0'
@@ -117,7 +117,7 @@ dependencies {
     implementation 'org.jetbrains:annotations:15.0'
     implementation 'com.github.kizitonwose:CalendarView:0.3.1'
     implementation "io.noties.markwon:editor:4.2.0"
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.9.0"
     implementation 'com.github.deano2390:MaterialShowcaseView:1.3.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.github.VaibhavLakhera:Circular-Progress-View:0.1.2"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     implementation 'de.hdodenhof:circleimageview:3.1.0'
 
     implementation 'com.mikepenz:itemanimators:1.1.0@aar'
-    implementation('com.github.jeancsanchez:JcPlayer:2.6.13') {
+    implementation('com.github.jeancsanchez:JcPlayer:2.7.2') {
         exclude group: 'com.android.support.constraint'
     }
     implementation 'com.mikepenz:crossfader:1.5.1@aar'

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseActivity.java
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseActivity.java
@@ -1,10 +1,8 @@
 package org.ole.planet.myplanet.base;
 
 import android.os.Bundle;
-import android.os.PersistableBundle;
 import android.view.MenuItem;
 
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 public abstract class BaseActivity extends AppCompatActivity {

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
@@ -32,7 +32,6 @@ import org.ole.planet.myplanet.ui.viewer.*
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import java.io.File
-import java.util.*
 
 abstract class BaseContainerFragment : BaseResourceFragment() {
     var timesRated: TextView? = null

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseDialogFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseDialogFragment.java
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.base;
 
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseMemberFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseMemberFragment.java
@@ -1,13 +1,13 @@
 package org.ole.planet.myplanet.base;
 
 import android.os.Bundle;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.RecyclerView;
-
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
 
 import org.ole.planet.myplanet.R;
 import org.ole.planet.myplanet.model.RealmUserModel;

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsAdapter.java
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsAdapter.java
@@ -21,7 +21,6 @@ import org.ole.planet.myplanet.utilities.Constants;
 import org.ole.planet.myplanet.utilities.Utilities;
 
 import java.util.Calendar;
-import java.util.HashMap;
 
 import io.realm.Realm;
 

--- a/app/src/test/java/org/ole/planet/myplanet/model/DocumentResponseTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/DocumentResponseTest.kt
@@ -1,0 +1,30 @@
+package org.ole.planet.myplanet.model
+
+import android.provider.DocumentsContract
+import junit.framework.TestCase
+import org.w3c.dom.Document
+
+class DocumentResponseTest : TestCase() {
+    private lateinit var response: DocumentResponse
+
+
+    public override fun setUp() {
+        super.setUp()
+        // Create a new DocumentResponse object for testing
+        response = DocumentResponse()
+        response.total_rows = 10.toString()
+        response.offset = 5.toString()
+
+    }
+
+    fun testGetTotal_rows() {
+        // Test that the getTotal_rows() method returns the correct value
+        assertEquals(10, response.total_rows.toInt())
+    }
+
+    fun testGetOffset() {
+        // Test that the getOffset() method returns the correct value
+        assertEquals(5, response.offset.toInt())
+    }
+
+}

--- a/app/src/test/java/org/ole/planet/myplanet/model/DocumentResponseTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/DocumentResponseTest.kt
@@ -1,8 +1,6 @@
 package org.ole.planet.myplanet.model
 
-import android.provider.DocumentsContract
 import junit.framework.TestCase
-import org.w3c.dom.Document
 
 class DocumentResponseTest : TestCase() {
     private lateinit var response: DocumentResponse

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.8.0'
     ext {
         setup = [
                 compileSdk: 28,
@@ -16,14 +16,14 @@ buildscript {
     }
 
     repositories {
-        jcenter()
+        mavenCentral()
         google()
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath 'io.realm:realm-gradle-plugin:5.14.0'
         classpath 'pl.droidsonroids.gif:android-gif-drawable:1.2.12'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -35,7 +35,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://google.bintray.com/exoplayer/' }
         maven { url 'https://google.bintray.com/flexbox-layout/' }
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         setup = [
                 compileSdk: 28,
                 buildTools: "28.0.0",
-                minSdk    : 19,
+                minSdk   : 19,
                 targetSdk : 28
         ]
 
@@ -17,14 +17,16 @@ buildscript {
 
     repositories {
         mavenCentral()
-        google()
         mavenCentral()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
+        google() 
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
-        classpath 'io.realm:realm-gradle-plugin:5.14.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath "io.realm:realm-gradle-plugin:10.14.0-SNAPSHOT"
         classpath 'pl.droidsonroids.gif:android-gif-drawable:1.2.12'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
@@ -34,12 +36,15 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
         mavenCentral()
         maven { url 'https://google.bintray.com/exoplayer/' }
         maven { url 'https://google.bintray.com/flexbox-layout/' }
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
         mavenCentral()
         maven { url "https://jitpack.io" }
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 10 10:06:07 EDT 2020
+#Fri Apr 07 18:15:27 EAT 2023
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Upgraded **com.github.jeancsanchez:JcPlayer:2.7.2** and fixed the failing gradle script build
- Replace references to synthetic properties with View Binding
- Replace the 'Parcelable' interface with the 'kotlin-parcelize' plugin
- `plugins {
    ...
    id 'kotlin-parcelize'
}
`

- Removed the 'kotlin-android-extensions' plugin  
- Enabled View Binding
- Unit test for **DocumentResponse** Model 
- Upgraded gradle version and gradle plugin to **7.4.2** and **7.5** respectively, as older versions may not support the io.realm:realm-gradle-plugin plugin.
- Checked for conflicting dependencies: Reviewed the project's dependencies to ensure that there are no conflicting versions of the **kotlin-gradle-plugin** or any other dependencies
- Updated depreciated and obsolete dependencies
