### PR TITLE
Improve download worker helpers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DownloadWorker.kt
@@ -19,6 +19,8 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.utilities.Utilities
+import org.ole.planet.myplanet.utilities.FileUtils.getFileNameFromUrl
+import org.ole.planet.myplanet.utilities.FileUtils.getSDPathFromUrl
 
 class DownloadWorker(val context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -200,15 +202,6 @@ class DownloadWorker(val context: Context, workerParams: WorkerParameters) : Cor
         } catch (e: Exception) {
             e.printStackTrace()
         }
-    }
-
-    private fun getSDPathFromUrl(url: String): File {
-        val fileName = getFileNameFromUrl(url)
-        return File(Utilities.SD_PATH, fileName)
-    }
-
-    private fun getFileNameFromUrl(url: String): String {
-        return url.substringAfterLast("/")
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- refactor path helpers in `DownloadWorker`
- use shared `FileUtils` helpers

## Testing
- `./gradlew lint` *(fails: Fetch remote repository)*

------
https://chatgpt.com/codex/tasks/task_e_686e15cbf9d8832bb4a6e18f0e5c97c1