### PR TITLE
teams: smoother list (fixes #4949) 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2162
-        versionName "0.21.62"
+        versionCode 2172
+        versionName "0.21.72"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -199,8 +199,9 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                     .notEqualTo("status", "archived")
                     .contains("name", charSequence.toString(), Case.INSENSITIVE)
                 val (list, conditionApplied) = getList(query)
+                val sortedList = sortTeams(list)
                 val adapterTeamList = AdapterTeamList(
-                    activity as Context, list, mRealm, childFragmentManager
+                    activity as Context, sortedList, mRealm, childFragmentManager
                 )
                 adapterTeamList.setTeamListener(this@TeamFragment)
                 fragmentTeamBinding.rvTeamList.adapter = adapterTeamList
@@ -249,6 +250,17 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
         }
     }
 
+    private fun sortTeams(list: List<RealmMyTeam>): List<RealmMyTeam> {
+        val user = user?.id
+        return list.sortedWith(compareByDescending<RealmMyTeam> { team ->
+            when {
+                RealmMyTeam.isTeamLeader(team.teamId, user, mRealm) -> 3
+                team.isMyTeam(user, mRealm) -> 2
+                else -> 1
+            }
+        })
+    }
+
     override fun onEditTeam(team: RealmMyTeam?) {
         createTeamAlert(team!!)
     }
@@ -257,7 +269,8 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
         activity?.runOnUiThread {
             val query = mRealm.where(RealmMyTeam::class.java).isEmpty("teamId").notEqualTo("status", "archived")
             val (filteredList, conditionApplied) = getList(query)
-            val adapterTeamList = AdapterTeamList(activity as Context, filteredList, mRealm, childFragmentManager).apply {
+            val sortedList = sortTeams(filteredList)
+            val adapterTeamList = AdapterTeamList(activity as Context, sortedList, mRealm, childFragmentManager).apply {
                 setType(type)
                 setTeamListener(this@TeamFragment)
             }


### PR DESCRIPTION
## Description

- fixes #4949 
- teams list initially is sorted on creation
- on searching team name users team are also sorted



## Screenshot
![image](https://github.com/user-attachments/assets/cdc1e1d4-a0e0-497c-8fb1-e9e38d9d4aaf)
![image](https://github.com/user-attachments/assets/ad88a2f1-e3ac-4d58-86e9-8a91d5991a74)

