### PR TITLE
all: safer non-string json (fixes #3260)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1421
-        versionName "0.14.21"
+        versionCode 1424
+        versionName "0.14.24"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/JsonUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/JsonUtils.kt
@@ -13,7 +13,13 @@ object JsonUtils {
         return try {
             if (jsonObject!!.has(fieldName)) {
                 val el: JsonElement = jsonObject.get(fieldName)
-                if (el is JsonNull) "" else el.asString
+                if (el is JsonNull) {
+                    ""
+                } else if (el.isJsonPrimitive && el.asJsonPrimitive.isString) {
+                    el.asString
+                } else {
+                    ""
+                }
             } else {
                 ""
             }
@@ -22,6 +28,7 @@ object JsonUtils {
             ""
         }
     }
+
 
     @JvmStatic
     fun getString(array: JsonArray, index: Int): String {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/JsonUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/JsonUtils.kt
@@ -29,7 +29,6 @@ object JsonUtils {
         }
     }
 
-
     @JvmStatic
     fun getString(array: JsonArray, index: Int): String {
         return try {


### PR DESCRIPTION
fixes #3260
this pr addresses `unsupportedOperationException` by enhance the getString method to explicitly check whether the JsonElement is a JsonPrimitive and is suitable for conversion to a string