### PR TITLE
fix fileUriExposedException crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -122,6 +122,16 @@
                 android:resource="@xml/provider_paths" />
         </provider>
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="org.ole.planet.myplanet.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <service
             android:name=".service.AutoSyncService"
             android:exported="false">

--- a/app/src/main/java/org/ole/planet/myplanet/ui/library/AddResourceFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/library/AddResourceFragment.java
@@ -19,6 +19,7 @@ import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.FileProvider;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
@@ -173,7 +174,15 @@ public class AddResourceFragment extends BottomSheetDialogFragment {
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         File dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);
         output = new File(dir, UUID.randomUUID().toString() + ".jpg");
-        intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(output));
+
+        // Generate a content URI using FileProvider
+        Uri photoURI = FileProvider.getUriForFile(requireContext(), "org.ole.planet.myplanet.fileprovider", output);
+
+        // Grant temporary permission to the camera app to access the file
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+        // Set the output URI
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
         startActivityForResult(intent, REQUEST_CAPTURE_PICTURE);
     }
 

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external_files" path="." />
+</paths>


### PR DESCRIPTION
Fixes #2160
which caused an app crash when adding a resource by capturing image
1. click red menu icon -> click add resource button -> click capture image to experience crash

Before
![Screenshot 2023-05-23 20 26 36](https://github.com/open-learning-exchange/myplanet/assets/64019708/135390f7-2698-40c1-8206-08e6cac9fa7f)

After
![Screenshot 2023-05-23 20 36 34](https://github.com/open-learning-exchange/myplanet/assets/64019708/62550f89-0cb0-44ca-a07d-7a569cf3278e)
