### PR TITLE
sync: automatic instead of crashing (fixes #2315)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 971
-        versionName "0.9.71"
+        versionCode 985
+        versionName "0.9.85"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.java
+++ b/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.java
@@ -9,6 +9,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import androidx.work.Worker;
@@ -46,10 +48,13 @@ public class AutoSyncWorker extends Worker implements SyncListener, Service.Chec
         preferences = context.getSharedPreferences(SyncManager.PREFS_NAME, MODE_PRIVATE);
         long lastSync = preferences.getLong("LastSync", 0);
         long currentTime = System.currentTimeMillis();
-        int syncInterval = preferences.getInt("autoSyncInterval", 60 * 60);
 
-        if ((currentTime - lastSync) > (syncInterval * 1000)) {
-            Utilities.toast(context, "Syncing started...");
+        if ((currentTime - lastSync) > (30)) {
+            // Post a Runnable to the main thread's Handler to show the Toast
+            Handler mainHandler = new Handler(Looper.getMainLooper());
+            mainHandler.post(() -> {
+                Utilities.toast(context, "Syncing started...");
+            });
             new Service(context).checkVersion(this, preferences);
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.java
+++ b/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.java
@@ -48,8 +48,9 @@ public class AutoSyncWorker extends Worker implements SyncListener, Service.Chec
         preferences = context.getSharedPreferences(SyncManager.PREFS_NAME, MODE_PRIVATE);
         long lastSync = preferences.getLong("LastSync", 0);
         long currentTime = System.currentTimeMillis();
+        int syncInterval = preferences.getInt("autoSyncInterval", 60 * 60);
 
-        if ((currentTime - lastSync) > (30)) {
+        if ((currentTime - lastSync) > (syncInterval * 1000)) {
             // Post a Runnable to the main thread's Handler to show the Toast
             Handler mainHandler = new Handler(Looper.getMainLooper());
             mainHandler.post(() -> {

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.9.71</string>
+    <string name="app_version">0.9.85</string>
 </resources>


### PR DESCRIPTION
fixes #2315
In this pull request
call autosync worker class on the main thread to prevent null exception error
make initial sync call on app launch