### PR TITLE
dashboard: smoother survey reminder cancel (fixes #5132)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2240
-        versionName "0.22.40"
+        versionCode 2253
+        versionName "0.22.53"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -18,6 +19,7 @@ import androidx.recyclerview.widget.RecyclerView
 import io.realm.Case
 import io.realm.Realm
 import kotlinx.coroutines.*
+import org.ole.planet.myplanet.MainApplication.Companion.mRealm
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentHomeBellBinding
 import org.ole.planet.myplanet.model.RealmCertification
@@ -129,8 +131,12 @@ class BellDashboardFragment : BaseDashboardFragment() {
             val alertDialog = AlertDialog.Builder(requireActivity(), R.style.AlertDialogTheme)
                 .setTitle(getString(R.string.surveys_to_complete, pendingSurveys.size, if (pendingSurveys.size > 1) "surveys" else "survey"))
                 .setView(dialogView)
-                .setPositiveButton(getString(R.string.ok)) { dialog, _ ->
+                //.setPositiveButton(getString(R.string.ok)) { dialog, _ ->
+                .setPositiveButton(getString(R.string.survey_ok)) { dialog, _ ->
                     homeItemClickListener?.openCallFragment(MySubmissionFragment.newInstance("survey"))
+                    dialog.dismiss()
+                }
+                .setNegativeButton(getString(R.string.survey_cancel)) { dialog, _->
                     dialog.dismiss()
                 }
                 .create()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -19,7 +18,6 @@ import androidx.recyclerview.widget.RecyclerView
 import io.realm.Case
 import io.realm.Realm
 import kotlinx.coroutines.*
-import org.ole.planet.myplanet.MainApplication.Companion.mRealm
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentHomeBellBinding
 import org.ole.planet.myplanet.model.RealmCertification

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -131,12 +131,11 @@ class BellDashboardFragment : BaseDashboardFragment() {
             val alertDialog = AlertDialog.Builder(requireActivity(), R.style.AlertDialogTheme)
                 .setTitle(getString(R.string.surveys_to_complete, pendingSurveys.size, if (pendingSurveys.size > 1) "surveys" else "survey"))
                 .setView(dialogView)
-                //.setPositiveButton(getString(R.string.ok)) { dialog, _ ->
-                .setPositiveButton(getString(R.string.survey_ok)) { dialog, _ ->
+                .setPositiveButton(getString(R.string.ok)) { dialog, _ ->
                     homeItemClickListener?.openCallFragment(MySubmissionFragment.newInstance("survey"))
                     dialog.dismiss()
                 }
-                .setNegativeButton(getString(R.string.survey_cancel)) { dialog, _->
+                .setNegativeButton(getString(R.string.cancel)) { dialog, _->
                     dialog.dismiss()
                 }
                 .create()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1226,5 +1226,7 @@
     <string name="local_resource">local resource</string>
     <string name="no_survey_submissions">no survey submissions</string>
     <string name="no_exam_submissions">no exam submissions</string>
+    <string name="survey_ok" translatable="false">OK</string>
+    <string name="survey_cancel" translatable="false">Cancel</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1226,7 +1226,5 @@
     <string name="local_resource">local resource</string>
     <string name="no_survey_submissions">no survey submissions</string>
     <string name="no_exam_submissions">no exam submissions</string>
-    <string name="survey_ok" translatable="false">OK</string>
-    <string name="survey_cancel" translatable="false">Cancel</string>
 
 </resources>


### PR DESCRIPTION
#5132 
Add CANCEL button in survey dialog next to OK button
<img width="256" alt="Screenshot 2025-01-27 at 2 30 48 PM" src="https://github.com/user-attachments/assets/0760b527-4e6f-427a-8ae5-e1ddf921718f" />
