### PR TITLE
actions: smoother build including codex dependabot (fixes #6063)

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - '*'
       - '!master'
+      - codex/**
   pull_request:
     branches:
-      - codex/**
       - dependabot/**
 
 jobs:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -6,9 +6,6 @@ on:
       - '*'
       - '!master'
       - codex/**
-  pull_request:
-    branches:
-      - codex/**
       - dependabot/**
 
 jobs:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '*'
       - '!master'
+  pull_request:
+    branches:
+      - codex/**
+      - dependabot/**
 
 jobs:
   build:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -8,6 +8,7 @@ on:
       - codex/**
   pull_request:
     branches:
+      - codex/**
       - dependabot/**
 
 jobs:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2606
-        versionName "0.26.6"
+        versionCode 2615
+        versionName "0.26.15"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- run Android build workflow on pull requests from `codex/**` and `dependabot/**` branches

## Testing
- `./gradlew test --no-daemon` *(failed: task killed due to restricted network)*
- `./gradlew assembleDebug --configuration-cache --no-daemon --warning-mode all --stacktrace` *(failed: task killed due to restricted network)*

------
https://chatgpt.com/codex/tasks/task_e_68595f6ac2f0832bad0e73a75d0b47f7