### PR TITLE
teams: smoother list icons (fixes #4666)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2055
-        versionName "0.20.55"
+        versionCode 2056
+        versionName "0.20.56"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2051
-        versionName "0.20.51"
+        versionCode 2055
+        versionName "0.20.55"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/res/layout/item_team_list.xml
+++ b/app/src/main/res/layout/item_team_list.xml
@@ -53,18 +53,6 @@
         android:padding="8dp"
         android:src="@drawable/ic_join_request"
         app:layout_constraintEnd_toStartOf="@id/btn_feedback"
-        app:layout_constraintStart_toEndOf="@+id/no_of_visits"
-        app:layout_constraintTop_toTopOf="parent"
-        app:tint="@color/daynight_textColor" />
-    <ImageView
-        android:id="@+id/edit_team"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:layout_marginStart="8dp"
-        android:background="?attr/selectableItemBackground"
-        android:padding="8dp"
-        android:src="@drawable/ic_edit"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:tint="@color/daynight_textColor" />
     <ImageView
@@ -75,7 +63,7 @@
         android:background="?attr/selectableItemBackground"
         android:padding="8dp"
         android:src="@drawable/ic_feedback"
-        app:layout_constraintEnd_toStartOf="@id/edit_team"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:tint="@color/daynight_textColor" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Description

- fixes #4666 
- Combined edit team and waiting icon behavior.

## Video

[teamListAlignment.webm](https://github.com/user-attachments/assets/6ea6d06f-225c-43c9-96d4-e8cc2f6ed2fb)
