### PR TITLE
teams: smoother team edit dark mode (fixes #4665)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2038
-        versionName "0.20.38"
+        versionCode 2045
+        versionName "0.20.45"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/res/layout/alert_create_team.xml
+++ b/app/src/main/res/layout/alert_create_team.xml
@@ -16,7 +16,8 @@
             android:layout_height="match_parent"
             android:padding="@dimen/padding_normal"
             android:textColorHint="@color/hint_color"
-            android:textColor="@color/daynight_textColor" />
+            android:textColor="@color/daynight_textColor"
+            android:backgroundTint="@color/hint_color" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -30,7 +31,8 @@
             android:layout_height="match_parent"
             android:padding="@dimen/padding_normal"
             android:textColorHint="@color/hint_color"
-            android:textColor="@color/daynight_textColor" />
+            android:textColor="@color/daynight_textColor"
+            android:backgroundTint="@color/hint_color" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout


### PR DESCRIPTION
## Description

- fixes #4665
- added background color as hintColor 

## Screenshot

![image](https://github.com/user-attachments/assets/0878998c-b4fb-4dd1-858b-68a948b33227)
