### PR TITLE
teams: circular member images (fixes #3623)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1590
-        versionName "0.15.90"
+        versionCode 1603
+        versionName "0.16.3"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/res/layout/fragment_member_detail.xml
+++ b/app/src/main/res/layout/fragment_member_detail.xml
@@ -23,7 +23,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
+        <de.hdodenhof.circleimageview.CircleImageView
             android:id="@+id/memberImage"
             android:layout_width="48dp"
             android:layout_height="48dp"


### PR DESCRIPTION
fixes #3623 
![image](https://github.com/open-learning-exchange/myplanet/assets/52076121/d9754114-7150-4d3f-ab4b-44350664d92e)
