### PR TITLE
Enable ViewBinding usage in fragments and activities

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
@@ -22,7 +22,8 @@ import org.ole.planet.myplanet.ui.team.AdapterTeam
 import org.ole.planet.myplanet.utilities.Utilities
 
 class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedListener {
-    private lateinit var fragmentAddLinkBinding: FragmentAddLinkBinding
+    private var _binding: FragmentAddLinkBinding? = null
+    private val binding get() = _binding!!
     override fun onNothingSelected(p0: AdapterView<*>?) {
     }
 
@@ -60,17 +61,17 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentAddLinkBinding = FragmentAddLinkBinding.inflate(inflater, container, false)
-        return fragmentAddLinkBinding.root
+        _binding = FragmentAddLinkBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         mRealm = DatabaseService(requireActivity()).realmInstance
-        fragmentAddLinkBinding.spnLink.onItemSelectedListener = this
-        fragmentAddLinkBinding.btnSave.setOnClickListener {
-            val type = fragmentAddLinkBinding.spnLink.selectedItem.toString()
-            val title = fragmentAddLinkBinding.etName.text.toString()
+        binding.spnLink.onItemSelectedListener = this
+        binding.btnSave.setOnClickListener {
+            val type = binding.spnLink.selectedItem.toString()
+            val title = binding.etName.text.toString()
             if (title.isEmpty()) {
                 Utilities.toast(requireActivity(), getString(R.string.title_is_required))
                 return@setOnClickListener
@@ -90,5 +91,10 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
 
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
@@ -17,12 +17,13 @@ import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.TimeUtils
 
 class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
-    private lateinit var fragmentTeamDetailBinding: FragmentTeamDetailBinding
+    private var _binding: FragmentTeamDetailBinding? = null
+    private val binding get() = _binding!!
     private var bottomSheetBehavior: BottomSheetBehavior<View>? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentTeamDetailBinding = FragmentTeamDetailBinding.inflate(inflater, container, false)
-        return fragmentTeamDetailBinding.root
+        _binding = FragmentTeamDetailBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -77,18 +78,23 @@ class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
     }
 
     private fun initCommunityTab() {
-        fragmentTeamDetailBinding.llActionButtons.visibility = View.GONE
+        binding.llActionButtons.visibility = View.GONE
         val settings = requireActivity().getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         val sParentcode = settings.getString("parentCode", "")
         val communityName = settings.getString("communityName", "")
-        fragmentTeamDetailBinding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), "$communityName@$sParentcode", true)
-        TabLayoutMediator(fragmentTeamDetailBinding.tabLayout, fragmentTeamDetailBinding.viewPager2) { tab, position ->
-            tab.text = (fragmentTeamDetailBinding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
+        binding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), "$communityName@$sParentcode", true)
+        TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->
+            tab.text = (binding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
         }.attach()
-        fragmentTeamDetailBinding.title.text = communityName
-        fragmentTeamDetailBinding.title.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
-        fragmentTeamDetailBinding.subtitle.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
-        fragmentTeamDetailBinding.subtitle.text = TimeUtils.getFormatedDateWithTime(Date().time)
-        fragmentTeamDetailBinding.appBar.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.secondary_bg))
+        binding.title.text = communityName
+        binding.title.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
+        binding.subtitle.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
+        binding.subtitle.text = TimeUtils.getFormatedDateWithTime(Date().time)
+        binding.appBar.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.secondary_bg))
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -138,7 +138,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         navigationView.labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_LABELED
         activityDashboardBinding.appBarBell.bellToolbar.inflateMenu(R.menu.menu_bell_dashboard)
         service = Service(this)
