### PR TITLE
add visibility wifi tower icon functionality (Fixes #2188)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.java
@@ -194,6 +194,12 @@ public class DashboardActivity extends DashboardElementActivity implements OnHom
         menuco = tl.getTabAt(5);
 
         showShowCaseViewVertical();
+        hideWifi();
+    }
+
+    private void hideWifi() {
+        Menu nav_Menu = bellToolbar.getMenu();
+        nav_Menu.findItem(R.id.menu_goOnline).setVisible((Constants.showBetaFeature(Constants.KEY_SYNC, this)));
     }
 
     private void checkUser() {


### PR DESCRIPTION
Fixes #2188 
Create function that will hide and show the wifi tower icon based on state set by the beta wifi switch