### PR TITLE
dashboard: smoother close (fixes #4397)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1926
-        versionName "0.19.26"
+        versionCode 1933
+        versionName "0.19.33"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -214,14 +214,14 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                             toast(context, getString(R.string.press_back_again_to_exit))
                             Handler(Looper.getMainLooper()).postDelayed({ doubleBackToExitPressedOnce = false }, 2000)
                         } else {
+                            val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+                            if (fragment is BaseContainerFragment) {
+                                fragment.handleBackPressed()
+
+                            }
                             finish()
                         }
                     }
-                }
-
-                val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
-                if (fragment is BaseContainerFragment) {
-                    fragment.handleBackPressed()
                 }
             }
         })

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -217,7 +217,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                             val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
                             if (fragment is BaseContainerFragment) {
                                 fragment.handleBackPressed()
-
                             }
                             finish()
                         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
@@ -214,15 +214,16 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                             toast(context, getString(R.string.press_back_again_to_exit))
                             Handler(Looper.getMainLooper()).postDelayed({ doubleBackToExitPressedOnce = false }, 2000)
                         } else {
+                            val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+                            if (fragment is BaseContainerFragment) {
+                                fragment.handleBackPressed()
+
+                            }
                             finish()
                         }
                     }
                 }
 
-//                val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
-//                if (fragment is BaseContainerFragment) {
-//                    fragment.handleBackPressed()
-//                }
             }
         })
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
@@ -214,11 +214,10 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                             toast(context, getString(R.string.press_back_again_to_exit))
                             Handler(Looper.getMainLooper()).postDelayed({ doubleBackToExitPressedOnce = false }, 2000)
                         } else {
-                            val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
-                            if (fragment is BaseContainerFragment) {
-                                fragment.handleBackPressed()
-
-                            }
+                           // val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+                           // if (fragment is BaseContainerFragment) {
+                           //     fragment.handleBackPressed()
+                           //  }
                             finish()
                         }
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
@@ -214,10 +214,10 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                             toast(context, getString(R.string.press_back_again_to_exit))
                             Handler(Looper.getMainLooper()).postDelayed({ doubleBackToExitPressedOnce = false }, 2000)
                         } else {
-                           // val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
-                           // if (fragment is BaseContainerFragment) {
-                           //     fragment.handleBackPressed()
-                           //  }
+                            //val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+                            //if (fragment is BaseContainerFragment) {
+                            //    fragment.handleBackPressed()
+                            //}
                             finish()
                         }
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
@@ -214,10 +214,10 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                             toast(context, getString(R.string.press_back_again_to_exit))
                             Handler(Looper.getMainLooper()).postDelayed({ doubleBackToExitPressedOnce = false }, 2000)
                         } else {
-//                           val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
-//                           if (fragment is BaseContainerFragment) {
-//                               fragment.handleBackPressed()
-//                           }
+//                          val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+//                          if (fragment is BaseContainerFragment) {
+//                              fragment.handleBackPressed()
+//                          }
                             finish()
                         }
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
@@ -214,10 +214,10 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                             toast(context, getString(R.string.press_back_again_to_exit))
                             Handler(Looper.getMainLooper()).postDelayed({ doubleBackToExitPressedOnce = false }, 2000)
                         } else {
-//                          val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
-//                          if (fragment is BaseContainerFragment) {
-//                              fragment.handleBackPressed()
-//                          }
+//                           val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+//                           if (fragment is BaseContainerFragment) {
+//                               fragment.handleBackPressed()
+//                           }
                             finish()
                         }
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
@@ -214,10 +214,10 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                             toast(context, getString(R.string.press_back_again_to_exit))
                             Handler(Looper.getMainLooper()).postDelayed({ doubleBackToExitPressedOnce = false }, 2000)
                         } else {
-                            //val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
-                            //if (fragment is BaseContainerFragment) {
-                            //    fragment.handleBackPressed()
-                            //}
+//                          val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+//                          if (fragment is BaseContainerFragment) {
+//                              fragment.handleBackPressed()
+//                          }
                             finish()
                         }
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
@@ -222,7 +222,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                         }
                     }
                 }
-
             }
         })
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
@@ -214,10 +214,10 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                             toast(context, getString(R.string.press_back_again_to_exit))
                             Handler(Looper.getMainLooper()).postDelayed({ doubleBackToExitPressedOnce = false }, 2000)
                         } else {
-//                          val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
-//                          if (fragment is BaseContainerFragment) {
-//                              fragment.handleBackPressed()
-//                          }
+//                            val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+//                            if (fragment is BaseContainerFragment) {
+//                                fragment.handleBackPressed()
+//                            }
                             finish()
                         }
                     }


### PR DESCRIPTION
## Description

Moved the logic of Base Fragment stack pop after double back is pressed.  (fixes #4397)

### Root cause
- We were poping base fragment on single back press, which would clear the fragment stack displaying white screen.

## Demo


https://github.com/user-attachments/assets/489f783d-6afe-43de-a778-4b6bdfc8152d


