### PR TITLE
actions: less warnings is more (fixes #3617)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1586
-        versionName "0.15.86"
+        versionCode 1588
+        versionName "0.15.88"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
@@ -1,8 +1,10 @@
 package org.ole.planet.myplanet.ui.news
 
+import android.app.Activity
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
+import android.os.Build
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.MenuItem
@@ -11,6 +13,7 @@ import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.PopupMenu
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
@@ -80,6 +83,7 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
         return ViewHolderNews(rowNewsBinding)
     }
 
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         if (holder is ViewHolderNews) {
             holder.bind(position)
@@ -329,6 +333,7 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     private fun deletePost(news: RealmNews?, context: Context) {
         if (!mRealm.isInTransaction) mRealm.beginTransaction()
         val position = list.indexOf(news)
@@ -341,9 +346,9 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
             if (context is ReplyActivity) {
                 val restartIntent = context.intent
                 context.finish()
-                context.overridePendingTransition(0, 0)
+                context.overrideActivityTransition(Activity.OVERRIDE_TRANSITION_OPEN, 0, 0, 0)
                 context.startActivity(restartIntent)
-                context.overridePendingTransition(0, 0)
+                context.overrideActivityTransition(Activity.OVERRIDE_TRANSITION_OPEN, 0, 0, 0)
             }
         }
         mRealm.commitTransaction()


### PR DESCRIPTION
fixes #3617 

updated overridePendingTransition in deletePost() to overrideActivityTransition

[delete_post.webm](https://github.com/open-learning-exchange/myplanet/assets/112584985/9a43a8d5-e54b-4825-b495-315d7216ad2a)
