### PR TITLE
teams: smoother selections (fixes #5298)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2308
-        versionName "0.23.8"
+        versionCode 2312
+        versionName "0.23.12"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmOfflineActivity
-import org.ole.planet.myplanet.model.RealmOfflineActivity.Companion.getRecentLogin
 import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
@@ -46,7 +45,19 @@ class UserProfileDbHandler(context: Context) {
     }
 
     fun onLogin() {
+        if (mRealm.isClosed) {
+            mRealm = realmService.realmInstance
+        }
+
         if (!mRealm.isInTransaction) {
+            mRealm.beginTransaction()
+        } else {
+            try {
+                mRealm.commitTransaction()
+            } catch (e: Exception) {
+                e.printStackTrace()
+                mRealm.cancelTransaction()
+            }
             mRealm.beginTransaction()
         }
         try {
@@ -68,7 +79,7 @@ class UserProfileDbHandler(context: Context) {
             val realm = realmService.realmInstance
             try {
                 realm.executeTransaction {
-                    val offlineActivities = getRecentLogin(it)
+                    val offlineActivities = RealmOfflineActivity.getRecentLogin(it)
                     offlineActivities?.logoutTime = Date().time
                 }
             } finally {


### PR DESCRIPTION
fixes #5298
This pr ensures realm instance is always available during team selection realm transactions