### PR TITLE
teams: smoother joining (fixes #4788)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2102
-        versionName "0.21.2"
+        versionCode 2103
+        versionName "0.21.3"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterMemberRequest.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterMemberRequest.kt
@@ -23,16 +23,25 @@ class AdapterMemberRequest(private val context: Context, private val list: Mutab
     }
 
     override fun onBindViewHolder(holder: ViewHolderUser, position: Int) {
-        rowMemberRequestBinding.tvName.text = list[position].name ?: list[position].toString()
+        val currentItem = list.getOrNull(position) ?: return
+        rowMemberRequestBinding.tvName.text = currentItem.name ?: currentItem.toString()
 
         if (isTeamLeader) {
             rowMemberRequestBinding.btnAccept.isEnabled = true
             rowMemberRequestBinding.btnReject.isEnabled = true
+
             rowMemberRequestBinding.btnAccept.setOnClickListener {
-                acceptReject(list[position], true, position)
+                val adapterPosition = holder.bindingAdapterPosition
+                if (adapterPosition != RecyclerView.NO_POSITION && adapterPosition < list.size) {
+                    acceptReject(list[adapterPosition], true, adapterPosition)
+                }
             }
+
             rowMemberRequestBinding.btnReject.setOnClickListener {
-                acceptReject(list[position], false, position)
+                val adapterPosition = holder.bindingAdapterPosition
+                if (adapterPosition != RecyclerView.NO_POSITION && adapterPosition < list.size) {
+                    acceptReject(list[adapterPosition], false, adapterPosition)
+                }
             }
         } else {
             rowMemberRequestBinding.btnAccept.isEnabled = false


### PR DESCRIPTION
## Description

- fixes #4788
- Previously the position element was being initialized on view Creation which would change the list size
- Now the position is fetched dynamically onClick instead of initializing at the onCreation.

## Screenshot

[Fixed crash of accept reject.webm](https://github.com/user-attachments/assets/f77417e8-7871-4b48-a58e-529f83096053)
