### PR TITLE
all: smoother `TimeUtils.kt` (fixes #6288)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 34
-        versionCode = 2680
-        versionName = "0.26.80"
+        versionCode = 2687
+        versionName = "0.26.87"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/TimeUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/TimeUtils.kt
@@ -1,76 +1,80 @@
 package org.ole.planet.myplanet.utilities
 
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Date
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.Period
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
-import java.util.TimeZone
 
 object TimeUtils {
     private val defaultLocale: Locale
         get() = Locale.getDefault()
 
+    private val utcZone: ZoneId = ZoneId.of("UTC")
+
     @JvmStatic
     fun getFormatedDate(date: Long?): String {
-        try {
-            val d = date?.let { Date(it) } ?: Date()
-            val f = SimpleDateFormat("EEEE, MMM dd, yyyy", defaultLocale)
-            f.timeZone = TimeZone.getTimeZone("UTC")
-            return f.format(d)
+        return try {
+            val instant = date?.let { Instant.ofEpochMilli(it) } ?: Instant.now()
+            val formatter = DateTimeFormatter.ofPattern("EEEE, MMM dd, yyyy", defaultLocale).withZone(utcZone)
+            formatter.format(instant)
         } catch (e: Exception) {
             e.printStackTrace()
+            "N/A"
         }
-        return "N/A"
     }
 
     @JvmStatic
     fun getFormatedDateWithTime(date: Long): String {
-        val d = Date(date)
-        val dateFormat = SimpleDateFormat("EEE dd, MMMM yyyy , hh:mm aa")
-        return dateFormat.format(d)
+        return try {
+            val instant = Instant.ofEpochMilli(date)
+            val formatter = DateTimeFormatter.ofPattern("EEE dd, MMMM yyyy , hh:mm aa", defaultLocale).withZone(ZoneId.systemDefault())
+            formatter.format(instant)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            "N/A"
+        }
     }
 
     @JvmStatic
     fun formatDateTZ(data: Long): String {
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-        return dateFormat.format(data)
+        return try {
+            val instant = Instant.ofEpochMilli(data)
+            val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault())
+            formatter.format(instant)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            ""
+        }
     }
 
     @JvmStatic
     fun getAge(date: String): Int {
-        val dateFormatTimeIncluded = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd")
-        val dob = Calendar.getInstance()
-        val today = Calendar.getInstance()
-        try {
-            if (date.contains("T")) {
-                val dt = dateFormatTimeIncluded.parse(date.replace("T".toRegex(), " ").replace(".000Z".toRegex(), ""))
-                if (dt != null) {
-                    dob.time = dt
-                }
-            } else {
-                val dt2 = dateFormat.parse(date)
-                if (dt2 != null) {
-                    dob.time = dt2
-                }
+        return try {
+            val cleaned = date.replace("T", " ").replace(".000Z", "")
+            val dob = try {
+                LocalDateTime.parse(cleaned, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                    .toLocalDate()
+            } catch (e: Exception) {
+                LocalDate.parse(cleaned, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
             }
+            val today = LocalDate.now()
+            Period.between(dob, today).years
         } catch (e: Exception) {
             e.printStackTrace()
+            0
         }
-        var age = today[Calendar.YEAR] - dob[Calendar.YEAR]
-        if (today[Calendar.DAY_OF_YEAR] < dob[Calendar.DAY_OF_YEAR]) {
-            age--
-        }
-        return age
     }
 
     @JvmStatic
     fun getFormatedDate(stringDate: String?, pattern: String?): String {
         return try {
-            val sf = SimpleDateFormat(pattern, defaultLocale)
-            sf.timeZone = TimeZone.getTimeZone("UTC")
-            val date = stringDate?.let { sf.parse(it) }
-            getFormatedDate(date?.time)
+            if (stringDate.isNullOrBlank() || pattern.isNullOrBlank()) return "N/A"
+            val formatter = DateTimeFormatter.ofPattern(pattern, defaultLocale).withZone(utcZone)
+            val instant = LocalDate.parse(stringDate, formatter).atStartOfDay(utcZone).toInstant()
+            getFormatedDate(instant.toEpochMilli())
         } catch (e: Exception) {
             e.printStackTrace()
             "N/A"
@@ -79,20 +83,34 @@ object TimeUtils {
 
     @JvmStatic
     fun currentDate(): String {
-        val c = Calendar.getInstance()
-        val dateFormat = SimpleDateFormat("EEE dd, MMMM yyyy")
-        return dateFormat.format(c.time)
+        return try {
+            val formatter = DateTimeFormatter.ofPattern("EEE dd, MMMM yyyy", defaultLocale).withZone(ZoneId.systemDefault())
+            formatter.format(Instant.now())
+        } catch (e: Exception) {
+            e.printStackTrace()
+            "N/A"
+        }
     }
 
     @JvmStatic
     fun formatDate(date: Long): String {
-        val dateFormat = SimpleDateFormat("EEE dd, MMMM yyyy")
-        return dateFormat.format(date)
+        return try {
+            val formatter = DateTimeFormatter.ofPattern("EEE dd, MMMM yyyy", defaultLocale).withZone(ZoneId.systemDefault())
+            formatter.format(Instant.ofEpochMilli(date))
+        } catch (e: Exception) {
+            e.printStackTrace()
+            ""
+        }
     }
 
     @JvmStatic
     fun formatDate(date: Long, format: String?): String {
-        val dateFormat = SimpleDateFormat(format)
-        return dateFormat.format(date)
+        return try {
+            val formatter = DateTimeFormatter.ofPattern(format ?: "", defaultLocale).withZone(ZoneId.systemDefault())
+            formatter.format(Instant.ofEpochMilli(date))
+        } catch (e: Exception) {
+            e.printStackTrace()
+            ""
+        }
     }
 }


### PR DESCRIPTION
## Summary
- switch `TimeUtils` implementation from legacy `SimpleDateFormat` to `java.time`

## Testing
- `./gradlew assembleDebug -x test` *(fails: terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_686e2a8d96fc832b98cceb1704bfe522