### PR TITLE
Add Jetpack Navigation skeleton

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -256,6 +256,11 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.2.0"))
 
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
+
+    // Jetpack Navigation
+    def nav_version = "2.7.7"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 }
 realm {
     syncEnabled = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -10,12 +10,12 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.slidingpanelayout.widget.SlidingPaneLayout
+import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import io.realm.Realm
 import io.realm.RealmList
@@ -72,24 +72,13 @@ class ChatHistoryListFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         val slidingPaneLayout = fragmentChatHistoryListBinding.slidingPaneLayout
         slidingPaneLayout.lockMode = SlidingPaneLayout.LOCK_MODE_LOCKED
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, ChatHistoryListOnBackPressedCallback(slidingPaneLayout))
 
         fragmentChatHistoryListBinding.toggleGroup.visibility = View.GONE
         fragmentChatHistoryListBinding.newChat.setOnClickListener {
             if (resources.getBoolean(R.bool.isLargeScreen)) {
-                val chatHistoryListFragment = ChatHistoryListFragment()
-                parentFragmentManager.beginTransaction().apply {
-                    replace(R.id.fragment_container, chatHistoryListFragment)
-                    addToBackStack("ChatHistoryList")
-                    commit()
-                }
+                findNavController().navigate(R.id.action_chatHistoryListFragment_self)
             } else {
-                val chatDetailFragment = ChatDetailFragment()
-                parentFragmentManager.beginTransaction().apply {
-                    replace(R.id.fragment_container, chatDetailFragment)
-                    addToBackStack("ChatDetail")
-                    commit()
-                }
+                findNavController().navigate(R.id.action_chatHistoryListFragment_to_chatDetailFragment)
             }
         }
 
