### PR TITLE
adding error handling for pdf resource addition (fixes #2195)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 918
-        versionName "0.9.18"
+        versionCode 919
+        versionName "0.9.19"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.java
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.java
@@ -206,17 +206,24 @@ public class FileUtils {
 
     public static String getImagePath(Context context, Uri uri) {
         Cursor cursor = context.getContentResolver().query(uri, null, null, null, null);
-        cursor.moveToFirst();
-        String document_id = cursor.getString(0);
-        document_id = document_id.substring(document_id.lastIndexOf(":") + 1);
-        cursor.close();
+        if (cursor != null && cursor.moveToFirst()) {
+            String document_id = cursor.getString(0);
+            document_id = document_id.substring(document_id.lastIndexOf(":") + 1);
+            cursor.close();
 
-        cursor = context.getContentResolver().query(android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI, null, MediaStore.Images.Media._ID + " = ? ", new String[]{document_id}, null);
-        cursor.moveToFirst();
-        String path = cursor.getString(cursor.getColumnIndex(MediaStore.Images.Media.DATA));
-        cursor.close();
-
-        return path;
+            cursor = context.getContentResolver().query(android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI, null, MediaStore.Images.Media._ID + " = ? ", new String[]{document_id}, null);
+            if (cursor != null && cursor.moveToFirst()) {
+                String path = cursor.getString(cursor.getColumnIndex(MediaStore.Images.Media.DATA));
+                cursor.close();
+                return path;
+            } else {
+                // Handle the case when the cursor is empty or null
+                return null; // or return an appropriate default value or handle the error accordingly
+            }
+        } else {
+            // Handle the case when the cursor is empty or null
+            return null; // or return an appropriate default value or handle the error accordingly
+        }
     }
 
     public static String getMediaType(String path) {

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.9.18</string>
+    <string name="app_version">0.9.19</string>
 </resources>


### PR DESCRIPTION
Fixes #2195 
error that occurs when adding a pdf resource is handled and the app no longer crashes but shows the user an error message 
![image](https://github.com/open-learning-exchange/myplanet/assets/64019708/bf56a37f-c5ab-4253-b5e4-a6a8cb68bacf)
