### PR TITLE
courses: text when filter results empty (fixes #1952)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1197
-        versionName "0.11.97"
+        versionCode 1201
+        versionName "0.12.1"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.java
@@ -59,6 +59,12 @@ public abstract class BaseRecyclerFragment<LI> extends BaseRecyclerParentFragmen
         ((TextView) v).setText(R.string.no_data_available_please_check_and_try_again);
     }
 
+    public static void showNoFilter(View v, int count) {
+        if (v == null) return;
+        v.setVisibility(count == 0 ? View.VISIBLE : View.GONE);
+        ((TextView) v).setText(R.string.no_course_matched_filter);
+    }
+
     public abstract int getLayout();
 
     public abstract RecyclerView.Adapter getAdapter();

--- a/app/src/main/java/org/ole/planet/myplanet/ui/course/CourseFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/course/CourseFragment.java
@@ -180,7 +180,7 @@ public class CourseFragment extends BaseRecyclerFragment<RealmMyCourse> implemen
             gradeLevel = spnGrade.getSelectedItem().toString().equals("All") ? "" : spnGrade.getSelectedItem().toString();
             subjectLevel = spnSubject.getSelectedItem().toString().equals("All") ? "" : spnSubject.getSelectedItem().toString();
             adapterCourses.setCourseList(filterCourseByTag(etSearch.getText().toString(), searchTags));
-            showNoData(tvMessage, adapterCourses.getItemCount());
+            showNoFilter(tvMessage, adapterCourses.getItemCount());
         }
 
         @Override

--- a/app/src/main/java/org/ole/planet/myplanet/ui/course/CourseFragment.java
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/course/CourseFragment.java
@@ -180,6 +180,7 @@ public class CourseFragment extends BaseRecyclerFragment<RealmMyCourse> implemen
             gradeLevel = spnGrade.getSelectedItem().toString().equals("All") ? "" : spnGrade.getSelectedItem().toString();
             subjectLevel = spnSubject.getSelectedItem().toString().equals("All") ? "" : spnSubject.getSelectedItem().toString();
             adapterCourses.setCourseList(filterCourseByTag(etSearch.getText().toString(), searchTags));
+            showNoData(tvMessage, adapterCourses.getItemCount());
         }
 
         @Override

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -956,5 +956,6 @@
     <string name="web_view">عرض الويب</string>
     <string name="invalid_configuration">تكوينات الخادم غير صالحة</string>
     <string name="date_reset">إعادة ضبط التاريخ</string>
-  
+    <string name="no_course_matched_filter">لا توجد دورات تطابق الفلتر</string>
+
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -961,5 +961,6 @@
     <string name="web_view">vista web</string>
     <string name="invalid_configuration">Configuraciones de servidor no válidas</string>
     <string name="date_reset">Restablecer fecha</string>
+    <string name="no_course_matched_filter">Ningún curso coincide con el filtro</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -961,5 +961,6 @@
     <string name="web_view">vue web</string>
     <string name="invalid_configuration">Configurations de serveur invalides</string>
     <string name="date_reset">Réinitialisation des dates</string>
+    <string name="no_course_matched_filter">Aucun cours ne correspond au filtre</string>
 
 </resources>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -961,5 +961,6 @@
     <string name="web_view">वेब दृश्य</string>
     <string name="invalid_configuration">अमान्य सर्भर विन्यास</string>
     <string name="date_reset">मिति रिसेट</string>
+    <string name="no_course_matched_filter">कुनै पनि पाठ्यक्रम मेल खाँदैन</string>
 
 </resources>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -950,5 +950,6 @@
     <string name="web_view">barashada webka</string>
     <string name="invalid_configuration">Dhamaan Suurtagal ah oo Serveryaasha ah</string>
     <string name="date_reset">Dib u habeynta taariikhda</string>
+    <string name="no_course_matched_filter">Ma jiro koorsooyin u dhigma filtarrada</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -685,6 +685,7 @@
     <string name="select_resource_to_open">"Select resource to open : "</string>
     <string name="shared_to_community">Shared to community</string>
     <string name="no_data_available_please_check_and_try_again">No data available, please check and try again.</string>
+    <string name="no_course_matched_filter">No courses matched filter</string>
     <string name="added_to_my_library">Added to my library</string>
     <string name="added_to_my_courses">Added to my courses</string>
     <string name="do_you_want_to_stay_online">Do you want to stay online?</string>


### PR DESCRIPTION
fixes #1952
When filtering courses, add background text "No courses matched filter" when no courses are returned
![Screenshot_20231218_234736_myPlanet 1](https://github.com/open-learning-exchange/myplanet/assets/46581520/da0fea62-9981-4fec-986f-3db9c5bbc81c)
