### PR TITLE
sync: smoother downloads execution (fixes #5318)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2317
-        versionName "0.23.17"
+        versionCode 2324
+        versionName "0.23.24"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
@@ -73,7 +73,7 @@ class MyDownloadService : Service() {
         val retrofitInterface = ApiClient.client?.create(ApiInterface::class.java)
         try {
             request = retrofitInterface?.downloadFile(header, url)
-            val response = request?.execute()
+            val response = request?.clone()?.execute()
 
             when {
                 response == null -> {


### PR DESCRIPTION
fixes #5318
this was a stacktrace during the sync where we have some downloads in the background so you can initiate a sync and check logcat if you see the log, also test if you are able to download a resource in courses and resources