### PR TITLE
Refactor SyncActivity server dialog

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
@@ -1,0 +1,313 @@
+package org.ole.planet.myplanet.ui.sync
+
+import android.text.TextUtils
+import android.view.View
+import android.widget.*
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.afollestad.materialdialogs.DialogAction
+import com.afollestad.materialdialogs.MaterialDialog
+import io.realm.Sort
+import org.ole.planet.myplanet.BuildConfig
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.databinding.DialogServerUrlBinding
+import org.ole.planet.myplanet.model.RealmCommunity
+import org.ole.planet.myplanet.ui.team.ServerAddressAdapter
+import org.ole.planet.myplanet.utilities.ServerConfigUtils
+
+fun SyncActivity.showConfigurationUIElements(
+    binding: DialogServerUrlBinding,
+    manualSelected: Boolean,
+    dialog: MaterialDialog,
+) {
+    serverAddresses.visibility = if (manualSelected) View.GONE else View.VISIBLE
+    syncToServerText.visibility = if (manualSelected) View.GONE else View.VISIBLE
+    positiveAction.visibility = if (manualSelected) View.VISIBLE else View.GONE
+    dialog.getActionButton(DialogAction.NEUTRAL).text =
+        if (manualSelected) {
+            getString(R.string.btn_sync_save)
+        } else {
+            if (showAdditionalServers) {
+                getString(R.string.show_less)
+            } else {
+                getString(R.string.show_more)
+            }
+        }
+    binding.ltAdvanced.visibility = if (manualSelected) View.VISIBLE else View.GONE
+    binding.switchServerUrl.visibility = if (manualSelected) View.VISIBLE else View.GONE
+
+    if (manualSelected) {
+        setupManualUi(binding)
+    } else {
+        setupServerListUi(binding, dialog)
+    }
+}
+
+fun SyncActivity.performSync(dialog: MaterialDialog) {
+    serverConfigAction = "sync"
+    val protocol = "${settings.getString("serverProtocol", "")}"
+    var url = "${serverUrl.text}"
+    val pin = "${serverPassword.text}"
+    editor.putString("serverURL", url).apply()
+    url = protocol + url
+    if (isUrlValid(url)) {
+        currentDialog = dialog
+        service.getMinApk(this, url, pin, this, "SyncActivity")
+    }
+}
+
+fun SyncActivity.onChangeServerUrl() {
+    val selected = spnCloud.selectedItem
+    if (selected is RealmCommunity && selected.isValid) {
+        serverUrl.setText(selected.localDomain)
+        protocolCheckIn.check(R.id.radio_https)
+        settings.getString("serverProtocol", getString(R.string.https_protocol))
+        serverPassword.setText(if (selected.weight == 0) "1983" else "")
+        serverPassword.isEnabled = selected.weight != 0
+    }
+}
+
+fun SyncActivity.setUrlAndPin(checked: Boolean) {
+    if (checked) {
+        onChangeServerUrl()
+    } else {
+        serverUrl.setText(settings.getString("serverURL", "")?.let { ServerConfigUtils.removeProtocol(it) })
+        serverPassword.setText(settings.getString("serverPin", ""))
+        protocolCheckIn.check(
+            if (TextUtils.equals(settings.getString("serverProtocol", ""), "http://")) {
+                R.id.radio_http
+            } else {
+                R.id.radio_https
+            }
+        )
+    }
+    serverUrl.isEnabled = !checked
+    serverPassword.isEnabled = !checked
+    serverPassword.clearFocus()
+    serverUrl.clearFocus()
+    protocolCheckIn.isEnabled = !checked
+}
+
+fun SyncActivity.protocolSemantics() {
+    protocolCheckIn.setOnCheckedChangeListener { _: RadioGroup?, i: Int ->
+        when (i) {
+            R.id.radio_http -> editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
+            R.id.radio_https -> editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
+        }
+    }
+}
+
+fun SyncActivity.refreshServerList() {
+    val filteredList = ServerConfigUtils.getFilteredList(
+        showAdditionalServers,
+        serverListAddresses,
+        settings.getString("pinnedServerUrl", null),
+    )
+    serverAddressAdapter?.updateList(filteredList)
+
+    val pinnedUrl = settings.getString("serverURL", "")
+    val pinnedIndex = filteredList.indexOfFirst {
+        it.url.replace(Regex("^https?://"), "") == pinnedUrl?.replace(Regex("^https?://"), "")
+    }
+    if (pinnedIndex != -1) {
+        serverAddressAdapter?.setSelectedPosition(pinnedIndex)
+    }
+}
+
+fun SyncActivity.setupManualUi(binding: DialogServerUrlBinding) {
+    if (settings.getString("serverProtocol", "") == getString(R.string.http_protocol)) {
+        binding.radioHttp.isChecked = true
+        editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
+    } else if (settings.getString("serverProtocol", "") == getString(R.string.https_protocol)) {
+        binding.radioHttps.isChecked = true
+        editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
+    }
+    serverUrl.setText(settings.getString("serverURL", "")?.let { ServerConfigUtils.removeProtocol(it) })
+    serverPassword.setText(settings.getString("serverPin", ""))
+    serverUrl.isEnabled = true
+    serverPassword.isEnabled = true
+}
+
+fun SyncActivity.setupServerListUi(binding: DialogServerUrlBinding, dialog: MaterialDialog) {
+    serverAddresses.layoutManager = LinearLayoutManager(this)
+    serverListAddresses = ServerConfigUtils.getServerAddresses(this)
+
+    val storedUrl = settings.getString("serverURL", null)
+    val storedPin = settings.getString("serverPin", null)
+    val urlWithoutProtocol = storedUrl?.replace(Regex("^https?://"), "")
+
+    serverAddressAdapter = ServerAddressAdapter(
+        ServerConfigUtils.getFilteredList(
+            showAdditionalServers,
+            serverListAddresses,
+            settings.getString("pinnedServerUrl", null),
+        ),
+        { serverListAddress ->
+            val actualUrl = serverListAddress.url.replace(Regex("^https?://"), "")
+            binding.inputServerUrl.setText(actualUrl)
+            binding.inputServerPassword.setText(ServerConfigUtils.getPinForUrl(actualUrl))
+            val protocol = if (
+                actualUrl == BuildConfig.PLANET_XELA_URL ||
+                actualUrl == BuildConfig.PLANET_SANPABLO_URL ||
+                actualUrl == BuildConfig.PLANET_URIUR_URL
+            ) "http://" else "https://"
+            editor.putString("serverProtocol", protocol).apply()
+            if (serverCheck) {
+                performSync(dialog)
+            }
+        },
+        { _, _ ->
+            clearDataDialog(getString(R.string.you_want_to_connect_to_a_different_server), false) {
+                serverAddressAdapter?.revertSelection()
+            }
+        },
+        urlWithoutProtocol,
+    )
+
+    serverAddresses.adapter = serverAddressAdapter
+
+    if (urlWithoutProtocol != null) {
+        val position = serverListAddresses.indexOfFirst { it.url.replace(Regex("^https?://"), "") == urlWithoutProtocol }
+        if (position != -1) {
+            serverAddressAdapter?.setSelectedPosition(position)
+            binding.inputServerUrl.setText(urlWithoutProtocol)
+            binding.inputServerPassword.setText(settings.getString("serverPin", ""))
+        }
+    }
+
+    if (!prefData.getManualConfig()) {
+        serverAddresses.visibility = View.VISIBLE
+        if (storedUrl != null && !syncFailed) {
+            val position = serverListAddresses.indexOfFirst { it.url.replace(Regex("^https?://"), "") == urlWithoutProtocol }
+            if (position != -1) {
+                serverAddressAdapter?.setSelectedPosition(position)
+                binding.inputServerUrl.setText(urlWithoutProtocol)
+                binding.inputServerPassword.setText(storedPin)
+            }
+        } else if (syncFailed) {
+            serverAddressAdapter?.clearSelection()
+        }
+    } else if (storedUrl != null) {
+        val position = serverListAddresses.indexOfFirst { it.url.replace(Regex("^https?://"), "") == urlWithoutProtocol }
+        if (position != -1) {
+            serverAddressAdapter?.setSelectedPosition(position)
+            binding.inputServerUrl.setText(urlWithoutProtocol)
+            binding.inputServerPassword.setText(storedPin)
+        }
+    }
+    serverUrl.isEnabled = false
+    serverPassword.isEnabled = false
+    editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
+}
+
+fun SyncActivity.onNeutralButtonClick(dialog: MaterialDialog) {
+    if (!prefData.getManualConfig()) {
+        showAdditionalServers = !showAdditionalServers
+        refreshServerList()
+        dialog.getActionButton(DialogAction.NEUTRAL).text =
+            if (showAdditionalServers) getString(R.string.show_less) else getString(R.string.show_more)
+    } else {
+        serverConfigAction = "save"
+        val protocol = "${settings.getString("serverProtocol", "")}"
+        var url = "${serverUrl.text}"
+        val pin = "${serverPassword.text}"
+        url = protocol + url
+        if (isUrlValid(url)) {
+            currentDialog = dialog
+            service.getMinApk(this, url, pin, this, "SyncActivity")
+        }
+    }
+}
+
+fun SyncActivity.initServerDialog(binding: DialogServerUrlBinding) {
+    spnCloud = binding.spnCloud
+    protocolCheckIn = binding.radioProtocol
+    serverUrl = binding.inputServerUrl
+    serverPassword = binding.inputServerPassword
+    serverAddresses = binding.serverUrls
+    syncToServerText = binding.syncToServerText
+    binding.deviceName.setText(org.ole.planet.myplanet.utilities.NetworkUtils.getDeviceName())
+}
+
+fun SyncActivity.setRadioProtocolListener(binding: DialogServerUrlBinding) {
+    binding.radioProtocol.setOnCheckedChangeListener { _: RadioGroup?, checkedId: Int ->
+        when (checkedId) {
+            R.id.radio_http -> editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
+            R.id.radio_https -> editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
+        }
+    }
+}
+
+fun SyncActivity.setupFastSyncOption(binding: DialogServerUrlBinding) {
+    val isFastSync = settings.getBoolean("fastSync", false)
+    binding.fastSync.isChecked = isFastSync
+    binding.fastSync.setOnCheckedChangeListener { _: CompoundButton?, checked: Boolean ->
+        editor.putBoolean("fastSync", checked).apply()
+    }
+}
+
+fun SyncActivity.handleManualConfiguration(
+    binding: DialogServerUrlBinding,
+    configurationId: String?,
+    dialog: MaterialDialog,
+) {
+    if (!prefData.getManualConfig()) {
+        binding.manualConfiguration.isChecked = false
+        showConfigurationUIElements(binding, false, dialog)
+    } else {
+        binding.manualConfiguration.isChecked = true
+        showConfigurationUIElements(binding, true, dialog)
+    }
+
+    binding.manualConfiguration.setOnCheckedChangeListener(null)
+    binding.manualConfiguration.setOnClickListener {
+        if (configurationId != null) {
+            binding.manualConfiguration.isChecked = prefData.getManualConfig()
+            if (prefData.getManualConfig()) {
+                clearDataDialog(getString(R.string.switching_off_manual_configuration_to_clear_data), false)
+            } else {
+                clearDataDialog(getString(R.string.switching_on_manual_configuration_to_clear_data), true)
+            }
+        } else {
+            val newCheckedState = !prefData.getManualConfig()
+            prefData.setManualConfig(newCheckedState)
+            if (newCheckedState) {
+                setupManualConfigEnabled(binding, dialog)
+            } else {
+                prefData.setManualConfig(false)
+                showConfigurationUIElements(binding, false, dialog)
+                editor.putBoolean("switchCloudUrl", false).apply()
+            }
+        }
+    }
+}
+
+fun SyncActivity.setupManualConfigEnabled(binding: DialogServerUrlBinding, dialog: MaterialDialog) {
+    prefData.setManualConfig(true)
+    editor.putString("serverURL", "").apply()
+    editor.putString("serverPin", "").apply()
+    binding.radioHttp.isChecked = true
+    editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
+    showConfigurationUIElements(binding, true, dialog)
+
+    val communities: List<RealmCommunity> =
+        mRealm.where(RealmCommunity::class.java).sort("weight", Sort.ASCENDING).findAll()
+    val nonEmptyCommunities = communities.filter { it.isValid && !TextUtils.isEmpty(it.name) }
+    binding.spnCloud.adapter = ArrayAdapter(this, R.layout.spinner_item_white, nonEmptyCommunities)
+    binding.spnCloud.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+            onChangeServerUrl()
+        }
+
+        override fun onNothingSelected(parent: AdapterView<*>?) {}
+    }
+
+    binding.switchServerUrl.setOnCheckedChangeListener { _: CompoundButton?, b: Boolean ->
+        editor.putBoolean("switchCloudUrl", b).apply()
+        binding.spnCloud.visibility = if (b) View.VISIBLE else View.GONE
+        setUrlAndPin(binding.switchServerUrl.isChecked)
+    }
+    serverUrl.addTextChangedListener(MyTextWatcher(serverUrl))
+    binding.switchServerUrl.isChecked = settings.getBoolean("switchCloudUrl", false)
+    setUrlAndPin(settings.getBoolean("switchCloudUrl", false))
+    protocolSemantics()
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -88,15 +88,15 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
     lateinit var syncIconDrawable: AnimationDrawable
     lateinit var prefData: SharedPrefManager
     lateinit var profileDbHandler: UserProfileDbHandler
