### PR TITLE
chat: smoother share note dark mode (fixes #5119)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2233
-        versionName "0.22.33"
+        versionCode 2242
+        versionName "0.22.42"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
@@ -196,7 +196,7 @@ class ChatHistoryListAdapter(var context: Context, private var chatHistory: List
 
     private fun showEditTextAndShareButton(team: RealmMyTeam? = null, section: String, chatHistory: RealmChatHistory) {
         val addNoteDialogBinding = AddNoteDialogBinding.inflate(LayoutInflater.from(context))
-        val builder = AlertDialog.Builder(context)
+        val builder = AlertDialog.Builder(context,  R.style.AlertDialogTheme)
         builder.setView(addNoteDialogBinding.root)
         builder.setPositiveButton(context.getString(R.string.share_chat)) { dialog, _ ->
             val serializedConversations = chatHistory.conversations?.map { serializeConversation(it) }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
@@ -196,7 +196,7 @@ class ChatHistoryListAdapter(var context: Context, private var chatHistory: List
 
     private fun showEditTextAndShareButton(team: RealmMyTeam? = null, section: String, chatHistory: RealmChatHistory) {
         val addNoteDialogBinding = AddNoteDialogBinding.inflate(LayoutInflater.from(context))
-        val builder = AlertDialog.Builder(context,  R.style.AlertDialogTheme)
+        val builder = AlertDialog.Builder(context, R.style.AlertDialogTheme)
         builder.setView(addNoteDialogBinding.root)
         builder.setPositiveButton(context.getString(R.string.share_chat)) { dialog, _ ->
             val serializedConversations = chatHistory.conversations?.map { serializeConversation(it) }

--- a/app/src/main/res/layout/add_note_dialog.xml
+++ b/app/src/main/res/layout/add_note_dialog.xml
@@ -10,6 +10,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:inputType="textMultiLine"
-        android:hint="@string/add_note" />
+        android:hint="@string/add_note"
+        android:textColor="@color/daynight_textColor"
+        android:textColorHint="@color/hint_color"
+        android:backgroundTint="@color/hint_color"
+        />
 
 </LinearLayout>

--- a/app/src/main/res/layout/add_note_dialog.xml
+++ b/app/src/main/res/layout/add_note_dialog.xml
@@ -13,7 +13,6 @@
         android:hint="@string/add_note"
         android:textColor="@color/daynight_textColor"
         android:textColorHint="@color/hint_color"
-        android:backgroundTint="@color/hint_color"
-        />
+        android:backgroundTint="@color/hint_color" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/add_note_dialog.xml
+++ b/app/src/main/res/layout/add_note_dialog.xml
@@ -14,5 +14,4 @@
         android:textColor="@color/daynight_textColor"
         android:textColorHint="@color/hint_color"
         android:backgroundTint="@color/hint_color" />
-
 </LinearLayout>


### PR DESCRIPTION
fixes #5119 

<img width="321" alt="Screenshot 2025-01-24 at 4 53 50 PM" src="https://github.com/user-attachments/assets/a7c38505-7c61-4001-a40e-0a307b6ff505" />
<img width="321" alt="Screenshot 2025-01-24 at 4 52 14 PM" src="https://github.com/user-attachments/assets/b56cbb2d-752c-4c15-b98d-dce9aa7faaa8" />
