### PR TITLE
teams: smoother calendar event creation (fixes #5652)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2503
-        versionName "0.25.3"
+        versionCode 2515
+        versionName "0.25.15"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamCalendarFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamCalendarFragment.kt
@@ -84,14 +84,14 @@ class TeamCalendarFragment : BaseTeamFragment() {
                 Utilities.toast(activity, getString(R.string.title_is_required))
             } else if (description.isEmpty()) {
                 Utilities.toast(activity, getString(R.string.description_is_required))
-            } else if (!link.isValidWebLink()) {
+            } else if (!link.isValidWebLink() && link.isNotEmpty()) {
                 Utilities.toast(activity, getString(R.string.invalid_url))
             } else {
-                println(link.isValidWebLink())
                 try {
                     if (!mRealm.isInTransaction) {
                         mRealm.beginTransaction()
                     }
+                    val defaultPlaceholder = getString(R.string.click_here_to_pick_time)
                     val meetup = mRealm.createObject(RealmMeetup::class.java, "${UUID.randomUUID()}")
                     meetup.title = title
                     meetup.meetupLink = link
@@ -100,8 +100,16 @@ class TeamCalendarFragment : BaseTeamFragment() {
                     meetup.creator = user?.name
                     meetup.startDate = start.timeInMillis
                     meetup.endDate = end.timeInMillis
-                    meetup.endTime = "${addMeetupBinding.tvEndTime.text}"
-                    meetup.startTime = "${addMeetupBinding.tvStartTime.text}"
+                    if (addMeetupBinding.tvStartTime.text == defaultPlaceholder) {
+                        meetup.startTime = ""
+                    } else {
+                        meetup.startTime = "${addMeetupBinding.tvStartTime.text}"
+                    }
+                    if (addMeetupBinding.tvEndTime.text == defaultPlaceholder) {
+                        meetup.endTime = ""
+                    } else {
+                        meetup.endTime = "${addMeetupBinding.tvEndTime.text}"
+                    }
                     meetup.createdDate = System.currentTimeMillis()
                     meetup.sourcePlanet = team?.teamPlanetCode
                     val jo = JsonObject()


### PR DESCRIPTION
fixes #5652 

before this pr the empty start and end time for event created on myplanet had wrong placeholders for planet.

<img width="937" alt="Screenshot 2025-04-30 at 3 48 34 PM" src="https://github.com/user-attachments/assets/da264809-f24d-49ab-88a3-3a0aaff1c890" />
