### PR TITLE
AppModule Hilt dependency injection 2

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet
 
+import dagger.hilt.android.HiltAndroidApp
 import android.app.Activity
 import android.app.Application
 import android.content.Context
@@ -50,6 +51,8 @@ import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.ThemeMode
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils.getVersionName
+
+@HiltAndroidApp
 
 class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/di/AppModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/AppModule.kt
@@ -1,0 +1,29 @@
+package org.ole.planet.myplanet.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import org.ole.planet.myplanet.datamanager.ApiClient
+import org.ole.planet.myplanet.datamanager.ApiInterface
+import org.ole.planet.myplanet.datamanager.DatabaseService
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabaseService(@ApplicationContext context: Context): DatabaseService {
+        return DatabaseService(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideApiInterface(): ApiInterface {
+        return ApiClient.getEnhancedClient()
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
@@ -8,6 +8,8 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import io.realm.Realm
 import io.realm.RealmResults
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseActivity
 import org.ole.planet.myplanet.databinding.ActivityCourseProgressBinding
@@ -23,8 +25,11 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtil
 
+
 class CourseProgressActivity : BaseActivity() {
     private lateinit var activityCourseProgressBinding: ActivityCourseProgressBinding
+    @Inject
+    lateinit var dbService: DatabaseService
     lateinit var realm: Realm
     var user: RealmUserModel? = null
     lateinit var courseId: String
@@ -35,7 +40,7 @@ class CourseProgressActivity : BaseActivity() {
         EdgeToEdgeUtil.setupEdgeToEdge(this, activityCourseProgressBinding.root)
         initActionBar()
         courseId = intent.getStringExtra("courseId").toString()
-        realm = DatabaseService(this).realmInstance
+        realm = dbService.realmInstance
         user = UserProfileDbHandler(this).userModel
         val courseProgress = RealmCourseProgress.getCourseProgress(realm, user?.id)
         val progress = courseProgress[courseId]

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -8,6 +8,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import io.realm.Realm
 import java.util.Date
 import java.util.UUID
@@ -33,10 +35,15 @@ import org.ole.planet.myplanet.utilities.CustomClickableSpan
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
 
+
+@AndroidEntryPoint
+
 class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     private lateinit var fragmentCourseStepBinding: FragmentCourseStepBinding
     var stepId: String? = null
-    private lateinit var dbService: DatabaseService
+    
+    @Inject
+    lateinit var dbService: DatabaseService
     private lateinit var cRealm: Realm
     private lateinit var step: RealmCourseStep
     private lateinit var resources: List<RealmMyLibrary>
@@ -54,7 +61,6 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentCourseStepBinding = FragmentCourseStepBinding.inflate(inflater, container, false)
-        dbService = DatabaseService(requireActivity())
         cRealm = dbService.realmInstance
         user = UserProfileDbHandler(requireContext()).userModel
         fragmentCourseStepBinding.btnTakeTest.visibility = View.VISIBLE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -10,6 +10,8 @@ import android.widget.SeekBar.OnSeekBarChangeListener
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager.widget.ViewPager
 import io.realm.Realm
@@ -39,8 +41,10 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.DialogUtils.getAlertDialog
 import org.ole.planet.myplanet.utilities.Utilities
 
+@AndroidEntryPoint
 class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnClickListener {
     private lateinit var fragmentTakeCourseBinding: FragmentTakeCourseBinding
+    @Inject
     lateinit var dbService: DatabaseService
     lateinit var mRealm: Realm
     private var currentCourse: RealmMyCourse? = null
@@ -60,7 +64,6 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentTakeCourseBinding = FragmentTakeCourseBinding.inflate(inflater, container, false)
-        dbService = DatabaseService(requireActivity())
         mRealm = dbService.realmInstance
         userModel = UserProfileDbHandler(requireContext()).userModel
         currentCourse = mRealm.where(RealmMyCourse::class.java).equalTo("courseId", courseId).findFirst()
@@ -266,7 +269,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     }
 
     private fun getCourseProgress(): Int {
-        val realm = DatabaseService(requireActivity()).realmInstance
+        val realm = dbService.realmInstance
         val user = UserProfileDbHandler(requireActivity()).userModel
         val courseProgressMap = RealmCourseProgress.getCourseProgress(realm, user?.id)
         val courseProgress = courseProgressMap[courseId]?.asJsonObject?.get("current")?.asInt

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import android.widget.DatePicker
 import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.LinearLayoutManager
+import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Realm
 import io.realm.RealmResults
 import io.realm.Sort
@@ -25,12 +26,13 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
 import org.ole.planet.myplanet.utilities.TimeUtils.formatDateTZ
 import org.ole.planet.myplanet.utilities.Utilities
+@AndroidEntryPoint
 
 class FinanceFragment : BaseTeamFragment() {
     private lateinit var fragmentFinanceBinding: FragmentFinanceBinding
     private lateinit var addTransactionBinding: AddTransactionBinding
-    private lateinit var fRealm: Realm
     private var adapterFinance: AdapterFinance? = null
+    private lateinit var fRealm: Realm
     var date: Calendar? = null
     var list: RealmResults<RealmMyTeam>? = null
     private var isAsc = false
@@ -48,7 +50,7 @@ class FinanceFragment : BaseTeamFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentFinanceBinding = FragmentFinanceBinding.inflate(inflater, container, false)
-        fRealm = DatabaseService(requireActivity()).realmInstance
+        fRealm = dbService.realmInstance
         date = Calendar.getInstance()
         fragmentFinanceBinding.tvFromDateCalendar.setOnClickListener {
             showDatePickerDialog(isFromDate = true)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
@@ -12,6 +12,8 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.LinearLayoutManager
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import com.google.gson.JsonObject
 import io.realm.RealmResults
 import io.realm.Sort
@@ -32,6 +34,7 @@ import org.ole.planet.myplanet.ui.team.BaseTeamFragment
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.Utilities
 
+@AndroidEntryPoint
 class ReportsFragment : BaseTeamFragment() {
     private lateinit var fragmentReportsBinding: FragmentReportsBinding
     var list: RealmResults<RealmMyTeam>? = null
@@ -43,7 +46,7 @@ class ReportsFragment : BaseTeamFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentReportsBinding = FragmentReportsBinding.inflate(inflater, container, false)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = dbService.realmInstance
         prefData = SharedPrefManager(requireContext())
         if (!isMember()) {
             fragmentReportsBinding.addReports.visibility = View.GONE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
@@ -9,9 +9,14 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+@AndroidEntryPoint
 
 abstract class BaseTeamFragment : BaseNewsFragment() {
+    @Inject
     lateinit var dbService: DatabaseService
+    
     var user: RealmUserModel? = null
     lateinit var teamId: String
     var team: RealmMyTeam? = null
@@ -22,7 +27,6 @@ abstract class BaseTeamFragment : BaseNewsFragment() {
         val sParentCode = settings?.getString("parentCode", "")
         val communityName = settings?.getString("communityName", "")
         teamId = requireArguments().getString("id", "") ?: "$communityName@$sParentCode"
-        dbService = DatabaseService(requireActivity())
         mRealm = dbService.realmInstance
         user = profileDbHandler.userModel?.let { mRealm.copyFromRealm(it) }
 


### PR DESCRIPTION
## Summary
- set up an `AppModule` with Hilt providers
- mark `MainApplication` as `@HiltAndroidApp`
- inject `DatabaseService` into course and team screens
- hook fragments and activities into Hilt via `@AndroidEntryPoint`

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68767bb5e850832bada32345d480bb0b