### PR TITLE
teams: smoother `AdapterNews.kt` (fixes #6050)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2606
-        versionName "0.26.6"
+        versionCode 2611
+        versionName "0.26.11"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
@@ -531,75 +531,104 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
         dialog.show()
     }
 
+    private fun isGuestUser() = user?.id?.startsWith("guest") == true
+
+    private fun shouldShowReplyButton() = listener != null && !fromLogin && !isGuestUser()
+
+    private fun getReplies(finalNews: RealmNews?): List<RealmNews> = mRealm.where(RealmNews::class.java)
+        .sort("time", Sort.DESCENDING)
+        .equalTo("replyTo", finalNews?.id, Case.INSENSITIVE)
+        .findAll()
+
+    private fun updateReplyCount(viewHolder: ViewHolderNews, replies: List<RealmNews>, position: Int) {
+        with(viewHolder.rowNewsBinding) {
+            btnShowReply.text = String.format("(%d)", replies.size)
+            btnShowReply.setTextColor(context.getColor(R.color.daynight_textColor))
+            val visible = replies.isNotEmpty() && !(position == 0 && parentNews != null) && shouldShowReplyButton()
+            btnShowReply.visibility = if (visible) View.VISIBLE else View.GONE
+        }
+    }
+
     private fun showReplyButton(holder: RecyclerView.ViewHolder, finalNews: RealmNews?, position: Int) {
         val viewHolder = holder as ViewHolderNews
-        val isGuest = user?.id?.startsWith("guest") == true
-        if (listener == null || fromLogin || isGuest) {
-            viewHolder.rowNewsBinding.btnReply.visibility = View.GONE
-        } else {
+        if (shouldShowReplyButton()) {
             viewHolder.rowNewsBinding.btnReply.visibility = if (nonTeamMember) View.GONE else View.VISIBLE
             viewHolder.rowNewsBinding.btnReply.setOnClickListener { showEditAlert(finalNews?.id, false) }
-        }
-        val replies: List<RealmNews> = mRealm.where(RealmNews::class.java)
-            .sort("time", Sort.DESCENDING)
-            .equalTo("replyTo", finalNews?.id, Case.INSENSITIVE)
-            .findAll()
-        viewHolder.rowNewsBinding.btnShowReply.text = String.format("(%d)", replies.size)
-        viewHolder.rowNewsBinding.btnShowReply.setTextColor(context.getColor(R.color.daynight_textColor))
-        viewHolder.rowNewsBinding.btnShowReply.visibility = if (replies.isNotEmpty()) {
-            View.VISIBLE
         } else {
-            View.GONE
+            viewHolder.rowNewsBinding.btnReply.visibility = View.GONE
         }
-        if (position == 0 && parentNews != null) {
-            viewHolder.rowNewsBinding.btnShowReply.visibility = View.GONE
-        }
-        if (listener == null || fromLogin) {
-            viewHolder.rowNewsBinding.btnShowReply.visibility = View.GONE
-        }
+
+        val replies = getReplies(finalNews)
+        updateReplyCount(viewHolder, replies, position)
+
         viewHolder.rowNewsBinding.btnShowReply.setOnClickListener {
             sharedPreferences?.setRepliedNewsId(finalNews?.id)
             listener?.showReply(finalNews, fromLogin, nonTeamMember)
         }
     }
 
-    private fun showEditAlert(id: String?, isEdit: Boolean) {
+    private data class EditDialogComponents(
+        val view: View,
+        val editText: EditText,
+        val inputLayout: com.google.android.material.textfield.TextInputLayout,
+        val imageLayout: LinearLayout
+    )
+
+    private fun createEditDialogComponents(): EditDialogComponents {
         val v = LayoutInflater.from(context).inflate(R.layout.alert_input, null)
         val tlInput = v.findViewById<com.google.android.material.textfield.TextInputLayout>(R.id.tl_input)
         val et = v.findViewById<EditText>(R.id.et_input)
-        v.findViewById<View>(R.id.ll_image).visibility = if (showBetaFeature(Constants.KEY_NEWSADDIMAGE, context)) View.VISIBLE else View.GONE
+        v.findViewById<View>(R.id.ll_image).visibility =
+            if (showBetaFeature(Constants.KEY_NEWSADDIMAGE, context)) View.VISIBLE else View.GONE
         val llImage = v.findViewById<LinearLayout>(R.id.ll_alert_image)
         v.findViewById<View>(R.id.add_news_image).setOnClickListener { listener?.addImage(llImage) }
-        val message = v.findViewById<TextView>(R.id.cust_msg)
+        return EditDialogComponents(v, et, tlInput, llImage)
+    }
+
+    private fun handlePositiveButton(
+        dialog: AlertDialog,
+        isEdit: Boolean,
+        components: EditDialogComponents,
+        news: RealmNews?
+    ) {
+        val s = components.editText.text.toString().trim()
+        if (s.isEmpty()) {
+            components.inputLayout.error = context.getString(R.string.please_enter_message)
+            return
+        }
+        if (isEdit) {
+            editPost(s, news)
+        } else {
+            postReply(s, news)
+        }
+        dialog.dismiss()
+    }
+
+    private fun showEditAlert(id: String?, isEdit: Boolean) {
+        val components = createEditDialogComponents()
+        val message = components.view.findViewById<TextView>(R.id.cust_msg)
         message.text = context.getString(if (isEdit) R.string.edit_post else R.string.reply)
-        val icon = v.findViewById<ImageView>(R.id.alert_icon)
+        val icon = components.view.findViewById<ImageView>(R.id.alert_icon)
         icon.setImageResource(R.drawable.ic_edit)
 
         val news = mRealm.where(RealmNews::class.java).equalTo("id", id).findFirst()
-        if (isEdit) et.setText(context.getString(R.string.message_placeholder, news?.message))
+        if (isEdit) {
+            components.editText.setText(context.getString(R.string.message_placeholder, news?.message))
+        }
         val dialog = AlertDialog.Builder(context, R.style.ReplyAlertDialog)
-            .setView(v)
+            .setView(components.view)
             .setPositiveButton(R.string.button_submit, null)
-            .setNegativeButton(R.string.cancel) { dialog, _ ->
+            .setNegativeButton(R.string.cancel) { d, _ ->
                 listener?.clearImages()
-                dialog.dismiss()
+                d.dismiss()
             }
             .create()
         dialog.show()
-        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener{
-            val s = et.text.toString().trim()
-            if (s.isEmpty()) {
-                tlInput.error = context.getString(R.string.please_enter_message)
-                return@setOnClickListener
-            }
-            if (isEdit) {
-                editPost(s, news)
-            } else {
-                postReply(s, news)
-            }
-            dialog.dismiss()
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+            handlePositiveButton(dialog, isEdit, components, news)
         }
     }
+
 
     private fun postReply(s: String?, news: RealmNews?) {
         if (!mRealm.isInTransaction) mRealm.beginTransaction()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
@@ -629,7 +629,6 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
         }
     }
 
-
     private fun postReply(s: String?, news: RealmNews?) {
         if (!mRealm.isInTransaction) mRealm.beginTransaction()
         val map = HashMap<String?, String>()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
@@ -585,12 +585,7 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
         return EditDialogComponents(v, et, tlInput, llImage)
     }
 
-    private fun handlePositiveButton(
-        dialog: AlertDialog,
-        isEdit: Boolean,
-        components: EditDialogComponents,
-        news: RealmNews?
-    ) {
+    private fun handlePositiveButton(dialog: AlertDialog, isEdit: Boolean, components: EditDialogComponents, news: RealmNews?) {
         val s = components.editText.text.toString().trim()
         if (s.isEmpty()) {
             components.inputLayout.error = context.getString(R.string.please_enter_message)


### PR DESCRIPTION
## Summary
- extract helper functions in AdapterNews for reply buttons
- refactor edit dialog creation and handling
- delete unused duplicate code

## Testing
- `./gradlew test --no-daemon` *(fails: could not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6859476af65c832ba5ef48899c009605