### PR TITLE
addresource: switch to FileProvider for video capture (fixes #2160)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 911
-        versionName "0.9.11"
+        versionCode 913
+        versionName "0.9.13"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -122,6 +122,16 @@
                 android:resource="@xml/provider_paths" />
         </provider>
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="org.ole.planet.myplanet.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <service
             android:name=".service.AutoSyncService"
             android:exported="false">

--- a/app/src/main/java/org/ole/planet/myplanet/ui/library/AddResourceFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/library/AddResourceFragment.java
@@ -19,6 +19,7 @@ import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.FileProvider;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
@@ -163,10 +164,20 @@ public class AddResourceFragment extends BottomSheetDialogFragment {
 
     private void dispatchTakeVideoIntent() {
         Intent takeVideoIntent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
-        takeVideoIntent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(new File(Utilities.SD_PATH + "/video/" + UUID.randomUUID().toString() + ".mp4")));
+        Uri videoUri = FileProvider.getUriForFile(getActivity(), "org.ole.planet.myplanet.fileprovider", createVideoFile());
+        takeVideoIntent.putExtra(MediaStore.EXTRA_OUTPUT, videoUri);
+        takeVideoIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
         if (takeVideoIntent.resolveActivity(getActivity().getPackageManager()) != null) {
             startActivityForResult(takeVideoIntent, REQUEST_VIDEO_CAPTURE);
         }
+    }
+
+    private File createVideoFile() {
+        File videoDir = new File(Utilities.SD_PATH + "/video/");
+        videoDir.mkdirs();
+        File videoFile = new File(videoDir, UUID.randomUUID().toString() + ".mp4");
+        return videoFile;
     }
 
     public void takePhoto() {

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.9.11</string>
+    <string name="app_version">0.9.13</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external_files" path="." />
+</paths>


### PR DESCRIPTION
fixes issue #2160
which was an error thrown when adding a resource by capturing image caused the app to crash 

click red menu icon -> click add resource button -> click capture image to experience crash
before fix
![captureImage](https://github.com/open-learning-exchange/myplanet/assets/64019708/724fcae2-b71b-4425-8d8e-f46cc8731372)

after fix 
click red menu icon -> click add resource button -> click capture image 
![Screenshot 2023-05-29 19 57 25](https://github.com/open-learning-exchange/myplanet/assets/64019708/f7707083-4fc9-4ae8-98cb-bdb1f0689fd7)

