### PR TITLE
login: smoother voices bottom drawer (fixes #5169)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2257
-        versionName "0.22.57"
+        versionCode 2290
+        versionName "0.22.90"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.tabs.TabLayoutMediator
 import org.ole.planet.myplanet.R
@@ -16,6 +17,7 @@ import java.util.Date
 
 class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
     private lateinit var fragmentTeamDetailBinding: FragmentTeamDetailBinding
+    private var bottomSheetBehavior: BottomSheetBehavior<View>? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentTeamDetailBinding = FragmentTeamDetailBinding.inflate(inflater, container, false)
@@ -24,7 +26,27 @@ class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initCommunityTab()
+         view.post {
+            val parent = view.parent as View
+            bottomSheetBehavior = BottomSheetBehavior.from(parent)
+
+            bottomSheetBehavior?.isFitToContents = false
+            bottomSheetBehavior?.peekHeight = BottomSheetBehavior.PEEK_HEIGHT_AUTO
+            bottomSheetBehavior?.state = BottomSheetBehavior.STATE_COLLAPSED
+
+            parent.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
+            parent.layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
+
+        }
+                initCommunityTab()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.let { d ->
+            val bottomSheet = d.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+            bottomSheet?.layoutParams?.height = ViewGroup.LayoutParams.WRAP_CONTENT
+        }
     }
 
     private fun initCommunityTab() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
@@ -26,26 +26,51 @@ class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-         view.post {
+        view.post {
             val parent = view.parent as View
             bottomSheetBehavior = BottomSheetBehavior.from(parent)
 
             bottomSheetBehavior?.isFitToContents = false
-            bottomSheetBehavior?.peekHeight = BottomSheetBehavior.PEEK_HEIGHT_AUTO
+            bottomSheetBehavior?.peekHeight = resources.displayMetrics.heightPixels / 7
+
             bottomSheetBehavior?.state = BottomSheetBehavior.STATE_COLLAPSED
+            bottomSheetBehavior?.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
+                override fun onStateChanged(bottomSheet: View, newState: Int) {
 
-            parent.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
-            parent.layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
+                    when (newState) {
+                        BottomSheetBehavior.STATE_HIDDEN -> {
+                            dismiss()
+                        }
+                    }
+                }
 
+                override fun onSlide(bottomSheet: View, slideOffset: Float) {
+                    val screenHeight = resources.displayMetrics.heightPixels
+                    val newHeight = (screenHeight * (0.25f + (0.75f * slideOffset))).toInt()
+
+                    bottomSheet.layoutParams.height = newHeight
+                    bottomSheet.requestLayout()
+
+                    when {
+                        slideOffset > 0.5f -> bottomSheetBehavior?.state = BottomSheetBehavior.STATE_EXPANDED
+                        slideOffset > 0.2f -> bottomSheetBehavior?.state = BottomSheetBehavior.STATE_HALF_EXPANDED
+                        slideOffset < -0.3f -> bottomSheetBehavior?.state = BottomSheetBehavior.STATE_HIDDEN
+                    }
+                }
+            })
         }
-                initCommunityTab()
+
+        initCommunityTab()
     }
 
     override fun onStart() {
         super.onStart()
         dialog?.let { d ->
             val bottomSheet = d.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
-            bottomSheet?.layoutParams?.height = ViewGroup.LayoutParams.WRAP_CONTENT
+            bottomSheet?.let {
+                it.layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT
+                it.requestLayout()
+            }
         }
     }
 

--- a/app/src/main/res/layout/fragment_news.xml
+++ b/app/src/main/res/layout/fragment_news.xml
@@ -95,7 +95,7 @@
             android:visibility="gone" />
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="0dp"
             android:layout_weight="1">
 
             <androidx.recyclerview.widget.RecyclerView
@@ -105,11 +105,11 @@
                 android:padding="@dimen/padding_normal" />
             <TextView
                 android:id="@+id/tv_message"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:gravity="center"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:textColor="@color/daynight_textColor"
-                android:textAlignment="center"/>
+                android:gravity="center" />
         </FrameLayout>
     </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_news.xml
+++ b/app/src/main/res/layout/fragment_news.xml
@@ -95,7 +95,7 @@
             android:visibility="gone" />
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
+            android:layout_height="match_parent"
             android:layout_weight="1">
 
             <androidx.recyclerview.widget.RecyclerView
@@ -105,10 +105,11 @@
                 android:padding="@dimen/padding_normal" />
             <TextView
                 android:id="@+id/tv_message"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:textColor="@color/daynight_textColor" />
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:textColor="@color/daynight_textColor"
+                android:textAlignment="center"/>
         </FrameLayout>
     </LinearLayout>
 </FrameLayout>


### PR DESCRIPTION
## Description

- fixes #5169
- implemented bottom sheet as to override its default implementation to block the scrollable on smaller screens


## Testing
- Test community  bottom sheet with / without sync
- Testing community section 

## Screenshot
- device: pixel , size: 5' , api: 35

[small screen community.webm](https://github.com/user-attachments/assets/0413dce9-cada-4a6b-84ea-a10d8ed97650)


- device size: 6.6 inch screen

[bottom sheet behaviour.webm](https://github.com/user-attachments/assets/3bf76163-d61e-49ac-920c-b8f020d00753)


