### PR TITLE
sync: smoother cloudcommunity mapping (fixes #5009)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2188
-        versionName "0.21.88"
+        versionCode 2193
+        versionName "0.21.93"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
fixes #5009
replaced the restrictive regular expression with a more robust and reliable method to extract the base URL using Uri.parse