### PR TITLE
enterprises: smoother remove inaccurate placeholder in finance (fixes #5685)

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -342,7 +342,7 @@
     <string name="mission"><![CDATA[Mission et Services]]></string>
     <string name="team">Équipes</string>
     <string name="applicants">Candidats</string>
-    <string name="finances">Finances</string>
+    <string name="finances">Finance</string>
     <string name="messages">messages</string>
     <string name="nodata">Aucune donnée disponible</string>
     <string name="note">Note *</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -342,7 +342,7 @@
     <string name="mission"><![CDATA[Mission & Adeegyada]]></string>
     <string name="team">Kooxaha</string>
     <string name="applicants">Loo baahan yahay</string>
-    <string name="finances">Maaliyadda</string>
+    <string name="finances">Maaliyad</string>
     <string name="messages">Fariimaha</string>
     <string name="nodata">Wax ma jirin</string>
     <string name="note">Fariin *</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,7 +342,7 @@
     <string name="mission"><![CDATA[Mission & Services]]></string>
     <string name="team">Teams</string>
     <string name="applicants">Applicants</string>
-    <string name="finances">Finances</string>
+    <string name="finances">Finance</string>
     <string name="messages">messages</string>
     <string name="nodata">No data available</string>
     <string name="note">Note *</string>


### PR DESCRIPTION
fixes #5685 

es, ar, and ne are already have a right word.

<img width="211" alt="Screenshot 2025-04-15 at 12 33 55 PM" src="https://github.com/user-attachments/assets/8760a686-1873-4b21-9014-a152aedf8121" />
