### PR TITLE
revert to MainApplication (fixes #2178)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 918
-        versionName "0.9.18"
+        versionCode 920
+        versionName "0.9.20"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.java
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.java
@@ -18,12 +18,21 @@ import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 import androidx.work.WorkRequest;
 
+import com.firebase.jobdispatcher.FirebaseJobDispatcher;
+import com.firebase.jobdispatcher.GooglePlayDriver;
+import com.firebase.jobdispatcher.Job;
+import com.firebase.jobdispatcher.Lifetime;
+import com.firebase.jobdispatcher.RetryStrategy;
+import com.firebase.jobdispatcher.Trigger;
 import com.jakewharton.threetenabp.AndroidThreeTen;
 
 import org.ole.planet.myplanet.callback.TeamPageListener;
 import org.ole.planet.myplanet.datamanager.DatabaseService;
 import org.ole.planet.myplanet.model.RealmApkLog;
 import org.ole.planet.myplanet.model.RealmUserModel;
+import org.ole.planet.myplanet.service.AutoSyncService;
+import org.ole.planet.myplanet.service.StayOnLineService;
+import org.ole.planet.myplanet.service.TaskNotificationService;
 import org.ole.planet.myplanet.service.UserProfileDbHandler;
 import org.ole.planet.myplanet.ui.sync.SyncActivity;
 import org.ole.planet.myplanet.utilities.AutoSyncWorker;
@@ -40,9 +49,8 @@ import java.util.concurrent.TimeUnit;
 
 import io.realm.Realm;
 
-
 public class MainApplication extends Application implements Application.ActivityLifecycleCallbacks {
-    public static WorkManager workManager;
+    public static FirebaseJobDispatcher dispatcher;
     public static Context context;
     public static SharedPreferences preferences;
     public static int syncFailedCount = 0;
@@ -51,7 +59,6 @@ public class MainApplication extends Application implements Application.Activity
     public static boolean isSyncRunning = false;
     public static boolean showHealthDialog = true;
     public static TeamPageListener listener;
-
     @SuppressLint("HardwareIds")
     public static String getAndroidId() {
         try {
@@ -60,6 +67,7 @@ public class MainApplication extends Application implements Application.Activity
             e.printStackTrace();
         }
         return "0";
+
     }
 
     @Override
@@ -73,74 +81,64 @@ public class MainApplication extends Application implements Application.Activity
         StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
         StrictMode.setVmPolicy(builder.build());
         builder.detectFileUriExposure();
+        dispatcher = new FirebaseJobDispatcher(new GooglePlayDriver(this));
         context = this;
         AndroidThreeTen.init(this);
 
         Realm.init(this);
         preferences = getSharedPreferences(SyncActivity.PREFS_NAME, MODE_PRIVATE);
-
         if (preferences.getBoolean("autoSync", false) && preferences.contains("autoSyncInterval")) {
-            if (workManager != null) {
-                workManager.cancelUniqueWork("autoSync");
-            }
-            createJob(preferences.getInt("autoSyncInterval", 60 * 60), AutoSyncWorker.class);
+            dispatcher.cancelAll();
+            createJob(preferences.getInt("autoSyncInterval", 60 * 60), AutoSyncService.class);
         } else {
-            if (workManager != null) {
-                workManager.cancelUniqueWork("autoSync");
-            }
+            dispatcher.cancelAll();
         }
-
-        createJob(5 * 60, StayOnLineWorker.class);
-        createJob(60, TaskNotificationWorker.class);
+        createJob(5 * 60, StayOnLineService.class);
+        createJob(60, TaskNotificationService.class);
         Thread.setDefaultUncaughtExceptionHandler((thread, e) -> handleUncaughtException(e));
         registerActivityLifecycleCallbacks(this);
     }
 
-    public void createWork(int sec, Class workerClass, String tag) {
-        Constraints constraints = new Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
+    public void createJob(int sec, Class jobClass) {
+        Job myJob = dispatcher.newJobBuilder()
+                .setService(jobClass)
+                .setTag("ole")
+                .setRecurring(true)
+                .setLifetime(Lifetime.FOREVER)
+                .setTrigger(Trigger.executionWindow(0, sec))
+                .setRetryStrategy(RetryStrategy.DEFAULT_LINEAR)
                 .build();
-
-        WorkRequest workRequest = new PeriodicWorkRequest.Builder(workerClass, sec, TimeUnit.SECONDS)
-                .setConstraints(constraints)
-                .setBackoffCriteria(BackoffPolicy.LINEAR, 5, TimeUnit.MINUTES)
-                .build();
-
-        if (workManager != null) {
-            workManager.enqueueUniquePeriodicWork(tag, ExistingPeriodicWorkPolicy.KEEP, (PeriodicWorkRequest) workRequest);
-        }
+        dispatcher.mustSchedule(myJob);
     }
 
-    public void createJob(int intervalSeconds, Class jobClass) {
-        PeriodicWorkRequest workRequest = new PeriodicWorkRequest.Builder(
-                jobClass,
-                intervalSeconds,
-                TimeUnit.SECONDS)
-                .build();
-        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                "ole",
-                ExistingPeriodicWorkPolicy.REPLACE,
-                workRequest);
+    @Override
+    public void onActivityCreated(Activity activity, Bundle bundle) {
+
     }
 
+    @Override
+    public void onActivityStarted(Activity activity) {
+
+    }
 
     @Override
-    public void onActivityCreated(Activity activity, Bundle bundle) {}
+    public void onActivityResumed(Activity activity) {
+
+    }
 
     @Override
-    public void onActivityStarted(Activity activity) {}
+    public void onActivityPaused(Activity activity) {
+
+    }
 
     @Override
-    public void onActivityResumed(Activity activity) {}
+    public void onActivityStopped(Activity activity) {
+    }
 
     @Override
-    public void onActivityPaused(Activity activity) {}
+    public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
 
-    @Override
-    public void onActivityStopped(Activity activity) {}
-
-    @Override
-    public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {}
+    }
 
     @Override
     public void onActivityDestroyed(Activity activity) {
@@ -152,7 +150,8 @@ public class MainApplication extends Application implements Application.Activity
         Utilities.log("Handle exception " + e.getMessage());
         DatabaseService service = new DatabaseService(this);
         Realm mRealm = service.getRealmInstance();
-        if (!mRealm.isInTransaction()) mRealm.beginTransaction();
+        if (!mRealm.isInTransaction())
+            mRealm.beginTransaction();
         RealmApkLog log = mRealm.createObject(RealmApkLog.class, UUID.randomUUID().toString());
         RealmUserModel model = new UserProfileDbHandler(this).getUserModel();
         if (model != null) {
@@ -169,6 +168,5 @@ public class MainApplication extends Application implements Application.Activity
         homeIntent.addCategory(Intent.CATEGORY_HOME);
         homeIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         startActivity(homeIntent);
-//        System.exit(2);
     }
 }

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.9.18</string>
+    <string name="app_version">0.9.20</string>
 </resources>


### PR DESCRIPTION
Fixes #2178 
To address this issue, it is necessary to revert the recent code changes made to the MainApplication class and restore the original code that encompassed the omitted functionality. By reverting to the previous version of the code, we can ensure that the application functions as intended and that the crucial features are reinstated.