### PR TITLE
dashboard: Update custom_notification_badge.xml(fixes #6025)

### DIFF
--- a/app/src/main/res/layout/custom_notification_badge.xml
+++ b/app/src/main/res/layout/custom_notification_badge.xml
@@ -23,5 +23,5 @@
         android:padding="3dp"
         android:text="0"
         android:textColor="@android:color/white"
-        android:textSize="10sp" />
+        android:textSize="10dp" />
 </FrameLayout>


### PR DESCRIPTION
Issue: When the font size was increased, the number on the badge icon got bigger, but the badge itself stayed the same size. This caused the number to get cut off at the bottom (as shown in the picture).

Fix: Changed the text size from sp to dp so the number only gets bigger when the screen is zoomed in, not when the font size is increased.

Before - 

![Screenshot_20250619_125232](https://github.com/user-attachments/assets/7da30899-d1ed-4916-988c-99b9044e128b)

After - 

![Screenshot_20250619_131816](https://github.com/user-attachments/assets/7ac1c3fb-e0d0-49f9-938a-4580e98ee964)

