### PR TITLE
all: better non-activity context handling (fixes #3915)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1711
-        versionName "0.17.11"
+        versionCode 1715
+        versionName "0.17.15"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -213,7 +213,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
         mRealm.commitTransaction()
         val homeIntent = Intent(Intent.ACTION_MAIN)
         homeIntent.addCategory(Intent.CATEGORY_HOME)
-        homeIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+        homeIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(homeIntent)
     }
 


### PR DESCRIPTION
fixes #3915

this pr will prevent the AndroidRuntimeException from being thrown when you start the activity