### PR TITLE
teams: smoother search (fixes #5479)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2384
-        versionName "0.23.84"
+        versionCode 2386
+        versionName "0.23.86"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -199,6 +199,10 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
         fragmentTeamBinding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
             override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {
+                if (TextUtils.isEmpty(charSequence)) {
+                    updatedTeamList()
+                    return
+                }
                 val query = mRealm.where(RealmMyTeam::class.java).isEmpty("teamId")
                     .notEqualTo("status", "archived")
                     .contains("name", charSequence.toString(), Case.INSENSITIVE)


### PR DESCRIPTION
fixes #5479 

initial ordering is preserved after the text in the search bar is cleared 


https://github.com/user-attachments/assets/7d57f2ad-2fe7-4713-943e-b6e6c1dd4b72

