### PR TITLE
Prepare for API 35 edge‑to‑edge

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,9 +9,9 @@ android {
     defaultConfig {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
-        targetSdk = 34
-        versionCode = 2665
-        versionName = "0.26.65"
+        targetSdk = 35
+        versionCode = 2666
+        versionName = "0.26.66"
         ndkVersion = '21.3.6528147'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseActivity.kt
@@ -3,8 +3,15 @@ package org.ole.planet.myplanet.base
 import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
 import android.view.MenuItem
+import android.view.View
+import android.view.WindowInsets
+import android.view.WindowManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import java.util.Locale
 import org.ole.planet.myplanet.ui.sync.SyncActivity
 import org.ole.planet.myplanet.utilities.LocaleHelper
@@ -17,6 +24,7 @@ abstract class BaseActivity : SyncActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setupEdgeToEdge()
         resetTitle()
         updateConfigurationIfNeeded()
     }
@@ -71,6 +79,20 @@ abstract class BaseActivity : SyncActivity() {
             true
         } else {
             super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun setupEdgeToEdge() {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            window.attributes.layoutInDisplayCutoutMode =
+                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
+        }
+        val root = findViewById<View>(android.R.id.content)
+        ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            WindowInsetsCompat.CONSUMED
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@ buildscript {
     ext {
         kotlin_version = '2.2.0'
         setup = [
-            compileSdk : 34,
+            compileSdk : 35,
             buildTools : "28.0.0",
             minSdk     : 21,
-            targetSdk  : 34
+            targetSdk  : 35
         ]
         versions = [
             supportLib : "28.0.0"


### PR DESCRIPTION
## Summary
- target and compile against SDK 35
- bump app version to 0.26.66
- handle window insets in `BaseActivity` for edge‑to‑edge

## Testing
- `./gradlew help`
- `./gradlew test -x lint --no-daemon` *(fails: Unable to delete directory)*

------
https://chatgpt.com/codex/tasks/task_e_68676cadd1ac832ba36c4706487c27be