### PR TITLE
teams: smoother experience (fixes #6130)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/JoinedMemberFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/JoinedMemberFragment.kt
@@ -11,7 +11,11 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
 
 class JoinedMemberFragment : BaseMemberFragment() {
-    private lateinit var memberChangeListener: MemberChangeListener
+    private var memberChangeListener: MemberChangeListener = object : MemberChangeListener {
+        override fun onMemberChanged() {
+            //fallback listener to prevent crash
+        }
+    }
 
     fun setMemberChangeListener(listener: MemberChangeListener) {
         this.memberChangeListener = listener


### PR DESCRIPTION
#6130 

Fix - implemented a fallback listener instead of lateinit to prevent crash.