### PR TITLE
resources: smoother details view (fixes #3543)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1555
-        versionName "0.15.55"
+        versionCode 1560
+        versionName "0.15.60"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
@@ -71,14 +71,14 @@ class AdapterResource(private val context: Context, private var libraryList: Lis
             holder.bind()
             holder.rowLibraryBinding.title.text = libraryList[position]?.title
             setMarkdownText(holder.rowLibraryBinding.description, libraryList[position]?.description!!)
-            holder.rowLibraryBinding.timesRated.text = "${libraryList[position]?.timesRated}${context.getString(R.string.total)}"
+            holder.rowLibraryBinding.timesRated.text = "${libraryList[position]?.timesRated} ${context.getString(R.string.total)}"
             holder.rowLibraryBinding.checkbox.isChecked = selectedItems.contains(libraryList[position])
             holder.rowLibraryBinding.checkbox.contentDescription = "${context.getString(R.string.selected)} ${libraryList[position]?.title}"
             holder.rowLibraryBinding.rating.text =
                 if (TextUtils.isEmpty(libraryList[position]?.averageRating)) {
                     "0.0"
                 } else {
-                    String.format("%.1f", libraryList[position]?.averageRating!!.toDouble())
+                    String.format("%.1f", libraryList[position]?.averageRating?.toDouble())
                 }
             holder.rowLibraryBinding.tvDate.text = libraryList[position]?.createdDate?.let { formatDate(it, "MMM dd, yyyy") }
             displayTagCloud(holder.rowLibraryBinding.flexboxDrawable, position)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -5,6 +5,7 @@ import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import android.widget.Toast
 import io.realm.Realm
 import org.ole.planet.myplanet.R
@@ -60,14 +61,18 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     }
 
     private fun setLibraryData() {
-        fragmentLibraryDetailBinding.tvTitle.text = String.format("%s%s", if (openFrom?.isEmpty() == true) "" else "$openFrom-", library.title)
-        fragmentLibraryDetailBinding.tvAuthor.text = library.author
-        fragmentLibraryDetailBinding.tvPublished.text = library.publisher
-        fragmentLibraryDetailBinding.tvMedia.text = library.mediaType
-        fragmentLibraryDetailBinding.tvSubject.text = library.subjectsAsString
-        fragmentLibraryDetailBinding.tvLanguage.text = library.language
-        fragmentLibraryDetailBinding.tvLicense.text = library.linkToLicense
-        fragmentLibraryDetailBinding.tvResource.text = listToString(library.resourceFor)
+        with(fragmentLibraryDetailBinding) {
+            tvTitle.text = if (openFrom.isNullOrEmpty()) library.title else "$openFrom-${library.title}"
+            timesRated.text = "${library.timesRated} ${requireContext().getString(R.string.total)}"
+            setTextViewVisibility(tvAuthor, llAuthor, library.author)
+            setTextViewVisibility(tvPublished, llPublisher, library.publisher)
+            setTextViewVisibility(tvMedia, llMedia, library.mediaType)
+            setTextViewVisibility(tvSubject, llSubject, library.subjectsAsString)
+            setTextViewVisibility(tvLanguage, llLanguage, library.language)
+            setTextViewVisibility(tvLicense, llLicense, library.linkToLicense)
+            setTextViewVisibility(tvResource, llResource, listToString(library.resourceFor))
+            setTextViewVisibility(tvType, llType, library.resourceType)
+        }
         profileDbHandler.setResourceOpenCount(library)
         try {
             onRatingChanged()
@@ -91,6 +96,15 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             fragmentLibraryDetailBinding.btnDownload.setImageResource(R.drawable.ic_play)
         }
         setClickListeners()
+    }
+
+    private fun setTextViewVisibility(textView: TextView, layout: View, text: String?) {
+        if (!text.isNullOrEmpty()) {
+            textView.text = text
+            layout.visibility = View.VISIBLE
+        } else {
+            layout.visibility = View.GONE
+        }
     }
 
     private fun setClickListeners() {

--- a/app/src/main/res/layout/fragment_library_detail.xml
+++ b/app/src/main/res/layout/fragment_library_detail.xml
@@ -25,7 +25,6 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
                     android:background="@color/colorPrimary"
                     android:minHeight="?attr/actionBarSize"
                     android:padding="8dp">
@@ -51,7 +50,6 @@
                         android:layout_weight="3"
                         android:textAllCaps="true"
                         android:textColor="@color/md_white_1000"
-                        android:textSize="@dimen/text_size_mid"
                         android:textStyle="bold" />
 
                     <ImageButton
@@ -61,8 +59,8 @@
                         android:layout_height="@dimen/_50dp"
                         android:layout_marginEnd="8dp"
                         android:background="@drawable/buttonyellow"
-                        android:padding="8dp"
                         android:text="@string/download"
+                        android:layout_gravity="center_vertical"
                         app:srcCompat="@drawable/ic_download"
                         app:tint="@color/md_black_1000"
                         android:contentDescription="@string/download" />
@@ -74,7 +72,6 @@
                         android:layout_height="@dimen/_50dp"
                         android:layout_gravity="center_vertical"
                         android:background="@drawable/buttonyellow"
-                        android:padding="8dp"
                         android:src="@drawable/close_x"
                         android:text="@string/btn_remove_lib"
                         app:tint="@color/md_black_1000"
@@ -84,29 +81,27 @@
 
                 <androidx.core.widget.NestedScrollView
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
+                    android:layout_height="wrap_content"
                     android:layout_gravity="center">
 
                     <LinearLayout
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:gravity="center"
                         android:orientation="vertical">
 
 
                         <LinearLayout
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:gravity="center"
                             android:orientation="vertical"
                             android:padding="@dimen/padding_normal">
 
                             <LinearLayout
                                 android:id="@+id/ll_rating"
                                 android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center"
-                                android:gravity="center">
+                                android:layout_height="wrap_content">
 
                                 <LinearLayout
                                     android:layout_width="wrap_content"
@@ -168,6 +163,7 @@
                             </LinearLayout>
 
                             <LinearLayout
+                                android:id="@+id/llAuthor"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content">
 
@@ -186,6 +182,7 @@
                             </LinearLayout>
 
                             <LinearLayout
+                                android:id="@+id/llPublisher"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content">
 
@@ -204,6 +201,7 @@
                             </LinearLayout>
 
                             <LinearLayout
+                                android:id="@+id/llMedia"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content">
 
@@ -222,6 +220,7 @@
                             </LinearLayout>
 
                             <LinearLayout
+                                android:id="@+id/llLanguage"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content">
 
@@ -240,6 +239,7 @@
                             </LinearLayout>
 
                             <LinearLayout
+                                android:id="@+id/llSubject"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content">
 
@@ -258,6 +258,7 @@
                             </LinearLayout>
 
                             <LinearLayout
+                                android:id="@+id/llLicense"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content">
 
@@ -276,6 +277,7 @@
                             </LinearLayout>
 
                             <LinearLayout
+                                android:id="@+id/llResource"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content">
 
@@ -294,6 +296,7 @@
                             </LinearLayout>
 
                             <LinearLayout
+                                android:id="@+id/llType"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content">
 


### PR DESCRIPTION
fixes #3543
only show if value is not empty

![Screenshot_20240603_144905](https://github.com/open-learning-exchange/myplanet/assets/64019708/e529cb7e-92c3-4845-b6e0-0e9b34c2e0fc)

central placement of buttons even with longer resource titles

![Screenshot_20240603_143140](https://github.com/open-learning-exchange/myplanet/assets/64019708/c80a28d3-3301-426e-a9cd-64d244af9575)

