### PR TITLE
chat: smoother search dark mode (fixes #5499)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2386
-        versionName "0.23.86"
+        versionCode 2389
+        versionName "0.23.89"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/res/layout/fragment_chat_history_list.xml
+++ b/app/src/main/res/layout/fragment_chat_history_list.xml
@@ -50,7 +50,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
                     android:text="@string/full_conversation_response"
-                    android:textSize="17sp"/>
+                    android:textSize="17sp"
                     android:textColor="@color/hint_color"
                     android:buttonTint="@color/hint_color"/>
                 <com.google.android.material.button.MaterialButtonToggleGroup


### PR DESCRIPTION
Changes the checkbox and text to lighter color in dark mode.
Note*: This issue got fixed before and it happened again.
fixes #5499 

<img width="276" alt="Screenshot 2025-03-18 at 12 51 35 PM" src="https://github.com/user-attachments/assets/d05758b7-2c96-433b-9c57-cc0923a39949" />
