### PR TITLE
Refactor Team screen to MVVM

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -101,8 +101,10 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                         alertCreateTeamBinding.etName.error = getString(R.string.please_enter_a_name)
                     } else -> {
                         if (team == null) {
+                            val selectedType = if (alertCreateTeamBinding.spnTeamType.selectedItemPosition == 0) "local" else "sync"
                             teamViewModel.createTeam(
                                 name,
+                                selectedType,
                                 map,
                                 alertCreateTeamBinding.switchPublic.isChecked
                             )

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamViewModel.kt
@@ -87,9 +87,9 @@ class TeamViewModel(application: Application) : AndroidViewModel(application) {
         _teams.value = realm.copyFromRealm(results)
     }
 
-    fun createTeam(name: String, map: HashMap<String, String>, isPublic: Boolean) {
+    fun createTeam(name: String, teamType: String?, map: HashMap<String, String>, isPublic: Boolean) {
         val currentUser = user ?: return
-        val teamType = type
+        val screenType = type
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
                 realm.executeTransaction { r ->
@@ -97,7 +97,7 @@ class TeamViewModel(application: Application) : AndroidViewModel(application) {
                     r.createObject(RealmMyTeam::class.java, teamId).apply {
                         status = "active"
                         createdDate = Date().time
-                        if (teamType == "enterprise") {
+                        if (screenType == "enterprise") {
                             this.type = "enterprise"
                             this.services = map["services"]
                             this.rules = map["rules"]


### PR DESCRIPTION
## Summary
- implement `TeamViewModel` to handle database operations and state via LiveData
- refactor `TeamFragment` to observe `TeamViewModel` and remove Realm usage
- expose `getUserId()` in the ViewModel and use it from the Fragment
- fix incorrect property assignment in `TeamViewModel`

## Testing
- `./gradlew :app:compileLiteDebugKotlin --console=plain -x lint`

------
https://chatgpt.com/codex/tasks/task_e_686cd9d8d6d8832bbd3c2ad213af511a