### PR TITLE
dashboard: smoother viewmodel refactor (fixes #5986)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2579
-        versionName "0.25.79"
+        versionCode 2581
+        versionName "0.25.81"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -435,7 +435,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-
     private fun setupRealmListeners() {
         if (mRealm.isInTransaction) {
             mRealm.commitTransaction()
@@ -540,7 +539,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         dashboardViewModel.createNotificationIfNotExists(realm, "storage", "$storageRatio", "storage", userId)
     }
 
-
     private fun openNotificationsList(userId: String) {
         val fragment = NotificationsFragment().apply {
             arguments = Bundle().apply {
@@ -556,7 +554,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             openNotificationsList(user?.id ?: "")
         }
     }
-
 
     private fun updateNotificationBadge(count: Int, onClickListener: View.OnClickListener) {
         val menuItem = activityDashboardBinding.appBarBell.bellToolbar.menu.findItem(R.id.action_notifications)
@@ -849,6 +846,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                 changeUX(R.string.menu_surveys, menuImageList[8]).withIdentifier(8)
             )
         }
+
     private val drawerItemsFooter: Array<IDrawerItem<*, *>>
         get() {
             val menuImageListFooter = ArrayList<Drawable>()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -28,7 +28,6 @@ import com.mikepenz.materialdrawer.AccountHeaderBuilder
 import com.mikepenz.materialdrawer.Drawer
 import com.mikepenz.materialdrawer.DrawerBuilder
 import com.mikepenz.materialdrawer.holder.DimenHolder
-import org.ole.planet.myplanet.ui.dashboard.DashboardViewModel
 import com.mikepenz.materialdrawer.model.PrimaryDrawerItem
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
 import com.mikepenz.materialdrawer.model.interfaces.Nameable
@@ -43,6 +42,7 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.base.BaseResourceFragment
+import org.ole.planet.myplanet.ui.dashboard.DashboardViewModel
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.ActivityDashboardBinding
 import org.ole.planet.myplanet.databinding.CustomTabBinding

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -13,6 +13,7 @@ import android.os.Looper
 import android.view.*
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
@@ -27,6 +28,7 @@ import com.mikepenz.materialdrawer.AccountHeaderBuilder
 import com.mikepenz.materialdrawer.Drawer
 import com.mikepenz.materialdrawer.DrawerBuilder
 import com.mikepenz.materialdrawer.holder.DimenHolder
+import org.ole.planet.myplanet.ui.dashboard.DashboardViewModel
 import com.mikepenz.materialdrawer.model.PrimaryDrawerItem
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
 import com.mikepenz.materialdrawer.model.interfaces.Nameable
@@ -48,7 +50,6 @@ import org.ole.planet.myplanet.datamanager.Service
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmTeamTask
@@ -83,7 +84,6 @@ import org.ole.planet.myplanet.utilities.Utilities.toast
 import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.util.Date
-import java.util.UUID
 import kotlin.math.ceil
 import kotlinx.coroutines.*
 
@@ -101,6 +101,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     private var tl: TabLayout? = null
     private var dl: DrawerLayout? = null
     private val realmListeners = mutableListOf<RealmListener>()
+    private val dashboardViewModel: DashboardViewModel by viewModels()
 
     private interface RealmListener {
         fun removeListener()
@@ -410,8 +411,8 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         if (isCompleted && !hasShownCongrats) {
             editor.putBoolean("has_shown_congrats", true).apply()
             val markdownContent = """
-        ${getString(R.string.community_earnings, calculateCommunityProgress(allVoiceCount, hasUnfinishedSurvey))}
-        ${getString(R.string.your_earnings, calculateIndividualProgress(voiceCount, hasUnfinishedSurvey))}
+        ${getString(R.string.community_earnings, dashboardViewModel.calculateCommunityProgress(allVoiceCount, hasUnfinishedSurvey))}
+        ${getString(R.string.your_earnings, dashboardViewModel.calculateIndividualProgress(voiceCount, hasUnfinishedSurvey))}
         ### ${getString(R.string.congratulations)} <br/>
     """.trimIndent()
             MarkdownDialog.newInstance(markdownContent, courseStatus, voiceCount, allVoiceCount, hasUnfinishedSurvey).show(supportFragmentManager, "markdown_dialog")
@@ -423,8 +424,8 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                 ""
             }
             val markdownContent = """
-        ${getString(R.string.community_earnings, calculateCommunityProgress(allVoiceCount, hasUnfinishedSurvey))}
-        ${getString(R.string.your_earnings, calculateIndividualProgress(voiceCount, hasUnfinishedSurvey))}
+        ${getString(R.string.community_earnings, dashboardViewModel.calculateCommunityProgress(allVoiceCount, hasUnfinishedSurvey))}
+        ${getString(R.string.your_earnings, dashboardViewModel.calculateIndividualProgress(voiceCount, hasUnfinishedSurvey))}
         ### ${getString(R.string.per_survey, courseTaskDone)} <br/>
         ### ${getString(R.string.share_opinion)} $voicesText <br/>
         ### ${getString(R.string.remember_sync)} <br/>
@@ -434,19 +435,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-    private fun calculateIndividualProgress(voiceCount: Int, hasUnfinishedSurvey: Boolean): Int {
-        val earnedDollarsVoice = minOf(voiceCount, 5) * 2
-        val earnedDollarsSurvey = if (!hasUnfinishedSurvey) 1 else 0
-        val total = earnedDollarsVoice + earnedDollarsSurvey
-        return total.coerceAtMost(500)
-    }
-
-    private fun calculateCommunityProgress (allVoiceCount: Int, hasUnfinishedSurvey: Boolean): Int {
-        val earnedDollarsVoice = minOf(allVoiceCount, 5) * 2
-        val earnedDollarsSurvey = if (!hasUnfinishedSurvey) 1 else 0
-        val total = earnedDollarsVoice + earnedDollarsSurvey
-        return total.coerceAtMost(11)
-    }
 
     private fun setupRealmListeners() {
         if (mRealm.isInTransaction) {
@@ -500,7 +488,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                     createNotifications(realm, userId)
                 }
 
-                unreadCount = getUnreadNotificationsSize(backgroundRealm, userId)
+                unreadCount = dashboardViewModel.getUnreadNotificationsSize(backgroundRealm, userId)
 
                 backgroundRealm.close()
                 backgroundRealm = null
@@ -531,12 +519,12 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     }
 
     private fun createNotifications(realm: Realm, userId: String?) {
-        updateResourceNotification(realm, userId)
+        dashboardViewModel.updateResourceNotification(realm, userId)
 
-        val pendingSurveys = getPendingSurveys(realm, userId)
-        val surveyTitles = getSurveyTitlesFromSubmissions(realm, pendingSurveys)
+        val pendingSurveys = dashboardViewModel.getPendingSurveys(realm, userId)
+        val surveyTitles = dashboardViewModel.getSurveyTitlesFromSubmissions(realm, pendingSurveys)
         surveyTitles.forEach { title ->
-            createNotificationIfNotExists(realm, "survey", "$title", title, userId)
+            dashboardViewModel.createNotificationIfNotExists(realm, "survey", "$title", title, userId)
         }
 
         val tasks = realm.where(RealmTeamTask::class.java)
@@ -545,34 +533,13 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             .equalTo("assignee", userId)
             .findAll()
         tasks.forEach { task ->
-            createNotificationIfNotExists(realm, "task", "${task.title} ${formatDate(task.deadline)}", task.id, userId)
+            dashboardViewModel.createNotificationIfNotExists(realm, "task", "${task.title} ${formatDate(task.deadline)}", task.id, userId)
         }
 
         val storageRatio = totalAvailableMemoryRatio
-        createNotificationIfNotExists(realm, "storage", "$storageRatio", "storage", userId)
+        dashboardViewModel.createNotificationIfNotExists(realm, "storage", "$storageRatio", "storage", userId)
     }
 
-    private fun updateResourceNotification(realm: Realm, userId: String?) {
-        val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
-        if (resourceCount > 0) {
-            val existingNotification = realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()
-
-            if (existingNotification != null) {
-                existingNotification.message = "$resourceCount"
-                existingNotification.relatedId = "$resourceCount"
-            } else {
-                createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
-            }
-        } else {
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()?.deleteFromRealm()
-        }
-    }
 
     private fun openNotificationsList(userId: String) {
         val fragment = NotificationsFragment().apply {
@@ -590,51 +557,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-    private fun createNotificationIfNotExists(realm: Realm, type: String, message: String, relatedId: String?, userId: String?) {
-        val existingNotification = realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("type", type)
-            .equalTo("relatedId", relatedId)
-            .findFirst()
-
-        if (existingNotification == null) {
-            realm.createObject(RealmNotification::class.java, "${UUID.randomUUID()}").apply {
-                this.userId = userId ?: ""
-                this.type = type
-                this.message = message
-                this.relatedId = relatedId
-                this.createdAt = Date()
-            }
-        }
-    }
-
-    private fun getPendingSurveys(realm: Realm, userId: String?): List<RealmSubmission> {
-        return realm.where(RealmSubmission::class.java)
-            .equalTo("userId", userId)
-            .equalTo("type", "survey")
-            .equalTo("status", "pending", Case.INSENSITIVE)
-            .findAll()
-    }
-
-    private fun getSurveyTitlesFromSubmissions(realm: Realm, submissions: List<RealmSubmission>): List<String> {
-        val titles = mutableListOf<String>()
-        submissions.forEach { submission ->
-            val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
-            val exam = realm.where(RealmStepExam::class.java)
-                .equalTo("id", examId)
-                .findFirst()
-            exam?.name?.let { titles.add(it) }
-        }
-        return titles
-    }
-
-    private fun getUnreadNotificationsSize(realm: Realm, userId: String?): Int {
-        return realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("isRead", false)
-            .count()
-            .toInt()
-    }
 
     private fun updateNotificationBadge(count: Int, onClickListener: View.OnClickListener) {
         val menuItem = activityDashboardBinding.appBarBell.bellToolbar.menu.findItem(R.id.action_notifications)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
@@ -435,7 +435,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-
     private fun setupRealmListeners() {
         if (mRealm.isInTransaction) {
             mRealm.commitTransaction()
@@ -555,7 +554,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             openNotificationsList(user?.id ?: "")
         }
     }
-
 
     private fun updateNotificationBadge(count: Int, onClickListener: View.OnClickListener) {
         val menuItem = activityDashboardBinding.appBarBell.bellToolbar.menu.findItem(R.id.action_notifications)
@@ -848,6 +846,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                 changeUX(R.string.menu_surveys, menuImageList[8]).withIdentifier(8)
             )
         }
+
     private val drawerItemsFooter: Array<IDrawerItem<*, *>>
         get() {
             val menuImageListFooter = ArrayList<Drawable>()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt.lite
@@ -13,6 +13,7 @@ import android.os.Looper
 import android.view.*
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
@@ -41,6 +42,7 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 //import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.base.BaseResourceFragment
+import org.ole.planet.myplanet.ui.dashboard.DashboardViewModel
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.ActivityDashboardBinding
 import org.ole.planet.myplanet.databinding.CustomTabBinding
@@ -48,7 +50,6 @@ import org.ole.planet.myplanet.datamanager.Service
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmTeamTask
@@ -83,7 +84,6 @@ import org.ole.planet.myplanet.utilities.Utilities.toast
 import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.util.Date
-import java.util.UUID
 import kotlin.math.ceil
 import kotlinx.coroutines.*
 
@@ -101,6 +101,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     private var tl: TabLayout? = null
     private var dl: DrawerLayout? = null
     private val realmListeners = mutableListOf<RealmListener>()
+    private val dashboardViewModel: DashboardViewModel by viewModels()
 
     private interface RealmListener {
         fun removeListener()
@@ -410,8 +411,8 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         if (isCompleted && !hasShownCongrats) {
             editor.putBoolean("has_shown_congrats", true).apply()
             val markdownContent = """
-        ${getString(R.string.community_earnings, calculateCommunityProgress(allVoiceCount, hasUnfinishedSurvey))}
-        ${getString(R.string.your_earnings, calculateIndividualProgress(voiceCount, hasUnfinishedSurvey))}
+        ${getString(R.string.community_earnings, dashboardViewModel.calculateCommunityProgress(allVoiceCount, hasUnfinishedSurvey))}
+        ${getString(R.string.your_earnings, dashboardViewModel.calculateIndividualProgress(voiceCount, hasUnfinishedSurvey))}
         ### ${getString(R.string.congratulations)} <br/>
     """.trimIndent()
             MarkdownDialog.newInstance(markdownContent, courseStatus, voiceCount, allVoiceCount, hasUnfinishedSurvey).show(supportFragmentManager, "markdown_dialog")
@@ -423,8 +424,8 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                 ""
             }
             val markdownContent = """
-        ${getString(R.string.community_earnings, calculateCommunityProgress(allVoiceCount, hasUnfinishedSurvey))}
-        ${getString(R.string.your_earnings, calculateIndividualProgress(voiceCount, hasUnfinishedSurvey))}
+        ${getString(R.string.community_earnings, dashboardViewModel.calculateCommunityProgress(allVoiceCount, hasUnfinishedSurvey))}
+        ${getString(R.string.your_earnings, dashboardViewModel.calculateIndividualProgress(voiceCount, hasUnfinishedSurvey))}
         ### ${getString(R.string.per_survey, courseTaskDone)} <br/>
         ### ${getString(R.string.share_opinion)} $voicesText <br/>
         ### ${getString(R.string.remember_sync)} <br/>
@@ -434,19 +435,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-    private fun calculateIndividualProgress(voiceCount: Int, hasUnfinishedSurvey: Boolean): Int {
-        val earnedDollarsVoice = minOf(voiceCount, 5) * 2
-        val earnedDollarsSurvey = if (!hasUnfinishedSurvey) 1 else 0
-        val total = earnedDollarsVoice + earnedDollarsSurvey
-        return total.coerceAtMost(500)
-    }
-
-    private fun calculateCommunityProgress (allVoiceCount: Int, hasUnfinishedSurvey: Boolean): Int {
-        val earnedDollarsVoice = minOf(allVoiceCount, 5) * 2
-        val earnedDollarsSurvey = if (!hasUnfinishedSurvey) 1 else 0
-        val total = earnedDollarsVoice + earnedDollarsSurvey
-        return total.coerceAtMost(11)
-    }
 
     private fun setupRealmListeners() {
         if (mRealm.isInTransaction) {
@@ -500,7 +488,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                     createNotifications(realm, userId)
                 }
 
-                unreadCount = getUnreadNotificationsSize(backgroundRealm, userId)
+                unreadCount = dashboardViewModel.getUnreadNotificationsSize(backgroundRealm, userId)
 
                 backgroundRealm.close()
                 backgroundRealm = null
@@ -531,12 +519,12 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     }
 
     private fun createNotifications(realm: Realm, userId: String?) {
-        updateResourceNotification(realm, userId)
+        dashboardViewModel.updateResourceNotification(realm, userId)
 
-        val pendingSurveys = getPendingSurveys(realm, userId)
-        val surveyTitles = getSurveyTitlesFromSubmissions(realm, pendingSurveys)
+        val pendingSurveys = dashboardViewModel.getPendingSurveys(realm, userId)
+        val surveyTitles = dashboardViewModel.getSurveyTitlesFromSubmissions(realm, pendingSurveys)
         surveyTitles.forEach { title ->
-            createNotificationIfNotExists(realm, "survey", "$title", title, userId)
+            dashboardViewModel.createNotificationIfNotExists(realm, "survey", "$title", title, userId)
         }
 
         val tasks = realm.where(RealmTeamTask::class.java)
@@ -545,33 +533,11 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             .equalTo("assignee", userId)
             .findAll()
         tasks.forEach { task ->
-            createNotificationIfNotExists(realm, "task", "${task.title} ${formatDate(task.deadline)}", task.id, userId)
+            dashboardViewModel.createNotificationIfNotExists(realm, "task", "${task.title} ${formatDate(task.deadline)}", task.id, userId)
         }
 
         val storageRatio = totalAvailableMemoryRatio
-        createNotificationIfNotExists(realm, "storage", "$storageRatio", "storage", userId)
-    }
-
-    private fun updateResourceNotification(realm: Realm, userId: String?) {
-        val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
-        if (resourceCount > 0) {
-            val existingNotification = realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()
-
-            if (existingNotification != null) {
-                existingNotification.message = "$resourceCount"
-                existingNotification.relatedId = "$resourceCount"
-            } else {
-                createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
-            }
-        } else {
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()?.deleteFromRealm()
-        }
+        dashboardViewModel.createNotificationIfNotExists(realm, "storage", "$storageRatio", "storage", userId)
     }
 
     private fun openNotificationsList(userId: String) {
@@ -590,51 +556,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-    private fun createNotificationIfNotExists(realm: Realm, type: String, message: String, relatedId: String?, userId: String?) {
-        val existingNotification = realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("type", type)
-            .equalTo("relatedId", relatedId)
-            .findFirst()
-
-        if (existingNotification == null) {
-            realm.createObject(RealmNotification::class.java, "${UUID.randomUUID()}").apply {
-                this.userId = userId ?: ""
-                this.type = type
-                this.message = message
-                this.relatedId = relatedId
-                this.createdAt = Date()
-            }
-        }
-    }
-
-    private fun getPendingSurveys(realm: Realm, userId: String?): List<RealmSubmission> {
-        return realm.where(RealmSubmission::class.java)
-            .equalTo("userId", userId)
-            .equalTo("type", "survey")
-            .equalTo("status", "pending", Case.INSENSITIVE)
-            .findAll()
-    }
-
-    private fun getSurveyTitlesFromSubmissions(realm: Realm, submissions: List<RealmSubmission>): List<String> {
-        val titles = mutableListOf<String>()
-        submissions.forEach { submission ->
-            val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
-            val exam = realm.where(RealmStepExam::class.java)
-                .equalTo("id", examId)
-                .findFirst()
-            exam?.name?.let { titles.add(it) }
-        }
-        return titles
-    }
-
-    private fun getUnreadNotificationsSize(realm: Realm, userId: String?): Int {
-        return realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("isRead", false)
-            .count()
-            .toInt()
-    }
 
     private fun updateNotificationBadge(count: Int, onClickListener: View.OnClickListener) {
         val menuItem = activityDashboardBinding.appBarBell.bellToolbar.menu.findItem(R.id.action_notifications)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -1,0 +1,96 @@
+package org.ole.planet.myplanet.ui.dashboard
+
+import androidx.lifecycle.ViewModel
+import io.realm.Case
+import io.realm.Realm
+import org.ole.planet.myplanet.base.BaseResourceFragment
+import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.model.RealmStepExam
+import org.ole.planet.myplanet.model.RealmSubmission
+import java.util.Date
+import java.util.UUID
+
+class DashboardViewModel : ViewModel() {
+    fun calculateIndividualProgress(voiceCount: Int, hasUnfinishedSurvey: Boolean): Int {
+        val earnedDollarsVoice = minOf(voiceCount, 5) * 2
+        val earnedDollarsSurvey = if (!hasUnfinishedSurvey) 1 else 0
+        val total = earnedDollarsVoice + earnedDollarsSurvey
+        return total.coerceAtMost(500)
+    }
+
+    fun calculateCommunityProgress(allVoiceCount: Int, hasUnfinishedSurvey: Boolean): Int {
+        val earnedDollarsVoice = minOf(allVoiceCount, 5) * 2
+        val earnedDollarsSurvey = if (!hasUnfinishedSurvey) 1 else 0
+        val total = earnedDollarsVoice + earnedDollarsSurvey
+        return total.coerceAtMost(11)
+    }
+
+    fun updateResourceNotification(realm: Realm, userId: String?) {
+        val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
+        if (resourceCount > 0) {
+            val existingNotification = realm.where(RealmNotification::class.java)
+                .equalTo("userId", userId)
+                .equalTo("type", "resource")
+                .findFirst()
+
+            if (existingNotification != null) {
+                existingNotification.message = "$resourceCount"
+                existingNotification.relatedId = "$resourceCount"
+            } else {
+                createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
+            }
+        } else {
+            realm.where(RealmNotification::class.java)
+                .equalTo("userId", userId)
+                .equalTo("type", "resource")
+                .findFirst()?.deleteFromRealm()
+        }
+    }
+
+    fun createNotificationIfNotExists(realm: Realm, type: String, message: String, relatedId: String?, userId: String?) {
+        val existingNotification = realm.where(RealmNotification::class.java)
+            .equalTo("userId", userId)
+            .equalTo("type", type)
+            .equalTo("relatedId", relatedId)
+            .findFirst()
+
+        if (existingNotification == null) {
+            realm.createObject(RealmNotification::class.java, "${UUID.randomUUID()}").apply {
+                this.userId = userId ?: ""
+                this.type = type
+                this.message = message
+                this.relatedId = relatedId
+                this.createdAt = Date()
+            }
+        }
+    }
+
+    fun getPendingSurveys(realm: Realm, userId: String?): List<RealmSubmission> {
+        return realm.where(RealmSubmission::class.java)
+            .equalTo("userId", userId)
+            .equalTo("type", "survey")
+            .equalTo("status", "pending", Case.INSENSITIVE)
+            .findAll()
+    }
+
+    fun getSurveyTitlesFromSubmissions(realm: Realm, submissions: List<RealmSubmission>): List<String> {
+        val titles = mutableListOf<String>()
+        submissions.forEach { submission ->
+            val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
+            val exam = realm.where(RealmStepExam::class.java)
+                .equalTo("id", examId)
+                .findFirst()
+            exam?.name?.let { titles.add(it) }
+        }
+        return titles
+    }
+
+    fun getUnreadNotificationsSize(realm: Realm, userId: String?): Int {
+        return realm.where(RealmNotification::class.java)
+            .equalTo("userId", userId)
+            .equalTo("isRead", false)
+            .count()
+            .toInt()
+    }
+}
+


### PR DESCRIPTION
## Summary
- extract calculation and notification helpers into `DashboardViewModel`
- use the new `DashboardViewModel` from `DashboardActivity`
- keep `.lite` version in sync with same refactor

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa40e6e30832b866a9afeb58eac10