### PR TITLE
actions: better `RealmOfflineActivity` (fixes #3089)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1340
-        versionName "0.13.40"
+        versionCode 1341
+        versionName "0.13.41"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
@@ -71,6 +71,7 @@ open class RealmOfflineActivity : RealmObject() {
                 .findFirst()
         }
 
+        @JvmStatic
         fun insert(mRealm: Realm, act: JsonObject?) {
             var activities = mRealm.where(RealmOfflineActivity::class.java)
                 .equalTo("_id", JsonUtils.getString("_id", act))


### PR DESCRIPTION
fixes #3089
this data ensures that offline logins are recorded in realm to show accurate number of visits
![Screenshot 2024-02-02 154358](https://github.com/open-learning-exchange/myplanet/assets/64019708/d037c1b6-197d-4ddb-b5b4-4b50f95c841e)
![Screenshot 2024-02-02 15 45 45](https://github.com/open-learning-exchange/myplanet/assets/64019708/e92d34dc-fc55-407c-a50a-286ca8911f6f)
