### PR TITLE
sync: enabling tunneled and proxied urls (fixes #3235)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1410
-        versionName "0.14.10"
+        versionCode 1413
+        versionName "0.14.13"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -64,8 +64,10 @@ class SyncManager private constructor(private val context: Context) {
             listener!!.onSyncComplete()
         }
         try {
-            mRealm.close()
-            td!!.stop()
+            if (::mRealm.isInitialized && !mRealm.isClosed) {
+                mRealm.close()
+                td!!.stop()
+            }
         } catch (e: Exception) {
             e.printStackTrace()
         }


### PR DESCRIPTION
fixes #3235
this pr check initialization of realm before closing realm and also alows the use of alternative urls
```
local ip        [http://192.168.x.y]
tunnel port  [http://tunnel.ole.org:abcde]
ssl proxy     https://planet.community.ole.org
```