### PR TITLE
teams: smoother survey navigation (fixes #5831)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2525
-        versionName "0.25.25"
+        versionCode 2530
+        versionName "0.25.30"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
@@ -193,22 +193,6 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
         return false
     }
 
-    fun createAnswer(answerList: RealmList<RealmAnswer>?): RealmAnswer? {
-        var list = answerList
-        if (list == null) {
-            list = RealmList()
-        }
-        val answer: RealmAnswer? = if (list.size > currentIndex) {
-            list[currentIndex]
-        } else {
-            mRealm.createObject(
-                RealmAnswer::class.java,
-                UUID.randomUUID().toString()
-            )
-        }
-        return answer
-    }
-
     fun addAnswer(compoundButton: CompoundButton) {
         val btnText = compoundButton.text.toString()
         val btnId = compoundButton.tag?.toString() ?: ""

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
@@ -10,8 +10,10 @@ import android.text.TextUtils
 import android.text.TextWatcher
 import android.view.Gravity
 import android.view.View
+import android.widget.CheckBox
 import android.widget.CompoundButton
 import android.widget.EditText
+import android.widget.RadioButton
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
@@ -208,10 +210,13 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
     }
 
     fun addAnswer(compoundButton: CompoundButton) {
-        if (compoundButton.tag != null) {
-            listAns?.set(compoundButton.text.toString() + "", compoundButton.tag.toString() + "")
-        } else {
-            ans = compoundButton.text.toString() + ""
+        val btnText = compoundButton.text.toString()
+        val btnId = compoundButton.tag?.toString() ?: ""
+
+        if (compoundButton is RadioButton) {
+            ans = btnId
+        } else if (compoundButton is CheckBox) {
+            listAns?.put(btnText, btnId)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
@@ -24,11 +24,9 @@ import io.noties.markwon.Markwon
 import io.noties.markwon.editor.MarkwonEditor
 import io.noties.markwon.editor.MarkwonEditorTextWatcher
 import io.realm.Realm
-import io.realm.RealmList
 import io.realm.RealmResults
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmExamQuestion
 import org.ole.planet.myplanet.model.RealmStepExam

--- a/app/src/main/res/layout/fragment_take_exam.xml
+++ b/app/src/main/res/layout/fragment_take_exam.xml
@@ -44,7 +44,6 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
                         app:tint="@color/md_black_1000" />
-
                     <TextView
                         android:id="@+id/tv_question_count"
                         android:layout_width="wrap_content"
@@ -61,7 +60,6 @@
                         app:layout_constraintEnd_toStartOf="@+id/btnNext"
                         app:layout_constraintStart_toEndOf="@+id/btnBack"
                         app:layout_constraintTop_toTopOf="parent" />
-
                     <ImageButton
                         android:id="@+id/btnNext"
                         style="@style/YellowButtons"
@@ -78,9 +76,7 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
                         app:tint="@color/md_black_1000" />
-
                 </androidx.constraintlayout.widget.ConstraintLayout>
-
 
                 <androidx.core.widget.NestedScrollView
                     android:id="@+id/container"
@@ -109,7 +105,6 @@
                                 android:layout_gravity="center"
                                 android:textColor="@color/daynight_textColor"
                                 android:textSize="18sp" />
-
                             <TextView
                                 android:id="@+id/tv_body"
                                 android:layout_width="match_parent"
@@ -126,7 +121,6 @@
                             android:layout_gravity="center_vertical"
                             android:orientation="vertical"
                             android:visibility="gone" />
-
                         <LinearLayout
                             android:id="@+id/ll_checkbox"
                             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_take_exam.xml
+++ b/app/src/main/res/layout/fragment_take_exam.xml
@@ -23,19 +23,64 @@
                 android:layout_height="match_parent"
                 android:orientation="vertical">
 
-                <TextView
-                    android:id="@+id/tv_question_count"
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize"
-                    android:layout_gravity="center"
-                    android:background="@color/colorPrimary"
-                    android:gravity="center_vertical"
-                    android:padding="@dimen/padding_normal"
-                    android:text="@string/step"
-                    android:textAllCaps="true"
-                    android:textColor="@color/md_white_1000"
-                    android:textSize="@dimen/text_size_mid"
-                    android:textStyle="bold" />
+                    android:layout_height="wrap_content"
+                    android:background="@color/colorPrimary">
+
+                    <ImageButton
+                        android:id="@+id/btnBack"
+                        style="@style/YellowButtons"
+                        android:layout_width="@dimen/_50dp"
+                        android:layout_height="@dimen/_50dp"
+                        android:layout_gravity="center_vertical"
+                        android:background="@drawable/buttonyellow"
+                        android:contentDescription="@string/btn_back"
+                        android:padding="8dp"
+                        android:src="@drawable/ic_left_arrow"
+                        android:text="@string/btn_back"
+                        android:visibility="gone"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:tint="@color/md_black_1000" />
+
+                    <TextView
+                        android:id="@+id/tv_question_count"
+                        android:layout_width="wrap_content"
+                        android:layout_height="?attr/actionBarSize"
+                        android:layout_gravity="center"
+                        android:gravity="center_vertical"
+                        android:padding="@dimen/padding_normal"
+                        android:text="@string/step"
+                        android:textAllCaps="true"
+                        android:textColor="@color/md_white_1000"
+                        android:textSize="@dimen/text_size_mid"
+                        android:textStyle="bold"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@+id/btnNext"
+                        app:layout_constraintStart_toEndOf="@+id/btnBack"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <ImageButton
+                        android:id="@+id/btnNext"
+                        style="@style/YellowButtons"
+                        android:layout_width="@dimen/_50dp"
+                        android:layout_height="@dimen/_50dp"
+                        android:layout_gravity="center_vertical"
+                        android:background="@drawable/buttonyellow"
+                        android:contentDescription="@string/btn_back"
+                        android:padding="8dp"
+                        android:visibility="gone"
+                        android:src="@drawable/ic_right_arrow"
+                        android:text="@string/btn_back"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:tint="@color/md_black_1000" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
 
                 <androidx.core.widget.NestedScrollView
                     android:id="@+id/container"
@@ -64,6 +109,7 @@
                                 android:layout_gravity="center"
                                 android:textColor="@color/daynight_textColor"
                                 android:textSize="18sp" />
+
                             <TextView
                                 android:id="@+id/tv_body"
                                 android:layout_width="match_parent"
@@ -80,6 +126,7 @@
                             android:layout_gravity="center_vertical"
                             android:orientation="vertical"
                             android:visibility="gone" />
+
                         <LinearLayout
                             android:id="@+id/ll_checkbox"
                             android:layout_width="match_parent"
@@ -94,8 +141,8 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="@dimen/padding_small"
-                    android:background="@color/card_bg">
+                    android:background="@color/card_bg"
+                    android:padding="@dimen/padding_small">
 
                     <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/tl_answer"
@@ -111,9 +158,9 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_vertical"
+                            android:backgroundTint="@color/hint_color"
                             android:hint="@string/your_ans"
-                            android:textColor="@color/daynight_textColor"
-                            android:backgroundTint="@color/hint_color" />
+                            android:textColor="@color/daynight_textColor" />
                     </com.google.android.material.textfield.TextInputLayout>
 
                     <Button


### PR DESCRIPTION
fixes #5831
Enable back and forth navigation to allow user to edit/confirm responses before finishing survey. 
[Screen_recording_20250515_162136.webm](https://github.com/user-attachments/assets/9f4831fc-ad75-472e-99fa-d9f105775959)

