### PR TITLE
sync: smoother error handling (fixes #5300)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2308
-        versionName "0.23.8"
+        versionCode 2314
+        versionName "0.23.14"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -76,7 +76,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
         val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         lateinit var defaultPref: SharedPreferences
 
-        fun createLog(type: String) {
+        fun createLog(type: String, error: String) {
             runBlocking {
                 withContext(Dispatchers.IO) {
                     val realm = Realm.getDefaultInstance()
@@ -92,7 +92,12 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                             log.time = "${Date().time}"
                             log.page = ""
                             log.version = getVersionName(context)
-                            log.type = type
+                            if (type == "File Not Found") {
+                                log.type = type
+                                log.error = error
+                            } else {
+                                log.type = type
+                            }
                         }
                     } catch (e: Exception) {
                         e.printStackTrace()
@@ -335,7 +340,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
             isFirstLaunch = false
         } else {
             applicationScope.launch {
-                createLog("foreground")
+                createLog("foreground", "")
             }
         }
     }
@@ -344,7 +349,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
 
     private fun onAppStarted() {
         applicationScope.launch {
-            createLog("new login")
+            createLog("new login", "")
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -446,7 +446,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                 syncIconDrawable.selectDrawable(0)
                 syncIcon.invalidateDrawable(syncIconDrawable)
                 MainApplication.applicationScope.launch {
-                    createLog("synced successfully")
+                    createLog("synced successfully", "")
                 }
                 showSnack(findViewById(android.R.id.content), getString(R.string.sync_completed))
                 if (settings.getBoolean("isAlternativeUrl", false)) {


### PR DESCRIPTION
fixes #5300
this pr does not show file not found error for downloads triggered during sync and also creates log with of the file with the error