### PR TITLE
Refactor ViewModels to unified UI state

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.SecurityDataCallback
 import org.ole.planet.myplanet.callback.SuccessListener
@@ -57,6 +57,7 @@ class Service(private val context: Context) {
     private val retrofitInterface: ApiInterface? = ApiClient.client?.create(ApiInterface::class.java)
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val serverAvailabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
+    private val networkRepository = NetworkRepository()
     private val configurationManager = ConfigurationManager(context, preferences, retrofitInterface)
 
     fun healthAccess(listener: SuccessListener) {
@@ -162,8 +163,8 @@ class Service(private val context: Context) {
         val mapping = serverUrlMapper.processUrl(updateUrl)
 
         CoroutineScope(Dispatchers.IO).launch {
-            val primaryAvailable = isServerReachable(mapping.primaryUrl)
-            val alternativeAvailable = mapping.alternativeUrl?.let { isServerReachable(it) } == true
+            val primaryAvailable = networkRepository.isServerReachable(mapping.primaryUrl)
+            val alternativeAvailable = mapping.alternativeUrl?.let { networkRepository.isServerReachable(it) } == true
 
             if (!primaryAvailable && alternativeAvailable) {
                 mapping.alternativeUrl.let { alternativeUrl ->

--- a/app/src/main/java/org/ole/planet/myplanet/model/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ChatViewModel.kt
@@ -1,38 +1,38 @@
 package org.ole.planet.myplanet.model
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import io.realm.RealmList
 
+data class ChatUiState(
+    val selectedChatHistory: RealmList<Conversation>? = null,
+    val selectedId: String = "",
+    val selectedRev: String = "",
+    val selectedAiProvider: String? = null
+)
+
 class ChatViewModel : ViewModel() {
-    private val _selectedChatHistory = MutableStateFlow<RealmList<Conversation>?>(null)
-    val selectedChatHistory: StateFlow<RealmList<Conversation>?> = _selectedChatHistory.asStateFlow()
-
-    private val _selectedId = MutableStateFlow("")
-    val selectedId: StateFlow<String> = _selectedId.asStateFlow()
-
-    private val _selectedRev = MutableStateFlow("")
-    val selectedRev: StateFlow<String> = _selectedRev.asStateFlow()
-
-    private val _selectedAiProvider = MutableStateFlow<String?>(null)
-    val selectedAiProvider: StateFlow<String?> = _selectedAiProvider.asStateFlow()
+    private val _uiState = MutableStateFlow(ChatUiState())
+    val uiState: StateFlow<ChatUiState> = _uiState.asStateFlow()
 
     fun setSelectedChatHistory(conversations: RealmList<Conversation>) {
-        _selectedChatHistory.value = conversations
+        _uiState.value = _uiState.value.copy(selectedChatHistory = conversations)
     }
 
     fun setSelectedId(id: String) {
-        _selectedId.value = id
+        _uiState.value = _uiState.value.copy(selectedId = id)
     }
 
     fun setSelectedRev(rev: String) {
-        _selectedRev.value = rev
+        _uiState.value = _uiState.value.copy(selectedRev = rev)
     }
 
     fun setSelectedAiProvider(aiProvider: String?) {
-        _selectedAiProvider.value = aiProvider
+        _uiState.value = _uiState.value.copy(selectedAiProvider = aiProvider)
     }
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.context
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.datamanager.ApiClient.client
 import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
@@ -72,6 +73,7 @@ open class RealmMyTeam : RealmObject() {
 
     companion object {
         private val concatenatedLinks = ArrayList<String>()
+        private val networkRepository = NetworkRepository()
 
         @JvmStatic
         fun insertMyTeams(doc: JsonObject, mRealm: Realm) {
@@ -270,9 +272,9 @@ open class RealmMyTeam : RealmObject() {
             val mapping = serverUrlMapper.processUrl(updateUrl)
 
             CoroutineScope(Dispatchers.IO).launch {
-                val primaryAvailable = MainApplication.isServerReachable(mapping.primaryUrl)
+                val primaryAvailable = networkRepository.isServerReachable(mapping.primaryUrl)
                 val alternativeAvailable =
-                    mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
+                    mapping.alternativeUrl?.let { networkRepository.isServerReachable(it) } == true
 
                 if (!primaryAvailable && alternativeAvailable) {
                     mapping.alternativeUrl.let { alternativeUrl ->

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NetworkRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NetworkRepository.kt
@@ -1,0 +1,31 @@
+package org.ole.planet.myplanet.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+
+class NetworkRepository {
+    suspend fun isServerReachable(urlString: String): Boolean {
+        if (urlString.isBlank()) return false
+        val formattedUrl = if (!urlString.startsWith("http://") && !urlString.startsWith("https://")) {
+            "http://$urlString"
+        } else {
+            urlString
+        }
+        return try {
+            val url = URL(formattedUrl)
+            val connection = withContext(Dispatchers.IO) { url.openConnection() } as HttpURLConnection
+            connection.requestMethod = "GET"
+            connection.connectTimeout = 5000
+            connection.readTimeout = 5000
+            withContext(Dispatchers.IO) { connection.connect() }
+            val responseCode = connection.responseCode
+            connection.disconnect()
+            responseCode in 200..299
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -23,7 +23,7 @@ import io.realm.Sort
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.SyncListener
@@ -52,6 +52,7 @@ class ChatHistoryListFragment : Fragment() {
     private val serverUrlMapper = ServerUrlMapper()
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
+    private val networkRepository = NetworkRepository()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -202,7 +203,7 @@ class ChatHistoryListFragment : Fragment() {
 
     private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
         serverUrlMapper.updateServerIfNecessary(mapping, settings) { url ->
-            isServerReachable(url)
+            networkRepository.isServerReachable(url)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -29,7 +29,7 @@ import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.callback.OnCourseItemSelected
@@ -86,6 +86,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     private val serverUrlMapper = ServerUrlMapper()
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
+    private val networkRepository = NetworkRepository()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -157,7 +158,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
 
     private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
         serverUrlMapper.updateServerIfNecessary(mapping, settings) { url ->
-            isServerReachable(url)
+            networkRepository.isServerReachable(url)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -89,8 +89,8 @@ class BellDashboardFragment : BaseDashboardFragment() {
         networkStatusJob?.cancel()
         networkStatusJob = viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.networkStatus.collect { status ->
-                    updateNetworkIndicator(status)
+                viewModel.uiState.collect { state ->
+                    updateNetworkIndicator(state.networkStatus)
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseDialogFragment
 import org.ole.planet.myplanet.callback.SuccessListener
@@ -47,6 +48,7 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
     private var submissions: RealmSubmission? = null
     var userModel: RealmUserModel? = null
     var shouldHideElements: Boolean? = null
+    private val networkRepository = NetworkRepository()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentUserInformationBinding = FragmentUserInformationBinding.inflate(inflater, container, false)
@@ -255,9 +257,9 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
         val mapping = serverUrlMapper.processUrl(updateUrl)
 
         CoroutineScope(Dispatchers.IO).launch {
-            val primaryAvailable = MainApplication.isServerReachable(mapping.primaryUrl)
+            val primaryAvailable = networkRepository.isServerReachable(mapping.primaryUrl)
             val alternativeAvailable =
-                mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
+                mapping.alternativeUrl?.let { networkRepository.isServerReachable(it) } == true
 
             if (!primaryAvailable && alternativeAvailable) {
                 mapping.alternativeUrl.let { alternativeUrl ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -16,7 +16,7 @@ import io.realm.RealmResults
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.SyncListener
@@ -44,6 +44,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     private val serverUrlMapper = ServerUrlMapper()
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
+    private val networkRepository = NetworkRepository()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -129,7 +130,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
 
     private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
         serverUrlMapper.updateServerIfNecessary(mapping, settings) { url ->
-            isServerReachable(url)
+            networkRepository.isServerReachable(url)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
@@ -32,7 +32,7 @@ import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.callback.SyncListener
@@ -68,6 +68,7 @@ class MyHealthFragment : Fragment() {
     private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
     lateinit var prefManager: SharedPrefManager
     lateinit var settings: SharedPreferences
+    private val networkRepository = NetworkRepository()
     private val serverUrlMapper = ServerUrlMapper()
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
@@ -140,7 +141,7 @@ class MyHealthFragment : Fragment() {
 
     private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
         serverUrlMapper.updateServerIfNecessary(mapping, settings) { url ->
-            isServerReachable(url)
+            networkRepository.isServerReachable(url)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -30,7 +30,7 @@ import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.callback.OnFilterListener
@@ -82,6 +82,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     private val serverUrlMapper = ServerUrlMapper()
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
+    private val networkRepository = NetworkRepository()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -153,7 +154,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
         serverUrlMapper.updateServerIfNecessary(mapping, settings) { url ->
-            isServerReachable(url)
+            networkRepository.isServerReachable(url)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.callback.SurveyAdoptListener
@@ -50,6 +50,7 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), SurveyAdoptListen
     private val serverUrlMapper = ServerUrlMapper()
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
+    private val networkRepository = NetworkRepository()
     private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
 
     override fun getLayout(): Int = R.layout.fragment_survey
@@ -122,7 +123,7 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), SurveyAdoptListen
 
     private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
         serverUrlMapper.updateServerIfNecessary(mapping, settings) { url ->
-            isServerReachable(url)
+            networkRepository.isServerReachable(url)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -34,6 +34,7 @@ import org.ole.planet.myplanet.BuildConfig
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.MainApplication.Companion.createLog
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseResourceFragment.Companion.backgroundDownload
 import org.ole.planet.myplanet.base.BaseResourceFragment.Companion.getAllLibraryList
@@ -103,6 +104,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
     var syncFailed = false
     lateinit var defaultPref: SharedPreferences
     lateinit var service: Service
+    private val networkRepository = NetworkRepository()
     var currentDialog: MaterialDialog? = null
     var serverConfigAction = ""
     var serverCheck = true
@@ -632,7 +634,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                 val serverUrl = settings.getString("serverURL", "")
                 if (!serverUrl.isNullOrEmpty()) {
                     MainApplication.applicationScope.launch(Dispatchers.IO) {
-                        val canReachServer = MainApplication.Companion.isServerReachable(serverUrl)
+                        val canReachServer = networkRepository.isServerReachable(serverUrl)
                         if (canReachServer) {
                             withContext(Dispatchers.Main) {
                                 startUpload("login")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.MemberChangeListener
 import org.ole.planet.myplanet.callback.SyncListener
@@ -49,6 +49,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     private val serverUrlMapper = ServerUrlMapper()
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
+    private val networkRepository = NetworkRepository()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -143,7 +144,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
 
     private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
         serverUrlMapper.updateServerIfNecessary(mapping, settings) { url ->
-            isServerReachable(url)
+            networkRepository.isServerReachable(url)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.repository.NetworkRepository
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
@@ -55,6 +55,7 @@ class AchievementFragment : BaseContainerFragment() {
     private val serverUrlMapper = ServerUrlMapper()
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
+    private val networkRepository = NetworkRepository()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -135,7 +136,7 @@ class AchievementFragment : BaseContainerFragment() {
 
     private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
         serverUrlMapper.updateServerIfNecessary(mapping, settings) { url ->
-            isServerReachable(url)
+            networkRepository.isServerReachable(url)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/SyncTimeLogger.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/SyncTimeLogger.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.repository.NetworkRepository
 
 class SyncTimeLogger private constructor() {
     private val processTimes = ConcurrentHashMap<String, Long>()
@@ -22,6 +23,7 @@ class SyncTimeLogger private constructor() {
     private var endTime: Long = 0
     private var isLogging = false
     private val handler = Handler(Looper.getMainLooper())
+    private val networkRepository = NetworkRepository()
 
     fun startLogging() {
         startTime = System.currentTimeMillis()
@@ -48,9 +50,9 @@ class SyncTimeLogger private constructor() {
             val mapping = serverUrlMapper.processUrl(updateUrl)
 
             CoroutineScope(Dispatchers.IO).launch {
-                val primaryAvailable = MainApplication.isServerReachable(mapping.primaryUrl)
+                val primaryAvailable = networkRepository.isServerReachable(mapping.primaryUrl)
                 val alternativeAvailable =
-                    mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
+                    mapping.alternativeUrl?.let { networkRepository.isServerReachable(it) } == true
 
                 if (!primaryAvailable && alternativeAvailable) {
                     mapping.alternativeUrl.let { alternativeUrl ->


### PR DESCRIPTION
## Summary
- create `NetworkRepository` for server reachability logic
- unify chat state in `ChatUiState`
- add `DashboardUiState` with notification refresh
- update `BellDashboardViewModel` to use `BellDashboardUiState`
- observe ViewModel state from Activities and Fragments
- replace global `isServerReachable` usage

## Testing
- `./gradlew assembleDebug` *(fails: Gradle output incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_687794ad0c2c832bb80cc47e807cd231