### PR TITLE
feedback: refactor update list (fixes #2381)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 990
-        versionName "0.9.90"
+        versionCode 992
+        versionName "0.9.92"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.java
@@ -2,17 +2,15 @@ package org.ole.planet.myplanet.ui.feedback;
 
 
 import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-
-import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.TextView;
 
 import org.ole.planet.myplanet.R;
 import org.ole.planet.myplanet.datamanager.DatabaseService;
@@ -68,12 +66,12 @@ public class FeedbackListFragment extends Fragment implements FeedbackFragment.O
 
     @Override
     public void onFeedbackSubmitted() {
-        rvFeedbacks.setLayoutManager(new LinearLayoutManager(getActivity()));
-        RealmResults<RealmFeedback> updatedList = mRealm.where(RealmFeedback.class).equalTo("owner", userModel.getName()).findAll();
-        if (userModel.isManager()) updatedList = mRealm.where(RealmFeedback.class).findAll();
-        AdapterFeedback adapterFeedback = new AdapterFeedback(getActivity(), updatedList);
-        adapterFeedback.updateData(updatedList);
-        rvFeedbacks.setAdapter(adapterFeedback);
-        adapterFeedback.notifyDataSetChanged();
+        mRealm.executeTransactionAsync(realm -> {}, () -> {
+            RealmResults<RealmFeedback> updatedList = mRealm.where(RealmFeedback.class).equalTo("owner", userModel.getName()).findAll();
+            if (userModel.isManager()) updatedList = mRealm.where(RealmFeedback.class).findAll();
+            AdapterFeedback adapterFeedback = new AdapterFeedback(getActivity(), updatedList);
+            rvFeedbacks.setAdapter(adapterFeedback);
+            adapterFeedback.notifyDataSetChanged();
+        });
     }
 }

--- a/app/src/main/res/values/versions.xml
+++ b/app/src/main/res/values/versions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_version">0.9.90</string>
+    <string name="app_version">0.9.92</string>
 </resources>


### PR DESCRIPTION
fixes #2381
used a RealmChangeListener in the second parameter of executeTransactionAsync.
The RealmChangeListener triggered the UI update only after the transaction had successfully completed, ensuring that the data queried was the latest