### PR TITLE
all: smoother arabic strings (fixes #4023)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1747
-        versionName "0.17.47"
+        versionCode 1754
+        versionName "0.17.54"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -116,7 +116,11 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
 
     private fun updateOfflineVisitsUI() {
         val offlineVisits = profileDbHandler.offlineVisits
-        view?.findViewById<TextView>(R.id.txtVisits)?.text = getString(R.string.offline_visits, offlineVisits)
+
+        if(offlineVisits in 3..10)
+            view?.findViewById<TextView>(R.id.txtVisits)?.text = getString(R.string.offline_visits, offlineVisits)
+        else
+            view?.findViewById<TextView>(R.id.txtVisits)?.text = getString(R.string.offline_visit, offlineVisits)
     }
 
     override fun forceDownloadNewsImages() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -116,11 +116,11 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
 
     private fun updateOfflineVisitsUI() {
         val offlineVisits = profileDbHandler.offlineVisits
-
-        if(offlineVisits in 3..10)
+        if (offlineVisits in 3..10) {
             view?.findViewById<TextView>(R.id.txtVisits)?.text = getString(R.string.offline_visits, offlineVisits)
-        else
+        } else {
             view?.findViewById<TextView>(R.id.txtVisits)?.text = getString(R.string.offline_visit, offlineVisits)
+        }
     }
 
     override fun forceDownloadNewsImages() {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1074,7 +1074,8 @@
     <string name="tag_selected">تم اختيار: %s</string>
     <string name="resources_size">الموارد [%d]</string>
     <string name="user_role">- %s</string>
-    <string name="offline_visits">%d زيارة</string>
+    <string name="offline_visit">%d زيارة</string>
+    <string name="offline_visits">%d زيارات</string>
     <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>
     <string name="three_strings">%1$s %2$s %3$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1074,6 +1074,7 @@
     <string name="tag_selected">Seleccionado: %s</string>
     <string name="resources_size">Recursos [%d]</string>
     <string name="user_role">- %s</string>
+    <string name="offline_visit">%d visita</string>
     <string name="offline_visits">%d visitas</string>
     <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1074,6 +1074,7 @@
     <string name="tag_selected">Sélectionné : %s</string>
     <string name="resources_size">Ressources [%d]</string>
     <string name="user_role">- %s</string>
+    <string name="offline_visit">%d visite</string>
     <string name="offline_visits">%d visites</string>
     <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -1074,6 +1074,7 @@
     <string name="tag_selected">%s छनोट गरिएको</string>
     <string name="resources_size">स्रोतहरू [%d]</string>
     <string name="user_role">- %s</string>
+    <string name="offline_visit">%d भ्रमण</string>
     <string name="offline_visits">%d भ्रमणहरू</string>
     <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -1074,6 +1074,7 @@
     <string name="tag_selected">Xulo: %s</string>
     <string name="resources_size">Xogta [%d]</string>
     <string name="user_role">- %s</string>
+    <string name="offline_visit">%d booqasho</string>
     <string name="offline_visits">%d booqasho</string>
     <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1072,6 +1072,7 @@
     <string name="tag_selected">Selected: %s</string>
     <string name="resources_size">Resources [%d]</string>
     <string name="user_role">- %s</string>
+    <string name="offline_visit">%d visit</string>
     <string name="offline_visits">%d visits</string>
     <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>


### PR DESCRIPTION
fixes #4023

Updated the word "زيارة" so it fits arabic standards:
- used as " زيارات" for number in range 3 to 10.

![زيارات](https://github.com/user-attachments/assets/b623bcab-29d8-4121-b68b-f25b2c148915)

- used as "زيارة" for the rest of the numbers

![زيارة](https://github.com/user-attachments/assets/d05b108b-d2df-463c-9945-026e44adb37d)