### PR TITLE
login: improve check version (fixes #2474)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 1025
-        versionName "0.10.25"
+        versionCode 1032
+        versionName "0.10.32"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.java
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.java
@@ -13,6 +13,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import org.ole.planet.myplanet.MainApplication;
+import org.ole.planet.myplanet.R;
 import org.ole.planet.myplanet.callback.SuccessListener;
 import org.ole.planet.myplanet.model.MyPlanet;
 import org.ole.planet.myplanet.model.RealmCommunity;
@@ -100,7 +101,7 @@ public class Service {
     public void checkVersion(CheckVersionCallback callback, SharedPreferences settings) {
         ApiInterface retrofitInterface = ApiClient.getClient().create(ApiInterface.class);
         if (settings.getString("couchdbURL", "").isEmpty()) {
-            callback.onError("Config not awailable.", true);
+            callback.onError(context.getString(R.string.config_not_available), true);
             return;
         }
         retrofitInterface.checkVersion(Utilities.getUpdateUrl(settings)).enqueue(new Callback<MyPlanet>() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1035,5 +1035,6 @@
     <string name="kindly_give_a_rating">Kindly give a rating</string>
     <string name="must_start_with_letter_or_number">Must start with letter or number</string>
     <string name="only_letters_numbers_and_are_allowed">Only letters, numbers and "_" , ".", "-" are allowed</string>
+    <string name="config_not_available" translatable="false">Config not available.</string>
 
 </resources>


### PR DESCRIPTION
This is a minor typo fix when checking the version. 
I initially noted this when I was logging in and there  was a `snackbar` with a typo error. 
So this PR will address the fix. 

Also I created a string resource instead of using a raw string