### PR TITLE
myCourses: mandatory survey before course finish (fixes #4776) 

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -257,7 +257,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
             }
         }
 
-        if (hasUnfinishedSurvey && courseId == "9517e3b45a5bb63e69bb8f269216974d") {
+        if (hasUnfinishedSurvey){
             fragmentTakeCourseBinding.finishStep.setOnClickListener {
                 Toast.makeText(context, getString(R.string.please_complete_survey), Toast.LENGTH_SHORT).show() }
         } else {


### PR DESCRIPTION
## Description

- fixes #4776
- there was a hardcoded mandatory courseId check for enforcing survey before finish


## Screenshot

[withoutTakingSurveyFIX.webm](https://github.com/user-attachments/assets/323d2ed3-0593-4822-8554-a9145e20c54e)
