### PR TITLE
sync: only init icon at login (fixes #3187)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1389
-        versionName "0.13.89"
+        versionCode 1390
+        versionName "0.13.90"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -334,10 +334,12 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
     }
 
     override fun onSyncFailed(s: String) {
-        syncIconDrawable = syncIcon.drawable as AnimationDrawable
-        syncIconDrawable.stop()
-        syncIconDrawable.selectDrawable(0)
-        syncIcon.invalidateDrawable(syncIconDrawable)
+        if (::syncIconDrawable.isInitialized) {
+            syncIconDrawable = syncIcon.drawable as AnimationDrawable
+            syncIconDrawable.stop()
+            syncIconDrawable.selectDrawable(0)
+            syncIcon.invalidateDrawable(syncIconDrawable)
+        }
         runOnUiThread {
             showAlert(this@SyncActivity, getString(R.string.sync_failed), s)
             showWifiSettingDialog(this@SyncActivity)


### PR DESCRIPTION
fixes #3187