### PR TITLE
all: smoother `CsvUtils.kt`  (fixes #6157)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 2636
-        versionName "0.26.36"
+        versionCode 2647
+        versionName "0.26.47"
         ndkVersion '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmAchievement.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmAchievement.kt
@@ -6,16 +6,13 @@ import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmAchievement : RealmObject() {
     var achievements: RealmList<String>? = null
@@ -121,24 +118,20 @@ open class RealmAchievement : RealmObject() {
         }
 
         @JvmStatic
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("achievementId", "achievement_rev", "purpose", "goals", "achievementsHeader", "references", "achievements"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
-        @JvmStatic
         fun achievementWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/achievements.csv", achievementDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/achievements.csv",
+                arrayOf(
+                    "achievementId",
+                    "achievement_rev",
+                    "purpose",
+                    "goals",
+                    "achievementsHeader",
+                    "references",
+                    "achievements"
+                ),
+                achievementDataList
+            )
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCertification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCertification.kt
@@ -3,15 +3,12 @@ package org.ole.planet.myplanet.model
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmCertification : RealmObject() {
     @PrimaryKey
@@ -56,24 +53,17 @@ open class RealmCertification : RealmObject() {
         }
 
         @JvmStatic
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("certificationId", "name", "courseIds"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         @JvmStatic
         fun certificationWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/certification.csv", certificationDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/certification.csv",
+                arrayOf(
+                    "certificationId",
+                    "name",
+                    "courseIds"
+                ),
+                certificationDataList
+            )
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCertification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCertification.kt
@@ -53,7 +53,6 @@ open class RealmCertification : RealmObject() {
         }
 
         @JvmStatic
-        @JvmStatic
         fun certificationWriteCsv() {
             CsvUtils.writeCsv(
                 "${context.getExternalFilesDir(null)}/ole/certification.csv",

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmChatHistory.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmChatHistory.kt
@@ -3,7 +3,6 @@ package org.ole.planet.myplanet.model
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmList
 import io.realm.RealmObject
@@ -11,9 +10,7 @@ import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
 import java.util.Date
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmChatHistory : RealmObject() {
     @PrimaryKey
@@ -95,23 +92,21 @@ open class RealmChatHistory : RealmObject() {
             }
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("chatHistoryId", "chatHistory_rev", "title", "createdDate", "updatedDate", "user", "aiProvider", "conversations"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun chatWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/chatHistory.csv", chatDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/chatHistory.csv",
+                arrayOf(
+                    "chatHistoryId",
+                    "chatHistory_rev",
+                    "title",
+                    "createdDate",
+                    "updatedDate",
+                    "user",
+                    "aiProvider",
+                    "conversations"
+                ),
+                chatDataList
+            )
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseProgress.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseProgress.kt
@@ -1,7 +1,6 @@
 package org.ole.planet.myplanet.model
 
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
@@ -10,9 +9,7 @@ import org.ole.planet.myplanet.model.RealmMyCourse.Companion.getCourseSteps
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.getMyCourseByUserId
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.isMyCourse
 import org.ole.planet.myplanet.utilities.JsonUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmCourseProgress : RealmObject() {
     @PrimaryKey
@@ -118,23 +115,23 @@ open class RealmCourseProgress : RealmObject() {
             progressDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("progressId", "progress_rev", "passed", "stepNum", "userId", "parentCode", "courseId", "createdOn", "createdDate", "updatedDate"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun progressWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/chatHistory.csv", progressDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/chatHistory.csv",
+                arrayOf(
+                    "progressId",
+                    "progress_rev",
+                    "passed",
+                    "stepNum",
+                    "userId",
+                    "parentCode",
+                    "courseId",
+                    "createdOn",
+                    "createdDate",
+                    "updatedDate"
+                ),
+                progressDataList
+            )
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmFeedback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmFeedback.kt
@@ -6,15 +6,12 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.stream.JsonReader
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 import java.io.StringReader
 
 open class RealmFeedback : RealmObject() {
@@ -153,23 +150,26 @@ open class RealmFeedback : RealmObject() {
             feedbacksDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("feedbackId", "title", "source", "status", "priority", "owner", "openTime", "type", "url", "parentCode", "state", "item", "messages"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun feedbackWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/feedback.csv", feedbacksDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/feedback.csv",
+                arrayOf(
+                    "feedbackId",
+                    "title",
+                    "source",
+                    "status",
+                    "priority",
+                    "owner",
+                    "openTime",
+                    "type",
+                    "url",
+                    "parentCode",
+                    "state",
+                    "item",
+                    "messages"
+                ),
+                feedbacksDataList
+            )
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMeetup.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMeetup.kt
@@ -2,15 +2,12 @@ package org.ole.planet.myplanet.model
 
 import android.text.TextUtils
 import com.google.gson.*
-import com.opencsv.CSVWriter
 import io.realm.*
 import io.realm.annotations.PrimaryKey
 import org.json.JSONArray
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.*
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmMeetup : RealmObject() {
     @PrimaryKey
@@ -92,19 +89,30 @@ open class RealmMeetup : RealmObject() {
         }
 
         @JvmStatic
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("meetupId", "userId", "meetupId_rev", "title", "description", "startDate", "endDate", "recurring", "startTime", "endTime", "category", "meetupLocation", "meetupLink", "createdBy", "day", "link", "teamId"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
+        fun meetupWriteCsv() {
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/meetups.csv",
+                arrayOf(
+                    "meetupId",
+                    "userId",
+                    "meetupId_rev",
+                    "title",
+                    "description",
+                    "startDate",
+                    "endDate",
+                    "recurring",
+                    "startTime",
+                    "endTime",
+                    "category",
+                    "meetupLocation",
+                    "meetupLink",
+                    "createdBy",
+                    "day",
+                    "link",
+                    "teamId"
+                ),
+                meetupDataList
+            )
         }
 
 
@@ -161,11 +169,6 @@ open class RealmMeetup : RealmObject() {
 
         private fun checkNull(s: String?): String {
             return if (TextUtils.isEmpty(s)) "" else s!!
-        }
-
-        @JvmStatic
-        fun meetupWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/meetups.csv", meetupDataList)
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
@@ -7,7 +7,6 @@ import android.util.Base64
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmList
 import io.realm.RealmObject
@@ -21,9 +20,7 @@ import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DownloadUtils.extractLinks
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.Utilities
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 import androidx.core.content.edit
 
 open class RealmMyCourse : RealmObject() {
@@ -144,23 +141,24 @@ open class RealmMyCourse : RealmObject() {
             courseDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("courseId", "course_rev", "languageOfInstruction", "courseTitle", "memberLimit", "description", "method", "gradeLevel", "subjectLevel", "createdDate", "steps"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun courseWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/course.csv", courseDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/course.csv",
+                arrayOf(
+                    "courseId",
+                    "course_rev",
+                    "languageOfInstruction",
+                    "courseTitle",
+                    "memberLimit",
+                    "description",
+                    "method",
+                    "gradeLevel",
+                    "subjectLevel",
+                    "createdDate",
+                    "steps"
+                ),
+                courseDataList
+            )
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyHealthPojo.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyHealthPojo.kt
@@ -3,16 +3,13 @@ package org.ole.planet.myplanet.model
 import android.text.TextUtils
 import com.google.gson.Gson
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.JsonUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmMyHealthPojo : RealmObject() {
     @PrimaryKey
@@ -107,23 +104,32 @@ open class RealmMyHealthPojo : RealmObject() {
             healthDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("healthId", "health_rev", "data", "temperature", "pulse", "bp", "height", "weight", "vision", "hearing", "date", "selfExamination", "planetCode", "hasInfo", "profileId", "creator", "age", "gender", "conditions"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun healthWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/health.csv", healthDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/health.csv",
+                arrayOf(
+                    "healthId",
+                    "health_rev",
+                    "data",
+                    "temperature",
+                    "pulse",
+                    "bp",
+                    "height",
+                    "weight",
+                    "vision",
+                    "hearing",
+                    "date",
+                    "selfExamination",
+                    "planetCode",
+                    "hasInfo",
+                    "profileId",
+                    "creator",
+                    "age",
+                    "gender",
+                    "conditions"
+                ),
+                healthDataList
+            )
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
@@ -5,7 +5,6 @@ import android.content.SharedPreferences
 import com.google.gson.JsonArray
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmList
 import io.realm.RealmObject
@@ -15,9 +14,7 @@ import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.NetworkUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 import java.util.Calendar
 import java.util.Date
 import java.util.UUID
@@ -373,23 +370,46 @@ open class RealmMyLibrary : RealmObject() {
             libraryDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                CSVWriter(FileWriter(file)).use { writer ->
-                    writer.writeNext(arrayOf("libraryId", "library_rev", "title", "description", "resourceRemoteAddress", "resourceLocalAddress", "resourceOffline", "resourceId", "addedBy", "uploadDate", "createdDate", "openWith", "articleDate", "kind", "language", "author", "year", "medium", "filename", "mediaType", "resourceType", "timesRated", "averageRating", "publisher", "linkToLicense", "subject", "level", "tags", "languages", "courseId", "stepId", "downloaded", "private"))
-                    data.forEach { row ->
-                        writer.writeNext(row)
-                    }
-                }
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun libraryWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/library.csv", libraryDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/library.csv",
+                arrayOf(
+                    "libraryId",
+                    "library_rev",
+                    "title",
+                    "description",
+                    "resourceRemoteAddress",
+                    "resourceLocalAddress",
+                    "resourceOffline",
+                    "resourceId",
+                    "addedBy",
+                    "uploadDate",
+                    "createdDate",
+                    "openWith",
+                    "articleDate",
+                    "kind",
+                    "language",
+                    "author",
+                    "year",
+                    "medium",
+                    "filename",
+                    "mediaType",
+                    "resourceType",
+                    "timesRated",
+                    "averageRating",
+                    "publisher",
+                    "linkToLicense",
+                    "subject",
+                    "level",
+                    "tags",
+                    "languages",
+                    "courseId",
+                    "stepId",
+                    "downloaded",
+                    "private"
+                ),
+                libraryDataList
+            )
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -6,7 +6,6 @@ import androidx.core.net.toUri
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmList
 import io.realm.RealmObject
@@ -29,9 +28,7 @@ import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.Utilities.getUrl
 import org.ole.planet.myplanet.utilities.Utilities.openDownloadService
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 import java.util.Date
 
 open class RealmMyTeam : RealmObject() {
@@ -175,23 +172,47 @@ open class RealmMyTeam : RealmObject() {
             teamDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("userId", "teamId", "teamId_rev", "name", "sourcePlanet", "title", "description", "limit", "status", "teamPlanetCode", "createdDate", "resourceId", "teamType", "route", "type", "services", "rules", "parentCode", "createdBy", "userPlanetCode", "isLeader", "amount", "date", "docType", "public", "beginningBalance", "sales", "otherIncome", "wages", "otherExpenses", "startDate", "endDate", "updatedDate", "courses"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun teamWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/team.csv", teamDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/team.csv",
+                arrayOf(
+                    "userId",
+                    "teamId",
+                    "teamId_rev",
+                    "name",
+                    "sourcePlanet",
+                    "title",
+                    "description",
+                    "limit",
+                    "status",
+                    "teamPlanetCode",
+                    "createdDate",
+                    "resourceId",
+                    "teamType",
+                    "route",
+                    "type",
+                    "services",
+                    "rules",
+                    "parentCode",
+                    "createdBy",
+                    "userPlanetCode",
+                    "isLeader",
+                    "amount",
+                    "date",
+                    "docType",
+                    "public",
+                    "beginningBalance",
+                    "sales",
+                    "otherIncome",
+                    "wages",
+                    "otherExpenses",
+                    "startDate",
+                    "endDate",
+                    "updatedDate",
+                    "courses"
+                ),
+                teamDataList
+            )
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmNews.kt
@@ -8,7 +8,6 @@ import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonSyntaxException
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmList
 import io.realm.RealmObject
@@ -18,9 +17,7 @@ import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DownloadUtils.extractLinks
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.Utilities
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 import java.util.Date
 import java.util.UUID
 
@@ -196,23 +193,34 @@ open class RealmNews : RealmObject() {
             newsDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("_id", "_rev", "viewableBy", "docType", "avatar", "updatedDate", "viewableId", "createdOn", "messageType", "messagePlanetCode", "replyTo", "parentCode", "user", "time", "message", "images", "labels", "viewIn", "chat", "news", "sharedBy"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun newsWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/news.csv", newsDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/news.csv",
+                arrayOf(
+                    "_id",
+                    "_rev",
+                    "viewableBy",
+                    "docType",
+                    "avatar",
+                    "updatedDate",
+                    "viewableId",
+                    "createdOn",
+                    "messageType",
+                    "messagePlanetCode",
+                    "replyTo",
+                    "parentCode",
+                    "user",
+                    "time",
+                    "message",
+                    "images",
+                    "labels",
+                    "viewIn",
+                    "chat",
+                    "news",
+                    "sharedBy"
+                ),
+                newsDataList
+            )
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.model
 
 import android.content.Context
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.Sort
@@ -11,9 +10,7 @@ import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.NetworkUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmOfflineActivity : RealmObject() {
     @PrimaryKey
@@ -99,23 +96,22 @@ open class RealmOfflineActivity : RealmObject() {
             offlineDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("id", "_rev", "userName", "type", "createdOn", "parentCode", "loginTime", "logoutTime", "androidId"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun offlineWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/offlineActivity.csv", offlineDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/offlineActivity.csv",
+                arrayOf(
+                    "id",
+                    "_rev",
+                    "userName",
+                    "type",
+                    "createdOn",
+                    "parentCode",
+                    "loginTime",
+                    "logoutTime",
+                    "androidId"
+                ),
+                offlineDataList
+            )
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmRating.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmRating.kt
@@ -2,16 +2,13 @@ package org.ole.planet.myplanet.model
 
 import com.google.gson.Gson
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.NetworkUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmRating : RealmObject() {
     @PrimaryKey
@@ -127,23 +124,25 @@ open class RealmRating : RealmObject() {
             ratingDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("_id", "_rev", "user", "item", "type", "title", "time", "comment", "rate", "createdOn", "parentCode", "planetCode"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun ratingWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/ratings.csv", ratingDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/ratings.csv",
+                arrayOf(
+                    "_id",
+                    "_rev",
+                    "user",
+                    "item",
+                    "type",
+                    "title",
+                    "time",
+                    "comment",
+                    "rate",
+                    "createdOn",
+                    "parentCode",
+                    "planetCode"
+                ),
+                ratingDataList
+            )
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
@@ -2,16 +2,13 @@ package org.ole.planet.myplanet.model
 
 import android.text.TextUtils
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmStepExam : RealmObject() {
     @PrimaryKey
@@ -104,23 +101,26 @@ open class RealmStepExam : RealmObject() {
             examDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("_id", "_rev", "name", "passingPercentage", "type", "createdBy", "sourcePlanet", "createdDate", "updatedDate", "totalMarks", "noOfQuestions", "isFromNation", "teamId"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun stepExamWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/stepExam.csv", examDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/stepExam.csv",
+                arrayOf(
+                    "_id",
+                    "_rev",
+                    "name",
+                    "passingPercentage",
+                    "type",
+                    "createdBy",
+                    "sourcePlanet",
+                    "createdDate",
+                    "updatedDate",
+                    "totalMarks",
+                    "noOfQuestions",
+                    "isFromNation",
+                    "teamId"
+                ),
+                examDataList
+            )
         }
 
         private fun checkIdsAndInsert(myCoursesID: String?, stepId: String?, myExam: RealmStepExam?) {

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
@@ -5,7 +5,6 @@ import android.text.TextUtils
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import com.opencsv.CSVWriter
 import io.realm.Case
 import io.realm.Realm
 import io.realm.RealmList
@@ -20,9 +19,7 @@ import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.NetworkUtils
 import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 import java.util.Date
 import java.util.UUID
 
@@ -132,23 +129,24 @@ open class RealmSubmission : RealmObject() {
             }
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("_id", "parentId", "type", "status", "grade", "startTime", "lastUpdateTime", "sender", "source", "parentCode", "user"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun submissionWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/submission.csv", submissionDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/submission.csv",
+                arrayOf(
+                    "_id",
+                    "parentId",
+                    "type",
+                    "status",
+                    "grade",
+                    "startTime",
+                    "lastUpdateTime",
+                    "sender",
+                    "source",
+                    "parentCode",
+                    "user"
+                ),
+                submissionDataList
+            )
         }
 
         private fun serializeExamResult(mRealm: Realm, sub: RealmSubmission, context: Context): JsonObject {

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
@@ -20,6 +20,7 @@ import org.ole.planet.myplanet.utilities.NetworkUtils
 import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.CsvUtils
+import java.io.IOException
 import java.util.Date
 import java.util.UUID
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTag.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTag.kt
@@ -2,16 +2,13 @@ package org.ole.planet.myplanet.model
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmTag : RealmObject() {
     @PrimaryKey
@@ -77,23 +74,21 @@ open class RealmTag : RealmObject() {
             tagDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("_id", "_rev", "name", "db", "docType", "tagId", "linkId", "attachedTo"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun tagWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/tags.csv", tagDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/tags.csv",
+                arrayOf(
+                    "_id",
+                    "_rev",
+                    "name",
+                    "db",
+                    "docType",
+                    "tagId",
+                    "linkId",
+                    "attachedTo"
+                ),
+                tagDataList
+            )
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
@@ -3,16 +3,13 @@ package org.ole.planet.myplanet.model
 import android.content.Context
 import android.text.TextUtils
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.NetworkUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 import java.util.Calendar
 
 open class RealmTeamLog : RealmObject() {
@@ -105,23 +102,22 @@ open class RealmTeamLog : RealmObject() {
             teamLogDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("_id", "_rev", "user", "type", "createdOn", "parentCode", "time", "teamId", "teamType"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun teamLogWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/teamLog.csv", teamLogDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/teamLog.csv",
+                arrayOf(
+                    "_id",
+                    "_rev",
+                    "user",
+                    "type",
+                    "createdOn",
+                    "parentCode",
+                    "time",
+                    "teamId",
+                    "teamType"
+                ),
+                teamLogDataList
+            )
         }
 
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamTask.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamTask.kt
@@ -3,15 +3,12 @@ package org.ole.planet.myplanet.model
 import android.text.TextUtils
 import com.google.gson.Gson
 import com.google.gson.JsonObject
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 
 open class RealmTeamTask : RealmObject() {
     @PrimaryKey
@@ -79,23 +76,25 @@ open class RealmTeamTask : RealmObject() {
             taskDataList.add(csvRow)
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("_id", "_rev", "title", "status", "deadline", "completedTime", "description", "link", "sync", "teams", "assignee", "completed"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun teamTaskWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/teamTask.csv", taskDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/teamTask.csv",
+                arrayOf(
+                    "_id",
+                    "_rev",
+                    "title",
+                    "status",
+                    "deadline",
+                    "completedTime",
+                    "description",
+                    "link",
+                    "sync",
+                    "teams",
+                    "assignee",
+                    "completed"
+                ),
+                taskDataList
+            )
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
@@ -6,7 +6,6 @@ import android.util.Base64
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import com.opencsv.CSVWriter
 import io.realm.Realm
 import io.realm.RealmList
 import io.realm.RealmObject
@@ -17,9 +16,7 @@ import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.NetworkUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils
-import java.io.File
-import java.io.FileWriter
-import java.io.IOException
+import org.ole.planet.myplanet.utilities.CsvUtils
 import java.io.InputStream
 import java.util.Locale
 import java.util.UUID
@@ -315,23 +312,27 @@ open class RealmUserModel : RealmObject() {
             return realm.where(RealmUserModel::class.java).equalTo("name", name).count() > 0
         }
 
-        fun writeCsv(filePath: String, data: List<Array<String>>) {
-            try {
-                val file = File(filePath)
-                file.parentFile?.mkdirs()
-                val writer = CSVWriter(FileWriter(file))
-                writer.writeNext(arrayOf("userAdmin", "_id", "name", "firstName", "lastName", "email", "phoneNumber", "planetCode", "parentCode", "password_scheme", "iterations", "derived_key", "salt", "level"))
-                for (row in data) {
-                    writer.writeNext(row)
-                }
-                writer.close()
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-        }
-
         fun userWriteCsv() {
-            writeCsv("${context.getExternalFilesDir(null)}/ole/userData.csv", userDataList)
+            CsvUtils.writeCsv(
+                "${context.getExternalFilesDir(null)}/ole/userData.csv",
+                arrayOf(
+                    "userAdmin",
+                    "_id",
+                    "name",
+                    "firstName",
+                    "lastName",
+                    "email",
+                    "phoneNumber",
+                    "planetCode",
+                    "parentCode",
+                    "password_scheme",
+                    "iterations",
+                    "derived_key",
+                    "salt",
+                    "level"
+                ),
+                userDataList
+            )
         }
 
         fun updateUserDetails(realm: Realm, userId: String?, firstName: String?, lastName: String?,

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
@@ -18,6 +18,7 @@ import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils
 import org.ole.planet.myplanet.utilities.CsvUtils
 import java.io.InputStream
+import java.io.File
 import java.util.Locale
 import java.util.UUID
 import androidx.core.net.toUri

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/CsvUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/CsvUtils.kt
@@ -1,0 +1,24 @@
+package org.ole.planet.myplanet.utilities
+
+import com.opencsv.CSVWriter
+import java.io.File
+import java.io.FileWriter
+import java.io.IOException
+
+object CsvUtils {
+    @JvmStatic
+    fun writeCsv(filePath: String, header: Array<String>, data: List<Array<String>>) {
+        try {
+            val file = File(filePath)
+            file.parentFile?.mkdirs()
+            CSVWriter(FileWriter(file)).use { writer ->
+                writer.writeNext(header)
+                data.forEach { row ->
+                    writer.writeNext(row)
+                }
+            }
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `CsvUtils.writeCsv`
- simplify per-model CSV export by calling `CsvUtils.writeCsv`

## Testing
- `./gradlew test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6862bba7bc40832b8ec11e22be0fbfa4