### PR TITLE
actions: less warnings is more (fixes #3667)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1605
-        versionName "0.16.5"
+        versionCode 1611
+        versionName "0.16.11"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityPagerAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityPagerAdapter.kt
@@ -1,6 +1,8 @@
 package org.ole.planet.myplanet.ui.community
 
+import android.os.Build
 import android.os.Bundle
+import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
@@ -11,9 +13,10 @@ import org.ole.planet.myplanet.ui.enterprises.FinanceFragment
 import org.ole.planet.myplanet.ui.news.NewsFragment
 
 class CommunityPagerAdapter(fm: FragmentActivity, private val id: String, private var fromLogin: Boolean) : FragmentStateAdapter(fm) {
-    var titles = arrayOf(context.getString(R.string.news), context.getString(R.string.community_leaders), context.getString(R.string.calendar), context.getString(
+    private var titles = arrayOf(context.getString(R.string.news), context.getString(R.string.community_leaders), context.getString(R.string.calendar), context.getString(
             R.string.services), context.getString(R.string.finances))
-    var titles_login = arrayOf(context.getString(R.string.news), context.getString(R.string.community_leaders), context.getString(R.string.calendar))
+    private var titlesLogin = arrayOf(context.getString(R.string.news), context.getString(R.string.community_leaders), context.getString(R.string.calendar))
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun createFragment(position: Int): Fragment {
         val fragment: Fragment = when (position) {
             0 -> {
@@ -42,7 +45,7 @@ class CommunityPagerAdapter(fm: FragmentActivity, private val id: String, privat
 
     override fun getItemCount(): Int {
         return if (fromLogin) {
-            titles_login.size
+            titlesLogin.size
         } else {
             titles.size
         }
@@ -50,7 +53,7 @@ class CommunityPagerAdapter(fm: FragmentActivity, private val id: String, privat
 
     fun getPageTitle(position: Int): CharSequence {
         return if (fromLogin) {
-            if (position < titles_login.size) titles_login[position] else ""
+            if (position < titlesLogin.size) titlesLogin[position] else ""
         } else {
             if (position < titles.size) titles[position] else ""
         }


### PR DESCRIPTION
fixes #3667 

`import com.borax12.materialdaterangepicker.date.DatePickerDialog` currently still uses deprecated fragmentManager and does not support the newer version supportFragmentManager yet.
I left fragmentManager in for now. 
Repository for material date range picker: https://github.com/heysupratim/material-daterange-picker