### PR TITLE
teams: smoother members priority sorting (fixes #5686)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2452
-        versionName "0.24.52"
+        versionCode 2461
+        versionName "0.24.61"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
fixes #5686
Priority groups:

1. User is team leader first
2. User is team member second
3: User is not a member

all groups sub sorting with descending numver of visits
[Screen_recording_20250415_144955.webm](https://github.com/user-attachments/assets/90087097-4f42-440c-a7ff-cadfe4d6a9f9)