@@ -242,26 +231,5 @@ class ChatHistoryListFragment : Fragment() {
         super.onDestroy()
         customProgressDialog?.dismiss()
         customProgressDialog = null
-    }
-}
-
-class ChatHistoryListOnBackPressedCallback(private val slidingPaneLayout: SlidingPaneLayout) :
-    OnBackPressedCallback(slidingPaneLayout.isSlideable && slidingPaneLayout.isOpen),
-    SlidingPaneLayout.PanelSlideListener {
-    init {
-        slidingPaneLayout.addPanelSlideListener(this)
-    }
-    override fun handleOnBackPressed() {
-        slidingPaneLayout.closePane()
-    }
-
-    override fun onPanelSlide(panel: View, slideOffset: Float) {}
-
-    override fun onPanelOpened(panel: View) {
-        isEnabled = true
-    }
-
-    override fun onPanelClosed(panel: View) {
-        isEnabled = false
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -98,6 +98,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     private val realmListeners = mutableListOf<RealmListener>()
     private val dashboardViewModel: DashboardViewModel by viewModels()
     private lateinit var challengeHelper: ChallengeHelper
+    private lateinit var navController: androidx.navigation.NavController
 
     private interface RealmListener {
         fun removeListener()
@@ -128,6 +129,9 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     private fun initViews() {
         activityDashboardBinding = ActivityDashboardBinding.inflate(layoutInflater)
         setContentView(activityDashboardBinding.root)
+        val navHost = supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as androidx.navigation.fragment.NavHostFragment
+        navController = navHost.navController
+        androidx.navigation.ui.NavigationUI.setupWithNavController(activityDashboardBinding.topBarNavigation, navController)
         setupUI(activityDashboardBinding.activityDashboardParentLayout, this@DashboardActivity)
         setSupportActionBar(activityDashboardBinding.myToolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(false)
@@ -223,10 +227,9 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         if (intent != null && intent.hasExtra("fragmentToOpen")) {
             val fragmentToOpen = intent.getStringExtra("fragmentToOpen")
             if ("feedbackList" == fragmentToOpen) {
-                openMyFragment(FeedbackListFragment())
+                navController.navigate(R.id.feedbackListFragment)
             }
         } else {
-            openCallFragment(BellDashboardFragment())
             activityDashboardBinding.appBarBell.bellToolbar.visibility = View.VISIBLE
         }
     }
@@ -244,10 +247,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         when (itemId) {
             R.id.action_chat -> {
                 if (user?.id?.startsWith("guest") == false) {
-                    openCallFragment(
-                        ChatHistoryListFragment(),
-                        ChatHistoryListFragment::class.java.simpleName
-                    )
+                    navController.navigate(R.id.chatHistoryListFragment)
                 } else {
                     guestDialog(this)
                 }
@@ -256,10 +256,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             R.id.action_sync -> logSyncInSharedPrefs()
             R.id.action_feedback -> {
                 if (user?.id?.startsWith("guest") == false) {
-                    openCallFragment(
-                        FeedbackListFragment(),
-                        FeedbackListFragment::class.java.simpleName
-                    )
+                    navController.navigate(R.id.feedbackListFragment)
                 } else {
                     guestDialog(this)
                 }
@@ -800,30 +797,30 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         item.isChecked = true
         when (item.itemId) {
             R.id.menu_library -> {
-                openCallFragment(ResourcesFragment())
+                navController.navigate(R.id.resourcesFragment)
             }
             R.id.menu_courses -> {
-                openCallFragment(CoursesFragment())
+                navController.navigate(R.id.coursesFragment)
             }
             R.id.menu_mycourses -> {
                 if (user?.id?.startsWith("guest") == true) {
                     guestDialog(this)
                 } else {
-                    openMyFragment(CoursesFragment())
+                    navController.navigate(R.id.coursesFragment)
                 }
             }
             R.id.menu_mylibrary -> {
                 if (user?.id?.startsWith("guest") == true) {
                     guestDialog(this)
                 } else {
-                    openMyFragment(ResourcesFragment())
+                    navController.navigate(R.id.resourcesFragment)
                 }
             }
             R.id.menu_enterprises -> {
                 openEnterpriseFragment()
             }
             R.id.menu_home -> {
-                openCallFragment(BellDashboardFragment())
+                navController.navigate(R.id.bellDashboardFragment)
             }
         }
         item.isChecked = true

--- a/app/src/main/res/layout/activity_dashboard.xml
+++ b/app/src/main/res/layout/activity_dashboard.xml
@@ -35,11 +35,12 @@
             app:itemTextColor="@drawable/drawable_nav_color"
             app:menu="@menu/menu_topbar" />
 
-        <FrameLayout
-            android:id="@+id/fragment_container"
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/nav_host_fragment"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1">
-        </FrameLayout>
+            android:layout_weight="1"
+            app:navGraph="@navigation/nav_graph"
+            app:defaultNavHost="true" />
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:startDestination="@id/bellDashboardFragment">
+
+    <fragment
+        android:id="@+id/bellDashboardFragment"
+        android:name="org.ole.planet.myplanet.ui.dashboard.BellDashboardFragment"
+        android:label="Home">
+        <action
+            android:id="@+id/action_bellDashboardFragment_to_teamFragment"
+            app:destination="@id/teamFragment" />
+        <action
+            android:id="@+id/action_bellDashboardFragment_to_chatHistoryListFragment"
+            app:destination="@id/chatHistoryListFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/teamFragment"
+        android:name="org.ole.planet.myplanet.ui.team.TeamFragment"
+        android:label="Teams" />
+
+    <fragment
+        android:id="@+id/resourcesFragment"
+        android:name="org.ole.planet.myplanet.ui.resources.ResourcesFragment"
+        android:label="Resources" />
+
+    <fragment
+        android:id="@+id/coursesFragment"
+        android:name="org.ole.planet.myplanet.ui.courses.CoursesFragment"
+        android:label="Courses" />
+
+    <fragment
+        android:id="@+id/chatHistoryListFragment"
+        android:name="org.ole.planet.myplanet.ui.chat.ChatHistoryListFragment"
+        android:label="Chat History">
+        <action
+            android:id="@+id/action_chatHistoryListFragment_to_chatDetailFragment"
+            app:destination="@id/chatDetailFragment" />
+        <action
+            android:id="@+id/action_chatHistoryListFragment_self"
+            app:destination="@id/chatHistoryListFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/chatDetailFragment"
+        android:name="org.ole.planet.myplanet.ui.chat.ChatDetailFragment"
+        android:label="Chat Detail" />
+
+    <fragment
+        android:id="@+id/feedbackListFragment"
+        android:name="org.ole.planet.myplanet.ui.feedback.FeedbackListFragment"
+        android:label="Feedback" />
+</navigation>


### PR DESCRIPTION
## Summary
- add AndroidX Navigation dependencies
- host a `NavHostFragment` in dashboard layout
- wire DashboardActivity bottom nav using `NavController`
- create a starter `nav_graph` with dashboard, teams, chat and more
- simplify chat history fragment navigation and remove custom back handler

## Testing
- `./gradlew assembleDebug -x test`

------
https://chatgpt.com/codex/tasks/task_e_686b7613e13c832bbf63ee2778ac2368