-        tl = findViewById(R.id.tab_layout)
+        tl = activityDashboardBinding.appBarBell.tabLayout
         activityDashboardBinding.root.viewTreeObserver.addOnGlobalLayoutListener { topBarVisible() }
         activityDashboardBinding.appBarBell.ivSetting.setOnClickListener {
             startActivity(Intent(this, SettingActivity::class.java))
@@ -541,7 +541,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
     private fun topBarVisible(){
         val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-        val tabLayout = findViewById<TabLayout>(R.id.tab_layout)
+        val tabLayout = activityDashboardBinding.appBarBell.tabLayout
 
         tabLayout.visibility = if (isLandscape) {
             View.VISIBLE
@@ -552,7 +552,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
     private fun topbarSetting() {
         UITheme()
-        val tabLayout = findViewById<TabLayout>(R.id.tab_layout)
+        val tabLayout = activityDashboardBinding.appBarBell.tabLayout
         tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
                 onClickTabItems(tab.position)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mymeetup/MyMeetupDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mymeetup/MyMeetupDetailFragment.kt
@@ -21,7 +21,8 @@ import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 
 class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
-    private lateinit var fragmentMyMeetupDetailBinding: FragmentMyMeetupDetailBinding
+    private var _binding: FragmentMyMeetupDetailBinding? = null
+    private val binding get() = _binding!!
     private var meetups: RealmMeetup? = null
     lateinit var mRealm: Realm
     private var meetUpId: String? = null
@@ -38,17 +39,17 @@ class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentMyMeetupDetailBinding = FragmentMyMeetupDetailBinding.inflate(inflater, container, false)
-        listDesc = fragmentMyMeetupDetailBinding.root.findViewById(R.id.list_desc)
-        listUsers = fragmentMyMeetupDetailBinding.root.findViewById(R.id.list_users)
-        tvJoined = fragmentMyMeetupDetailBinding.root.findViewById(R.id.tv_joined)
-        fragmentMyMeetupDetailBinding.btnInvite.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
-        fragmentMyMeetupDetailBinding.btnLeave.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
-        fragmentMyMeetupDetailBinding.btnLeave.setOnClickListener(this)
+        _binding = FragmentMyMeetupDetailBinding.inflate(inflater, container, false)
+        listDesc = binding.contentMeetupDetail.listDesc
+        listUsers = binding.contentMeetupDetail.listUsers
+        tvJoined = binding.contentMeetupDetail.tvJoined
+        binding.btnInvite.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
+        binding.btnLeave.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
+        binding.btnLeave.setOnClickListener(this)
         mRealm = DatabaseService(requireActivity()).realmInstance
         profileDbHandler = UserProfileDbHandler(requireContext())
         user = profileDbHandler?.userModel?.let { mRealm.copyFromRealm(it) }
-        return fragmentMyMeetupDetailBinding.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -66,7 +67,7 @@ class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
     }
 
     private fun setUpData() {
-        fragmentMyMeetupDetailBinding.meetupTitle.text = meetups?.title
+        binding.meetupTitle.text = meetups?.title
         val map: HashMap<String, String>? = meetups?.let { getHashMap(it) }
         val keys = ArrayList(map?.keys ?: emptyList())
         listDesc?.adapter = object : ArrayAdapter<String?>(requireActivity(), R.layout.row_description, keys) {
@@ -92,11 +93,16 @@ class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
         mRealm.executeTransaction {
             if (meetups?.userId?.isEmpty() == true) {
                 meetups?.userId = user?.id
-                fragmentMyMeetupDetailBinding.btnLeave.setText(R.string.leave)
+                binding.btnLeave.setText(R.string.leave)
             } else {
                 meetups?.userId = ""
-                fragmentMyMeetupDetailBinding.btnLeave.setText(R.string.join)
+                binding.btnLeave.setText(R.string.join)
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SendSurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SendSurveyFragment.kt
@@ -21,22 +21,23 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.utilities.Utilities
 
 class SendSurveyFragment : BaseDialogFragment() {
-    private lateinit var fragmentSendSurveyBinding: FragmentSendSurveyBinding
+    private var _binding: FragmentSendSurveyBinding? = null
+    private val binding get() = _binding!!
     lateinit var mRealm: Realm
     lateinit var dbService: DatabaseService
     override val key: String
         get() = "surveyId"
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentSendSurveyBinding = FragmentSendSurveyBinding.inflate(inflater, container, false)
+        _binding = FragmentSendSurveyBinding.inflate(inflater, container, false)
         dbService = DatabaseService(requireActivity())
         mRealm = dbService.realmInstance
         if (TextUtils.isEmpty(id)) {
             dismiss()
-            return fragmentSendSurveyBinding.root
+            return binding.root
         }
-        fragmentSendSurveyBinding.btnCancel.setOnClickListener { dismiss() }
-        return fragmentSendSurveyBinding.root
+        binding.btnCancel.setOnClickListener { dismiss() }
+        return binding.root
     }
 
     private fun createSurveySubmission(userId: String?) {
@@ -59,8 +60,8 @@ class SendSurveyFragment : BaseDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         val users: List<RealmUserModel> = mRealm.where(RealmUserModel::class.java).findAll()
         initListView(users)
-        fragmentSendSurveyBinding.sendSurvey.setOnClickListener {
-            for (i in fragmentSendSurveyBinding.listUsers.selectedItemsList.indices) {
+        binding.sendSurvey.setOnClickListener {
+            for (i in binding.listUsers.selectedItemsList.indices) {
                 val u = users[i]
                 createSurveySubmission(u.id)
             }
@@ -71,7 +72,12 @@ class SendSurveyFragment : BaseDialogFragment() {
 
     private fun initListView(users: List<RealmUserModel>) {
         val adapter = ArrayAdapter(requireActivity(), R.layout.rowlayout, R.id.checkBoxRowLayout, users)
-        fragmentSendSurveyBinding.listUsers.choiceMode = ListView.CHOICE_MODE_MULTIPLE
-        fragmentSendSurveyBinding.listUsers.adapter = adapter
+        binding.listUsers.choiceMode = ListView.CHOICE_MODE_MULTIPLE
+        binding.listUsers.adapter = adapter
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
@@ -45,7 +45,8 @@ import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 import org.ole.planet.myplanet.utilities.Utilities
 
 class MyTeamsDetailFragment : BaseNewsFragment() {
-    private lateinit var fragmentMyTeamsDetailBinding: FragmentMyTeamsDetailBinding
+    private var _binding: FragmentMyTeamsDetailBinding? = null
+    private val binding get() = _binding!!
     lateinit var tvDescription: TextView
     var user: RealmUserModel? = null
     var teamId: String? = null
@@ -67,33 +68,32 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentMyTeamsDetailBinding = FragmentMyTeamsDetailBinding.inflate(inflater, container, false)
-        val v: View = fragmentMyTeamsDetailBinding.root
-        initializeViews(v)
+        _binding = FragmentMyTeamsDetailBinding.inflate(inflater, container, false)
+        initializeViews()
         dbService = DatabaseService(requireActivity())
         mRealm = dbService.realmInstance
         user = profileDbHandler.userModel?.let { mRealm.copyFromRealm(it) }
         team = mRealm.where(RealmMyTeam::class.java).equalTo("_id", teamId).findFirst()
-        return fragmentMyTeamsDetailBinding.root
+        return binding.root
     }
 
-    private fun initializeViews(v: View) {
-        llRv = v.findViewById(R.id.ll_rv)
-        rvDiscussion = v.findViewById(R.id.rv_discussion)
-        tvDescription = v.findViewById(R.id.description)
-        tabLayout = v.findViewById(R.id.tab_layout)
-        listContent = v.findViewById(R.id.list_content)
-        fragmentMyTeamsDetailBinding.btnInvite.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) {
+    private fun initializeViews() {
+        llRv = binding.contentTeamDetail.llRv
+        rvDiscussion = binding.contentTeamDetail.rvDiscussion
+        tvDescription = binding.contentTeamDetail.description
+        tabLayout = binding.contentTeamDetail.tabLayout
+        listContent = binding.contentTeamDetail.listContent
+        binding.btnInvite.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) {
             View.VISIBLE
         } else {
             View.GONE
         }
-        fragmentMyTeamsDetailBinding.btnLeave.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) {
+        binding.btnLeave.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) {
             View.VISIBLE
         } else {
             View.GONE
         }
-        v.findViewById<View>(R.id.add_message).setOnClickListener { showAddMessage() }
+        binding.contentTeamDetail.addMessage.setOnClickListener { showAddMessage() }
     }
 
     private fun showAddMessage() {
@@ -123,7 +123,7 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        fragmentMyTeamsDetailBinding.title.text = team?.name
+        binding.title.text = team?.name
         tvDescription.text = team?.description
         setTeamList()
     }
@@ -175,6 +175,11 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
         log.parentCode = user?.parentCode
         log.time = Date().time
         mRealm.commitTransaction()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun showRecyclerView(realmNewsList: List<RealmNews?>?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/AudioPlayerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/AudioPlayerActivity.kt
@@ -36,8 +36,7 @@ class AudioPlayerActivity : AppCompatActivity(), JcPlayerManagerListener {
         }
 
         extractedFileName = FileUtils.nameWithoutExtension(filePath).toString()
-        val textView: TextView = findViewById(R.id.textView)
-        textView.text = extractedFileName
+        activityAudioPlayerBinding.textView.text = extractedFileName
     }
 
     private fun playDownloadedAudio() {

--- a/app/src/main/res/layout/fragment_my_meetup_detail.xml
+++ b/app/src/main/res/layout/fragment_my_meetup_detail.xml
@@ -67,7 +67,9 @@
                 </LinearLayout>
 
 
-                <include layout="@layout/content_meetup_detail" />
+                <include
+                    android:id="@+id/contentMeetupDetail"
+                    layout="@layout/content_meetup_detail" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_my_teams_detail.xml
+++ b/app/src/main/res/layout/fragment_my_teams_detail.xml
@@ -62,7 +62,9 @@
 
                 </LinearLayout>
 
-                <include layout="@layout/content_team_detail_tab" />
+                <include
+                    android:id="@+id/contentTeamDetail"
+                    layout="@layout/content_team_detail_tab" />
 
             </LinearLayout>
         </androidx.cardview.widget.CardView>


### PR DESCRIPTION
## Summary
- use ViewBinding in AudioPlayerActivity, DashboardActivity, AddLinkFragment, HomeCommunityDialogFragment, SendSurveyFragment, MyMeetupDetailFragment, and MyTeamsDetailFragment
- update layouts to expose included bindings

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_686cd9a449c4832bae678d25493a4003