### PR TITLE
teams: smoother chat share dark mode (fixes #5281)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2301
-        versionName "0.23.1"
+        versionCode 2302
+        versionName "0.23.2"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
@@ -30,6 +30,7 @@ import org.ole.planet.myplanet.ui.news.ExpandableListAdapter
 import org.ole.planet.myplanet.ui.news.GrandChildAdapter
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment.Companion.settings
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
+import org.osmdroid.views.overlay.gridlines.LatLonGridlineOverlay.backgroundColor
 import java.util.Date
 
 class ChatHistoryListAdapter(var context: Context, private var chatHistory: List<RealmChatHistory>, private val fragment: ChatHistoryListFragment) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -185,12 +186,13 @@ class ChatHistoryListAdapter(var context: Context, private var chatHistory: List
         grandChildDialogBinding.recyclerView.layoutManager = LinearLayoutManager(context)
         grandChildDialogBinding.recyclerView.adapter = grandChildAdapter
 
-        val builder = AlertDialog.Builder(context)
+        val builder = AlertDialog.Builder(context,R.style.CustomAlertDialog)
         builder.setView(grandChildDialogBinding.root)
         builder.setPositiveButton(context.getString(R.string.close)) { _, _ ->
             dialog?.dismiss()
         }
         dialog = builder.create()
+        dialog.window?.setBackgroundDrawable(ColorDrawable(backgroundColor))
         dialog.show()
     }
 

--- a/app/src/main/res/layout/expandable_list_grand_child_item.xml
+++ b/app/src/main/res/layout/expandable_list_grand_child_item.xml
@@ -13,5 +13,4 @@
         android:textSize="16sp"
         android:paddingBottom="10dp"
         android:textColor="@color/daynight_textColor" />
-
 </LinearLayout>

--- a/app/src/main/res/layout/expandable_list_grand_child_item.xml
+++ b/app/src/main/res/layout/expandable_list_grand_child_item.xml
@@ -12,6 +12,6 @@
         android:layout_marginStart="10dp"
         android:textSize="16sp"
         android:paddingBottom="10dp"
-        android:textColor="@color/md_black_1000" />
+        android:textColor="@color/daynight_textColor" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/grand_child_recyclerview_dialog.xml
+++ b/app/src/main/res/layout/grand_child_recyclerview_dialog.xml
@@ -11,7 +11,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
         android:layout_marginTop="10dp"
-        android:textColor="@color/md_black_1000"
+        android:textColor="@color/daynight_textColor"
         android:textSize="16sp"
         android:textStyle="bold" />
 


### PR DESCRIPTION
fixes #5281 
<img width="236" alt="team-darkMode" src="https://github.com/user-attachments/assets/c02421a0-cf72-497f-b94a-c0f52a8528b6" />
<img width="235" alt="enterprise-darkMode" src="https://github.com/user-attachments/assets/81656ec6-13c4-4a0d-8261-fdf272e90cd4" />
