### PR TITLE
Refactor news adapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/ChatHandler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/ChatHandler.kt
@@ -1,0 +1,53 @@
+package org.ole.planet.myplanet.ui.news
+
+import android.content.Context
+import android.view.View
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.gson.Gson
+import org.ole.planet.myplanet.model.Conversation
+import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.ui.chat.ChatAdapter
+import org.ole.planet.myplanet.databinding.RowNewsBinding
+
+class ChatHandler(
+    private val context: Context,
+    private val listener: AdapterNews.OnNewsItemClickListener?,
+    var sessionUser: RealmUserModel?
+) {
+    fun handleChat(binding: RowNewsBinding, news: RealmNews) {
+        if (news.newsId?.isNotEmpty() == true) {
+            val conversations = Gson().fromJson(news.conversations, Array<Conversation>::class.java).toList()
+            val chatAdapter = ChatAdapter(ArrayList(), context, binding.recyclerGchat)
+
+            if (sessionUser?.id?.startsWith("guest") == false) {
+                chatAdapter.setOnChatItemClickListener(object : ChatAdapter.OnChatItemClickListener {
+                    override fun onChatItemClick(position: Int, chatItem: String) {
+                        listener?.onNewsItemClick(news)
+                    }
+                })
+            }
+
+            for (conversation in conversations) {
+                val query = conversation.query
+                val response = conversation.response
+                if (query != null) {
+                    chatAdapter.addQuery(query)
+                }
+                chatAdapter.responseSource = ChatAdapter.RESPONSE_SOURCE_SHARED_VIEW_MODEL
+                if (response != null) {
+                    chatAdapter.addResponse(response)
+                }
+            }
+
+            binding.recyclerGchat.adapter = chatAdapter
+            binding.recyclerGchat.layoutManager = LinearLayoutManager(context)
+            binding.recyclerGchat.visibility = View.VISIBLE
+            binding.sharedChat.visibility = View.VISIBLE
+        } else {
+            binding.recyclerGchat.visibility = View.GONE
+            binding.sharedChat.visibility = View.GONE
+        }
+    }
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/ImageLoader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/ImageLoader.kt
@@ -1,0 +1,103 @@
+package org.ole.planet.myplanet.ui.news
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.ImageView
+import androidx.core.graphics.drawable.toDrawable
+import com.bumptech.glide.Glide
+import com.github.chrisbanes.photoview.PhotoView
+import io.realm.Realm
+import java.io.File
+import java.util.Locale
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.databinding.RowNewsBinding
+import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.utilities.JsonUtils
+
+class ImageLoader(private val context: Context, private val realm: Realm) {
+    fun loadImage(binding: RowNewsBinding, news: RealmNews?) {
+        val imageUrls = news?.imageUrls
+        if (!imageUrls.isNullOrEmpty()) {
+            try {
+                val imgObject = com.google.gson.Gson().fromJson(imageUrls[0], com.google.gson.JsonObject::class.java)
+                val path = JsonUtils.getString("imageUrl", imgObject)
+                val request = Glide.with(context)
+                val target = if (path.lowercase(Locale.getDefault()).endsWith(".gif")) {
+                    request.asGif().load(if (File(path).exists()) File(path) else path)
+                } else {
+                    request.load(if (File(path).exists()) File(path) else path)
+                }
+                target.placeholder(R.drawable.ic_loading)
+                    .error(R.drawable.ic_loading)
+                    .into(binding.imgNews)
+                binding.imgNews.visibility = View.VISIBLE
+                binding.imgNews.setOnClickListener {
+                    showZoomableImage(it.context, path)
+                }
+                return
+            } catch (_: Exception) {
+            }
+        }
+
+        news?.imagesArray?.let { imagesArray ->
+            if (imagesArray.size() > 0) {
+                val ob = imagesArray[0]?.asJsonObject
+                val resourceId = JsonUtils.getString("resourceId", ob)
+                val library = realm.where(RealmMyLibrary::class.java)
+                    .equalTo("_id", resourceId)
+                    .findFirst()
+                val basePath = context.getExternalFilesDir(null)
+                if (library != null && basePath != null) {
+                    val imageFile = File(basePath, "ole/${'$'}{library.id}/${'$'}{library.resourceLocalAddress}")
+                    if (imageFile.exists()) {
+                        val request = Glide.with(context)
+                        val isGif = library.resourceLocalAddress?.lowercase(Locale.getDefault())?.endsWith(".gif") == true
+                        val target = if (isGif) {
+                            request.asGif().load(imageFile)
+                        } else {
+                            request.load(imageFile)
+                        }
+                        target.placeholder(R.drawable.ic_loading)
+                            .error(R.drawable.ic_loading)
+                            .into(binding.imgNews)
+                        binding.imgNews.visibility = View.VISIBLE
+                        binding.imgNews.setOnClickListener {
+                            showZoomableImage(it.context, imageFile.toString())
+                        }
+                        return
+                    }
+                }
+            }
+        }
+        binding.imgNews.visibility = View.GONE
+    }
+
+    fun showZoomableImage(context: Context, imageUrl: String) {
+        val dialog = Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen)
+        val view = LayoutInflater.from(context).inflate(R.layout.dialog_zoomable_image, null)
+        val photoView = view.findViewById<PhotoView>(R.id.photoView)
+        val closeButton = view.findViewById<ImageView>(R.id.closeButton)
+
+        dialog.setContentView(view)
+        dialog.window?.setBackgroundDrawable(Color.BLACK.toDrawable())
+
+        val request = Glide.with(context)
+        val target = if (imageUrl.lowercase(Locale.getDefault()).endsWith(".gif")) {
+            val file = File(imageUrl)
+            if (file.exists()) request.asGif().load(file) else request.asGif().load(imageUrl)
+        } else {
+            val file = File(imageUrl)
+            if (file.exists()) request.load(file) else request.load(imageUrl)
+        }
+        target.error(R.drawable.ic_loading).into(photoView)
+
+        closeButton.setOnClickListener { dialog.dismiss() }
+
+        dialog.show()
+    }
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsPermissionChecker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsPermissionChecker.kt
@@ -1,0 +1,49 @@
+package org.ole.planet.myplanet.ui.news
+
+import io.realm.Realm
+import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.model.RealmUserModel
+
+class NewsPermissionChecker(
+    private val realm: Realm,
+    private val currentUser: RealmUserModel?,
+    private val sessionUser: RealmUserModel?,
+    private val fromLogin: Boolean,
+    private val nonTeamMember: Boolean,
+    private val teamId: String?
+) {
+    fun isTeamLeader(): Boolean {
+        if (teamId == null) return false
+        val team = realm.where(RealmMyTeam::class.java)
+            .equalTo("teamId", teamId)
+            .equalTo("isLeader", true)
+            .findFirst()
+        return team?.userId == currentUser?._id
+    }
+
+    fun isGuestUser() = sessionUser?.id?.startsWith("guest") == true
+
+    private fun isOwner(news: RealmNews?) = news?.userId == currentUser?._id
+
+    private fun isSharedByCurrentUser(news: RealmNews?) = news?.sharedBy == currentUser?._id
+
+    private fun isAdmin() = currentUser?.level.equals("admin", ignoreCase = true)
+
+    private fun isLoggedInAndMember() = !fromLogin && !nonTeamMember
+
+    fun canEdit(news: RealmNews?) =
+        isLoggedInAndMember() && (isOwner(news) || isAdmin() || isTeamLeader())
+
+    fun canDelete(news: RealmNews?) =
+        isLoggedInAndMember() && (isOwner(news) || isSharedByCurrentUser(news) || isAdmin() || isTeamLeader())
+
+    fun canReply() = isLoggedInAndMember() && !isGuestUser()
+
+    fun canAddLabel(news: RealmNews?) =
+        isLoggedInAndMember() && (isOwner(news) || isTeamLeader() || isAdmin())
+
+    fun canShare(news: RealmNews?) =
+        isLoggedInAndMember() && news?.isCommunityNews == false && !isGuestUser()
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsViewBinder.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsViewBinder.kt
@@ -1,0 +1,75 @@
+package org.ole.planet.myplanet.ui.news
+
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import io.realm.Realm
+import org.ole.planet.myplanet.MainApplication
+import org.ole.planet.myplanet.databinding.RowNewsBinding
+import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
+import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
+import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.Utilities
+import org.ole.planet.myplanet.utilities.makeExpandable
+
+class NewsViewBinder(
+    private val realm: Realm,
+    private val currentUser: RealmUserModel?,
+    private val profileDbHandler: UserProfileDbHandler
+) {
+    fun configureUser(binding: RowNewsBinding, news: RealmNews): RealmUserModel? {
+        val userModel = realm.where(RealmUserModel::class.java)
+            .equalTo("id", news.userId)
+            .findFirst()
+        val userFullName = userModel?.getFullNameWithMiddleName()?.trim()
+        if (userModel != null && currentUser != null) {
+            binding.tvName.text =
+                if (userFullName.isNullOrEmpty()) news.userName else userFullName
+            Utilities.loadImage(userModel.userImage, binding.imgUser)
+        } else {
+            binding.tvName.text = news.userName
+            Utilities.loadImage(null, binding.imgUser)
+        }
+        return userModel
+    }
+
+    fun setMessageAndDate(binding: RowNewsBinding, news: RealmNews, sharedTeamName: String, teamName: String) {
+        val markdownContentWithLocalPaths = prependBaseUrlToImages(
+            news.message,
+            "file://" + MainApplication.context.getExternalFilesDir(null) + "/ole/",
+            600,
+            350
+        )
+        setMarkdownText(binding.tvMessage, markdownContentWithLocalPaths)
+        val fulltext = binding.tvMessage.text
+        binding.tvMessage.makeExpandable(
+            fullText = fulltext,
+            collapsedMaxLines = 6
+        )
+        binding.tvDate.text =
+            if (sharedTeamName.isEmpty() || teamName.isNotEmpty()) {
+                formatDate(news.time)
+            } else {
+                "${'$'}{formatDate(news.time)} | Shared from ${'$'}sharedTeamName"
+            }
+        binding.tvEdited.visibility = if (news.isEdited) View.VISIBLE else View.GONE
+    }
+
+    fun setMemberClickListeners(binding: RowNewsBinding, userModel: RealmUserModel?, currentLeader: RealmUserModel?, fromLogin: Boolean) {
+        if (!fromLogin) {
+            binding.imgUser.setOnClickListener {
+                val activity = it.context as AppCompatActivity
+                val model = userModel ?: currentLeader
+                NewsActions.showMemberDetails(activity, model, profileDbHandler)
+            }
+            binding.tvName.setOnClickListener {
+                val activity = it.context as AppCompatActivity
+                val model = userModel ?: currentLeader
+                NewsActions.showMemberDetails(activity, model, profileDbHandler)
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsViewModel.kt
@@ -1,0 +1,74 @@
+package org.ole.planet.myplanet.ui.news
+
+import android.content.SharedPreferences
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import io.realm.Case
+import io.realm.Realm
+import io.realm.RealmResults
+import io.realm.Sort
+import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.model.RealmUserModel
+
+class NewsViewModel : ViewModel() {
+    private val _newsList = MutableLiveData<List<RealmNews?>>()
+    val newsList: LiveData<List<RealmNews?>> = _newsList
+
+    fun loadNews(realm: Realm, user: RealmUserModel?, settings: SharedPreferences) {
+        val results = realm.where(RealmNews::class.java)
+            .sort("time", Sort.DESCENDING)
+            .isEmpty("replyTo")
+            .equalTo("docType", "message", Case.INSENSITIVE)
+            .findAllAsync()
+
+        results.addChangeListener { res ->
+            _newsList.postValue(filterNewsList(res, user, settings))
+        }
+        _newsList.value = filterNewsList(results, user, settings)
+    }
+
+    fun addNews(news: RealmNews?) {
+        news ?: return
+        val current = _newsList.value?.toMutableList() ?: mutableListOf()
+        current.add(0, news)
+        _newsList.value = current
+    }
+
+    fun getAllNews(realm: Realm, user: RealmUserModel?, settings: SharedPreferences): List<RealmNews?> {
+        val allNews: RealmResults<RealmNews> = realm.where(RealmNews::class.java)
+            .isEmpty("replyTo")
+            .equalTo("docType", "message", Case.INSENSITIVE)
+            .findAll()
+        return filterNewsList(allNews, user, settings)
+    }
+
+    private fun filterNewsList(results: Iterable<RealmNews>, user: RealmUserModel?, settings: SharedPreferences): List<RealmNews?> {
+        val filteredList: MutableList<RealmNews?> = ArrayList()
+        for (news in results) {
+            if (news.viewableBy.equals("community", ignoreCase = true)) {
+                filteredList.add(news)
+                continue
+            }
+            if (!news.viewIn.isNullOrEmpty()) {
+                val ar = Gson().fromJson(news.viewIn, JsonArray::class.java)
+                for (e in ar) {
+                    val ob = e.asJsonObject
+                    var userId = "${'$'}{user?.planetCode}@${'$'}{user?.parentCode}"
+                    if (userId.isEmpty() || userId == "@") {
+                        val planet = settings.getString("planetCode", "") ?: ""
+                        val parent = settings.getString("parentCode", "") ?: ""
+                        userId = "${'$'}planet@${'$'}parent"
+                    }
+                    if (ob != null && ob.has("_id") && ob["_id"].asString.equals(userId, ignoreCase = true)) {
+                        filteredList.add(news)
+                        break
+                    }
+                }
+            }
+        }
+        return filteredList
+    }
+}


### PR DESCRIPTION
## Summary
- introduce helper classes `NewsPermissionChecker`, `NewsViewBinder`, `ChatHandler` and `ImageLoader`
- clean up `AdapterNews` to delegate responsibilities
- simplify permission logic and image handling
- introduce `NewsViewModel` and connect it to `NewsFragment`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687552c99a84832b844dd4a9e36b45c5