### PR TITLE
Refactor offline status logic

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DownloadWorker.kt
@@ -8,17 +8,15 @@ import androidx.core.app.NotificationCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import io.realm.Realm
 import java.io.BufferedInputStream
-import java.io.File
 import java.io.FileOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.Download
-import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.utilities.Utilities
+import org.ole.planet.myplanet.utilities.DownloadUtils
 import org.ole.planet.myplanet.utilities.FileUtils.getFileNameFromUrl
 import org.ole.planet.myplanet.utilities.FileUtils.getSDPathFromUrl
 
@@ -122,7 +120,7 @@ class DownloadWorker(val context: Context, workerParams: WorkerParameters) : Cor
             output.close()
             bis.close()
         }
-        changeOfflineStatus(url)
+        DownloadUtils.updateResourceOfflineStatus(url)
     }
 
     private fun initializeNotificationChannels() {
@@ -185,24 +183,6 @@ class DownloadWorker(val context: Context, workerParams: WorkerParameters) : Cor
         LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(intent)
     }
 
-    private fun changeOfflineStatus(url: String) {
-        val currentFileName = getFileNameFromUrl(url)
-        try {
-            val backgroundRealm = Realm.getDefaultInstance()
-            backgroundRealm.use { realm ->
-                realm.executeTransaction {
-                    realm.where(RealmMyLibrary::class.java)
-                        .equalTo("resourceLocalAddress", currentFileName)
-                        .findAll()?.forEach {
-                            it.resourceOffline = true
-                            it.downloadedRev = it._rev
-                        }
-                }
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
 
     companion object {
         const val WORKER_NOTIFICATION_ID = 3

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DownloadUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DownloadUtils.kt
@@ -2,7 +2,9 @@ package org.ole.planet.myplanet.utilities
 
 import java.util.regex.Pattern
 import kotlin.text.isNotEmpty
+import io.realm.Realm
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.utilities.FileUtils
 
 object DownloadUtils {
     @JvmStatic
@@ -38,5 +40,25 @@ object DownloadUtils {
             }
         }
         return links
+    }
+
+    @JvmStatic
+    fun updateResourceOfflineStatus(url: String) {
+        val currentFileName = FileUtils.getFileNameFromUrl(url)
+        try {
+            val backgroundRealm = Realm.getDefaultInstance()
+            backgroundRealm.use { realm ->
+                realm.executeTransaction {
+                    realm.where(RealmMyLibrary::class.java)
+                        .equalTo("resourceLocalAddress", currentFileName)
+                        .findAll()?.forEach {
+                            it.resourceOffline = true
+                            it.downloadedRev = it._rev
+                        }
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- centralize offline status updates in `DownloadUtils`
- simplify `DownloadWorker` and `MyDownloadService` by using the new helper

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_686f7fe7c650832bb2935bf1e5ffa7d0