### PR TITLE
sync: update success message (fixes #2354)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1543
-        versionName "0.15.43"
+        versionCode 1545
+        versionName "0.15.45"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
@@ -508,7 +508,7 @@ class UploadManager(context: Context) : FileUploadService() {
                     e.printStackTrace()
                 }
             }
-        }, Realm.Transaction.OnSuccess { listener.onSuccess("Crash log uploaded.") })
+        }, Realm.Transaction.OnSuccess {})
     }
 
     fun uploadSearchActivity() {


### PR DESCRIPTION
fixes #2354 
omitted the `crash log uploaded` message after successful sync using the sync icon.