### PR TITLE
mySubmissions: smother search (fixes #5023)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/submission/MySubmissionFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submission/MySubmissionFragment.kt
@@ -104,11 +104,12 @@ class MySubmissionFragment : Fragment(), CompoundButton.OnCheckedChangeListener 
 
         val adapter = AdapterMySubmission(requireActivity(), submissions, exams)
         val itemCount = adapter.itemCount
-        showNoData(fragmentMySubmissionBinding.tvMessage, itemCount, "submission")
-
-        if (itemCount == 0) {
-            fragmentMySubmissionBinding.llSearch.visibility = View.GONE
-            fragmentMySubmissionBinding.title.visibility = View.GONE
+        if(s.isNullOrEmpty()){
+            showNoData(fragmentMySubmissionBinding.tvMessage, itemCount, "submission")
+                if (itemCount == 0) {
+                fragmentMySubmissionBinding.llSearch.visibility = View.GONE
+                fragmentMySubmissionBinding.title.visibility = View.GONE
+            }
         }
         adapter.setmRealm(mRealm)
         adapter.setType(type)


### PR DESCRIPTION
## Description

- fixes #5023
- distinguish between initial no data and search no data.

## Test

- On app start navigate to mySubmissions, if you have none (NO Data) will be shown without the search bar
- Now go to Github course and submit the test
- Now you will see the data
- Now search for a dummy submission which is not present. 
- The search bar still remains invluding other elements of the submission

## Screenshot

![image](https://github.com/user-attachments/assets/103d3937-f6a0-4afe-9d19-587a8ae6cf97)
