### PR TITLE
Introduce Jetpack Navigation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlinx-serialization'
 apply plugin: 'dagger.hilt.android.plugin'
 apply plugin: 'realm-android'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 android {
     compileSdk = 35
     defaultConfig {
@@ -190,6 +191,8 @@ dependencies {
     implementation "androidx.work:work-runtime:2.10.2"
     implementation "androidx.slidingpanelayout:slidingpanelayout:1.2.0"
     implementation 'androidx.preference:preference-ktx:1.2.1'
+    implementation "androidx.navigation:navigation-fragment-ktx:2.7.7"
+    implementation "androidx.navigation:navigation-ui-ktx:2.7.7"
 
     implementation 'com.google.code.gson:gson:2.13.1'
     implementation 'com.google.android.material:material:1.12.0'

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -73,6 +73,8 @@ import org.ole.planet.myplanet.ui.survey.SurveyFragment
 import org.ole.planet.myplanet.ui.sync.DashboardElementActivity
 import org.ole.planet.myplanet.ui.team.TeamFragment
 import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
+import androidx.navigation.findNavController
+import org.ole.planet.myplanet.NavGraphDirections
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 import org.ole.planet.myplanet.utilities.DialogUtils.guestDialog
@@ -738,19 +740,15 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     }
 
     override fun openLibraryDetailFragment(library: RealmMyLibrary?) {
-        val f: Fragment = ResourceDetailFragment()
-        val b = Bundle()
-        b.putString("libraryId", library?.resourceId)
-        f.arguments = b
-        openCallFragment(f)
+        val navController = findNavController(R.id.nav_host_fragment)
+        val action = NavGraphDirections.actionGlobalResourceDetailFragment(library?.resourceId)
+        navController.navigate(action)
     }
 
     override fun sendSurvey(current: RealmStepExam?) {
-        val f = SendSurveyFragment()
-        val b = Bundle()
-        b.putString("surveyId", current?.id)
-        f.arguments = b
-        f.show(supportFragmentManager, "")
+        val navController = findNavController(R.id.nav_host_fragment)
+        val action = NavGraphDirections.actionGlobalSendSurveyFragment(current?.id)
+        navController.navigate(action)
     }
 
     private val drawerItems: Array<IDrawerItem<*, *>>

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/DashboardElementActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/DashboardElementActivity.kt
@@ -22,6 +22,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.navigation.findNavController
 import com.afollestad.materialdialogs.MaterialDialog
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import kotlinx.coroutines.CoroutineScope
@@ -38,10 +39,13 @@ import org.ole.planet.myplanet.ui.community.CommunityTabFragment
 import org.ole.planet.myplanet.ui.courses.CoursesFragment
 import org.ole.planet.myplanet.ui.dashboard.BellDashboardFragment
 import org.ole.planet.myplanet.ui.dashboard.DashboardFragment
+import org.ole.planet.myplanet.ui.dashboard.SurveyFragment
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.ui.rating.RatingFragment.Companion.newInstance
+import org.ole.planet.myplanet.ui.resources.ResourceDetailFragment
 import org.ole.planet.myplanet.ui.resources.ResourcesFragment
 import org.ole.planet.myplanet.ui.team.TeamFragment
+import org.ole.planet.myplanet.NavGraphDirections
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
@@ -89,40 +93,22 @@ abstract class DashboardElementActivity : SyncActivity(), FragmentManager.OnBack
     }
 
     fun openCallFragment(newFragment: Fragment, tag: String?) {
-        val fragmentManager = supportFragmentManager
-        if(c<2){
-            c=0
-        }
-        val existingFragment = fragmentManager.findFragmentByTag(tag)
-        if (tag == "") {
-            c++
-            if(c>2){
-                c--
-                fragmentManager.popBackStack(tag, 0)
-            }else{
-                fragmentManager.beginTransaction()
-                    .replace(R.id.fragment_container, newFragment, tag)
-                    .addToBackStack(tag)
-                    .commit()
+        val navController = findNavController(R.id.nav_host_fragment)
+        when (newFragment) {
+            is BellDashboardFragment -> navController.navigate(R.id.bellDashboardFragment)
+            is ResourcesFragment -> navController.navigate(R.id.resourcesFragment)
+            is CoursesFragment -> navController.navigate(R.id.coursesFragment)
+            is TeamFragment -> navController.navigate(R.id.teamFragment)
+            is CommunityTabFragment -> navController.navigate(R.id.communityTabFragment)
+            is SurveyFragment -> navController.navigate(R.id.surveyFragment)
+            is ResourceDetailFragment -> {
+                val libraryId = newFragment.arguments?.getString("libraryId")
+                val action = NavGraphDirections.actionGlobalResourceDetailFragment(libraryId)
+                navController.navigate(action)
             }
-        } else {
-            if (existingFragment != null && existingFragment.isVisible) {
-                return
-            } else if (existingFragment != null) {
-                if(c>0 && c>2){
-                    c=0
-                }
-                fragmentManager.popBackStack(tag, 0)
-            } else {
-                if(c>0 && c>2){
-                    c=0
-                }
-                if(tag!="") {
-                    fragmentManager.beginTransaction()
-                        .replace(R.id.fragment_container, newFragment, tag)
-                        .addToBackStack(tag)
-                        .commit()
-                }
+            else -> {
+                // default fallback to dashboard
+                navController.navigate(R.id.bellDashboardFragment)
             }
         }
     }

--- a/app/src/main/res/layout/activity_dashboard.xml
+++ b/app/src/main/res/layout/activity_dashboard.xml
@@ -35,11 +35,13 @@
             app:itemTextColor="@drawable/drawable_nav_color"
             app:menu="@menu/menu_topbar" />
 
-        <FrameLayout
-            android:id="@+id/fragment_container"
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/nav_host_fragment"
+            android:name="androidx.navigation.fragment.NavHostFragment"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1">
-        </FrameLayout>
+            android:layout_weight="1"
+            app:defaultNavHost="true"
+            app:navGraph="@navigation/nav_graph" />
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/bellDashboardFragment">
+
+    <fragment
+        android:id="@+id/bellDashboardFragment"
+        android:name="org.ole.planet.myplanet.ui.dashboard.BellDashboardFragment"
+        android:label="Bell Dashboard" />
+
+    <fragment
+        android:id="@+id/resourcesFragment"
+        android:name="org.ole.planet.myplanet.ui.resources.ResourcesFragment"
+        android:label="Resources" />
+
+    <fragment
+        android:id="@+id/coursesFragment"
+        android:name="org.ole.planet.myplanet.ui.courses.CoursesFragment"
+        android:label="Courses" />
+
+    <fragment
+        android:id="@+id/teamFragment"
+        android:name="org.ole.planet.myplanet.ui.team.TeamFragment"
+        android:label="Team" />
+
+    <fragment
+        android:id="@+id/communityTabFragment"
+        android:name="org.ole.planet.myplanet.ui.community.CommunityTabFragment"
+        android:label="Community" />
+
+    <fragment
+        android:id="@+id/surveyFragment"
+        android:name="org.ole.planet.myplanet.ui.survey.SurveyFragment"
+        android:label="Survey" />
+
+    <fragment
+        android:id="@+id/resourceDetailFragment"
+        android:name="org.ole.planet.myplanet.ui.resources.ResourceDetailFragment"
+        android:label="Resource Detail">
+        <argument
+            android:name="libraryId"
+            app:argType="string" />
+    </fragment>
+
+    <action
+        android:id="@+id/action_global_resourceDetailFragment"
+        app:destination="@id/resourceDetailFragment" />
+
+    <dialog
+        android:id="@+id/sendSurveyFragment"
+        android:name="org.ole.planet.myplanet.ui.survey.SendSurveyFragment"
+        android:label="Send Survey">
+        <argument
+            android:name="surveyId"
+            app:argType="string" />
+    </dialog>
+
+    <action
+        android:id="@+id/action_global_sendSurveyFragment"
+        app:destination="@id/sendSurveyFragment" />
+</navigation>

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ buildscript {
         classpath "com.google.dagger:hilt-android-gradle-plugin:2.56.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.7.7"
         // NOTE: Do not place your application dependencies here
     }
 }


### PR DESCRIPTION
## Summary
- add Jetpack Navigation Component dependencies
- create `nav_graph.xml` with main destinations and global actions
- embed `NavHostFragment` in dashboard layout
- replace manual fragment transactions with `NavController.navigate`

## Testing
- `./gradlew assembleDebug` *(fails: Gradle build stalled)*

------
https://chatgpt.com/codex/tasks/task_e_686cda0cfe9c832b8d6fa565dc4c2365