-    private lateinit var spnCloud: Spinner
-    private lateinit var protocolCheckIn: RadioGroup
-    private lateinit var serverUrl: EditText
-    private lateinit var serverPassword: EditText
-    private lateinit var serverAddresses: RecyclerView
-    private lateinit var syncToServerText: TextView
+    lateinit var spnCloud: Spinner
+    lateinit var protocolCheckIn: RadioGroup
+    lateinit var serverUrl: EditText
+    lateinit var serverPassword: EditText
+    lateinit var serverAddresses: RecyclerView
+    lateinit var syncToServerText: TextView
     var selectedTeamId: String? = null
     lateinit var positiveAction: View
-    private lateinit var neutralAction: View
+    lateinit var neutralAction: View
     lateinit var processedUrl: String
     var isSync = false
     var forceSync = false
@@ -104,11 +104,11 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
     lateinit var defaultPref: SharedPreferences
     lateinit var service: Service
     var currentDialog: MaterialDialog? = null
-    private var serverConfigAction = ""
-    private var serverCheck = true
-    private var showAdditionalServers = false
-    private var serverAddressAdapter : ServerAddressAdapter? = null
-    private lateinit var serverListAddresses: List<ServerAddressesModel>
+    var serverConfigAction = ""
+    var serverCheck = true
+    var showAdditionalServers = false
+    var serverAddressAdapter: ServerAddressAdapter? = null
+    lateinit var serverListAddresses: List<ServerAddressesModel>
     private var isProgressDialogShowing = false
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
@@ -688,85 +688,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
             dialog.getActionButton(DialogAction.NEUTRAL).text = getString(R.string.show_more)
         }
     }
