### PR TITLE
sync: `.interupt` to stop threads (fixes #3261)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1421
-        versionName "0.14.21"
+        versionCode 1425
+        versionName "0.14.25"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -66,7 +66,7 @@ class SyncManager private constructor(private val context: Context) {
         try {
             if (::mRealm.isInitialized && !mRealm.isClosed) {
                 mRealm.close()
-                td?.stop()
+                td?.interrupt()
             }
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
fixes #3261
this pr replaces deprecated `stop()` with `interrupt()` which is a more cooperative approach, where the thread is signalled to stop at the next convenient moment