### PR TITLE
teams: smoother survey order title (fixes #5478)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2384
-        versionName "0.23.84"
+        versionCode 2388
+        versionName "0.23.88"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
@@ -63,15 +63,11 @@ class AdapterSurvey(private val context: Context, private val mRealm: Realm, pri
     }
 
     private fun SortSurveyListByName(isAscend: Boolean){
-        val list = examList.toList()
-        Collections.sort(list) { survey1, survey2 ->
-            if (isAscend) {
-                survey1?.name!!.compareTo(survey2?.name!!)
-            } else {
-                survey2?.name!!.compareTo(survey1?.name!!)
-            }
+        examList = if (isAscend) {
+            examList.sortedBy { it.name?.lowercase() }
+        } else {
+            examList.sortedByDescending { it.name?.lowercase() }
         }
-        examList = list
     }
 
     fun toggleTitleSortOrder() {


### PR DESCRIPTION
fixes #5478 

survey order by title was case sensitive all the survey's with lowercase were shown at the end of the list.


<img width="251" alt="Screenshot 2025-03-17 at 1 36 40 PM" src="https://github.com/user-attachments/assets/51e845bf-b5ce-49fe-af72-aa688c5fa352" />
