### PR TITLE
resources: smoother recording audio permissions (fixes #5702)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2464
-        versionName "0.24.64"
+        versionCode 2479
+        versionName "0.24.79"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -93,16 +93,16 @@ class AddResourceFragment : BottomSheetDialogFragment() {
             } else {
                 if (!shouldShowRequestPermissionRationale(Manifest.permission.RECORD_AUDIO)) {
                     AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
-                        .setTitle("Permission Required")
-                        .setMessage("Microphone permission is required to record audio. Please enable it in the app settings.")
-                        .setPositiveButton("Settings") { dialog, _ ->
+                        .setTitle(R.string.permission_required)
+                        .setMessage(R.string.microphone_permission_required)
+                        .setPositiveButton(R.string.settings) { dialog, _ ->
                             dialog.dismiss()
                             val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
                             val uri: Uri = Uri.fromParts("package", requireContext().packageName, null)
                             intent.data = uri
                             startActivity(intent)
                         }
-                        .setNegativeButton("Cancel") { dialog, _ -> dialog.dismiss() }
+                        .setNegativeButton(R.string.cancel) { dialog, _ -> dialog.dismiss() }
                         .show()
                 } else {
                     Utilities.toast(requireContext(), "Microphone permission is required to record audio.")
@@ -165,11 +165,11 @@ class AddResourceFragment : BottomSheetDialogFragment() {
                     AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
                         .setTitle("Permission Needed")
                         .setMessage("This app needs microphone permission to record audio.")
-                        .setPositiveButton("OK") { rationaleDialog, _ ->
+                        .setPositiveButton(R.string.ok) { rationaleDialog, _ ->
                             rationaleDialog.dismiss()
                             requestPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
                         }
-                        .setNegativeButton("Cancel") { rationaleDialog, _ ->
+                        .setNegativeButton(R.string.cancel) { rationaleDialog, _ ->
                             rationaleDialog.dismiss()
                         }
                         .show()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -92,7 +92,7 @@ class AddResourceFragment : BottomSheetDialogFragment() {
                 }
             } else {
                 if (!shouldShowRequestPermissionRationale(Manifest.permission.RECORD_AUDIO)) {
-                    AlertDialog.Builder(requireContext())
+                    AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
                         .setTitle("Permission Required")
                         .setMessage("Microphone permission is required to record audio. Please enable it in the app settings.")
                         .setPositiveButton("Settings") { dialog, _ ->
@@ -162,7 +162,7 @@ class AddResourceFragment : BottomSheetDialogFragment() {
                 != PackageManager.PERMISSION_GRANTED
             ) {
                 if (shouldShowRequestPermissionRationale(Manifest.permission.RECORD_AUDIO)) {
-                    AlertDialog.Builder(requireContext())
+                    AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
                         .setTitle("Permission Needed")
                         .setMessage("This app needs microphone permission to record audio.")
                         .setPositiveButton("OK") { rationaleDialog, _ ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -1,17 +1,19 @@
 package org.ole.planet.myplanet.ui.resources
 
+import android.Manifest
 import android.app.Dialog
 import android.content.ContentValues
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.database.Cursor
-import android.graphics.drawable.ColorDrawable
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.provider.MediaStore
+import android.provider.Settings
 import android.text.TextUtils
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -57,6 +59,7 @@ class AddResourceFragment : BottomSheetDialogFragment() {
     private lateinit var captureImageLauncher: ActivityResultLauncher<Uri>
     private lateinit var captureVideoLauncher: ActivityResultLauncher<Uri>
     private lateinit var openFolderLauncher: ActivityResultLauncher<String>
+    private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
@@ -80,6 +83,30 @@ class AddResourceFragment : BottomSheetDialogFragment() {
                 startIntent(uri, REQUEST_FILE_SELECTION)
             } else {
                 Utilities.toast(activity, "no file selected")
+            }
+        }
+        requestPermissionLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                if (!audioRecorderService?.isRecording()!!) {
+                    audioRecorderService?.startRecording()
+                }
+            } else {
+                if (!shouldShowRequestPermissionRationale(Manifest.permission.RECORD_AUDIO)) {
+                    AlertDialog.Builder(requireContext())
+                        .setTitle("Permission Required")
+                        .setMessage("Microphone permission is required to record audio. Please enable it in the app settings.")
+                        .setPositiveButton("Settings") { dialog, _ ->
+                            dialog.dismiss()
+                            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                            val uri: Uri = Uri.fromParts("package", requireContext().packageName, null)
+                            intent.data = uri
+                            startActivity(intent)
+                        }
+                        .setNegativeButton("Cancel") { dialog, _ -> dialog.dismiss() }
+                        .show()
+                } else {
+                    Utilities.toast(requireContext(), "Microphone permission is required to record audio.")
+                }
             }
         }
     }
@@ -131,10 +158,30 @@ class AddResourceFragment : BottomSheetDialogFragment() {
 
         createAudioRecorderService(dialog)
         alertSoundRecorderBinding.fabRecord.setOnClickListener {
-            if (!audioRecorderService?.isRecording()!!) {
-                audioRecorderService?.startRecording()
+            if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.RECORD_AUDIO)
+                != PackageManager.PERMISSION_GRANTED
+            ) {
+                if (shouldShowRequestPermissionRationale(Manifest.permission.RECORD_AUDIO)) {
+                    AlertDialog.Builder(requireContext())
+                        .setTitle("Permission Needed")
+                        .setMessage("This app needs microphone permission to record audio.")
+                        .setPositiveButton("OK") { rationaleDialog, _ ->
+                            rationaleDialog.dismiss()
+                            requestPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                        }
+                        .setNegativeButton("Cancel") { rationaleDialog, _ ->
+                            rationaleDialog.dismiss()
+                        }
+                        .show()
+                } else {
+                    requestPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                }
             } else {
-                audioRecorderService?.stopRecording()
+                if (!audioRecorderService?.isRecording()!!) {
+                    audioRecorderService?.startRecording()
+                } else {
+                    audioRecorderService?.stopRecording()
+                }
             }
         }
         dialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.dismiss)) { _: DialogInterface?, _: Int ->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1269,5 +1269,7 @@
     <string name="none">لا شيء</string>
     <string name="your_health_data_will_appear_here_as_you_continue_tracking_it">ستظهر بيانات صحتك هنا مع استمرارك في تتبعها</string>
     <string name="no_health_records_available">لا توجد سجلات صحية متاحة</string>
+    <string name="permission_required">مطلوب إذن</string>
+    <string name="microphone_permission_required">يلزم الحصول على إذن الميكروفون لتسجيل الصوت. يُرجى تفعيله من إعدادات التطبيق</string>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1269,5 +1269,7 @@
     <string name="none">Ninguno</string>
     <string name="your_health_data_will_appear_here_as_you_continue_tracking_it">Sus datos de salud aparecerán aquí a medida que continúe registrándolos</string>
     <string name="no_health_records_available">No hay registros de salud disponibles</string>
+    <string name="permission_required">Se requiere permiso</string>
+    <string name="microphone_permission_required">Se requiere permiso del micrófono para grabar audio. Actívalo en la configuración de la aplicación.</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1269,5 +1269,7 @@
     <string name="none">Aucun</string>
     <string name="your_health_data_will_appear_here_as_you_continue_tracking_it">Vos données de santé apparaîtront ici au fur et à mesure que vous continuez à les suivre</string>
     <string name="no_health_records_available">Aucun dossier de santé disponible</string>
+    <string name="permission_required">Autorisation requise</string>
+    <string name="microphone_permission_required">L\'autorisation du microphone est requise pour l\'enregistrement audio. Veuillez l'activer dans les paramètres de l\'application.</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1270,6 +1270,6 @@
     <string name="your_health_data_will_appear_here_as_you_continue_tracking_it">Vos données de santé apparaîtront ici au fur et à mesure que vous continuez à les suivre</string>
     <string name="no_health_records_available">Aucun dossier de santé disponible</string>
     <string name="permission_required">Autorisation requise</string>
-    <string name="microphone_permission_required">L\'autorisation du microphone est requise pour l\'enregistrement audio. Veuillez l'activer dans les paramètres de l\'application.</string>
+    <string name="microphone_permission_required">L\'autorisation du microphone est requise pour l\'enregistrement audio. Veuillez l\'activer dans les paramètres de l\'application.</string>
 
 </resources>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -1269,5 +1269,7 @@
     <string name="none">कुनै पनि होइन</string>
     <string name="your_health_data_will_appear_here_as_you_continue_tracking_it">तपाईंले ट्र्याकिङ जारी राख्दा तपाईंको स्वास्थ्य डेटा यहाँ देखिनेछ</string>
     <string name="no_health_records_available">कुनै स्वास्थ्य रेकर्ड उपलब्ध छैन</string>
+    <string name="permission_required">अनुमति आवश्यक छ</string>
+    <string name="microphone_permission_required">अडियो रेकर्ड गर्न माइक्रोफोन अनुमति आवश्यक छ। कृपया एप सेटिङहरूमा गई यसलाई सक्षम पार्नुहोस्।</string>
 
 </resources>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -1269,5 +1269,7 @@
     <string name="none">Midna</string>
     <string name="your_health_data_will_appear_here_as_you_continue_tracking_it">Xogtaada caafimaadka waxay halkan ka muuqan doontaa markaad sii waddo la socodka</string>
     <string name="no_health_records_available">Ma jiraan diiwaanada caafimaadka ee la heli karo</string>
+    <string name="permission_required">Ogolaanshaha ayaa loo baahan yahay</string>
+    <string name="microphone_permission_required">Ogolaanshaha makarafoonka ayaa loo baahan yahay si loo duubo codka Fadlan awood u geli goobaha abka</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1269,5 +1269,6 @@
     <string name="none">None</string>
     <string name="your_health_data_will_appear_here_as_you_continue_tracking_it">Your health data will appear here as you continue tracking it</string>
     <string name="no_health_records_available">No health records available</string>
-
+    <string name="permission_required">Permission Required</string>
+    <string name="microphone_permission_required">Microphone permission is required to record audio. Please enable it in the app settings.</string>
 </resources>


### PR DESCRIPTION
fixes #5702


the app was crashing if the user previously declined the audio permission and than tried to create the audio resource.
Now if the user has denied the permission before, they would be negvigated to the settings where they can change the permissions.

https://github.com/user-attachments/assets/926d01ee-afaa-4158-949f-db652ee1d886

