### PR TITLE
resources: smoother video play management (fixes #3951)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1720
-        versionName "0.17.20"
+        versionCode 1726
+        versionName "0.17.26"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/VideoPlayerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/VideoPlayerActivity.kt
@@ -114,6 +114,16 @@ class VideoPlayerActivity : AppCompatActivity(), AuthSessionUpdater.AuthCallback
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        exoPlayer?.playWhenReady = true
+    }
+
+    override fun onPause() {
+        super.onPause()
+        exoPlayer?.playWhenReady = false
+    }
+
     override fun onStop() {
         super.onStop()
         releasePlayer()


### PR DESCRIPTION
fixes #3951
in this pr the onResume and onPause methods are added to manage the playback state. The video playback will pause when the activity is paused and resume when the activity is resumed. This ensures that the video doesn’t continue playing in the background when the activity is not in the foreground.