### PR TITLE
survey: show text area for `other` option in survey questions (fixes #5604)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
@@ -31,6 +31,7 @@ import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 import java.util.Arrays
 import java.util.Date
 import java.util.Locale
+import androidx.core.view.isVisible
 
 class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButton.OnCheckedChangeListener, ImageCaptureCallback {
     private lateinit var fragmentTakeExamBinding: FragmentTakeExamBinding
@@ -172,6 +173,11 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
         rdBtn.isChecked = choice == oldAnswer
         rdBtn.setOnCheckedChangeListener(this)
         fragmentTakeExamBinding.groupChoices.addView(rdBtn)
+
+        if (choice.equals("Other", ignoreCase = true) && choice == oldAnswer) {
+            fragmentTakeExamBinding.etAnswer.visibility = View.VISIBLE
+            fragmentTakeExamBinding.etAnswer.setText(oldAnswer)
+        }
     }
 
     private fun addCompoundButton(choice: JsonObject?, isRadio: Boolean, oldAnswer: String) {
@@ -222,7 +228,8 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
     }
 
     private fun showTextInput(type: String?) {
-        if (type.equals("input", ignoreCase = true) || type.equals("textarea", ignoreCase = true)) {
+        if (type.equals("input", ignoreCase = true) || type.equals("textarea", ignoreCase = true) ||
+            (fragmentTakeExamBinding.etAnswer.isVisible)) {
             ans = fragmentTakeExamBinding.etAnswer.text.toString()
         }
     }
@@ -306,8 +313,18 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
         mRealm.close()
     }
 
-    override fun onCheckedChanged(compoundButton: CompoundButton, b: Boolean) {
-        if (b) {
+    override fun onCheckedChanged(compoundButton: CompoundButton, isChecked: Boolean) {
+        if (isChecked) {
+            val selectedText = "${compoundButton.text}"
+
+            if (selectedText.equals("Other", ignoreCase = true)) {
+                fragmentTakeExamBinding.etAnswer.visibility = View.VISIBLE
+                fragmentTakeExamBinding.etAnswer.requestFocus()
+            } else {
+                fragmentTakeExamBinding.etAnswer.visibility = View.GONE
+                fragmentTakeExamBinding.etAnswer.text.clear()
+            }
+
             addAnswer(compoundButton)
         } else if (compoundButton.tag != null) {
             listAns?.remove("${compoundButton.text}")


### PR DESCRIPTION
fixes #5604

https://github.com/user-attachments/assets/8ebce12c-80fb-4edf-9272-6ad119b1a3f2

