### PR TITLE
Optimize datamanager IO

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/FileUploadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/FileUploadService.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.datamanager
 import com.google.gson.JsonObject
 import java.io.File
 import java.io.IOException
+import java.net.URLConnection
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody
@@ -46,8 +47,7 @@ open class FileUploadService {
     private fun uploadDoc(id: String, rev: String, format: String, f: File, name: String, listener: SuccessListener) {
         val apiInterface = ApiClient.client?.create(ApiInterface::class.java)
         try {
-            val connection = f.toURI().toURL().openConnection()
-            val mimeType = connection.contentType
+            val mimeType = URLConnection.guessContentTypeFromName(f.name) ?: "application/octet-stream"
             val body = FileUtils.fullyReadFileToBytes(f)
                 .toRequestBody("application/octet-stream".toMediaTypeOrNull())
             val url = String.format(format, Utilities.getUrl(), id, name)


### PR DESCRIPTION
## Summary
- improve Retrofit creation for reuse
- avoid expensive URLConnection in file uploads
- use buffered streams and constants for downloads
- clean up redundant imports

## Testing
- `./gradlew help --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687a15a33878832b9e10c7a0a6cb05d4