### PR TITLE
actions: less warnings is more (fixes #3772)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1640
-        versionName "0.16.40"
+        versionCode 1656
+        versionName "0.16.56"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
fixes #3772

`ACTION_INSTALL_PACKAGE` deprecated
now using `android.content.pm.PackageInstaller` instead


modified `getImagePath()` to address error using `getColumnIndex()`: `Value must be ≥ 0 but getColumnIndex can be -1`
`DATA` is also deprecated starting from API level 29, changed it to use `DocumentFile` instead.