### PR TITLE
all: smoother surveys status (fixes #4757)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2089
-        versionName "0.20.89"
+        versionCode 2091
+        versionName "0.20.91"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -152,8 +152,9 @@ class BellDashboardFragment : BaseDashboardFragment() {
     private fun getSurveyTitlesFromSubmissions(submissions: List<RealmSubmission>, realm: Realm): List<String> {
         val titles = mutableListOf<String>()
         submissions.forEach { submission ->
+            val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
             val exam = realm.where(RealmStepExam::class.java)
-                .equalTo("id", submission.parentId)
+                .equalTo("id", examId)
                 .findFirst()
             exam?.name?.let { titles.add(it) }
         }


### PR DESCRIPTION
## Description

- fixes #4757
-  if submission id has stepexam id @ course id, I am extracting stepexam id from it to get the step exam object


## Screenshot

![fixed survey issue](https://github.com/user-attachments/assets/071d1fd7-08f2-4d55-af72-5479d8bd42d9)