### PR TITLE
community: show leaders username (fixes #3455)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/AdapterLeader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/AdapterLeader.kt
@@ -20,7 +20,11 @@ class AdapterLeader(var context: Context, var leaders: List<RealmUserModel>) :
     }
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         if (holder is ViewHolderLeader) {
-            holder.title.text = leaders[position].toString()
+            if (leaders[position].firstName == null) {
+                holder.title.text = leaders[position].name
+            } else {
+                holder.title.text = "${leaders[position]}"
+            }
             holder.tv_description.text = leaders[position].email
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/LeadersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/LeadersFragment.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.ui.community
 
 import android.content.*
 import android.os.Bundle
+//import android.util.Log
 import android.view.*
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
@@ -41,9 +42,15 @@ class LeadersFragment : Fragment() {
                 val docObject = docsArray.getJSONObject(i)
                 val user = RealmUserModel()
                 user.name = docObject.getString("name")
-                user.firstName = docObject.getString("firstName")
-                user.lastName = docObject.getString("lastName")
-                user.email = docObject.getString("email")
+                if (!docObject.isNull("firstName")) {
+                    user.firstName = docObject.getString("firstName")
+                }
+                if (!docObject.isNull("lastName")) {
+                    user.lastName = docObject.getString("lastName")
+                }
+                if (!docObject.isNull("email")) {
+                    user.email = docObject.getString("email")
+                }
                 leadersList.add(user)
             }
         } catch (e: JSONException) {


### PR DESCRIPTION
fixes #3455
in this pr if the community leaders firstname and last name are null we use the username as the fallback to prevent empty list
![Screenshot_20240516_124226](https://github.com/open-learning-exchange/myplanet/assets/64019708/cdad8ea2-7540-44e6-9c96-b8fb05c19b6d)
