### PR TITLE
all: smoother `MainApplication.kt` (fixes #6340)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2697
-        versionName = "0.26.97"
+        versionCode = 2713
+        versionName = "0.27.13"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -76,7 +76,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
         val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         lateinit var defaultPref: SharedPreferences
 
-        fun createLog(type: String, error: String) {
+        fun createLog(type: String, error: String = "") {
             applicationScope.launch(Dispatchers.IO) {
                 val realm = Realm.getDefaultInstance()
                 val settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
@@ -86,17 +86,13 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                         val model = UserProfileDbHandler(context).userModel
                         log.parentCode = settings.getString("parentCode", "")
                         log.createdOn = settings.getString("planetCode", "")
-                        if (model != null) {
-                            log.userId = model.id
-                        }
+                        model?.let { log.userId = it.id }
                         log.time = "${Date().time}"
                         log.page = ""
                         log.version = getVersionName(context)
-                        if (type == "File Not Found" || type == "anr" || type == "sync summary") {
-                            log.type = type
+                        log.type = type
+                        if (error.isNotEmpty()) {
                             log.error = error
-                        } else {
-                            log.type = type
                         }
                     }
                 } catch (e: Exception) {
@@ -161,35 +157,12 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
 
         fun handleUncaughtException(e: Throwable) {
             e.printStackTrace()
-            applicationScope.launch(Dispatchers.IO) {
-                try {
-                    val realm = Realm.getDefaultInstance()
-                    try {
-                        realm.executeTransaction { r ->
-                            val log = r.createObject(RealmApkLog::class.java, "${UUID.randomUUID()}")
-                            val model = UserProfileDbHandler(context).userModel
-                            if (model != null) {
-                                log.parentCode = model.parentCode
-                                log.createdOn = model.planetCode
-                                log.userId = model.id
-                            }
-                            log.time = "${Date().time}"
-                            log.page = ""
-                            log.version = getVersionName(context)
-                            log.type = RealmApkLog.ERROR_TYPE_CRASH
-                            log.setError(e)
-                        }
-                    } finally {
-                        realm.close()
-                    }
-                } catch (ex: Exception) {
-                    ex.printStackTrace()
-                }
-            }
+            createLog(RealmApkLog.ERROR_TYPE_CRASH, e.stackTraceToString())
 
-            val homeIntent = Intent(Intent.ACTION_MAIN)
-            homeIntent.addCategory(Intent.CATEGORY_HOME)
-            homeIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+            val homeIntent = Intent(Intent.ACTION_MAIN).apply {
+                addCategory(Intent.CATEGORY_HOME)
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+            }
             context.startActivity(homeIntent)
         }
     }
@@ -201,19 +174,37 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
 
     override fun onCreate() {
         super.onCreate()
+        initApp()
+        setupPreferences()
+        setupStrictMode()
+        setupAnrWatchdog()
+        scheduleWorkersOnStart()
+        registerExceptionHandler()
+        setupLifecycleCallbacks()
+        configureTheme()
+        observeNetworkForDownloads()
+    }
+
+    private fun initApp() {
         context = this
         initialize(applicationScope)
         startListenNetworkState()
+    }
 
+    private fun setupPreferences() {
         preferences = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         service = DatabaseService(context)
         mRealm = service.realmInstance
         defaultPref = PreferenceManager.getDefaultSharedPreferences(this)
+    }
 
+    private fun setupStrictMode() {
         val builder = VmPolicy.Builder()
         StrictMode.setVmPolicy(builder.build())
         builder.detectFileUriExposure()
+    }
 
+    private fun setupAnrWatchdog() {
         anrWatchdog = ANRWatchdog(timeout = 5000L, listener = object : ANRWatchdog.ANRListener {
             override fun onAppNotResponding(message: String, blockedThread: Thread, duration: Long) {
                 applicationScope.launch {
@@ -222,7 +213,9 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
             }
         })
         anrWatchdog.start()
+    }
 
+    private fun scheduleWorkersOnStart() {
         if (preferences?.getBoolean("autoSync", false) == true && preferences?.contains("autoSyncInterval") == true) {
             val syncInterval = preferences?.getInt("autoSyncInterval", 60 * 60)
             scheduleAutoSyncWork(syncInterval)
@@ -231,16 +224,25 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
         }
         scheduleStayOnlineWork()
         scheduleTaskNotificationWork()
+    }
 
+    private fun registerExceptionHandler() {
         Thread.setDefaultUncaughtExceptionHandler { _: Thread?, e: Throwable ->
             handleUncaughtException(e)
         }
+    }
+
+    private fun setupLifecycleCallbacks() {
         registerActivityLifecycleCallbacks(this)
         onAppStarted()
+    }
 
+    private fun configureTheme() {
         val savedThemeMode = getCurrentThemeMode()
         applyThemeMode(savedThemeMode)
+    }
 
+    private fun observeNetworkForDownloads() {
         isNetworkConnectedFlow.onEach { isConnected ->
             if (isConnected) {
                 val serverUrl = preferences?.getString("serverURL", "")
@@ -249,10 +251,8 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                         val canReachServer = withContext(Dispatchers.IO) {
                             isServerReachable(serverUrl)
                         }
-                        if (canReachServer) {
-                            if (defaultPref.getBoolean("beta_auto_download", false)) {
-                                backgroundDownload(downloadAllFiles(getAllLibraryList(mRealm)))
-                            }
+                        if (canReachServer && defaultPref.getBoolean("beta_auto_download", false)) {
+                            backgroundDownload(downloadAllFiles(getAllLibraryList(mRealm)))
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- refactor `MainApplication` to break up `onCreate` logic
- simplify crash logging

## Testing
- `./gradlew -q help`

------
https://chatgpt.com/codex/tasks/task_e_687685ac8d08832baf31628a64fd5e91