### PR TITLE
make wifiStatusSwitch() public (Fixes #2188)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/DashboardElementActivity.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/DashboardElementActivity.java
@@ -130,7 +130,7 @@ public abstract class DashboardElementActivity extends AppCompatActivity impleme
     }
 
     @SuppressLint("RestrictedApi")
-    private void wifiStatusSwitch() {
+    public void wifiStatusSwitch() {
         ActionMenuItemView goOnline = findViewById(R.id.menu_goOnline);
         Drawable resIcon = getResources().getDrawable(R.drawable.goonline);
         ConnectivityManager connManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);


### PR DESCRIPTION
Fixes #2188 
Make wifiStatusSwitch() public to be able to access it anywhere in the project