### PR TITLE
Replace singletons with Hilt injected services

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -9,6 +9,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.os.StrictMode
 import android.os.StrictMode.VmPolicy
+import dagger.hilt.android.HiltAndroidApp
 import android.provider.Settings
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
@@ -51,6 +52,7 @@ import org.ole.planet.myplanet.utilities.ThemeMode
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils.getVersionName
 
+@HiltAndroidApp
 class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
     companion object {
         private const val AUTO_SYNC_WORK_TAG = "autoSyncWork"

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ManagerSync.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ManagerSync.kt
@@ -19,10 +19,12 @@ import org.ole.planet.myplanet.utilities.Utilities
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+import dagger.hilt.android.qualifiers.ApplicationContext
 
-class ManagerSync private constructor(context: Context) {
-    private val settings: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    private val dbService: DatabaseService = DatabaseService(context)
+@Singleton
+class ManagerSync @Inject constructor(@ApplicationContext context: Context, private val dbService: DatabaseService, private val settings: SharedPreferences) {
     private val mRealm: Realm = dbService.realmInstance
 
     fun login(userName: String?, password: String?, listener: SyncListener) {
@@ -92,15 +94,5 @@ class ManagerSync private constructor(context: Context) {
         val roles = jsonDoc?.get("roles")?.asJsonArray
         val isManager = roles.toString().lowercase(Locale.getDefault()).contains("manager")
         return jsonDoc?.get("isUserAdmin")?.asBoolean == true || isManager
-    }
-
-    companion object {
-        private var ourInstance: ManagerSync? = null
-        @JvmStatic
-        val instance: ManagerSync?
-            get() {
-                ourInstance = ManagerSync(MainApplication.context)
-                return ourInstance
-            }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -31,6 +31,7 @@ import org.ole.planet.myplanet.model.RealmCommunity
 import org.ole.planet.myplanet.model.RealmUserModel.Companion.isUserExists
 import org.ole.planet.myplanet.model.RealmUserModel.Companion.populateUsersTable
 import org.ole.planet.myplanet.service.UploadToShelfService
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.ui.sync.ProcessUserDataActivity
 import org.ole.planet.myplanet.ui.sync.SyncActivity
 import org.ole.planet.myplanet.utilities.AndroidDecrypter.Companion.generateIv
@@ -264,7 +265,8 @@ class Service(private val context: Context) {
                 if (res?.body() != null) {
                     val model = populateUsersTable(res.body(), realm1, settings)
                     if (model != null) {
-                        UploadToShelfService(MainApplication.context).saveKeyIv(retrofitInterface, model, obj)
+                        val uploadService = DiUtils.appEntryPoint(MainApplication.context).uploadToShelfService()
+                        uploadService.saveKeyIv(model, obj)
                     }
                 }
             } catch (e: IOException) {

--- a/app/src/main/java/org/ole/planet/myplanet/di/AppEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/AppEntryPoint.kt
@@ -1,0 +1,18 @@
+package org.ole.planet.myplanet.di
+
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.service.UploadToShelfService
+import org.ole.planet.myplanet.service.SyncManager
+import org.ole.planet.myplanet.datamanager.ManagerSync
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface AppEntryPoint {
+    fun uploadManager(): UploadManager
+    fun uploadToShelfService(): UploadToShelfService
+    fun syncManager(): SyncManager
+    fun managerSync(): ManagerSync
+}

--- a/app/src/main/java/org/ole/planet/myplanet/di/AppModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/AppModule.kt
@@ -1,0 +1,39 @@
+package org.ole.planet.myplanet.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Singleton
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.datamanager.ApiClient
+import org.ole.planet.myplanet.datamanager.ApiInterface
+import io.realm.Realm
+import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabaseService(@ApplicationContext context: Context): DatabaseService {
+        return DatabaseService(context)
+    }
+
+    @Provides
+    fun provideRealm(service: DatabaseService): Realm = service.realmInstance
+
+    @Provides
+    @Singleton
+    fun provideApiInterface(): ApiInterface = ApiClient.client.create(ApiInterface::class.java)
+
+    @Provides
+    @Singleton
+    fun provideSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/di/DiUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DiUtils.kt
@@ -1,0 +1,10 @@
+package org.ole.planet.myplanet.di
+
+import android.content.Context
+import dagger.hilt.android.EntryPointAccessors
+
+object DiUtils {
+    fun appEntryPoint(context: Context): AppEntryPoint {
+        return EntryPointAccessors.fromApplication(context.applicationContext, AppEntryPoint::class.java)
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -22,6 +22,7 @@ import org.ole.planet.myplanet.datamanager.ApiClient.client
 import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DownloadUtils.extractLinks
@@ -289,14 +290,15 @@ open class RealmMyTeam : RealmObject() {
         private fun uploadTeamActivities(context: Context) {
             MainApplication.applicationScope.launch {
                 try {
+                    val entry = DiUtils.appEntryPoint(context)
                     withContext(Dispatchers.IO) {
-                        UploadManager.instance?.uploadTeams()
+                        entry.uploadManager().uploadTeams()
                     }
                     withContext(Dispatchers.IO) {
                         val apiInterface = client?.create(ApiInterface::class.java)
                         val realm = DatabaseService(context).realmInstance
                         realm.executeTransaction { transactionRealm ->
-                            UploadManager.instance?.uploadTeamActivities(transactionRealm, apiInterface)
+                            entry.uploadManager().uploadTeamActivities(transactionRealm, apiInterface)
                         }
                     }
                 } catch (e: Exception) {

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.datamanager.ApiClient.client
-import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.di.DiUtils
@@ -295,10 +294,9 @@ open class RealmMyTeam : RealmObject() {
                         entry.uploadManager().uploadTeams()
                     }
                     withContext(Dispatchers.IO) {
-                        val apiInterface = client?.create(ApiInterface::class.java)
                         val realm = DatabaseService(context).realmInstance
                         realm.executeTransaction { transactionRealm ->
-                            entry.uploadManager().uploadTeamActivities(transactionRealm, apiInterface)
+                            entry.uploadManager().uploadTeamActivities(transactionRealm)
                         }
                     }
                 } catch (e: Exception) {

--- a/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.kt
@@ -16,6 +16,7 @@ import org.ole.planet.myplanet.datamanager.Service.CheckVersionCallback
 import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.ui.sync.LoginActivity
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.utilities.DialogUtils.startDownloadUpdate
 import org.ole.planet.myplanet.utilities.Utilities
 
@@ -54,30 +55,32 @@ class AutoSyncWorker(private val context: Context, workerParams: WorkerParameter
     override fun onCheckingVersion() {}
     override fun onError(msg: String, blockSync: Boolean) {
         if (!blockSync) {
-            SyncManager.instance?.start(this, "upload")
-            UploadToShelfService.instance?.uploadUserData {
+            val entry = DiUtils.appEntryPoint(context)
+            entry.syncManager().start(this, "upload")
+            entry.uploadToShelfService().uploadUserData {
                 Service(MainApplication.context).healthAccess {
-                    UploadToShelfService.instance?.uploadHealth()
+                    entry.uploadToShelfService().uploadHealth()
                 }
             }
             if (!MainApplication.isSyncRunning) {
                 MainApplication.isSyncRunning = true
-                UploadManager.instance?.uploadExamResult(this)
-                UploadManager.instance?.uploadFeedback(this)
-                UploadManager.instance?.uploadAchievement()
-                UploadManager.instance?.uploadResourceActivities("")
-                UploadManager.instance?.uploadUserActivities(this)
-                UploadManager.instance?.uploadCourseActivities()
-                UploadManager.instance?.uploadSearchActivity()
-                UploadManager.instance?.uploadRating()
-                UploadManager.instance?.uploadResource(this)
-                UploadManager.instance?.uploadNews()
-                UploadManager.instance?.uploadTeams()
-                UploadManager.instance?.uploadTeamTask()
-                UploadManager.instance?.uploadMeetups()
-                UploadManager.instance?.uploadCrashLog()
-                UploadManager.instance?.uploadSubmissions()
-                UploadManager.instance?.uploadActivities { MainApplication.isSyncRunning = false }
+                val manager = entry.uploadManager()
+                manager.uploadExamResult(this)
+                manager.uploadFeedback(this)
+                manager.uploadAchievement()
+                manager.uploadResourceActivities("")
+                manager.uploadUserActivities(this)
+                manager.uploadCourseActivities()
+                manager.uploadSearchActivity()
+                manager.uploadRating()
+                manager.uploadResource(this)
+                manager.uploadNews()
+                manager.uploadTeams()
+                manager.uploadTeamTask()
+                manager.uploadMeetups()
+                manager.uploadCrashLog()
+                manager.uploadSubmissions()
+                manager.uploadActivities { MainApplication.isSyncRunning = false }
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -91,7 +91,6 @@ class SyncManager @Inject constructor(
         cancelBackgroundSync()
         cancel(context, 111)
         isSyncing = false
-        ourInstance = null
         settings.edit { putLong("LastSync", Date().time) }
         listener?.onSyncComplete()
         try {

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
@@ -23,6 +23,7 @@ import org.ole.planet.myplanet.utilities.VersionUtils.getAndroidId
 import retrofit2.*
 import javax.inject.Inject
 import javax.inject.Singleton
+import dagger.hilt.android.qualifiers.ApplicationContext
 
 private const val BATCH_SIZE = 50
 
@@ -36,7 +37,7 @@ private inline fun <T> Iterable<T>.processInBatches(action: (T) -> Unit) {
 
 @Singleton
 class UploadManager @Inject constructor(
-    private val context: Context,
+    @ApplicationContext private val context: Context,
     val pref: SharedPreferences,
     private val dbService: DatabaseService,
     private val apiInterface: ApiInterface
@@ -469,7 +470,7 @@ class UploadManager @Inject constructor(
                     e.printStackTrace()
                 }
             }
-            uploadTeamActivities(transactionRealm, apiInterface)
+            uploadTeamActivities(transactionRealm)
         }, {
             realm.close()
             listener.onSuccess("User activities sync completed successfully")
@@ -480,7 +481,7 @@ class UploadManager @Inject constructor(
         }
     }
 
-    fun uploadTeamActivities(realm: Realm, apiInterface: ApiInterface?) {
+    fun uploadTeamActivities(realm: Realm) {
         val logs = realm.where(RealmTeamLog::class.java).isNull("_rev").findAll()
         logs.processInBatches { log ->
                 try {
@@ -607,11 +608,11 @@ class UploadManager @Inject constructor(
 
             if (hasLooper) {
                 realm.executeTransactionAsync { realm: Realm ->
-                    uploadCrashLogData(realm, apiInterface)
+                    uploadCrashLogData(realm)
                 }
             } else {
                 realm.executeTransaction { realm: Realm ->
-                    uploadCrashLogData(realm, apiInterface)
+                    uploadCrashLogData(realm)
                 }
             }
         } catch (e: Exception) {
@@ -619,7 +620,7 @@ class UploadManager @Inject constructor(
         }
     }
 
-    private fun uploadCrashLogData(realm: Realm, apiInterface: ApiInterface?) {
+    private fun uploadCrashLogData(realm: Realm) {
         val logs: RealmResults<RealmApkLog> = realm.where(RealmApkLog::class.java).isNull("_rev").findAll()
 
         logs.processInBatches { act ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -34,6 +34,7 @@ import org.ole.planet.myplanet.model.Conversation
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils
@@ -163,7 +164,8 @@ class ChatHistoryListFragment : Fragment() {
     }
 
     private fun startSyncManager() {
-        SyncManager.instance?.start(object : SyncListener {
+        val entry = DiUtils.appEntryPoint(requireContext())
+        entry.syncManager().start(object : SyncListener {
             override fun onSyncStarted() {
                 activity?.runOnUiThread {
                     if (isAdded && !requireActivity().isFinishing) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -45,6 +45,7 @@ import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmTag.Companion.getTagsArray
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.resources.CollectionsFragment
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
@@ -117,7 +118,8 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     }
 
     private fun startSyncManager() {
-        SyncManager.instance?.start(object : SyncListener {
+        val entry = DiUtils.appEntryPoint(requireContext())
+        entry.syncManager().start(object : SyncListener {
             override fun onSyncStarted() {
                 activity?.runOnUiThread {
                     if (isAdded && !requireActivity().isFinishing) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -297,7 +297,7 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
             override fun onSuccess(success: String?) {}
         }
 
-        val newUploadManager = UploadManager(MainApplication.context)
+        val newUploadManager = DiUtils.appEntryPoint(requireContext()).uploadManager()
         newUploadManager.uploadExamResult(successListener)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -33,6 +33,7 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.team.TeamDetailFragment
 import org.ole.planet.myplanet.ui.team.TeamPage
@@ -278,7 +279,8 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
         MainApplication.applicationScope.launch {
             try {
                 withContext(Dispatchers.IO) {
-                    UploadManager.instance?.uploadSubmissions()
+                    val manager = DiUtils.appEntryPoint(requireContext()).uploadManager()
+                    manager.uploadSubmissions()
                 }
 
                 withContext(Dispatchers.Main) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -25,6 +25,7 @@ import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment.OnFeedbackSubmittedListener
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
@@ -90,7 +91,8 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     }
 
     private fun startSyncManager() {
-        SyncManager.instance?.start(object : SyncListener {
+        val entry = DiUtils.appEntryPoint(requireContext())
+        entry.syncManager().start(object : SyncListener {
             override fun onSyncStarted() {
                 activity?.runOnUiThread {
                     if (isAdded && !requireActivity().isFinishing) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
@@ -13,6 +13,7 @@ import org.ole.planet.myplanet.databinding.FragmentMyPersonalsBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.resources.AddResourceFragment
 import org.ole.planet.myplanet.utilities.DialogUtils
@@ -88,7 +89,8 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
         pg.setText("Please wait......")
         pg.show()
         if (personal != null) {
-            UploadManager.instance?.uploadMyPersonal(personal) { s: String? ->
+            val manager = DiUtils.appEntryPoint(requireContext()).uploadManager()
+            manager.uploadMyPersonal(personal) { s: String? ->
                 if (s != null) {
                     Utilities.toast(activity, s)
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
@@ -44,6 +44,7 @@ import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmMyHealthPojo
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
@@ -104,7 +105,8 @@ class MyHealthFragment : Fragment() {
     }
 
     private fun startSyncManager() {
-        SyncManager.instance?.start(object : SyncListener {
+        val entry = DiUtils.appEntryPoint(requireContext())
+        entry.syncManager().start(object : SyncListener {
             override fun onSyncStarted() {
                 activity?.runOnUiThread {
                     if (isAdded && !requireActivity().isFinishing) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -48,6 +48,7 @@ import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmTag.Companion.getTagsArray
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils
@@ -113,7 +114,8 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     }
 
     private fun startSyncManager() {
-        SyncManager.instance?.start(object : SyncListener {
+        val entry = DiUtils.appEntryPoint(requireContext())
+        entry.syncManager().start(object : SyncListener {
             override fun onSyncStarted() {
                 activity?.runOnUiThread {
                     if (isAdded && !requireActivity().isFinishing) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
@@ -27,6 +27,7 @@ import org.ole.planet.myplanet.callback.SyncListener
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.service.SyncManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.CustomSpinner
@@ -86,7 +87,8 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), SurveyAdoptListen
     }
 
     private fun startSyncManager() {
-        SyncManager.instance?.start(object : SyncListener {
+        val entry = DiUtils.appEntryPoint(requireContext())
+        entry.syncManager().start(object : SyncListener {
             override fun onSyncStarted() {
                 activity?.runOnUiThread {
                     if (isAdded && !requireActivity().isFinishing) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -41,6 +41,7 @@ import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UploadToShelfService
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.DialogUtils.showAlert
@@ -182,10 +183,11 @@ abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
     }
 
     fun startUpload(source: String, userName: String? = null, securityCallback: SecurityDataCallback? = null) {
+        val entry = DiUtils.appEntryPoint(applicationContext)
         if (source == "becomeMember") {
-            UploadToShelfService.instance?.uploadSingleUserData(userName, object : SuccessListener {
+            entry.uploadToShelfService().uploadSingleUserData(userName, object : SuccessListener {
                 override fun onSuccess(success: String?) {
-                    UploadToShelfService.instance?.uploadSingleUserHealth("org.couchdb.user:${userName}", object : SuccessListener {
+                    entry.uploadToShelfService().uploadSingleUserHealth("org.couchdb.user:${userName}", object : SuccessListener {
                         override fun onSuccess(success: String?) {
                             userName?.let { name ->
                                 fetchAndLogUserSecurityData(name, securityCallback)
@@ -198,23 +200,24 @@ abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
             })
             return
         } else if (source == "login") {
-            UploadManager.instance?.uploadUserActivities(this@ProcessUserDataActivity)
+            entry.uploadManager().uploadUserActivities(this@ProcessUserDataActivity)
             return
         }
         customProgressDialog.setText(context.getString(R.string.uploading_data_to_server_please_wait))
         customProgressDialog.show()
 
-        UploadManager.instance?.uploadAchievement()
-        UploadManager.instance?.uploadNews()
-        UploadManager.instance?.uploadResourceActivities("")
-        UploadManager.instance?.uploadCourseActivities()
-        UploadManager.instance?.uploadSearchActivity()
-        UploadManager.instance?.uploadTeams()
-        UploadManager.instance?.uploadRating()
-        UploadManager.instance?.uploadTeamTask()
-        UploadManager.instance?.uploadMeetups()
-        UploadManager.instance?.uploadSubmissions()
-        UploadManager.instance?.uploadCrashLog()
+        val manager = entry.uploadManager()
+        manager.uploadAchievement()
+        manager.uploadNews()
+        manager.uploadResourceActivities("")
+        manager.uploadCourseActivities()
+        manager.uploadSearchActivity()
+        manager.uploadTeams()
+        manager.uploadRating()
+        manager.uploadTeamTask()
+        manager.uploadMeetups()
+        manager.uploadSubmissions()
+        manager.uploadCrashLog()
 
         val asyncOperationsCounter = AtomicInteger(0)
         val totalAsyncOperations = 6
@@ -230,42 +233,42 @@ abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
             }
         }
 
-        UploadToShelfService.instance?.uploadUserData {
-            UploadToShelfService.instance?.uploadHealth()
+        entry.uploadToShelfService().uploadUserData {
+            entry.uploadToShelfService().uploadHealth()
             checkAllOperationsComplete()
         }
 
-        UploadManager.instance?.uploadUserActivities(object : SuccessListener {
+        manager.uploadUserActivities(object : SuccessListener {
             override fun onSuccess(success: String?) {
                 checkAllOperationsComplete()
             }
         })
 
-        UploadManager.instance?.uploadExamResult(object : SuccessListener {
+        manager.uploadExamResult(object : SuccessListener {
             override fun onSuccess(success: String?) {
                 checkAllOperationsComplete()
             }
         })
 
-        UploadManager.instance?.uploadFeedback(object : SuccessListener {
+        manager.uploadFeedback(object : SuccessListener {
             override fun onSuccess(success: String?) {
                 checkAllOperationsComplete()
             }
         })
 
-        UploadManager.instance?.uploadResource(object : SuccessListener {
+        manager.uploadResource(object : SuccessListener {
             override fun onSuccess(success: String?) {
                 checkAllOperationsComplete()
             }
         })
 
-        UploadManager.instance?.uploadSubmitPhotos(object : SuccessListener {
+        manager.uploadSubmitPhotos(object : SuccessListener {
             override fun onSuccess(success: String?) {
                 checkAllOperationsComplete()
             }
         })
 
-        UploadManager.instance?.uploadActivities(object : SuccessListener {
+        manager.uploadActivities(object : SuccessListener {
             override fun onSuccess(success: String?) {
                 checkAllOperationsComplete()
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -48,6 +48,7 @@ import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.team.AdapterTeam.OnUserSelectedListener
 import org.ole.planet.myplanet.utilities.*
 import org.ole.planet.myplanet.utilities.AndroidDecrypter.Companion.androidDecrypter
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.Constants.autoSynFeature
 import org.ole.planet.myplanet.utilities.DialogUtils.getUpdateDialog
@@ -360,7 +361,8 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
     }
 
     fun startSync(type: String) {
-        SyncManager.instance?.start(this@SyncActivity, type)
+        val entry = DiUtils.appEntryPoint(this)
+        entry.syncManager().start(this@SyncActivity, type)
     }
 
     private fun saveConfigAndContinue(

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -31,6 +31,7 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils
@@ -104,7 +105,8 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     }
 
     private fun startSyncManager() {
-        SyncManager.instance?.start(object : SyncListener {
+        val entry = DiUtils.appEntryPoint(requireContext())
+        entry.syncManager().start(object : SyncListener {
             override fun onSyncStarted() {
                 activity?.runOnUiThread {
                     if (isAdded && !requireActivity().isFinishing) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
@@ -35,6 +35,7 @@ import org.ole.planet.myplanet.model.RealmAchievement
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils
@@ -97,7 +98,8 @@ class AchievementFragment : BaseContainerFragment() {
     }
 
     private fun startSyncManager() {
-        SyncManager.instance?.start(object : SyncListener {
+        val entry = DiUtils.appEntryPoint(requireContext())
+        entry.syncManager().start(object : SyncListener {
             override fun onSyncStarted() {
                 activity?.runOnUiThread {
                     if (isAdded && !requireActivity().isFinishing) {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/AuthHelper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/AuthHelper.kt
@@ -9,6 +9,7 @@ import java.util.regex.Pattern
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.SyncListener
 import org.ole.planet.myplanet.datamanager.ManagerSync
+import org.ole.planet.myplanet.di.DiUtils
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.ui.sync.LoginActivity
 
@@ -64,7 +65,7 @@ object AuthHelper {
             return
         }
 
-        ManagerSync.instance?.login(name, password, object : SyncListener {
+        DiUtils.appEntryPoint(activity).managerSync().login(name, password, object : SyncListener {
             override fun onSyncStarted() {
                 activity.customProgressDialog.setText(activity.getString(R.string.please_wait))
                 activity.customProgressDialog.show()

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/SyncTimeLogger.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/SyncTimeLogger.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.di.DiUtils
 
 class SyncTimeLogger private constructor() {
     private val processTimes = ConcurrentHashMap<String, Long>()
@@ -72,7 +73,8 @@ class SyncTimeLogger private constructor() {
         MainApplication.applicationScope.launch {
             try {
                 withContext(Dispatchers.IO) {
-                    UploadManager.instance?.uploadCrashLog()
+                    val entry = DiUtils.appEntryPoint(MainApplication.context)
+                    entry.uploadManager().uploadCrashLog()
                 }
             } catch (e: Exception) {
                 e.printStackTrace()


### PR DESCRIPTION
## Summary
- migrate `MainApplication` to `@HiltAndroidApp`
- provide app dependencies via `AppModule`
- access services through `Hilt` entry points
- inject dependencies into managers and workers
- remove old singleton access patterns

## Testing
- `./gradlew test --dry-run` *(fails: fetch remote repository)*

------
https://chatgpt.com/codex/tasks/task_e_687df57ea048832ba02f3517f0f9aaaa