### PR TITLE
sync: smoother configuration call (fixes #3402)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1502
-        versionName "0.15.2"
+        versionCode 1505
+        versionName "0.15.5"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiInterface.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiInterface.kt
@@ -61,5 +61,5 @@ interface ApiInterface {
     fun checkAiProviders(@Url url: String?): Call<ResponseBody>
 
     @GET
-    fun getConfiguration(@Header("Authorization") header: String?, @Url url: String?): Call<JsonObject>
+    fun getConfiguration(@Url url: String?): Call<JsonObject>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -312,8 +312,7 @@ class Service(private val context: Context) {
             couchdbURL = uri.scheme + "://" + url_user + ":" + url_pwd + "@" + uri.host + ":" + if (uri.port == -1) (if (uri.scheme == "http") 80 else 443) else uri.port
         }
 
-        val header= "Basic " + Base64.encodeToString(("$url_user:$url_pwd").toByteArray(), Base64.NO_WRAP)
-        retrofitInterface?.getConfiguration(header, getUrl(couchdbURL) + "/configurations/_all_docs?include_docs=true")?.enqueue(object : Callback<JsonObject?> {
+        retrofitInterface?.getConfiguration("${getUrl(couchdbURL)}/configurations/_all_docs?include_docs=true")?.enqueue(object : Callback<JsonObject?> {
             override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
                 if (response.isSuccessful) {
                     val jsonObject = response.body()


### PR DESCRIPTION
fixes #3402 
this pr removes unnecessary header in get configuration api call which was causing an unathorizes error preventing sync