### PR TITLE
Refactor to centralize offline status logic

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DownloadWorker.kt
@@ -8,7 +8,6 @@ import androidx.core.app.NotificationCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import io.realm.Realm
 import java.io.BufferedInputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -17,10 +16,10 @@ import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.Download
-import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.FileUtils.getFileNameFromUrl
 import org.ole.planet.myplanet.utilities.FileUtils.getSDPathFromUrl
+import org.ole.planet.myplanet.utilities.DownloadUtils.markResourceOffline
 
 class DownloadWorker(val context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -122,7 +121,7 @@ class DownloadWorker(val context: Context, workerParams: WorkerParameters) : Cor
             output.close()
             bis.close()
         }
-        changeOfflineStatus(url)
+        markResourceOffline(url)
     }
 
     private fun initializeNotificationChannels() {
@@ -185,24 +184,6 @@ class DownloadWorker(val context: Context, workerParams: WorkerParameters) : Cor
         LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(intent)
     }
 
-    private fun changeOfflineStatus(url: String) {
-        val currentFileName = getFileNameFromUrl(url)
-        try {
-            val backgroundRealm = Realm.getDefaultInstance()
-            backgroundRealm.use { realm ->
-                realm.executeTransaction {
-                    realm.where(RealmMyLibrary::class.java)
-                        .equalTo("resourceLocalAddress", currentFileName)
-                        .findAll()?.forEach {
-                            it.resourceOffline = true
-                            it.downloadedRev = it._rev
-                        }
-                }
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
 
     companion object {
         const val WORKER_NOTIFICATION_ID = 3

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
@@ -19,7 +19,6 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
-import io.realm.Realm
 import java.io.BufferedInputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -34,11 +33,11 @@ import okhttp3.ResponseBody
 import org.ole.planet.myplanet.MainApplication.Companion.createLog
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.Download
-import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.utilities.FileUtils.availableExternalMemorySize
 import org.ole.planet.myplanet.utilities.FileUtils.externalMemoryAvailable
 import org.ole.planet.myplanet.utilities.FileUtils.getFileNameFromUrl
 import org.ole.planet.myplanet.utilities.FileUtils.getSDPathFromUrl
+import org.ole.planet.myplanet.utilities.DownloadUtils.markResourceOffline
 import org.ole.planet.myplanet.utilities.Utilities.header
 import retrofit2.Call
 
@@ -287,7 +286,7 @@ class MyDownloadService : Service() {
 
     private fun onDownloadComplete(url: String) {
         if ((outputFile?.length() ?: 0) > 0) {
-            changeOfflineStatus(url)
+            markResourceOffline(url)
         }
         completedDownloadsCount++
 
@@ -324,26 +323,6 @@ class MyDownloadService : Service() {
         notificationManager?.notify(COMPLETION_NOTIFICATION_ID, completionNotification.build())
     }
 
-    private fun changeOfflineStatus(url: String) {
-        CoroutineScope(Dispatchers.IO).launch {
-            val currentFileName = getFileNameFromUrl(url)
-            try {
-                val backgroundRealm = Realm.getDefaultInstance()
-                backgroundRealm.use { realm ->
-                    realm.executeTransaction {
-                        realm.where(RealmMyLibrary::class.java)
-                            .equalTo("resourceLocalAddress", currentFileName)
-                            .findAll()?.forEach {
-                                it.resourceOffline = true
-                                it.downloadedRev = it._rev
-                            }
-                    }
-                }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-    }
 
     companion object {
         const val PREFS_NAME = "MyPrefsFile"


### PR DESCRIPTION
## Summary
- add `markResourceOffline` helper in `DownloadUtils`
- use helper from `DownloadWorker` and `MyDownloadService`
- remove duplicate Realm code

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_686f7ff15a4c832bbad154bb0d33b256