### PR TITLE
Refactor database and session access

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -33,11 +33,13 @@ import org.ole.planet.myplanet.base.BaseResourceFragment.Companion.backgroundDow
 import org.ole.planet.myplanet.base.BaseResourceFragment.Companion.getAllLibraryList
 import org.ole.planet.myplanet.callback.TeamPageListener
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.datamanager.RealmProvider
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.service.AutoSyncWorker
 import org.ole.planet.myplanet.service.StayOnlineWorker
 import org.ole.planet.myplanet.service.TaskNotificationWorker
 import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserSession
 import org.ole.planet.myplanet.utilities.ANRWatchdog
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DownloadUtils.downloadAllFiles
@@ -206,8 +208,10 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
         startListenNetworkState()
 
         preferences = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+        RealmProvider.init(context)
         service = DatabaseService(context)
         mRealm = service.realmInstance
+        UserSession.init(context)
         defaultPref = PreferenceManager.getDefaultSharedPreferences(this)
 
         val builder = VmPolicy.Builder()

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/RealmProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/RealmProvider.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.datamanager
 
 import android.content.Context
 import io.realm.Realm
+import org.ole.planet.myplanet.datamanager.DatabaseService
 
 /**
  * Singleton provider for Realm instances used across the app.

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/RealmProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/RealmProvider.kt
@@ -1,0 +1,24 @@
+package org.ole.planet.myplanet.datamanager
+
+import android.content.Context
+import io.realm.Realm
+
+/**
+ * Singleton provider for Realm instances used across the app.
+ * Call [init] once with application context before requesting any Realm.
+ */
+object RealmProvider {
+    /**
+     * Initialize Realm configuration if it hasn't been done already.
+     */
+    fun init(context: Context) {
+        if (Realm.getDefaultConfiguration() == null) {
+            DatabaseService(context.applicationContext)
+        }
+    }
+
+    /**
+     * Returns a new [Realm] instance using the default configuration.
+     */
+    fun getRealm(): Realm = Realm.getDefaultInstance()
+}

