### PR TITLE
Refactor network retry logic

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadToShelfService.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.JsonUtils.getJsonArray
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
 import org.ole.planet.myplanet.utilities.Utilities
+import org.ole.planet.myplanet.utilities.RetryUtils
 import retrofit2.Response
 
 class UploadToShelfService(context: Context) {
@@ -206,42 +207,21 @@ class UploadToShelfService(context: Context) {
         ob.addProperty("key", keyString)
         ob.addProperty("iv", iv)
         ob.addProperty("createdOn", Date().time)
-        var success = false
-        var attemptCount = 0
         val maxAttempts = 3
         val retryDelayMs = 2000L
 
-        while (!success && attemptCount < maxAttempts) {
-            attemptCount++
-            try {
-                val response: Response<JsonObject>? = apiInterface?.postDoc(header, "application/json", "${Utilities.getUrl()}/$table", ob)?.execute()
-
-                if (response != null) {
-
-                    if (response.isSuccessful && response.body() != null) {
-                        model.key = keyString
-                        model.iv = iv
-                        success = true
-                    } else {
-                        if (attemptCount < maxAttempts) {
-                            Thread.sleep(retryDelayMs)
-                        }
-                    }
-                } else {
-                    if (attemptCount < maxAttempts) {
-                        Thread.sleep(retryDelayMs)
-                    }
-                }
-            } catch (e: Exception) {
-                if (attemptCount >= maxAttempts) {
-                    throw IOException("Failed to save key/IV after $maxAttempts attempts", e)
-                } else {
-                    Thread.sleep(retryDelayMs)
-                }
-            }
+        val response = RetryUtils.retry(
+            maxAttempts = maxAttempts,
+            delayMs = retryDelayMs,
+            shouldRetry = { resp -> resp == null || !resp.isSuccessful || resp.body() == null }
+        ) {
+            apiInterface?.postDoc(header, "application/json", "${Utilities.getUrl()}/$table", ob)?.execute()
         }
 
-        if (!success) {
+        if (response?.isSuccessful == true && response.body() != null) {
+            model.key = keyString
+            model.iv = iv
+        } else {
             val errorMessage = "Failed to save key/IV after $maxAttempts attempts"
             throw IOException(errorMessage)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
@@ -1,0 +1,37 @@
+package org.ole.planet.myplanet.utilities
+
+object RetryUtils {
+    fun <T> retry(
+        maxAttempts: Int = 3,
+        delayMs: Long = 2000L,
+        shouldRetry: (T?) -> Boolean = { it == null },
+        block: () -> T?
+    ): T? {
+        var attempt = 0
+        var result: T? = null
+        var lastException: Exception? = null
+
+        while (attempt < maxAttempts) {
+            try {
+                result = block()
+            } catch (e: Exception) {
+                lastException = e
+                result = null
+            }
+            if (!shouldRetry(result)) {
+                return result
+            }
+            attempt++
+            if (attempt < maxAttempts) {
+                try {
+                    Thread.sleep(delayMs)
+                } catch (ie: InterruptedException) {
+                    // ignore
+                }
+            }
+        }
+        lastException?.printStackTrace()
+        return result
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `RetryUtils` with a generic retry helper
- refactor `ApiClient.executeWithRetry` to use the new helper
- replace manual retry loop in `UploadToShelfService` with `RetryUtils`

## Testing
- `./gradlew assembleDebug -x test`

------
https://chatgpt.com/codex/tasks/task_e_686e26f4cd9c832b8c84dd1c0941663c