### PR TITLE
sync: smoother realm threads (fixes #5307)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2314
-        versionName "0.23.14"
+        versionCode 2316
+        versionName "0.23.16"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -210,7 +210,7 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             }
             setUpLanguageButton()
             if (NetworkUtils.isNetworkConnected) {
-                service.syncPlanetServers(mRealm) { success: String? ->
+                service.syncPlanetServers { success: String? ->
                     toast(this, success)
                 }
             }


### PR DESCRIPTION
fixes #5307

pr resolves issue by
- Opening a new Realm instance on the background thread
- Close it after the transaction completes
- Ensure the callback is posted on the main thread