### PR TITLE
sync: smoother caching (fixes #5676)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2450
-        versionName "0.24.50"
+        versionCode 2460
+        versionName "0.24.60"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
fixes #5676
uses a serverAvailabilityCache (ConcurrentHashMap) to store server availability status with timestamps and checks if there's a cached result less than 30 seconds old before making a network request which helps reduce network overhead

Users get faster responses when the cache is valid, rather than waiting for network calls every time