### PR TITLE
dashboard: smoother `BellDashboardFragment.kt` surveys (fixes #6338)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2697
-        versionName = "0.26.97"
+        versionCode = 2717
+        versionName = "0.27.17"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- modularize network indicator handling
- consolidate survey dialogs into reusable function
- update pending survey checks to use new helper

## Testing
- `./gradlew test` *(fails: missing Android SDK platform 35)*
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_6876854af0ac832b988c837d39587cce