### PR TITLE
resources: smoother download dialog (fixes #4958)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2170
-        versionName "0.21.70"
+        versionCode 2173
+        versionName "0.21.73"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -98,19 +98,26 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     protected fun showDownloadDialog(dbMyLibrary: List<RealmMyLibrary?>) {
-        if (isAdded) {
-            Service(MainApplication.context).isPlanetAvailable(object : PlanetAvailableListener {
-                override fun isAvailable() {
-                    if (dbMyLibrary.isNotEmpty()) {
-                        if (!isAdded) {
-                            return
-                        }
-                        val inflater = activity?.layoutInflater
-                        val rootView = requireActivity().findViewById<ViewGroup>(android.R.id.content)
-                        convertView = inflater?.inflate(R.layout.my_library_alertdialog, rootView, false)
-                        val alertDialogBuilder = AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
-                        alertDialogBuilder.setView(convertView).setTitle(R.string.download_suggestion)
-                        alertDialogBuilder.setPositiveButton(R.string.download_selected) { _: DialogInterface?, _: Int ->
+        if (!isAdded) return
+        Service(MainApplication.context).isPlanetAvailable(object : PlanetAvailableListener {
+            override fun isAvailable() {
+                if (!isAdded) return
+                if (dbMyLibrary.isEmpty()) {
+                    activity?.let {
+                        Utilities.toast(it, getString(R.string.no_resources_to_download))
+                    }
+                    return
+                }
+
+                activity?.let { fragmentActivity ->
+                    val inflater = fragmentActivity.layoutInflater
+                    val rootView = fragmentActivity.findViewById<ViewGroup>(android.R.id.content)
+                    convertView = inflater.inflate(R.layout.my_library_alertdialog, rootView, false)
+
+                    val alertDialogBuilder = AlertDialog.Builder(fragmentActivity, R.style.AlertDialogTheme)
+                    alertDialogBuilder.setView(convertView)
+                        .setTitle(R.string.download_suggestion)
+                        .setPositiveButton(R.string.download_selected) { _: DialogInterface?, _: Int ->
                             lv?.selectedItemsList?.let {
                                 addToLibrary(dbMyLibrary, it)
                                 downloadFiles(dbMyLibrary, it)
@@ -121,23 +128,20 @@ abstract class BaseResourceFragment : Fragment() {
                             }
                             startDownload(downloadAllFiles(dbMyLibrary))
                         }.setNegativeButton(R.string.txt_cancel, null)
-                        val alertDialog = alertDialogBuilder.create()
-                        createListView(dbMyLibrary, alertDialog)
-                        alertDialog.show()
-                        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = (lv?.selectedItemsList?.size ?: 0) > 0
-                    } else {
-                        Utilities.toast(requireContext(), getString(R.string.no_resources_to_download))
-                    }
+                    val alertDialog = alertDialogBuilder.create()
+                    createListView(dbMyLibrary, alertDialog)
+                    alertDialog.show()
+                    alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = (lv?.selectedItemsList?.size ?: 0) > 0
                 }
+            }
 
-                override fun notAvailable() {
-                    if (!isAdded) {
-                        return
-                    }
-                    Utilities.toast(requireContext(), getString(R.string.planet_not_available))
+            override fun notAvailable() {
+                if (!isAdded) return
+                activity?.let {
+                    Utilities.toast(it, getString(R.string.planet_not_available))
                 }
-            })
-        }
+            }
+        })
     }
 
     fun showPendingSurveyDialog() {


### PR DESCRIPTION
fixes #4958
leveraged the Activity's context through activity reference instead of requireContext() to prevent crashes when context is not added