### PR TITLE
resources: smoother ratings dark mode (fixes #4223)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1852
-        versionName "0.18.52"
+        versionCode 1856
+        versionName "0.18.56"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/res/layout/row_course.xml
+++ b/app/src/main/res/layout/row_course.xml
@@ -123,7 +123,8 @@
                     android:isIndicator="true"
                     android:numStars="5"
                     android:stepSize="1"
-                    android:progressTint="@color/daynight_textColor" />
+                    android:progressTint="@color/daynight_textColor"
+                    android:progressBackgroundTint="@color/empty_rating"/>
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/layout/row_library.xml
+++ b/app/src/main/res/layout/row_library.xml
@@ -13,134 +13,127 @@
         android:orientation="vertical"
         android:layout_height="wrap_content">
 
-
-
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:orientation="horizontal"
-        android:layout_height="wrap_content">
-
-        <CheckBox
-            android:id="@+id/checkbox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center"
-            android:padding="@dimen/padding_large"
-            android:buttonTint="@color/daynight_textColor" />
-        <TextView
-            android:id="@+id/title"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="4dp"
-            android:textColor="@color/daynight_textColor"
-            android:textSize="@dimen/text_size_mid"
-            android:textStyle="bold" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/description"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:maxLines="2"
-                android:padding="4dp"
-                android:textColor="@color/daynight_textColor" />
-            <com.google.android.flexbox.FlexboxLayout
-                android:id="@+id/flexbox_drawable"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:alignContent="space_around"
-                app:alignItems="flex_start"
-                app:flexWrap="wrap"
-                app:showDivider="middle" />
-            <TextView
-                android:id="@+id/tv_date"
+            android:orientation="horizontal"
+            android:layout_height="wrap_content">
+    
+            <CheckBox
+                android:id="@+id/checkbox"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="@dimen/padding_normal"
-                android:textColor="@color/daynight_textColor" />
-        </LinearLayout>
-
-        <ImageView
-            android:id="@+id/iv_downloaded"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_margin="@dimen/padding_small" />
-        <LinearLayout
-            android:id="@+id/ll_rating"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center"
-            android:orientation="vertical"
-            android:padding="8dp">
-
-            <TextView
-                android:id="@+id/times_rated"
-                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:gravity="center"
-                android:padding="4dp"
-                android:text="@string/zero_total"
-                android:textColor="@color/daynight_textColor" />
-            <androidx.appcompat.widget.AppCompatRatingBar
-                android:id="@+id/rating_bar"
-                style="@style/Base.Widget.AppCompat.RatingBar.Small"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:focusable="false"
-                android:isIndicator="true"
-                android:numStars="5"
-                android:stepSize="1"
-                android:progressTint="@color/daynight_textColor"
-                android:progressBackgroundTint="@color/empty_rating"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center"
-            android:orientation="vertical"
-            android:padding="4dp">
-
+                android:padding="@dimen/padding_large"
+                android:buttonTint="@color/daynight_textColor" />
             <TextView
-                android:id="@+id/rating"
+                android:id="@+id/title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:gravity="center"
                 android:padding="4dp"
-                android:text="@string/zero_point_zero"
                 android:textColor="@color/daynight_textColor"
-                android:textSize="@dimen/text_size_large"
+                android:textSize="@dimen/text_size_mid"
                 android:textStyle="bold" />
-            <TextView
-                android:id="@+id/average"
-                android:layout_width="match_parent"
+        </LinearLayout>
+    
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+    
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+    
+                <TextView
+                    android:id="@+id/description"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="2"
+                    android:padding="4dp"
+                    android:textColor="@color/daynight_textColor" />
+                <com.google.android.flexbox.FlexboxLayout
+                    android:id="@+id/flexbox_drawable"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:alignContent="space_around"
+                    app:alignItems="flex_start"
+                    app:flexWrap="wrap"
+                    app:showDivider="middle" />
+                <TextView
+                    android:id="@+id/tv_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/padding_normal"
+                    android:textColor="@color/daynight_textColor" />
+            </LinearLayout>
+    
+            <ImageView
+                android:id="@+id/iv_downloaded"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:text="@string/average"
-                android:textColor="@color/daynight_textColor" />
+                android:layout_margin="@dimen/padding_small" />
+            <LinearLayout
+                android:id="@+id/ll_rating"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:padding="8dp">
+    
+                <TextView
+                    android:id="@+id/times_rated"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:padding="4dp"
+                    android:text="@string/zero_total"
+                    android:textColor="@color/daynight_textColor" />
+                <androidx.appcompat.widget.AppCompatRatingBar
+                    android:id="@+id/rating_bar"
+                    style="@style/Base.Widget.AppCompat.RatingBar.Small"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:focusable="false"
+                    android:isIndicator="true"
+                    android:numStars="5"
+                    android:stepSize="1"
+                    android:progressTint="@color/daynight_textColor"
+                    android:progressBackgroundTint="@color/empty_rating"/>
+            </LinearLayout>
+    
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:padding="4dp">
+    
+                <TextView
+                    android:id="@+id/rating"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:padding="4dp"
+                    android:text="@string/zero_point_zero"
+                    android:textColor="@color/daynight_textColor"
+                    android:textSize="@dimen/text_size_large"
+                    android:textStyle="bold" />
+                <TextView
+                    android:id="@+id/average"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/average"
+                    android:textColor="@color/daynight_textColor" />
+            </LinearLayout>
         </LinearLayout>
-    </LinearLayout>
-
-
-
-
     </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/row_library.xml
+++ b/app/src/main/res/layout/row_library.xml
@@ -13,29 +13,30 @@
         android:orientation="vertical"
         android:layout_height="wrap_content">
 
+
+
+
     <LinearLayout
         android:layout_width="match_parent"
         android:orientation="horizontal"
         android:layout_height="wrap_content">
 
-    <CheckBox
-        android:id="@+id/checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:padding="@dimen/padding_large"
-        android:buttonTint="@color/daynight_textColor" />
-
-    <TextView
-        android:id="@+id/title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="4dp"
-        android:textColor="@color/daynight_textColor"
-        android:textSize="@dimen/text_size_mid"
-        android:textStyle="bold" />
-
+        <CheckBox
+            android:id="@+id/checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:padding="@dimen/padding_large"
+            android:buttonTint="@color/daynight_textColor" />
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:textColor="@color/daynight_textColor"
+            android:textSize="@dimen/text_size_mid"
+            android:textStyle="bold" />
     </LinearLayout>
 
     <LinearLayout
@@ -56,7 +57,6 @@
                 android:maxLines="2"
                 android:padding="4dp"
                 android:textColor="@color/daynight_textColor" />
-
             <com.google.android.flexbox.FlexboxLayout
                 android:id="@+id/flexbox_drawable"
                 android:layout_width="match_parent"
@@ -65,14 +65,12 @@
                 app:alignItems="flex_start"
                 app:flexWrap="wrap"
                 app:showDivider="middle" />
-
             <TextView
                 android:id="@+id/tv_date"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:padding="@dimen/padding_normal"
                 android:textColor="@color/daynight_textColor" />
-
         </LinearLayout>
 
         <ImageView
@@ -81,7 +79,6 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_margin="@dimen/padding_small" />
-
         <LinearLayout
             android:id="@+id/ll_rating"
             android:layout_width="wrap_content"
@@ -100,7 +97,6 @@
                 android:padding="4dp"
                 android:text="@string/zero_total"
                 android:textColor="@color/daynight_textColor" />
-
             <androidx.appcompat.widget.AppCompatRatingBar
                 android:id="@+id/rating_bar"
                 style="@style/Base.Widget.AppCompat.RatingBar.Small"
@@ -133,7 +129,6 @@
                 android:textColor="@color/daynight_textColor"
                 android:textSize="@dimen/text_size_large"
                 android:textStyle="bold" />
-
             <TextView
                 android:id="@+id/average"
                 android:layout_width="match_parent"
@@ -141,11 +136,11 @@
                 android:layout_gravity="center"
                 android:text="@string/average"
                 android:textColor="@color/daynight_textColor" />
-
         </LinearLayout>
-
     </LinearLayout>
 
-    </LinearLayout>
 
+
+
+    </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/row_library.xml
+++ b/app/src/main/res/layout/row_library.xml
@@ -109,8 +109,9 @@
                 android:focusable="false"
                 android:isIndicator="true"
                 android:numStars="5"
-                android:stepSize="1" />
-
+                android:stepSize="1"
+                android:progressTint="@color/daynight_textColor"
+                android:progressBackgroundTint="@color/empty_rating"/>
         </LinearLayout>
 
         <LinearLayout

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -36,4 +36,5 @@
     <!-- changes logout button area background from white to whatever the background color for the drawer is.
     Without it, the drawer and logout button area are different colors -->
     <color name="material_drawer_background">@color/colorPrimary</color>
+    <color name="empty_rating">@color/md_white_1000</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -37,4 +37,5 @@
     Without it, the drawer and logout button area are different colors -->
     <color name="material_drawer_background">@color/colorPrimary</color>
     <color name="selected_color">#80B0E0E6</color>
+    <color name="empty_rating">@color/md_grey_500</color>
 </resources>


### PR DESCRIPTION
### Description

Added a new colour for empty ratings in dark and light mode.
Changed row_library to be consistent with row_course.


fixes-  #4223

### Output

![Courses Rating full](https://github.com/user-attachments/assets/93f2d1cd-6563-403d-b1e0-b78aebfbfea0)
![empty course rating](https://github.com/user-attachments/assets/5ce15084-a446-4a2e-91e0-c64f085c0895)
![Empty Rating Library](https://github.com/user-attachments/assets/79468ad9-6c6b-4daf-895b-fbbf82aac91d)
