### PR TITLE
Fix hint_serverURL id in resources

### DIFF
--- a/app/src/main/res/layout/dialog_server_url_.xml
+++ b/app/src/main/res/layout/dialog_server_url_.xml
@@ -87,7 +87,7 @@
                 android:layout_marginTop="16dp"
                 app:hintTextColor="@color/hint_color"
                 app:boxStrokeColor="@color/daynight_textColor"
-                android:hint="@string/hint_serverURl"
+                android:hint="@string/hint_serverURL"
                 app:layout_constraintTop_toBottomOf="@+id/spn_cloud">
 
                 <EditText

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -27,7 +27,7 @@
     <string name="err_msg_name">الرجاء إدخال اسم المستخدم</string>
     <string name="err_msg_password">الرجاء إدخال كلمة المرور</string>
     <string name="err_msg_login">اسم المستخدم و/أو كلمة المرور غير متطابقة</string>
-    <string name="hint_serverURl">planet الملكية الفكرية</string>
+    <string name="hint_serverURL">planet الملكية الفكرية</string>
     <string name="hint_serverPin">رمز الخادم</string>
     <string name="radio_protocol">البروتوكول:</string>
     <string name="radio_http">http</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -27,7 +27,7 @@
     <string name="err_msg_name">Ingresa tu nombre de usuario</string>
     <string name="err_msg_password">Ingresa la contraseña</string>
     <string name="err_msg_login">El nombre de usuario y/o la contraseña no coinciden</string>
-    <string name="hint_serverURl">planet ipag</string>
+    <string name="hint_serverURL">planet ipag</string>
     <string name="hint_serverPin">pin del servidor</string>
     <string name="radio_protocol">Protocolo:</string>
     <string name="radio_http">http</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -27,7 +27,7 @@
     <string name="err_msg_name">Entrez votre nom d\'utilisateur</string>
     <string name="err_msg_password">Entrez le mot de passe</string>
     <string name="err_msg_login">Le nom d\'utilisateur et/ou le mot de passe ne correspondent pas</string>
-    <string name="hint_serverURl">planet adresse IP</string>
+    <string name="hint_serverURL">planet adresse IP</string>
     <string name="hint_serverPin">code serveur</string>
     <string name="radio_protocol">Protocole:</string>
     <string name="radio_http">http</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -27,7 +27,7 @@
     <string name="err_msg_name">तपाईंको प्रयोगकर्तानाम लेख्नुहोस्</string>
     <string name="err_msg_password">पासवर्ड लेख्नुहोस्</string>
     <string name="err_msg_login">प्रयोगकर्तानाम र/वा पासवर्ड मेल खान्छैन</string>
-    <string name="hint_serverURl">planet आईपि</string>
+    <string name="hint_serverURL">planet आईपि</string>
     <string name="hint_serverPin">सर्भर पिन</string>
     <string name="radio_protocol">प्रोटोकल:</string>
     <string name="radio_http">http</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -27,7 +27,7 @@
     <string name="err_msg_name">Geli magaca isticmaalaha</string>
     <string name="err_msg_password">Geli erayga sirta ah</string>
     <string name="err_msg_login">Magaca isticmaalaha iyo/ama erayga sirta ah isma dhigmaan</string>
-    <string name="hint_serverURl">planet ip</string>
+    <string name="hint_serverURL">planet ip</string>
     <string name="hint_serverPin">pin-ka adeegsiga</string>
     <string name="radio_protocol">Protokolka:</string>
     <string name="radio_http">http</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="err_msg_name">Enter your username</string>
     <string name="err_msg_password">Enter the password</string>
     <string name="err_msg_login">Username and/or password do not match</string>
-    <string name="hint_serverURl">planet ip</string>
+    <string name="hint_serverURL">planet ip</string>
     <string name="hint_serverPin">server pin</string>
     <string name="radio_protocol">Protocol:</string>
     <string name="radio_http">http</string>


### PR DESCRIPTION
## Summary
- rename `hint_serverURl` string id to `hint_serverURL` across all resources
- update dialog layout to use the new string id

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f735d62e8832b927f7a189a85479e