### PR TITLE
resources: smoother filename extraction (fixes #3509)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 34
         versionCode 1543
-        versionName "0.15.43"
+        versionName "0.15.51"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
@@ -23,9 +23,7 @@ class CSVViewerActivity : AppCompatActivity() {
         val csvFileOpenIntent = intent
         val fileName = csvFileOpenIntent.getStringExtra("TOUCHED_FILE")
         if (!fileName.isNullOrEmpty()) {
-            val nameWithExtension = FileUtils.extractFileName(fileName)
-            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-            activityCsvviewerBinding.csvFileName.text = nameWithoutExtension
+            activityCsvviewerBinding.csvFileName.text = FileUtils.nameWithoutExtension(fileName)
             activityCsvviewerBinding.csvFileName.visibility = View.VISIBLE
         } else {
             activityCsvviewerBinding.csvFileName.text = "No file selected"

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
@@ -22,10 +22,15 @@ class CSVViewerActivity : AppCompatActivity() {
     private fun renderCSVFile() {
         val csvFileOpenIntent = intent
         val fileName = csvFileOpenIntent.getStringExtra("TOUCHED_FILE")
-        val nameWithExtension = FileUtils.extractFileName(fileName)
-        val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-        activityCsvviewerBinding.csvFileName.text = nameWithoutExtension
-        activityCsvviewerBinding.csvFileName.visibility = View.VISIBLE
+        if (!fileName.isNullOrEmpty()) {
+            val nameWithExtension = FileUtils.extractFileName(fileName)
+            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+            activityCsvviewerBinding.csvFileName.text = nameWithoutExtension
+            activityCsvviewerBinding.csvFileName.visibility = View.VISIBLE
+        } else {
+            activityCsvviewerBinding.csvFileName.text = "No file selected"
+            activityCsvviewerBinding.csvFileName.visibility = View.VISIBLE
+        }
 
         try {
             val csvFile: File = if (fileName!!.startsWith("/")) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.opencsv.CSVParserBuilder
 import com.opencsv.CSVReaderBuilder
 import org.ole.planet.myplanet.databinding.ActivityCsvviewerBinding
+import org.ole.planet.myplanet.utilities.FileUtils
 import java.io.File
 import java.io.FileReader
 
@@ -21,16 +22,11 @@ class CSVViewerActivity : AppCompatActivity() {
     private fun renderCSVFile() {
         val csvFileOpenIntent = intent
         val fileName = csvFileOpenIntent.getStringExtra("TOUCHED_FILE")
-        if (!fileName.isNullOrEmpty()) {
-            val regex = Regex(".+/(.+\\.csv)")
-            val matchResult = regex.find(fileName)
-            val nameWithExtension = matchResult?.groupValues?.get(1)
-            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-            activityCsvviewerBinding.csvFileName.text = nameWithoutExtension
-            activityCsvviewerBinding.csvFileName.visibility = View.VISIBLE
+        val nameWithExtension = FileUtils.extractFileName(fileName)
+        val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+        activityCsvviewerBinding.csvFileName.text = nameWithoutExtension
+        activityCsvviewerBinding.csvFileName.visibility = View.VISIBLE
 
-
-        }
         try {
             val csvFile: File = if (fileName!!.startsWith("/")) {
                 File(fileName)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ImageViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ImageViewerActivity.kt
@@ -26,9 +26,7 @@ class ImageViewerActivity : AppCompatActivity() {
         val imageOpenIntent = intent
         fileName = imageOpenIntent.getStringExtra("TOUCHED_FILE")
         if (!fileName.isNullOrEmpty()) {
-            val nameWithExtension = FileUtils.extractFileName(fileName)
-            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-            activityImageViewerBinding.imageFileName.text = nameWithoutExtension
+            activityImageViewerBinding.imageFileName.text = FileUtils.nameWithoutExtension(fileName)
             activityImageViewerBinding.imageFileName.visibility = View.VISIBLE
         } else {
             activityImageViewerBinding.imageFileName.text = "No file selected"

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ImageViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ImageViewerActivity.kt
@@ -25,10 +25,15 @@ class ImageViewerActivity : AppCompatActivity() {
         val isFullPath = intent.getBooleanExtra("isFullPath", false)
         val imageOpenIntent = intent
         fileName = imageOpenIntent.getStringExtra("TOUCHED_FILE")
-        val nameWithExtension = FileUtils.extractFileName(fileName)
-        val nameWithoutExtension = nameWithExtension?.substringBefore(".")
-        activityImageViewerBinding.imageFileName.text = nameWithoutExtension
-        activityImageViewerBinding.imageFileName.visibility = View.VISIBLE
+        if (!fileName.isNullOrEmpty()) {
+            val nameWithExtension = FileUtils.extractFileName(fileName)
+            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+            activityImageViewerBinding.imageFileName.text = nameWithoutExtension
+            activityImageViewerBinding.imageFileName.visibility = View.VISIBLE
+        } else {
+            activityImageViewerBinding.imageFileName.text = "No file selected"
+            activityImageViewerBinding.imageFileName.visibility = View.VISIBLE
+        }
 
         if (fileName?.matches(".*[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}.*".toRegex()) == true) {
             displayCapturedImage()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ImageViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ImageViewerActivity.kt
@@ -7,6 +7,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.request.RequestOptions
 import org.ole.planet.myplanet.databinding.ActivityImageViewerBinding
+import org.ole.planet.myplanet.utilities.FileUtils
 import java.io.File
 import java.util.regex.Pattern
 
@@ -24,15 +25,11 @@ class ImageViewerActivity : AppCompatActivity() {
         val isFullPath = intent.getBooleanExtra("isFullPath", false)
         val imageOpenIntent = intent
         fileName = imageOpenIntent.getStringExtra("TOUCHED_FILE")
-        if (fileName != null && fileName?.isNotEmpty() == true) {
-            val regex = Regex(".+/([^/]+\\.(jpg|jpeg|png|gif|bmp))")
+        val nameWithExtension = FileUtils.extractFileName(fileName)
+        val nameWithoutExtension = nameWithExtension?.substringBefore(".")
+        activityImageViewerBinding.imageFileName.text = nameWithoutExtension
+        activityImageViewerBinding.imageFileName.visibility = View.VISIBLE
 
-            val matchResult = regex.find(fileName ?: "")
-            val nameWithExtension = matchResult?.groupValues?.get(1)
-            val nameWithoutExtension = nameWithExtension?.substringBefore(".")
-            activityImageViewerBinding.imageFileName.text = nameWithoutExtension
-            activityImageViewerBinding.imageFileName.visibility = View.VISIBLE
-        }
         if (fileName?.matches(".*[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}.*".toRegex()) == true) {
             displayCapturedImage()
         } else {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/MarkdownViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/MarkdownViewerActivity.kt
@@ -26,11 +26,15 @@ class MarkdownViewerActivity : AppCompatActivity() {
     private fun renderMarkdownFile() {
         val markdownOpenIntent = intent
         fileName = markdownOpenIntent.getStringExtra("TOUCHED_FILE")
-        val nameWithExtension = FileUtils.extractFileName(fileName)
-        val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-        activityMarkdownViewerBinding.markdownFileName.text = nameWithoutExtension
-        activityMarkdownViewerBinding.markdownFileName.visibility = View.VISIBLE
-
+        if (!fileName.isNullOrEmpty()) {
+            val nameWithExtension = FileUtils.extractFileName(fileName)
+            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+            activityMarkdownViewerBinding.markdownFileName.text = nameWithoutExtension
+            activityMarkdownViewerBinding.markdownFileName.visibility = View.VISIBLE
+        } else {
+            activityMarkdownViewerBinding.markdownFileName.text = "No file selected"
+            activityMarkdownViewerBinding.markdownFileName.visibility = View.VISIBLE
+        }
         try {
             val basePath = getExternalFilesDir(null)
             val markdownFile = File(basePath, "ole/$fileName")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/MarkdownViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/MarkdownViewerActivity.kt
@@ -27,9 +27,8 @@ class MarkdownViewerActivity : AppCompatActivity() {
         val markdownOpenIntent = intent
         fileName = markdownOpenIntent.getStringExtra("TOUCHED_FILE")
         if (!fileName.isNullOrEmpty()) {
-            val nameWithExtension = FileUtils.extractFileName(fileName)
-            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-            activityMarkdownViewerBinding.markdownFileName.text = nameWithoutExtension
+
+            activityMarkdownViewerBinding.markdownFileName.text = FileUtils.nameWithoutExtension(fileName)
             activityMarkdownViewerBinding.markdownFileName.visibility = View.VISIBLE
         } else {
             activityMarkdownViewerBinding.markdownFileName.text = "No file selected"

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/MarkdownViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/MarkdownViewerActivity.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ActivityMarkdownViewerBinding
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 import java.io.BufferedReader
 import java.io.File
@@ -25,15 +26,11 @@ class MarkdownViewerActivity : AppCompatActivity() {
     private fun renderMarkdownFile() {
         val markdownOpenIntent = intent
         fileName = markdownOpenIntent.getStringExtra("TOUCHED_FILE")
-        if (!fileName.isNullOrEmpty()) {
+        val nameWithExtension = FileUtils.extractFileName(fileName)
+        val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+        activityMarkdownViewerBinding.markdownFileName.text = nameWithoutExtension
+        activityMarkdownViewerBinding.markdownFileName.visibility = View.VISIBLE
 
-            val regex = Regex(".+/(.+\\.md)")
-            val matchResult = regex.find(fileName ?: "")
-            val nameWithExtension = matchResult?.groupValues?.get(1)
-            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-            activityMarkdownViewerBinding.markdownFileName.text = nameWithoutExtension
-            activityMarkdownViewerBinding.markdownFileName.visibility = View.VISIBLE
-        }
         try {
             val basePath = getExternalFilesDir(null)
             val markdownFile = File(basePath, "ole/$fileName")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
@@ -58,11 +58,15 @@ class PDFReaderActivity : AppCompatActivity(), OnPageChangeListener, OnLoadCompl
     private fun renderPdfFile() {
         val pdfOpenIntent = intent
         fileName = pdfOpenIntent.getStringExtra("TOUCHED_FILE")
-        val nameWithExtension = FileUtils.extractFileName(fileName)
-        val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-        activityPdfreaderBinding.pdfFileName.text = nameWithoutExtension
-        activityPdfreaderBinding.pdfFileName.visibility = View.VISIBLE
-
+        if (!fileName.isNullOrEmpty()) {
+            val nameWithExtension = FileUtils.extractFileName(fileName)
+            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+            activityPdfreaderBinding.pdfFileName.text = nameWithoutExtension
+            activityPdfreaderBinding.pdfFileName.visibility = View.VISIBLE
+        } else {
+            activityPdfreaderBinding.pdfFileName.text = "No file selected"
+            activityPdfreaderBinding.pdfFileName.visibility = View.VISIBLE
+        }
         val file = File(getExternalFilesDir(null), "ole/$fileName")
         if (file.exists()) {
             try {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
@@ -17,6 +17,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.service.AudioRecorderService
 import org.ole.planet.myplanet.service.AudioRecorderService.AudioRecordListener
 import org.ole.planet.myplanet.ui.resources.AddResourceFragment
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.IntentUtils.openAudioFile
 import org.ole.planet.myplanet.utilities.NotificationUtil.cancellAll
 import org.ole.planet.myplanet.utilities.NotificationUtil.create
@@ -57,14 +58,11 @@ class PDFReaderActivity : AppCompatActivity(), OnPageChangeListener, OnLoadCompl
     private fun renderPdfFile() {
         val pdfOpenIntent = intent
         fileName = pdfOpenIntent.getStringExtra("TOUCHED_FILE")
-        if (fileName != null && fileName?.isNotEmpty() == true) {
-            val regex = Regex(".+/(.+\\.pdf)")
-            val matchResult = regex.find(fileName ?: "")
-            val nameWithExtension = matchResult?.groupValues?.get(1)
-            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-            activityPdfreaderBinding.pdfFileName.text = nameWithoutExtension
-            activityPdfreaderBinding.pdfFileName.visibility = View.VISIBLE
-        }
+        val nameWithExtension = FileUtils.extractFileName(fileName)
+        val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+        activityPdfreaderBinding.pdfFileName.text = nameWithoutExtension
+        activityPdfreaderBinding.pdfFileName.visibility = View.VISIBLE
+
         val file = File(getExternalFilesDir(null), "ole/$fileName")
         if (file.exists()) {
             try {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
@@ -59,9 +59,7 @@ class PDFReaderActivity : AppCompatActivity(), OnPageChangeListener, OnLoadCompl
         val pdfOpenIntent = intent
         fileName = pdfOpenIntent.getStringExtra("TOUCHED_FILE")
         if (!fileName.isNullOrEmpty()) {
-            val nameWithExtension = FileUtils.extractFileName(fileName)
-            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-            activityPdfreaderBinding.pdfFileName.text = nameWithoutExtension
+            activityPdfreaderBinding.pdfFileName.text = FileUtils.nameWithoutExtension(fileName)
             activityPdfreaderBinding.pdfFileName.visibility = View.VISIBLE
         } else {
             activityPdfreaderBinding.pdfFileName.text = "No file selected"

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/TextFileViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/TextFileViewerActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import org.ole.planet.myplanet.databinding.ActivityTextfileViewerBinding
+import org.ole.planet.myplanet.utilities.FileUtils
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
@@ -21,15 +22,10 @@ class TextFileViewerActivity : AppCompatActivity() {
     private fun renderTextFile() {
         val textFileOpenIntent = intent
         fileName = textFileOpenIntent.getStringExtra("TOUCHED_FILE")
-        if (fileName != null && fileName?.isNotEmpty() == true) {
-
-            val regex = Regex(".+/(.+\\.txt)")
-            val matchResult = regex.find(fileName ?: "")
-            val nameWithExtension = matchResult?.groupValues?.get(1)
-            val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-            activityTextfileViewerBinding.textFileName.text = nameWithoutExtension
-            activityTextfileViewerBinding.textFileName.visibility = View.VISIBLE
-        }
+        val nameWithExtension = FileUtils.extractFileName(fileName)
+        val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+        activityTextfileViewerBinding.textFileName.text = nameWithoutExtension
+        activityTextfileViewerBinding.textFileName.visibility = View.VISIBLE
         renderTextFileThread()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/TextFileViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/TextFileViewerActivity.kt
@@ -22,13 +22,17 @@ class TextFileViewerActivity : AppCompatActivity() {
     private fun renderTextFile() {
         val textFileOpenIntent = intent
         fileName = textFileOpenIntent.getStringExtra("TOUCHED_FILE")
-        val nameWithExtension = FileUtils.extractFileName(fileName)
-        val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-        activityTextfileViewerBinding.textFileName.text = nameWithoutExtension
-        activityTextfileViewerBinding.textFileName.visibility = View.VISIBLE
+        if (!fileName.isNullOrEmpty()) {
+            val nameWithExtension = FileUtils.extractFileName(fileName)
+                val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+                activityTextfileViewerBinding.textFileName.text = nameWithoutExtension
+                activityTextfileViewerBinding.textFileName.visibility = View.VISIBLE
+        } else {
+            activityTextfileViewerBinding.textFileName.text = "No file selected"
+            activityTextfileViewerBinding.textFileName.visibility = View.VISIBLE
+        }
         renderTextFileThread()
     }
-
     private fun renderTextFileThread() {
         val openTextFileThread: Thread = object : Thread() {
             override fun run() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/TextFileViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/TextFileViewerActivity.kt
@@ -23,10 +23,8 @@ class TextFileViewerActivity : AppCompatActivity() {
         val textFileOpenIntent = intent
         fileName = textFileOpenIntent.getStringExtra("TOUCHED_FILE")
         if (!fileName.isNullOrEmpty()) {
-            val nameWithExtension = FileUtils.extractFileName(fileName)
-                val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
-                activityTextfileViewerBinding.textFileName.text = nameWithoutExtension
-                activityTextfileViewerBinding.textFileName.visibility = View.VISIBLE
+            activityTextfileViewerBinding.textFileName.text = FileUtils.nameWithoutExtension(fileName)
+            activityTextfileViewerBinding.textFileName.visibility = View.VISIBLE
         } else {
             activityTextfileViewerBinding.textFileName.text = "No file selected"
             activityTextfileViewerBinding.textFileName.visibility = View.VISIBLE

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
@@ -414,4 +414,13 @@ object FileUtils {
         val regex = Regex(".+/(.+\\.[a-zA-Z0-9]+)")
         return regex.find(filePath)?.groupValues?.get(1)
     }
+
+    fun nameWithoutExtension(fileName: String?): String?{
+        extractFileName(fileName)
+        val nameWithExtension = FileUtils.extractFileName(fileName)
+        val nameWithoutExtension = nameWithExtension?.substringBeforeLast(".")
+        return nameWithoutExtension
+    }
+
+
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
@@ -409,4 +409,9 @@ object FileUtils {
             return Pair(totalBytes, availableBytes)
         }
     }
+    fun extractFileName(filePath: String?): String?{
+        if(filePath.isNullOrEmpty()) return null
+        val regex = Regex(".+/(.+\\.[a-zA-Z0-9]+)")
+        return regex.find(filePath)?.groupValues?.get(1)
+    }
 }


### PR DESCRIPTION
fixes #3509 
Added a function `extractFileName` to `FileUtils.kt` which will extract the filename regardless of filetype. Currently implemented in csv, image, markdown, pdf, and text files. 