### PR TITLE
surveys: smoother check (fixes #3893)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1703
-        versionName "0.17.3"
+        versionCode 1709
+        versionName "0.17.9"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -96,7 +96,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         recyclerView.adapter = adapter
         if (isMyCourseLib && adapter.itemCount != 0 && courseLib == "courses") {
             resources?.let { showDownloadDialog(it) }
-        } else if (isMyCourseLib && courseLib == null) {
+        } else if (isMyCourseLib && courseLib == null && !isSurvey) {
             showDownloadDialog(getLibraryList(mRealm))
         }
         return v

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerParentFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerParentFragment.kt
@@ -73,4 +73,8 @@ abstract class BaseRecyclerParentFragment<LI> : BaseResourceFragment() {
         list.forEach { array.add(it) }
         return array
     }
+
+    companion object {
+        var isSurvey: Boolean = false
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.*
 import org.json.JSONException
 import org.json.JSONObject
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseRecyclerParentFragment
 import org.ole.planet.myplanet.databinding.FragmentHomeBellBinding
 import org.ole.planet.myplanet.model.RealmCertification
 import org.ole.planet.myplanet.model.RealmCourseProgress
@@ -202,7 +203,10 @@ class BellDashboardFragment : BaseDashboardFragment() {
         fragmentHomeBellBinding.homeCardCourses.myCoursesImageButton.setOnClickListener { openHelperFragment(CoursesFragment()) }
         fragmentHomeBellBinding.fabMyProgress.setOnClickListener { openHelperFragment(MyProgressFragment()) }
         fragmentHomeBellBinding.fabMyActivity.setOnClickListener { openHelperFragment(MyActivityFragment()) }
-        fragmentHomeBellBinding.fabSurvey.setOnClickListener { openHelperFragment(SurveyFragment()) }
+        fragmentHomeBellBinding.fabSurvey.setOnClickListener {
+            BaseRecyclerParentFragment.isSurvey = true
+            openHelperFragment(SurveyFragment())
+        }
         fragmentHomeBellBinding.cardProfileBell.fabFeedback.setOnClickListener { openHelperFragment(FeedbackListFragment()) }
         fragmentHomeBellBinding.homeCardMyLife.myLifeImageButton.setOnClickListener { homeItemClickListener?.openCallFragment(LifeFragment()) }
         fragmentHomeBellBinding.fabNotification.setOnClickListener { showNotificationFragment() }


### PR DESCRIPTION
fixes #3893 

when navigating to surveys from the home bell, a popup for myLibrary downloads would show

[Screen_recording_20240719_110536.webm](https://github.com/user-attachments/assets/0db45ce3-3a5b-409a-8ce2-9fc3966cb371)
