### PR TITLE
all: smoother download (fixes #3955)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 1984
-        versionName "0.19.84"
+        versionCode 1997
+        versionName "0.19.97"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -174,6 +174,11 @@ abstract class BaseResourceFragment : Fragment() {
                 override fun isAvailable() {
                     if (urls.isNotEmpty()) {
                         prgDialog.show()
+                        if (urls.size>1){
+                            prgDialog.setPositiveButton("disabling", isVisible = false){
+                                prgDialog.dismiss()
+                            }
+                        }
                         Utilities.openDownloadService(activity, urls, false)
                     }
                 }
@@ -198,7 +203,12 @@ abstract class BaseResourceFragment : Fragment() {
         }
     }
 
-    open fun onDownloadComplete() {}
+    open fun onDownloadComplete() {
+        prgDialog.setPositiveButton("Finish", isVisible = true){
+            prgDialog.dismiss()
+        }
+    }
+
     fun createListView(dbMyLibrary: List<RealmMyLibrary?>, alertDialog: AlertDialog) {
         lv = convertView?.findViewById(R.id.alertDialog_listView)
         val names = ArrayList<String?>()

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -174,7 +174,6 @@ abstract class BaseResourceFragment : Fragment() {
                 override fun isAvailable() {
                     if (urls.isNotEmpty()) {
                         prgDialog.show()
-//                        prgDialog.setPositiveButton("disabling", isVisible = false){ prgDialog.dismiss() }
                         Utilities.openDownloadService(activity, urls, false)
                     }
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -174,11 +174,7 @@ abstract class BaseResourceFragment : Fragment() {
                 override fun isAvailable() {
                     if (urls.isNotEmpty()) {
                         prgDialog.show()
-                        if (urls.size>1){
-                            prgDialog.setPositiveButton("disabling", isVisible = false){
-                                prgDialog.dismiss()
-                            }
-                        }
+//                        prgDialog.setPositiveButton("disabling", isVisible = false){ prgDialog.dismiss() }
                         Utilities.openDownloadService(activity, urls, false)
                     }
                 }
@@ -207,6 +203,7 @@ abstract class BaseResourceFragment : Fragment() {
         prgDialog.setPositiveButton("Finish", isVisible = true){
             prgDialog.dismiss()
         }
+        prgDialog.setNegativeButton("disabling", isVisible = false){ prgDialog.dismiss() }
     }
 
     fun createListView(dbMyLibrary: List<RealmMyLibrary?>, alertDialog: AlertDialog) {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -25,9 +25,6 @@ object DialogUtils {
         val prgDialog = CustomProgressDialog(context)
         prgDialog.setTitle(context.getString(R.string.downloading_file))
         prgDialog.setMax(100)
-        prgDialog.setPositiveButton(context.getString(R.string.finish), isVisible = true) {
-            prgDialog.dismiss()
-        }
         prgDialog.setNegativeButton(context.getString(R.string.stop_download), isVisible = true) {
             context.stopService(Intent(context, MyDownloadService::class.java))
             prgDialog.dismiss()


### PR DESCRIPTION
Fix: #3955 

Case 1: more than 1 file to download - disable `Finish` button

https://github.com/user-attachments/assets/921ad77c-1eb0-4afa-8a62-9f1060866a1e

Case 2: only 1 file to download - `Finish` button visible 

https://github.com/user-attachments/assets/61d6b7dc-dcc2-4c6c-80bd-a32f1080fb25

