### PR TITLE
Rollback SDK to 34

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'kotlinx-serialization'
 apply plugin: 'dagger.hilt.android.plugin'
 apply plugin: 'realm-android'
 android {
-    compileSdk 35
+    compileSdk 34
     defaultConfig {
         applicationId "org.ole.planet.myplanet"
         minSdkVersion 26
-        targetSdkVersion 35
+        targetSdkVersion 34
         versionCode 2656
         versionName "0.26.56"
         ndkVersion '21.3.6528147'

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@ buildscript {
     ext {
         kotlin_version = '2.2.0'
         setup = [
-            compileSdk : 35,
+            compileSdk : 34,
             buildTools : "28.0.0",
             minSdk     : 21,
-            targetSdk  : 35
+            targetSdk  : 34
         ]
         versions = [
             supportLib : "28.0.0"


### PR DESCRIPTION
## Summary
- downgrade compileSdk/targetSdk to 34

## Testing
- `./gradlew help`
- `./gradlew test` *(fails: preparing Install Android SDK Build-Tools 35)*

------
https://chatgpt.com/codex/tasks/task_e_6866b22334cc832bb2b0be787426a4b5