### PR TITLE
dashboard: truncate longer usernames (fixes #1859)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -102,7 +102,22 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
             .equalTo("type", KEY_LOGIN)
             .findAllAsync()
         v.findViewById<TextView>(R.id.txtRole).text = getString(R.string.user_role, model?.getRoleAsString())
-        v.findViewById<TextView>(R.id.txtFullName).text =getString(R.string.user_name, fullName, profileDbHandler.offlineVisits)
+        val truncatedName = if (!fullName.isNullOrEmpty()) {
+            if (fullName!!.length > 15) {
+                fullName!!.take(15) + ".."
+            } else {
+                fullName
+            }
+        } else {
+            "Unknown"
+        }
+
+        v.findViewById<TextView>(R.id.txtFullName).text = getString(
+            R.string.user_name,
+            truncatedName,
+            profileDbHandler.offlineVisits
+        )
+
     }
 
     override fun forceDownloadNewsImages() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -131,10 +131,25 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             val userProfileModel = profileDbHandler.userModel
             if (userProfileModel != null) {
                 var name: String? = userProfileModel.getFullName()
+
                 if (name.isNullOrBlank()) {
                     name = profileDbHandler.userModel?.name
                 }
-                activityDashboardBinding.appBarBell.appTitleName.text = getString(R.string.planet_name, name)
+
+                val truncatedName = if (!name.isNullOrBlank()) {
+                    if (name.length > 15) {
+                        name.take(15) + ".."
+                    } else {
+                        name
+                    }
+                } else {
+                    ""
+                }
+
+                activityDashboardBinding.appBarBell.appTitleName.text = getString(
+                    R.string.planet_name,
+                    truncatedName
+                )
             } else {
                 activityDashboardBinding.appBarBell.appTitleName.text = getString(R.string.app_project_name)
             }


### PR DESCRIPTION
## Description

- fixes #1859 
- added code to truncate long usernames

## Screenshots

![truncate username](https://github.com/user-attachments/assets/17c0e5f5-faf7-4dfb-861e-7ff795dbe96e)
