### PR TITLE
surveys: smoother sorting (fixes #3898)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1699
-        versionName "0.16.99"
+        versionCode 1705
+        versionName "0.17.5"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
@@ -128,5 +128,11 @@ open class RealmStepExam : RealmObject() {
             }
             return ids
         }
+
+        @JvmStatic
+        fun getSurveyCreationTime(surveyId: String, mRealm: Realm): Long? {
+            val survey = mRealm.where(RealmStepExam::class.java).equalTo("id", surveyId).findFirst()
+            return survey?.createdDate
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -48,7 +48,7 @@ class AdapterCourses(private val context: Context, private var courseList: List<
     private var mRealm: Realm? = null
     private val config: ChipCloudConfig
     private var isAscending = true
-    private var isTitleAscending = true
+    private var isTitleAscending = false
     private var areAllSelected = true
     var userModel: RealmUserModel?= null
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
@@ -33,7 +33,7 @@ class AdapterResource(private val context: Context, private var libraryList: Lis
     private var homeItemClickListener: OnHomeItemClickListener? = null
     private var ratingChangeListener: OnRatingChangeListener? = null
     private var isAscending = true
-    private var isTitleAscending = true
+    private var isTitleAscending = false
 
     init {
         if (context is OnHomeItemClickListener) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
@@ -15,6 +15,7 @@ import org.ole.planet.myplanet.model.RealmSubmission.Companion.getNoOfSubmission
 import org.ole.planet.myplanet.model.RealmSubmission.Companion.getRecentSubmissionDate
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
 import org.ole.planet.myplanet.ui.survey.AdapterSurvey.ViewHolderSurvey
+import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 
 class AdapterSurvey(private val context: Context, private val examList: List<RealmStepExam>, private val mRealm: Realm, private val userId: String) : RecyclerView.Adapter<ViewHolderSurvey>() {
     private lateinit var rowSurveyBinding: RowSurveyBinding
@@ -46,8 +47,10 @@ class AdapterSurvey(private val context: Context, private val examList: List<Rea
             )
         val noOfSubmission = getNoOfSubmissionByUser(examList[position].id, userId, mRealm)
         val subDate = getRecentSubmissionDate(examList[position].id, userId, mRealm)
+        val createdDate = RealmStepExam.getSurveyCreationTime(examList[position].id!!, mRealm)
         rowSurveyBinding.tvNoSubmissions.text = noOfSubmission
-        rowSurveyBinding.tvDate.text = subDate
+        rowSurveyBinding.tvDateCompleted.text = subDate
+        rowSurveyBinding.tvDate.text = formatDate(createdDate!!, "MMM dd, yyyy")
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
@@ -3,17 +3,18 @@ package org.ole.planet.myplanet.ui.survey
 import android.os.Bundle
 import android.view.View
 import android.widget.AdapterView
-import android.widget.Spinner
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import io.realm.Sort
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.model.RealmStepExam
+import org.ole.planet.myplanet.utilities.CustomSpinner
 
 class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>() {
     private lateinit var addNewSurvey: FloatingActionButton
-    private lateinit var spn: Spinner
+    private lateinit var spn: CustomSpinner
+    private var isTitleAscending = true
     override fun getLayout(): Int {
         return R.layout.fragment_survey
     }
@@ -37,18 +38,36 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>() {
             override fun onItemSelected(adapterView: AdapterView<*>?, view: View?, i: Int, l: Long) {
                 if (view != null) {
                     if (i == 0) {
-                        recyclerView.adapter = activity?.let { act -> model?.id?.let { id -> AdapterSurvey(act, safeCastList(getList(RealmStepExam::class.java, "name", Sort.ASCENDING), RealmStepExam::class.java), mRealm, id) } }
+                        recyclerView.adapter = activity?.let { act -> model?.id?.let { id -> AdapterSurvey(act, safeCastList(getList(RealmStepExam::class.java, "createdDate", Sort.ASCENDING), RealmStepExam::class.java), mRealm, id) } }
+                    } else if (i == 1){
+                        recyclerView.adapter = activity?.let { act -> model?.id?.let { id -> AdapterSurvey(act, safeCastList(getList(RealmStepExam::class.java, "createdDate", Sort.DESCENDING), RealmStepExam::class.java), mRealm, id) } }
                     } else {
-                        recyclerView.adapter = activity?.let { act -> model?.id?.let { id -> AdapterSurvey(act, safeCastList(getList(RealmStepExam::class.java, "name", Sort.DESCENDING), RealmStepExam::class.java), mRealm, id) } }
+                        toggleTitleSortOrder()
                     }
                 }
             }
 
             override fun onNothingSelected(adapterView: AdapterView<*>?) {}
         }
+
+        spn.onSameItemSelected(object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(adapterView: AdapterView<*>?, view: View?, i: Int, l: Long) {
+                if (i == 2) {
+                    toggleTitleSortOrder()
+                }
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>?) {}
+        })
     }
 
     fun <T> safeCastList(items: List<Any?>, clazz: Class<T>): List<T> {
         return items.mapNotNull { it?.takeIf(clazz::isInstance)?.let(clazz::cast) }
+    }
+
+    fun toggleTitleSortOrder() {
+        isTitleAscending = !isTitleAscending
+        val sort = if (isTitleAscending) Sort.ASCENDING else Sort.DESCENDING
+        recyclerView.adapter = AdapterSurvey(requireActivity(), safeCastList(getList(RealmStepExam::class.java, "name", sort), RealmStepExam::class.java), mRealm, model?.id!!)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/CustomSpinner.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/CustomSpinner.kt
@@ -1,0 +1,18 @@
+package org.ole.planet.myplanet.utilities
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatSpinner
+
+class CustomSpinner(context: Context, attrs: AttributeSet?) : AppCompatSpinner(context, attrs) {
+    private var listener: OnItemSelectedListener? = null
+
+    override fun setSelection(position: Int) {
+        super.setSelection(position)
+        listener?.onItemSelected(null, null, position, 0)
+    }
+
+    fun onSameItemSelected(listener: OnItemSelectedListener) {
+        this.listener = listener
+    }
+}

--- a/app/src/main/res/layout/fragment_survey.xml
+++ b/app/src/main/res/layout/fragment_survey.xml
@@ -10,7 +10,7 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <Spinner
+        <org.ole.planet.myplanet.utilities.CustomSpinner
             android:id="@+id/spn_sort"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/row_survey.xml
+++ b/app/src/main/res/layout/row_survey.xml
@@ -28,7 +28,7 @@
                 android:textStyle="bold" />
 
             <TextView
-                android:id="@+id/tv_date"
+                android:id="@+id/tv_date_completed"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
@@ -50,16 +50,31 @@
             android:layout_height="wrap_content"
             android:padding="@dimen/padding_small">
 
-            <TextView
-                android:id="@+id/tv_no_submissions"
+            <LinearLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_weight="1"
-                android:padding="@dimen/padding_small"
-                android:textColor="@color/colorPrimary"
-                android:textSize="@dimen/text_size_mid"
-                android:textStyle="bold" />
+                android:layout_weight="2"
+                android:orientation="vertical"
+                android:padding="4dp">
+
+                <TextView
+                    android:id="@+id/tv_no_submissions"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:padding="@dimen/padding_normal"
+                    android:textColor="@color/colorPrimary"
+                    android:textSize="@dimen/text_size_mid"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/tv_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/padding_normal"
+                    android:textColor="@color/colorPrimary" />
+
+            </LinearLayout>
 
             <Button
                 android:id="@+id/send_survey"


### PR DESCRIPTION
fixes #3898 

By default, every time "Order By Title" is first selected it sorts A-Z, but when reselecting it again, it becomes Z-A. Also, sort by date options originally sorted by name. I changed this to sort by createdDate, but without the creation date showing, it can sometimes be confusing what date it is sorting by, especially if you have dates showing for completing the survey. What do you all think about showing the creation date (for example, Created on: ...)?