### PR TITLE
myLife: not allow empty string (fixes #5263)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddExaminationActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddExaminationActivity.kt
@@ -160,7 +160,11 @@ class AddExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedChan
         activityAddExaminationBinding.containerOtherDiagnosis.removeAllViews()
         val chipCloud = ChipCloud(this, activityAddExaminationBinding.containerOtherDiagnosis, config)
         for (s in customDiag?: emptySet()) {
-            chipCloud.addChip(s)
+            if (s.isNullOrBlank()) {
+                    continue
+            } else {
+                    chipCloud.addChip(s)
+            }
         }
         chipCloud.setDeleteListener { _: Int, s1: String? -> customDiag?.remove(s1) }
         preloadCustomDiagnosis(chipCloud)


### PR DESCRIPTION
fixes #5263 

Not allow empty string on myHealth -> ADD EXAMINATION -> Other Diagnosis