### PR TITLE
resources: show only filename (fixes #3499)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1540
-        versionName "0.15.40"
+        versionCode 1543
+        versionName "0.15.43"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
@@ -24,10 +24,12 @@ class CSVViewerActivity : AppCompatActivity() {
         if (!fileName.isNullOrEmpty()) {
             val regex = Regex(".+/(.+\\.csv)")
             val matchResult = regex.find(fileName)
-            val name = matchResult?.groupValues?.get(1)
-
-            activityCsvviewerBinding.csvFileName.text = name
+            val nameWithExtension = matchResult?.groupValues?.get(1)
+            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+            activityCsvviewerBinding.csvFileName.text = nameWithoutExtension
             activityCsvviewerBinding.csvFileName.visibility = View.VISIBLE
+
+
         }
         try {
             val csvFile: File = if (fileName!!.startsWith("/")) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ImageViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ImageViewerActivity.kt
@@ -28,8 +28,9 @@ class ImageViewerActivity : AppCompatActivity() {
             val regex = Regex(".+/([^/]+\\.(jpg|jpeg|png|gif|bmp))")
 
             val matchResult = regex.find(fileName ?: "")
-            val name = matchResult?.groupValues?.get(1)
-            activityImageViewerBinding.imageFileName.text = name
+            val nameWithExtension = matchResult?.groupValues?.get(1)
+            val nameWithoutExtension = nameWithExtension?.substringBefore(".")
+            activityImageViewerBinding.imageFileName.text = nameWithoutExtension
             activityImageViewerBinding.imageFileName.visibility = View.VISIBLE
         }
         if (fileName?.matches(".*[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}.*".toRegex()) == true) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/MarkdownViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/MarkdownViewerActivity.kt
@@ -26,11 +26,12 @@ class MarkdownViewerActivity : AppCompatActivity() {
         val markdownOpenIntent = intent
         fileName = markdownOpenIntent.getStringExtra("TOUCHED_FILE")
         if (!fileName.isNullOrEmpty()) {
+
             val regex = Regex(".+/(.+\\.md)")
             val matchResult = regex.find(fileName ?: "")
-            val name = matchResult?.groupValues?.get(1)
-
-            activityMarkdownViewerBinding.markdownFileName.text = name
+            val nameWithExtension = matchResult?.groupValues?.get(1)
+            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+            activityMarkdownViewerBinding.markdownFileName.text = nameWithoutExtension
             activityMarkdownViewerBinding.markdownFileName.visibility = View.VISIBLE
         }
         try {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
@@ -60,9 +60,9 @@ class PDFReaderActivity : AppCompatActivity(), OnPageChangeListener, OnLoadCompl
         if (fileName != null && fileName?.isNotEmpty() == true) {
             val regex = Regex(".+/(.+\\.pdf)")
             val matchResult = regex.find(fileName ?: "")
-            val name = matchResult?.groupValues?.get(1)
-
-            activityPdfreaderBinding.pdfFileName.text = name
+            val nameWithExtension = matchResult?.groupValues?.get(1)
+            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+            activityPdfreaderBinding.pdfFileName.text = nameWithoutExtension
             activityPdfreaderBinding.pdfFileName.visibility = View.VISIBLE
         }
         val file = File(getExternalFilesDir(null), "ole/$fileName")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/TextFileViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/TextFileViewerActivity.kt
@@ -22,11 +22,12 @@ class TextFileViewerActivity : AppCompatActivity() {
         val textFileOpenIntent = intent
         fileName = textFileOpenIntent.getStringExtra("TOUCHED_FILE")
         if (fileName != null && fileName?.isNotEmpty() == true) {
+
             val regex = Regex(".+/(.+\\.txt)")
             val matchResult = regex.find(fileName ?: "")
-            val name = matchResult?.groupValues?.get(1)
-
-            activityTextfileViewerBinding.textFileName.text = name
+            val nameWithExtension = matchResult?.groupValues?.get(1)
+            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+            activityTextfileViewerBinding.textFileName.text = nameWithoutExtension
             activityTextfileViewerBinding.textFileName.visibility = View.VISIBLE
         }
         renderTextFileThread()


### PR DESCRIPTION
(fixes #3499)
removed file extension from resource names for images, csv, markdown, pdf, and text 
![image](https://github.com/open-learning-exchange/myplanet/assets/52076121/2ce17e16-2bc2-4687-bb9f-76cdf13b94c2)
![image](https://github.com/open-learning-exchange/myplanet/assets/52076121/aa2fa520-ae36-4a03-b71c-724c01739d1f)
![image](https://github.com/open-learning-exchange/myplanet/assets/52076121/5e2fe5d8-b079-4a3c-8a97-a61af467b2cd)

There are no markdown or text files to test for resources which is why they are not imaged. 