### PR TITLE
enterprises: smoother csv export (fixes #5142)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2246
-        versionName "0.22.46"
+        versionCode 2256
+        versionName "0.22.56"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
@@ -239,14 +239,11 @@ class ReportsFragment : BaseTeamFragment() {
             fragmentReportsBinding.rvReports.layoutManager = LinearLayoutManager(activity)
             fragmentReportsBinding.rvReports.adapter = adapterReports
             adapterReports.notifyDataSetChanged()
-
             //check if the list is empty
-            if(results.isEmpty()) {
+            if (results.isEmpty()) {
                 //if the list is empty, makes the EXPORT CSV invisible
                 fragmentReportsBinding.exportCSV.visibility = View.GONE
-                Toast.makeText(requireContext(),"The list is empty", Toast.LENGTH_SHORT).show()
-            }
-            else {
+            } else {
                 fragmentReportsBinding.exportCSV.visibility = View.VISIBLE
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
@@ -8,7 +8,6 @@ import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
@@ -8,6 +8,7 @@ import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
@@ -238,6 +239,16 @@ class ReportsFragment : BaseTeamFragment() {
             fragmentReportsBinding.rvReports.layoutManager = LinearLayoutManager(activity)
             fragmentReportsBinding.rvReports.adapter = adapterReports
             adapterReports.notifyDataSetChanged()
+
+            //check if the list is empty
+            if(results.isEmpty()) {
+                //if the list is empty, makes the EXPORT CSV invisible
+                fragmentReportsBinding.exportCSV.visibility = View.GONE
+                Toast.makeText(requireContext(),"The list is empty", Toast.LENGTH_SHORT).show()
+            }
+            else {
+                fragmentReportsBinding.exportCSV.visibility = View.VISIBLE
+            }
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
@@ -238,9 +238,8 @@ class ReportsFragment : BaseTeamFragment() {
             fragmentReportsBinding.rvReports.layoutManager = LinearLayoutManager(activity)
             fragmentReportsBinding.rvReports.adapter = adapterReports
             adapterReports.notifyDataSetChanged()
-            //check if the list is empty
+
             if (results.isEmpty()) {
-                //if the list is empty, makes the EXPORT CSV invisible
                 fragmentReportsBinding.exportCSV.visibility = View.GONE
             } else {
                 fragmentReportsBinding.exportCSV.visibility = View.VISIBLE


### PR DESCRIPTION
fixes #5142 
hide the export csv button when the list is empty. 
<img width="323" alt="Screenshot 2025-01-28 at 2 43 36 PM" src="https://github.com/user-attachments/assets/76231ef5-e2ea-4cf3-a24d-fefe1e5f50ca" />
<img width="315" alt="Screenshot 2025-01-28 at 2 44 47 PM" src="https://github.com/user-attachments/assets/f9602307-2e4b-4280-ab6d-4d008dd31ec8" />

https://github.com/user-attachments/assets/a5708f4d-3acc-4ea2-874e-5c39aca5e5c4

