### PR TITLE
sync: clear app data (fixes #3369)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1476
-        versionName "0.14.76"
+        versionCode 1480
+        versionName "0.14.80"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiInterface.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiInterface.kt
@@ -59,4 +59,7 @@ interface ApiInterface {
 
     @GET
     fun checkAiProviders(@Url url: String?): Call<ResponseBody>
+
+    @GET
+    fun getConfiguration(@Header("Authorization") header: String?, @Url url: String?): Call<JsonObject>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -159,8 +159,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
 
     override fun onConfigurationIdReceived(id: String) {
         val savedId = settings.getString("configurationId", null)
-        Log.d("SyncActivity", "onConfigurationIdReceived: $id")
-        Log.d("SyncActivity", "onConfigurationIdsaved: $savedId")
         if (serverConfigAction == "sync") {
             if (savedId == null) {
                 settings.edit().putString("configurationId", id).apply()
@@ -171,7 +169,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                 showDifferentServerDialog()
             }
         } else if (serverConfigAction == "save") {
-            Log.d("SyncActivity", "serverConfigAction: save")
             if (savedId == null || id == savedId) {
                 if (selectedTeamId == null) {
                     currentDialog?.let { saveConfigAndContinue(it) }
@@ -212,8 +209,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
             tempStorage[key] = settings.getBoolean(key, false)
         }
         settings.edit().clear().commit()
-        val sharedPreferences = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-        val editor = sharedPreferences.edit()
+        val editor = settings.edit()
         for ((key, value) in tempStorage) {
             editor.putBoolean(key, value)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
@@ -16,7 +16,6 @@ import com.bumptech.glide.Glide
 import fisk.chipcloud.ChipCloudConfig
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.R
-
 import org.ole.planet.myplanet.datamanager.MyDownloadService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME


### PR DESCRIPTION
fixes #3369
this pr adds a feature if the app notices a learner trying to sync to a different server it clears the app data to prevent mixup of data from different servers in the couchDb
[cleardata.webm](https://github.com/open-learning-exchange/myplanet/assets/64019708/328773b6-4d57-4b89-a51a-ecea37371048)