-    private fun showConfigurationUIElements(binding: DialogServerUrlBinding, manualSelected: Boolean, dialog: MaterialDialog) {
-        serverAddresses.visibility = if (manualSelected) View.GONE else View.VISIBLE
-        syncToServerText.visibility = if (manualSelected) View.GONE else View.VISIBLE
-        positiveAction.visibility = if (manualSelected) View.VISIBLE else View.GONE
-        dialog.getActionButton(DialogAction.NEUTRAL).text =
-            if (manualSelected) {
-                getString(R.string.btn_sync_save)
-            } else {
-                if (showAdditionalServers) {
-                    getString(R.string.show_less)
-                } else {
-                    getString(R.string.show_more)
-                }
-            }
-        binding.ltAdvanced.visibility = if (manualSelected) View.VISIBLE else View.GONE
-        binding.switchServerUrl.visibility = if (manualSelected) View.VISIBLE else View.GONE
-
-        if (manualSelected) {
-            setupManualUi(binding)
-        } else {
-            setupServerListUi(binding, dialog)
-        }
-    }
-
-    private fun performSync(dialog: MaterialDialog) {
-        serverConfigAction = "sync"
-        val protocol = "${settings.getString("serverProtocol", "")}"
-        var url = "${serverUrl.text}"
-        val pin = "${serverPassword.text}"
-        editor.putString("serverURL", url).apply()
-        url = protocol + url
-        if (isUrlValid(url)) {
-            currentDialog = dialog
-            service.getMinApk(this, url, pin, this, "SyncActivity")
-        }
-    }
-
-    private fun onChangeServerUrl() {
-        val selected = spnCloud.selectedItem
-        if (selected is RealmCommunity && selected.isValid) {
-            serverUrl.setText(selected.localDomain)
-            protocolCheckIn.check(R.id.radio_https)
-            settings.getString("serverProtocol", getString(R.string.https_protocol))
-            serverPassword.setText(if (selected.weight == 0) "1983" else "")
-            serverPassword.isEnabled = selected.weight != 0
-        }
-    }
-
-    private fun setUrlAndPin(checked: Boolean) {
-        if (checked) {
-            onChangeServerUrl()
-        } else {
-            serverUrl.setText(settings.getString("serverURL", "")?.let { ServerConfigUtils.removeProtocol(it) })
-            serverPassword.setText(settings.getString("serverPin", ""))
-            protocolCheckIn.check(
-                if (TextUtils.equals(settings.getString("serverProtocol", ""), "http://")) {
-                    R.id.radio_http
-                } else {
-                    R.id.radio_https
-                }
-            )
-        }
-        serverUrl.isEnabled = !checked
-        serverPassword.isEnabled = !checked
-        serverPassword.clearFocus()
-        serverUrl.clearFocus()
-        protocolCheckIn.isEnabled = !checked
-    }
-
-    private fun protocolSemantics() {
-        protocolCheckIn.setOnCheckedChangeListener { _: RadioGroup?, i: Int ->
-            when (i) {
-                R.id.radio_http -> editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
-                R.id.radio_https -> editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
-            }
-        }
-    }
-
-
     fun continueSync(dialog: MaterialDialog, url: String, isAlternativeUrl: Boolean, defaultUrl: String) {
         processedUrl = saveConfigAndContinue(dialog, url, isAlternativeUrl, defaultUrl)
         if (TextUtils.isEmpty(processedUrl)) return
@@ -888,214 +809,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         super.onDestroy()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
-        }
-    }
-
-    private fun initServerDialog(binding: DialogServerUrlBinding) {
-        spnCloud = binding.spnCloud
-        protocolCheckIn = binding.radioProtocol
-        serverUrl = binding.inputServerUrl
-        serverPassword = binding.inputServerPassword
-        serverAddresses = binding.serverUrls
-        syncToServerText = binding.syncToServerText
-        binding.deviceName.setText(NetworkUtils.getDeviceName())
-    }
-
-    private fun handleManualConfiguration(binding: DialogServerUrlBinding, configurationId: String?, dialog: MaterialDialog) {
-        if (!prefData.getManualConfig()) {
-            binding.manualConfiguration.isChecked = false
-            showConfigurationUIElements(binding, false, dialog)
-        } else {
-            binding.manualConfiguration.isChecked = true
-            showConfigurationUIElements(binding, true, dialog)
-        }
-
-        binding.manualConfiguration.setOnCheckedChangeListener(null)
-        binding.manualConfiguration.setOnClickListener {
-            if (configurationId != null) {
-                binding.manualConfiguration.isChecked = prefData.getManualConfig()
-                if (prefData.getManualConfig()) {
-                    clearDataDialog(getString(R.string.switching_off_manual_configuration_to_clear_data), false)
-                } else {
-                    clearDataDialog(getString(R.string.switching_on_manual_configuration_to_clear_data), true)
-                }
-            } else {
-                val newCheckedState = !prefData.getManualConfig()
-                prefData.setManualConfig(newCheckedState)
-                if (newCheckedState) {
-                    setupManualConfigEnabled(binding, dialog)
-                } else {
-                    prefData.setManualConfig(false)
-                    showConfigurationUIElements(binding, false, dialog)
-                    editor.putBoolean("switchCloudUrl", false).apply()
-                }
-            }
-        }
-    }
-
-    private fun setupManualConfigEnabled(binding: DialogServerUrlBinding, dialog: MaterialDialog) {
-        prefData.setManualConfig(true)
-        editor.putString("serverURL", "").apply()
-        editor.putString("serverPin", "").apply()
-        binding.radioHttp.isChecked = true
-        editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
-        showConfigurationUIElements(binding, true, dialog)
-
-        val communities: List<RealmCommunity> =
-            mRealm.where(RealmCommunity::class.java).sort("weight", Sort.ASCENDING).findAll()
-        val nonEmptyCommunities = communities.filter { it.isValid && !TextUtils.isEmpty(it.name) }
-        binding.spnCloud.adapter = ArrayAdapter(this, R.layout.spinner_item_white, nonEmptyCommunities)
-        binding.spnCloud.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-                onChangeServerUrl()
-            }
-
-            override fun onNothingSelected(parent: AdapterView<*>?) {}
-        }
-
-        binding.switchServerUrl.setOnCheckedChangeListener { _: CompoundButton?, b: Boolean ->
-            editor.putBoolean("switchCloudUrl", b).apply()
-            binding.spnCloud.visibility = if (b) View.VISIBLE else View.GONE
-            setUrlAndPin(binding.switchServerUrl.isChecked)
-        }
-        serverUrl.addTextChangedListener(MyTextWatcher(serverUrl))
-        binding.switchServerUrl.isChecked = settings.getBoolean("switchCloudUrl", false)
-        setUrlAndPin(settings.getBoolean("switchCloudUrl", false))
-        protocolSemantics()
-    }
-
-    private fun setRadioProtocolListener(binding: DialogServerUrlBinding) {
-        binding.radioProtocol.setOnCheckedChangeListener { _: RadioGroup?, checkedId: Int ->
-            when (checkedId) {
-                R.id.radio_http -> editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
-                R.id.radio_https -> editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
-            }
-        }
-    }
-
-    private fun setupFastSyncOption(binding: DialogServerUrlBinding) {
-        val isFastSync = settings.getBoolean("fastSync", false)
-        binding.fastSync.isChecked = isFastSync
-        binding.fastSync.setOnCheckedChangeListener { _: CompoundButton?, checked: Boolean ->
-            editor.putBoolean("fastSync", checked).apply()
-        }
-    }
-
-    private fun refreshServerList() {
-        val filteredList = ServerConfigUtils.getFilteredList(
-            showAdditionalServers,
-            serverListAddresses,
-            settings.getString("pinnedServerUrl", null),
-        )
-        serverAddressAdapter?.updateList(filteredList)
-
-        val pinnedUrl = settings.getString("serverURL", "")
-        val pinnedIndex = filteredList.indexOfFirst {
-            it.url.replace(Regex("^https?://"), "") == pinnedUrl?.replace(Regex("^https?://"), "")
-        }
-        if (pinnedIndex != -1) {
-            serverAddressAdapter?.setSelectedPosition(pinnedIndex)
-        }
-    }
-
-    private fun setupManualUi(binding: DialogServerUrlBinding) {
-        if (settings.getString("serverProtocol", "") == getString(R.string.http_protocol)) {
-            binding.radioHttp.isChecked = true
-            editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
-        } else if (settings.getString("serverProtocol", "") == getString(R.string.https_protocol)) {
-            binding.radioHttps.isChecked = true
-            editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
-        }
-        serverUrl.setText(settings.getString("serverURL", "")?.let { ServerConfigUtils.removeProtocol(it) })
-        serverPassword.setText(settings.getString("serverPin", ""))
-        serverUrl.isEnabled = true
-        serverPassword.isEnabled = true
-    }
-
-    private fun setupServerListUi(binding: DialogServerUrlBinding, dialog: MaterialDialog) {
-        serverAddresses.layoutManager = LinearLayoutManager(this)
-        serverListAddresses = ServerConfigUtils.getServerAddresses(this)
-
-        val storedUrl = settings.getString("serverURL", null)
-        val storedPin = settings.getString("serverPin", null)
-        val urlWithoutProtocol = storedUrl?.replace(Regex("^https?://"), "")
-
-        serverAddressAdapter = ServerAddressAdapter(
-            ServerConfigUtils.getFilteredList(
-                showAdditionalServers,
-                serverListAddresses,
-                settings.getString("pinnedServerUrl", null),
-            ),
-            { serverListAddress ->
-                val actualUrl = serverListAddress.url.replace(Regex("^https?://"), "")
-                binding.inputServerUrl.setText(actualUrl)
-                binding.inputServerPassword.setText(ServerConfigUtils.getPinForUrl(actualUrl))
-                val protocol = if (actualUrl == BuildConfig.PLANET_XELA_URL || actualUrl == BuildConfig.PLANET_SANPABLO_URL || actualUrl == BuildConfig.PLANET_URIUR_URL) "http://" else "https://"
-                editor.putString("serverProtocol", protocol).apply()
-                if (serverCheck) {
-                    performSync(dialog)
-                }
-            },
-            { _, _ ->
-                clearDataDialog(getString(R.string.you_want_to_connect_to_a_different_server), false) {
-                    serverAddressAdapter?.revertSelection()
-                }
-            },
-            urlWithoutProtocol,
-        )
-
-        serverAddresses.adapter = serverAddressAdapter
-
-        if (urlWithoutProtocol != null) {
-            val position = serverListAddresses.indexOfFirst { it.url.replace(Regex("^https?://"), "") == urlWithoutProtocol }
-            if (position != -1) {
-                serverAddressAdapter?.setSelectedPosition(position)
-                binding.inputServerUrl.setText(urlWithoutProtocol)
-                binding.inputServerPassword.setText(settings.getString("serverPin", ""))
-            }
-        }
-
-        if (!prefData.getManualConfig()) {
-            serverAddresses.visibility = View.VISIBLE
-            if (storedUrl != null && !syncFailed) {
-                val position = serverListAddresses.indexOfFirst { it.url.replace(Regex("^https?://"), "") == urlWithoutProtocol }
-                if (position != -1) {
-                    serverAddressAdapter?.setSelectedPosition(position)
-                    binding.inputServerUrl.setText(urlWithoutProtocol)
-                    binding.inputServerPassword.setText(storedPin)
-                }
-            } else if (syncFailed) {
-                serverAddressAdapter?.clearSelection()
-            }
-        } else if (storedUrl != null) {
-            val position = serverListAddresses.indexOfFirst { it.url.replace(Regex("^https?://"), "") == urlWithoutProtocol }
-            if (position != -1) {
-                serverAddressAdapter?.setSelectedPosition(position)
-                binding.inputServerUrl.setText(urlWithoutProtocol)
-                binding.inputServerPassword.setText(storedPin)
-            }
-        }
-        serverUrl.isEnabled = false
-        serverPassword.isEnabled = false
-        editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
-    }
-
-    private fun onNeutralButtonClick(dialog: MaterialDialog) {
-        if (!prefData.getManualConfig()) {
-            showAdditionalServers = !showAdditionalServers
-            refreshServerList()
-            dialog.getActionButton(DialogAction.NEUTRAL).text =
-                if (showAdditionalServers) getString(R.string.show_less) else getString(R.string.show_more)
-        } else {
-            serverConfigAction = "save"
-            val protocol = "${settings.getString("serverProtocol", "")}"
-            var url = "${serverUrl.text}"
-            val pin = "${serverPassword.text}"
-            url = protocol + url
-            if (isUrlValid(url)) {
-                currentDialog = dialog
-                service.getMinApk(this, url, pin, this, "SyncActivity")
-            }
         }
     }
     companion object {


### PR DESCRIPTION
## Summary
- extract server dialog helpers from `SyncActivity` to a new extension file
- simplify `SyncActivity` by removing dialog helper methods and adjusting property visibility

## Testing
- `./gradlew ktlintFormat` *(fails: task not found)*
- `./gradlew assembleDebug` *(interrupted due to time)*


------
https://chatgpt.com/codex/tasks/task_e_686645ebc918832ba422d22efad3624c