### PR TITLE
all: clickable survey notifications (fixes #4417)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1971
-        versionName "0.19.71"
+        versionCode 1975
+        versionName "0.19.75"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -106,7 +106,6 @@ class NotificationsFragment : Fragment() {
                 Log.d("NotificationsFragment", "storage clicked")
             }
             "survey" -> {
-                Log.d("NotificationsFragment", "survey clicked")
                 val currentStepExam = mRealm.where(RealmStepExam::class.java).equalTo("name", notification.relatedId)
                     .findFirst()
                 if(context is OnHomeItemClickListener) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -21,9 +21,11 @@ import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentNotificationsBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.resources.ResourcesFragment
+import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
 import org.ole.planet.myplanet.ui.team.TeamDetailFragment
 import java.util.ArrayList
 
@@ -101,10 +103,15 @@ class NotificationsFragment : Fragment() {
     private fun handleNotificationClick(notification: RealmNotification) {
         when (notification.type) {
             "storage" -> {
-                Log.d("ole2", "storage clicked")
+                Log.d("NotificationsFragment", "storage clicked")
             }
             "survey" -> {
-                Log.d("ole2", "survey clicked")
+                Log.d("NotificationsFragment", "survey clicked")
+                val currentStepExam = mRealm.where(RealmStepExam::class.java).equalTo("name", notification.relatedId)
+                    .findFirst()
+                if(context is OnHomeItemClickListener) {
+                    AdapterMySubmission.openSurvey(context as OnHomeItemClickListener, currentStepExam?.id, false)
+                }
             }
             "task" -> {
                 val taskId = notification.relatedId


### PR DESCRIPTION
## Description

-  fixes #4417
- Fetches RealmStepExam data based on the name of survey
- Opens a AdapterMySubmission for that particular stepExam id.

## Video

https://github.com/user-attachments/assets/8fc99ed6-8f92-4ed5-8425-2b6148800b3b

