### PR TITLE
Refactor container resource handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
@@ -35,6 +35,7 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler.Companion.KEY_RESOUR
 import org.ole.planet.myplanet.ui.courses.AdapterCourses
 import org.ole.planet.myplanet.ui.viewer.*
 import org.ole.planet.myplanet.utilities.FileUtils
+import org.ole.planet.myplanet.utilities.ResourceOpener
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.Utilities
 import java.io.File
@@ -95,7 +96,7 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
             shouldAutoOpenAfterDownload = false
             pendingAutoOpenLibrary = null
             if (library.isResourceOffline() || FileUtils.checkFileExist(Utilities.getUrl(library))) {
-                openFileType(library, "offline")
+                ResourceOpener.openFileType(requireActivity(), library, "offline", profileDbHandler)
             }
         }
     }
@@ -123,23 +124,6 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
         if (context is OnHomeItemClickListener) {
             homeItemClickListener = context
         }
-    }
-    private fun openIntent(items: RealmMyLibrary, typeClass: Class<*>?) {
-        val fileOpenIntent = Intent(activity, typeClass)
-        if (items.resourceLocalAddress?.contains("ole/audio") == true || items.resourceLocalAddress?.contains("ole/video") == true) {
-            fileOpenIntent.putExtra("TOUCHED_FILE", items.resourceLocalAddress)
-            fileOpenIntent.putExtra("RESOURCE_TITLE", items.title)
-        } else {
-            fileOpenIntent.putExtra("TOUCHED_FILE", items.id + "/" + items.resourceLocalAddress)
-            fileOpenIntent.putExtra("RESOURCE_TITLE", items.title)
-        }
-        startActivity(fileOpenIntent)
-    }
-    private fun openPdf(item: RealmMyLibrary) {
-        val fileOpenIntent = Intent(activity, PDFReaderActivity::class.java)
-        fileOpenIntent.putExtra("TOUCHED_FILE", item.id + "/" + item.resourceLocalAddress)
-        fileOpenIntent.putExtra("resourceId", item.id)
-        startActivity(fileOpenIntent)
     }
 
     private fun dismissProgressDialog() {
@@ -205,13 +189,13 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
 
         val offlineItem = matchingItems.firstOrNull { it.isResourceOffline() }
         if (offlineItem != null) {
-            openFileType(offlineItem, "offline")
+            ResourceOpener.openFileType(requireActivity(), offlineItem, "offline", profileDbHandler)
             return
         }
 
         when {
-            items.isResourceOffline() -> openFileType(items, "offline")
-            FileUtils.getFileExtension(items.resourceLocalAddress) == "mp4" -> openFileType(items, "online")
+            items.isResourceOffline() -> ResourceOpener.openFileType(requireActivity(), items, "offline", profileDbHandler)
+            FileUtils.getFileExtension(items.resourceLocalAddress) == "mp4" -> ResourceOpener.openFileType(requireActivity(), items, "online", profileDbHandler)
             else -> {
                 val arrayList = arrayListOf(Utilities.getUrl(items))
                 startDownloadWithAutoOpen(arrayList, items)
@@ -227,11 +211,11 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
 
         if (mimetype != null) {
             if (mimetype.contains("image")) {
-                openIntent(items, ImageViewerActivity::class.java)
+                ResourceOpener.openIntent(requireActivity(), items, ImageViewerActivity::class.java)
             } else if (mimetype.contains("pdf")) {
-                openPdf(items)
+                ResourceOpener.openPdf(requireActivity(), items)
             } else if (mimetype.contains("audio")) {
-                openIntent(items, AudioPlayerActivity::class.java)
+                ResourceOpener.openIntent(requireActivity(), items, AudioPlayerActivity::class.java)
             } else {
                 checkMoreFileExtensions(extension, items)
             }
@@ -241,13 +225,13 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
     private fun checkMoreFileExtensions(extension: String?, items: RealmMyLibrary) {
         when (extension) {
             "txt" -> {
-                openIntent(items, TextFileViewerActivity::class.java)
+                ResourceOpener.openIntent(requireActivity(), items, TextFileViewerActivity::class.java)
             }
             "md" -> {
-                openIntent(items, MarkdownViewerActivity::class.java)
+                ResourceOpener.openIntent(requireActivity(), items, MarkdownViewerActivity::class.java)
             }
             "csv" -> {
-                openIntent(items, CSVViewerActivity::class.java)
+                ResourceOpener.openIntent(requireActivity(), items, CSVViewerActivity::class.java)
             }
             "apk" -> {
                 installApk(items)
@@ -297,36 +281,7 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
 
     private fun openFileType(items: RealmMyLibrary, videoType: String) {
         dismissProgressDialog()
-        val mimetype = Utilities.getMimeType(items.resourceLocalAddress)
-        if (mimetype == null) {
-            Utilities.toast(activity, getString(R.string.unable_to_open_resource))
-            return
-        }
-        profileDbHandler = UserProfileDbHandler(requireContext())
-        profileDbHandler.setResourceOpenCount(items, KEY_RESOURCE_OPEN)
-        if (mimetype.startsWith("video")) {
-            playVideo(videoType, items)
-        } else {
-            checkFileExtension(items)
-        }
-    }
-    open fun playVideo(videoType: String, items: RealmMyLibrary) {
-        val intent = Intent(activity, VideoPlayerActivity::class.java)
-        val bundle = Bundle()
-        bundle.putString("videoType", videoType)
-        if (videoType == "online") {
-            bundle.putString("videoURL", "" + Utilities.getUrl(items))
-            bundle.putString("Auth", "" + auth)
-        } else if (videoType == "offline") {
-            if (items.resourceRemoteAddress == null && items.resourceLocalAddress != null) {
-                bundle.putString("videoURL", items.resourceLocalAddress)
-            } else {
-                bundle.putString("videoURL", "" + Uri.fromFile(File("" + FileUtils.getSDPathFromUrl(items.resourceRemoteAddress))))
-            }
-            bundle.putString("Auth", "")
-        }
-        intent.putExtras(bundle)
-        startActivity(intent)
+        ResourceOpener.openFileType(requireActivity(), items, videoType, profileDbHandler)
     }
 
     private fun showResourceList(downloadedResources: List<RealmMyLibrary>?) {

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt.lite
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt.lite
@@ -35,6 +35,7 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler.Companion.KEY_RESOUR
 import org.ole.planet.myplanet.ui.courses.AdapterCourses
 import org.ole.planet.myplanet.ui.viewer.*
 import org.ole.planet.myplanet.utilities.FileUtils
+import org.ole.planet.myplanet.utilities.ResourceOpener
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.Utilities
 import java.io.File
@@ -95,7 +96,7 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
             shouldAutoOpenAfterDownload = false
             pendingAutoOpenLibrary = null
             if (library.isResourceOffline() || FileUtils.checkFileExist(Utilities.getUrl(library))) {
-                openFileType(library, "offline")
+                ResourceOpener.openFileType(requireActivity(), library, "offline", profileDbHandler)
             }
         }
     }
@@ -123,23 +124,6 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
         if (context is OnHomeItemClickListener) {
             homeItemClickListener = context
         }
-    }
-    private fun openIntent(items: RealmMyLibrary, typeClass: Class<*>?) {
-        val fileOpenIntent = Intent(activity, typeClass)
-        if (items.resourceLocalAddress?.contains("ole/audio") == true || items.resourceLocalAddress?.contains("ole/video") == true) {
-            fileOpenIntent.putExtra("TOUCHED_FILE", items.resourceLocalAddress)
-            fileOpenIntent.putExtra("RESOURCE_TITLE", items.title)
-        } else {
-            fileOpenIntent.putExtra("TOUCHED_FILE", items.id + "/" + items.resourceLocalAddress)
-            fileOpenIntent.putExtra("RESOURCE_TITLE", items.title)
-        }
-        startActivity(fileOpenIntent)
-    }
-    private fun openPdf(item: RealmMyLibrary) {
-        val fileOpenIntent = Intent(activity, PDFReaderActivity::class.java)
-        fileOpenIntent.putExtra("TOUCHED_FILE", item.id + "/" + item.resourceLocalAddress)
-        fileOpenIntent.putExtra("resourceId", item.id)
-        startActivity(fileOpenIntent)
     }
 
     private fun dismissProgressDialog() {
@@ -205,13 +189,13 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
 
         val offlineItem = matchingItems.firstOrNull { it.isResourceOffline() }
         if (offlineItem != null) {
-            openFileType(offlineItem, "offline")
+            ResourceOpener.openFileType(requireActivity(), offlineItem, "offline", profileDbHandler)
             return
         }
 
         when {
-            items.isResourceOffline() -> openFileType(items, "offline")
-            FileUtils.getFileExtension(items.resourceLocalAddress) == "mp4" -> openFileType(items, "online")
+            items.isResourceOffline() -> ResourceOpener.openFileType(requireActivity(), items, "offline", profileDbHandler)
+            FileUtils.getFileExtension(items.resourceLocalAddress) == "mp4" -> ResourceOpener.openFileType(requireActivity(), items, "online", profileDbHandler)
             else -> {
                 val arrayList = arrayListOf(Utilities.getUrl(items))
                 startDownloadWithAutoOpen(arrayList, items)
@@ -227,11 +211,11 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
 
         if (mimetype != null) {
             if (mimetype.contains("image")) {
-                openIntent(items, ImageViewerActivity::class.java)
+                ResourceOpener.openIntent(requireActivity(), items, ImageViewerActivity::class.java)
             } else if (mimetype.contains("pdf")) {
-                openPdf(items)
+                ResourceOpener.openPdf(requireActivity(), items)
             } else if (mimetype.contains("audio")) {
-                openIntent(items, AudioPlayerActivity::class.java)
+                ResourceOpener.openIntent(requireActivity(), items, AudioPlayerActivity::class.java)
             } else {
                 checkMoreFileExtensions(extension, items)
             }
@@ -241,13 +225,13 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
     private fun checkMoreFileExtensions(extension: String?, items: RealmMyLibrary) {
         when (extension) {
             "txt" -> {
-                openIntent(items, TextFileViewerActivity::class.java)
+                ResourceOpener.openIntent(requireActivity(), items, TextFileViewerActivity::class.java)
             }
             "md" -> {
-                openIntent(items, MarkdownViewerActivity::class.java)
+                ResourceOpener.openIntent(requireActivity(), items, MarkdownViewerActivity::class.java)
             }
             "csv" -> {
-                openIntent(items, CSVViewerActivity::class.java)
+                ResourceOpener.openIntent(requireActivity(), items, CSVViewerActivity::class.java)
             }
 //            "apk" -> {
 //                installApk(items)
@@ -297,36 +281,7 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
 
     private fun openFileType(items: RealmMyLibrary, videoType: String) {
         dismissProgressDialog()
-        val mimetype = Utilities.getMimeType(items.resourceLocalAddress)
-        if (mimetype == null) {
-            Utilities.toast(activity, getString(R.string.unable_to_open_resource))
-            return
-        }
-        profileDbHandler = UserProfileDbHandler(requireContext())
-        profileDbHandler.setResourceOpenCount(items, KEY_RESOURCE_OPEN)
-        if (mimetype.startsWith("video")) {
-            playVideo(videoType, items)
-        } else {
-            checkFileExtension(items)
-        }
-    }
-    open fun playVideo(videoType: String, items: RealmMyLibrary) {
-        val intent = Intent(activity, VideoPlayerActivity::class.java)
-        val bundle = Bundle()
-        bundle.putString("videoType", videoType)
-        if (videoType == "online") {
-            bundle.putString("videoURL", "" + Utilities.getUrl(items))
-            bundle.putString("Auth", "" + auth)
-        } else if (videoType == "offline") {
-            if (items.resourceRemoteAddress == null && items.resourceLocalAddress != null) {
-                bundle.putString("videoURL", items.resourceLocalAddress)
-            } else {
-                bundle.putString("videoURL", "" + Uri.fromFile(File("" + FileUtils.getSDPathFromUrl(items.resourceRemoteAddress))))
-            }
-            bundle.putString("Auth", "")
-        }
-        intent.putExtras(bundle)
-        startActivity(intent)
+        ResourceOpener.openFileType(requireActivity(), items, videoType, profileDbHandler)
     }
 
     private fun showResourceList(downloadedResources: List<RealmMyLibrary>?) {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/ResourceOpener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/ResourceOpener.kt
@@ -1,0 +1,98 @@
+package org.ole.planet.myplanet.utilities
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Toast
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.base.BaseResourceFragment
+import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.ui.viewer.*
+import java.io.File
+
+object ResourceOpener {
+    fun openIntent(activity: Activity, items: RealmMyLibrary, typeClass: Class<*>) {
+        val fileOpenIntent = Intent(activity, typeClass)
+        if (items.resourceLocalAddress?.contains("ole/audio") == true ||
+            items.resourceLocalAddress?.contains("ole/video") == true) {
+            fileOpenIntent.putExtra("TOUCHED_FILE", items.resourceLocalAddress)
+            fileOpenIntent.putExtra("RESOURCE_TITLE", items.title)
+        } else {
+            fileOpenIntent.putExtra("TOUCHED_FILE", items.id + "/" + items.resourceLocalAddress)
+            fileOpenIntent.putExtra("RESOURCE_TITLE", items.title)
+        }
+        activity.startActivity(fileOpenIntent)
+    }
+
+    fun openPdf(activity: Activity, item: RealmMyLibrary) {
+        val fileOpenIntent = Intent(activity, PDFReaderActivity::class.java)
+        fileOpenIntent.putExtra("TOUCHED_FILE", item.id + "/" + item.resourceLocalAddress)
+        fileOpenIntent.putExtra("resourceId", item.id)
+        activity.startActivity(fileOpenIntent)
+    }
+
+    private fun checkMoreFileExtensions(activity: Activity, extension: String?, items: RealmMyLibrary) {
+        when (extension) {
+            "txt" -> openIntent(activity, items, TextFileViewerActivity::class.java)
+            "md" -> openIntent(activity, items, MarkdownViewerActivity::class.java)
+            "csv" -> openIntent(activity, items, CSVViewerActivity::class.java)
+            else -> Toast.makeText(activity,
+                activity.getString(R.string.this_file_type_is_currently_unsupported),
+                Toast.LENGTH_LONG).show()
+        }
+    }
+
+    fun checkFileExtension(activity: Activity, items: RealmMyLibrary) {
+        val filenameArray = items.resourceLocalAddress?.split(".")?.toTypedArray()
+        val extension = filenameArray?.get(filenameArray.size - 1)
+        val mimetype = Utilities.getMimeType(items.resourceLocalAddress)
+
+        if (mimetype != null) {
+            when {
+                mimetype.contains("image") -> openIntent(activity, items, ImageViewerActivity::class.java)
+                mimetype.contains("pdf") -> openPdf(activity, items)
+                mimetype.contains("audio") -> openIntent(activity, items, AudioPlayerActivity::class.java)
+                else -> checkMoreFileExtensions(activity, extension, items)
+            }
+        }
+    }
+
+    fun playVideo(activity: Activity, videoType: String, items: RealmMyLibrary) {
+        val intent = Intent(activity, VideoPlayerActivity::class.java)
+        val bundle = Bundle()
+        bundle.putString("videoType", videoType)
+        if (videoType == "online") {
+            bundle.putString("videoURL", "" + Utilities.getUrl(items))
+            bundle.putString("Auth", "" + BaseResourceFragment.auth)
+        } else if (videoType == "offline") {
+            if (items.resourceRemoteAddress == null && items.resourceLocalAddress != null) {
+                bundle.putString("videoURL", items.resourceLocalAddress)
+            } else {
+                bundle.putString(
+                    "videoURL",
+                    "" + Uri.fromFile(File("" + FileUtils.getSDPathFromUrl(items.resourceRemoteAddress)))
+                )
+            }
+            bundle.putString("Auth", "")
+        }
+        intent.putExtras(bundle)
+        activity.startActivity(intent)
+    }
+
+    fun openFileType(activity: Activity, items: RealmMyLibrary, videoType: String, profileDbHandler: UserProfileDbHandler) {
+        val mimetype = Utilities.getMimeType(items.resourceLocalAddress)
+        if (mimetype == null) {
+            Utilities.toast(activity, activity.getString(R.string.unable_to_open_resource))
+            return
+        }
+        profileDbHandler.setResourceOpenCount(items, UserProfileDbHandler.KEY_RESOURCE_OPEN)
+        if (mimetype.startsWith("video")) {
+            playVideo(activity, videoType, items)
+        } else {
+            checkFileExtension(activity, items)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `ResourceOpener` utility to centralize file opening
- delegate `BaseContainerFragment` logic to `ResourceOpener`
- keep lite fragment consistent and remove an extra blank line

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686383a718c4832bb52610f17c2dc404