### PR TITLE
chat: smoother provider availability (fixes #6014)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2597
-        versionName "0.25.97"
+        versionCode 2598
+        versionName "0.25.98"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -240,11 +240,12 @@ class ChatDetailFragment : Fragment() {
                             response.body()?.let { responseBody ->
                                 try {
                                     val responseString = responseBody.string()
-                                    val aiProvidersResponse: Map<String, Boolean> = Gson().fromJson(
-                                        responseString,
-                                        object : TypeToken<Map<String, Boolean>>() {}.type
-                                    )
-                                    updateAIButtons(aiProvidersResponse)
+                                    val aiProvidersResponse: Map<String, Boolean> = Gson().fromJson(responseString, object : TypeToken<Map<String, Boolean>>() {}.type)
+                                    if (aiProvidersResponse.values.all { !it }) {
+                                        onFailError()
+                                    } else {
+                                        updateAIButtons(aiProvidersResponse)
+                                    }
                                 } catch (e: JsonSyntaxException) {
                                     e.printStackTrace()
                                     onFailError()


### PR DESCRIPTION
fixes #6014
show message of inactive providers. Scenario testable on planet uriur

[Screen_recording_20250619_134507.webm](https://github.com/user-attachments/assets/a69020e9-cbdb-468c-bb61-540932543584)
