### PR TITLE
teams: smoother finances default (fixes #5007)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2199
-        versionName "0.21.99"
+        versionCode 2203
+        versionName "0.22.3"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
@@ -53,7 +53,6 @@ class FinanceFragment : BaseTeamFragment() {
         list = fRealm.where(RealmMyTeam::class.java).notEqualTo("status", "archived")
             .equalTo("teamId", teamId).equalTo("docType", "transaction")
             .sort("date", Sort.DESCENDING).findAllAsync()
-
         list?.addChangeListener { results ->
             updatedFinanceList(results)
         }
@@ -191,11 +190,19 @@ class FinanceFragment : BaseTeamFragment() {
 
     private fun updatedFinanceList(results: RealmResults<RealmMyTeam>) {
         activity?.runOnUiThread {
-            adapterFinance = AdapterFinance(requireActivity(), results)
-            fragmentFinanceBinding.rvFinance.layoutManager = LinearLayoutManager(activity)
-            fragmentFinanceBinding.rvFinance.adapter = adapterFinance
-            adapterFinance?.notifyDataSetChanged()
-            calculateTotal(results)
+            if (!results.isEmpty()) {
+                adapterFinance = AdapterFinance(requireActivity(), results)
+                fragmentFinanceBinding.rvFinance.layoutManager = LinearLayoutManager(activity)
+                fragmentFinanceBinding.rvFinance.adapter = adapterFinance
+                adapterFinance?.notifyDataSetChanged()
+                calculateTotal(results)
+            } else {
+                fragmentFinanceBinding.rvFinance.adapter = null
+                fragmentFinanceBinding.dataLayout.visibility= View.GONE
+                fragmentFinanceBinding.tvNodata.visibility= View.VISIBLE
+
+            }
         }
     }
+
 }

--- a/app/src/main/res/layout/fragment_finance.xml
+++ b/app/src/main/res/layout/fragment_finance.xml
@@ -7,6 +7,7 @@
     tools:context=".ui.enterprises.FinanceFragment">
 
     <LinearLayout
+        android:id="@+id/data_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">

--- a/app/src/main/res/layout/fragment_finance.xml
+++ b/app/src/main/res/layout/fragment_finance.xml
@@ -105,7 +105,6 @@
                 android:textColor="@color/daynight_textColor"
                 android:textSize="@dimen/text_size_mid"
                 android:textStyle="bold" />
-
             <TextView
                 android:id="@+id/credit"
                 android:layout_width="0dp"
@@ -116,7 +115,6 @@
                 android:textColor="@color/daynight_textColor"
                 android:textSize="@dimen/text_size_mid"
                 android:textStyle="bold" />
-
             <TextView
                 android:id="@+id/debit"
                 android:layout_width="0dp"
@@ -127,8 +125,6 @@
                 android:textColor="@color/daynight_textColor"
                 android:textSize="@dimen/text_size_mid"
                 android:textStyle="bold" />
-
-
             <TextView
                 android:id="@+id/balance"
                 android:layout_width="0dp"


### PR DESCRIPTION
## Description
- fixes #5007
- hiding filter elementds when no data
- visible no data message



## Screenshot

![image](https://github.com/user-attachments/assets/28be9f3e-ce26-4dcc-b025-d7c081e5502d)
