### PR TITLE
courses: better title filter (fixes #2201)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/course/AdapterCourses.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/course/AdapterCourses.java
@@ -31,6 +31,8 @@ import org.ole.planet.myplanet.utilities.TimeUtils;
 import org.ole.planet.myplanet.utilities.Utilities;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 
@@ -52,6 +54,7 @@ public class AdapterCourses extends RecyclerView.Adapter<RecyclerView.ViewHolder
     private Realm mRealm;
     private ChipCloudConfig config;
     private Markwon markwon;
+    private boolean isTitleAscending = true;
 
     public AdapterCourses(Context context, List<RealmMyCourse> courseList, HashMap<String, JsonObject> map) {
         this.map = map;
@@ -86,6 +89,23 @@ public class AdapterCourses extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
     public void setCourseList(List<RealmMyCourse> courseList) {
         this.courseList = courseList;
+        sortCourseListByTitle();
+        notifyDataSetChanged();
+    }
+
+    private void sortCourseListByTitle() {
+        Collections.sort(courseList, (course1, course2) -> {
+            if (isTitleAscending) {
+                return course1.getCourseTitle().compareToIgnoreCase(course2.getCourseTitle());
+            } else {
+                return course2.getCourseTitle().compareToIgnoreCase(course1.getCourseTitle());
+            }
+        });
+    }
+
+    public void toggleTitleSortOrder() {
+        isTitleAscending = !isTitleAscending;
+        sortCourseListByTitle();
         notifyDataSetChanged();
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/course/CourseFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/course/CourseFragment.java
@@ -127,7 +127,7 @@ public class CourseFragment extends BaseRecyclerFragment<RealmMyCourse> implemen
         orderByDate = getView().findViewById(R.id.order_by_date_button);
         orderByTitle = getView().findViewById(R.id.order_by_title_button);
         orderByDate.setOnClickListener(view -> adapterCourses.setCourseList(getList(RealmMyCourse.class, "createdDate")));
-        orderByTitle.setOnClickListener(view -> adapterCourses.setCourseList(getList(RealmMyCourse.class, "courseTitle")));
+        orderByTitle.setOnClickListener(view -> adapterCourses.toggleTitleSortOrder());
     }
 
     private void initializeView() {


### PR DESCRIPTION
fixes #2201 
courses are now filtered on click, are filtered from ascending to descending by title and vice versa depending on the state of the shown data
![Screenshot 2023-07-03 13 43 55](https://github.com/open-learning-exchange/myplanet/assets/64019708/c4f5330d-3611-44e1-9815-f6dd54ffa2f2)
