### PR TITLE
sync: smoother downloads (fixes #3728)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1633
-        versionName "0.16.33"
+        versionCode 1636
+        versionName "0.16.36"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
@@ -211,8 +211,4 @@ class MyDownloadService(context: Context, params: WorkerParameters) : Worker(con
             }
         }
     }
-
-//    override fun onTaskRemoved(rootIntent: Intent) {
-//        notificationManager?.cancel(0)
-//    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
@@ -1,18 +1,20 @@
 package org.ole.planet.myplanet.datamanager
 
-import android.app.IntentService
 import android.app.NotificationManager
+import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import androidx.core.app.NotificationCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
 import io.realm.Realm
 import okhttp3.ResponseBody
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
-import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
+import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.NotificationUtil
 import org.ole.planet.myplanet.utilities.Utilities
@@ -26,16 +28,16 @@ import java.io.OutputStream
 import kotlin.math.pow
 import kotlin.math.roundToInt
 
-class MyDownloadService : IntentService("Download Service") {
-    var count = 0
-    var data = ByteArray(1024 * 4)
+class MyDownloadService(context: Context, params: WorkerParameters) : Worker(context, params) {
+    private var count = 0
+    private var data = ByteArray(1024 * 4)
     private var outputFile: File? = null
     private var notificationBuilder: NotificationCompat.Builder? = null
     private var notificationManager: NotificationManager? = null
     private var totalFileSize = 0
     private var preferences: SharedPreferences? = null
     private var url: String? = null
-    private var urls: ArrayList<String>? = null
+    private lateinit var urls: Array<String>
     private var currentIndex = 0
     private var request: Call<ResponseBody>? = null
     private var completeAll = false
@@ -48,25 +50,30 @@ class MyDownloadService : IntentService("Download Service") {
         databaseService.realmInstance
     }
 
-    override fun onHandleIntent(intent: Intent?) {
-        preferences = applicationContext.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-        notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-        if (urls == null) {
-            stopSelf()
+    override fun doWork(): Result {
+        preferences = applicationContext.getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE)
+        notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        urls = inputData.getStringArray("urls") ?: return Result.failure()
+        fromSync = inputData.getBoolean("fromSync", false)
+
+        if (urls.isEmpty()) {
+            return Result.failure()
         }
-        notificationBuilder = NotificationCompat.Builder(this, "11")
+
+        notificationBuilder = NotificationCompat.Builder(applicationContext, "11")
         NotificationUtil.setChannel(notificationManager)
         val noti = notificationBuilder?.setSmallIcon(R.mipmap.ic_launcher)
             ?.setContentTitle("OLE Download")?.setContentText("Downloading File...")
             ?.setAutoCancel(true)?.build()
         notificationManager?.notify(0, noti)
-        urls = intent?.getStringArrayListExtra("urls")
-        fromSync = intent?.getBooleanExtra("fromSync", false) == true
-        for (i in urls?.indices ?: emptyList()) {
-            url = urls?.get(i)
+
+        for (i in urls.indices) {
+            url = urls[i]
             currentIndex = i
             initDownload(fromSync)
         }
+
+        return Result.success()
     }
 
     private fun initDownload(fromSync: Boolean) {
@@ -101,7 +108,6 @@ class MyDownloadService : IntentService("Download Service") {
         d.failed = true
         d.message = message
         sendIntent(d, fromSync)
-        stopSelf()
     }
 
     @Throws(IOException::class)
@@ -169,7 +175,7 @@ class MyDownloadService : IntentService("Download Service") {
         val intent = Intent(DashboardActivity.MESSAGE_PROGRESS)
         intent.putExtra("download", download)
         intent.putExtra("fromSync", fromSync)
-        LocalBroadcastManager.getInstance(this@MyDownloadService).sendBroadcast(intent)
+        LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(intent)
     }
 
     private fun onDownloadComplete() {
@@ -191,20 +197,20 @@ class MyDownloadService : IntentService("Download Service") {
         notificationManager?.notify(0, notificationBuilder?.build())
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        if (!completeAll) {
-            stopDownload()
-        }
-    }
-
-    private fun stopDownload() {
-        if (request != null && outputFile != null) {
-            request?.cancel()
-            outputFile?.delete()
-            notificationManager?.cancelAll()
-        }
-    }
+//    override fun onDestroy() {
+//        super.onDestroy()
+//        if (!completeAll) {
+//            stopDownload()
+//        }
+//    }
+//
+//    private fun stopDownload() {
+//        if (request != null && outputFile != null) {
+//            request?.cancel()
+//            outputFile?.delete()
+//            notificationManager?.cancelAll()
+//        }
+//    }
 
     private fun changeOfflineStatus() {
         val currentFileName = FileUtils.getFileNameFromUrl(url)
@@ -221,7 +227,7 @@ class MyDownloadService : IntentService("Download Service") {
         }
     }
 
-    override fun onTaskRemoved(rootIntent: Intent) {
-        notificationManager?.cancel(0)
-    }
+//    override fun onTaskRemoved(rootIntent: Intent) {
+//        notificationManager?.cancel(0)
+//    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
@@ -197,21 +197,6 @@ class MyDownloadService(context: Context, params: WorkerParameters) : Worker(con
         notificationManager?.notify(0, notificationBuilder?.build())
     }
 
-//    override fun onDestroy() {
-//        super.onDestroy()
-//        if (!completeAll) {
-//            stopDownload()
-//        }
-//    }
-//
-//    private fun stopDownload() {
-//        if (request != null && outputFile != null) {
-//            request?.cancel()
-//            outputFile?.delete()
-//            notificationManager?.cancelAll()
-//        }
-//    }
-
     private fun changeOfflineStatus() {
         val currentFileName = FileUtils.getFileNameFromUrl(url)
         mRealm.executeTransaction { realm: Realm ->

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -132,8 +132,7 @@ object DialogUtils {
             }
 
             override fun onFail() {
-                val url = ArrayList<String>()
-                url.add(path)
+                val url = arrayListOf(path)
                 if (progressDialog != null) {
                     progressDialog.setText(context.getString(R.string.downloading_file))
                     progressDialog.setCancelable(false)

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.graphics.Color
 import android.net.Uri
+import androidx.work.Data
 import android.text.TextUtils
 import android.text.format.DateUtils
 import android.util.Base64
@@ -13,6 +14,8 @@ import android.util.Patterns
 import android.webkit.MimeTypeMap
 import android.widget.ImageView
 import android.widget.Toast
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
 import com.bumptech.glide.Glide
 import fisk.chipcloud.ChipCloudConfig
 import org.ole.planet.myplanet.MainApplication.Companion.context
@@ -56,11 +59,20 @@ object Utilities {
     }
 
     fun openDownloadService(context: Context?, urls: ArrayList<String>, fromSync: Boolean) {
-        val intent = Intent(context, MyDownloadService::class.java)
-        intent.putStringArrayListExtra("urls", urls)
-        intent.putExtra("fromSync", fromSync)
-        context?.startService(intent)
+        val inputData = Data.Builder()
+            .putStringArray("urls", urls.toTypedArray())
+            .putBoolean("fromSync", fromSync)
+            .build()
+
+        val downloadWorkRequest = OneTimeWorkRequest.Builder(MyDownloadService::class.java)
+            .setInputData(inputData)
+            .build()
+
+        context?.let {
+            WorkManager.getInstance(it).enqueue(downloadWorkRequest)
+        }
     }
+
 
     @JvmStatic
     fun toast(context: Context?, s: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
@@ -73,7 +73,6 @@ object Utilities {
         }
     }
 
-
     @JvmStatic
     fun toast(context: Context?, s: String?) {
         context ?: return


### PR DESCRIPTION
fixes #3728

Updated `MyDownloadService.kt` to use `WorkManager` instead of deprecated `IntentService`
Modified `Utilities.kt` and `DialogUtils.kt` to use new `MyDownloadService.kt`