--- a/app/src/main/java/org/ole/planet/myplanet/service/UserSession.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UserSession.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.service
 
 import android.content.Context
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.service.UserProfileDbHandler
 
 /**
  * Provides the current logged in [RealmUserModel].

--- a/app/src/main/java/org/ole/planet/myplanet/service/UserSession.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UserSession.kt
@@ -1,0 +1,19 @@
+package org.ole.planet.myplanet.service
+
+import android.content.Context
+import org.ole.planet.myplanet.model.RealmUserModel
+
+/**
+ * Provides the current logged in [RealmUserModel].
+ * Must be initialised once with application context.
+ */
+object UserSession {
+    private var handler: UserProfileDbHandler? = null
+
+    fun init(context: Context) {
+        handler = UserProfileDbHandler(context.applicationContext)
+    }
+
+    val user: RealmUserModel?
+        get() = handler?.userModel
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -37,7 +37,6 @@ import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentChatDetailBinding
 import org.ole.planet.myplanet.datamanager.RealmProvider
-import org.ole.planet.myplanet.datamanager.RealmProvider
 import org.ole.planet.myplanet.model.AiProvider
 import org.ole.planet.myplanet.model.ChatModel
 import org.ole.planet.myplanet.model.ChatRequestModel

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -36,7 +36,8 @@ import okhttp3.RequestBody
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentChatDetailBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.datamanager.RealmProvider
+import org.ole.planet.myplanet.datamanager.RealmProvider
 import org.ole.planet.myplanet.model.AiProvider
 import org.ole.planet.myplanet.model.ChatModel
 import org.ole.planet.myplanet.model.ChatRequestModel
@@ -48,7 +49,7 @@ import org.ole.planet.myplanet.model.Data
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmChatHistory.Companion.addConversationToChatHistory
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserSession
 import org.ole.planet.myplanet.ui.chat.ChatApiHelper
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.utilities.Constants
@@ -108,8 +109,9 @@ class ChatDetailFragment : Fragment() {
     }
 
     private fun initChatComponents() {
-        mRealm = DatabaseService(requireContext()).realmInstance
-        user = UserProfileDbHandler(requireContext()).userModel
+        RealmProvider.init(requireContext())
+        mRealm = RealmProvider.getRealm()
+        user = UserSession.user
         mAdapter = ChatAdapter(ArrayList(), requireContext(), fragmentChatDetailBinding.recyclerGchat)
         fragmentChatDetailBinding.recyclerGchat.apply {
             adapter = mAdapter

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -25,19 +25,19 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.SyncListener
 import org.ole.planet.myplanet.databinding.FragmentChatHistoryListBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.datamanager.RealmProvider
 import org.ole.planet.myplanet.model.ChatViewModel
 import org.ole.planet.myplanet.model.Conversation
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserSession
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
+import org.ole.planet.myplanet.utilities.showEmpty
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 
 class ChatHistoryListFragment : Fragment() {
@@ -63,7 +63,7 @@ class ChatHistoryListFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentChatHistoryListBinding = FragmentChatHistoryListBinding.inflate(inflater, container, false)
-        user = UserProfileDbHandler(requireContext()).userModel
+        user = UserSession.user
 
         return fragmentChatHistoryListBinding.root
     }
@@ -207,7 +207,8 @@ class ChatHistoryListFragment : Fragment() {
     }
 
     fun refreshChatHistoryList() {
-        val mRealm = DatabaseService(requireActivity()).realmInstance
+        RealmProvider.init(requireContext())
+        val mRealm = RealmProvider.getRealm()
         val list = mRealm.where(RealmChatHistory::class.java).equalTo("user", user?.name)
             .sort("id", Sort.DESCENDING)
             .findAll()
@@ -231,7 +232,7 @@ class ChatHistoryListFragment : Fragment() {
             fragmentChatHistoryListBinding.recyclerView.visibility = View.VISIBLE
         }
 
-        showNoData(fragmentChatHistoryListBinding.noChats, list.size, "chatHistory")
+        fragmentChatHistoryListBinding.noChats.showEmpty(list.size, "chatHistory")
         if (list.isEmpty()) {
             fragmentChatHistoryListBinding.searchBar.visibility = View.GONE
             fragmentChatHistoryListBinding.recyclerView.visibility = View.GONE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -53,6 +53,8 @@ import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Utilities
+import org.ole.planet.myplanet.datamanager.RealmProvider
+import org.ole.planet.myplanet.service.UserSession
 
 open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCallback,
     SyncListener {
@@ -111,7 +113,8 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     override fun forceDownloadNewsImages() {
-        mRealm = DatabaseService(requireContext()).realmInstance
+        RealmProvider.init(requireContext())
+        mRealm = RealmProvider.getRealm()
         Utilities.toast(activity, getString(R.string.please_select_starting_date))
         val now = Calendar.getInstance()
         val dpd = DatePickerDialog(requireActivity(), { _: DatePicker?, i: Int, i1: Int, i2: Int ->
@@ -210,7 +213,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
 
     private fun myTeamInit(flexboxLayout: FlexboxLayout): Int {
         val dbMyTeam = RealmMyTeam.getMyTeamsByUserId(mRealm, settings)
-        val userId = UserProfileDbHandler(requireContext()).userModel?.id
+        val userId = UserSession.user?.id
         for ((count, ob) in dbMyTeam.withIndex()) {
             val v = LayoutInflater.from(activity).inflate(R.layout.item_home_my_team, flexboxLayout, false)
             val name = v.findViewById<TextView>(R.id.tv_name)
@@ -254,7 +257,8 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     private fun setUpMyLife(userId: String?) {
-        val realm = DatabaseService(requireContext()).realmInstance
+        RealmProvider.init(requireContext())
+        val realm = RealmProvider.getRealm()
         val realmObjects = RealmMyLife.getMyLifeByUserId(mRealm, settings)
         if (realmObjects.isEmpty()) {
             if (!realm.isInTransaction) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
@@ -16,16 +16,17 @@ import io.realm.Sort
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseNewsFragment
 import org.ole.planet.myplanet.databinding.FragmentNewsBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.datamanager.RealmProvider
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNews.Companion.createNews
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserSession
 import org.ole.planet.myplanet.ui.chat.ChatDetailFragment
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 import org.ole.planet.myplanet.utilities.FileUtils.openOleFolder
+import org.ole.planet.myplanet.utilities.showEmpty
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
 import org.ole.planet.myplanet.utilities.KeyboardUtils.setupUI
 
@@ -38,8 +39,9 @@ class NewsFragment : BaseNewsFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentNewsBinding = FragmentNewsBinding.inflate(inflater, container, false)
         llImage = fragmentNewsBinding.llImages
-        mRealm = DatabaseService(requireActivity()).realmInstance
-        user = UserProfileDbHandler(requireContext()).userModel
+        RealmProvider.init(requireContext())
+        mRealm = RealmProvider.getRealm()
+        user = UserSession.user
         setupUI(fragmentNewsBinding.newsFragmentParentLayout, requireActivity())
         if (user?.id?.startsWith("guest") == true) {
             fragmentNewsBinding.btnNewVoice.visibility = View.GONE
@@ -185,7 +187,7 @@ class NewsFragment : BaseNewsFragment() {
             adapterNews?.setListener(this)
             adapterNews?.registerAdapterDataObserver(observer)
             fragmentNewsBinding.rvNews.adapter = adapterNews
-            adapterNews?.let { showNoData(fragmentNewsBinding.tvMessage, it.itemCount, "news") }
+            adapterNews?.let { fragmentNewsBinding.tvMessage.showEmpty(it.itemCount, "news") }
             fragmentNewsBinding.llAddNews.visibility = View.GONE
             fragmentNewsBinding.btnNewVoice.text = getString(R.string.new_voice)
             adapterNews?.notifyDataSetChanged()
@@ -223,15 +225,15 @@ class NewsFragment : BaseNewsFragment() {
 
     private val observer: AdapterDataObserver = object : AdapterDataObserver() {
         override fun onChanged() {
-            adapterNews?.let { showNoData(fragmentNewsBinding.tvMessage, it.itemCount, "news") }
+            adapterNews?.let { fragmentNewsBinding.tvMessage.showEmpty(it.itemCount, "news") }
         }
 
         override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-            adapterNews?.let { showNoData(fragmentNewsBinding.tvMessage, it.itemCount, "news") }
+            adapterNews?.let { fragmentNewsBinding.tvMessage.showEmpty(it.itemCount, "news") }
         }
 
         override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
-            adapterNews?.let { showNoData(fragmentNewsBinding.tvMessage, it.itemCount, "news") }
+            adapterNews?.let { fragmentNewsBinding.tvMessage.showEmpty(it.itemCount, "news") }
         }
     }
     private fun getSortDate(news: RealmNews?): Long {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.ui.team
 
-import android.content.DialogInterface
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -11,7 +10,6 @@ import android.widget.ArrayAdapter
 import android.widget.LinearLayout
 import android.widget.ListView
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -23,7 +21,6 @@ import java.util.UUID
 import org.json.JSONArray
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseNewsFragment
-import org.ole.planet.myplanet.databinding.AlertInputBinding
 import org.ole.planet.myplanet.databinding.FragmentMyTeamsDetailBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyCourse
@@ -43,6 +40,7 @@ import org.ole.planet.myplanet.ui.userprofile.UserDetailFragment
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 import org.ole.planet.myplanet.utilities.Utilities
+import org.ole.planet.myplanet.utilities.DialogUtils
 
 class MyTeamsDetailFragment : BaseNewsFragment() {
     private lateinit var fragmentMyTeamsDetailBinding: FragmentMyTeamsDetailBinding
@@ -97,28 +95,20 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
     }
 
     private fun showAddMessage() {
-        val alertInputBinding = AlertInputBinding.inflate(layoutInflater)
-        alertInputBinding.tlInput.hint = getString(R.string.enter_message)
-        alertInputBinding.custMsg.text = getString(R.string.add_message)
-
-        val dialog = AlertDialog.Builder(requireActivity(), R.style.CustomAlertDialog)
-            .setView(alertInputBinding.root)
-            .setPositiveButton(R.string.save) { _: DialogInterface?, _: Int ->
-                val msg = "${alertInputBinding.tlInput.editText?.text}".trim { it <= ' ' }
-                if (msg.isEmpty()) {
-                    Utilities.toast(activity, R.string.message_is_required.toString())
-                    return@setPositiveButton
-                }
-                val map = HashMap<String?, String>()
-                map["viewableBy"] = "teams"
-                map["viewableId"] = teamId!!
-                map["message"] = msg
-                map["messageType"] = team?.teamType!!
-                map["messagePlanetCode"] = team?.teamPlanetCode!!
-                createNews(map, mRealm, user, imageList)
-                rvDiscussion.adapter?.notifyItemInserted(0)
-            }.setNegativeButton(R.string.cancel, null).create()
-        dialog.show()
+        DialogUtils.showInputDialog(
+            requireContext(),
+            getString(R.string.add_message),
+            getString(R.string.enter_message)
+        ) { msg ->
+            val map = HashMap<String?, String>()
+            map["viewableBy"] = "teams"
+            map["viewableId"] = teamId!!
+            map["message"] = msg
+            map["messageType"] = team?.teamType!!
+            map["messagePlanetCode"] = team?.teamPlanetCode!!
+            createNews(map, mRealm, user, imageList)
+            rvDiscussion.adapter?.notifyItemInserted(0)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -20,11 +20,11 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.databinding.AlertCreateTeamBinding
 import org.ole.planet.myplanet.databinding.FragmentTeamBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.datamanager.RealmProvider
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getMyTeamsByUserId
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserSession
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Utilities
@@ -56,8 +56,9 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentTeamBinding = FragmentTeamBinding.inflate(inflater, container, false)
-        mRealm = DatabaseService(requireContext()).realmInstance
-        user = UserProfileDbHandler(requireActivity()).userModel
+        RealmProvider.init(requireContext())
+        mRealm = RealmProvider.getRealm()
+        user = UserSession.user
 
         if (user?.isGuest() == true) {
             fragmentTeamBinding.addTeam.visibility = View.GONE
@@ -162,7 +163,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     }
 
     private fun createTeam(name: String?, type: String?, map: HashMap<String, String>, isPublic: Boolean) {
-        val user = UserProfileDbHandler(requireContext()).userModel!!
+        val user = UserSession.user!!
         if (!mRealm.isInTransaction) mRealm.beginTransaction()
         val teamId = AndroidDecrypter.generateIv()
         val team = mRealm.createObject(RealmMyTeam::class.java, teamId)

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -13,6 +13,7 @@ import com.google.android.material.snackbar.Snackbar
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.DialogProgressBinding
+import org.ole.planet.myplanet.databinding.AlertInputBinding
 import org.ole.planet.myplanet.datamanager.MyDownloadService
 import org.ole.planet.myplanet.datamanager.Service
 import org.ole.planet.myplanet.model.MyPlanet

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -141,6 +141,42 @@ object DialogUtils {
             .show()
     }
 
+    /**
+     * Display a simple input dialog used for creating or editing items.
+     * This avoids repeating AlertDialog boilerplate across fragments.
+     */
+    @JvmStatic
+    fun showInputDialog(
+        context: Context,
+        title: String,
+        hint: String,
+        onResult: (String) -> Unit
+    ) {
+        val binding = AlertInputBinding.inflate(LayoutInflater.from(context))
+        binding.tlInput.hint = hint
+        binding.custMsg.text = title
+
+        val dialog = AlertDialog.Builder(context, R.style.CustomAlertDialog)
+            .setView(binding.root)
+            .setPositiveButton(R.string.save, null)
+            .setNegativeButton(R.string.cancel, null)
+            .create()
+
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                val text = binding.tlInput.editText?.text.toString().trim()
+                if (text.isEmpty()) {
+                    binding.tlInput.error = context.getString(R.string.name_is_required)
+                } else {
+                    onResult(text)
+                    dialog.dismiss()
+                }
+            }
+        }
+
+        dialog.show()
+    }
+
     @JvmStatic
     fun getAlertDialog(context: Context, title: String, v: View): AlertDialog {
         return AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialog))

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/EmptyStateExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/EmptyStateExtensions.kt
@@ -1,0 +1,37 @@
+package org.ole.planet.myplanet.utilities
+
+import android.view.View
+import android.widget.TextView
+import androidx.annotation.StringRes
+import org.ole.planet.myplanet.R
+
+/**
+ * Utility extension to update an empty state text view based on list count.
+ */
+
+private val emptyMessages = mapOf(
+    "courses" to R.string.no_courses,
+    "resources" to R.string.no_resources,
+    "finances" to R.string.no_finance_record,
+    "news" to R.string.no_voices_available,
+    "teamCourses" to R.string.no_team_courses,
+    "teamResources" to R.string.no_team_resources,
+    "tasks" to R.string.no_tasks,
+    "members" to R.string.no_join_request_available,
+    "discussions" to R.string.no_news,
+    "survey" to R.string.no_surveys,
+    "survey_submission" to R.string.no_survey_submissions,
+    "exam_submission" to R.string.no_exam_submissions,
+    "team" to R.string.no_teams,
+    "enterprise" to R.string.no_enterprise,
+    "chatHistory" to R.string.no_chats,
+    "feedback" to R.string.no_feedback,
+    "reports" to R.string.no_reports
+)
+
+fun TextView.showEmpty(count: Int, source: String) {
+    visibility = if (count == 0) View.VISIBLE else View.GONE
+    @StringRes val res = emptyMessages[source]
+        ?: R.string.no_data_available_please_check_and_try_again
+    setText(res)
+}


### PR DESCRIPTION
## Summary
- centralize Realm initialization with `RealmProvider`
- add `UserSession` singleton for accessing logged in user
- standardize empty state handling with `showEmpty` extension
- add reusable `showInputDialog` helper
- refactor fragments to use new providers

## Testing
- `./gradlew assembleDebug` *(fails: BUILD SUCCESSFUL not confirmed)*

------
https://chatgpt.com/codex/tasks/task_e_686b75cb6874832b96a1991833033612