### PR TITLE
chat: smoother transaction for realm (fixes #3419)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1502
-        versionName "0.15.2"
+        versionCode 1504
+        versionName "0.15.4"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmChatHistory.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmChatHistory.kt
@@ -44,11 +44,12 @@ open class RealmChatHistory : RealmObject() {
             return conversations
         }
 
-        @JvmStatic
         fun addConversationToChatHistory(mRealm: Realm, chatHistoryId: String?, query: String?, response: String?) {
             val chatHistory = mRealm.where(RealmChatHistory::class.java).equalTo("_id", chatHistoryId).findFirst()
             if (chatHistory != null) {
-                mRealm.beginTransaction()
+                if (!mRealm.isInTransaction) {
+                    mRealm.beginTransaction()
+                }
                 try {
                     val conversation = Conversation()
                     conversation.query = query
@@ -58,7 +59,6 @@ open class RealmChatHistory : RealmObject() {
                     }
                     chatHistory.conversations?.add(conversation)
                     mRealm.copyToRealmOrUpdate(chatHistory)
-                    mRealm.commitTransaction()
                 } catch (e: Exception) {
                     mRealm.cancelTransaction()
                     e.printStackTrace()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -417,10 +417,12 @@ class ChatDetailFragment : Fragment() {
         try {
             mRealm = Realm.getDefaultInstance()
             addConversationToChatHistory(mRealm, _id, query, chatResponse)
+            mRealm.commitTransaction()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            mRealm.cancelTransaction()
         } finally {
-            if (::mRealm.isInitialized && !mRealm.isClosed) {
-                mRealm.close()
-            }
+            mRealm.close()
         }
     }
 


### PR DESCRIPTION
fixes #3419
this pr ensures that a new transaction is not started if one is already active in the given chat Realm instance 