### PR TITLE
courses: smoother retake test (fixes #4532)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2008
-        versionName "0.20.8"
+        versionCode 2013
+        versionName "0.20.13"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.text.Spannable
 import android.text.method.LinkMovementMethod
 import android.text.style.URLSpan
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -133,9 +134,21 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
                     .notEqualTo("status", "pending", Case.INSENSITIVE).count()
             }
             if (questions != null && questions.size > 0) {
-                if (submissionsCount != null) {
-                    fragmentCourseStepBinding.btnTakeTest.text = if (submissionsCount > 0) { getString(R.string.retake_test, stepExams.size) } else { getString(R.string.take_test, stepExams.size) }
-                }
+                val examId=questions[0]?.examId
+
+                val isSubmitted = step.courseId?.let { courseId ->
+                    val parentId = "$examId@$courseId"
+                    Log.d("4532","CourseStepFragment:: step.courseId: "+step.courseId+"  examId: "+firstStepId+" find submission parent ID: "+parentId)
+
+                    cRealm.where(RealmSubmission::class.java)
+                        .equalTo("parentId", parentId)
+                        .equalTo("status", "complete", Case.INSENSITIVE)
+                        .equalTo("type", "exam")
+                        .findFirst() != null
+                } ?: false
+                Log.d("4532","CourseStepFragment:: Found submission?: "+isSubmitted)
+
+                fragmentCourseStepBinding.btnTakeTest.text = if (isSubmitted) { getString(R.string.retake_test, stepExams.size) } else { getString(R.string.take_test, stepExams.size) }
                 fragmentCourseStepBinding.btnTakeTest.visibility = View.VISIBLE
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -130,7 +130,7 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
             val firstStepId = stepExams[0].id
             val questions = cRealm.where(RealmExamQuestion::class.java).equalTo("examId", firstStepId).findAll()
             val submissionsCount = step.courseId?.let {
-                cRealm.where(RealmSubmission::class.java).contains("parentId", it)
+                cRealm.where(RealmSubmission::class.java).equalTo("userId",user?.id).contains("parentId", it)
                     .notEqualTo("status", "pending", Case.INSENSITIVE).count()
             }
             if (questions != null && questions.size > 0) {
@@ -138,19 +138,19 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
 
                 val isSubmitted = step.courseId?.let { courseId ->
                     val parentId = "$examId@$courseId"
-                    Log.d("4532","CourseStepFragment:: step.courseId: "+step.courseId+"  examId: "+firstStepId+" find submission parent ID: "+parentId)
+                    Log.d("CourseStepFragment"," step.courseId: "+step.courseId+"  examId: "+firstStepId+" find submission parent ID: "+parentId)
 
                     cRealm.where(RealmSubmission::class.java)
+                        .equalTo("userId",user?.id)
                         .equalTo("parentId", parentId)
-                        .equalTo("status", "complete", Case.INSENSITIVE)
                         .equalTo("type", "exam")
                         .findFirst() != null
                 } ?: false
-                Log.d("4532","CourseStepFragment:: Found submission?: "+isSubmitted)
+                Log.d("CourseStepFragment","Found submission?: "+isSubmitted+" , count: "+submissionsCount)
 
                 fragmentCourseStepBinding.btnTakeTest.text = if (isSubmitted) { getString(R.string.retake_test, stepExams.size) } else { getString(R.string.take_test, stepExams.size) }
                 fragmentCourseStepBinding.btnTakeTest.visibility = View.VISIBLE
-            }
+            };
         }
         if (stepSurvey.isNotEmpty()) {
             val firstStepId = stepSurvey[0].id

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.text.Spannable
 import android.text.method.LinkMovementMethod
 import android.text.style.URLSpan
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -138,19 +137,15 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
 
                 val isSubmitted = step.courseId?.let { courseId ->
                     val parentId = "$examId@$courseId"
-                    Log.d("CourseStepFragment"," step.courseId: "+step.courseId+"  examId: "+firstStepId+" find submission parent ID: "+parentId)
-
                     cRealm.where(RealmSubmission::class.java)
                         .equalTo("userId",user?.id)
                         .equalTo("parentId", parentId)
                         .equalTo("type", "exam")
                         .findFirst() != null
                 } ?: false
-                Log.d("CourseStepFragment","Found submission?: "+isSubmitted+" , count: "+submissionsCount)
-
                 fragmentCourseStepBinding.btnTakeTest.text = if (isSubmitted) { getString(R.string.retake_test, stepExams.size) } else { getString(R.string.take_test, stepExams.size) }
                 fragmentCourseStepBinding.btnTakeTest.visibility = View.VISIBLE
-            };
+            }
         }
         if (stepSurvey.isNotEmpty()) {
             val firstStepId = stepSurvey[0].id

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.ui.exam
 
 import android.os.Bundle
 import android.text.TextUtils
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -75,19 +76,22 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
     private fun createSubmission() {
         startTransaction()
         sub = createSubmission(sub, mRealm)
-        if (TextUtils.isEmpty(id)) {
+        if (!TextUtils.isEmpty(exam?.id)) {
             sub?.parentId = if (!TextUtils.isEmpty(exam?.courseId)) {
                 exam?.id + "@" + exam?.courseId
             } else {
                 exam?.id
             }
-        } else {
+        } else if(!TextUtils.isEmpty(id)){
             sub?.parentId = if (!TextUtils.isEmpty(exam?.courseId)) {
                 id + "@" + exam?.courseId
             } else {
                 id
             }
         }
+        Log.d("TakeExamFragment"," Id: "+id)
+
+        Log.d("TakeExamFragment"," submitting examId: "+exam?.id+"  , examCourseid: "+exam?.courseId+" == result "+sub?.parentId)
         sub?.userId = user?.id
         sub?.status = "pending"
         sub?.type = type

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.ui.exam
 
 import android.os.Bundle
 import android.text.TextUtils
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -89,9 +88,6 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
                 id
             }
         }
-        Log.d("TakeExamFragment"," Id: "+id)
-
-        Log.d("TakeExamFragment"," submitting examId: "+exam?.id+"  , examCourseid: "+exam?.courseId+" == result "+sub?.parentId)
         sub?.userId = user?.id
         sub?.status = "pending"
         sub?.type = type


### PR DESCRIPTION
## Description

- fixes #4532 

## Changes
 - Now for the button, we check if an entry from the current user exists with id of exam and course id
 - While submitting we priortize the use of examId+@+courseId  , instead of the earlier id + examId
 - All step exams have a course id and an exam id

## Video 

[Take, Retake Test.webm](https://github.com/user-attachments/assets/a33ab2d8-d262-4ede-9820-5a1b894bbae6)
