### PR TITLE
Inject context into utilities

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -43,11 +43,13 @@ import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DownloadUtils.downloadAllFiles
 import org.ole.planet.myplanet.utilities.LocaleHelper
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+import org.ole.planet.myplanet.utilities.NetworkUtils
 import org.ole.planet.myplanet.utilities.NotificationUtil.cancelAll
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.ThemeMode
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils.getVersionName
+
 class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
     companion object {
         private const val AUTO_SYNC_WORK_TAG = "autoSyncWork"
@@ -73,6 +75,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
         val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         lateinit var defaultPref: SharedPreferences
         lateinit var networkUtils: NetworkUtils
+
         fun createLog(type: String, error: String = "") {
             applicationScope.launch(Dispatchers.IO) {
                 val realm = Realm.getDefaultInstance()
@@ -97,28 +100,41 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                 } finally {
                     realm.close()
                 }
+            }
+        }
+
         private fun applyThemeMode(themeMode: String?) {
             when (themeMode) {
                 ThemeMode.LIGHT -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
                 ThemeMode.DARK -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
                 ThemeMode.FOLLOW_SYSTEM -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+            }
+        }
+
         fun setThemeMode(themeMode: String) {
             val sharedPreferences = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
             with(sharedPreferences.edit()) {
                 putString("theme_mode", themeMode)
                 commit()
+            }
             applyThemeMode(themeMode)
+        }
+
         suspend fun isServerReachable(urlString: String): Boolean {
             val serverUrlMapper = ServerUrlMapper()
             val mapping = serverUrlMapper.processUrl(urlString)
             val urlsToTry = mutableListOf(urlString)
             mapping.alternativeUrl?.let { urlsToTry.add(it) }
+
             return try {
                 if (urlString.isBlank()) return false
+
                 val formattedUrl = if (!urlString.startsWith("http://") && !urlString.startsWith("https://")) {
                     "http://$urlString"
                 } else {
                     urlString
+                }
+
                 val url = URL(formattedUrl)
                 val connection = withContext(Dispatchers.IO) {
                     url.openConnection()
@@ -128,22 +144,34 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                 connection.readTimeout = 5000
                 withContext(Dispatchers.IO) {
                     connection.connect()
+                }
                 val responseCode = connection.responseCode
                 connection.disconnect()
                 responseCode in 200..299
+
+            } catch (e: Exception) {
+                e.printStackTrace()
                 false
+            }
+        }
+
         fun handleUncaughtException(e: Throwable) {
             e.printStackTrace()
             createLog(RealmApkLog.ERROR_TYPE_CRASH, e.stackTraceToString())
+
             val homeIntent = Intent(Intent.ACTION_MAIN).apply {
                 addCategory(Intent.CATEGORY_HOME)
                 flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+            }
             context.startActivity(homeIntent)
+        }
     }
+
     private var activityReferences = 0
     private var isActivityChangingConfigurations = false
     private var isFirstLaunch = true
     private lateinit var anrWatchdog: ANRWatchdog
+
     override fun onCreate() {
         super.onCreate()
         initApp()
@@ -155,43 +183,65 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
         setupLifecycleCallbacks()
         configureTheme()
         observeNetworkForDownloads()
+    }
+
     private fun initApp() {
         context = this
         networkUtils = NetworkUtils(this, applicationScope)
         networkUtils.startListenNetworkState()
+    }
+
     private fun setupPreferences() {
         preferences = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         service = DatabaseService(context)
         mRealm = service.realmInstance
         defaultPref = PreferenceManager.getDefaultSharedPreferences(this)
+    }
+
     private fun setupStrictMode() {
         val builder = VmPolicy.Builder()
         StrictMode.setVmPolicy(builder.build())
         builder.detectFileUriExposure()
+    }
+
     private fun setupAnrWatchdog() {
         anrWatchdog = ANRWatchdog(timeout = 5000L, listener = object : ANRWatchdog.ANRListener {
             override fun onAppNotResponding(message: String, blockedThread: Thread, duration: Long) {
                 applicationScope.launch {
                     createLog("anr", "ANR detected! Duration: ${duration}ms\n $message")
+                }
+            }
         })
         anrWatchdog.start()
+    }
+
     private fun scheduleWorkersOnStart() {
         if (preferences?.getBoolean("autoSync", false) == true && preferences?.contains("autoSyncInterval") == true) {
             val syncInterval = preferences?.getInt("autoSyncInterval", 60 * 60)
             scheduleAutoSyncWork(syncInterval)
         } else {
             cancelAutoSyncWork()
+        }
         scheduleStayOnlineWork()
         scheduleTaskNotificationWork()
+    }
+
     private fun registerExceptionHandler() {
         Thread.setDefaultUncaughtExceptionHandler { _: Thread?, e: Throwable ->
             handleUncaughtException(e)
+        }
+    }
+
     private fun setupLifecycleCallbacks() {
         registerActivityLifecycleCallbacks(this)
         onAppStarted()
+    }
+
     private fun configureTheme() {
         val savedThemeMode = getCurrentThemeMode()
         applyThemeMode(savedThemeMode)
+    }
+
     private fun observeNetworkForDownloads() {
         networkUtils.isNetworkConnectedFlow.onEach { isConnected ->
             if (isConnected) {
@@ -200,61 +250,113 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                     applicationScope.launch {
                         val canReachServer = withContext(Dispatchers.IO) {
                             isServerReachable(serverUrl)
+                        }
                         if (canReachServer && defaultPref.getBoolean("beta_auto_download", false)) {
                             backgroundDownload(downloadAllFiles(getAllLibraryList(mRealm)))
+                        }
+                    }
+                }
+            }
         }.launchIn(applicationScope)
+    }
+
     private fun scheduleAutoSyncWork(syncInterval: Int?) {
         val autoSyncWork: PeriodicWorkRequest? = syncInterval?.let { PeriodicWorkRequest.Builder(AutoSyncWorker::class.java, it.toLong(), TimeUnit.SECONDS).build() }
         val workManager = WorkManager.getInstance(this)
         if (autoSyncWork != null) {
             workManager.enqueueUniquePeriodicWork(AUTO_SYNC_WORK_TAG, ExistingPeriodicWorkPolicy.UPDATE, autoSyncWork)
+        }
+    }
+
     private fun cancelAutoSyncWork() {
+        val workManager = WorkManager.getInstance(this)
         workManager.cancelUniqueWork(AUTO_SYNC_WORK_TAG)
+    }
+
     private fun scheduleStayOnlineWork() {
         val stayOnlineWork: PeriodicWorkRequest = PeriodicWorkRequest.Builder(StayOnlineWorker::class.java, 900, TimeUnit.SECONDS).build()
+        val workManager = WorkManager.getInstance(this)
         workManager.enqueueUniquePeriodicWork(STAY_ONLINE_WORK_TAG, ExistingPeriodicWorkPolicy.UPDATE, stayOnlineWork)
+    }
+
     private fun scheduleTaskNotificationWork() {
         val taskNotificationWork: PeriodicWorkRequest = PeriodicWorkRequest.Builder(TaskNotificationWorker::class.java, 900, TimeUnit.SECONDS).build()
+        val workManager = WorkManager.getInstance(this)
         workManager.enqueueUniquePeriodicWork(TASK_NOTIFICATION_WORK_TAG, ExistingPeriodicWorkPolicy.UPDATE, taskNotificationWork)
+    }
+
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(LocaleHelper.onAttach(base))
         Utilities.setContext(base)
+    }
+
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
+
         if (getCurrentThemeMode() != ThemeMode.FOLLOW_SYSTEM) return
+
         val isNightMode = (newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
         val themeToApply = if (isNightMode) ThemeMode.DARK else ThemeMode.LIGHT
+
         applyThemeMode(themeToApply)
+    }
+
     private fun getCurrentThemeMode(): String {
         val sharedPreferences = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         return sharedPreferences.getString("theme_mode", ThemeMode.FOLLOW_SYSTEM) ?: ThemeMode.FOLLOW_SYSTEM
+    }
+
     override fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
+
     override fun onActivityStarted(activity: Activity) {
         if (++activityReferences == 1 && !isActivityChangingConfigurations) {
             onAppForegrounded()
+        }
+    }
+
     override fun onActivityResumed(activity: Activity) {}
+
     override fun onActivityPaused(activity: Activity) {}
+
     override fun onActivityStopped(activity: Activity) {
         isActivityChangingConfigurations = activity.isChangingConfigurations
         if (--activityReferences == 0 && !isActivityChangingConfigurations) {
             onAppBackgrounded()
+        }
+    }
+
     override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {}
+
     override fun onActivityDestroyed(activity: Activity) {
         cancelAll(this)
+    }
+
     private fun onAppForegrounded() {
         if (isFirstLaunch) {
             isFirstLaunch = false
+        } else {
             applicationScope.launch {
                 createLog("foreground", "")
+            }
+        }
+    }
+
     private fun onAppBackgrounded() {}
+
     private fun onAppStarted() {
         applicationScope.launch {
             createLog("new login", "")
+        }
+    }
+
     private fun onAppClosed() {}
+
     override fun onTerminate() {
         if (::anrWatchdog.isInitialized) {
             anrWatchdog.stop()
+        }
         super.onTerminate()
         onAppClosed()
         applicationScope.cancel()
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
@@ -52,6 +52,7 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
     private var timesRated: TextView? = null
     var rating: TextView? = null
     private var ratingBar: AppCompatRatingBar? = null
+    private lateinit var courseRatingUtils: CourseRatingUtils
     private val installUnknownSourcesRequestCode = 112
     var hasInstallPermission = hasInstallPermission(MainApplication.context)
     private var currentLibrary: RealmMyLibrary? = null
@@ -73,11 +74,12 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
             }
         }
         prefData = SharedPrefManager(requireContext())
+        courseRatingUtils = CourseRatingUtils(requireContext())
     }
 
     fun setRatings(`object`: JsonObject?) {
         if (`object` != null) {
-            CourseRatingUtils.showRating(`object`, rating, timesRated, ratingBar)
+            courseRatingUtils.showRating(`object`, rating, timesRated, ratingBar)
         }
     }
     fun getUrlsAndStartDownload(lib: List<RealmMyLibrary?>, urls: ArrayList<String>) {

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ConfigurationManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ConfigurationManager.kt
@@ -18,17 +18,15 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.ui.sync.SyncActivity
 import org.ole.planet.myplanet.utilities.DialogUtils.CustomProgressDialog
 import org.ole.planet.myplanet.utilities.LocaleHelper
-import org.ole.planet.myplanet.utilities.NetworkUtils.extractProtocol
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.UrlUtils
 import org.ole.planet.myplanet.utilities.Utilities
-
 class ConfigurationManager(
     private val context: Context,
     private val preferences: SharedPreferences,
     private val retrofitInterface: ApiInterface?
 ) {
-
     fun getMinApk(
         listener: Service.ConfigurationIdListener?,
         url: String,
@@ -39,7 +37,6 @@ class ConfigurationManager(
         val serverUrlMapper = ServerUrlMapper()
         val mapping = serverUrlMapper.processUrl(url)
         val urlsToTry = mutableListOf(url).apply { mapping.alternativeUrl?.let { add(it) } }
-
         MainApplication.applicationScope.launch {
             val customProgressDialog = withContext(Dispatchers.Main) {
                 CustomProgressDialog(context).apply {
@@ -47,12 +44,9 @@ class ConfigurationManager(
                     show()
                 }
             }
-
             try {
                 val deferreds = urlsToTry.map { currentUrl ->
                     async { checkConfigurationUrl(currentUrl, pin, customProgressDialog) }
-                }
-
                 val result = try {
                     val allResults = deferreds.awaitAll()
                     allResults.firstOrNull { it is UrlCheckResult.Success }
@@ -61,8 +55,6 @@ class ConfigurationManager(
                 } catch (e: Exception) {
                     e.printStackTrace()
                     UrlCheckResult.Failure(url)
-                }
-
                 when (result) {
                     is UrlCheckResult.Success -> {
                         val isAlternativeUrl = result.url != url
@@ -71,60 +63,41 @@ class ConfigurationManager(
                     }
                     is UrlCheckResult.Failure -> {
                         activity.syncFailed = true
-                        val errorMessage = when (extractProtocol(url)) {
+                        val errorMessage = when (networkUtils.extractProtocol(url)) {
                             context.getString(R.string.http_protocol) -> context.getString(R.string.device_couldn_t_reach_local_server)
                             context.getString(R.string.https_protocol) -> context.getString(R.string.device_couldn_t_reach_nation_server)
                             else -> context.getString(R.string.device_couldn_t_reach_local_server)
                         }
                         showAlertDialog(errorMessage, false)
-                    }
-                }
             } catch (e: Exception) {
                 e.printStackTrace()
                 activity.syncFailed = true
                 withContext(Dispatchers.Main) {
                     showAlertDialog(context.getString(R.string.device_couldn_t_reach_local_server), false)
-                }
             } finally {
                 customProgressDialog.dismiss()
-            }
         }
     }
-
     private suspend fun checkConfigurationUrl(currentUrl: String, pin: String, customProgressDialog: CustomProgressDialog): UrlCheckResult {
         return try {
             val versionsResponse = retrofitInterface?.getConfiguration("$currentUrl/versions")?.execute()
-
             if (versionsResponse?.isSuccessful == true) {
                 val jsonObject = versionsResponse.body()
                 val minApkVersion = jsonObject?.get("minapk")?.asString
                 val currentVersion = context.getString(R.string.app_version)
-
                 if (minApkVersion != null && isVersionAllowed(currentVersion, minApkVersion)) {
                     val couchdbURL = buildCouchdbUrl(currentUrl, pin)
-
                     withContext(Dispatchers.Main) {
                         customProgressDialog.setText(context.getString(R.string.checking_server))
-                    }
-
                     fetchConfiguration(couchdbURL)?.let { (id, code) ->
                         return UrlCheckResult.Success(id, code, currentUrl)
-                    }
-                }
-            }
-
             UrlCheckResult.Failure(currentUrl)
         } catch (e: Exception) {
             e.printStackTrace()
-            UrlCheckResult.Failure(currentUrl)
-        }
-    }
-
     private suspend fun fetchConfiguration(couchdbURL: String): Pair<String, String>? {
         val configResponse = retrofitInterface
             ?.getConfiguration("${getUrl(couchdbURL)}/configurations/_all_docs?include_docs=true")
             ?.execute()
-
         if (configResponse?.isSuccessful == true) {
             val rows = configResponse.body()?.getAsJsonArray("rows")
             if (rows != null && rows.size() > 0) {
@@ -134,18 +107,11 @@ class ConfigurationManager(
                 val code = doc.getAsJsonPrimitive("code").asString
                 processConfigurationDoc(doc)
                 return Pair(id, code)
-            }
-        }
         return null
-    }
-
     private suspend fun processConfigurationDoc(doc: JsonObject) {
         val parentCode = doc.getAsJsonPrimitive("parentCode").asString
-
         withContext(Dispatchers.IO) {
             preferences.edit { putString("parentCode", parentCode) }
-        }
-
         if (doc.has("preferredLang")) {
             val preferredLang = doc.getAsJsonPrimitive("preferredLang").asString
             val languageCode = getLanguageCodeFromName(preferredLang)
@@ -153,20 +119,11 @@ class ConfigurationManager(
                 withContext(Dispatchers.IO) {
                     LocaleHelper.setLocale(context, languageCode)
                     preferences.edit { putString("pendingLanguageChange", languageCode) }
-                }
-            }
-        }
-
         if (doc.has("models")) {
             val modelsMap = doc.getAsJsonObject("models").entrySet()
                 .associate { it.key to it.value.asString }
-
             withContext(Dispatchers.IO) {
                 preferences.edit { putString("ai_models", Gson().toJson(modelsMap)) }
-            }
-        }
-    }
-
     private fun buildCouchdbUrl(currentUrl: String, pin: String): String {
         val uri = currentUrl.toUri()
         return if (currentUrl.contains("@")) {
@@ -175,30 +132,18 @@ class ConfigurationManager(
         } else {
             val urlUser = "satellite"
             "${uri.scheme}://$urlUser:$pin@${uri.host}:${if (uri.port == -1) if (uri.scheme == "http") 80 else 443 else uri.port}"
-        }
-    }
-
     sealed class UrlCheckResult {
         data class Success(val id: String, val code: String, val url: String) : UrlCheckResult()
         data class Failure(val url: String) : UrlCheckResult()
-    }
-
     private fun isVersionAllowed(currentVersion: String, minApkVersion: String): Boolean {
         return compareVersions(currentVersion, minApkVersion) >= 0
-    }
-
     private fun compareVersions(version1: String, version2: String): Int {
         val parts1 = version1.removeSuffix("-lite").removePrefix("v").split(".").map { it.toInt() }
         val parts2 = version2.removePrefix("v").split(".").map { it.toInt() }
-
         for (i in 0 until kotlin.math.min(parts1.size, parts2.size)) {
             if (parts1[i] != parts2[i]) {
                 return parts1[i].compareTo(parts2[i])
-            }
-        }
         return parts1.size.compareTo(parts2.size)
-    }
-
     private fun getLanguageCodeFromName(languageName: String): String? {
         return when (languageName.lowercase()) {
             "english" -> "en"
@@ -208,9 +153,6 @@ class ConfigurationManager(
             "arabic", "العربية" -> "ar"
             "french", "français" -> "fr"
             else -> null
-        }
-    }
-
     fun showAlertDialog(message: String?, playStoreRedirect: Boolean) {
         MainApplication.applicationScope.launch(Dispatchers.Main) {
             val builder = AlertDialog.Builder(context, R.style.CustomAlertDialog)
@@ -219,25 +161,16 @@ class ConfigurationManager(
             builder.setNegativeButton(R.string.okay) { dialog: DialogInterface, _: Int ->
                 if (playStoreRedirect) {
                     Utilities.openPlayStore()
-                }
                 dialog.cancel()
-            }
             val alert = builder.create()
             alert.show()
-        }
-    }
-
     private fun getUrl(couchdbURL: String): String {
         return UrlUtils.dbUrl(couchdbURL)
-    }
-
     private fun getUserInfo(uri: android.net.Uri): Array<String> {
         val ar = arrayOf("", "")
         val info = uri.userInfo?.split(":".toRegex())?.dropLastWhile { it.isEmpty() }?.toTypedArray()
         if ((info?.size ?: 0) > 1) {
             ar[0] = "${info?.get(0)}"
             ar[1] = "${info?.get(1)}"
-        }
         return ar
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -41,8 +41,7 @@ import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.LocaleHelper
-import org.ole.planet.myplanet.utilities.NetworkUtils
-import org.ole.planet.myplanet.utilities.NetworkUtils.isNetworkConnectedFlow
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.Sha256Utils
 import org.ole.planet.myplanet.utilities.UrlUtils
@@ -51,14 +50,12 @@ import org.ole.planet.myplanet.utilities.VersionUtils
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-
 class Service(private val context: Context) {
     private val preferences: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val retrofitInterface: ApiInterface? = ApiClient.client?.create(ApiInterface::class.java)
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val serverAvailabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
     private val configurationManager = ConfigurationManager(context, preferences, retrofitInterface)
-
     fun healthAccess(listener: SuccessListener) {
         retrofitInterface?.healthAccess(Utilities.getHealthAccessUrl(preferences))?.enqueue(object : Callback<ResponseBody> {
             override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
@@ -68,17 +65,12 @@ class Service(private val context: Context) {
                     listener.onSuccess("")
                 }
             }
-
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
                 listener.onSuccess("")
-            }
         })
     }
-
     fun checkCheckSum(callback: ChecksumCallback, path: String?) {
         retrofitInterface?.getChecksum(Utilities.getChecksumUrl(preferences))?.enqueue(object : Callback<ResponseBody> {
-            override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
-                if (response.code() == 200) {
                     try {
                         val checksum = response.body()?.string()
                         if (TextUtils.isEmpty(checksum)) {
@@ -94,19 +86,9 @@ class Service(private val context: Context) {
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
-                }
                 callback.onFail()
-            }
-
-            override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                callback.onFail()
-            }
-        })
-    }
-
     fun checkVersion(callback: CheckVersionCallback, settings: SharedPreferences) {
         if (shouldPromptForSettings(settings)) return
-
         serviceScope.launch {
             callback.onCheckingVersion()
             try {
@@ -114,20 +96,13 @@ class Service(private val context: Context) {
                 if (planetInfo == null) {
                     callback.onError(context.getString(R.string.version_not_found), true)
                     return@launch
-                }
-
                 preferences.edit {
-                    putInt("LastWifiID", NetworkUtils.getCurrentNetworkId(context))
+                    putInt("LastWifiID", networkUtils.getCurrentNetworkId(context))
                     putString("versionDetail", Gson().toJson(planetInfo))
-                }
-
                 val rawApkVersion = fetchApkVersionString(settings)
                 val versionStr = Gson().fromJson(rawApkVersion, String::class.java)
                 if (versionStr.isNullOrEmpty()) {
                     callback.onError(context.getString(R.string.planet_is_up_to_date), false)
-                    return@launch
-                }
-
                 val apkVersion = parseApkVersionString(versionStr)
                     ?: run {
                         callback.onError(
@@ -135,45 +110,29 @@ class Service(private val context: Context) {
                             false
                         )
                         return@launch
-                    }
-
                 handleVersionEvaluation(planetInfo, apkVersion, callback)
             } catch (e: Exception) {
                 e.printStackTrace()
                 callback.onError(context.getString(R.string.connection_failed), true)
-            }
         }
-    }
-
     fun isPlanetAvailable(callback: PlanetAvailableListener?) {
         val updateUrl = "${preferences.getString("serverURL", "")}"
         serverAvailabilityCache[updateUrl]?.let { (available, timestamp) ->
             if (System.currentTimeMillis() - timestamp < 30000) {
                 if (available) {
                     callback?.isAvailable()
-                } else {
                     callback?.notAvailable()
-                }
                 return
-            }
-        }
-
         val serverUrlMapper = ServerUrlMapper()
         val mapping = serverUrlMapper.processUrl(updateUrl)
-
         CoroutineScope(Dispatchers.IO).launch {
             val primaryAvailable = isServerReachable(mapping.primaryUrl)
             val alternativeAvailable = mapping.alternativeUrl?.let { isServerReachable(it) } == true
-
             if (!primaryAvailable && alternativeAvailable) {
                 mapping.alternativeUrl.let { alternativeUrl ->
                     val uri = updateUrl.toUri()
                     val editor = preferences.edit()
-
                     serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, preferences)
-                }
-            }
-
             withContext(Dispatchers.Main) {
                 retrofitInterface?.isPlanetAvailable(Utilities.getUpdateUrl(preferences))?.enqueue(object : Callback<ResponseBody?> {
                     override fun onResponse(call: Call<ResponseBody?>, response: Response<ResponseBody?>) {
@@ -183,18 +142,10 @@ class Service(private val context: Context) {
                             callback.isAvailable()
                         } else {
                             callback?.notAvailable()
-                        }
-                    }
-
                     override fun onFailure(call: Call<ResponseBody?>, t: Throwable) {
                         serverAvailabilityCache[updateUrl] = Pair(false, System.currentTimeMillis())
                         callback?.notAvailable()
-                    }
                 })
-            }
-        }
-    }
-
     fun becomeMember(realm: Realm, obj: JsonObject, callback: CreateUserCallback, securityCallback: SecurityDataCallback? = null) {
         isPlanetAvailable(object : PlanetAvailableListener {
             override fun isAvailable() {
@@ -202,7 +153,6 @@ class Service(private val context: Context) {
                     override fun onResponse(call: Call<JsonObject>, response: Response<JsonObject>) {
                         if (response.body() != null && response.body()?.has("_id") == true) {
                             callback.onSuccess(context.getString(R.string.unable_to_create_user_user_already_exists))
-                        } else {
                             retrofitInterface.putDoc(null, "application/json", "${Utilities.getUrl()}/_users/org.couchdb.user:${obj["name"].asString}", obj).enqueue(object : Callback<JsonObject> {
                                 override fun onResponse(call: Call<JsonObject>, response: Response<JsonObject>) {
                                     if (response.body() != null && response.body()?.has("id") == true) {
@@ -211,27 +161,16 @@ class Service(private val context: Context) {
                                     } else {
                                         callback.onSuccess(context.getString(R.string.unable_to_create_user_user_already_exists))
                                     }
-                                }
-
                                 override fun onFailure(call: Call<JsonObject>, t: Throwable) {
                                     callback.onSuccess(context.getString(R.string.unable_to_create_user_user_already_exists))
-                                }
                             })
-                        }
-                    }
-
                     override fun onFailure(call: Call<JsonObject>, t: Throwable) {
                         callback.onSuccess(context.getString(R.string.unable_to_create_user_user_already_exists))
-                    }
-                })
-            }
-
             override fun notAvailable() {
                 val settings = MainApplication.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                 if (isUserExists(realm, obj["name"].asString)) {
                     callback.onSuccess(context.getString(R.string.unable_to_create_user_user_already_exists))
                     return
-                }
                 realm.beginTransaction()
                 val model = populateUsersTable(obj, realm, settings)
                 val keyString = generateKey()
@@ -239,60 +178,38 @@ class Service(private val context: Context) {
                 if (model != null) {
                     model.key = keyString
                     model.iv = iv
-                }
                 realm.commitTransaction()
                 Utilities.toast(MainApplication.context, context.getString(R.string.not_connect_to_planet_created_user_offline))
                 callback.onSuccess(context.getString(R.string.not_connect_to_planet_created_user_offline))
                 securityCallback?.onSecurityDataUpdated()
-            }
-        })
-    }
-
     private fun uploadToShelf(obj: JsonObject) {
         retrofitInterface?.putDoc(null, "application/json", Utilities.getUrl() + "/shelf/org.couchdb.user:" + obj["name"].asString, JsonObject())?.enqueue(object : Callback<JsonObject?> {
             override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {}
-
             override fun onFailure(call: Call<JsonObject?>, t: Throwable) {}
-        })
-    }
-
     private fun saveUserToDb(realm: Realm, id: String, obj: JsonObject, callback: CreateUserCallback, securityCallback: SecurityDataCallback? = null) {
         val settings = MainApplication.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         realm.executeTransactionAsync({ realm1: Realm? ->
-            try {
                 val res = retrofitInterface?.getJsonObject(Utilities.header, "${Utilities.getUrl()}/_users/$id")?.execute()
                 if (res?.body() != null) {
                     val model = populateUsersTable(res.body(), realm1, settings)
                     if (model != null) {
                         UploadToShelfService(MainApplication.context).saveKeyIv(retrofitInterface, model, obj)
-                    }
-                }
             } catch (e: IOException) {
-                e.printStackTrace()
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
         }, {
             callback.onSuccess(context.getString(R.string.user_created_successfully))
             if (context is ProcessUserDataActivity) {
                 context.runOnUiThread {
                     val userName = "${obj["name"].asString}"
                     context.startUpload("becomeMember", userName, securityCallback)
-                }
-            }
         }) { error: Throwable ->
             error.printStackTrace()
             callback.onSuccess(context.getString(R.string.unable_to_save_user_please_sync))
             securityCallback?.onSecurityDataUpdated()
-        }
-    }
-
     fun syncPlanetServers(callback: SuccessListener) {
         retrofitInterface?.getJsonObject("", "https://planet.earth.ole.org/db/communityregistrationrequests/_all_docs?include_docs=true")?.enqueue(object : Callback<JsonObject?> {
             override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
                 if (response.body() != null) {
                     val arr = JsonUtils.getJsonArray("rows", response.body())
-
                     Executors.newSingleThreadExecutor().execute {
                         val backgroundRealm = Realm.getDefaultInstance()
                         try {
@@ -305,128 +222,74 @@ class Service(private val context: Context) {
                                     val community = realm1.createObject(RealmCommunity::class.java, id)
                                     if (JsonUtils.getString("name", jsonDoc) == "learning") {
                                         community.weight = 0
-                                    }
                                     community.localDomain = JsonUtils.getString("localDomain", jsonDoc)
                                     community.name = JsonUtils.getString("name", jsonDoc)
                                     community.parentDomain = JsonUtils.getString("parentDomain", jsonDoc)
                                     community.registrationRequest = JsonUtils.getString("registrationRequest", jsonDoc)
-                                }
-                            }
                         } catch (e: Exception) {
                             e.printStackTrace()
                         } finally {
                             backgroundRealm.close()
-                        }
-                    }
-                }
-            }
-
             override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
                 callback.onSuccess(context.getString(R.string.server_sync_has_failed))
-            }
-        })
-    }
-
     fun getMinApk(listener: ConfigurationIdListener?, url: String, pin: String, activity: SyncActivity, callerActivity: String) {
         configurationManager.getMinApk(listener, url, pin, activity, callerActivity)
-    }
-
     fun showAlertDialog(message: String?, playStoreRedirect: Boolean) {
         configurationManager.showAlertDialog(message, playStoreRedirect)
-    }
-
     private fun getUrl(couchdbURL: String): String {
         return UrlUtils.dbUrl(couchdbURL)
-    }
-
     private fun getUserInfo(uri: Uri): Array<String> {
         val ar = arrayOf("", "")
         val info = uri.userInfo?.split(":".toRegex())?.dropLastWhile { it.isEmpty() }?.toTypedArray()
         if ((info?.size ?: 0) > 1) {
             ar[0] = "${info?.get(0)}"
             ar[1] = "${info?.get(1)}"
-        }
         return ar
-    }
-
     private fun shouldPromptForSettings(settings: SharedPreferences): Boolean {
         if (!settings.getBoolean("isAlternativeUrl", false)) {
             if (settings.getString("couchdbURL", "").isNullOrEmpty()) {
                 (context as? SyncActivity)?.settingDialog()
                 return true
-            }
-        }
         return false
-    }
-
     private suspend fun fetchVersionInfo(settings: SharedPreferences): MyPlanet? =
         withContext(Dispatchers.IO) {
             val result = ApiClient.executeWithResult {
                 retrofitInterface?.checkVersion(Utilities.getUpdateUrl(settings))?.execute()
-            }
             when (result) {
                 is NetworkResult.Success -> result.data
                 else -> null
-            }
-        }
-
     private suspend fun fetchApkVersionString(settings: SharedPreferences): String? =
-        withContext(Dispatchers.IO) {
-            val result = ApiClient.executeWithResult {
                 retrofitInterface?.getApkVersion(Utilities.getApkVersionUrl(settings))?.execute()
-            }
-            when (result) {
                 is NetworkResult.Success -> result.data.string()
-                else -> null
-            }
-        }
-
     private fun parseApkVersionString(raw: String?): Int? {
         if (raw.isNullOrEmpty()) return null
         var vsn = raw.replace("v".toRegex(), "")
         vsn = vsn.replace("\\.".toRegex(), "")
         val cleaned = if (vsn.startsWith("0")) vsn.replaceFirst("0", "") else vsn
         return cleaned.toIntOrNull()
-    }
-
     private fun handleVersionEvaluation(info: MyPlanet, apkVersion: Int, callback: CheckVersionCallback) {
         val currentVersion = VersionUtils.getVersionCode(context)
         if (showBetaFeature(KEY_UPGRADE_MAX, context) && info.latestapkcode > currentVersion) {
             callback.onUpdateAvailable(info, false)
             return
-        }
         if (apkVersion > currentVersion) {
             callback.onUpdateAvailable(info, currentVersion >= info.minapkcode)
-            return
-        }
         if (currentVersion < info.minapkcode && apkVersion < info.minapkcode) {
             callback.onUpdateAvailable(info, true)
         } else {
             callback.onError(context.getString(R.string.planet_is_up_to_date), false)
-        }
-    }
-
     interface CheckVersionCallback {
         fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean)
         fun onCheckingVersion()
         fun onError(msg: String, blockSync: Boolean)
-    }
-
     interface CreateUserCallback {
         fun onSuccess(message: String)
-    }
-
     interface ChecksumCallback {
         fun onMatch()
         fun onFail()
-    }
-
     interface PlanetAvailableListener {
         fun isAvailable()
         fun notAvailable()
-    }
-
     interface ConfigurationIdListener {
         fun onConfigurationIdReceived(id: String, code: String, url: String, defaultUrl: String, isAlternativeUrl: Boolean, callerActivity: String)
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -50,12 +50,14 @@ import org.ole.planet.myplanet.utilities.VersionUtils
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+
 class Service(private val context: Context) {
     private val preferences: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val retrofitInterface: ApiInterface? = ApiClient.client?.create(ApiInterface::class.java)
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private val serverAvailabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
     private val configurationManager = ConfigurationManager(context, preferences, retrofitInterface)
+
     fun healthAccess(listener: SuccessListener) {
         retrofitInterface?.healthAccess(Utilities.getHealthAccessUrl(preferences))?.enqueue(object : Callback<ResponseBody> {
             override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
@@ -65,12 +67,17 @@ class Service(private val context: Context) {
                     listener.onSuccess("")
                 }
             }
+
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
                 listener.onSuccess("")
+            }
         })
     }
+
     fun checkCheckSum(callback: ChecksumCallback, path: String?) {
         retrofitInterface?.getChecksum(Utilities.getChecksumUrl(preferences))?.enqueue(object : Callback<ResponseBody> {
+            override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
+                if (response.code() == 200) {
                     try {
                         val checksum = response.body()?.string()
                         if (TextUtils.isEmpty(checksum)) {
@@ -86,9 +93,19 @@ class Service(private val context: Context) {
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
+                }
                 callback.onFail()
+            }
+
+            override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
+                callback.onFail()
+            }
+        })
+    }
+
     fun checkVersion(callback: CheckVersionCallback, settings: SharedPreferences) {
         if (shouldPromptForSettings(settings)) return
+
         serviceScope.launch {
             callback.onCheckingVersion()
             try {
@@ -96,13 +113,20 @@ class Service(private val context: Context) {
                 if (planetInfo == null) {
                     callback.onError(context.getString(R.string.version_not_found), true)
                     return@launch
+                }
+
                 preferences.edit {
                     putInt("LastWifiID", networkUtils.getCurrentNetworkId(context))
                     putString("versionDetail", Gson().toJson(planetInfo))
+                }
+
                 val rawApkVersion = fetchApkVersionString(settings)
                 val versionStr = Gson().fromJson(rawApkVersion, String::class.java)
                 if (versionStr.isNullOrEmpty()) {
                     callback.onError(context.getString(R.string.planet_is_up_to_date), false)
+                    return@launch
+                }
+
                 val apkVersion = parseApkVersionString(versionStr)
                     ?: run {
                         callback.onError(
@@ -110,29 +134,45 @@ class Service(private val context: Context) {
                             false
                         )
                         return@launch
+                    }
+
                 handleVersionEvaluation(planetInfo, apkVersion, callback)
             } catch (e: Exception) {
                 e.printStackTrace()
                 callback.onError(context.getString(R.string.connection_failed), true)
+            }
         }
+    }
+
     fun isPlanetAvailable(callback: PlanetAvailableListener?) {
         val updateUrl = "${preferences.getString("serverURL", "")}"
         serverAvailabilityCache[updateUrl]?.let { (available, timestamp) ->
             if (System.currentTimeMillis() - timestamp < 30000) {
                 if (available) {
                     callback?.isAvailable()
+                } else {
                     callback?.notAvailable()
+                }
                 return
+            }
+        }
+
         val serverUrlMapper = ServerUrlMapper()
         val mapping = serverUrlMapper.processUrl(updateUrl)
+
         CoroutineScope(Dispatchers.IO).launch {
             val primaryAvailable = isServerReachable(mapping.primaryUrl)
             val alternativeAvailable = mapping.alternativeUrl?.let { isServerReachable(it) } == true
+
             if (!primaryAvailable && alternativeAvailable) {
                 mapping.alternativeUrl.let { alternativeUrl ->
                     val uri = updateUrl.toUri()
                     val editor = preferences.edit()
+
                     serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, preferences)
+                }
+            }
+
             withContext(Dispatchers.Main) {
                 retrofitInterface?.isPlanetAvailable(Utilities.getUpdateUrl(preferences))?.enqueue(object : Callback<ResponseBody?> {
                     override fun onResponse(call: Call<ResponseBody?>, response: Response<ResponseBody?>) {
@@ -142,10 +182,18 @@ class Service(private val context: Context) {
                             callback.isAvailable()
                         } else {
                             callback?.notAvailable()
+                        }
+                    }
+
                     override fun onFailure(call: Call<ResponseBody?>, t: Throwable) {
                         serverAvailabilityCache[updateUrl] = Pair(false, System.currentTimeMillis())
                         callback?.notAvailable()
+                    }
                 })
+            }
+        }
+    }
+
     fun becomeMember(realm: Realm, obj: JsonObject, callback: CreateUserCallback, securityCallback: SecurityDataCallback? = null) {
         isPlanetAvailable(object : PlanetAvailableListener {
             override fun isAvailable() {
@@ -153,6 +201,7 @@ class Service(private val context: Context) {
                     override fun onResponse(call: Call<JsonObject>, response: Response<JsonObject>) {
                         if (response.body() != null && response.body()?.has("_id") == true) {
                             callback.onSuccess(context.getString(R.string.unable_to_create_user_user_already_exists))
+                        } else {
                             retrofitInterface.putDoc(null, "application/json", "${Utilities.getUrl()}/_users/org.couchdb.user:${obj["name"].asString}", obj).enqueue(object : Callback<JsonObject> {
                                 override fun onResponse(call: Call<JsonObject>, response: Response<JsonObject>) {
                                     if (response.body() != null && response.body()?.has("id") == true) {
@@ -161,16 +210,27 @@ class Service(private val context: Context) {
                                     } else {
                                         callback.onSuccess(context.getString(R.string.unable_to_create_user_user_already_exists))
                                     }
+                                }
+
                                 override fun onFailure(call: Call<JsonObject>, t: Throwable) {
                                     callback.onSuccess(context.getString(R.string.unable_to_create_user_user_already_exists))
+                                }
                             })
+                        }
+                    }
+
                     override fun onFailure(call: Call<JsonObject>, t: Throwable) {
                         callback.onSuccess(context.getString(R.string.unable_to_create_user_user_already_exists))
+                    }
+                })
+            }
+
             override fun notAvailable() {
                 val settings = MainApplication.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                 if (isUserExists(realm, obj["name"].asString)) {
                     callback.onSuccess(context.getString(R.string.unable_to_create_user_user_already_exists))
                     return
+                }
                 realm.beginTransaction()
                 val model = populateUsersTable(obj, realm, settings)
                 val keyString = generateKey()
@@ -178,38 +238,60 @@ class Service(private val context: Context) {
                 if (model != null) {
                     model.key = keyString
                     model.iv = iv
+                }
                 realm.commitTransaction()
                 Utilities.toast(MainApplication.context, context.getString(R.string.not_connect_to_planet_created_user_offline))
                 callback.onSuccess(context.getString(R.string.not_connect_to_planet_created_user_offline))
                 securityCallback?.onSecurityDataUpdated()
+            }
+        })
+    }
+
     private fun uploadToShelf(obj: JsonObject) {
         retrofitInterface?.putDoc(null, "application/json", Utilities.getUrl() + "/shelf/org.couchdb.user:" + obj["name"].asString, JsonObject())?.enqueue(object : Callback<JsonObject?> {
             override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {}
+
             override fun onFailure(call: Call<JsonObject?>, t: Throwable) {}
+        })
+    }
+
     private fun saveUserToDb(realm: Realm, id: String, obj: JsonObject, callback: CreateUserCallback, securityCallback: SecurityDataCallback? = null) {
         val settings = MainApplication.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         realm.executeTransactionAsync({ realm1: Realm? ->
+            try {
                 val res = retrofitInterface?.getJsonObject(Utilities.header, "${Utilities.getUrl()}/_users/$id")?.execute()
                 if (res?.body() != null) {
                     val model = populateUsersTable(res.body(), realm1, settings)
                     if (model != null) {
                         UploadToShelfService(MainApplication.context).saveKeyIv(retrofitInterface, model, obj)
+                    }
+                }
             } catch (e: IOException) {
+                e.printStackTrace()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }, {
             callback.onSuccess(context.getString(R.string.user_created_successfully))
             if (context is ProcessUserDataActivity) {
                 context.runOnUiThread {
                     val userName = "${obj["name"].asString}"
                     context.startUpload("becomeMember", userName, securityCallback)
+                }
+            }
         }) { error: Throwable ->
             error.printStackTrace()
             callback.onSuccess(context.getString(R.string.unable_to_save_user_please_sync))
             securityCallback?.onSecurityDataUpdated()
+        }
+    }
+
     fun syncPlanetServers(callback: SuccessListener) {
         retrofitInterface?.getJsonObject("", "https://planet.earth.ole.org/db/communityregistrationrequests/_all_docs?include_docs=true")?.enqueue(object : Callback<JsonObject?> {
             override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
                 if (response.body() != null) {
                     val arr = JsonUtils.getJsonArray("rows", response.body())
+
                     Executors.newSingleThreadExecutor().execute {
                         val backgroundRealm = Realm.getDefaultInstance()
                         try {
@@ -222,74 +304,128 @@ class Service(private val context: Context) {
                                     val community = realm1.createObject(RealmCommunity::class.java, id)
                                     if (JsonUtils.getString("name", jsonDoc) == "learning") {
                                         community.weight = 0
+                                    }
                                     community.localDomain = JsonUtils.getString("localDomain", jsonDoc)
                                     community.name = JsonUtils.getString("name", jsonDoc)
                                     community.parentDomain = JsonUtils.getString("parentDomain", jsonDoc)
                                     community.registrationRequest = JsonUtils.getString("registrationRequest", jsonDoc)
+                                }
+                            }
                         } catch (e: Exception) {
                             e.printStackTrace()
                         } finally {
                             backgroundRealm.close()
+                        }
+                    }
+                }
+            }
+
             override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
                 callback.onSuccess(context.getString(R.string.server_sync_has_failed))
+            }
+        })
+    }
+
     fun getMinApk(listener: ConfigurationIdListener?, url: String, pin: String, activity: SyncActivity, callerActivity: String) {
         configurationManager.getMinApk(listener, url, pin, activity, callerActivity)
+    }
+
     fun showAlertDialog(message: String?, playStoreRedirect: Boolean) {
         configurationManager.showAlertDialog(message, playStoreRedirect)
+    }
+
     private fun getUrl(couchdbURL: String): String {
         return UrlUtils.dbUrl(couchdbURL)
+    }
+
     private fun getUserInfo(uri: Uri): Array<String> {
         val ar = arrayOf("", "")
         val info = uri.userInfo?.split(":".toRegex())?.dropLastWhile { it.isEmpty() }?.toTypedArray()
         if ((info?.size ?: 0) > 1) {
             ar[0] = "${info?.get(0)}"
             ar[1] = "${info?.get(1)}"
+        }
         return ar
+    }
+
     private fun shouldPromptForSettings(settings: SharedPreferences): Boolean {
         if (!settings.getBoolean("isAlternativeUrl", false)) {
             if (settings.getString("couchdbURL", "").isNullOrEmpty()) {
                 (context as? SyncActivity)?.settingDialog()
                 return true
+            }
+        }
         return false
+    }
+
     private suspend fun fetchVersionInfo(settings: SharedPreferences): MyPlanet? =
         withContext(Dispatchers.IO) {
             val result = ApiClient.executeWithResult {
                 retrofitInterface?.checkVersion(Utilities.getUpdateUrl(settings))?.execute()
+            }
             when (result) {
                 is NetworkResult.Success -> result.data
                 else -> null
+            }
+        }
+
     private suspend fun fetchApkVersionString(settings: SharedPreferences): String? =
+        withContext(Dispatchers.IO) {
+            val result = ApiClient.executeWithResult {
                 retrofitInterface?.getApkVersion(Utilities.getApkVersionUrl(settings))?.execute()
+            }
+            when (result) {
                 is NetworkResult.Success -> result.data.string()
+                else -> null
+            }
+        }
+
     private fun parseApkVersionString(raw: String?): Int? {
         if (raw.isNullOrEmpty()) return null
         var vsn = raw.replace("v".toRegex(), "")
         vsn = vsn.replace("\\.".toRegex(), "")
         val cleaned = if (vsn.startsWith("0")) vsn.replaceFirst("0", "") else vsn
         return cleaned.toIntOrNull()
+    }
+
     private fun handleVersionEvaluation(info: MyPlanet, apkVersion: Int, callback: CheckVersionCallback) {
         val currentVersion = VersionUtils.getVersionCode(context)
         if (showBetaFeature(KEY_UPGRADE_MAX, context) && info.latestapkcode > currentVersion) {
             callback.onUpdateAvailable(info, false)
             return
+        }
         if (apkVersion > currentVersion) {
             callback.onUpdateAvailable(info, currentVersion >= info.minapkcode)
+            return
+        }
         if (currentVersion < info.minapkcode && apkVersion < info.minapkcode) {
             callback.onUpdateAvailable(info, true)
         } else {
             callback.onError(context.getString(R.string.planet_is_up_to_date), false)
+        }
+    }
+
     interface CheckVersionCallback {
         fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean)
         fun onCheckingVersion()
         fun onError(msg: String, blockSync: Boolean)
+    }
+
     interface CreateUserCallback {
         fun onSuccess(message: String)
+    }
+
     interface ChecksumCallback {
         fun onMatch()
         fun onFail()
+    }
+
     interface PlanetAvailableListener {
         fun isAvailable()
         fun notAvailable()
+    }
+
     interface ConfigurationIdListener {
         fun onConfigurationIdReceived(id: String, code: String, url: String, defaultUrl: String, isAlternativeUrl: Boolean, callerActivity: String)
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/MyPlanet.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/MyPlanet.kt
@@ -13,9 +13,8 @@ import java.util.Calendar
 import java.util.Date
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
-import org.ole.planet.myplanet.utilities.NetworkUtils
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.VersionUtils
-
 class MyPlanet : Serializable {
     var planetVersion: String? = null
 //    var latestapk: String? = null
@@ -28,7 +27,6 @@ class MyPlanet : Serializable {
     override fun toString(): String {
         return appname!!
     }
-
     companion object {
         @JvmStatic
         fun getMyPlanetActivities(context: Context, pref: SharedPreferences, model: RealmUserModel): JsonObject {
@@ -36,7 +34,7 @@ class MyPlanet : Serializable {
             val preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             val planet = Gson().fromJson(preferences.getString("versionDetail", ""), MyPlanet::class.java)
             if (planet != null) postJSON.addProperty("planetVersion", planet.planetVersion)
-            postJSON.addProperty("_id", VersionUtils.getAndroidId(MainApplication.context) + "@" + NetworkUtils.getUniqueIdentifier())
+            postJSON.addProperty("_id", VersionUtils.getAndroidId(MainApplication.context) + "@" + networkUtils.getUniqueIdentifier())
             postJSON.addProperty("last_synced", pref.getLong("LastSync", 0))
             postJSON.addProperty("parentCode", model.parentCode)
             postJSON.addProperty("createdOn", model.planetCode)
@@ -44,28 +42,15 @@ class MyPlanet : Serializable {
             postJSON.add("usages", getTabletUsages(context))
             return postJSON
         }
-
-        @JvmStatic
         fun getNormalMyPlanetActivities(context: Context, pref: SharedPreferences, model: RealmUserModel): JsonObject {
-            val postJSON = JsonObject()
-            val preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            val planet = Gson().fromJson(preferences.getString("versionDetail", ""), MyPlanet::class.java)
-            if (planet != null) postJSON.addProperty("planetVersion", planet.planetVersion)
-            postJSON.addProperty("last_synced", pref.getLong("LastSync", 0))
-            postJSON.addProperty("parentCode", model.parentCode)
-            postJSON.addProperty("createdOn", model.planetCode)
             postJSON.addProperty("version", VersionUtils.getVersionCode(context))
             postJSON.addProperty("versionName", VersionUtils.getVersionName(context))
-            postJSON.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
+            postJSON.addProperty("androidId", networkUtils.getUniqueIdentifier())
             postJSON.addProperty("uniqueAndroidId", VersionUtils.getAndroidId(MainApplication.context))
-            postJSON.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
-            postJSON.addProperty("deviceName", NetworkUtils.getDeviceName())
+            postJSON.addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
+            postJSON.addProperty("deviceName", networkUtils.getDeviceName())
             postJSON.addProperty("time", Date().time)
             postJSON.addProperty("type", "sync")
-            return postJSON
-        }
-
-        @JvmStatic
         fun getTabletUsages(context: Context): JsonArray {
             val cal = Calendar.getInstance()
             val settings = MainApplication.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -79,8 +64,6 @@ class MyPlanet : Serializable {
                 }
             }
             return arr
-        }
-
         private fun addStats(s: UsageStats, arr: JsonArray, context: Context) {
             if (s.packageName == MainApplication.context.packageName) {
                 val `object` = JsonObject()
@@ -91,12 +74,9 @@ class MyPlanet : Serializable {
                 `object`.addProperty("totalUsed", if (totalUsed > 0) totalUsed else 0)
                 `object`.addProperty("version", VersionUtils.getVersionCode(context))
                 `object`.addProperty("versionName", VersionUtils.getVersionName(context))
-                `object`.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-                `object`.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
-                `object`.addProperty("deviceName", NetworkUtils.getDeviceName())
+                `object`.addProperty("androidId", networkUtils.getUniqueIdentifier())
+                `object`.addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
+                `object`.addProperty("deviceName", networkUtils.getDeviceName())
                 `object`.addProperty("time", Date().time)
                 arr.add(`object`)
-            }
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/MyPlanet.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/MyPlanet.kt
@@ -15,6 +15,7 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.VersionUtils
+
 class MyPlanet : Serializable {
     var planetVersion: String? = null
 //    var latestapk: String? = null
@@ -27,6 +28,7 @@ class MyPlanet : Serializable {
     override fun toString(): String {
         return appname!!
     }
+
     companion object {
         @JvmStatic
         fun getMyPlanetActivities(context: Context, pref: SharedPreferences, model: RealmUserModel): JsonObject {
@@ -42,7 +44,16 @@ class MyPlanet : Serializable {
             postJSON.add("usages", getTabletUsages(context))
             return postJSON
         }
+
+        @JvmStatic
         fun getNormalMyPlanetActivities(context: Context, pref: SharedPreferences, model: RealmUserModel): JsonObject {
+            val postJSON = JsonObject()
+            val preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val planet = Gson().fromJson(preferences.getString("versionDetail", ""), MyPlanet::class.java)
+            if (planet != null) postJSON.addProperty("planetVersion", planet.planetVersion)
+            postJSON.addProperty("last_synced", pref.getLong("LastSync", 0))
+            postJSON.addProperty("parentCode", model.parentCode)
+            postJSON.addProperty("createdOn", model.planetCode)
             postJSON.addProperty("version", VersionUtils.getVersionCode(context))
             postJSON.addProperty("versionName", VersionUtils.getVersionName(context))
             postJSON.addProperty("androidId", networkUtils.getUniqueIdentifier())
@@ -51,6 +62,10 @@ class MyPlanet : Serializable {
             postJSON.addProperty("deviceName", networkUtils.getDeviceName())
             postJSON.addProperty("time", Date().time)
             postJSON.addProperty("type", "sync")
+            return postJSON
+        }
+
+        @JvmStatic
         fun getTabletUsages(context: Context): JsonArray {
             val cal = Calendar.getInstance()
             val settings = MainApplication.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -64,6 +79,8 @@ class MyPlanet : Serializable {
                 }
             }
             return arr
+        }
+
         private fun addStats(s: UsageStats, arr: JsonArray, context: Context) {
             if (s.packageName == MainApplication.context.packageName) {
                 val `object` = JsonObject()
@@ -79,4 +96,7 @@ class MyPlanet : Serializable {
                 `object`.addProperty("deviceName", networkUtils.getDeviceName())
                 `object`.addProperty("time", Date().time)
                 arr.add(`object`)
+            }
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmApkLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmApkLog.kt
@@ -5,8 +5,7 @@ import com.google.gson.JsonObject
 import io.realm.RealmObject
 import io.realm.annotations.Ignore
 import io.realm.annotations.PrimaryKey
-import org.ole.planet.myplanet.utilities.NetworkUtils
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 open class RealmApkLog : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -19,7 +18,6 @@ open class RealmApkLog : RealmObject() {
     var version: String? = null
     var createdOn: String? = null
     var time: String? = null
-
     fun setError(e: Throwable) {
         error += "--------- Stack trace ---------\n\n"
         appendReport(e)
@@ -27,12 +25,10 @@ open class RealmApkLog : RealmObject() {
         val cause = e.cause
         appendReport(cause)
     }
-
     private fun appendReport(cause: Throwable?) {
         if (cause != null) {
             error += """
                 $cause
-                
                 
                 """.trimIndent()
             val arr = cause.stackTrace
@@ -42,12 +38,9 @@ open class RealmApkLog : RealmObject() {
             }
         }
         error += "-------------------------------\n\n"
-    }
-
     companion object {
         @Ignore
         const val ERROR_TYPE_CRASH = "crash"
-
         @JvmStatic
         fun serialize(log: RealmApkLog, context: Context): JsonObject {
             val `object` = JsonObject()
@@ -59,12 +52,9 @@ open class RealmApkLog : RealmObject() {
             `object`.addProperty("version", log.version)
             `object`.addProperty("createdOn", log.createdOn)
             `object`.addProperty("androidId", log.createdOn)
-            `object`.addProperty("createdOn", log.createdOn)
-            `object`.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            `object`.addProperty("deviceName", NetworkUtils.getDeviceName())
-            `object`.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
+            `object`.addProperty("androidId", networkUtils.getUniqueIdentifier())
+            `object`.addProperty("deviceName", networkUtils.getDeviceName())
+            `object`.addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
             `object`.addProperty("parentCode", log.parentCode)
             return `object`
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmApkLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmApkLog.kt
@@ -6,6 +6,7 @@ import io.realm.RealmObject
 import io.realm.annotations.Ignore
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 open class RealmApkLog : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -18,6 +19,7 @@ open class RealmApkLog : RealmObject() {
     var version: String? = null
     var createdOn: String? = null
     var time: String? = null
+
     fun setError(e: Throwable) {
         error += "--------- Stack trace ---------\n\n"
         appendReport(e)
@@ -25,10 +27,12 @@ open class RealmApkLog : RealmObject() {
         val cause = e.cause
         appendReport(cause)
     }
+
     private fun appendReport(cause: Throwable?) {
         if (cause != null) {
             error += """
                 $cause
+                
                 
                 """.trimIndent()
             val arr = cause.stackTrace
@@ -38,9 +42,12 @@ open class RealmApkLog : RealmObject() {
             }
         }
         error += "-------------------------------\n\n"
+    }
+
     companion object {
         @Ignore
         const val ERROR_TYPE_CRASH = "crash"
+
         @JvmStatic
         fun serialize(log: RealmApkLog, context: Context): JsonObject {
             val `object` = JsonObject()
@@ -52,9 +59,12 @@ open class RealmApkLog : RealmObject() {
             `object`.addProperty("version", log.version)
             `object`.addProperty("createdOn", log.createdOn)
             `object`.addProperty("androidId", log.createdOn)
+            `object`.addProperty("createdOn", log.createdOn)
             `object`.addProperty("androidId", networkUtils.getUniqueIdentifier())
             `object`.addProperty("deviceName", networkUtils.getDeviceName())
             `object`.addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
             `object`.addProperty("parentCode", log.parentCode)
             return `object`
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseActivity.kt
@@ -8,8 +8,7 @@ import java.util.Date
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.utilities.NetworkUtils
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 open class RealmCourseActivity : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -22,7 +21,6 @@ open class RealmCourseActivity : RealmObject() {
     var parentCode: String? = null
     var type: String? = null
     var user: String? = null
-
     companion object {
         @JvmStatic
         suspend fun createActivity(realm: Realm, userModel: RealmUserModel?, course: RealmMyCourse?) {
@@ -45,8 +43,6 @@ open class RealmCourseActivity : RealmObject() {
                 }
             }
         }
-
-        @JvmStatic
         fun serializeSerialize(realmCourseActivities: RealmCourseActivity): JsonObject {
             val ob = JsonObject()
             ob.addProperty("user", realmCourseActivities.user)
@@ -56,9 +52,8 @@ open class RealmCourseActivity : RealmObject() {
             ob.addProperty("time", realmCourseActivities.time)
             ob.addProperty("createdOn", realmCourseActivities.createdOn)
             ob.addProperty("parentCode", realmCourseActivities.parentCode)
-            ob.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            ob.addProperty("deviceName", NetworkUtils.getDeviceName())
+            ob.addProperty("androidId", networkUtils.getUniqueIdentifier())
+            ob.addProperty("deviceName", networkUtils.getDeviceName())
             return ob
-        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseActivity.kt
@@ -9,6 +9,7 @@ import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 open class RealmCourseActivity : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -21,6 +22,7 @@ open class RealmCourseActivity : RealmObject() {
     var parentCode: String? = null
     var type: String? = null
     var user: String? = null
+
     companion object {
         @JvmStatic
         suspend fun createActivity(realm: Realm, userModel: RealmUserModel?, course: RealmMyCourse?) {
@@ -43,6 +45,8 @@ open class RealmCourseActivity : RealmObject() {
                 }
             }
         }
+
+        @JvmStatic
         fun serializeSerialize(realmCourseActivities: RealmCourseActivity): JsonObject {
             val ob = JsonObject()
             ob.addProperty("user", realmCourseActivities.user)
@@ -55,5 +59,6 @@ open class RealmCourseActivity : RealmObject() {
             ob.addProperty("androidId", networkUtils.getUniqueIdentifier())
             ob.addProperty("deviceName", networkUtils.getDeviceName())
             return ob
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
@@ -16,8 +16,7 @@ import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.JsonUtils
-import org.ole.planet.myplanet.utilities.NetworkUtils
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 open class RealmMyLibrary : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -61,7 +60,6 @@ open class RealmMyLibrary : RealmObject() {
     var stepId: String? = null
     var isPrivate: Boolean = false
     var attachments: RealmList<RealmAttachment>? = null
-
     fun serializeResource(): JsonObject {
         return JsonObject().apply {
             addProperty("_id", _id)
@@ -100,96 +98,54 @@ open class RealmMyLibrary : RealmObject() {
     private fun RealmList<String>?.toJsonArray(): JsonArray {
         return JsonArray().apply {
             this@toJsonArray?.forEach { add(it) }
-        }
-    }
     fun setUserId(userId: String?) {
         if (userId.isNullOrBlank()) return
-
         if (this.userId == null) {
             this.userId = RealmList()
-        }
         if (!this.userId!!.contains(userId)) {
             this.userId?.add(userId)
-        }
-    }
     fun isResourceOffline(): Boolean {
         return resourceOffline && _rev == downloadedRev
-    }
     private fun JsonArray?.setListIfNotNull(targetList: RealmList<String>?, setter: (String) -> Unit) {
         this?.forEach { jsonElement ->
             val value = jsonElement.takeIf { it !is JsonNull }?.asString ?: return@forEach
             if (value !in targetList.orEmpty()) {
                 setter(value)
-            }
-        }
-    }
-
     fun setResourceFor(array: JsonArray, resource: RealmMyLibrary?) {
         array.setListIfNotNull(resource?.resourceFor) { resource?.resourceFor?.add(it) }
-    }
-
     fun setSubject(array: JsonArray, resource: RealmMyLibrary?) {
         array.setListIfNotNull(resource?.subject) { resource?.subject?.add(it) }
-    }
-
     fun setLevel(array: JsonArray, resource: RealmMyLibrary?) {
         array.setListIfNotNull(resource?.level) { resource?.level?.add(it) }
-    }
-
     fun setTag(array: JsonArray, resource: RealmMyLibrary?) {
         array.setListIfNotNull(resource?.tag) { resource?.tag?.add(it) }
-    }
-
     fun setLanguages(array: JsonArray, resource: RealmMyLibrary?) {
         array.setListIfNotNull(resource?.languages) { resource?.languages?.add(it) }
-    }
-
     fun setUserId(userId: RealmList<String>?) {
         this.userId = userId
-    }
-
     val subjectsAsString: String
         get() = subject?.joinToString(", ") ?: ""
-
     override fun toString(): String {
         return title ?: ""
-    }
-
     fun removeUserId(id: String?) {
         userId?.remove(id)
-    }
-
     fun needToUpdate(): Boolean {
         return !resourceOffline || resourceLocalAddress != null && _rev != downloadedRev
-    }
-
     companion object {
         fun getMyLibraryByUserId(mRealm: Realm, settings: SharedPreferences?): List<RealmMyLibrary> {
             val libs = mRealm.where(RealmMyLibrary::class.java).findAll()
             return getMyLibraryByUserId(settings?.getString("userId", "--"), libs, mRealm)
-        }
-
         fun getMyLibraryByUserId(userId: String?, libs: List<RealmMyLibrary>, mRealm: Realm): List<RealmMyLibrary> {
             val ids = RealmMyTeam.getResourceIdsByUser(userId, mRealm)
             return libs.filter { it.userId?.contains(userId) == true || it.resourceId in ids }
-        }
-
         @JvmStatic
         fun getMyLibraryByUserId(userId: String?, libs: List<RealmMyLibrary>): List<RealmMyLibrary> {
             return libs.filter { it.userId?.contains(userId) == true }
-        }
-
-        @JvmStatic
         fun getOurLibrary(userId: String?, libs: List<RealmMyLibrary>): List<RealmMyLibrary> {
             return libs.filter { it.userId?.contains(userId) == false }
-        }
-
         private fun getIds(mRealm: Realm): Array<String?> {
             val list = mRealm.where(RealmMyLibrary::class.java).findAll()
             return list.map { it.resourceId }.toTypedArray()
-        }
-
-        @JvmStatic
         fun removeDeletedResource(newIds: List<String?>, mRealm: Realm) {
             val ids = getIds(mRealm)
             ids.filterNot { it in newIds }.forEach { id ->
@@ -197,10 +153,6 @@ open class RealmMyLibrary : RealmObject() {
                     realm.where(RealmMyLibrary::class.java).equalTo("resourceId", id).findAll()
                         .deleteAllFromRealm()
                 }
-            }
-        }
-
-        @JvmStatic
         fun serialize(personal: RealmMyLibrary, user: RealmUserModel?): JsonObject {
             return JsonObject().apply {
                 addProperty("title", personal.title)
@@ -223,37 +175,20 @@ open class RealmMyLibrary : RealmObject() {
                 addProperty("sourcePlanet", user?.planetCode)
                 addProperty("resideOn", user?.planetCode)
                 addProperty("updatedDate", Calendar.getInstance().timeInMillis)
-                addProperty("createdDate", personal.createdDate)
-                addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-                addProperty("deviceName", NetworkUtils.getDeviceName())
-                addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
-            }
-        }
-
+                addProperty("androidId", networkUtils.getUniqueIdentifier())
+                addProperty("deviceName", networkUtils.getDeviceName())
+                addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
         private fun insertResources(doc: JsonObject, mRealm: Realm) {
             insertMyLibrary("", doc, mRealm)
-        }
-
-        @JvmStatic
         fun createStepResource(mRealm: Realm, res: JsonObject, myCoursesID: String?, stepId: String?) {
             insertMyLibrary("", stepId, myCoursesID, res, mRealm)
-        }
-
-        @JvmStatic
         fun insertMyLibrary(userId: String?, doc: JsonObject, mRealm: Realm) {
             insertMyLibrary(userId, "", "", doc, mRealm)
-        }
-
-        @JvmStatic
         fun createFromResource(resource: RealmMyLibrary?, mRealm: Realm, userId: String?) {
             if (!mRealm.isInTransaction) {
                 mRealm.beginTransaction()
-            }
             resource?.setUserId(userId)
             mRealm.commitTransaction()
-        }
-
-        @JvmStatic
         fun insertMyLibrary(userId: String?, stepId: String?, courseId: String?, doc: JsonObject, mRealm: Realm) {
             if (doc.entrySet().isEmpty()) return
             val resourceId = JsonUtils.getString("_id", doc)
@@ -261,16 +196,13 @@ open class RealmMyLibrary : RealmObject() {
             var resource = mRealm.where(RealmMyLibrary::class.java).equalTo("id", resourceId).findFirst()
             if (resource == null) {
                 resource = mRealm.createObject(RealmMyLibrary::class.java, resourceId)
-            }
             resource?.apply {
                 setUserId(userId)
                 _id = resourceId
                 if (!stepId.isNullOrBlank()) {
                     this.stepId = stepId
-                }
                 if (!courseId.isNullOrBlank()) {
                     this.courseId = courseId
-                }
                 _rev = JsonUtils.getString("_rev", doc)
                 this.resourceId = resourceId
                 title = JsonUtils.getString("title", doc)
@@ -280,10 +212,8 @@ open class RealmMyLibrary : RealmObject() {
                     if (this.attachments == null) {
                         this.attachments = RealmList()
                     }
-
                     attachments.entrySet().forEach { (key, attachmentValue) ->
                         val attachmentObj = attachmentValue.asJsonObject
-
                         val realmAttachment = mRealm.createObject(RealmAttachment::class.java, UUID.randomUUID().toString())
                         realmAttachment.apply {
                             name = key
@@ -293,16 +223,11 @@ open class RealmMyLibrary : RealmObject() {
                             isStub = attachmentObj.get("stub")?.asBoolean == true
                             revpos = attachmentObj.get("revpos")?.asInt ?: 0
                         }
-
                         this.attachments?.add(realmAttachment)
-
                         if (key.indexOf("/") < 0) {
                             resourceRemoteAddress = "${settings.getString("couchdbURL", "http://")}/resources/$resourceId/$key"
                             resourceLocalAddress = key
                             resourceOffline = FileUtils.checkFileExist(resourceRemoteAddress)
-                        }
-                    }
-                }
                 filename = JsonUtils.getString("filename", doc)
                 averageRating = JsonUtils.getString("averageRating", doc)
                 uploadDate = JsonUtils.getString("uploadDate", doc)
@@ -326,15 +251,8 @@ open class RealmMyLibrary : RealmObject() {
                 setTag(JsonUtils.getJsonArray("tags", doc), this)
                 isPrivate = JsonUtils.getBoolean("private", doc)
                 setLanguages(JsonUtils.getJsonArray("languages", doc), this)
-            }
-        }
-
-        @JvmStatic
         fun listToString(list: RealmList<String>?): String {
             return list?.joinToString(", ") ?: ""
-        }
-
-        @JvmStatic
         fun save(allDocs: JsonArray, mRealm: Realm): List<String> {
             val list: MutableList<String> = ArrayList()
             allDocs.forEach { doc ->
@@ -343,41 +261,21 @@ open class RealmMyLibrary : RealmObject() {
                 if (!id.startsWith("_design")) {
                     list.add(id)
                     insertResources(document, mRealm)
-                }
-            }
             return list
-        }
-
-        @JvmStatic
         fun getMyLibIds(realm: Realm?, userId: String?): JsonArray {
             val myLibraries = userId?.let { realm?.where(RealmMyLibrary::class.java)?.contains("userId", it)?.findAll() }
             return JsonArray().apply { myLibraries?.forEach { lib -> add(lib.id) }
-            }
-        }
-        @JvmStatic
         fun getLevels(libraries: List<RealmMyLibrary>): Set<String> {
             return libraries.flatMap { it.level ?: emptyList() }.toSet()
-        }
-
-        @JvmStatic
         fun getArrayList(libraries: List<RealmMyLibrary>, type: String): Set<String?> {
             return libraries.mapNotNull { if (type == "mediums") it.mediaType else it.language }.filterNot { it.isBlank() }.toSet()
-        }
-
-        @JvmStatic
         fun getSubjects(libraries: List<RealmMyLibrary>): Set<String> {
             return libraries.flatMap { it.subject ?: emptyList() }.toSet()
-        }
-    }
 }
-
 open class RealmAttachment : RealmObject() {
-    @PrimaryKey
-    var id: String? = null
     var name: String? = null
     var contentType: String? = null
     var length: Long = 0
     var digest: String? = null
     var isStub: Boolean = false
     var revpos: Int = 0
-}

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyPersonal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyPersonal.kt
@@ -6,8 +6,7 @@ import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import java.util.Date
 import org.ole.planet.myplanet.utilities.FileUtils
-import org.ole.planet.myplanet.utilities.NetworkUtils
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 open class RealmMyPersonal : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -20,7 +19,6 @@ open class RealmMyPersonal : RealmObject() {
     var userId: String? = null
     var userName: String? = null
     var path: String? = null
-
     companion object {
         @JvmStatic
         fun serialize(personal: RealmMyPersonal, context: Context): JsonObject {
@@ -35,9 +33,9 @@ open class RealmMyPersonal : RealmObject() {
             `object`.addProperty("resourceType", "Activities")
             `object`.addProperty("private", true)
             val object1 = JsonObject()
-            `object`.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            `object`.addProperty("deviceName", NetworkUtils.getDeviceName())
-            `object`.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
+            `object`.addProperty("androidId", networkUtils.getUniqueIdentifier())
+            `object`.addProperty("deviceName", networkUtils.getDeviceName())
+            `object`.addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
             object1.addProperty("users", personal.userId)
             `object`.add("privateFor", object1)
             return `object`

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyPersonal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyPersonal.kt
@@ -7,6 +7,7 @@ import io.realm.annotations.PrimaryKey
 import java.util.Date
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 open class RealmMyPersonal : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -19,6 +20,7 @@ open class RealmMyPersonal : RealmObject() {
     var userId: String? = null
     var userName: String? = null
     var path: String? = null
+
     companion object {
         @JvmStatic
         fun serialize(personal: RealmMyPersonal, context: Context): JsonObject {

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmNewsLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmNewsLog.kt
@@ -5,6 +5,7 @@ import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 open class RealmNewsLog : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -14,6 +15,7 @@ open class RealmNewsLog : RealmObject() {
     var time: Long? = null
     var userId: String? = null
     var androidId: String? = null
+
     companion object {
         @JvmStatic
         fun serialize(log: RealmNewsLog): JsonObject {

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmNewsLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmNewsLog.kt
@@ -4,8 +4,7 @@ import com.google.gson.JsonObject
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.utilities.NetworkUtils
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 open class RealmNewsLog : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -15,7 +14,6 @@ open class RealmNewsLog : RealmObject() {
     var time: Long? = null
     var userId: String? = null
     var androidId: String? = null
-
     companion object {
         @JvmStatic
         fun serialize(log: RealmNewsLog): JsonObject {
@@ -23,10 +21,10 @@ open class RealmNewsLog : RealmObject() {
             ob.addProperty("user", log.userId)
             ob.addProperty("type", log.type)
             ob.addProperty("time", log.time)
-            ob.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            ob.addProperty("deviceName", NetworkUtils.getDeviceName())
+            ob.addProperty("androidId", networkUtils.getUniqueIdentifier())
+            ob.addProperty("deviceName", networkUtils.getDeviceName())
             ob.addProperty(
-                "customDeviceName", NetworkUtils.getCustomDeviceName(MainApplication.context)
+                "customDeviceName", networkUtils.getCustomDeviceName(MainApplication.context)
             )
             return ob
         }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
@@ -9,6 +9,7 @@ import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 open class RealmOfflineActivity : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -29,6 +30,7 @@ open class RealmOfflineActivity : RealmObject() {
             _id = JsonUtils.getString("_id", r)
         }
     }
+
     companion object {
         @JvmStatic
         fun serializeLoginActivities(realmOfflineActivities: RealmOfflineActivity, context: Context): JsonObject {
@@ -47,15 +49,23 @@ open class RealmOfflineActivity : RealmObject() {
             }
             if (realmOfflineActivities._rev != null) {
                 ob.addProperty("_rev", realmOfflineActivities._rev)
+            }
             return ob
+        }
+
+        @JvmStatic
         fun getRecentLogin(mRealm: Realm): RealmOfflineActivity? {
             return mRealm.where(RealmOfflineActivity::class.java)
                 .equalTo("type", UserProfileDbHandler.KEY_LOGIN).sort("loginTime", Sort.DESCENDING)
                 .findFirst()
+        }
+
+        @JvmStatic
         fun insert(mRealm: Realm, act: JsonObject?) {
             var activities = mRealm.where(RealmOfflineActivity::class.java).equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
             if (activities == null) {
                 activities = mRealm.createObject(RealmOfflineActivity::class.java, JsonUtils.getString("_id", act))
+            }
             if (activities != null) {
                 activities._rev = JsonUtils.getString("_rev", act)
                 activities._id = JsonUtils.getString("_id", act)
@@ -64,6 +74,10 @@ open class RealmOfflineActivity : RealmObject() {
                 activities.userName = JsonUtils.getString("user", act)
                 activities.parentCode = JsonUtils.getString("parentCode", act)
                 activities.createdOn = JsonUtils.getString("createdOn", act)
+                activities.userName = JsonUtils.getString("user", act)
                 activities.logoutTime = JsonUtils.getLong("logoutTime", act)
                 activities.androidId = JsonUtils.getString("androidId", act)
+            }
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
@@ -8,8 +8,7 @@ import io.realm.Sort
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.JsonUtils
-import org.ole.planet.myplanet.utilities.NetworkUtils
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 open class RealmOfflineActivity : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -30,7 +29,6 @@ open class RealmOfflineActivity : RealmObject() {
             _id = JsonUtils.getString("_id", r)
         }
     }
-
     companion object {
         @JvmStatic
         fun serializeLoginActivities(realmOfflineActivities: RealmOfflineActivity, context: Context): JsonObject {
@@ -41,31 +39,23 @@ open class RealmOfflineActivity : RealmObject() {
             ob.addProperty("logoutTime", realmOfflineActivities.logoutTime)
             ob.addProperty("createdOn", realmOfflineActivities.createdOn)
             ob.addProperty("parentCode", realmOfflineActivities.parentCode)
-            ob.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            ob.addProperty("deviceName", NetworkUtils.getDeviceName())
-            ob.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
+            ob.addProperty("androidId", networkUtils.getUniqueIdentifier())
+            ob.addProperty("deviceName", networkUtils.getDeviceName())
+            ob.addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
             if (realmOfflineActivities._id != null) {
                 ob.addProperty("_id", realmOfflineActivities.logoutTime)
             }
             if (realmOfflineActivities._rev != null) {
                 ob.addProperty("_rev", realmOfflineActivities._rev)
-            }
             return ob
-        }
-
-        @JvmStatic
         fun getRecentLogin(mRealm: Realm): RealmOfflineActivity? {
             return mRealm.where(RealmOfflineActivity::class.java)
                 .equalTo("type", UserProfileDbHandler.KEY_LOGIN).sort("loginTime", Sort.DESCENDING)
                 .findFirst()
-        }
-
-        @JvmStatic
         fun insert(mRealm: Realm, act: JsonObject?) {
             var activities = mRealm.where(RealmOfflineActivity::class.java).equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
             if (activities == null) {
                 activities = mRealm.createObject(RealmOfflineActivity::class.java, JsonUtils.getString("_id", act))
-            }
             if (activities != null) {
                 activities._rev = JsonUtils.getString("_rev", act)
                 activities._id = JsonUtils.getString("_id", act)
@@ -74,10 +64,6 @@ open class RealmOfflineActivity : RealmObject() {
                 activities.userName = JsonUtils.getString("user", act)
                 activities.parentCode = JsonUtils.getString("parentCode", act)
                 activities.createdOn = JsonUtils.getString("createdOn", act)
-                activities.userName = JsonUtils.getString("user", act)
                 activities.logoutTime = JsonUtils.getLong("logoutTime", act)
                 activities.androidId = JsonUtils.getString("androidId", act)
-            }
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmRating.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmRating.kt
@@ -7,8 +7,7 @@ import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
-import org.ole.planet.myplanet.utilities.NetworkUtils
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 open class RealmRating : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -26,7 +25,6 @@ open class RealmRating : RealmObject() {
     var planetCode: String? = null
     var type: String? = null
     var user: String? = null
-
     companion object {
         @JvmStatic
         fun getRatings(mRealm: Realm, type: String?, userId: String?): HashMap<String?, JsonObject> {
@@ -38,29 +36,20 @@ open class RealmRating : RealmObject() {
             }
             return map
         }
-
-        @JvmStatic
         fun getRatingsById(mRealm: Realm, type: String?, id: String?, userid: String?): JsonObject? {
             val r = mRealm.where(RealmRating::class.java).equalTo("type", type).equalTo("item", id).findAll()
             if (r.isEmpty()) {
                 return null
-            }
             val `object` = JsonObject()
             var totalRating = 0
-            for (rating in r) {
                 totalRating += rating.rate
-            }
             val ratingObject = mRealm.where(RealmRating::class.java).equalTo("type", type)
                 .equalTo("userId", userid).equalTo("item", id).findFirst()
             if (ratingObject != null) {
                 `object`.addProperty("ratingByUser", ratingObject.rate)
-            }
             `object`.addProperty("averageRating", totalRating.toFloat() / r.size)
             `object`.addProperty("total", r.size)
             return `object`
-        }
-
-        @JvmStatic
         fun serializeRating(realmRating: RealmRating): JsonObject {
             val ob = JsonObject()
             if (realmRating._id != null) ob.addProperty("_id", realmRating._id)
@@ -75,18 +64,14 @@ open class RealmRating : RealmObject() {
             ob.addProperty("createdOn", realmRating.createdOn)
             ob.addProperty("parentCode", realmRating.parentCode)
             ob.addProperty("planetCode", realmRating.planetCode)
-            ob.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
-            ob.addProperty("deviceName", NetworkUtils.getDeviceName())
-            ob.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
+            ob.addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
+            ob.addProperty("deviceName", networkUtils.getDeviceName())
+            ob.addProperty("androidId", networkUtils.getUniqueIdentifier())
             return ob
-        }
-
-        @JvmStatic
         fun insert(mRealm: Realm, act: JsonObject) {
             var rating = mRealm.where(RealmRating::class.java).equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
             if (rating == null) {
                 rating = mRealm.createObject(RealmRating::class.java, JsonUtils.getString("_id", act))
-            }
             if (rating != null) {
                 rating._rev = JsonUtils.getString("_rev", act)
                 rating._id = JsonUtils.getString("_id", act)
@@ -102,7 +87,5 @@ open class RealmRating : RealmObject() {
                 rating.parentCode = JsonUtils.getString("parentCode", act)
                 rating.parentCode = JsonUtils.getString("planetCode", act)
                 rating.createdOn = JsonUtils.getString("createdOn", act)
-            }
-        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmRating.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmRating.kt
@@ -8,6 +8,7 @@ import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 open class RealmRating : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -25,6 +26,7 @@ open class RealmRating : RealmObject() {
     var planetCode: String? = null
     var type: String? = null
     var user: String? = null
+
     companion object {
         @JvmStatic
         fun getRatings(mRealm: Realm, type: String?, userId: String?): HashMap<String?, JsonObject> {
@@ -36,20 +38,29 @@ open class RealmRating : RealmObject() {
             }
             return map
         }
+
+        @JvmStatic
         fun getRatingsById(mRealm: Realm, type: String?, id: String?, userid: String?): JsonObject? {
             val r = mRealm.where(RealmRating::class.java).equalTo("type", type).equalTo("item", id).findAll()
             if (r.isEmpty()) {
                 return null
+            }
             val `object` = JsonObject()
             var totalRating = 0
+            for (rating in r) {
                 totalRating += rating.rate
+            }
             val ratingObject = mRealm.where(RealmRating::class.java).equalTo("type", type)
                 .equalTo("userId", userid).equalTo("item", id).findFirst()
             if (ratingObject != null) {
                 `object`.addProperty("ratingByUser", ratingObject.rate)
+            }
             `object`.addProperty("averageRating", totalRating.toFloat() / r.size)
             `object`.addProperty("total", r.size)
             return `object`
+        }
+
+        @JvmStatic
         fun serializeRating(realmRating: RealmRating): JsonObject {
             val ob = JsonObject()
             if (realmRating._id != null) ob.addProperty("_id", realmRating._id)
@@ -68,10 +79,14 @@ open class RealmRating : RealmObject() {
             ob.addProperty("deviceName", networkUtils.getDeviceName())
             ob.addProperty("androidId", networkUtils.getUniqueIdentifier())
             return ob
+        }
+
+        @JvmStatic
         fun insert(mRealm: Realm, act: JsonObject) {
             var rating = mRealm.where(RealmRating::class.java).equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
             if (rating == null) {
                 rating = mRealm.createObject(RealmRating::class.java, JsonUtils.getString("_id", act))
+            }
             if (rating != null) {
                 rating._rev = JsonUtils.getString("_rev", act)
                 rating._id = JsonUtils.getString("_id", act)
@@ -87,5 +102,7 @@ open class RealmRating : RealmObject() {
                 rating.parentCode = JsonUtils.getString("parentCode", act)
                 rating.parentCode = JsonUtils.getString("planetCode", act)
                 rating.createdOn = JsonUtils.getString("createdOn", act)
+            }
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmResourceActivity.kt
@@ -8,6 +8,7 @@ import io.realm.annotations.PrimaryKey
 import java.util.Date
 import java.util.UUID
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 open class RealmResourceActivity : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -21,6 +22,7 @@ open class RealmResourceActivity : RealmObject() {
     var type: String? = null
     var user: String? = null
     var androidId: String? = null
+
     companion object {
         @JvmStatic
         fun serializeResourceActivities(realmResourceActivities: RealmResourceActivity): JsonObject {
@@ -36,6 +38,8 @@ open class RealmResourceActivity : RealmObject() {
             ob.addProperty("deviceName", networkUtils.getDeviceName())
             return ob
         }
+
+        @JvmStatic
         fun onSynced(mRealm: Realm, settings: SharedPreferences) {
             if (!mRealm.isInTransaction) {
                 mRealm.beginTransaction()
@@ -44,6 +48,7 @@ open class RealmResourceActivity : RealmObject() {
                 ?: return
             if (user.id?.startsWith("guest") == true) {
                 return
+            }
             val activities = mRealm.createObject(RealmResourceActivity::class.java, UUID.randomUUID().toString())
             activities.user = user.name
             activities._rev = null
@@ -53,5 +58,6 @@ open class RealmResourceActivity : RealmObject() {
             activities.type = "sync"
             activities.time = Date().time
             mRealm.commitTransaction()
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmResourceActivity.kt
@@ -7,8 +7,7 @@ import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import java.util.Date
 import java.util.UUID
-import org.ole.planet.myplanet.utilities.NetworkUtils
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 open class RealmResourceActivity : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -22,7 +21,6 @@ open class RealmResourceActivity : RealmObject() {
     var type: String? = null
     var user: String? = null
     var androidId: String? = null
-
     companion object {
         @JvmStatic
         fun serializeResourceActivities(realmResourceActivities: RealmResourceActivity): JsonObject {
@@ -34,12 +32,10 @@ open class RealmResourceActivity : RealmObject() {
             ob.addProperty("time", realmResourceActivities.time)
             ob.addProperty("createdOn", realmResourceActivities.createdOn)
             ob.addProperty("parentCode", realmResourceActivities.parentCode)
-            ob.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            ob.addProperty("deviceName", NetworkUtils.getDeviceName())
+            ob.addProperty("androidId", networkUtils.getUniqueIdentifier())
+            ob.addProperty("deviceName", networkUtils.getDeviceName())
             return ob
         }
-
-        @JvmStatic
         fun onSynced(mRealm: Realm, settings: SharedPreferences) {
             if (!mRealm.isInTransaction) {
                 mRealm.beginTransaction()
@@ -48,7 +44,6 @@ open class RealmResourceActivity : RealmObject() {
                 ?: return
             if (user.id?.startsWith("guest") == true) {
                 return
-            }
             val activities = mRealm.createObject(RealmResourceActivity::class.java, UUID.randomUUID().toString())
             activities.user = user.name
             activities._rev = null
@@ -58,6 +53,5 @@ open class RealmResourceActivity : RealmObject() {
             activities.type = "sync"
             activities.time = Date().time
             mRealm.commitTransaction()
-        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
@@ -5,9 +5,8 @@ import com.google.gson.JsonObject
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.utilities.NetworkUtils
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.VersionUtils
-
 open class RealmSearchActivity(
     @PrimaryKey
     var id: String = "",
@@ -29,15 +28,14 @@ open class RealmSearchActivity(
         obj.addProperty("user", user)
         obj.addProperty("androidId", VersionUtils.getAndroidId(MainApplication.context))
         obj.addProperty(
-            "customDeviceName", NetworkUtils.getCustomDeviceName(MainApplication.context)
+            "customDeviceName", networkUtils.getCustomDeviceName(MainApplication.context)
         )
-        obj.addProperty("deviceName", NetworkUtils.getDeviceName())
+        obj.addProperty("deviceName", networkUtils.getDeviceName())
         obj.addProperty("createdOn", createdOn)
         obj.addProperty("parentCode", parentCode)
         obj.add("filter", Gson().fromJson(filter, JsonObject::class.java))
         return obj
     }
-
     companion object {
         @JvmStatic
         fun insert(log: RealmNewsLog): JsonObject {
@@ -45,10 +43,9 @@ open class RealmSearchActivity(
             ob.addProperty("user", log.userId)
             ob.addProperty("type", log.type)
             ob.addProperty("time", log.time)
-            ob.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            ob.addProperty("deviceName", NetworkUtils.getDeviceName())
-            ob.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(MainApplication.context))
+            ob.addProperty("androidId", networkUtils.getUniqueIdentifier())
+            ob.addProperty("deviceName", networkUtils.getDeviceName())
+            ob.addProperty("customDeviceName", networkUtils.getCustomDeviceName(MainApplication.context))
             return ob
         }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
@@ -7,6 +7,7 @@ import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.VersionUtils
+
 open class RealmSearchActivity(
     @PrimaryKey
     var id: String = "",
@@ -36,6 +37,7 @@ open class RealmSearchActivity(
         obj.add("filter", Gson().fromJson(filter, JsonObject::class.java))
         return obj
     }
+
     companion object {
         @JvmStatic
         fun insert(log: RealmNewsLog): JsonObject {
@@ -48,4 +50,5 @@ open class RealmSearchActivity(
             ob.addProperty("customDeviceName", networkUtils.getCustomDeviceName(MainApplication.context))
             return ob
         }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
@@ -22,6 +22,7 @@ import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
+
 open class RealmSubmission : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -44,22 +45,27 @@ open class RealmSubmission : RealmObject() {
     var parent: String? = null
     var membershipDoc: RealmMembershipDoc? = null
     var isUpdated = false
+
     companion object {
         @JvmStatic
         fun insert(mRealm: Realm, submission: JsonObject) {
             if (submission.has("_attachments")) {
                 return
             }
+
             var transactionStarted = false
+
             try {
                 if (!mRealm.isInTransaction) {
                     mRealm.beginTransaction()
                     transactionStarted = true
                 }
+
                 val id = JsonUtils.getString("_id", submission)
                 var sub = mRealm.where(RealmSubmission::class.java).equalTo("_id", id).findFirst()
                 if (sub == null) {
                     sub = mRealm.createObject(RealmSubmission::class.java, id)
+                }
                 sub?._id = id
                 sub?.status = JsonUtils.getString("status", submission)
                 sub?._rev = JsonUtils.getString("_rev", submission)
@@ -75,6 +81,7 @@ open class RealmSubmission : RealmObject() {
                 sub?.parent = Gson().toJson(JsonUtils.getJsonObject("parent", submission))
                 sub?.user = Gson().toJson(JsonUtils.getJsonObject("user", submission))
                 sub.team = JsonUtils.getString("team", submission)
+
                 val userJson = JsonUtils.getJsonObject("user", submission)
                 if (userJson.has("membershipDoc")) {
                     val membershipJson = JsonUtils.getJsonObject("membershipDoc", userJson)
@@ -83,30 +90,41 @@ open class RealmSubmission : RealmObject() {
                         membership.teamId = JsonUtils.getString("teamId", membershipJson)
                         sub?.membershipDoc = membership
                     }
+                }
+
                 val userId = JsonUtils.getString("_id", JsonUtils.getJsonObject("user", submission))
                 sub?.userId = if (userId.contains("@")) {
                     val us = userId.split("@".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
                     if (us[0].startsWith("org.couchdb.user:")) us[0] else "org.couchdb.user:${us[0]}"
                 } else {
                     userId
+                }
+
                 if (transactionStarted) {
                     mRealm.commitTransaction()
+                }
             } catch (e: Exception) {
                 e.printStackTrace()
                 if (transactionStarted && mRealm.isInTransaction) {
                     mRealm.cancelTransaction()
+                }
+            }
         }
+
         private fun serializeExamResult(mRealm: Realm, sub: RealmSubmission, context: Context): JsonObject {
             val `object` = JsonObject()
             val user = mRealm.where(RealmUserModel::class.java).equalTo("id", sub.userId).findFirst()
             var examId = sub.parentId
             if (sub.parentId?.contains("@") == true) {
                 examId = sub.parentId!!.split("@".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()[0]
+            }
             val exam = mRealm.where(RealmStepExam::class.java).equalTo("id", examId).findFirst()
             if (!TextUtils.isEmpty(sub._id)) {
                 `object`.addProperty("_id", sub._id)
+            }
             if (!TextUtils.isEmpty(sub._rev)) {
                 `object`.addProperty("_rev", sub._rev)
+            }
             `object`.addProperty("parentId", sub.parentId)
             `object`.addProperty("type", sub.type)
             `object`.addProperty("team", sub.team)
@@ -128,80 +146,141 @@ open class RealmSubmission : RealmObject() {
                 `object`.add("user", user?.serialize())
             } else {
                 `object`.add("user", JsonParser.parseString(sub.user))
+            }
             return `object`
+        }
+
+        @JvmStatic
         fun isStepCompleted(realm: Realm, id: String?, userId: String?): Boolean {
             val exam = realm.where(RealmStepExam::class.java).equalTo("stepId", id).findFirst() ?: return true
             return exam.id?.let {
                 realm.where(RealmSubmission::class.java).equalTo("userId", userId)
                     .contains("parentId", it).notEqualTo("status", "pending").findFirst()
             } != null
+        }
+
+        @JvmStatic
         fun createSubmission(sub: RealmSubmission?, mRealm: Realm): RealmSubmission {
             var submission = sub
             if (submission == null || submission.status == "complete" && (submission.type == "exam" || submission.type == "survey"))
                 submission = mRealm.createObject(RealmSubmission::class.java, UUID.randomUUID().toString())
             submission!!.lastUpdateTime = Date().time
             return submission
+        }
+
+        @JvmStatic
         @Throws(IOException::class)
         fun continueResultUpload(sub: RealmSubmission, apiInterface: ApiInterface?, realm: Realm, context: Context) {
             if (!TextUtils.isEmpty(sub.userId) && sub.userId?.startsWith("guest") == true) return
             val `object`: JsonObject? = if (TextUtils.isEmpty(sub._id)) {
                 apiInterface?.postDoc(Utilities.header, "application/json", Utilities.getUrl() + "/submissions", serializeExamResult(realm, sub, context))?.execute()?.body()
+            } else {
                 apiInterface?.putDoc(Utilities.header, "application/json", Utilities.getUrl() + "/submissions/" + sub._id, serializeExamResult(realm, sub, context))?.execute()?.body()
+            }
             if (`object` != null) {
                 sub._id = JsonUtils.getString("id", `object`)
                 sub._rev = JsonUtils.getString("rev", `object`)
+            }
+        }
+
         fun generateParentId(courseId: String?, examId: String?): String? {
             return if (!examId.isNullOrEmpty()) {
                 if (!courseId.isNullOrEmpty()) {
                     "$examId@$courseId"
+                } else {
                     examId
+                }
+            } else {
                 null
+            }
+        }
+
+        @JvmStatic
         fun getNoOfSubmissionByUser(id: String?, courseId: String?, userId: String?, mRealm: Realm): String {
             if (id == null || userId == null) return "No Submissions Found"
+
             val submissionParentId = generateParentId(courseId, id)
             if (submissionParentId.isNullOrEmpty()) return "No Submissions Found"
+
             val submissionCount = mRealm.where(RealmSubmission::class.java)
                 .equalTo("parentId", submissionParentId)
                 .equalTo("userId", userId)
                 .`in`("status", arrayOf("complete", "pending"))
                 .count().toInt()
+
             val pluralizedString = if (submissionCount == 1) "time" else "times"
             return "${context.getString(R.string.survey_taken)} $submissionCount $pluralizedString"
+        }
+
+        @JvmStatic
         fun getNoOfSubmissionByTeam(teamId: String?, examId: String?, mRealm: Realm): String {
+            val submissionCount = mRealm.where(RealmSubmission::class.java)
                 .equalTo("team", teamId)
                 .equalTo("type", "survey")
                 .equalTo("parentId", examId)
                 .equalTo("status", "complete")
+                .count().toInt()
+
+            val pluralizedString = if (submissionCount == 1) "time" else "times"
+            return "${context.getString(R.string.survey_taken)} $submissionCount $pluralizedString"
+        }
+
+        @JvmStatic
         fun getNoOfSurveySubmissionByUser(userId: String?, mRealm: Realm): Int {
             if (userId == null) return 0
+
             return mRealm.where(RealmSubmission::class.java)
+                .equalTo("userId", userId)
+                .equalTo("type", "survey")
                 .equalTo("status", "pending", Case.INSENSITIVE)
+                .count().toInt()
+        }
+
+        @JvmStatic
         fun getRecentSubmissionDate(id: String?, courseId:String?, userId: String?, mRealm: Realm): String {
             if (id == null || userId == null) return ""
             val submissionParentId= generateParentId(courseId, id)
             if(submissionParentId.isNullOrEmpty())  return ""
             val recentSubmission = mRealm.where(RealmSubmission::class.java)
+                .equalTo("parentId", submissionParentId)
+                .equalTo("userId", userId)
                 .sort("startTime", Sort.DESCENDING)
                 .findFirst()
             return recentSubmission?.startTime?.let { TimeUtils.getFormatedDateWithTime(it) } ?: ""
+        }
+
+        @JvmStatic
         fun getExamMap(mRealm: Realm, submissions: List<RealmSubmission>?): HashMap<String?, RealmStepExam> {
             val exams = HashMap<String?, RealmStepExam>()
             for (sub in submissions ?: emptyList()){
                 var id = sub.parentId
                 if (checkParentId(sub.parentId)) {
                     id = sub.parentId!!.split("@".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()[0]
+                }
                 val survey = mRealm.where(RealmStepExam::class.java).equalTo("id", id).findFirst()
                 if (survey != null) {
                     exams[sub.parentId] = survey
+                }
+            }
             return exams
+        }
+
         private fun checkParentId(parentId: String?): Boolean {
             return parentId != null && parentId.contains("@")
+        }
+
+        @JvmStatic
         fun serialize(mRealm: Realm, submission: RealmSubmission): JsonObject {
             val jsonObject = JsonObject()
+
+            try {
                 if (!submission._id.isNullOrEmpty()) {
                     jsonObject.addProperty("_id", submission._id)
+                }
                 if (!submission._rev.isNullOrEmpty()) {
                     jsonObject.addProperty("_rev", submission._rev)
+                }
+
                 jsonObject.addProperty("parentId", submission.parentId ?: "")
                 jsonObject.addProperty("type", submission.type ?: "survey")
                 jsonObject.addProperty("userId", submission.userId ?: "")
@@ -214,24 +293,38 @@ open class RealmSubmission : RealmObject() {
                 jsonObject.addProperty("startTime", submission.startTime)
                 jsonObject.addProperty("lastUpdateTime", submission.lastUpdateTime)
                 jsonObject.addProperty("grade", submission.grade)
+
                 if (!submission.parent.isNullOrEmpty()) {
                     jsonObject.add("parent", JsonParser.parseString(submission.parent))
+                }
+
                 if (!submission.user.isNullOrEmpty()) {
                     val userJson = JsonParser.parseString(submission.user).asJsonObject
                     if (submission.membershipDoc != null) {
                         val membershipJson = JsonObject()
                         membershipJson.addProperty("teamId", submission.membershipDoc?.teamId ?: "")
+
                         userJson.add("membershipDoc", membershipJson)
+                    }
                     jsonObject.add("user", userJson)
+                }
+
                 val questions = mRealm.where(RealmExamQuestion::class.java)
                     .equalTo("examId", submission.parentId)
                     .findAll()
                 val serializedQuestions = RealmExamQuestion.serializeQuestions(questions)
                 jsonObject.add("questions", serializedQuestions)
+
                 val answersArray = RealmAnswer.serializeRealmAnswer(submission.answers ?: RealmList())
                 jsonObject.add("answers", answersArray)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
             return jsonObject
+        }
     }
 }
+
 open class RealmMembershipDoc : RealmObject() {
     var teamId: String? = null
+}

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
@@ -19,10 +19,9 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseResourceFragment.Companion.settings
 import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.utilities.JsonUtils
-import org.ole.planet.myplanet.utilities.NetworkUtils
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
-
 open class RealmSubmission : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -45,27 +44,22 @@ open class RealmSubmission : RealmObject() {
     var parent: String? = null
     var membershipDoc: RealmMembershipDoc? = null
     var isUpdated = false
-
     companion object {
         @JvmStatic
         fun insert(mRealm: Realm, submission: JsonObject) {
             if (submission.has("_attachments")) {
                 return
             }
-
             var transactionStarted = false
-
             try {
                 if (!mRealm.isInTransaction) {
                     mRealm.beginTransaction()
                     transactionStarted = true
                 }
-
                 val id = JsonUtils.getString("_id", submission)
                 var sub = mRealm.where(RealmSubmission::class.java).equalTo("_id", id).findFirst()
                 if (sub == null) {
                     sub = mRealm.createObject(RealmSubmission::class.java, id)
-                }
                 sub?._id = id
                 sub?.status = JsonUtils.getString("status", submission)
                 sub?._rev = JsonUtils.getString("_rev", submission)
@@ -81,7 +75,6 @@ open class RealmSubmission : RealmObject() {
                 sub?.parent = Gson().toJson(JsonUtils.getJsonObject("parent", submission))
                 sub?.user = Gson().toJson(JsonUtils.getJsonObject("user", submission))
                 sub.team = JsonUtils.getString("team", submission)
-
                 val userJson = JsonUtils.getJsonObject("user", submission)
                 if (userJson.has("membershipDoc")) {
                     val membershipJson = JsonUtils.getJsonObject("membershipDoc", userJson)
@@ -90,41 +83,30 @@ open class RealmSubmission : RealmObject() {
                         membership.teamId = JsonUtils.getString("teamId", membershipJson)
                         sub?.membershipDoc = membership
                     }
-                }
-
                 val userId = JsonUtils.getString("_id", JsonUtils.getJsonObject("user", submission))
                 sub?.userId = if (userId.contains("@")) {
                     val us = userId.split("@".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
                     if (us[0].startsWith("org.couchdb.user:")) us[0] else "org.couchdb.user:${us[0]}"
                 } else {
                     userId
-                }
-
                 if (transactionStarted) {
                     mRealm.commitTransaction()
-                }
             } catch (e: Exception) {
                 e.printStackTrace()
                 if (transactionStarted && mRealm.isInTransaction) {
                     mRealm.cancelTransaction()
-                }
-            }
         }
-
         private fun serializeExamResult(mRealm: Realm, sub: RealmSubmission, context: Context): JsonObject {
             val `object` = JsonObject()
             val user = mRealm.where(RealmUserModel::class.java).equalTo("id", sub.userId).findFirst()
             var examId = sub.parentId
             if (sub.parentId?.contains("@") == true) {
                 examId = sub.parentId!!.split("@".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()[0]
-            }
             val exam = mRealm.where(RealmStepExam::class.java).equalTo("id", examId).findFirst()
             if (!TextUtils.isEmpty(sub._id)) {
                 `object`.addProperty("_id", sub._id)
-            }
             if (!TextUtils.isEmpty(sub._rev)) {
                 `object`.addProperty("_rev", sub._rev)
-            }
             `object`.addProperty("parentId", sub.parentId)
             `object`.addProperty("type", sub.type)
             `object`.addProperty("team", sub.team)
@@ -132,9 +114,9 @@ open class RealmSubmission : RealmObject() {
             `object`.addProperty("startTime", sub.startTime)
             `object`.addProperty("lastUpdateTime", sub.lastUpdateTime)
             `object`.addProperty("status", sub.status)
-            `object`.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            `object`.addProperty("deviceName", NetworkUtils.getDeviceName())
-            `object`.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
+            `object`.addProperty("androidId", networkUtils.getUniqueIdentifier())
+            `object`.addProperty("deviceName", networkUtils.getDeviceName())
+            `object`.addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
             `object`.addProperty("sender", sub.sender)
             `object`.addProperty("source", settings?.getString("planetCode", ""))
             `object`.addProperty("parentCode", settings?.getString("parentCode", ""))
@@ -146,141 +128,80 @@ open class RealmSubmission : RealmObject() {
                 `object`.add("user", user?.serialize())
             } else {
                 `object`.add("user", JsonParser.parseString(sub.user))
-            }
             return `object`
-        }
-
-        @JvmStatic
         fun isStepCompleted(realm: Realm, id: String?, userId: String?): Boolean {
             val exam = realm.where(RealmStepExam::class.java).equalTo("stepId", id).findFirst() ?: return true
             return exam.id?.let {
                 realm.where(RealmSubmission::class.java).equalTo("userId", userId)
                     .contains("parentId", it).notEqualTo("status", "pending").findFirst()
             } != null
-        }
-
-        @JvmStatic
         fun createSubmission(sub: RealmSubmission?, mRealm: Realm): RealmSubmission {
             var submission = sub
             if (submission == null || submission.status == "complete" && (submission.type == "exam" || submission.type == "survey"))
                 submission = mRealm.createObject(RealmSubmission::class.java, UUID.randomUUID().toString())
             submission!!.lastUpdateTime = Date().time
             return submission
-        }
-
-        @JvmStatic
         @Throws(IOException::class)
         fun continueResultUpload(sub: RealmSubmission, apiInterface: ApiInterface?, realm: Realm, context: Context) {
             if (!TextUtils.isEmpty(sub.userId) && sub.userId?.startsWith("guest") == true) return
             val `object`: JsonObject? = if (TextUtils.isEmpty(sub._id)) {
                 apiInterface?.postDoc(Utilities.header, "application/json", Utilities.getUrl() + "/submissions", serializeExamResult(realm, sub, context))?.execute()?.body()
-            } else {
                 apiInterface?.putDoc(Utilities.header, "application/json", Utilities.getUrl() + "/submissions/" + sub._id, serializeExamResult(realm, sub, context))?.execute()?.body()
-            }
             if (`object` != null) {
                 sub._id = JsonUtils.getString("id", `object`)
                 sub._rev = JsonUtils.getString("rev", `object`)
-            }
-        }
-
         fun generateParentId(courseId: String?, examId: String?): String? {
             return if (!examId.isNullOrEmpty()) {
                 if (!courseId.isNullOrEmpty()) {
                     "$examId@$courseId"
-                } else {
                     examId
-                }
-            } else {
                 null
-            }
-        }
-
-        @JvmStatic
         fun getNoOfSubmissionByUser(id: String?, courseId: String?, userId: String?, mRealm: Realm): String {
             if (id == null || userId == null) return "No Submissions Found"
-
             val submissionParentId = generateParentId(courseId, id)
             if (submissionParentId.isNullOrEmpty()) return "No Submissions Found"
-
             val submissionCount = mRealm.where(RealmSubmission::class.java)
                 .equalTo("parentId", submissionParentId)
                 .equalTo("userId", userId)
                 .`in`("status", arrayOf("complete", "pending"))
                 .count().toInt()
-
             val pluralizedString = if (submissionCount == 1) "time" else "times"
             return "${context.getString(R.string.survey_taken)} $submissionCount $pluralizedString"
-        }
-
-        @JvmStatic
         fun getNoOfSubmissionByTeam(teamId: String?, examId: String?, mRealm: Realm): String {
-            val submissionCount = mRealm.where(RealmSubmission::class.java)
                 .equalTo("team", teamId)
                 .equalTo("type", "survey")
                 .equalTo("parentId", examId)
                 .equalTo("status", "complete")
-                .count().toInt()
-
-            val pluralizedString = if (submissionCount == 1) "time" else "times"
-            return "${context.getString(R.string.survey_taken)} $submissionCount $pluralizedString"
-        }
-
-        @JvmStatic
         fun getNoOfSurveySubmissionByUser(userId: String?, mRealm: Realm): Int {
             if (userId == null) return 0
-
             return mRealm.where(RealmSubmission::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "survey")
                 .equalTo("status", "pending", Case.INSENSITIVE)
-                .count().toInt()
-        }
-
-        @JvmStatic
         fun getRecentSubmissionDate(id: String?, courseId:String?, userId: String?, mRealm: Realm): String {
             if (id == null || userId == null) return ""
             val submissionParentId= generateParentId(courseId, id)
             if(submissionParentId.isNullOrEmpty())  return ""
             val recentSubmission = mRealm.where(RealmSubmission::class.java)
-                .equalTo("parentId", submissionParentId)
-                .equalTo("userId", userId)
                 .sort("startTime", Sort.DESCENDING)
                 .findFirst()
             return recentSubmission?.startTime?.let { TimeUtils.getFormatedDateWithTime(it) } ?: ""
-        }
-
-        @JvmStatic
         fun getExamMap(mRealm: Realm, submissions: List<RealmSubmission>?): HashMap<String?, RealmStepExam> {
             val exams = HashMap<String?, RealmStepExam>()
             for (sub in submissions ?: emptyList()){
                 var id = sub.parentId
                 if (checkParentId(sub.parentId)) {
                     id = sub.parentId!!.split("@".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()[0]
-                }
                 val survey = mRealm.where(RealmStepExam::class.java).equalTo("id", id).findFirst()
                 if (survey != null) {
                     exams[sub.parentId] = survey
-                }
-            }
             return exams
-        }
-
         private fun checkParentId(parentId: String?): Boolean {
             return parentId != null && parentId.contains("@")
-        }
-
-        @JvmStatic
         fun serialize(mRealm: Realm, submission: RealmSubmission): JsonObject {
             val jsonObject = JsonObject()
-
-            try {
                 if (!submission._id.isNullOrEmpty()) {
                     jsonObject.addProperty("_id", submission._id)
-                }
                 if (!submission._rev.isNullOrEmpty()) {
                     jsonObject.addProperty("_rev", submission._rev)
-                }
-
                 jsonObject.addProperty("parentId", submission.parentId ?: "")
                 jsonObject.addProperty("type", submission.type ?: "survey")
                 jsonObject.addProperty("userId", submission.userId ?: "")
@@ -293,38 +214,24 @@ open class RealmSubmission : RealmObject() {
                 jsonObject.addProperty("startTime", submission.startTime)
                 jsonObject.addProperty("lastUpdateTime", submission.lastUpdateTime)
                 jsonObject.addProperty("grade", submission.grade)
-
                 if (!submission.parent.isNullOrEmpty()) {
                     jsonObject.add("parent", JsonParser.parseString(submission.parent))
-                }
-
                 if (!submission.user.isNullOrEmpty()) {
                     val userJson = JsonParser.parseString(submission.user).asJsonObject
                     if (submission.membershipDoc != null) {
                         val membershipJson = JsonObject()
                         membershipJson.addProperty("teamId", submission.membershipDoc?.teamId ?: "")
-
                         userJson.add("membershipDoc", membershipJson)
-                    }
                     jsonObject.add("user", userJson)
-                }
-
                 val questions = mRealm.where(RealmExamQuestion::class.java)
                     .equalTo("examId", submission.parentId)
                     .findAll()
                 val serializedQuestions = RealmExamQuestion.serializeQuestions(questions)
                 jsonObject.add("questions", serializedQuestions)
-
                 val answersArray = RealmAnswer.serializeRealmAnswer(submission.answers ?: RealmList())
                 jsonObject.add("answers", answersArray)
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
             return jsonObject
-        }
     }
 }
-
 open class RealmMembershipDoc : RealmObject() {
     var teamId: String? = null
-}

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
@@ -9,6 +9,7 @@ import io.realm.annotations.PrimaryKey
 import java.util.Calendar
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 open class RealmTeamLog : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -27,16 +28,24 @@ open class RealmTeamLog : RealmObject() {
         fun getVisitCount(realm: Realm, userName: String?, teamId: String?): Long {
             return realm.where(RealmTeamLog::class.java).equalTo("type", "teamVisit").equalTo("user", userName).equalTo("teamId", teamId).count()
         }
+
+        @JvmStatic
         fun getLastVisit(realm: Realm, userName: String?, teamId: String?): Long? {
             return realm.where(RealmTeamLog::class.java)
                 .equalTo("type", "teamVisit")
                 .equalTo("user", userName)
                 .equalTo("teamId", teamId)
                 .max("time")?.toLong()
+        }
+
+        @JvmStatic
         fun getVisitByTeam(realm: Realm, teamId: String?): Long {
             val calendar = Calendar.getInstance()
             calendar.add(Calendar.DAY_OF_YEAR, -30)
             return realm.where(RealmTeamLog::class.java).equalTo("type", "teamVisit").equalTo("teamId", teamId).greaterThan("time", calendar.timeInMillis).count()
+        }
+
+        @JvmStatic
         fun serializeTeamActivities(log: RealmTeamLog, context: Context): JsonObject {
             val ob = JsonObject()
             ob.addProperty("user", log.user)
@@ -54,11 +63,15 @@ open class RealmTeamLog : RealmObject() {
                 ob.addProperty("_id", log._id)
             }
             return ob
+        }
+
+        @JvmStatic
         fun insert(mRealm: Realm, act: JsonObject?) {
             var tag = mRealm.where(RealmTeamLog::class.java)
                 .equalTo("id", JsonUtils.getString("_id", act)).findFirst()
             if (tag == null) {
                 tag = mRealm.createObject(RealmTeamLog::class.java, JsonUtils.getString("_id", act))
+            }
             if (tag != null) {
                 tag._rev = JsonUtils.getString("_rev", act)
                 tag._id = JsonUtils.getString("_id", act)
@@ -69,5 +82,7 @@ open class RealmTeamLog : RealmObject() {
                 tag.time = JsonUtils.getLong("time", act)
                 tag.teamId = JsonUtils.getString("teamId", act)
                 tag.teamType = JsonUtils.getString("teamType", act)
+            }
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
@@ -8,8 +8,7 @@ import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import java.util.Calendar
 import org.ole.planet.myplanet.utilities.JsonUtils
-import org.ole.planet.myplanet.utilities.NetworkUtils
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 open class RealmTeamLog : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -28,24 +27,16 @@ open class RealmTeamLog : RealmObject() {
         fun getVisitCount(realm: Realm, userName: String?, teamId: String?): Long {
             return realm.where(RealmTeamLog::class.java).equalTo("type", "teamVisit").equalTo("user", userName).equalTo("teamId", teamId).count()
         }
-
-        @JvmStatic
         fun getLastVisit(realm: Realm, userName: String?, teamId: String?): Long? {
             return realm.where(RealmTeamLog::class.java)
                 .equalTo("type", "teamVisit")
                 .equalTo("user", userName)
                 .equalTo("teamId", teamId)
                 .max("time")?.toLong()
-        }
-
-        @JvmStatic
         fun getVisitByTeam(realm: Realm, teamId: String?): Long {
             val calendar = Calendar.getInstance()
             calendar.add(Calendar.DAY_OF_YEAR, -30)
             return realm.where(RealmTeamLog::class.java).equalTo("type", "teamVisit").equalTo("teamId", teamId).greaterThan("time", calendar.timeInMillis).count()
-        }
-
-        @JvmStatic
         fun serializeTeamActivities(log: RealmTeamLog, context: Context): JsonObject {
             val ob = JsonObject()
             ob.addProperty("user", log.user)
@@ -55,23 +46,19 @@ open class RealmTeamLog : RealmObject() {
             ob.addProperty("teamType", log.teamType)
             ob.addProperty("time", log.time)
             ob.addProperty("teamId", log.teamId)
-            ob.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            ob.addProperty("deviceName", NetworkUtils.getDeviceName())
-            ob.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
+            ob.addProperty("androidId", networkUtils.getUniqueIdentifier())
+            ob.addProperty("deviceName", networkUtils.getDeviceName())
+            ob.addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
             if (!TextUtils.isEmpty(log._rev)) {
                 ob.addProperty("_rev", log._rev)
                 ob.addProperty("_id", log._id)
             }
             return ob
-        }
-
-        @JvmStatic
         fun insert(mRealm: Realm, act: JsonObject?) {
             var tag = mRealm.where(RealmTeamLog::class.java)
                 .equalTo("id", JsonUtils.getString("_id", act)).findFirst()
             if (tag == null) {
                 tag = mRealm.createObject(RealmTeamLog::class.java, JsonUtils.getString("_id", act))
-            }
             if (tag != null) {
                 tag._rev = JsonUtils.getString("_rev", act)
                 tag._id = JsonUtils.getString("_id", act)
@@ -82,7 +69,5 @@ open class RealmTeamLog : RealmObject() {
                 tag.time = JsonUtils.getLong("time", act)
                 tag.teamId = JsonUtils.getString("teamId", act)
                 tag.teamType = JsonUtils.getString("teamType", act)
-            }
-        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
@@ -20,10 +20,9 @@ import org.json.JSONException
 import org.json.JSONObject
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.JsonUtils
-import org.ole.planet.myplanet.utilities.NetworkUtils
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils
-
 open class RealmUserModel : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -57,7 +56,6 @@ open class RealmUserModel : RealmObject() {
     var isUpdated = false
     var isShowTopbar = false
     var isArchived = false
-
     fun serialize(): JsonObject {
         val jsonObject = JsonObject()
         if (_id?.isNotEmpty() == true) {
@@ -68,14 +66,13 @@ open class RealmUserModel : RealmObject() {
         jsonObject.add("roles", getRoles())
         if (_id?.isEmpty() == true) {
             jsonObject.addProperty("password", password)
-            jsonObject.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
+            jsonObject.addProperty("androidId", networkUtils.getUniqueIdentifier())
             jsonObject.addProperty("uniqueAndroidId", VersionUtils.getAndroidId(context))
-            jsonObject.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
+            jsonObject.addProperty("customDeviceName", networkUtils.getCustomDeviceName(context))
         } else {
             jsonObject.addProperty("derived_key", derived_key)
             jsonObject.addProperty("salt", salt)
             jsonObject.addProperty("password_scheme", password_scheme)
-        }
         jsonObject.addProperty("isUserAdmin", userAdmin)
         jsonObject.addProperty("joinDate", joinDate)
         jsonObject.addProperty("firstName", firstName)
@@ -94,27 +91,20 @@ open class RealmUserModel : RealmObject() {
         } catch (e: NumberFormatException) {
             e.printStackTrace()
             jsonObject.addProperty("iterations", 10)
-        }
         jsonObject.addProperty("parentCode", parentCode)
         jsonObject.addProperty("planetCode", planetCode)
         jsonObject.addProperty("birthPlace", birthPlace)
         jsonObject.addProperty("isArchived", isArchived)
-
         val base64Image = encodeImageToBase64(userImage)
-
         if (!base64Image.isNullOrEmpty()) {
             val attachmentObject = JsonObject()
             val imageData = JsonObject()
             imageData.addProperty("content_type", "image/jpeg")
             imageData.addProperty("data", base64Image)
-
             attachmentObject.add("img", imageData)
             jsonObject.add("_attachments", attachmentObject)
-        }
-
         return jsonObject
     }
-
     fun encodeImageToBase64(imagePath: String?): String? {
         if (imagePath.isNullOrEmpty()) return null
         return try {
@@ -124,41 +114,24 @@ open class RealmUserModel : RealmObject() {
             } else {
                 File(imagePath).inputStream()
             }
-
             inputStream?.use {
                 val bytes = it.readBytes()
                 Base64.encodeToString(bytes, Base64.NO_WRAP)
-            }
         } catch (e: Exception) {
-            e.printStackTrace()
             null
-        }
-    }
-
     private fun getRoles(): JsonArray {
         val ar = JsonArray()
         for (s in rolesList ?: emptyList())    {
             ar.add(s)
-        }
         return ar
-    }
-
     fun setRoles(roles: RealmList<String?>?) {
         rolesList = roles
-    }
-
     fun getRoleAsString(): String {
         return StringUtils.join(rolesList, ",")
-    }
-
     fun getFullName(): String {
         return "$firstName $lastName"
-    }
-
     fun getFullNameWithMiddleName(): String {
         return "$firstName ${middleName ?: ""} $lastName"
-    }
-
     fun addImageUrl(jsonDoc: JsonObject?) {
         if (jsonDoc?.has("_attachments") == true) {
             val element = JsonParser.parseString(jsonDoc["_attachments"].asJsonObject.toString())
@@ -167,31 +140,18 @@ open class RealmUserModel : RealmObject() {
             for ((key1) in entries) {
                 userImage = Utilities.getUserImageUrl(id, key1)
                 break
-            }
-        }
-    }
-
     fun isManager(): Boolean {
         val roles = getRoles()
         val isManager = roles.toString().lowercase(Locale.ROOT).contains("manager") || userAdmin ?: false
         return isManager
-    }
-
     fun isLeader(): Boolean {
-        val roles = getRoles()
         return roles.toString().lowercase(Locale.ROOT).contains("leader")
-    }
-
     fun isGuest(): Boolean {
         val hasGuestId = _id?.startsWith("guest_") == true
         val hasGuestRole = rolesList?.any { it?.lowercase() == "guest" } == true
         return hasGuestId || (hasGuestRole && rolesList?.any { it?.lowercase() == "learner" } != true)
-    }
-
     override fun toString(): String {
         return "$name"
-    }
-
     companion object {
         @JvmStatic
         fun createGuestUser(username: String?, mRealm: Realm, settings: SharedPreferences): RealmUserModel? {
@@ -204,28 +164,22 @@ open class RealmUserModel : RealmObject() {
             `object`.add("roles", rolesArray)
             if (!mRealm.isInTransaction) mRealm.beginTransaction()
             return populateUsersTable(`object`, mRealm, settings)
-        }
-
-        @JvmStatic
         fun populateUsersTable(jsonDoc: JsonObject?, mRealm: Realm?, settings: SharedPreferences): RealmUserModel? {
             if (jsonDoc == null || mRealm == null) return null
             try {
                 val id = JsonUtils.getString("_id", jsonDoc).takeIf { it.isNotEmpty() } ?: UUID.randomUUID().toString()
                 val userName = JsonUtils.getString("name", jsonDoc)
                 var user: RealmUserModel? = null
-
                 if (!mRealm.isInTransaction) {
                     mRealm.executeTransaction { realm ->
                         user = realm.where(RealmUserModel::class.java)
                             .equalTo("_id", id)
                             .findFirst()
-
                         if (user == null && id.startsWith("org.couchdb.user:") && userName.isNotEmpty()) {
                             val guestUser = realm.where(RealmUserModel::class.java)
                                 .equalTo("name", userName)
                                 .beginsWith("_id", "guest_")
                                 .findFirst()
-
                             if (guestUser != null) {
                                 val tempData = JsonObject()
                                 tempData.addProperty("_id", id)
@@ -245,7 +199,6 @@ open class RealmUserModel : RealmObject() {
                                 tempData.addProperty("joinDate", guestUser.joinDate)
                                 tempData.addProperty("isShowTopbar", guestUser.isShowTopbar)
                                 tempData.addProperty("isArchived", guestUser.isArchived)
-
                                 val rolesArray = JsonArray()
                                 guestUser.rolesList?.forEach { role ->
                                     rolesArray.add(role)
@@ -256,23 +209,18 @@ open class RealmUserModel : RealmObject() {
                                 insertIntoUsers(tempData, user!!, settings)
                             }
                         }
-
                         if (user == null) {
                             user = realm.createObject(RealmUserModel::class.java, id)
-                        }
                         insertIntoUsers(jsonDoc, user!!, settings)
                     }
                 } else {
                     user = mRealm.where(RealmUserModel::class.java)
                         .equalTo("_id", id)
                         .findFirst()
-
                     if (user == null && id.startsWith("org.couchdb.user:") && userName.isNotEmpty()) {
                         val guestUser = mRealm.where(RealmUserModel::class.java)
                             .equalTo("name", userName)
                             .beginsWith("_id", "guest_")
-                            .findFirst()
-
                         if (guestUser != null) {
                             val tempData = JsonObject()
                             tempData.addProperty("_id", id)
@@ -295,33 +243,23 @@ open class RealmUserModel : RealmObject() {
                             val rolesArray = JsonArray()
                             guestUser.rolesList?.forEach { role ->
                                 rolesArray.add(role)
-                            }
                             tempData.add("roles", rolesArray)
                             guestUser.deleteFromRealm()
                             user = mRealm.createObject(RealmUserModel::class.java, id)
                             insertIntoUsers(tempData, user!!, settings)
-                        }
-                    }
-
                     if (user == null) {
                         user = mRealm.createObject(RealmUserModel::class.java, id)
-                    }
                     insertIntoUsers(jsonDoc, user!!, settings)
                 }
                 return user
             } catch (err: Exception) {
                 err.printStackTrace()
-            }
             return null
-        }
-
         private fun insertIntoUsers(jsonDoc: JsonObject?, user: RealmUserModel, settings: SharedPreferences) {
             if (jsonDoc == null) return
-
             val planetCodes = JsonUtils.getString("planetCode", jsonDoc)
             val rolesArray = JsonUtils.getJsonArray("roles", jsonDoc)
             val newId = JsonUtils.getString("_id", jsonDoc)
-
             user.apply {
                 _rev = JsonUtils.getString("_rev", jsonDoc)
                 _id = newId
@@ -329,73 +267,48 @@ open class RealmUserModel : RealmObject() {
                 setRoles(RealmList<String?>().apply {
                     for (i in 0 until rolesArray.size()) {
                         add(JsonUtils.getString(rolesArray, i))
-                    }
                 })
                 userAdmin = JsonUtils.getBoolean("isUserAdmin", jsonDoc)
                 val newJoinDate = JsonUtils.getLong("joinDate", jsonDoc)
                 if (newJoinDate != 0L || joinDate == 0L) {
                     joinDate = newJoinDate
-                }
-
                 val newFirstName = JsonUtils.getString("firstName", jsonDoc)
                 if (newFirstName.isNotEmpty() || firstName.isNullOrEmpty()) {
                     firstName = newFirstName
-                }
-
                 val newLastName = JsonUtils.getString("lastName", jsonDoc)
                 if (newLastName.isNotEmpty() || lastName.isNullOrEmpty()) {
                     lastName = newLastName
-                }
-
                 val newMiddleName = JsonUtils.getString("middleName", jsonDoc)
                 if (newMiddleName.isNotEmpty() || middleName.isNullOrEmpty()) {
                     middleName = newMiddleName
-                }
-
                 val newEmail = JsonUtils.getString("email", jsonDoc)
                 if (newEmail.isNotEmpty() || email.isNullOrEmpty()) {
                     email = newEmail
-                }
-
                 val newPhoneNumber = JsonUtils.getString("phoneNumber", jsonDoc)
                 if (newPhoneNumber.isNotEmpty() || phoneNumber.isNullOrEmpty()) {
                     phoneNumber = newPhoneNumber
-                }
-
                 val newLevel = JsonUtils.getString("level", jsonDoc)
                 if (newLevel.isNotEmpty() || level.isNullOrEmpty()) {
                     level = newLevel
-                }
-
                 val newLanguage = JsonUtils.getString("language", jsonDoc)
                 if (newLanguage.isNotEmpty() || language.isNullOrEmpty()) {
                     language = newLanguage
-                }
-
                 val newGender = JsonUtils.getString("gender", jsonDoc)
                 if (newGender.isNotEmpty() || gender.isNullOrEmpty()) {
                     gender = newGender
-                }
-
                 val newDob = JsonUtils.getString("birthDate", jsonDoc)
                 if (newDob.isNotEmpty() || dob.isNullOrEmpty()) {
                     dob = newDob
-                }
-
                 val newBirthPlace = JsonUtils.getString("birthPlace", jsonDoc)
                 if (newBirthPlace.isNotEmpty() || birthPlace.isNullOrEmpty()) {
                     birthPlace = newBirthPlace
-                }
-
                 val newAge = JsonUtils.getString("age", jsonDoc)
                 if (newAge.isNotEmpty() || age.isNullOrEmpty()) {
                     age = newAge
-                }
                 planetCode = planetCodes
                 parentCode = JsonUtils.getString("parentCode", jsonDoc)
                 if (_id?.isEmpty() == true) {
                     password = JsonUtils.getString("password", jsonDoc)
-                }
                 password_scheme = JsonUtils.getString("password_scheme", jsonDoc)
                 iterations = JsonUtils.getString("iterations", jsonDoc)
                 derived_key = JsonUtils.getString("derived_key", jsonDoc)
@@ -403,20 +316,12 @@ open class RealmUserModel : RealmObject() {
                 isShowTopbar = true
                 isArchived = JsonUtils.getBoolean("isArchived", jsonDoc)
                 addImageUrl(jsonDoc)
-            }
-
             if (planetCodes.isNotEmpty()) {
                 settings.edit { putString("planetCode", planetCodes) }
-            }
-        }
-
-        @JvmStatic
         fun isUserExists(realm: Realm, name: String?): Boolean {
             return realm.where(RealmUserModel::class.java)
                 .equalTo("name", name)
                 .not().beginsWith("_id", "guest").count() > 0
-        }
-
         fun updateUserDetails(realm: Realm, userId: String?, firstName: String?, lastName: String?,
         middleName: String?, email: String?, phoneNumber: String?, level: String?, language: String?,
         gender: String?, dob: String?, onSuccess: () -> Unit) {
@@ -433,19 +338,13 @@ open class RealmUserModel : RealmObject() {
                     user.gender = gender
                     user.dob = dob
                     user.isUpdated = true
-                }
             }, {
                 onSuccess.invoke()
                 Utilities.toast(context, "User details updated successfully")
             }) {
                 Utilities.toast(context, "User details update failed")
-            }
-        }
-
-        @JvmStatic
         fun parseLeadersJson(jsonString: String): List<RealmUserModel> {
             val leadersList = mutableListOf<RealmUserModel>()
-            try {
                 val jsonObject = JSONObject(jsonString)
                 val docsArray = jsonObject.getJSONArray("docs")
                 for (i in 0 until docsArray.length()) {
@@ -454,27 +353,18 @@ open class RealmUserModel : RealmObject() {
                     user.name = docObject.getString("name")
                     if (!docObject.isNull("firstName")) {
                         user.firstName = docObject.getString("firstName")
-                    }
                     if (!docObject.isNull("lastName")) {
                         user.lastName = docObject.getString("lastName")
-                    }
                     if (!docObject.isNull("email")) {
                         user.email = docObject.getString("email")
-                    }
                     leadersList.add(user)
-                }
             } catch (e: JSONException) {
                 e.printStackTrace()
-            }
             return leadersList
-        }
-
-        @JvmStatic
         fun cleanupDuplicateUsers(realm: Realm) {
             realm.executeTransaction { mRealm ->
                 val allUsers = mRealm.where(RealmUserModel::class.java).findAll()
                 val usersByName = allUsers.groupBy { it.name }
-
                 usersByName.forEach { (_, users) ->
                     if (users.size > 1) {
                         val sortedUsers = users.sortedWith { user1, user2 ->
@@ -484,15 +374,6 @@ open class RealmUserModel : RealmObject() {
                                 user1._id?.startsWith("guest_") == true &&
                                         user2._id?.startsWith("org.couchdb.user:") == true -> 1
                                 else -> 0
-                            }
-                        }
-
                         for (i in 1 until sortedUsers.size) {
                             sortedUsers[i].deleteFromRealm()
-                        }
-                    }
-                }
-            }
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
@@ -23,6 +23,7 @@ import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils
+
 open class RealmUserModel : RealmObject() {
     @PrimaryKey
     var id: String? = null
@@ -56,6 +57,7 @@ open class RealmUserModel : RealmObject() {
     var isUpdated = false
     var isShowTopbar = false
     var isArchived = false
+
     fun serialize(): JsonObject {
         val jsonObject = JsonObject()
         if (_id?.isNotEmpty() == true) {
@@ -73,6 +75,7 @@ open class RealmUserModel : RealmObject() {
             jsonObject.addProperty("derived_key", derived_key)
             jsonObject.addProperty("salt", salt)
             jsonObject.addProperty("password_scheme", password_scheme)
+        }
         jsonObject.addProperty("isUserAdmin", userAdmin)
         jsonObject.addProperty("joinDate", joinDate)
         jsonObject.addProperty("firstName", firstName)
@@ -91,20 +94,27 @@ open class RealmUserModel : RealmObject() {
         } catch (e: NumberFormatException) {
             e.printStackTrace()
             jsonObject.addProperty("iterations", 10)
+        }
         jsonObject.addProperty("parentCode", parentCode)
         jsonObject.addProperty("planetCode", planetCode)
         jsonObject.addProperty("birthPlace", birthPlace)
         jsonObject.addProperty("isArchived", isArchived)
+
         val base64Image = encodeImageToBase64(userImage)
+
         if (!base64Image.isNullOrEmpty()) {
             val attachmentObject = JsonObject()
             val imageData = JsonObject()
             imageData.addProperty("content_type", "image/jpeg")
             imageData.addProperty("data", base64Image)
+
             attachmentObject.add("img", imageData)
             jsonObject.add("_attachments", attachmentObject)
+        }
+
         return jsonObject
     }
+
     fun encodeImageToBase64(imagePath: String?): String? {
         if (imagePath.isNullOrEmpty()) return null
         return try {
@@ -114,24 +124,41 @@ open class RealmUserModel : RealmObject() {
             } else {
                 File(imagePath).inputStream()
             }
+
             inputStream?.use {
                 val bytes = it.readBytes()
                 Base64.encodeToString(bytes, Base64.NO_WRAP)
+            }
         } catch (e: Exception) {
+            e.printStackTrace()
             null
+        }
+    }
+
     private fun getRoles(): JsonArray {
         val ar = JsonArray()
         for (s in rolesList ?: emptyList())    {
             ar.add(s)
+        }
         return ar
+    }
+
     fun setRoles(roles: RealmList<String?>?) {
         rolesList = roles
+    }
+
     fun getRoleAsString(): String {
         return StringUtils.join(rolesList, ",")
+    }
+
     fun getFullName(): String {
         return "$firstName $lastName"
+    }
+
     fun getFullNameWithMiddleName(): String {
         return "$firstName ${middleName ?: ""} $lastName"
+    }
+
     fun addImageUrl(jsonDoc: JsonObject?) {
         if (jsonDoc?.has("_attachments") == true) {
             val element = JsonParser.parseString(jsonDoc["_attachments"].asJsonObject.toString())
@@ -140,18 +167,31 @@ open class RealmUserModel : RealmObject() {
             for ((key1) in entries) {
                 userImage = Utilities.getUserImageUrl(id, key1)
                 break
+            }
+        }
+    }
+
     fun isManager(): Boolean {
         val roles = getRoles()
         val isManager = roles.toString().lowercase(Locale.ROOT).contains("manager") || userAdmin ?: false
         return isManager
+    }
+
     fun isLeader(): Boolean {
+        val roles = getRoles()
         return roles.toString().lowercase(Locale.ROOT).contains("leader")
+    }
+
     fun isGuest(): Boolean {
         val hasGuestId = _id?.startsWith("guest_") == true
         val hasGuestRole = rolesList?.any { it?.lowercase() == "guest" } == true
         return hasGuestId || (hasGuestRole && rolesList?.any { it?.lowercase() == "learner" } != true)
+    }
+
     override fun toString(): String {
         return "$name"
+    }
+
     companion object {
         @JvmStatic
         fun createGuestUser(username: String?, mRealm: Realm, settings: SharedPreferences): RealmUserModel? {
@@ -164,22 +204,28 @@ open class RealmUserModel : RealmObject() {
             `object`.add("roles", rolesArray)
             if (!mRealm.isInTransaction) mRealm.beginTransaction()
             return populateUsersTable(`object`, mRealm, settings)
+        }
+
+        @JvmStatic
         fun populateUsersTable(jsonDoc: JsonObject?, mRealm: Realm?, settings: SharedPreferences): RealmUserModel? {
             if (jsonDoc == null || mRealm == null) return null
             try {
                 val id = JsonUtils.getString("_id", jsonDoc).takeIf { it.isNotEmpty() } ?: UUID.randomUUID().toString()
                 val userName = JsonUtils.getString("name", jsonDoc)
                 var user: RealmUserModel? = null
+
                 if (!mRealm.isInTransaction) {
                     mRealm.executeTransaction { realm ->
                         user = realm.where(RealmUserModel::class.java)
                             .equalTo("_id", id)
                             .findFirst()
+
                         if (user == null && id.startsWith("org.couchdb.user:") && userName.isNotEmpty()) {
                             val guestUser = realm.where(RealmUserModel::class.java)
                                 .equalTo("name", userName)
                                 .beginsWith("_id", "guest_")
                                 .findFirst()
+
                             if (guestUser != null) {
                                 val tempData = JsonObject()
                                 tempData.addProperty("_id", id)
@@ -199,6 +245,7 @@ open class RealmUserModel : RealmObject() {
                                 tempData.addProperty("joinDate", guestUser.joinDate)
                                 tempData.addProperty("isShowTopbar", guestUser.isShowTopbar)
                                 tempData.addProperty("isArchived", guestUser.isArchived)
+
                                 val rolesArray = JsonArray()
                                 guestUser.rolesList?.forEach { role ->
                                     rolesArray.add(role)
@@ -209,18 +256,23 @@ open class RealmUserModel : RealmObject() {
                                 insertIntoUsers(tempData, user!!, settings)
                             }
                         }
+
                         if (user == null) {
                             user = realm.createObject(RealmUserModel::class.java, id)
+                        }
                         insertIntoUsers(jsonDoc, user!!, settings)
                     }
                 } else {
                     user = mRealm.where(RealmUserModel::class.java)
                         .equalTo("_id", id)
                         .findFirst()
+
                     if (user == null && id.startsWith("org.couchdb.user:") && userName.isNotEmpty()) {
                         val guestUser = mRealm.where(RealmUserModel::class.java)
                             .equalTo("name", userName)
                             .beginsWith("_id", "guest_")
+                            .findFirst()
+
                         if (guestUser != null) {
                             val tempData = JsonObject()
                             tempData.addProperty("_id", id)
@@ -243,23 +295,33 @@ open class RealmUserModel : RealmObject() {
                             val rolesArray = JsonArray()
                             guestUser.rolesList?.forEach { role ->
                                 rolesArray.add(role)
+                            }
                             tempData.add("roles", rolesArray)
                             guestUser.deleteFromRealm()
                             user = mRealm.createObject(RealmUserModel::class.java, id)
                             insertIntoUsers(tempData, user!!, settings)
+                        }
+                    }
+
                     if (user == null) {
                         user = mRealm.createObject(RealmUserModel::class.java, id)
+                    }
                     insertIntoUsers(jsonDoc, user!!, settings)
                 }
                 return user
             } catch (err: Exception) {
                 err.printStackTrace()
+            }
             return null
+        }
+
         private fun insertIntoUsers(jsonDoc: JsonObject?, user: RealmUserModel, settings: SharedPreferences) {
             if (jsonDoc == null) return
+
             val planetCodes = JsonUtils.getString("planetCode", jsonDoc)
             val rolesArray = JsonUtils.getJsonArray("roles", jsonDoc)
             val newId = JsonUtils.getString("_id", jsonDoc)
+
             user.apply {
                 _rev = JsonUtils.getString("_rev", jsonDoc)
                 _id = newId
@@ -267,48 +329,73 @@ open class RealmUserModel : RealmObject() {
                 setRoles(RealmList<String?>().apply {
                     for (i in 0 until rolesArray.size()) {
                         add(JsonUtils.getString(rolesArray, i))
+                    }
                 })
                 userAdmin = JsonUtils.getBoolean("isUserAdmin", jsonDoc)
                 val newJoinDate = JsonUtils.getLong("joinDate", jsonDoc)
                 if (newJoinDate != 0L || joinDate == 0L) {
                     joinDate = newJoinDate
+                }
+
                 val newFirstName = JsonUtils.getString("firstName", jsonDoc)
                 if (newFirstName.isNotEmpty() || firstName.isNullOrEmpty()) {
                     firstName = newFirstName
+                }
+
                 val newLastName = JsonUtils.getString("lastName", jsonDoc)
                 if (newLastName.isNotEmpty() || lastName.isNullOrEmpty()) {
                     lastName = newLastName
+                }
+
                 val newMiddleName = JsonUtils.getString("middleName", jsonDoc)
                 if (newMiddleName.isNotEmpty() || middleName.isNullOrEmpty()) {
                     middleName = newMiddleName
+                }
+
                 val newEmail = JsonUtils.getString("email", jsonDoc)
                 if (newEmail.isNotEmpty() || email.isNullOrEmpty()) {
                     email = newEmail
+                }
+
                 val newPhoneNumber = JsonUtils.getString("phoneNumber", jsonDoc)
                 if (newPhoneNumber.isNotEmpty() || phoneNumber.isNullOrEmpty()) {
                     phoneNumber = newPhoneNumber
+                }
+
                 val newLevel = JsonUtils.getString("level", jsonDoc)
                 if (newLevel.isNotEmpty() || level.isNullOrEmpty()) {
                     level = newLevel
+                }
+
                 val newLanguage = JsonUtils.getString("language", jsonDoc)
                 if (newLanguage.isNotEmpty() || language.isNullOrEmpty()) {
                     language = newLanguage
+                }
+
                 val newGender = JsonUtils.getString("gender", jsonDoc)
                 if (newGender.isNotEmpty() || gender.isNullOrEmpty()) {
                     gender = newGender
+                }
+
                 val newDob = JsonUtils.getString("birthDate", jsonDoc)
                 if (newDob.isNotEmpty() || dob.isNullOrEmpty()) {
                     dob = newDob
+                }
+
                 val newBirthPlace = JsonUtils.getString("birthPlace", jsonDoc)
                 if (newBirthPlace.isNotEmpty() || birthPlace.isNullOrEmpty()) {
                     birthPlace = newBirthPlace
+                }
+
                 val newAge = JsonUtils.getString("age", jsonDoc)
                 if (newAge.isNotEmpty() || age.isNullOrEmpty()) {
                     age = newAge
+                }
                 planetCode = planetCodes
                 parentCode = JsonUtils.getString("parentCode", jsonDoc)
                 if (_id?.isEmpty() == true) {
                     password = JsonUtils.getString("password", jsonDoc)
+                }
                 password_scheme = JsonUtils.getString("password_scheme", jsonDoc)
                 iterations = JsonUtils.getString("iterations", jsonDoc)
                 derived_key = JsonUtils.getString("derived_key", jsonDoc)
@@ -316,12 +403,20 @@ open class RealmUserModel : RealmObject() {
                 isShowTopbar = true
                 isArchived = JsonUtils.getBoolean("isArchived", jsonDoc)
                 addImageUrl(jsonDoc)
+            }
+
             if (planetCodes.isNotEmpty()) {
                 settings.edit { putString("planetCode", planetCodes) }
+            }
+        }
+
+        @JvmStatic
         fun isUserExists(realm: Realm, name: String?): Boolean {
             return realm.where(RealmUserModel::class.java)
                 .equalTo("name", name)
                 .not().beginsWith("_id", "guest").count() > 0
+        }
+
         fun updateUserDetails(realm: Realm, userId: String?, firstName: String?, lastName: String?,
         middleName: String?, email: String?, phoneNumber: String?, level: String?, language: String?,
         gender: String?, dob: String?, onSuccess: () -> Unit) {
@@ -338,13 +433,19 @@ open class RealmUserModel : RealmObject() {
                     user.gender = gender
                     user.dob = dob
                     user.isUpdated = true
+                }
             }, {
                 onSuccess.invoke()
                 Utilities.toast(context, "User details updated successfully")
             }) {
                 Utilities.toast(context, "User details update failed")
+            }
+        }
+
+        @JvmStatic
         fun parseLeadersJson(jsonString: String): List<RealmUserModel> {
             val leadersList = mutableListOf<RealmUserModel>()
+            try {
                 val jsonObject = JSONObject(jsonString)
                 val docsArray = jsonObject.getJSONArray("docs")
                 for (i in 0 until docsArray.length()) {
@@ -353,18 +454,27 @@ open class RealmUserModel : RealmObject() {
                     user.name = docObject.getString("name")
                     if (!docObject.isNull("firstName")) {
                         user.firstName = docObject.getString("firstName")
+                    }
                     if (!docObject.isNull("lastName")) {
                         user.lastName = docObject.getString("lastName")
+                    }
                     if (!docObject.isNull("email")) {
                         user.email = docObject.getString("email")
+                    }
                     leadersList.add(user)
+                }
             } catch (e: JSONException) {
                 e.printStackTrace()
+            }
             return leadersList
+        }
+
+        @JvmStatic
         fun cleanupDuplicateUsers(realm: Realm) {
             realm.executeTransaction { mRealm ->
                 val allUsers = mRealm.where(RealmUserModel::class.java).findAll()
                 val usersByName = allUsers.groupBy { it.name }
+
                 usersByName.forEach { (_, users) ->
                     if (users.size > 1) {
                         val sortedUsers = users.sortedWith { user1, user2 ->
@@ -374,6 +484,15 @@ open class RealmUserModel : RealmObject() {
                                 user1._id?.startsWith("guest_") == true &&
                                         user2._id?.startsWith("org.couchdb.user:") == true -> 1
                                 else -> 0
+                            }
+                        }
+
                         for (i in 1 until sortedUsers.size) {
                             sortedUsers[i].deleteFromRealm()
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/service/StayOnlineWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/StayOnlineWorker.kt
@@ -8,10 +8,11 @@ import androidx.work.WorkerParameters
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 class StayOnlineWorker(private val context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
     override fun doWork(): Result {
         if (showBetaFeature(Constants.KEY_SYNC, context)) {
-            if (isWifiConnected()) {
+            if (networkUtils.isWifiConnected()) {
                 LocalBroadcastManager.getInstance(context).sendBroadcast(Intent("SHOW_WIFI_ALERT"))
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/service/StayOnlineWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/StayOnlineWorker.kt
@@ -7,8 +7,7 @@ import androidx.work.Worker
 import androidx.work.WorkerParameters
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
-import org.ole.planet.myplanet.utilities.NetworkUtils.isWifiConnected
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 class StayOnlineWorker(private val context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
     override fun doWork(): Result {
         if (showBetaFeature(Constants.KEY_SYNC, context)) {

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
@@ -21,7 +21,9 @@ import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils.getAndroidId
 import retrofit2.*
+
 private const val BATCH_SIZE = 50
+
 private inline fun <T> Iterable<T>.processInBatches(action: (T) -> Unit) {
     chunked(BATCH_SIZE).forEach { chunk ->
         chunk.forEach { item ->
@@ -29,9 +31,11 @@ private inline fun <T> Iterable<T>.processInBatches(action: (T) -> Unit) {
         }
     }
 }
+
 class UploadManager(var context: Context) : FileUploadService() {
     var pref: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val dbService: DatabaseService = DatabaseService(context)
+
     companion object {
         var instance: UploadManager? = null
             get() {
@@ -41,8 +45,12 @@ class UploadManager(var context: Context) : FileUploadService() {
                 return field
             }
             private set
+    }
+
     private fun getRealm(): Realm {
         return dbService.realmInstance
+    }
+
     private fun uploadNewsActivities() {
         val apiInterface = client?.create(ApiInterface::class.java)
         val realm = getRealm()
@@ -50,9 +58,11 @@ class UploadManager(var context: Context) : FileUploadService() {
             val newsLog: List<RealmNewsLog> = realm.where(RealmNewsLog::class.java)
                 .isNull("_id").or().isEmpty("_id")
                 .findAll()
+
             newsLog.processInBatches { news ->
                     try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/myplanet_activities", RealmNewsLog.serialize(news))?.execute()?.body()
+
                         if (`object` != null) {
                             news._id = getString("id", `object`)
                             news._rev = getString("rev", `object`)
@@ -60,49 +70,97 @@ class UploadManager(var context: Context) : FileUploadService() {
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
+            }
+        }
+
+    }
+
     fun uploadActivities(listener: SuccessListener?) {
+        val apiInterface = client?.create(ApiInterface::class.java)
         val model = UserProfileDbHandler(MainApplication.context).userModel ?: run {
             listener?.onSuccess("Cannot upload activities: user model is null")
             return
+        }
+
         if (model.isManager()) {
             listener?.onSuccess("Skipping activities upload for manager")
+            return
+        }
+
         try {
             apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/myplanet_activities", MyPlanet.getNormalMyPlanetActivities(MainApplication.context, pref, model))?.enqueue(object : Callback<JsonObject?> {
                 override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {}
+
                 override fun onFailure(call: Call<JsonObject?>, t: Throwable) {}
             })
+
             apiInterface?.getJsonObject(Utilities.header, "${Utilities.getUrl()}/myplanet_activities/${getAndroidId(MainApplication.context)}@${networkUtils.getUniqueIdentifier()}")?.enqueue(object : Callback<JsonObject?> {
                 override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
                     var `object` = response.body()
+
                     if (`object` != null) {
                         val usages = `object`.getAsJsonArray("usages")
                         usages.addAll(MyPlanet.getTabletUsages(context))
                         `object`.add("usages", usages)
                     } else {
                         `object` = MyPlanet.getMyPlanetActivities(context, pref, model)
+                    }
+
                     apiInterface.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/myplanet_activities", `object`).enqueue(object : Callback<JsonObject?> {
                         override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
                             listener?.onSuccess("My planet activities uploaded successfully")
+                        }
+
                         override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
                             listener?.onSuccess("Failed to upload activities: ${t.message}")
+                        }
                     })
+                }
+
                 override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
                     val `object` = MyPlanet.getMyPlanetActivities(context, pref, model)
+                    apiInterface.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/myplanet_activities", `object`).enqueue(object : Callback<JsonObject?> {
+                        override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
+                            listener?.onSuccess("My planet activities uploaded successfully")
+                        }
+
+                        override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
+                            listener?.onSuccess("Failed to upload activities: ${t.message}")
+                        }
+                    })
+                }
+            })
         } catch (e: Exception) {
             e.printStackTrace()
             listener?.onSuccess("Failed to upload activities: ${e.message}")
+        }
+    }
+
     fun uploadExamResult(listener: SuccessListener) {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+
         realm.executeTransactionAsync({ realm: Realm ->
             val submissions: List<RealmSubmission> = realm.where(RealmSubmission::class.java).findAll()
+
             submissions.processInBatches { sub ->
+                    try {
                         if ((sub.answers?.size ?: 0) > 0) {
                             RealmSubmission.continueResultUpload(sub, apiInterface, realm, context)
+                        }
                     } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
+            }
         }, {
             uploadCourseProgress()
             listener.onSuccess("Result sync completed successfully")
         }) { e: Throwable ->
+            e.printStackTrace()
             listener.onSuccess("Error during result sync: ${e.message}")
+        }
+    }
+
     private fun createImage(user: RealmUserModel?, imgObject: JsonObject?): JsonObject {
         val `object` = JsonObject()
         `object`.addProperty("title", getString("fileName", imgObject))
@@ -119,37 +177,75 @@ class UploadManager(var context: Context) : FileUploadService() {
         `object`.add("privateFor", object1)
         `object`.addProperty("mediaType", "image")
         return `object`
+    }
+
     fun uploadAchievement() {
+        val realm = getRealm()
+        realm.executeTransactionAsync { realm: Realm ->
             val list: List<RealmAchievement> = realm.where(RealmAchievement::class.java).findAll()
             list.processInBatches { sub ->
                 try {
                     if (sub._id?.startsWith("guest") == true) {
                         return@processInBatches
+                    }
                 } catch (e: IOException) {
                     e.printStackTrace()
+                }
+            }
+        }
+
+    }
+
     private fun uploadCourseProgress() {
+        val apiInterface = client?.create(ApiInterface::class.java)
+        val realm = getRealm()
+        realm.executeTransactionAsync { realm: Realm ->
             val data: List<RealmCourseProgress> = realm.where(RealmCourseProgress::class.java).isNull("_id").findAll()
             var successCount = 0
             var skipCount = 0
             var errorCount = 0
+
             data.processInBatches { sub ->
+                    try {
                         if (sub.userId?.startsWith("guest") == true) {
                             skipCount++
                             return@processInBatches
+                        }
+
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/courses_progress", RealmCourseProgress.serializeProgress(sub))?.execute()?.body()
+                        if (`object` != null) {
                             sub._id = getString("id", `object`)
                             sub._rev = getString("rev", `object`)
                             successCount++
                         } else {
                             errorCount++
+                        }
+                    } catch (e: IOException) {
                         errorCount++
+                        e.printStackTrace()
+                    }
+            }
+
+        }
+    }
+
     fun uploadFeedback(listener: SuccessListener) {
+        val apiInterface = client?.create(ApiInterface::class.java)
+        val realm = getRealm()
         realm.executeTransactionAsync(Realm.Transaction { realm: Realm ->
             val feedbacks: List<RealmFeedback> = realm.where(RealmFeedback::class.java).findAll()
+
             if (feedbacks.isEmpty()) {
                 return@Transaction
+            }
+
+            var successCount = 0
+            var errorCount = 0
+
             feedbacks.processInBatches { feedback ->
+                try {
                     val res: Response<JsonObject>? = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/feedback", RealmFeedback.serializeFeedback(feedback))?.execute()
+
                     val r = res?.body()
                     if (r != null) {
                         val revElement = r["rev"]
@@ -157,80 +253,176 @@ class UploadManager(var context: Context) : FileUploadService() {
                         if (revElement != null && idElement != null) {
                             feedback._rev = revElement.asString
                             feedback._id = idElement.asString
+                            successCount++
+                        } else {
+                            errorCount++
+                        }
+                    } else {
+                        errorCount++
+                    }
+                } catch (e: IOException) {
                     errorCount++
+                    e.printStackTrace()
+                }
+            }
+        }, {
             listener.onSuccess("Feedback sync completed successfully")
         }, { error ->
             listener.onSuccess("Feedback sync failed: ${error.message}")
             error.printStackTrace()
         })
+    }
+
     fun uploadSubmitPhotos(listener: SuccessListener?) {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+        realm.executeTransactionAsync { realm: Realm ->
             val data: List<RealmSubmitPhotos> = realm.where(RealmSubmitPhotos::class.java).equalTo("uploaded", false).findAll()
+            data.processInBatches { sub ->
+                    try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/submissions", RealmSubmitPhotos.serializeRealmSubmitPhotos(sub))?.execute()?.body()
+                        if (`object` != null) {
                             val rev = getString("rev", `object`)
                             val id = getString("id", `object`)
                             sub.uploaded = true
                             sub._rev = rev
                             sub._id = id
                             uploadAttachment(id, rev, sub, listener!!)
+                        }
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
+            }
             if (data.isEmpty()) {
                 listener?.onSuccess("No photos to upload")
+            }
+        }
+    }
+
     fun uploadResource(listener: SuccessListener?) {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+
+        realm.executeTransactionAsync({ realm: Realm ->
             val user = realm.where(RealmUserModel::class.java)
                 .equalTo("id", pref.getString("userId", ""))
                 .findFirst()
+
             val data: List<RealmMyLibrary> = realm.where(RealmMyLibrary::class.java)
                 .isNull("_rev")
+                .findAll()
+
+            if (data.isEmpty()) {
                 return@executeTransactionAsync
+            }
+
+            data.processInBatches { sub ->
+                try {
                     val `object` = apiInterface?.postDoc(
                         Utilities.header,
                         "application/json",
                         "${Utilities.getUrl()}/resources",
                         RealmMyLibrary.serialize(sub, user)
                     )?.execute()?.body()
+
+                    if (`object` != null) {
                         val rev = getString("rev", `object`)
                         val id = getString("id", `object`)
                         sub._rev = rev
                         sub._id = id
                         uploadAttachment(id, rev, sub, listener!!)
+                    }
                 } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
+        }, {
             listener?.onSuccess("No resources to upload")
         }) { error ->
             listener?.onSuccess("Resource upload failed: ${error.message}")
+        }
+    }
+
     fun uploadMyPersonal(personal: RealmMyPersonal, listener: SuccessListener) {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+
         if (!personal.isUploaded) {
             apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/resources", RealmMyPersonal.serialize(personal, context))?.enqueue(object : Callback<JsonObject?> {
+                override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
                     val `object` = response.body()
+                    if (`object` != null) {
                         try {
                             if (!realm.isInTransaction) {
                                 realm.beginTransaction()
                             }
+                            val rev = getString("rev", `object`)
+                            val id = getString("id", `object`)
                             personal.isUploaded = true
                             personal._rev = rev
                             personal._id = id
                             realm.commitTransaction()
+
                             uploadAttachment(id, rev, personal, listener)
                         } catch (e: Exception) {
                             if (realm.isInTransaction) {
                                 realm.cancelTransaction()
+                            }
                             listener.onSuccess("Error updating personal resource: ${e.message}")
+                        }
+                    } else {
                         listener.onSuccess("Failed to upload personal resource: No response")
+                    }
+                }
+
+                override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
                     listener.onSuccess("Unable to upload resource: ${t.message}")
+                }
+            })
         } else {
             listener.onSuccess("Resource already uploaded")
+        }
+    }
+
     fun uploadTeamTask() {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+        realm.executeTransactionAsync { realm: Realm ->
             val list: List<RealmTeamTask> = realm.where(RealmTeamTask::class.java).findAll()
             val tasksToUpload = list.filter { task ->
                 TextUtils.isEmpty(task._id) || task.isUpdated
+            }
+
             tasksToUpload.processInBatches { task ->
+                    try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/tasks", RealmTeamTask.serialize(realm, task))?.execute()?.body()
+
+                        if (`object` != null) {
+                            val rev = getString("rev", `object`)
+                            val id = getString("id", `object`)
                             task._rev = rev
                             task._id = id
+                        }
+                    } catch (e: IOException) {
+                        e.printStackTrace()
+                    }
+            }
+        }
+    }
+
     fun uploadSubmissions() {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+
+        realm.executeTransactionAsync { realm: Realm ->
             val list: List<RealmSubmission> = realm.where(RealmSubmission::class.java)
                 .equalTo("isUpdated", true).or().isEmpty("_id").findAll()
+
             list.processInBatches { submission ->
+                    try {
                         val requestJson = RealmSubmission.serialize(realm, submission)
                         val response = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/submissions", requestJson)?.execute()
+
                         val jsonObject = response?.body()
                         if (jsonObject != null) {
                             val rev = getString("rev", jsonObject)
@@ -238,54 +430,141 @@ class UploadManager(var context: Context) : FileUploadService() {
                             submission._rev = rev
                             submission._id = id
                             submission.isUpdated = false
+                        }
+                    } catch (e: IOException) {
+                        e.printStackTrace()
+                    }
+            }
+        }
+    }
+
     fun uploadTeams() {
+        val apiInterface = client?.create(ApiInterface::class.java)
+        val realm = getRealm()
+
+        realm.executeTransactionAsync { realm: Realm ->
             val teams: List<RealmMyTeam> = realm.where(RealmMyTeam::class.java).equalTo("updated", true).findAll()
             teams.processInBatches { team ->
+                    try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/teams", RealmMyTeam.serialize(team))?.execute()?.body()
+                        if (`object` != null) {
                             team._rev = getString("rev", `object`)
                             team.updated = false
+                        }
+                    } catch (e: IOException) {
+                        e.printStackTrace()
+                    }
+            }
+        }
+    }
+
     fun uploadUserActivities(listener: SuccessListener) {
+        val apiInterface = client?.create(ApiInterface::class.java)
+        val model = UserProfileDbHandler(MainApplication.context).userModel ?: run {
             listener.onSuccess("Cannot upload user activities: user model is null")
+            return
+        }
+
+        if (model.isManager()) {
             listener.onSuccess("Skipping user activities upload for manager")
+            return
+        }
+
+        val realm = getRealm()
         realm.executeTransactionAsync({ transactionRealm: Realm ->
             val activities = transactionRealm.where(RealmOfflineActivity::class.java).isNull("_rev").equalTo("type", "login").findAll()
+
             activities.processInBatches { act ->
+                try {
                     if (act.userId?.startsWith("guest") == true) {
+                        return@processInBatches
+                    }
+
                     val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/login_activities", RealmOfflineActivity.serializeLoginActivities(act, context))?.execute()?.body()
                     act.changeRev(`object`)
+                } catch (e: IOException) {
+                    e.printStackTrace()
+                }
+            }
             uploadTeamActivities(transactionRealm, apiInterface)
+        }, {
             realm.close()
             listener.onSuccess("User activities sync completed successfully")
+        }) { e: Throwable ->
+            realm.close()
+            e.printStackTrace()
             listener.onSuccess(e.message)
+        }
+    }
+
     fun uploadTeamActivities(realm: Realm, apiInterface: ApiInterface?) {
         val logs = realm.where(RealmTeamLog::class.java).isNull("_rev").findAll()
         logs.processInBatches { log ->
+                try {
                     val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/team_activities", RealmTeamLog.serializeTeamActivities(log, context))?.execute()?.body()
+                    if (`object` != null) {
                         log._id = getString("id", `object`)
                         log._rev = getString("rev", `object`)
+                    }
+                } catch (e: IOException) {
+                    e.printStackTrace()
+                }
+        }
+    }
+
     fun uploadRating() {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+
+        realm.executeTransactionAsync { realm: Realm ->
             val activities = realm.where(RealmRating::class.java).equalTo("isUpdated", true).findAll()
+            activities.processInBatches { act ->
+                    try {
                         if (act.userId?.startsWith("guest") == true) {
+                            return@processInBatches
+                        }
+
                         val `object`: Response<JsonObject>? =
                             if (TextUtils.isEmpty(act._id)) {
                                 apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/ratings", RealmRating.serializeRating(act))?.execute()
                             } else {
                                 apiInterface?.putDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/ratings/" + act._id, RealmRating.serializeRating(act))?.execute()
+                            }
                         if (`object`?.body() != null) {
                             act._id = getString("id", `object`.body())
                             act._rev = getString("rev", `object`.body())
                             act.isUpdated = false
+                        }
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
+            }
+        }
+    }
+
     fun uploadNews() {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+
+        realm.executeTransactionAsync { realm: Realm ->
             val activities = realm.where(RealmNews::class.java).findAll()
+            activities.processInBatches { act ->
+                    try {
+                        if (act.userId?.startsWith("guest") == true) {
+                            return@processInBatches
+                        }
+
                         val `object` = RealmNews.serializeNews(act)
                         val image = act.imagesArray
                         val user = realm.where(RealmUserModel::class.java).equalTo("id", pref.getString("userId", "")).findFirst()
+
                         if (act.imageUrls != null && act.imageUrls?.isNotEmpty() == true) {
                             act.imageUrls?.chunked(5)?.forEach { imageChunk ->
                                 imageChunk.forEach { imageObject ->
                                     val imgObject = Gson().fromJson(imageObject, JsonObject::class.java)
                                     val ob = createImage(user, imgObject)
                                     val response = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/resources", ob)?.execute()?.body()
+
                                     val rev = getString("rev", response)
                                     val id = getString("id", response)
                                     val f = File(getString("imageUrl", imgObject))
@@ -296,13 +575,16 @@ class UploadManager(var context: Context) : FileUploadService() {
                                     val body = FileUtils.fullyReadFileToBytes(f)
                                         .toRequestBody("application/octet-stream".toMediaTypeOrNull())
                                     val url = String.format(format, Utilities.getUrl(), id, name)
+
                                     val res = apiInterface?.uploadResource(getHeaderMap(mimeType, rev), url, body)?.execute()
                                     val attachment = res?.body()
+
                                     val resourceObject = JsonObject()
                                     resourceObject.addProperty("resourceId", getString("id", attachment))
                                     resourceObject.addProperty("filename", getString("fileName", imgObject))
                                     val markdown = "![](resources/" + getString("id", attachment) + "/" + getString("fileName", imgObject) + ")"
                                     resourceObject.addProperty("markdown", markdown)
+
                                     var msg = getString("message", `object`)
                                     msg += """
                                     
@@ -311,54 +593,158 @@ class UploadManager(var context: Context) : FileUploadService() {
                                     `object`.addProperty("message", msg)
                                     image.add(resourceObject)
                                 }
+                            }
+                        }
+
                         act.images = Gson().toJson(image)
                         `object`.add("images", image)
+
                         val newsUploadResponse: Response<JsonObject>? =
+                            if (TextUtils.isEmpty(act._id)) {
                                 apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/news", `object`)?.execute()
+                            } else {
                                 apiInterface?.putDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/news/" + act._id, `object`)?.execute()
+                            }
                         if (newsUploadResponse?.body() != null) {
                             act.imageUrls?.clear()
                             act._id = getString("id", newsUploadResponse.body())
                             act._rev = getString("rev", newsUploadResponse.body())
+                        }
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
+                }
+            }
         uploadNewsActivities()
+    }
+
     fun uploadCrashLog() {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+
+        try {
             val hasLooper = Looper.myLooper() != null
+
             if (hasLooper) {
                 realm.executeTransactionAsync { realm: Realm ->
                     uploadCrashLogData(realm, apiInterface)
+                }
             } else {
                 realm.executeTransaction { realm: Realm ->
+                    uploadCrashLogData(realm, apiInterface)
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
     private fun uploadCrashLogData(realm: Realm, apiInterface: ApiInterface?) {
         val logs: RealmResults<RealmApkLog> = realm.where(RealmApkLog::class.java).isNull("_rev").findAll()
+
         logs.processInBatches { act ->
+                try {
                     val o = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/apk_logs", RealmApkLog.serialize(act, context))?.execute()?.body()
+
                     if (o != null) {
                         act._rev = getString("rev", o)
+                    }
+                } catch (e: IOException) {
+                    e.printStackTrace()
+                }
+        }
+    }
+
     fun uploadSearchActivity() {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+        realm.executeTransactionAsync { realm: Realm ->
             val logs: RealmResults<RealmSearchActivity> = realm.where(RealmSearchActivity::class.java).isEmpty("_rev").findAll()
             logs.processInBatches { act ->
+                    try {
                         val o = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/search_activities", act.serialize())?.execute()?.body()
                         if (o != null) {
                             act._rev = getString("rev", o)
+                        }
+                    } catch (e: IOException) {
+                        e.printStackTrace()
+                    }
+            }
+        }
+
+    }
+
     fun uploadResourceActivities(type: String) {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+
         val db = if (type == "sync") {
             "admin_activities"
+        } else {
             "resource_activities"
+        }
+
+        realm.executeTransactionAsync { realm: Realm ->
             val activities: RealmResults<RealmResourceActivity> =
                 if (type == "sync") {
                     realm.where(RealmResourceActivity::class.java).isNull("_rev").equalTo("type", "sync").findAll()
                 } else {
                     realm.where(RealmResourceActivity::class.java).isNull("_rev").notEqualTo("type", "sync").findAll()
+                }
+            activities.processInBatches { act ->
+                    try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/" + db, RealmResourceActivity.serializeResourceActivities(act))?.execute()?.body()
+
+                        if (`object` != null) {
                             act._rev = getString("rev", `object`)
                             act._id = getString("id", `object`)
+                        }
+                    } catch (e: IOException) {
+                        e.printStackTrace()
+                    }
+            }
+        }
+    }
+
     fun uploadCourseActivities() {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+
+        realm.executeTransactionAsync { realm: Realm ->
             val activities: RealmResults<RealmCourseActivity> = realm.where(RealmCourseActivity::class.java).isNull("_rev").notEqualTo("type", "sync").findAll()
+            activities.processInBatches { act ->
+                    try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/course_activities", RealmCourseActivity.serializeSerialize(act))?.execute()?.body()
+
+                        if (`object` != null) {
+                            act._rev = getString("rev", `object`)
+                            act._id = getString("id", `object`)
+                        }
+                    } catch (e: IOException) {
+                        e.printStackTrace()
+                    }
+            }
+        }
+    }
+
     fun uploadMeetups() {
+        val realm = getRealm()
+        val apiInterface = client?.create(ApiInterface::class.java)
+        realm.executeTransactionAsync { realm: Realm ->
             val meetups: List<RealmMeetup> = realm.where(RealmMeetup::class.java).findAll()
             meetups.processInBatches { meetup ->
+                    try {
                         val meetupJson = RealmMeetup.serialize(meetup)
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/meetups", meetupJson)?.execute()?.body()
+
+                        if (`object` != null) {
                             meetup.meetupId = getString("id", `object`)
                             meetup.meetupIdRev = getString("rev", `object`)
+                        }
+                    } catch (e: IOException) {
+                        e.printStackTrace()
+                    }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
@@ -17,13 +17,11 @@ import org.ole.planet.myplanet.model.*
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
-import org.ole.planet.myplanet.utilities.NetworkUtils
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils.getAndroidId
 import retrofit2.*
-
 private const val BATCH_SIZE = 50
-
 private inline fun <T> Iterable<T>.processInBatches(action: (T) -> Unit) {
     chunked(BATCH_SIZE).forEach { chunk ->
         chunk.forEach { item ->
@@ -31,11 +29,9 @@ private inline fun <T> Iterable<T>.processInBatches(action: (T) -> Unit) {
         }
     }
 }
-
 class UploadManager(var context: Context) : FileUploadService() {
     var pref: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val dbService: DatabaseService = DatabaseService(context)
-
     companion object {
         var instance: UploadManager? = null
             get() {
@@ -45,12 +41,8 @@ class UploadManager(var context: Context) : FileUploadService() {
                 return field
             }
             private set
-    }
-
     private fun getRealm(): Realm {
         return dbService.realmInstance
-    }
-
     private fun uploadNewsActivities() {
         val apiInterface = client?.create(ApiInterface::class.java)
         val realm = getRealm()
@@ -58,11 +50,9 @@ class UploadManager(var context: Context) : FileUploadService() {
             val newsLog: List<RealmNewsLog> = realm.where(RealmNewsLog::class.java)
                 .isNull("_id").or().isEmpty("_id")
                 .findAll()
-
             newsLog.processInBatches { news ->
                     try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/myplanet_activities", RealmNewsLog.serialize(news))?.execute()?.body()
-
                         if (`object` != null) {
                             news._id = getString("id", `object`)
                             news._rev = getString("rev", `object`)
@@ -70,97 +60,49 @@ class UploadManager(var context: Context) : FileUploadService() {
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
-            }
-        }
-
-    }
-
     fun uploadActivities(listener: SuccessListener?) {
-        val apiInterface = client?.create(ApiInterface::class.java)
         val model = UserProfileDbHandler(MainApplication.context).userModel ?: run {
             listener?.onSuccess("Cannot upload activities: user model is null")
             return
-        }
-
         if (model.isManager()) {
             listener?.onSuccess("Skipping activities upload for manager")
-            return
-        }
-
         try {
             apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/myplanet_activities", MyPlanet.getNormalMyPlanetActivities(MainApplication.context, pref, model))?.enqueue(object : Callback<JsonObject?> {
                 override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {}
-
                 override fun onFailure(call: Call<JsonObject?>, t: Throwable) {}
             })
-
-            apiInterface?.getJsonObject(Utilities.header, "${Utilities.getUrl()}/myplanet_activities/${getAndroidId(MainApplication.context)}@${NetworkUtils.getUniqueIdentifier()}")?.enqueue(object : Callback<JsonObject?> {
+            apiInterface?.getJsonObject(Utilities.header, "${Utilities.getUrl()}/myplanet_activities/${getAndroidId(MainApplication.context)}@${networkUtils.getUniqueIdentifier()}")?.enqueue(object : Callback<JsonObject?> {
                 override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
                     var `object` = response.body()
-
                     if (`object` != null) {
                         val usages = `object`.getAsJsonArray("usages")
                         usages.addAll(MyPlanet.getTabletUsages(context))
                         `object`.add("usages", usages)
                     } else {
                         `object` = MyPlanet.getMyPlanetActivities(context, pref, model)
-                    }
-
                     apiInterface.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/myplanet_activities", `object`).enqueue(object : Callback<JsonObject?> {
                         override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
                             listener?.onSuccess("My planet activities uploaded successfully")
-                        }
-
                         override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
                             listener?.onSuccess("Failed to upload activities: ${t.message}")
-                        }
                     })
-                }
-
                 override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
                     val `object` = MyPlanet.getMyPlanetActivities(context, pref, model)
-                    apiInterface.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/myplanet_activities", `object`).enqueue(object : Callback<JsonObject?> {
-                        override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
-                            listener?.onSuccess("My planet activities uploaded successfully")
-                        }
-
-                        override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
-                            listener?.onSuccess("Failed to upload activities: ${t.message}")
-                        }
-                    })
-                }
-            })
         } catch (e: Exception) {
             e.printStackTrace()
             listener?.onSuccess("Failed to upload activities: ${e.message}")
-        }
-    }
-
     fun uploadExamResult(listener: SuccessListener) {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-
         realm.executeTransactionAsync({ realm: Realm ->
             val submissions: List<RealmSubmission> = realm.where(RealmSubmission::class.java).findAll()
-
             submissions.processInBatches { sub ->
-                    try {
                         if ((sub.answers?.size ?: 0) > 0) {
                             RealmSubmission.continueResultUpload(sub, apiInterface, realm, context)
-                        }
                     } catch (e: Exception) {
-                        e.printStackTrace()
-                    }
-            }
         }, {
             uploadCourseProgress()
             listener.onSuccess("Result sync completed successfully")
         }) { e: Throwable ->
-            e.printStackTrace()
             listener.onSuccess("Error during result sync: ${e.message}")
-        }
-    }
-
     private fun createImage(user: RealmUserModel?, imgObject: JsonObject?): JsonObject {
         val `object` = JsonObject()
         `object`.addProperty("title", getString("fileName", imgObject))
@@ -171,81 +113,43 @@ class UploadManager(var context: Context) : FileUploadService() {
         `object`.addProperty("resideOn", user.parentCode)
         `object`.addProperty("sourcePlanet", user.planetCode)
         val object1 = JsonObject()
-        `object`.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-        `object`.addProperty("deviceName", NetworkUtils.getDeviceName())
-        `object`.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(MainApplication.context))
+        `object`.addProperty("androidId", networkUtils.getUniqueIdentifier())
+        `object`.addProperty("deviceName", networkUtils.getDeviceName())
+        `object`.addProperty("customDeviceName", networkUtils.getCustomDeviceName(MainApplication.context))
         `object`.add("privateFor", object1)
         `object`.addProperty("mediaType", "image")
         return `object`
-    }
-
     fun uploadAchievement() {
-        val realm = getRealm()
-        realm.executeTransactionAsync { realm: Realm ->
             val list: List<RealmAchievement> = realm.where(RealmAchievement::class.java).findAll()
             list.processInBatches { sub ->
                 try {
                     if (sub._id?.startsWith("guest") == true) {
                         return@processInBatches
-                    }
                 } catch (e: IOException) {
                     e.printStackTrace()
-                }
-            }
-        }
-
-    }
-
     private fun uploadCourseProgress() {
-        val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
-        realm.executeTransactionAsync { realm: Realm ->
             val data: List<RealmCourseProgress> = realm.where(RealmCourseProgress::class.java).isNull("_id").findAll()
             var successCount = 0
             var skipCount = 0
             var errorCount = 0
-
             data.processInBatches { sub ->
-                    try {
                         if (sub.userId?.startsWith("guest") == true) {
                             skipCount++
                             return@processInBatches
-                        }
-
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/courses_progress", RealmCourseProgress.serializeProgress(sub))?.execute()?.body()
-                        if (`object` != null) {
                             sub._id = getString("id", `object`)
                             sub._rev = getString("rev", `object`)
                             successCount++
                         } else {
                             errorCount++
-                        }
-                    } catch (e: IOException) {
                         errorCount++
-                        e.printStackTrace()
-                    }
-            }
-
-        }
-    }
-
     fun uploadFeedback(listener: SuccessListener) {
-        val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
         realm.executeTransactionAsync(Realm.Transaction { realm: Realm ->
             val feedbacks: List<RealmFeedback> = realm.where(RealmFeedback::class.java).findAll()
-
             if (feedbacks.isEmpty()) {
                 return@Transaction
-            }
-
-            var successCount = 0
-            var errorCount = 0
-
             feedbacks.processInBatches { feedback ->
-                try {
                     val res: Response<JsonObject>? = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/feedback", RealmFeedback.serializeFeedback(feedback))?.execute()
-
                     val r = res?.body()
                     if (r != null) {
                         val revElement = r["rev"]
@@ -253,176 +157,80 @@ class UploadManager(var context: Context) : FileUploadService() {
                         if (revElement != null && idElement != null) {
                             feedback._rev = revElement.asString
                             feedback._id = idElement.asString
-                            successCount++
-                        } else {
-                            errorCount++
-                        }
-                    } else {
-                        errorCount++
-                    }
-                } catch (e: IOException) {
                     errorCount++
-                    e.printStackTrace()
-                }
-            }
-        }, {
             listener.onSuccess("Feedback sync completed successfully")
         }, { error ->
             listener.onSuccess("Feedback sync failed: ${error.message}")
             error.printStackTrace()
         })
-    }
-
     fun uploadSubmitPhotos(listener: SuccessListener?) {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-        realm.executeTransactionAsync { realm: Realm ->
             val data: List<RealmSubmitPhotos> = realm.where(RealmSubmitPhotos::class.java).equalTo("uploaded", false).findAll()
-            data.processInBatches { sub ->
-                    try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/submissions", RealmSubmitPhotos.serializeRealmSubmitPhotos(sub))?.execute()?.body()
-                        if (`object` != null) {
                             val rev = getString("rev", `object`)
                             val id = getString("id", `object`)
                             sub.uploaded = true
                             sub._rev = rev
                             sub._id = id
                             uploadAttachment(id, rev, sub, listener!!)
-                        }
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                    }
-            }
             if (data.isEmpty()) {
                 listener?.onSuccess("No photos to upload")
-            }
-        }
-    }
-
     fun uploadResource(listener: SuccessListener?) {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-
-        realm.executeTransactionAsync({ realm: Realm ->
             val user = realm.where(RealmUserModel::class.java)
                 .equalTo("id", pref.getString("userId", ""))
                 .findFirst()
-
             val data: List<RealmMyLibrary> = realm.where(RealmMyLibrary::class.java)
                 .isNull("_rev")
-                .findAll()
-
-            if (data.isEmpty()) {
                 return@executeTransactionAsync
-            }
-
-            data.processInBatches { sub ->
-                try {
                     val `object` = apiInterface?.postDoc(
                         Utilities.header,
                         "application/json",
                         "${Utilities.getUrl()}/resources",
                         RealmMyLibrary.serialize(sub, user)
                     )?.execute()?.body()
-
-                    if (`object` != null) {
                         val rev = getString("rev", `object`)
                         val id = getString("id", `object`)
                         sub._rev = rev
                         sub._id = id
                         uploadAttachment(id, rev, sub, listener!!)
-                    }
                 } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
-        }, {
             listener?.onSuccess("No resources to upload")
         }) { error ->
             listener?.onSuccess("Resource upload failed: ${error.message}")
-        }
-    }
-
     fun uploadMyPersonal(personal: RealmMyPersonal, listener: SuccessListener) {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-
         if (!personal.isUploaded) {
             apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/resources", RealmMyPersonal.serialize(personal, context))?.enqueue(object : Callback<JsonObject?> {
-                override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
                     val `object` = response.body()
-                    if (`object` != null) {
                         try {
                             if (!realm.isInTransaction) {
                                 realm.beginTransaction()
                             }
-                            val rev = getString("rev", `object`)
-                            val id = getString("id", `object`)
                             personal.isUploaded = true
                             personal._rev = rev
                             personal._id = id
                             realm.commitTransaction()
-
                             uploadAttachment(id, rev, personal, listener)
                         } catch (e: Exception) {
                             if (realm.isInTransaction) {
                                 realm.cancelTransaction()
-                            }
                             listener.onSuccess("Error updating personal resource: ${e.message}")
-                        }
-                    } else {
                         listener.onSuccess("Failed to upload personal resource: No response")
-                    }
-                }
-
-                override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
                     listener.onSuccess("Unable to upload resource: ${t.message}")
-                }
-            })
         } else {
             listener.onSuccess("Resource already uploaded")
-        }
-    }
-
     fun uploadTeamTask() {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-        realm.executeTransactionAsync { realm: Realm ->
             val list: List<RealmTeamTask> = realm.where(RealmTeamTask::class.java).findAll()
             val tasksToUpload = list.filter { task ->
                 TextUtils.isEmpty(task._id) || task.isUpdated
-            }
-
             tasksToUpload.processInBatches { task ->
-                    try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/tasks", RealmTeamTask.serialize(realm, task))?.execute()?.body()
-
-                        if (`object` != null) {
-                            val rev = getString("rev", `object`)
-                            val id = getString("id", `object`)
                             task._rev = rev
                             task._id = id
-                        }
-                    } catch (e: IOException) {
-                        e.printStackTrace()
-                    }
-            }
-        }
-    }
-
     fun uploadSubmissions() {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-
-        realm.executeTransactionAsync { realm: Realm ->
             val list: List<RealmSubmission> = realm.where(RealmSubmission::class.java)
                 .equalTo("isUpdated", true).or().isEmpty("_id").findAll()
-
             list.processInBatches { submission ->
-                    try {
                         val requestJson = RealmSubmission.serialize(realm, submission)
                         val response = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/submissions", requestJson)?.execute()
-
                         val jsonObject = response?.body()
                         if (jsonObject != null) {
                             val rev = getString("rev", jsonObject)
@@ -430,141 +238,54 @@ class UploadManager(var context: Context) : FileUploadService() {
                             submission._rev = rev
                             submission._id = id
                             submission.isUpdated = false
-                        }
-                    } catch (e: IOException) {
-                        e.printStackTrace()
-                    }
-            }
-        }
-    }
-
     fun uploadTeams() {
-        val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
-
-        realm.executeTransactionAsync { realm: Realm ->
             val teams: List<RealmMyTeam> = realm.where(RealmMyTeam::class.java).equalTo("updated", true).findAll()
             teams.processInBatches { team ->
-                    try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/teams", RealmMyTeam.serialize(team))?.execute()?.body()
-                        if (`object` != null) {
                             team._rev = getString("rev", `object`)
                             team.updated = false
-                        }
-                    } catch (e: IOException) {
-                        e.printStackTrace()
-                    }
-            }
-        }
-    }
-
     fun uploadUserActivities(listener: SuccessListener) {
-        val apiInterface = client?.create(ApiInterface::class.java)
-        val model = UserProfileDbHandler(MainApplication.context).userModel ?: run {
             listener.onSuccess("Cannot upload user activities: user model is null")
-            return
-        }
-
-        if (model.isManager()) {
             listener.onSuccess("Skipping user activities upload for manager")
-            return
-        }
-
-        val realm = getRealm()
         realm.executeTransactionAsync({ transactionRealm: Realm ->
             val activities = transactionRealm.where(RealmOfflineActivity::class.java).isNull("_rev").equalTo("type", "login").findAll()
-
             activities.processInBatches { act ->
-                try {
                     if (act.userId?.startsWith("guest") == true) {
-                        return@processInBatches
-                    }
-
                     val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/login_activities", RealmOfflineActivity.serializeLoginActivities(act, context))?.execute()?.body()
                     act.changeRev(`object`)
-                } catch (e: IOException) {
-                    e.printStackTrace()
-                }
-            }
             uploadTeamActivities(transactionRealm, apiInterface)
-        }, {
             realm.close()
             listener.onSuccess("User activities sync completed successfully")
-        }) { e: Throwable ->
-            realm.close()
-            e.printStackTrace()
             listener.onSuccess(e.message)
-        }
-    }
-
     fun uploadTeamActivities(realm: Realm, apiInterface: ApiInterface?) {
         val logs = realm.where(RealmTeamLog::class.java).isNull("_rev").findAll()
         logs.processInBatches { log ->
-                try {
                     val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/team_activities", RealmTeamLog.serializeTeamActivities(log, context))?.execute()?.body()
-                    if (`object` != null) {
                         log._id = getString("id", `object`)
                         log._rev = getString("rev", `object`)
-                    }
-                } catch (e: IOException) {
-                    e.printStackTrace()
-                }
-        }
-    }
-
     fun uploadRating() {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-
-        realm.executeTransactionAsync { realm: Realm ->
             val activities = realm.where(RealmRating::class.java).equalTo("isUpdated", true).findAll()
-            activities.processInBatches { act ->
-                    try {
                         if (act.userId?.startsWith("guest") == true) {
-                            return@processInBatches
-                        }
-
                         val `object`: Response<JsonObject>? =
                             if (TextUtils.isEmpty(act._id)) {
                                 apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/ratings", RealmRating.serializeRating(act))?.execute()
                             } else {
                                 apiInterface?.putDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/ratings/" + act._id, RealmRating.serializeRating(act))?.execute()
-                            }
                         if (`object`?.body() != null) {
                             act._id = getString("id", `object`.body())
                             act._rev = getString("rev", `object`.body())
                             act.isUpdated = false
-                        }
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                    }
-            }
-        }
-    }
-
     fun uploadNews() {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-
-        realm.executeTransactionAsync { realm: Realm ->
             val activities = realm.where(RealmNews::class.java).findAll()
-            activities.processInBatches { act ->
-                    try {
-                        if (act.userId?.startsWith("guest") == true) {
-                            return@processInBatches
-                        }
-
                         val `object` = RealmNews.serializeNews(act)
                         val image = act.imagesArray
                         val user = realm.where(RealmUserModel::class.java).equalTo("id", pref.getString("userId", "")).findFirst()
-
                         if (act.imageUrls != null && act.imageUrls?.isNotEmpty() == true) {
                             act.imageUrls?.chunked(5)?.forEach { imageChunk ->
                                 imageChunk.forEach { imageObject ->
                                     val imgObject = Gson().fromJson(imageObject, JsonObject::class.java)
                                     val ob = createImage(user, imgObject)
                                     val response = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/resources", ob)?.execute()?.body()
-
                                     val rev = getString("rev", response)
                                     val id = getString("id", response)
                                     val f = File(getString("imageUrl", imgObject))
@@ -575,16 +296,13 @@ class UploadManager(var context: Context) : FileUploadService() {
                                     val body = FileUtils.fullyReadFileToBytes(f)
                                         .toRequestBody("application/octet-stream".toMediaTypeOrNull())
                                     val url = String.format(format, Utilities.getUrl(), id, name)
-
                                     val res = apiInterface?.uploadResource(getHeaderMap(mimeType, rev), url, body)?.execute()
                                     val attachment = res?.body()
-
                                     val resourceObject = JsonObject()
                                     resourceObject.addProperty("resourceId", getString("id", attachment))
                                     resourceObject.addProperty("filename", getString("fileName", imgObject))
                                     val markdown = "![](resources/" + getString("id", attachment) + "/" + getString("fileName", imgObject) + ")"
                                     resourceObject.addProperty("markdown", markdown)
-
                                     var msg = getString("message", `object`)
                                     msg += """
                                     
@@ -593,158 +311,54 @@ class UploadManager(var context: Context) : FileUploadService() {
                                     `object`.addProperty("message", msg)
                                     image.add(resourceObject)
                                 }
-                            }
-                        }
-
                         act.images = Gson().toJson(image)
                         `object`.add("images", image)
-
                         val newsUploadResponse: Response<JsonObject>? =
-                            if (TextUtils.isEmpty(act._id)) {
                                 apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/news", `object`)?.execute()
-                            } else {
                                 apiInterface?.putDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/news/" + act._id, `object`)?.execute()
-                            }
                         if (newsUploadResponse?.body() != null) {
                             act.imageUrls?.clear()
                             act._id = getString("id", newsUploadResponse.body())
                             act._rev = getString("rev", newsUploadResponse.body())
-                        }
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                    }
-                }
-            }
         uploadNewsActivities()
-    }
-
     fun uploadCrashLog() {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-
-        try {
             val hasLooper = Looper.myLooper() != null
-
             if (hasLooper) {
                 realm.executeTransactionAsync { realm: Realm ->
                     uploadCrashLogData(realm, apiInterface)
-                }
             } else {
                 realm.executeTransaction { realm: Realm ->
-                    uploadCrashLogData(realm, apiInterface)
-                }
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
     private fun uploadCrashLogData(realm: Realm, apiInterface: ApiInterface?) {
         val logs: RealmResults<RealmApkLog> = realm.where(RealmApkLog::class.java).isNull("_rev").findAll()
-
         logs.processInBatches { act ->
-                try {
                     val o = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/apk_logs", RealmApkLog.serialize(act, context))?.execute()?.body()
-
                     if (o != null) {
                         act._rev = getString("rev", o)
-                    }
-                } catch (e: IOException) {
-                    e.printStackTrace()
-                }
-        }
-    }
-
     fun uploadSearchActivity() {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-        realm.executeTransactionAsync { realm: Realm ->
             val logs: RealmResults<RealmSearchActivity> = realm.where(RealmSearchActivity::class.java).isEmpty("_rev").findAll()
             logs.processInBatches { act ->
-                    try {
                         val o = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/search_activities", act.serialize())?.execute()?.body()
                         if (o != null) {
                             act._rev = getString("rev", o)
-                        }
-                    } catch (e: IOException) {
-                        e.printStackTrace()
-                    }
-            }
-        }
-
-    }
-
     fun uploadResourceActivities(type: String) {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-
         val db = if (type == "sync") {
             "admin_activities"
-        } else {
             "resource_activities"
-        }
-
-        realm.executeTransactionAsync { realm: Realm ->
             val activities: RealmResults<RealmResourceActivity> =
                 if (type == "sync") {
                     realm.where(RealmResourceActivity::class.java).isNull("_rev").equalTo("type", "sync").findAll()
                 } else {
                     realm.where(RealmResourceActivity::class.java).isNull("_rev").notEqualTo("type", "sync").findAll()
-                }
-            activities.processInBatches { act ->
-                    try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/" + db, RealmResourceActivity.serializeResourceActivities(act))?.execute()?.body()
-
-                        if (`object` != null) {
                             act._rev = getString("rev", `object`)
                             act._id = getString("id", `object`)
-                        }
-                    } catch (e: IOException) {
-                        e.printStackTrace()
-                    }
-            }
-        }
-    }
-
     fun uploadCourseActivities() {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-
-        realm.executeTransactionAsync { realm: Realm ->
             val activities: RealmResults<RealmCourseActivity> = realm.where(RealmCourseActivity::class.java).isNull("_rev").notEqualTo("type", "sync").findAll()
-            activities.processInBatches { act ->
-                    try {
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/course_activities", RealmCourseActivity.serializeSerialize(act))?.execute()?.body()
-
-                        if (`object` != null) {
-                            act._rev = getString("rev", `object`)
-                            act._id = getString("id", `object`)
-                        }
-                    } catch (e: IOException) {
-                        e.printStackTrace()
-                    }
-            }
-        }
-    }
-
     fun uploadMeetups() {
-        val realm = getRealm()
-        val apiInterface = client?.create(ApiInterface::class.java)
-        realm.executeTransactionAsync { realm: Realm ->
             val meetups: List<RealmMeetup> = realm.where(RealmMeetup::class.java).findAll()
             meetups.processInBatches { meetup ->
-                    try {
                         val meetupJson = RealmMeetup.serialize(meetup)
                         val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/meetups", meetupJson)?.execute()?.body()
-
-                        if (`object` != null) {
                             meetup.meetupId = getString("id", `object`)
                             meetup.meetupIdRev = getString("rev", `object`)
-                        }
-                    } catch (e: IOException) {
-                        e.printStackTrace()
-                    }
-            }
-        }
-    }
-}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -52,6 +52,7 @@ class AdapterCourses(
     private var isTitleAscending = false
     private var areAllSelected = false
     var userModel: RealmUserModel?= null
+    private val courseRatingUtils = CourseRatingUtils(context)
 
     init {
         if (context is OnHomeItemClickListener) {
@@ -301,7 +302,7 @@ class AdapterCourses(
         showProgress(viewHolder.rowCourseBinding, position)
         if (map.containsKey(courseList[position]!!.courseId)) {
             val `object` = map[courseList[position]!!.courseId]
-            CourseRatingUtils.showRating(
+            courseRatingUtils.showRating(
                 `object`,
                 viewHolder.rowCourseBinding.rating,
                 viewHolder.rowCourseBinding.timesRated,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardViewModel.kt
@@ -9,12 +9,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
-import org.ole.planet.myplanet.utilities.NetworkUtils.isNetworkConnectedFlow
-
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 class BellDashboardViewModel : ViewModel() {
     private val _networkStatus = MutableStateFlow<NetworkStatus>(NetworkStatus.Disconnected)
     val networkStatus: StateFlow<NetworkStatus> = _networkStatus.asStateFlow()
-
     init {
         viewModelScope.launch {
             isNetworkConnectedFlow.collect { isConnected ->
@@ -22,25 +20,15 @@ class BellDashboardViewModel : ViewModel() {
             }
         }
     }
-
     private fun updateNetworkStatus(isConnected: Boolean) {
-        viewModelScope.launch {
             _networkStatus.value = when {
                 !isConnected -> NetworkStatus.Disconnected
                 else -> NetworkStatus.Connecting
-            }
-        }
-    }
-
     suspend fun checkServerConnection(serverUrl: String): Boolean {
         return withContext(Dispatchers.IO) {
             isServerReachable(serverUrl)
-        }
-    }
 }
-
 sealed class NetworkStatus {
     object Disconnected : NetworkStatus()
     object Connecting : NetworkStatus()
     object Connected : NetworkStatus()
-}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardViewModel.kt
@@ -10,25 +10,37 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 class BellDashboardViewModel : ViewModel() {
     private val _networkStatus = MutableStateFlow<NetworkStatus>(NetworkStatus.Disconnected)
     val networkStatus: StateFlow<NetworkStatus> = _networkStatus.asStateFlow()
+
     init {
         viewModelScope.launch {
-            isNetworkConnectedFlow.collect { isConnected ->
+            networkUtils.isNetworkConnectedFlow.collect { isConnected ->
                 updateNetworkStatus(isConnected)
             }
         }
     }
+
     private fun updateNetworkStatus(isConnected: Boolean) {
+        viewModelScope.launch {
             _networkStatus.value = when {
                 !isConnected -> NetworkStatus.Disconnected
                 else -> NetworkStatus.Connecting
+            }
+        }
+    }
+
     suspend fun checkServerConnection(serverUrl: String): Boolean {
         return withContext(Dispatchers.IO) {
             isServerReachable(serverUrl)
+        }
+    }
 }
+
 sealed class NetworkStatus {
     object Disconnected : NetworkStatus()
     object Connecting : NetworkStatus()
     object Connected : NetworkStatus()
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
@@ -39,6 +39,7 @@ import org.ole.planet.myplanet.ui.survey.SurveyFragment
 import org.ole.planet.myplanet.utilities.CameraUtils.ImageCaptureCallback
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.Utilities
+
 abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
     var exam: RealmStepExam? = null
     lateinit var db: DatabaseService
@@ -54,12 +55,13 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
     var sub: RealmSubmission? = null
     var listAns: HashMap<String, String>? = null
     var isMySurvey = false
-    private var uniqueId = getUniqueIdentifier()
+    private var uniqueId = networkUtils.getUniqueIdentifier()
     var date = Date().toString()
     private var photoPath: String? = ""
     var submitId = ""
     var isTeam: Boolean = false
     var teamId: String? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         db = DatabaseService(requireActivity())
@@ -74,6 +76,7 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
             checkType()
         }
     }
+
     private fun checkId() {
         if (TextUtils.isEmpty(stepId)) {
             id = requireArguments().getString("id")
@@ -85,31 +88,45 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
                     sub?.parentId
                 }
             }
+        }
+    }
+
     private fun checkType() {
         if (requireArguments().containsKey("type")) {
             type = requireArguments().getString("type")
+        }
+    }
+
     fun initExam() {
         exam = if (!TextUtils.isEmpty(stepId)) {
             mRealm.where(RealmStepExam::class.java).equalTo("stepId", stepId).findFirst()
         } else {
             mRealm.where(RealmStepExam::class.java).equalTo("id", id).findFirst()
+        }
+    }
+
     var isLastAnsvalid = false
     fun checkAnsAndContinue(cont: Boolean) {
         if (cont) {
             isLastAnsvalid = true
             currentIndex += 1
             continueExam()
+        } else {
             isLastAnsvalid = false
             val toast = Toast.makeText(activity, getString(R.string.incorrect_ans), Toast.LENGTH_SHORT)
             toast.show()
             Handler(Looper.getMainLooper()).postDelayed({
                 toast.cancel()
             }, 1000)
+        }
+    }
+
     private fun continueExam() {
         if (currentIndex < (questions?.size ?: 0)) {
             startExam(questions?.get(currentIndex))
         } else if (isTeam == true && type?.startsWith("survey") == true) {
             showUserInfoDialog()
+        } else {
             saveCourseProgress()
             val titleView = TextView(requireContext()).apply {
                 text = "${getString(R.string.thank_you_for_taking_this)}$type! ${getString(R.string.we_wish_you_all_the_best)}"
@@ -118,11 +135,16 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
                 setTypeface(null, Typeface.BOLD)
                 gravity = Gravity.CENTER
                 setPadding(20, 25, 20, 0)
+            }
+
             AlertDialog.Builder(requireActivity(), R.style.AlertDialogTheme)
                 .setCustomTitle(titleView)
                 .setPositiveButton(getString(R.string.finish)) { _: DialogInterface?, _: Int ->
                     parentFragmentManager.popBackStack()
                 }.setCancelable(false).show()
+        }
+    }
+
     private fun saveCourseProgress() {
         val progress = mRealm.where(RealmCourseProgress::class.java)
             .equalTo("courseId", exam?.courseId)
@@ -131,25 +153,41 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
             if (!mRealm.isInTransaction) mRealm.beginTransaction()
             progress.passed = sub?.status == "graded"
             mRealm.commitTransaction()
+        }
+    }
+
     private fun showUserInfoDialog() {
         if (!isMySurvey && !exam?.isFromNation!!) {
             UserInformationFragment.getInstance(sub?.id, teamId, !isMySurvey && !exam?.isFromNation!!).show(childFragmentManager, "")
+        } else {
+            if (!mRealm.isInTransaction) mRealm.beginTransaction()
             sub?.status = "complete"
+            mRealm.commitTransaction()
             Utilities.toast(activity, getString(R.string.thank_you_for_taking_this_survey))
             navigateToSurveyList(requireActivity())
+        }
+    }
+
     companion object {
         fun navigateToSurveyList(activity: FragmentActivity) {
             val surveyListFragment = SurveyFragment()
             activity.supportFragmentManager.beginTransaction()
                 .replace(R.id.fragment_container, surveyListFragment)
                 .commit()
+        }
+    }
+
     fun addAnswer(compoundButton: CompoundButton) {
         val btnText = compoundButton.text.toString()
         val btnId = compoundButton.tag?.toString() ?: ""
+
         if (compoundButton is RadioButton) {
             ans = btnId
         } else if (compoundButton is CheckBox) {
             listAns?.put(btnText, btnId)
+        }
+    }
+
     abstract fun startExam(question: RealmExamQuestion?)
     private fun insertIntoSubmitPhotos(submitId: String?) {
         mRealm.beginTransaction()
@@ -163,19 +201,26 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
         submit.photoLocation = photoPath
         submit.uploaded = false
         mRealm.commitTransaction()
+    }
+
     override fun onImageCapture(fileUri: String?) {
         photoPath = fileUri
         insertIntoSubmitPhotos(submitId)
+    }
+
     fun setMarkdownViewAndShowInput(etAnswer: EditText, type: String, oldAnswer: String?) {
         etAnswer.visibility = View.VISIBLE
         val markwon = Markwon.create(requireActivity())
         val editor = MarkwonEditor.create(markwon)
         if (type.equals("textarea", ignoreCase = true)) {
             etAnswer.addTextChangedListener(MarkwonEditorTextWatcher.withProcess(editor))
+        } else {
             etAnswer.addTextChangedListener(object : TextWatcher {
                 override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
                 override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
                 override fun afterTextChanged(editable: Editable) {}
             })
+        }
         etAnswer.setText(oldAnswer)
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
@@ -22,9 +22,8 @@ import org.ole.planet.myplanet.model.RealmNewsLog
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtil
 import org.ole.planet.myplanet.utilities.JsonUtils
-import org.ole.planet.myplanet.utilities.NetworkUtils
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.Utilities
-
 class NewsDetailActivity : BaseActivity() {
     private lateinit var activityNewsDetailBinding: ActivityNewsDetailBinding
     var news: RealmNews? = null
@@ -48,18 +47,15 @@ class NewsDetailActivity : BaseActivity() {
         val userId = user.id
         realm.executeTransactionAsync {
             val newsLog: RealmNewsLog = it.createObject(RealmNewsLog::class.java, UUID.randomUUID().toString())
-            newsLog.androidId = NetworkUtils.getUniqueIdentifier()
+            newsLog.androidId = networkUtils.getUniqueIdentifier()
             newsLog.type = "news"
             newsLog.time = Date().time
             newsLog.userId = userId
-        }
         initViews()
     }
-
     private fun initViews() {
         title = news?.userName
         var msg: String? = news?.message
-
         if (news?.imageUrls != null && (news?.imageUrls?.size ?: 0) > 0) {
             msg = loadLocalImage()
         } else {
@@ -75,7 +71,6 @@ class NewsDetailActivity : BaseActivity() {
                 )
             }
             loadImage()
-        }
         msg = msg?.replace(
             "\n",
             "<div/><br/><div style=\" word-wrap: break-word;page-break-after: always;  word-spacing: 2px;\" >"
@@ -87,11 +82,7 @@ class NewsDetailActivity : BaseActivity() {
             "text/html",
             "utf-8",
             null
-        )
-    }
-
     private fun loadLocalImage(): String? {
-        var msg: String? = news?.message
         try {
             val imgObject = Gson().fromJson(news?.imageUrls?.get(0), JsonObject::class.java)
             activityNewsDetailBinding.img.visibility = View.VISIBLE
@@ -102,13 +93,8 @@ class NewsDetailActivity : BaseActivity() {
                 msg += "<br/><img width=\"50%\" src=\"file://" + JsonUtils.getString(
                     "imageUrl", imageObject
                 ) + "\"><br/>"
-            }
         } catch (e: Exception) {
-            loadImage()
-        }
         return msg
-    }
-
     private fun loadImage() {
         if ((news?.imagesArray?.size() ?: 0) > 0) {
             val ob = news?.imagesArray?.get(0)?.asJsonObject
@@ -121,8 +107,5 @@ class NewsDetailActivity : BaseActivity() {
                     .into(activityNewsDetailBinding.img)
                 activityNewsDetailBinding.img.visibility = View.VISIBLE
                 return
-            }
-        }
         activityNewsDetailBinding.img.visibility = View.GONE
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
@@ -24,6 +24,7 @@ import org.ole.planet.myplanet.utilities.EdgeToEdgeUtil
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.Utilities
+
 class NewsDetailActivity : BaseActivity() {
     private lateinit var activityNewsDetailBinding: ActivityNewsDetailBinding
     var news: RealmNews? = null
@@ -51,11 +52,14 @@ class NewsDetailActivity : BaseActivity() {
             newsLog.type = "news"
             newsLog.time = Date().time
             newsLog.userId = userId
+        }
         initViews()
     }
+
     private fun initViews() {
         title = news?.userName
         var msg: String? = news?.message
+
         if (news?.imageUrls != null && (news?.imageUrls?.size ?: 0) > 0) {
             msg = loadLocalImage()
         } else {
@@ -71,6 +75,7 @@ class NewsDetailActivity : BaseActivity() {
                 )
             }
             loadImage()
+        }
         msg = msg?.replace(
             "\n",
             "<div/><br/><div style=\" word-wrap: break-word;page-break-after: always;  word-spacing: 2px;\" >"
@@ -82,7 +87,11 @@ class NewsDetailActivity : BaseActivity() {
             "text/html",
             "utf-8",
             null
+        )
+    }
+
     private fun loadLocalImage(): String? {
+        var msg: String? = news?.message
         try {
             val imgObject = Gson().fromJson(news?.imageUrls?.get(0), JsonObject::class.java)
             activityNewsDetailBinding.img.visibility = View.VISIBLE
@@ -93,8 +102,13 @@ class NewsDetailActivity : BaseActivity() {
                 msg += "<br/><img width=\"50%\" src=\"file://" + JsonUtils.getString(
                     "imageUrl", imageObject
                 ) + "\"><br/>"
+            }
         } catch (e: Exception) {
+            loadImage()
+        }
         return msg
+    }
+
     private fun loadImage() {
         if ((news?.imagesArray?.size() ?: 0) > 0) {
             val ob = news?.imagesArray?.get(0)?.asJsonObject
@@ -107,5 +121,8 @@ class NewsDetailActivity : BaseActivity() {
                     .into(activityNewsDetailBinding.img)
                 activityNewsDetailBinding.img.visibility = View.VISIBLE
                 return
+            }
+        }
         activityNewsDetailBinding.img.visibility = View.GONE
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
@@ -38,6 +38,7 @@ class AdapterResource(private val context: Context, private var libraryList: Lis
     private var isAscending = true
     private var isTitleAscending = false
     var userModel: RealmUserModel ?= null
+    private val courseRatingUtils = CourseRatingUtils(context)
 
     init {
         if (context is OnHomeItemClickListener) {
@@ -103,7 +104,7 @@ class AdapterResource(private val context: Context, private var libraryList: Lis
                 }
             if (ratingMap.containsKey(libraryList[position]?.resourceId)) {
                 val `object` = ratingMap[libraryList[position]?.resourceId]
-                CourseRatingUtils.showRating(
+                courseRatingUtils.showRating(
                     `object`,
                     holder.rowLibraryBinding.rating,
                     holder.rowLibraryBinding.timesRated,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -28,6 +28,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.view.ViewCompat
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -47,6 +48,7 @@ import org.ole.planet.myplanet.utilities.*
 import org.ole.planet.myplanet.utilities.FileUtils.availableOverTotalMemoryFormattedString
 import org.ole.planet.myplanet.utilities.Utilities.getUrl
 import org.ole.planet.myplanet.utilities.Utilities.toast
+
 class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
     private lateinit var activityLoginBinding: ActivityLoginBinding
     private var guest = false
@@ -56,6 +58,7 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
     private val backPressedInterval: Long = 2000
     private var teamList = java.util.ArrayList<String?>()
     private var teamAdapter: ArrayAdapter<String?>? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         activityLoginBinding = ActivityLoginBinding.inflate(layoutInflater)
@@ -74,6 +77,7 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
         inputName = activityLoginBinding.inputName
         inputPassword = activityLoginBinding.inputPassword
         service = Service(this)
+
         activityLoginBinding.tvAvailableSpace.text = buildString {
             append(getString(R.string.available_space_colon))
             append(" ")
@@ -88,16 +92,22 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
         processedUrl = getUrl()
         if (forceSync) {
             isSync = false
+        }
         val versionInfo = if (Build.VERSION.SDK_INT >= TIRAMISU) {
             intent.getSerializableExtra("versionInfo", MyPlanet::class.java)
         } else {
             @Suppress("DEPRECATION")
             intent.getSerializableExtra("versionInfo") as? MyPlanet
+        }
+
         if (versionInfo != null) {
             onUpdateAvailable(versionInfo, intent.getBooleanExtra("cancelable", false))
+        } else {
             service.checkVersion(this, settings)
+        }
         checkUsagesPermission()
         forceSyncTrigger()
+
         val url = getUrl()
         if (url.isNotEmpty() && url != "/db") {
             activityLoginBinding.openCommunity.visibility = View.VISIBLE
@@ -105,20 +115,31 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                 HomeCommunityDialogFragment().show(supportFragmentManager, "")
             }
             HomeCommunityDialogFragment().show(supportFragmentManager, "")
+        } else {
             activityLoginBinding.openCommunity.visibility = View.GONE
+        }
         activityLoginBinding.btnFeedback.setOnClickListener {
             FeedbackFragment().show(supportFragmentManager, "")
+        }
+
         guest = intent.getBooleanExtra("guest", false)
         val username = intent.getStringExtra("username")
         val password = intent.getStringExtra("password")
         val autoLogin = intent.getBooleanExtra("auto_login", false)
+
         if (guest) {
             resetGuestAsMember(username)
+        }
+
         if (autoLogin && username != null && password != null) {
             lifecycleScope.launch {
                 delay(500)
                 submitForm(username, password)
+            }
+        }
+
         getTeamMembers()
+
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 if (System.currentTimeMillis() - backPressedTime < backPressedInterval) {
@@ -127,14 +148,18 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                     toast(this@LoginActivity, getString(R.string.press_back_again_to_exit))
                     backPressedTime = System.currentTimeMillis()
                 }
+            }
         })
         val selectDarkModeButton = activityLoginBinding.themeToggleButton
         selectDarkModeButton.setOnClickListener {
             ThemeManager.showThemeDialog(this)
+        }
     }
+
     private fun declareElements() {
         if (!defaultPref.contains("beta_addImageToMessage")) {
             defaultPref.edit { putBoolean("beta_addImageToMessage", true) }
+        }
         activityLoginBinding.customDeviceName.text = getCustomDeviceName()
         btnSignIn.setOnClickListener {
             if (TextUtils.isEmpty(activityLoginBinding.inputName.text.toString())) {
@@ -144,10 +169,12 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             } else {
                 if (mRealm.isClosed) {
                     mRealm = Realm.getDefaultInstance()
+                }
                 val enterUserName = activityLoginBinding.inputName.text.toString().trimEnd()
                 val user = mRealm.where(RealmUserModel::class.java).equalTo("name", enterUserName).findFirst()
                 if (user == null || !user.isArchived) {
                     submitForm(enterUserName, activityLoginBinding.inputPassword.text.toString())
+                } else {
                     val builder = AlertDialog.Builder(this)
                     builder.setMessage("member ${activityLoginBinding.inputName.text} is archived")
                     builder.setCancelable(false)
@@ -158,19 +185,33 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                     }
                     val dialog = builder.create()
                     dialog.show()
+                }
+            }
+        }
         if (!settings.contains("serverProtocol")) settings.edit {
             putString("serverProtocol", "http://")
+        }
         activityLoginBinding.becomeMember.setOnClickListener {
             activityLoginBinding.inputName.setText(R.string.empty_text)
             becomeAMember()
+        }
+
         activityLoginBinding.imgBtnSetting.setOnClickListener {
+            activityLoginBinding.inputName.setText(R.string.empty_text)
             settingDialog()
+        }
+
         activityLoginBinding.btnGuestLogin.setOnClickListener {
             if (getUrl().isNotEmpty()) {
                 activityLoginBinding.inputName.setText(R.string.empty_text)
                 showGuestLoginDialog()
+            } else {
                 toast(this, getString(R.string.please_enter_server_url_first))
                 settingDialog()
+            }
+        }
+    }
+
     private fun declareMoreElements() {
         try {
             mRealm = Realm.getDefaultInstance()
@@ -181,16 +222,21 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                 val protocol = settings.getString("serverProtocol", "")
                 val serverUrl = "${settings.getString("serverURL", "")}"
                 val serverPin = "${settings.getString("serverPin", "")}"
+
                 val url = if (serverUrl.startsWith("http://") || serverUrl.startsWith("https://")) {
                     serverUrl
+                } else {
                     "$protocol$serverUrl"
+                }
                 syncIconDrawable.start()
+
                 val dialogServerUrlBinding = DialogServerUrlBinding.inflate(LayoutInflater.from(this))
                 val contextWrapper = ContextThemeWrapper(this, R.style.AlertDialogTheme)
                 val builder = MaterialDialog.Builder(contextWrapper).customView(dialogServerUrlBinding.root, true)
                 val dialog = builder.build()
                 currentDialog = dialog
                 service.getMinApk(this, url, serverPin, this, "LoginActivity")
+            }
             declareHideKeyboardElements()
             activityLoginBinding.lblVersion.text = getString(R.string.version, resources.getText(R.string.app_version))
             activityLoginBinding.inputName.addTextChangedListener(MyTextWatcher(activityLoginBinding.inputName))
@@ -199,29 +245,45 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                 if (actionId == EditorInfo.IME_ACTION_DONE || event != null && event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_ENTER) {
                     btnSignIn.performClick()
                     return@setOnEditorActionListener true
+                }
                 false
+            }
             setUpLanguageButton()
             if (networkUtils.isNetworkConnected) {
                 service.syncPlanetServers { success: String? ->
                     toast(this, success)
+                }
+            }
             activityLoginBinding.inputName.addTextChangedListener(object : TextWatcher {
                 override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
+
                 override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                     val lowercaseText = s.toString().lowercase()
                     if (s.toString() != lowercaseText) {
                         activityLoginBinding.inputName.setText(lowercaseText)
                         activityLoginBinding.inputName.setSelection(lowercaseText.length)
+                    }
+                }
+
                 override fun afterTextChanged(s: Editable) {}
             })
             if(getUrl().isNotEmpty()){
                 updateTeamDropdown()
+            }
         } finally {
             if (!mRealm.isClosed) {
                 mRealm.close()
+            }
+        }
+    }
+
     fun updateTeamDropdown() {
         if (mRealm.isClosed) {
+            mRealm = Realm.getDefaultInstance()
+        }
         val teams: List<RealmMyTeam>? = mRealm.where(RealmMyTeam::class.java)
             ?.isEmpty("teamId")?.equalTo("status", "active")?.findAll()
+
         if (!teams.isNullOrEmpty()) {
             activityLoginBinding.team.visibility = View.VISIBLE
             teamAdapter = ArrayAdapter(this, R.layout.spinner_item_white, teamList)
@@ -231,6 +293,8 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             for (team in teams) {
                 if (team.isValid) {
                     teamList.add(team.name)
+                }
+            }
             activityLoginBinding.team.adapter = teamAdapter
             val lastSelection = prefData.getSelectedTeamId()
             if (!lastSelection.isNullOrEmpty()) {
@@ -240,6 +304,10 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                         val lastSelectedPosition = i + 1
                         activityLoginBinding.team.setSelection(lastSelectedPosition)
                         break
+                    }
+                }
+            }
+
             activityLoginBinding.team.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
                 override fun onItemSelected(parentView: AdapterView<*>?, selectedItemView: View?, position: Int, id: Long) {
                     if (position > 0) {
@@ -249,16 +317,31 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                             prefData.setSelectedTeamId(selectedTeam._id)
                             getTeamMembers()
                         }
+                    }
+                }
+
                 override fun onNothingSelected(parentView: AdapterView<*>?) {}
+            }
+        } else {
             activityLoginBinding.team.visibility = View.GONE
+        }
+    }
+
     private fun setUpLanguageButton() {
         updateLanguageButtonText()
+
         activityLoginBinding.btnLang.setOnClickListener {
             showLanguageSelectionDialog()
+        }
+    }
+
     private fun updateLanguageButtonText() {
         val currentLanguage = LocaleHelper.getLanguage(this)
         activityLoginBinding.btnLang.text = getLanguageString(currentLanguage)
+    }
+
     private fun showLanguageSelectionDialog() {
+        val currentLanguage = LocaleHelper.getLanguage(this)
         val options = arrayOf(
             getString(R.string.english),
             getString(R.string.spanish),
@@ -269,6 +352,7 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
         )
         val languageCodes = arrayOf("en", "es", "so", "ne", "ar", "fr")
         val checkedItem = languageCodes.indexOf(currentLanguage)
+
         AlertDialog.Builder(this, R.style.AlertDialogTheme)
             .setTitle(getString(R.string.select_language))
             .setSingleChoiceItems(
@@ -280,16 +364,26 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                     LocaleHelper.setLocale(this, selectedLanguage)
                     recreate()
                     dialog.dismiss()
+                } else {
+                    dialog.dismiss()
+                }
+            }
             .setNegativeButton(R.string.cancel, null)
             .show()
+    }
+
     private fun updateConfiguration(languageCode: String) {
         val locale = Locale(languageCode)
         Locale.setDefault(locale)
         val config = resources.configuration
         config.setLocale(locale)
         resources.updateConfiguration(config, resources.displayMetrics)
+    }
+
     override fun attachBaseContext(newBase: Context) {
         super.attachBaseContext(LocaleHelper.onAttach(newBase))
+    }
+
     private fun declareHideKeyboardElements() {
         activityLoginBinding.constraintLayout.setOnTouchListener { view, event ->
             when (event?.action) {
@@ -297,7 +391,13 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                     view?.let {
                         hideKeyboard(it)
                         it.performClick()
+                    }
+                }
+            }
             true
+        }
+    }
+
     fun getTeamMembers() {
         selectedTeamId = prefData.getSelectedTeamId().toString()
         if (selectedTeamId?.isNotEmpty() == true) {
@@ -305,21 +405,32 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             val userList = (users as? MutableList<RealmUserModel>)?.map {
                 User(it.name ?: "", it.name ?: "", "", it.userImage ?: "", "team")
             } ?: emptyList()
+
             val existingUsers = prefData.getSavedUsers().toMutableList()
             val filteredExistingUsers = existingUsers.filter { it.source != "team" }
             val updatedUserList = userList.filterNot { user -> filteredExistingUsers.any { it.name == user.name } } + filteredExistingUsers
             prefData.setSavedUsers(updatedUserList)
+        }
+
         updateTeamDropdown()
+
         if (mAdapter == null) {
             mAdapter = TeamListAdapter(prefData.getSavedUsers().toMutableList(), this, this)
             activityLoginBinding.recyclerView.layoutManager = LinearLayoutManager(this)
             activityLoginBinding.recyclerView.adapter = mAdapter
+        } else {
             mAdapter?.updateList(prefData.getSavedUsers().toMutableList())
+        }
+
         activityLoginBinding.recyclerView.isNestedScrollingEnabled = true
         activityLoginBinding.recyclerView.scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
         activityLoginBinding.recyclerView.isVerticalScrollBarEnabled = true
+
         activityLoginBinding.recyclerView.post {
             mAdapter?.notifyDataSetChanged()
+        }
+    }
+
     override fun onItemClick(user: User) {
         if (user.password?.isEmpty() == true && user.source != "guest") {
             Glide.with(this)
@@ -327,16 +438,27 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                 .placeholder(R.drawable.profile)
                 .error(R.drawable.profile)
                 .into(activityLoginBinding.userProfile)
+
             activityLoginBinding.inputName.setText(user.name)
+        } else {
             if (user.source == "guest"){
                 val model = RealmUserModel.createGuestUser(user.name, mRealm, settings)?.let { mRealm.copyFromRealm(it) }
                 if (model == null) {
                     toast(this, getString(R.string.unable_to_login))
+                } else {
                     saveUserInfoPref(settings, "", model)
                     onLogin()
+                }
+            } else {
                 submitForm(user.name, user.password)
+            }
+        }
+    }
+
     private fun submitForm(name: String?, password: String?) {
         AuthHelper.login(this, name, password)
+    }
+
     internal fun showGuestDialog(username: String) {
         val builder = AlertDialog.Builder(this)
         builder.setTitle("$username is already a guest")
@@ -348,16 +470,29 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             val model = RealmUserModel.createGuestUser(username, mRealm, settings)?.let { mRealm.copyFromRealm(it) }
             if (model == null) {
                 toast(this, getString(R.string.unable_to_login))
+            } else {
                 saveUserInfoPref(settings, "", model)
                 onLogin()
+            }
+        }
         val dialog = builder.create()
         dialog.show()
+    }
+
     internal fun showUserAlreadyMemberDialog(username: String) {
+        val builder = AlertDialog.Builder(this)
         builder.setTitle("$username is already a member")
         builder.setMessage("Continue to login if this is you")
+        builder.setCancelable(false)
         builder.setNegativeButton("Cancel") { dialog: DialogInterface, _: Int -> dialog.dismiss() }
         builder.setPositiveButton("login") { dialog: DialogInterface, _: Int ->
+            dialog.dismiss()
             activityLoginBinding.inputName.setText(username)
+        }
+        val dialog = builder.create()
+        dialog.show()
+    }
+
     fun saveUsers(name: String?, password: String?, source: String) {
         if (source === "guest") {
             val newUser = User("", name, password, "", "guest")
@@ -369,24 +504,47 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                 if (name1 == newUser.name?.trim { it <= ' ' }) {
                     newUserExists = true
                     break
+                }
+            }
             if (!newUserExists) {
                 existingUsers.add(newUser)
                 prefData.setSavedUsers(existingUsers)
+            }
         } else if (source === "member") {
             var userProfile = profileDbHandler.userModel?.userImage
             val userName: String? = profileDbHandler.userModel?.name
             if (userProfile == null) {
                 userProfile = ""
+            }
             val newUser = User(userName, name, password, userProfile, "member")
             val existingUsers: MutableList<User> = ArrayList(prefData.getSavedUsers())
+            var newUserExists = false
             for ((fullName1) in existingUsers) {
                 if (fullName1 == newUser.fullName?.trim { it <= ' ' }) {
+                    newUserExists = true
+                    break
+                }
+            }
+            if (!newUserExists) {
+                existingUsers.add(newUser)
+                prefData.setSavedUsers(existingUsers)
+            }
+        }
+    }
+
     private fun becomeAMember() {
         if (getUrl().isNotEmpty()) {
             startActivity(Intent(this, BecomeMemberActivity::class.java))
+        } else {
             toast(this, getString(R.string.please_enter_server_url_first))
+            settingDialog()
+        }
+    }
+
     fun getCustomDeviceName(): String? {
         return settings.getString("customDeviceName", networkUtils.getDeviceName())
+    }
+
     private fun resetGuestAsMember(username: String?) {
         val existingUsers = prefData.getSavedUsers().toMutableList()
         var newUserExists = false
@@ -394,15 +552,24 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             if (name == username) {
                 newUserExists = true
                 break
+            }
+        }
         if (newUserExists) {
             val iterator = existingUsers.iterator()
             while (iterator.hasNext()) {
                 val (_, name) = iterator.next()
                 if (name == username) {
                     iterator.remove()
+                }
+            }
             prefData.setSavedUsers(existingUsers)
+        }
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         if (!mRealm.isClosed) {
             mRealm.close()
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -47,7 +47,6 @@ import org.ole.planet.myplanet.utilities.*
 import org.ole.planet.myplanet.utilities.FileUtils.availableOverTotalMemoryFormattedString
 import org.ole.planet.myplanet.utilities.Utilities.getUrl
 import org.ole.planet.myplanet.utilities.Utilities.toast
-
 class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
     private lateinit var activityLoginBinding: ActivityLoginBinding
     private var guest = false
@@ -57,7 +56,6 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
     private val backPressedInterval: Long = 2000
     private var teamList = java.util.ArrayList<String?>()
     private var teamAdapter: ArrayAdapter<String?>? = null
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         activityLoginBinding = ActivityLoginBinding.inflate(layoutInflater)
@@ -76,7 +74,6 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
         inputName = activityLoginBinding.inputName
         inputPassword = activityLoginBinding.inputPassword
         service = Service(this)
-
         activityLoginBinding.tvAvailableSpace.text = buildString {
             append(getString(R.string.available_space_colon))
             append(" ")
@@ -91,22 +88,16 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
         processedUrl = getUrl()
         if (forceSync) {
             isSync = false
-        }
         val versionInfo = if (Build.VERSION.SDK_INT >= TIRAMISU) {
             intent.getSerializableExtra("versionInfo", MyPlanet::class.java)
         } else {
             @Suppress("DEPRECATION")
             intent.getSerializableExtra("versionInfo") as? MyPlanet
-        }
-
         if (versionInfo != null) {
             onUpdateAvailable(versionInfo, intent.getBooleanExtra("cancelable", false))
-        } else {
             service.checkVersion(this, settings)
-        }
         checkUsagesPermission()
         forceSyncTrigger()
-
         val url = getUrl()
         if (url.isNotEmpty() && url != "/db") {
             activityLoginBinding.openCommunity.visibility = View.VISIBLE
@@ -114,31 +105,20 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                 HomeCommunityDialogFragment().show(supportFragmentManager, "")
             }
             HomeCommunityDialogFragment().show(supportFragmentManager, "")
-        } else {
             activityLoginBinding.openCommunity.visibility = View.GONE
-        }
         activityLoginBinding.btnFeedback.setOnClickListener {
             FeedbackFragment().show(supportFragmentManager, "")
-        }
-
         guest = intent.getBooleanExtra("guest", false)
         val username = intent.getStringExtra("username")
         val password = intent.getStringExtra("password")
         val autoLogin = intent.getBooleanExtra("auto_login", false)
-
         if (guest) {
             resetGuestAsMember(username)
-        }
-
         if (autoLogin && username != null && password != null) {
             lifecycleScope.launch {
                 delay(500)
                 submitForm(username, password)
-            }
-        }
-
         getTeamMembers()
-
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 if (System.currentTimeMillis() - backPressedTime < backPressedInterval) {
@@ -147,18 +127,14 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                     toast(this@LoginActivity, getString(R.string.press_back_again_to_exit))
                     backPressedTime = System.currentTimeMillis()
                 }
-            }
         })
         val selectDarkModeButton = activityLoginBinding.themeToggleButton
         selectDarkModeButton.setOnClickListener {
             ThemeManager.showThemeDialog(this)
-        }
     }
-
     private fun declareElements() {
         if (!defaultPref.contains("beta_addImageToMessage")) {
             defaultPref.edit { putBoolean("beta_addImageToMessage", true) }
-        }
         activityLoginBinding.customDeviceName.text = getCustomDeviceName()
         btnSignIn.setOnClickListener {
             if (TextUtils.isEmpty(activityLoginBinding.inputName.text.toString())) {
@@ -168,12 +144,10 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             } else {
                 if (mRealm.isClosed) {
                     mRealm = Realm.getDefaultInstance()
-                }
                 val enterUserName = activityLoginBinding.inputName.text.toString().trimEnd()
                 val user = mRealm.where(RealmUserModel::class.java).equalTo("name", enterUserName).findFirst()
                 if (user == null || !user.isArchived) {
                     submitForm(enterUserName, activityLoginBinding.inputPassword.text.toString())
-                } else {
                     val builder = AlertDialog.Builder(this)
                     builder.setMessage("member ${activityLoginBinding.inputName.text} is archived")
                     builder.setCancelable(false)
@@ -184,33 +158,19 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                     }
                     val dialog = builder.create()
                     dialog.show()
-                }
-            }
-        }
         if (!settings.contains("serverProtocol")) settings.edit {
             putString("serverProtocol", "http://")
-        }
         activityLoginBinding.becomeMember.setOnClickListener {
             activityLoginBinding.inputName.setText(R.string.empty_text)
             becomeAMember()
-        }
-
         activityLoginBinding.imgBtnSetting.setOnClickListener {
-            activityLoginBinding.inputName.setText(R.string.empty_text)
             settingDialog()
-        }
-
         activityLoginBinding.btnGuestLogin.setOnClickListener {
             if (getUrl().isNotEmpty()) {
                 activityLoginBinding.inputName.setText(R.string.empty_text)
                 showGuestLoginDialog()
-            } else {
                 toast(this, getString(R.string.please_enter_server_url_first))
                 settingDialog()
-            }
-        }
-    }
-
     private fun declareMoreElements() {
         try {
             mRealm = Realm.getDefaultInstance()
@@ -221,21 +181,16 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                 val protocol = settings.getString("serverProtocol", "")
                 val serverUrl = "${settings.getString("serverURL", "")}"
                 val serverPin = "${settings.getString("serverPin", "")}"
-
                 val url = if (serverUrl.startsWith("http://") || serverUrl.startsWith("https://")) {
                     serverUrl
-                } else {
                     "$protocol$serverUrl"
-                }
                 syncIconDrawable.start()
-
                 val dialogServerUrlBinding = DialogServerUrlBinding.inflate(LayoutInflater.from(this))
                 val contextWrapper = ContextThemeWrapper(this, R.style.AlertDialogTheme)
                 val builder = MaterialDialog.Builder(contextWrapper).customView(dialogServerUrlBinding.root, true)
                 val dialog = builder.build()
                 currentDialog = dialog
                 service.getMinApk(this, url, serverPin, this, "LoginActivity")
-            }
             declareHideKeyboardElements()
             activityLoginBinding.lblVersion.text = getString(R.string.version, resources.getText(R.string.app_version))
             activityLoginBinding.inputName.addTextChangedListener(MyTextWatcher(activityLoginBinding.inputName))
@@ -244,45 +199,29 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                 if (actionId == EditorInfo.IME_ACTION_DONE || event != null && event.action == KeyEvent.ACTION_DOWN && event.keyCode == KeyEvent.KEYCODE_ENTER) {
                     btnSignIn.performClick()
                     return@setOnEditorActionListener true
-                }
                 false
-            }
             setUpLanguageButton()
-            if (NetworkUtils.isNetworkConnected) {
+            if (networkUtils.isNetworkConnected) {
                 service.syncPlanetServers { success: String? ->
                     toast(this, success)
-                }
-            }
             activityLoginBinding.inputName.addTextChangedListener(object : TextWatcher {
                 override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
-
                 override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                     val lowercaseText = s.toString().lowercase()
                     if (s.toString() != lowercaseText) {
                         activityLoginBinding.inputName.setText(lowercaseText)
                         activityLoginBinding.inputName.setSelection(lowercaseText.length)
-                    }
-                }
-
                 override fun afterTextChanged(s: Editable) {}
             })
             if(getUrl().isNotEmpty()){
                 updateTeamDropdown()
-            }
         } finally {
             if (!mRealm.isClosed) {
                 mRealm.close()
-            }
-        }
-    }
-
     fun updateTeamDropdown() {
         if (mRealm.isClosed) {
-            mRealm = Realm.getDefaultInstance()
-        }
         val teams: List<RealmMyTeam>? = mRealm.where(RealmMyTeam::class.java)
             ?.isEmpty("teamId")?.equalTo("status", "active")?.findAll()
-
         if (!teams.isNullOrEmpty()) {
             activityLoginBinding.team.visibility = View.VISIBLE
             teamAdapter = ArrayAdapter(this, R.layout.spinner_item_white, teamList)
@@ -292,8 +231,6 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             for (team in teams) {
                 if (team.isValid) {
                     teamList.add(team.name)
-                }
-            }
             activityLoginBinding.team.adapter = teamAdapter
             val lastSelection = prefData.getSelectedTeamId()
             if (!lastSelection.isNullOrEmpty()) {
@@ -303,10 +240,6 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                         val lastSelectedPosition = i + 1
                         activityLoginBinding.team.setSelection(lastSelectedPosition)
                         break
-                    }
-                }
-            }
-
             activityLoginBinding.team.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
                 override fun onItemSelected(parentView: AdapterView<*>?, selectedItemView: View?, position: Int, id: Long) {
                     if (position > 0) {
@@ -316,31 +249,16 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                             prefData.setSelectedTeamId(selectedTeam._id)
                             getTeamMembers()
                         }
-                    }
-                }
-
                 override fun onNothingSelected(parentView: AdapterView<*>?) {}
-            }
-        } else {
             activityLoginBinding.team.visibility = View.GONE
-        }
-    }
-
     private fun setUpLanguageButton() {
         updateLanguageButtonText()
-
         activityLoginBinding.btnLang.setOnClickListener {
             showLanguageSelectionDialog()
-        }
-    }
-
     private fun updateLanguageButtonText() {
         val currentLanguage = LocaleHelper.getLanguage(this)
         activityLoginBinding.btnLang.text = getLanguageString(currentLanguage)
-    }
-
     private fun showLanguageSelectionDialog() {
-        val currentLanguage = LocaleHelper.getLanguage(this)
         val options = arrayOf(
             getString(R.string.english),
             getString(R.string.spanish),
@@ -351,7 +269,6 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
         )
         val languageCodes = arrayOf("en", "es", "so", "ne", "ar", "fr")
         val checkedItem = languageCodes.indexOf(currentLanguage)
-
         AlertDialog.Builder(this, R.style.AlertDialogTheme)
             .setTitle(getString(R.string.select_language))
             .setSingleChoiceItems(
@@ -363,26 +280,16 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                     LocaleHelper.setLocale(this, selectedLanguage)
                     recreate()
                     dialog.dismiss()
-                } else {
-                    dialog.dismiss()
-                }
-            }
             .setNegativeButton(R.string.cancel, null)
             .show()
-    }
-
     private fun updateConfiguration(languageCode: String) {
         val locale = Locale(languageCode)
         Locale.setDefault(locale)
         val config = resources.configuration
         config.setLocale(locale)
         resources.updateConfiguration(config, resources.displayMetrics)
-    }
-
     override fun attachBaseContext(newBase: Context) {
         super.attachBaseContext(LocaleHelper.onAttach(newBase))
-    }
-
     private fun declareHideKeyboardElements() {
         activityLoginBinding.constraintLayout.setOnTouchListener { view, event ->
             when (event?.action) {
@@ -390,13 +297,7 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                     view?.let {
                         hideKeyboard(it)
                         it.performClick()
-                    }
-                }
-            }
             true
-        }
-    }
-
     fun getTeamMembers() {
         selectedTeamId = prefData.getSelectedTeamId().toString()
         if (selectedTeamId?.isNotEmpty() == true) {
@@ -404,32 +305,21 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             val userList = (users as? MutableList<RealmUserModel>)?.map {
                 User(it.name ?: "", it.name ?: "", "", it.userImage ?: "", "team")
             } ?: emptyList()
-
             val existingUsers = prefData.getSavedUsers().toMutableList()
             val filteredExistingUsers = existingUsers.filter { it.source != "team" }
             val updatedUserList = userList.filterNot { user -> filteredExistingUsers.any { it.name == user.name } } + filteredExistingUsers
             prefData.setSavedUsers(updatedUserList)
-        }
-
         updateTeamDropdown()
-
         if (mAdapter == null) {
             mAdapter = TeamListAdapter(prefData.getSavedUsers().toMutableList(), this, this)
             activityLoginBinding.recyclerView.layoutManager = LinearLayoutManager(this)
             activityLoginBinding.recyclerView.adapter = mAdapter
-        } else {
             mAdapter?.updateList(prefData.getSavedUsers().toMutableList())
-        }
-
         activityLoginBinding.recyclerView.isNestedScrollingEnabled = true
         activityLoginBinding.recyclerView.scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
         activityLoginBinding.recyclerView.isVerticalScrollBarEnabled = true
-
         activityLoginBinding.recyclerView.post {
             mAdapter?.notifyDataSetChanged()
-        }
-    }
-
     override fun onItemClick(user: User) {
         if (user.password?.isEmpty() == true && user.source != "guest") {
             Glide.with(this)
@@ -437,27 +327,16 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                 .placeholder(R.drawable.profile)
                 .error(R.drawable.profile)
                 .into(activityLoginBinding.userProfile)
-
             activityLoginBinding.inputName.setText(user.name)
-        } else {
             if (user.source == "guest"){
                 val model = RealmUserModel.createGuestUser(user.name, mRealm, settings)?.let { mRealm.copyFromRealm(it) }
                 if (model == null) {
                     toast(this, getString(R.string.unable_to_login))
-                } else {
                     saveUserInfoPref(settings, "", model)
                     onLogin()
-                }
-            } else {
                 submitForm(user.name, user.password)
-            }
-        }
-    }
-
     private fun submitForm(name: String?, password: String?) {
         AuthHelper.login(this, name, password)
-    }
-
     internal fun showGuestDialog(username: String) {
         val builder = AlertDialog.Builder(this)
         builder.setTitle("$username is already a guest")
@@ -469,29 +348,16 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             val model = RealmUserModel.createGuestUser(username, mRealm, settings)?.let { mRealm.copyFromRealm(it) }
             if (model == null) {
                 toast(this, getString(R.string.unable_to_login))
-            } else {
                 saveUserInfoPref(settings, "", model)
                 onLogin()
-            }
-        }
         val dialog = builder.create()
         dialog.show()
-    }
-
     internal fun showUserAlreadyMemberDialog(username: String) {
-        val builder = AlertDialog.Builder(this)
         builder.setTitle("$username is already a member")
         builder.setMessage("Continue to login if this is you")
-        builder.setCancelable(false)
         builder.setNegativeButton("Cancel") { dialog: DialogInterface, _: Int -> dialog.dismiss() }
         builder.setPositiveButton("login") { dialog: DialogInterface, _: Int ->
-            dialog.dismiss()
             activityLoginBinding.inputName.setText(username)
-        }
-        val dialog = builder.create()
-        dialog.show()
-    }
-
     fun saveUsers(name: String?, password: String?, source: String) {
         if (source === "guest") {
             val newUser = User("", name, password, "", "guest")
@@ -503,47 +369,24 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
                 if (name1 == newUser.name?.trim { it <= ' ' }) {
                     newUserExists = true
                     break
-                }
-            }
             if (!newUserExists) {
                 existingUsers.add(newUser)
                 prefData.setSavedUsers(existingUsers)
-            }
         } else if (source === "member") {
             var userProfile = profileDbHandler.userModel?.userImage
             val userName: String? = profileDbHandler.userModel?.name
             if (userProfile == null) {
                 userProfile = ""
-            }
             val newUser = User(userName, name, password, userProfile, "member")
             val existingUsers: MutableList<User> = ArrayList(prefData.getSavedUsers())
-            var newUserExists = false
             for ((fullName1) in existingUsers) {
                 if (fullName1 == newUser.fullName?.trim { it <= ' ' }) {
-                    newUserExists = true
-                    break
-                }
-            }
-            if (!newUserExists) {
-                existingUsers.add(newUser)
-                prefData.setSavedUsers(existingUsers)
-            }
-        }
-    }
-
     private fun becomeAMember() {
         if (getUrl().isNotEmpty()) {
             startActivity(Intent(this, BecomeMemberActivity::class.java))
-        } else {
             toast(this, getString(R.string.please_enter_server_url_first))
-            settingDialog()
-        }
-    }
-
     fun getCustomDeviceName(): String? {
-        return settings.getString("customDeviceName", NetworkUtils.getDeviceName())
-    }
-
+        return settings.getString("customDeviceName", networkUtils.getDeviceName())
     private fun resetGuestAsMember(username: String?) {
         val existingUsers = prefData.getSavedUsers().toMutableList()
         var newUserExists = false
@@ -551,24 +394,15 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
             if (name == username) {
                 newUserExists = true
                 break
-            }
-        }
         if (newUserExists) {
             val iterator = existingUsers.iterator()
             while (iterator.hasNext()) {
                 val (_, name) = iterator.next()
                 if (name == username) {
                     iterator.remove()
-                }
-            }
             prefData.setSavedUsers(existingUsers)
-        }
-    }
-
     override fun onDestroy() {
         super.onDestroy()
         if (!mRealm.isClosed) {
             mRealm.close()
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
@@ -13,7 +13,6 @@ import org.ole.planet.myplanet.databinding.DialogServerUrlBinding
 import org.ole.planet.myplanet.model.RealmCommunity
 import org.ole.planet.myplanet.ui.sync.ServerAddressAdapter
 import org.ole.planet.myplanet.utilities.ServerConfigUtils
-
 fun SyncActivity.showConfigurationUIElements(
     binding: DialogServerUrlBinding,
     manualSelected: Boolean,
@@ -34,14 +33,12 @@ fun SyncActivity.showConfigurationUIElements(
         }
     binding.ltAdvanced.visibility = if (manualSelected) View.VISIBLE else View.GONE
     binding.switchServerUrl.visibility = if (manualSelected) View.VISIBLE else View.GONE
-
     if (manualSelected) {
         setupManualUi(binding)
     } else {
         setupServerListUi(binding, dialog)
     }
 }
-
 fun SyncActivity.performSync(dialog: MaterialDialog) {
     serverConfigAction = "sync"
     val protocol = "${settings.getString("serverProtocol", "")}"
@@ -52,9 +49,6 @@ fun SyncActivity.performSync(dialog: MaterialDialog) {
     if (isUrlValid(url)) {
         currentDialog = dialog
         service.getMinApk(this, url, pin, this, "SyncActivity")
-    }
-}
-
 fun SyncActivity.onChangeServerUrl() {
     val selected = spnCloud.selectedItem
     if (selected is RealmCommunity && selected.isValid) {
@@ -63,39 +57,26 @@ fun SyncActivity.onChangeServerUrl() {
         settings.getString("serverProtocol", getString(R.string.https_protocol))
         serverPassword.setText(if (selected.weight == 0) "1983" else "")
         serverPassword.isEnabled = selected.weight != 0
-    }
-}
-
 fun SyncActivity.setUrlAndPin(checked: Boolean) {
     if (checked) {
         onChangeServerUrl()
-    } else {
         serverUrl.setText(settings.getString("serverURL", "")?.let { ServerConfigUtils.removeProtocol(it) })
         serverPassword.setText(settings.getString("serverPin", ""))
         protocolCheckIn.check(
             if (TextUtils.equals(settings.getString("serverProtocol", ""), "http://")) {
                 R.id.radio_http
-            } else {
                 R.id.radio_https
-            }
         )
-    }
     serverUrl.isEnabled = !checked
     serverPassword.isEnabled = !checked
     serverPassword.clearFocus()
     serverUrl.clearFocus()
     protocolCheckIn.isEnabled = !checked
-}
-
 fun SyncActivity.protocolSemantics() {
     protocolCheckIn.setOnCheckedChangeListener { _: RadioGroup?, i: Int ->
         when (i) {
             R.id.radio_http -> editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
             R.id.radio_https -> editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
-        }
-    }
-}
-
 fun SyncActivity.refreshServerList() {
     val filteredList = ServerConfigUtils.getFilteredList(
         showAdditionalServers,
@@ -103,16 +84,11 @@ fun SyncActivity.refreshServerList() {
         settings.getString("pinnedServerUrl", null),
     )
     serverAddressAdapter?.updateList(filteredList)
-
     val pinnedUrl = settings.getString("serverURL", "")
     val pinnedIndex = filteredList.indexOfFirst {
         it.url.replace(Regex("^https?://"), "") == pinnedUrl?.replace(Regex("^https?://"), "")
-    }
     if (pinnedIndex != -1) {
         serverAddressAdapter?.setSelectedPosition(pinnedIndex)
-    }
-}
-
 fun SyncActivity.setupManualUi(binding: DialogServerUrlBinding) {
     if (settings.getString("serverProtocol", "") == getString(R.string.http_protocol)) {
         binding.radioHttp.isChecked = true
@@ -120,21 +96,16 @@ fun SyncActivity.setupManualUi(binding: DialogServerUrlBinding) {
     } else if (settings.getString("serverProtocol", "") == getString(R.string.https_protocol)) {
         binding.radioHttps.isChecked = true
         editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
-    }
     serverUrl.setText(settings.getString("serverURL", "")?.let { ServerConfigUtils.removeProtocol(it) })
     serverPassword.setText(settings.getString("serverPin", ""))
     serverUrl.isEnabled = true
     serverPassword.isEnabled = true
-}
-
 fun SyncActivity.setupServerListUi(binding: DialogServerUrlBinding, dialog: MaterialDialog) {
     serverAddresses.layoutManager = LinearLayoutManager(this)
     serverListAddresses = ServerConfigUtils.getServerAddresses(this)
-
     val storedUrl = settings.getString("serverURL", null)
     val storedPin = settings.getString("serverPin", null)
     val urlWithoutProtocol = storedUrl?.replace(Regex("^https?://"), "")
-
     serverAddressAdapter = ServerAddressAdapter(
         ServerConfigUtils.getFilteredList(
             showAdditionalServers,
@@ -153,27 +124,18 @@ fun SyncActivity.setupServerListUi(binding: DialogServerUrlBinding, dialog: Mate
             editor.putString("serverProtocol", protocol).apply()
             if (serverCheck) {
                 performSync(dialog)
-            }
         },
         { _, _ ->
             clearDataDialog(getString(R.string.you_want_to_connect_to_a_different_server), false) {
                 serverAddressAdapter?.revertSelection()
-            }
-        },
         urlWithoutProtocol,
-    )
-
     serverAddresses.adapter = serverAddressAdapter
-
     if (urlWithoutProtocol != null) {
         val position = serverListAddresses.indexOfFirst { it.url.replace(Regex("^https?://"), "") == urlWithoutProtocol }
         if (position != -1) {
             serverAddressAdapter?.setSelectedPosition(position)
             binding.inputServerUrl.setText(urlWithoutProtocol)
             binding.inputServerPassword.setText(settings.getString("serverPin", ""))
-        }
-    }
-
     if (!prefData.getManualConfig()) {
         serverAddresses.visibility = View.VISIBLE
         if (storedUrl != null && !syncFailed) {
@@ -182,30 +144,18 @@ fun SyncActivity.setupServerListUi(binding: DialogServerUrlBinding, dialog: Mate
                 serverAddressAdapter?.setSelectedPosition(position)
                 binding.inputServerUrl.setText(urlWithoutProtocol)
                 binding.inputServerPassword.setText(storedPin)
-            }
         } else if (syncFailed) {
             serverAddressAdapter?.clearSelection()
-        }
     } else if (storedUrl != null) {
-        val position = serverListAddresses.indexOfFirst { it.url.replace(Regex("^https?://"), "") == urlWithoutProtocol }
-        if (position != -1) {
-            serverAddressAdapter?.setSelectedPosition(position)
-            binding.inputServerUrl.setText(urlWithoutProtocol)
             binding.inputServerPassword.setText(storedPin)
-        }
-    }
     serverUrl.isEnabled = false
     serverPassword.isEnabled = false
     editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
-}
-
 fun SyncActivity.onNeutralButtonClick(dialog: MaterialDialog) {
-    if (!prefData.getManualConfig()) {
         showAdditionalServers = !showAdditionalServers
         refreshServerList()
         dialog.getActionButton(DialogAction.NEUTRAL).text =
             if (showAdditionalServers) getString(R.string.show_less) else getString(R.string.show_more)
-    } else {
         serverConfigAction = "save"
         val protocol = "${settings.getString("serverProtocol", "")}"
         var url = "${serverUrl.text}"
@@ -214,10 +164,6 @@ fun SyncActivity.onNeutralButtonClick(dialog: MaterialDialog) {
         if (isUrlValid(url)) {
             currentDialog = dialog
             service.getMinApk(this, url, pin, this, "SyncActivity")
-        }
-    }
-}
-
 fun SyncActivity.initServerDialog(binding: DialogServerUrlBinding) {
     spnCloud = binding.spnCloud
     protocolCheckIn = binding.radioProtocol
@@ -225,62 +171,35 @@ fun SyncActivity.initServerDialog(binding: DialogServerUrlBinding) {
     serverPassword = binding.inputServerPassword
     serverAddresses = binding.serverUrls
     syncToServerText = binding.syncToServerText
-    binding.deviceName.setText(org.ole.planet.myplanet.utilities.NetworkUtils.getDeviceName())
-}
-
+    binding.deviceName.setText(org.ole.planet.myplanet.utilities.networkUtils.getDeviceName())
 fun SyncActivity.setRadioProtocolListener(binding: DialogServerUrlBinding) {
     binding.radioProtocol.setOnCheckedChangeListener { _: RadioGroup?, checkedId: Int ->
         when (checkedId) {
-            R.id.radio_http -> editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
-            R.id.radio_https -> editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
-        }
-    }
-}
-
 fun SyncActivity.setupFastSyncOption(binding: DialogServerUrlBinding) {
     val isFastSync = settings.getBoolean("fastSync", false)
     binding.fastSync.isChecked = isFastSync
     binding.fastSync.setOnCheckedChangeListener { _: CompoundButton?, checked: Boolean ->
         editor.putBoolean("fastSync", checked).apply()
-    }
-}
-
 fun SyncActivity.handleManualConfiguration(
-    binding: DialogServerUrlBinding,
     configurationId: String?,
-    dialog: MaterialDialog,
-) {
-    if (!prefData.getManualConfig()) {
         binding.manualConfiguration.isChecked = false
         showConfigurationUIElements(binding, false, dialog)
-    } else {
         binding.manualConfiguration.isChecked = true
         showConfigurationUIElements(binding, true, dialog)
-    }
-
     binding.manualConfiguration.setOnCheckedChangeListener(null)
     binding.manualConfiguration.setOnClickListener {
         if (configurationId != null) {
             binding.manualConfiguration.isChecked = prefData.getManualConfig()
             if (prefData.getManualConfig()) {
                 clearDataDialog(getString(R.string.switching_off_manual_configuration_to_clear_data), false)
-            } else {
                 clearDataDialog(getString(R.string.switching_on_manual_configuration_to_clear_data), true)
-            }
-        } else {
             val newCheckedState = !prefData.getManualConfig()
             prefData.setManualConfig(newCheckedState)
             if (newCheckedState) {
                 setupManualConfigEnabled(binding, dialog)
-            } else {
                 prefData.setManualConfig(false)
                 showConfigurationUIElements(binding, false, dialog)
                 editor.putBoolean("switchCloudUrl", false).apply()
-            }
-        }
-    }
-}
-
 fun SyncActivity.setupManualConfigEnabled(binding: DialogServerUrlBinding, dialog: MaterialDialog) {
     prefData.setManualConfig(true)
     editor.putString("serverURL", "").apply()
@@ -288,7 +207,6 @@ fun SyncActivity.setupManualConfigEnabled(binding: DialogServerUrlBinding, dialo
     binding.radioHttp.isChecked = true
     editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
     showConfigurationUIElements(binding, true, dialog)
-
     val communities: List<RealmCommunity> =
         mRealm.where(RealmCommunity::class.java).sort("weight", Sort.ASCENDING).findAll()
     val nonEmptyCommunities = communities.filter { it.isValid && !TextUtils.isEmpty(it.name) }
@@ -296,18 +214,12 @@ fun SyncActivity.setupManualConfigEnabled(binding: DialogServerUrlBinding, dialo
     binding.spnCloud.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
         override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
             onChangeServerUrl()
-        }
-
         override fun onNothingSelected(parent: AdapterView<*>?) {}
-    }
-
     binding.switchServerUrl.setOnCheckedChangeListener { _: CompoundButton?, b: Boolean ->
         editor.putBoolean("switchCloudUrl", b).apply()
         binding.spnCloud.visibility = if (b) View.VISIBLE else View.GONE
         setUrlAndPin(binding.switchServerUrl.isChecked)
-    }
     serverUrl.addTextChangedListener(MyTextWatcher(serverUrl))
     binding.switchServerUrl.isChecked = settings.getBoolean("switchCloudUrl", false)
     setUrlAndPin(settings.getBoolean("switchCloudUrl", false))
     protocolSemantics()
-}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
@@ -13,6 +13,8 @@ import org.ole.planet.myplanet.databinding.DialogServerUrlBinding
 import org.ole.planet.myplanet.model.RealmCommunity
 import org.ole.planet.myplanet.ui.sync.ServerAddressAdapter
 import org.ole.planet.myplanet.utilities.ServerConfigUtils
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 fun SyncActivity.showConfigurationUIElements(
     binding: DialogServerUrlBinding,
     manualSelected: Boolean,
@@ -33,12 +35,14 @@ fun SyncActivity.showConfigurationUIElements(
         }
     binding.ltAdvanced.visibility = if (manualSelected) View.VISIBLE else View.GONE
     binding.switchServerUrl.visibility = if (manualSelected) View.VISIBLE else View.GONE
+
     if (manualSelected) {
         setupManualUi(binding)
     } else {
         setupServerListUi(binding, dialog)
     }
 }
+
 fun SyncActivity.performSync(dialog: MaterialDialog) {
     serverConfigAction = "sync"
     val protocol = "${settings.getString("serverProtocol", "")}"
@@ -49,6 +53,9 @@ fun SyncActivity.performSync(dialog: MaterialDialog) {
     if (isUrlValid(url)) {
         currentDialog = dialog
         service.getMinApk(this, url, pin, this, "SyncActivity")
+    }
+}
+
 fun SyncActivity.onChangeServerUrl() {
     val selected = spnCloud.selectedItem
     if (selected is RealmCommunity && selected.isValid) {
@@ -57,26 +64,39 @@ fun SyncActivity.onChangeServerUrl() {
         settings.getString("serverProtocol", getString(R.string.https_protocol))
         serverPassword.setText(if (selected.weight == 0) "1983" else "")
         serverPassword.isEnabled = selected.weight != 0
+    }
+}
+
 fun SyncActivity.setUrlAndPin(checked: Boolean) {
     if (checked) {
         onChangeServerUrl()
+    } else {
         serverUrl.setText(settings.getString("serverURL", "")?.let { ServerConfigUtils.removeProtocol(it) })
         serverPassword.setText(settings.getString("serverPin", ""))
         protocolCheckIn.check(
             if (TextUtils.equals(settings.getString("serverProtocol", ""), "http://")) {
                 R.id.radio_http
+            } else {
                 R.id.radio_https
+            }
         )
+    }
     serverUrl.isEnabled = !checked
     serverPassword.isEnabled = !checked
     serverPassword.clearFocus()
     serverUrl.clearFocus()
     protocolCheckIn.isEnabled = !checked
+}
+
 fun SyncActivity.protocolSemantics() {
     protocolCheckIn.setOnCheckedChangeListener { _: RadioGroup?, i: Int ->
         when (i) {
             R.id.radio_http -> editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
             R.id.radio_https -> editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
+        }
+    }
+}
+
 fun SyncActivity.refreshServerList() {
     val filteredList = ServerConfigUtils.getFilteredList(
         showAdditionalServers,
@@ -84,11 +104,16 @@ fun SyncActivity.refreshServerList() {
         settings.getString("pinnedServerUrl", null),
     )
     serverAddressAdapter?.updateList(filteredList)
+
     val pinnedUrl = settings.getString("serverURL", "")
     val pinnedIndex = filteredList.indexOfFirst {
         it.url.replace(Regex("^https?://"), "") == pinnedUrl?.replace(Regex("^https?://"), "")
+    }
     if (pinnedIndex != -1) {
         serverAddressAdapter?.setSelectedPosition(pinnedIndex)
+    }
+}
+
 fun SyncActivity.setupManualUi(binding: DialogServerUrlBinding) {
     if (settings.getString("serverProtocol", "") == getString(R.string.http_protocol)) {
         binding.radioHttp.isChecked = true
@@ -96,16 +121,21 @@ fun SyncActivity.setupManualUi(binding: DialogServerUrlBinding) {
     } else if (settings.getString("serverProtocol", "") == getString(R.string.https_protocol)) {
         binding.radioHttps.isChecked = true
         editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
+    }
     serverUrl.setText(settings.getString("serverURL", "")?.let { ServerConfigUtils.removeProtocol(it) })
     serverPassword.setText(settings.getString("serverPin", ""))
     serverUrl.isEnabled = true
     serverPassword.isEnabled = true
+}
+
 fun SyncActivity.setupServerListUi(binding: DialogServerUrlBinding, dialog: MaterialDialog) {
     serverAddresses.layoutManager = LinearLayoutManager(this)
     serverListAddresses = ServerConfigUtils.getServerAddresses(this)
+
     val storedUrl = settings.getString("serverURL", null)
     val storedPin = settings.getString("serverPin", null)
     val urlWithoutProtocol = storedUrl?.replace(Regex("^https?://"), "")
+
     serverAddressAdapter = ServerAddressAdapter(
         ServerConfigUtils.getFilteredList(
             showAdditionalServers,
@@ -124,18 +154,27 @@ fun SyncActivity.setupServerListUi(binding: DialogServerUrlBinding, dialog: Mate
             editor.putString("serverProtocol", protocol).apply()
             if (serverCheck) {
                 performSync(dialog)
+            }
         },
         { _, _ ->
             clearDataDialog(getString(R.string.you_want_to_connect_to_a_different_server), false) {
                 serverAddressAdapter?.revertSelection()
+            }
+        },
         urlWithoutProtocol,
+    )
+
     serverAddresses.adapter = serverAddressAdapter
+
     if (urlWithoutProtocol != null) {
         val position = serverListAddresses.indexOfFirst { it.url.replace(Regex("^https?://"), "") == urlWithoutProtocol }
         if (position != -1) {
             serverAddressAdapter?.setSelectedPosition(position)
             binding.inputServerUrl.setText(urlWithoutProtocol)
             binding.inputServerPassword.setText(settings.getString("serverPin", ""))
+        }
+    }
+
     if (!prefData.getManualConfig()) {
         serverAddresses.visibility = View.VISIBLE
         if (storedUrl != null && !syncFailed) {
@@ -144,18 +183,30 @@ fun SyncActivity.setupServerListUi(binding: DialogServerUrlBinding, dialog: Mate
                 serverAddressAdapter?.setSelectedPosition(position)
                 binding.inputServerUrl.setText(urlWithoutProtocol)
                 binding.inputServerPassword.setText(storedPin)
+            }
         } else if (syncFailed) {
             serverAddressAdapter?.clearSelection()
+        }
     } else if (storedUrl != null) {
+        val position = serverListAddresses.indexOfFirst { it.url.replace(Regex("^https?://"), "") == urlWithoutProtocol }
+        if (position != -1) {
+            serverAddressAdapter?.setSelectedPosition(position)
+            binding.inputServerUrl.setText(urlWithoutProtocol)
             binding.inputServerPassword.setText(storedPin)
+        }
+    }
     serverUrl.isEnabled = false
     serverPassword.isEnabled = false
     editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
+}
+
 fun SyncActivity.onNeutralButtonClick(dialog: MaterialDialog) {
+    if (!prefData.getManualConfig()) {
         showAdditionalServers = !showAdditionalServers
         refreshServerList()
         dialog.getActionButton(DialogAction.NEUTRAL).text =
             if (showAdditionalServers) getString(R.string.show_less) else getString(R.string.show_more)
+    } else {
         serverConfigAction = "save"
         val protocol = "${settings.getString("serverProtocol", "")}"
         var url = "${serverUrl.text}"
@@ -164,6 +215,10 @@ fun SyncActivity.onNeutralButtonClick(dialog: MaterialDialog) {
         if (isUrlValid(url)) {
             currentDialog = dialog
             service.getMinApk(this, url, pin, this, "SyncActivity")
+        }
+    }
+}
+
 fun SyncActivity.initServerDialog(binding: DialogServerUrlBinding) {
     spnCloud = binding.spnCloud
     protocolCheckIn = binding.radioProtocol
@@ -171,35 +226,62 @@ fun SyncActivity.initServerDialog(binding: DialogServerUrlBinding) {
     serverPassword = binding.inputServerPassword
     serverAddresses = binding.serverUrls
     syncToServerText = binding.syncToServerText
-    binding.deviceName.setText(org.ole.planet.myplanet.utilities.networkUtils.getDeviceName())
+    binding.deviceName.setText(networkUtils.getDeviceName())
+}
+
 fun SyncActivity.setRadioProtocolListener(binding: DialogServerUrlBinding) {
     binding.radioProtocol.setOnCheckedChangeListener { _: RadioGroup?, checkedId: Int ->
         when (checkedId) {
+            R.id.radio_http -> editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
+            R.id.radio_https -> editor.putString("serverProtocol", getString(R.string.https_protocol)).apply()
+        }
+    }
+}
+
 fun SyncActivity.setupFastSyncOption(binding: DialogServerUrlBinding) {
     val isFastSync = settings.getBoolean("fastSync", false)
     binding.fastSync.isChecked = isFastSync
     binding.fastSync.setOnCheckedChangeListener { _: CompoundButton?, checked: Boolean ->
         editor.putBoolean("fastSync", checked).apply()
+    }
+}
+
 fun SyncActivity.handleManualConfiguration(
+    binding: DialogServerUrlBinding,
     configurationId: String?,
+    dialog: MaterialDialog,
+) {
+    if (!prefData.getManualConfig()) {
         binding.manualConfiguration.isChecked = false
         showConfigurationUIElements(binding, false, dialog)
+    } else {
         binding.manualConfiguration.isChecked = true
         showConfigurationUIElements(binding, true, dialog)
+    }
+
     binding.manualConfiguration.setOnCheckedChangeListener(null)
     binding.manualConfiguration.setOnClickListener {
         if (configurationId != null) {
             binding.manualConfiguration.isChecked = prefData.getManualConfig()
             if (prefData.getManualConfig()) {
                 clearDataDialog(getString(R.string.switching_off_manual_configuration_to_clear_data), false)
+            } else {
                 clearDataDialog(getString(R.string.switching_on_manual_configuration_to_clear_data), true)
+            }
+        } else {
             val newCheckedState = !prefData.getManualConfig()
             prefData.setManualConfig(newCheckedState)
             if (newCheckedState) {
                 setupManualConfigEnabled(binding, dialog)
+            } else {
                 prefData.setManualConfig(false)
                 showConfigurationUIElements(binding, false, dialog)
                 editor.putBoolean("switchCloudUrl", false).apply()
+            }
+        }
+    }
+}
+
 fun SyncActivity.setupManualConfigEnabled(binding: DialogServerUrlBinding, dialog: MaterialDialog) {
     prefData.setManualConfig(true)
     editor.putString("serverURL", "").apply()
@@ -207,6 +289,7 @@ fun SyncActivity.setupManualConfigEnabled(binding: DialogServerUrlBinding, dialo
     binding.radioHttp.isChecked = true
     editor.putString("serverProtocol", getString(R.string.http_protocol)).apply()
     showConfigurationUIElements(binding, true, dialog)
+
     val communities: List<RealmCommunity> =
         mRealm.where(RealmCommunity::class.java).sort("weight", Sort.ASCENDING).findAll()
     val nonEmptyCommunities = communities.filter { it.isValid && !TextUtils.isEmpty(it.name) }
@@ -214,12 +297,18 @@ fun SyncActivity.setupManualConfigEnabled(binding: DialogServerUrlBinding, dialo
     binding.spnCloud.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
         override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
             onChangeServerUrl()
+        }
+
         override fun onNothingSelected(parent: AdapterView<*>?) {}
+    }
+
     binding.switchServerUrl.setOnCheckedChangeListener { _: CompoundButton?, b: Boolean ->
         editor.putBoolean("switchCloudUrl", b).apply()
         binding.spnCloud.visibility = if (b) View.VISIBLE else View.GONE
         setUrlAndPin(binding.switchServerUrl.isChecked)
+    }
     serverUrl.addTextChangedListener(MyTextWatcher(serverUrl))
     binding.switchServerUrl.isChecked = settings.getBoolean("switchCloudUrl", false)
     setUrlAndPin(settings.getBoolean("switchCloudUrl", false))
     protocolSemantics()
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -56,14 +56,11 @@ import org.ole.planet.myplanet.utilities.DialogUtils.showSnack
 import org.ole.planet.myplanet.utilities.DialogUtils.showWifiSettingDialog
 import org.ole.planet.myplanet.utilities.DownloadUtils.downloadAllFiles
 import org.ole.planet.myplanet.utilities.FileUtils.availableOverTotalMemoryFormattedString
-import org.ole.planet.myplanet.utilities.NetworkUtils.extractProtocol
-import org.ole.planet.myplanet.utilities.NetworkUtils.getCustomDeviceName
-import org.ole.planet.myplanet.utilities.NetworkUtils.isNetworkConnectedFlow
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.NotificationUtil.cancelAll
 import org.ole.planet.myplanet.utilities.ServerConfigUtils
 import org.ole.planet.myplanet.utilities.Utilities.getRelativeTime
 import org.ole.planet.myplanet.utilities.Utilities.openDownloadService
-
 abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVersionCallback,
     OnUserSelectedListener, ConfigurationIdListener {
     private lateinit var syncDate: TextView
@@ -110,7 +107,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
     var serverAddressAdapter: ServerAddressAdapter? = null
     lateinit var serverListAddresses: List<ServerAddressesModel>
     private var isProgressDialogShowing = false
-
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -124,10 +120,8 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         defaultPref = PreferenceManager.getDefaultSharedPreferences(this)
         processedUrl = Utilities.getUrl()
     }
-
     override fun onConfigurationIdReceived(id: String, code: String, url: String, defaultUrl: String, isAlternativeUrl: Boolean, callerActivity: String) {
         val savedId = settings.getString("configurationId", null)
-
         when (callerActivity) {
             "LoginActivity", "DashboardActivity"-> {
                 if (isAlternativeUrl) {
@@ -146,39 +140,26 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                             continueSync(it, url, isAlternativeUrl, defaultUrl)
                         }
                     } else if (id == savedId) {
-                        currentDialog?.let {
-                            continueSync(it, url, isAlternativeUrl, defaultUrl)
-                        }
                     } else {
                         clearDataDialog(getString(R.string.you_want_to_connect_to_a_different_server), false)
                     }
                 } else if (serverConfigAction == "save") {
                     if (savedId == null || id == savedId) {
                         currentDialog?.let { saveConfigAndContinue(it, "", false, defaultUrl) }
-                    } else {
-                        clearDataDialog(getString(R.string.you_want_to_connect_to_a_different_server), false)
-                    }
-                }
-            }
         }
-    }
-
     fun clearDataDialog(message: String, config: Boolean, onCancel: () -> Unit = {}) {
         AlertDialog.Builder(this, R.style.AlertDialogTheme)
             .setMessage(message)
             .setPositiveButton(getString(R.string.clear_data)) { dialog, _ ->
                 (dialog as AlertDialog).getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = false
                 dialog.getButton(AlertDialog.BUTTON_NEGATIVE).isEnabled = false
-
                 lifecycleScope.launch {
                     try {
                         customProgressDialog.setText(getString(R.string.clearing_data))
                         customProgressDialog.show()
-
                         clearRealmDb()
                         prefData.setManualConfig(config)
                         clearSharedPref()
-
                         delay(500)
                         restartApp()
                     } catch (e: Exception) {
@@ -186,16 +167,10 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                         customProgressDialog.dismiss()
                         dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = true
                         dialog.getButton(AlertDialog.BUTTON_NEGATIVE).isEnabled = true
-                    }
-                }
-            }
             .setNegativeButton(getString(R.string.cancel)) { _, _ ->
                 onCancel()
-            }
             .setCancelable(false)
             .show()
-    }
-
     private fun clearInternalStorage() {
         val myDir = File(Utilities.SD_PATH)
         if (myDir.isDirectory) {
@@ -203,23 +178,15 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
             if (children != null) {
                 for (i in children.indices) {
                     File(myDir, children[i]).delete()
-                }
-            }
-        }
         editor.putBoolean("firstRun", false).apply()
-    }
-
     fun sync(dialog: MaterialDialog) {
         spinner = dialog.findViewById(R.id.intervalDropper) as Spinner
         syncSwitch = dialog.findViewById(R.id.syncSwitch) as SwitchCompat
         intervalLabel = dialog.findViewById(R.id.intervalLabel) as TextView
         syncSwitch.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
             setSpinnerVisibility(isChecked)
-        }
         syncSwitch.isChecked = settings.getBoolean("autoSync", true)
         dateCheck(dialog)
-    }
-
     private fun setSpinnerVisibility(isChecked: Boolean) {
         if (isChecked) {
             intervalLabel.visibility = View.VISIBLE
@@ -227,9 +194,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         } else {
             spinner.visibility = View.GONE
             intervalLabel.visibility = View.GONE
-        }
-    }
-
     suspend fun isServerReachable(processedUrl: String?, type: String): Boolean {
         return withContext(Dispatchers.IO) {
             val apiInterface = client?.create(ApiInterface::class.java)
@@ -238,18 +202,13 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                      if (processedUrl?.contains("/db") == true) {
                          val processedUrlWithoutDb = processedUrl.replace("/db", "")
                          apiInterface?.isPlanetAvailable("$processedUrlWithoutDb/db/_all_dbs")?.execute()
-                    } else {
                          apiInterface?.isPlanetAvailable("$processedUrl/db/_all_dbs")?.execute()
-                    }
                 } else {
                     apiInterface?.isPlanetAvailable("$processedUrl/_all_dbs")?.execute()
-                }
-
                 when {
                     response?.isSuccessful == true -> {
                         val ss = response.body()?.string()
                         val myList = ss?.split(",")?.dropLastWhile { it.isEmpty() }
-
                         if ((myList?.size ?: 0) < 8) {
                             withContext(Dispatchers.Main) {
                                 customProgressDialog.dismiss()
@@ -257,51 +216,33 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                             }
                             false
                         } else {
-                            withContext(Dispatchers.Main) {
                                 startSync(type)
-                            }
                             true
-                        }
-                    }
                     else -> {
                         syncFailed = true
-                        val protocol = extractProtocol("$processedUrl")
+                        val protocol = networkUtils.extractProtocol("$processedUrl")
                         val errorMessage = when (protocol) {
                             context.getString(R.string.http_protocol) -> context.getString(R.string.device_couldn_t_reach_local_server)
                             context.getString(R.string.https_protocol) -> context.getString(R.string.device_couldn_t_reach_nation_server)
                             else -> ""
-                        }
                         withContext(Dispatchers.Main) {
                             customProgressDialog.dismiss()
                             alertDialogOkay(errorMessage)
-                        }
                         false
-                    }
-                }
             } catch (e: Exception) {
                 e.printStackTrace()
                 false
-            }
-        }
-    }
-
     private fun dateCheck(dialog: MaterialDialog) {
         // Check if the user never synced
         syncDate = dialog.findViewById(R.id.lastDateSynced) as TextView
         syncDate.text = getString(R.string.last_sync_date, convertDate())
         syncDropdownAdd()
-    }
-
     // Converts OS date to human date
     private fun convertDate(): String {
         val lastSynced = settings.getLong("LastSync", 0)
         return if (lastSynced == 0L) {
             " Never Synced"
-        } else {
             getRelativeTime(lastSynced)
-        }
-    }
-
     private fun syncDropdownAdd() {
         val list: MutableList<String> = ArrayList()
         list.add("1 " + getString(R.string.hour))
@@ -309,32 +250,22 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         val spinnerArrayAdapter = ArrayAdapter(this, R.layout.spinner_item, list)
         spinnerArrayAdapter.setDropDownViewResource(R.layout.spinner_item)
         spinner.adapter = spinnerArrayAdapter
-    }
-
     private fun saveSyncInfoToPreference() {
         editor.putBoolean("autoSync", syncSwitch.isChecked)
         editor.putInt("autoSyncInterval", syncTimeInterval[spinner.selectedItemPosition])
         editor.putInt("autoSyncPosition", spinner.selectedItemPosition)
         editor.apply()
-    }
-
     fun authenticateUser(settings: SharedPreferences?, username: String?, password: String?, isManagerMode: Boolean): Boolean {
         return try {
             if (settings != null) {
                 this.settings = settings
-            }
             if (mRealm.isEmpty) {
                 alertDialogOkay(getString(R.string.server_not_configured_properly_connect_this_device_with_planet_server))
-                false
             } else {
                 checkName(username, password, isManagerMode)
-            }
         } catch (e: Exception) {
             e.printStackTrace()
             false
-        }
-    }
-
     private fun checkName(username: String?, password: String?, isManagerMode: Boolean): Boolean {
         try {
             val user = mRealm.where(RealmUserModel::class.java).equalTo("name", username).findFirst()
@@ -343,26 +274,14 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                     if (username == it.name && password == it.password) {
                         saveUserInfoPref(settings, password, it)
                         return true
-                    }
-                } else {
                     if (androidDecrypter(username, password, it.derived_key, it.salt)) {
                         if (isManagerMode && !it.isManager()) return false
-                        saveUserInfoPref(settings, password, it)
-                        return true
-                    }
-                }
-            }
         } catch (err: Exception) {
             err.printStackTrace()
             return false
-        }
         return false
-    }
-
     fun startSync(type: String) {
         SyncManager.instance?.start(this@SyncActivity, type)
-    }
-
     private fun saveConfigAndContinue(
         dialog: MaterialDialog,
         url: String,
@@ -373,129 +292,81 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         saveSyncInfoToPreference()
         return if (isAlternativeUrl) {
             handleAlternativeUrlSave(dialog, url, defaultUrl)
-        } else {
             handleRegularUrlSave(dialog)
-        }
-    }
-
     private fun handleAlternativeUrlSave(
-        dialog: MaterialDialog,
-        url: String,
-        defaultUrl: String
-    ): String {
         val password = if (settings.getString("serverPin", "") != "") {
             settings.getString("serverPin", "")!!
-        } else {
             (dialog.customView?.findViewById<View>(R.id.input_server_Password) as EditText).text.toString()
-        }
-
         val couchdbURL = ServerConfigUtils.saveAlternativeUrl(url, password, settings, editor)
         if (isUrlValid(url)) setUrlParts(defaultUrl, password) else ""
         return couchdbURL
-    }
-
     private fun handleRegularUrlSave(dialog: MaterialDialog): String {
         val protocol = settings.getString("serverProtocol", "")
         var url = (dialog.customView?.findViewById<View>(R.id.input_server_url) as EditText).text.toString()
         val pin = (dialog.customView?.findViewById<View>(R.id.input_server_Password) as EditText).text.toString()
-
         editor.putString(
             "customDeviceName",
             (dialog.customView?.findViewById<View>(R.id.deviceName) as EditText).text.toString()
         ).apply()
-
         url = protocol + url
         return if (isUrlValid(url)) setUrlParts(url, pin) else ""
-    }
-
     override fun onSyncStarted() {
         customProgressDialog.setText(getString(R.string.syncing_data_please_wait))
         customProgressDialog.show()
         isProgressDialogShowing = true
-    }
-
     override fun onSyncFailed(msg: String?) {
         if (isProgressDialogShowing) {
             customProgressDialog.dismiss()
-        }
         if (::syncIconDrawable.isInitialized) {
             syncIconDrawable = syncIcon.drawable as AnimationDrawable
             syncIconDrawable.stop()
             syncIconDrawable.selectDrawable(0)
             syncIcon.invalidateDrawable(syncIconDrawable)
-        }
         runOnUiThread {
             showAlert(this@SyncActivity, getString(R.string.sync_failed), msg)
             showWifiSettingDialog(this@SyncActivity)
-        }
-    }
-
     override fun onSyncComplete() {
         val activityContext = this@SyncActivity
         lifecycleScope.launch(Dispatchers.IO) {
-            try {
                 var attempt = 0
                 while (true) {
                     val realm = Realm.getDefaultInstance()
                     var dataInserted = false
-
-                    try {
                         realm.refresh()
                         val realmResults = realm.where(RealmUserModel::class.java).findAll()
                         if (!realmResults.isEmpty()) {
                             dataInserted = true
                             break
-                        }
                     } finally {
                         realm.close()
-                    }
                     attempt++
                     delay(1000)
-                }
-
                 withContext(Dispatchers.Main) {
                     forceSyncTrigger()
                     val syncedUrl = settings.getString("serverURL", null)?.let { ServerConfigUtils.removeProtocol(it) }
                     if (syncedUrl != null && serverListAddresses.any { it.url.replace(Regex("^https?://"), "") == syncedUrl }) {
                         editor.putString("pinnedServerUrl", syncedUrl).apply()
-                    }
-
                     customProgressDialog.dismiss()
-
                     if (::syncIconDrawable.isInitialized) {
                         syncIconDrawable = syncIcon.drawable as AnimationDrawable
                         syncIconDrawable.stop()
                         syncIconDrawable.selectDrawable(0)
                         syncIcon.invalidateDrawable(syncIconDrawable)
-                    }
-
                     lifecycleScope.launch {
                         createLog("synced successfully", "")
-                    }
-
                     lifecycleScope.launch(Dispatchers.IO) {
                         val pendingLanguage = settings.getString("pendingLanguageChange", null)
                         if (pendingLanguage != null) {
-                            withContext(Dispatchers.Main) {
                                 editor.remove("pendingLanguageChange").apply()
-
                                 LocaleHelper.setLocale(this@SyncActivity, pendingLanguage)
                                 updateUIWithNewLanguage()
-                            }
-                        }
-                    }
-
                     showSnack(activityContext.findViewById(android.R.id.content), getString(R.string.sync_completed))
-
                     if (settings.getBoolean("isAlternativeUrl", false)) {
                         editor.putString("alternativeUrl", "")
                         editor.putString("processedAlternativeUrl", "")
                         editor.putBoolean("isAlternativeUrl", false)
                         editor.apply()
-                    }
-
                     downloadAdditionalResources()
-
                     val betaAutoDownload = defaultPref.getBoolean("beta_auto_download", false)
                     if (betaAutoDownload) {
                         withContext(Dispatchers.IO) {
@@ -504,35 +375,17 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                                 backgroundDownload(downloadAllFiles(getAllLibraryList(downloadRealm)))
                             } finally {
                                 downloadRealm.close()
-                            }
-                        }
-                    }
-
                     cancelAll(activityContext)
-
                     if (activityContext is LoginActivity) {
                         activityContext.updateTeamDropdown()
-                    }
-                }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-    }
-
     private fun updateUIWithNewLanguage() {
-        try {
             if (::lblLastSyncDate.isInitialized) {
                 lblLastSyncDate.text = getString(R.string.last_sync, getRelativeTime(Date().time))
-            }
-
             lblVersion.text = getString(R.string.app_version)
             tvAvailableSpace.text = buildString {
                 append(getString(R.string.available_space_colon))
                 append(" ")
                 append(availableOverTotalMemoryFormattedString)
-            }
-
             inputName.hint = getString(R.string.hint_name)
             inputPassword.hint = getString(R.string.password)
             btnSignIn.text = getString(R.string.btn_sign_in)
@@ -543,12 +396,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
             val currentLanguage = LocaleHelper.getLanguage(this)
             btnLang.text = getLanguageString(currentLanguage)
             invalidateOptionsMenu()
-        } catch (e: Exception) {
-            e.printStackTrace()
             recreate()
-        }
-    }
-
     fun getLanguageString(languageCode: String): String {
         return when (languageCode) {
             "en" -> getString(R.string.english)
@@ -558,51 +406,31 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
             "ar" -> getString(R.string.arabic)
             "fr" -> getString(R.string.french)
             else -> getString(R.string.english)
-        }
-    }
-
     private fun downloadAdditionalResources() {
         val storedJsonConcatenatedLinks = settings.getString("concatenated_links", null)
         if (storedJsonConcatenatedLinks != null) {
             val storedConcatenatedLinks: ArrayList<String> = Json.decodeFromString(storedJsonConcatenatedLinks)
             openDownloadService(context, storedConcatenatedLinks, true)
-        }
-    }
-
     fun forceSyncTrigger(): Boolean {
         if (settings.getLong(getString(R.string.last_syncs), 0) <= 0) {
             lblLastSyncDate.text = getString(R.string.last_synced_never)
-        } else {
             val lastSyncMillis = settings.getLong(getString(R.string.last_syncs), 0)
             var relativeTime = getRelativeTime(lastSyncMillis)
-
             if (relativeTime.matches(Regex("^\\d{1,2} seconds ago$"))) {
                 relativeTime = getString(R.string.a_few_seconds_ago)
-            }
-
             lblLastSyncDate.text = getString(R.string.last_sync, relativeTime)
-        }
         if (autoSynFeature(Constants.KEY_AUTOSYNC_, applicationContext) && autoSynFeature(Constants.KEY_AUTOSYNC_WEEKLY, applicationContext)) {
             return checkForceSync(7)
         } else if (autoSynFeature(Constants.KEY_AUTOSYNC_, applicationContext) && autoSynFeature(Constants.KEY_AUTOSYNC_MONTHLY, applicationContext)) {
             return checkForceSync(30)
-        }
-        return false
-    }
-
     fun showWifiDialog() {
         if (intent.getBooleanExtra("showWifiDialog", false)) {
             showWifiSettingDialog(this)
-        }
-    }
-
     private fun checkForceSync(maxDays: Int): Boolean {
         cal_today = Calendar.getInstance(Locale.ENGLISH)
         cal_last_Sync = Calendar.getInstance(Locale.ENGLISH)
         val lastSyncTime = settings.getLong("LastSync", -1)
         if (lastSyncTime <= 0) {
-            return false
-        }
         cal_last_Sync.timeInMillis = lastSyncTime
         cal_today.timeInMillis = System.currentTimeMillis()
         val msDiff = cal_today.timeInMillis - cal_last_Sync.timeInMillis
@@ -612,21 +440,14 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
             alertDialogBuilder.setMessage("${getString(R.string.it_has_been_more_than)}${(daysDiff - 1)}${getString(R.string.days_since_you_last_synced_this_device)}${getString(R.string.connect_it_to_the_server_over_wifi_and_sync_it_to_reactivate_this_tablet)}")
             alertDialogBuilder.setPositiveButton(R.string.okay) { _: DialogInterface?, _: Int ->
                 Toast.makeText(applicationContext, getString(R.string.connect_to_the_server_over_wifi_and_sync_your_device_to_continue), Toast.LENGTH_LONG).show()
-            }
             alertDialogBuilder.show()
             true
-        } else {
-            false
-        }
-    }
-
     fun onLogin() {
         val handler = UserProfileDbHandler(this)
         handler.onLogin()
         handler.onDestroy()
         editor.putBoolean(Constants.KEY_LOGIN, true).commit()
         openDashboard()
-
         isNetworkConnectedFlow.onEach { isConnected ->
             if (isConnected) {
                 val serverUrl = settings.getString("serverURL", "")
@@ -634,9 +455,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                     MainApplication.applicationScope.launch(Dispatchers.IO) {
                         val canReachServer = MainApplication.Companion.isServerReachable(serverUrl)
                         if (canReachServer) {
-                            withContext(Dispatchers.Main) {
                                 startUpload("login")
-                            }
                             withContext(Dispatchers.Default) {
                                 val backgroundRealm = Realm.getDefaultInstance()
                                 try {
@@ -644,18 +463,10 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                                 } finally {
                                     backgroundRealm.close()
                                 }
-                            }
-                        }
-                    }
-                }
-            }
         }.launchIn(MainApplication.applicationScope)
-    }
-
     fun settingDialog() {
         val binding = DialogServerUrlBinding.inflate(LayoutInflater.from(this))
         initServerDialog(binding)
-
         val contextWrapper = ContextThemeWrapper(this, R.style.AlertDialogTheme)
         val dialog = MaterialDialog.Builder(contextWrapper)
             .customView(binding.root, true)
@@ -664,120 +475,72 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
             .neutralText(R.string.btn_sync_save)
             .onPositive { d: MaterialDialog, _: DialogAction? -> performSync(d) }
             .build()
-
         positiveAction = dialog.getActionButton(DialogAction.POSITIVE)
         neutralAction = dialog.getActionButton(DialogAction.NEUTRAL)
-
         handleManualConfiguration(binding, settings.getString("configurationId", null), dialog)
         setRadioProtocolListener(binding)
         binding.clearData.setOnClickListener {
             clearDataDialog(getString(R.string.are_you_sure_you_want_to_clear_data), false)
-        }
         setupFastSyncOption(binding)
-
         showAdditionalServers = false
         if (::serverListAddresses.isInitialized && settings.getString("serverURL", "")?.isNotEmpty() == true) {
             refreshServerList()
-        }
-
         neutralAction.setOnClickListener { onNeutralButtonClick(dialog) }
-
         dialog.show()
         sync(dialog)
         if (!prefData.getManualConfig()) {
             dialog.getActionButton(DialogAction.NEUTRAL).text = getString(R.string.show_more)
-        }
-    }
     fun continueSync(dialog: MaterialDialog, url: String, isAlternativeUrl: Boolean, defaultUrl: String) {
         processedUrl = saveConfigAndContinue(dialog, url, isAlternativeUrl, defaultUrl)
         if (TextUtils.isEmpty(processedUrl)) return
         isSync = true
         if (checkPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) && settings.getBoolean("firstRun", true)) {
             clearInternalStorage()
-        }
         Service(this).isPlanetAvailable(object : PlanetAvailableListener {
             override fun isAvailable() {
                 Service(context).checkVersion(this@SyncActivity, settings)
-            }
             override fun notAvailable() {
                 if (!isFinishing) {
                     syncFailed = true
                     showAlert(context, "Error", getString(R.string.planet_server_not_reachable))
-                }
-            }
         })
-    }
-
     override fun onSuccess(success: String?) {
         if (customProgressDialog.isShowing() == true && success?.contains("Crash") == true) {
-            customProgressDialog.dismiss()
-        }
         if (::btnSignIn.isInitialized) {
             showSnack(btnSignIn, success)
-        }
         editor.putLong("lastUsageUploaded", Date().time).apply()
         if (::lblLastSyncDate.isInitialized) {
             lblLastSyncDate.text = getString(R.string.message_placeholder, "${getString(R.string.last_sync, getRelativeTime(Date().time))} >>")
-        }
         syncFailed = false
-    }
-
     override fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean) {
-        mRealm = Realm.getDefaultInstance()
         val builder = getUpdateDialog(this, info, customProgressDialog)
         if (cancelable || getCustomDeviceName(this).endsWith("###")) {
             builder.setNegativeButton(R.string.update_later) { _: DialogInterface?, _: Int ->
                 continueSyncProcess()
-            }
-        } else {
             mRealm.executeTransactionAsync { realm: Realm -> realm.deleteAll() }
-        }
         builder.setCancelable(cancelable)
         builder.show()
-    }
-
     override fun onCheckingVersion() {
         customProgressDialog.setText(getString(R.string.checking_version))
-        customProgressDialog.show()
-    }
-
     fun registerReceiver() {
         val bManager = LocalBroadcastManager.getInstance(this)
         val intentFilter = IntentFilter()
         intentFilter.addAction(DashboardActivity.MESSAGE_PROGRESS)
         bManager.registerReceiver(broadcastReceiver, intentFilter)
-    }
-
     override fun onError(msg: String, blockSync: Boolean) {
         Utilities.toast(this, msg)
         if (msg.startsWith("Config")) {
             settingDialog()
-        }
         customProgressDialog.dismiss()
         if (!blockSync) continueSyncProcess() else {
-            syncIconDrawable.stop()
-            syncIconDrawable.selectDrawable(0)
-        }
-    }
-
     private fun continueSyncProcess() {
-        try {
             lifecycleScope.launch {
                 if (isSync) {
                     isServerReachable(processedUrl, "sync")
                 } else if (forceSync) {
                     isServerReachable(processedUrl, "upload")
                     startUpload("")
-                }
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
-
     override fun onSelectedUser(userModel: RealmUserModel) {
-        mRealm = Realm.getDefaultInstance()
         val layoutChildLoginBinding = LayoutChildLoginBinding.inflate(layoutInflater)
         AlertDialog.Builder(this).setView(layoutChildLoginBinding.root)
             .setTitle(R.string.please_enter_your_password)
@@ -786,45 +549,29 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                 if (authenticateUser(settings, userModel.name, password, false)) {
                     Toast.makeText(applicationContext, getString(R.string.thank_you), Toast.LENGTH_SHORT).show()
                     onLogin()
-                } else {
                     alertDialogOkay(getString(R.string.err_msg_login))
-                }
             }.setNegativeButton(R.string.cancel, null).show()
-    }
-
     inner class MyTextWatcher(var view: View?) : TextWatcher {
         override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
         override fun onTextChanged(s: CharSequence, i: Int, i1: Int, i2: Int) {
             if (view?.id == R.id.input_server_url) {
                 positiveAction.isEnabled = "$s".trim { it <= ' ' }.isNotEmpty() && URLUtil.isValidUrl("${settings.getString("serverProtocol", "")}$s")
-            }
-        }
         override fun afterTextChanged(editable: Editable) {}
-    }
-
     override fun onDestroy() {
         super.onDestroy()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
-        }
-    }
     companion object {
         lateinit var cal_today: Calendar
         lateinit var cal_last_Sync: Calendar
-
         suspend fun clearRealmDb() {
             withContext(Dispatchers.IO) {
                 val realm = Realm.getDefaultInstance()
                 try {
                     realm.executeTransaction { transactionRealm ->
                         transactionRealm.deleteAll()
-                    }
                 } finally {
                     realm.close()
-                }
-            }
-        }
-
         fun clearSharedPref() {
             val settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
             val editor = settings.edit()
@@ -832,22 +579,15 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
             val tempStorage = HashMap<String, Boolean>()
             for (key in keysToKeep) {
                 tempStorage[key] = settings.getBoolean(key, false)
-            }
             editor.clear().apply()
             for ((key, value) in tempStorage) {
                 editor.putBoolean(key, value)
-            }
             editor.commit()
-
             val preferences = PreferenceManager.getDefaultSharedPreferences(context)
             preferences.edit { clear() }
-        }
-
         fun restartApp() {
             val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
             val mainIntent = Intent.makeRestartActivityTask(intent?.component)
             context.startActivity(mainIntent)
             Runtime.getRuntime().exit(0)
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/BecomeMemberActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/BecomeMemberActivity.kt
@@ -28,17 +28,14 @@ import org.ole.planet.myplanet.ui.sync.LoginActivity
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils.CustomProgressDialog
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtil
-import org.ole.planet.myplanet.utilities.NetworkUtils
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils
 import org.ole.planet.myplanet.utilities.AuthHelper
-
 class BecomeMemberActivity : BaseActivity() {
     private lateinit var activityBecomeMemberBinding: ActivityBecomeMemberBinding
     var dob: String = ""
     var guest: Boolean = false
-
-
     private data class MemberInfo(
         val username: String,
         var password: String,
@@ -53,17 +50,13 @@ class BecomeMemberActivity : BaseActivity() {
         val birthDate: String,
         val gender: String?
     )
-
     private fun usernameValidationError(username: String, realm: Realm? = null): String? {
         return AuthHelper.validateUsername(this, username, realm)
     }
-
     private fun selectedGender(): String? = when {
         activityBecomeMemberBinding.male.isChecked -> "male"
         activityBecomeMemberBinding.female.isChecked -> "female"
         else -> null
-    }
-
     private fun showDatePickerDialog() {
         val now = Calendar.getInstance()
         val dpd = DatePickerDialog(
@@ -75,8 +68,6 @@ class BecomeMemberActivity : BaseActivity() {
         dpd.setTitle(getString(R.string.select_date_of_birth))
         dpd.datePicker.maxDate = now.timeInMillis
         dpd.show()
-    }
-
     private fun collectMemberInfo() = MemberInfo(
         activityBecomeMemberBinding.etUsername.text.toString(),
         activityBecomeMemberBinding.etPassword.text.toString(),
@@ -90,14 +81,11 @@ class BecomeMemberActivity : BaseActivity() {
         activityBecomeMemberBinding.etPhone.text.toString(),
         dob,
         selectedGender()
-    )
-
     private fun validateMemberInfo(info: MemberInfo, realm: Realm): Boolean {
         usernameValidationError(info.username, realm)?.let {
             activityBecomeMemberBinding.etUsername.error = it
             return false
         }
-
         return when {
             info.password.isEmpty() -> {
                 activityBecomeMemberBinding.etPassword.error = getString(R.string.please_enter_a_password)
@@ -105,20 +93,11 @@ class BecomeMemberActivity : BaseActivity() {
             }
             info.password != info.rePassword -> {
                 activityBecomeMemberBinding.etRePassword.error = getString(R.string.password_doesn_t_match)
-                false
-            }
             info.email.isNotEmpty() && !Utilities.isValidEmail(info.email) -> {
                 activityBecomeMemberBinding.etEmail.error = getString(R.string.invalid_email)
-                false
-            }
             info.gender == null -> {
                 Utilities.toast(this, getString(R.string.please_select_gender))
-                false
-            }
             else -> true
-        }
-    }
-
     private fun buildMemberJson(info: MemberInfo) = JsonObject().apply {
         addProperty("name", info.username)
         addProperty("firstName", info.fName)
@@ -137,34 +116,26 @@ class BecomeMemberActivity : BaseActivity() {
         addProperty("gender", info.gender)
         addProperty("type", "user")
         addProperty("betaEnabled", false)
-        addProperty("androidId", NetworkUtils.getUniqueIdentifier())
+        addProperty("androidId", networkUtils.getUniqueIdentifier())
         addProperty("uniqueAndroidId", VersionUtils.getAndroidId(MainApplication.context))
-        addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(MainApplication.context))
+        addProperty("customDeviceName", networkUtils.getCustomDeviceName(MainApplication.context))
         val roles = JsonArray().apply { add("learner") }
         add("roles", roles)
-    }
-
     private fun addMember(info: MemberInfo, realm: Realm) {
         val obj = buildMemberJson(info)
         val customProgressDialog = CustomProgressDialog(this).apply {
             setText(getString(R.string.creating_member_account))
             show()
-        }
-
         Service(this).becomeMember(realm, obj, object : Service.CreateUserCallback {
             override fun onSuccess(success: String) {
                 runOnUiThread { Utilities.toast(this@BecomeMemberActivity, success) }
-            }
         }, object : SecurityDataCallback {
             override fun onSecurityDataUpdated() {
                 runOnUiThread {
                     customProgressDialog.dismiss()
                     autoLoginNewMember(info.username, info.password)
                 }
-            }
         })
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         activityBecomeMemberBinding = ActivityBecomeMemberBinding.inflate(layoutInflater)
@@ -178,58 +149,38 @@ class BecomeMemberActivity : BaseActivity() {
         activityBecomeMemberBinding.spnLang.adapter = lnAadapter
         activityBecomeMemberBinding.txtDob.setOnClickListener {
             showDatePickerDialog()
-        }
         val levels = resources.getStringArray(R.array.level)
         val lvAdapter  = ArrayAdapter(this, R.layout.become_a_member_spinner_layout, levels)
         activityBecomeMemberBinding.spnLevel.adapter = lvAdapter
-
         val username = intent.getStringExtra("username") ?: ""
         guest = intent.getBooleanExtra("guest", false)
-
         settings = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         setupTextWatchers(mRealm)
-
         if (guest) {
             activityBecomeMemberBinding.etUsername.setText(username)
             activityBecomeMemberBinding.etUsername.isFocusable = false
-        }
-
-
         activityBecomeMemberBinding.btnCancel.setOnClickListener {
             finish()
-        }
-
         activityBecomeMemberBinding.btnSubmit.setOnClickListener {
             val info = collectMemberInfo()
             if (validateMemberInfo(info, mRealm)) {
                 addMember(info, mRealm)
-            }
-        }
-    }
-
     private fun autoLoginNewMember(username: String, password: String) {
         val mRealm = DatabaseService(this).realmInstance
         RealmUserModel.cleanupDuplicateUsers(mRealm)
         mRealm.close()
-
         val intent = Intent(this, LoginActivity::class.java)
         intent.putExtra("username", username)
         intent.putExtra("password", password)
         intent.putExtra("auto_login", true)
-        if (guest) {
             intent.putExtra("guest", guest)
-        }
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
         startActivity(intent)
         finish()
-    }
-
     private fun setupTextWatchers(mRealm: Realm) {
         activityBecomeMemberBinding.etUsername.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-
             override fun afterTextChanged(s: Editable?) {
                 val input = s?.toString() ?: ""
                 val error = usernameValidationError(input, mRealm)
@@ -242,20 +193,10 @@ class BecomeMemberActivity : BaseActivity() {
                         activityBecomeMemberBinding.etUsername.setSelection(lowercase.length)
                     }
                     activityBecomeMemberBinding.etUsername.error = null
-                }
-            }
-        })
-
         activityBecomeMemberBinding.etPassword.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable) {
                 if (activityBecomeMemberBinding.etPassword.text.toString().isEmpty()) {
                     activityBecomeMemberBinding.etRePassword.setText("")
-                }
-            }
-
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
-
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
-        })
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/CourseRatingUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/CourseRatingUtils.kt
@@ -1,14 +1,13 @@
 package org.ole.planet.myplanet.utilities
 
+import android.content.Context
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatRatingBar
 import com.google.gson.JsonObject
 import java.util.Locale
-import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.R
 
-object CourseRatingUtils {
-    @JvmStatic
+class CourseRatingUtils(private val context: Context) {
     fun showRating(obj: JsonObject?, average: TextView?, ratingCount: TextView?, ratingBar: AppCompatRatingBar?) {
         average?.text = String.format(Locale.getDefault(), "%.2f", obj?.get("averageRating")?.asFloat)
         ratingCount?.text = context.getString(R.string.rating_count_format, obj?.get("total")?.asInt)

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -19,7 +19,6 @@ import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.sync.SyncActivity
 import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
-
 object DialogUtils {
     @JvmStatic
     fun getProgressDialog(context: Context): CustomProgressDialog {
@@ -32,7 +31,6 @@ object DialogUtils {
         }
         return prgDialog
     }
-
     fun guestDialog(context: Context) {
         val profileDbHandler = UserProfileDbHandler(context)
         val builder = android.app.AlertDialog.Builder(context, R.style.CustomAlertDialog)
@@ -41,45 +39,32 @@ object DialogUtils {
         builder.setCancelable(false)
         builder.setPositiveButton(context.getString(R.string.become_a_member), null)
         builder.setNegativeButton(context.getString(R.string.cancel), null)
-
         val dialog = builder.create()
         dialog.show()
-
         val becomeMember = dialog.getButton(android.app.AlertDialog.BUTTON_POSITIVE)
         val cancel = dialog.getButton(android.app.AlertDialog.BUTTON_NEGATIVE)
         becomeMember.contentDescription = context.getString(R.string.confirm_membership)
         cancel.contentDescription = context.getString(R.string.cancel)
-
         becomeMember.setOnClickListener {
             val guest = true
             val intent = Intent(context, BecomeMemberActivity::class.java)
             intent.putExtra("username", profileDbHandler.userModel?.name)
             intent.putExtra("guest", guest)
             context.startActivity(intent)
-        }
         cancel.setOnClickListener {
             dialog.dismiss()
-        }
-    }
-
-    @JvmStatic
     fun showError(prgDialog: CustomProgressDialog?, message: String?) {
         prgDialog?.setTitle(message)
         prgDialog?.disableNegativeButton()
-    }
-
-    @JvmStatic
     fun showWifiSettingDialog(context: Context) {
-        if (!NetworkUtils.isWifiBluetoothEnabled()) return
+        if (!networkUtils.isWifiBluetoothEnabled()) return
         showDialog(context)
-    }
-
     private fun showDialog(context: Context) {
         if (MainApplication.syncFailedCount > 3) {
             val pd = AlertDialog.Builder(context, R.style.AlertDialogTheme)
             var message = ""
-            if (NetworkUtils.isBluetoothEnabled()) message += "Bluetooth"
-            if (NetworkUtils.isWifiEnabled()) {
+            if (networkUtils.isBluetoothEnabled()) message += "Bluetooth"
+            if (networkUtils.isWifiEnabled()) {
                 if (message.isNotEmpty()) message += " and "
                     message += "Wi-Fi"
             }
@@ -87,7 +72,6 @@ object DialogUtils {
             message += context.getString(R.string.is_on_please_turn_of_to_save_battery)
             } else {
             message = context.getString(R.string.is_on_please_turn_of_to_save_battery)
-            }
             pd.setMessage(message)
             pd.setPositiveButton(context.getString(R.string.go_to_settings)) { _, _ ->
                 MainApplication.syncFailedCount = 0
@@ -97,17 +81,9 @@ object DialogUtils {
             pd.setCancelable(false)
             val d = pd.create()
             d.show()
-        }
-    }
-
-    @JvmStatic
     fun showSnack(v: View?, s: String?) {
         if (v != null) {
             s?.let { Snackbar.make(v, it, Snackbar.LENGTH_LONG).show() }
-        }
-    }
-
-    @JvmStatic
     fun showAlert(context: Context?, title: String?, message: String?) {
         if (context is Activity && !context.isFinishing) {
             AlertDialog.Builder(context, R.style.AlertDialogTheme)
@@ -119,10 +95,6 @@ object DialogUtils {
                     }
                 }
                 .show()
-        }
-    }
-
-    @JvmStatic
     fun getAlertDialog(context: Context, message: String, pos: String, listener: DialogInterface.OnClickListener?): AlertDialog {
         return AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialog))
             .setMessage(message)
@@ -130,66 +102,38 @@ object DialogUtils {
             .setPositiveButton(pos, listener)
             .setNegativeButton(R.string.button_cancel, null)
             .show()
-    }
-
-    @JvmStatic
     fun showCloseAlert(context: Context, title: String?, message: String) {
         AlertDialog.Builder(context, R.style.CustomAlertDialog)
             .setTitle(title)
-            .setMessage(message)
             .setPositiveButton(R.string.close, null)
-            .show()
-    }
-
-    @JvmStatic
     fun getAlertDialog(context: Context, title: String, v: View): AlertDialog {
-        return AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialog))
-            .setTitle(title)
             .setIcon(R.drawable.ic_edit)
             .setView(v)
             .setPositiveButton(R.string.submit, null)
             .setNegativeButton(R.string.cancel, null)
-            .show()
-    }
-
-    @JvmStatic
     fun getUpdateDialog(context: Context, info: MyPlanet?, progressDialog: CustomProgressDialog?): AlertDialog.Builder {
         return AlertDialog.Builder(context, R.style.CustomAlertDialog)
             .setTitle(R.string.new_version_of_my_planet_available)
             .setMessage(R.string.download_first_to_continue)
             .setNeutralButton(R.string.upgrade_local) { _, _ ->
                 startDownloadUpdate(context, Utilities.getApkUpdateUrl(info?.localapkpath), progressDialog)
-            }
             .setPositiveButton(R.string.upgrade) { _, _ ->
                 info?.apkpath?.let { startDownloadUpdate(context, it, progressDialog) }
-            }
-    }
-
-    @JvmStatic
     fun startDownloadUpdate(context: Context, path: String, progressDialog: CustomProgressDialog?) {
         Service(MainApplication.context).checkCheckSum(object : Service.ChecksumCallback {
             override fun onMatch() {
                 Utilities.toast(MainApplication.context, context.getString(R.string.apk_already_exists))
                 FileUtils.installApk(context, path)
-            }
-
             override fun onFail() {
                 val urls = arrayListOf(path)
                 if (progressDialog != null) {
                     progressDialog.setText(context.getString(R.string.downloading_file))
                     progressDialog.setCancelable(false)
                     progressDialog.show()
-                }
                 MyDownloadService.startService(context, "$urls", false)
-            }
         }, path)
-    }
-
-    @JvmStatic
     fun getCustomProgressDialog(context: Context): CustomProgressDialog {
         return CustomProgressDialog(context)
-    }
-
     class CustomProgressDialog(context: Context) {
         private val binding: DialogProgressBinding = DialogProgressBinding.inflate(LayoutInflater.from(context))
         private val dialogBuilder: AlertDialog.Builder = AlertDialog.Builder(context, R.style.CustomAlertDialog)
@@ -199,74 +143,45 @@ object DialogUtils {
         private var dialog: AlertDialog? = null
         private var positiveButtonAction: (() -> Unit)? = null
         private var negativeButtonAction: (() -> Unit)? = null
-
         init {
             dialogBuilder.setView(binding.root)
             dialogBuilder.setCancelable(false)
             binding.buttonPositive.setOnClickListener {
                 positiveButtonAction?.invoke()
-            }
             binding.buttonNegative.setOnClickListener {
                 negativeButtonAction?.invoke()
-            }
-        }
         fun setPositiveButton(text: String, isVisible: Boolean = true, listener: () -> Unit) {
             binding.buttonPositive.text = text
             positiveButtonAction = listener
             binding.buttonPositive.visibility = if (isVisible) View.VISIBLE else View.GONE
-        }
-
         fun setNegativeButton(text: String = "Cancel", isVisible: Boolean = true, listener: () -> Unit) {
             binding.buttonNegative.text = text
             negativeButtonAction = listener
             binding.buttonNegative.visibility = if (isVisible) View.VISIBLE else View.GONE
-        }
-
         fun show() {
             if (dialog == null) {
                 dialog = dialogBuilder.create()
-            }
             if (dialog?.isShowing == false) {
                 dialog?.show()
-            }
-        }
-
         fun dismiss() {
             dialog?.dismiss()
-        }
-
         fun setCancelable(state: Boolean) {
             dialog?.setCancelable(state)
-        }
-
         private fun setIndeterminate() {
             progressBar.isIndeterminate = false
-        }
-
         fun setMax(maxValue: Int) {
             progressBar.max = maxValue
-        }
-
         fun setProgress(value: Int) {
             setIndeterminate()
             progressBar.progress = value
-        }
-
         fun setText(text: String) {
             progressText.text = text
             progressText.visibility = View.VISIBLE
-        }
-
         fun setTitle(text: String?) {
             progressTitle.visibility = View.VISIBLE
             progressTitle.text = text
-        }
         fun isShowing(): Boolean {
             return dialog?.isShowing == true
-        }
-
         fun disableNegativeButton() {
             binding.buttonNegative.isEnabled = false
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -19,6 +19,8 @@ import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.sync.SyncActivity
 import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
+import org.ole.planet.myplanet.MainApplication.Companion.networkUtils
+
 object DialogUtils {
     @JvmStatic
     fun getProgressDialog(context: Context): CustomProgressDialog {
@@ -31,6 +33,7 @@ object DialogUtils {
         }
         return prgDialog
     }
+
     fun guestDialog(context: Context) {
         val profileDbHandler = UserProfileDbHandler(context)
         val builder = android.app.AlertDialog.Builder(context, R.style.CustomAlertDialog)
@@ -39,26 +42,39 @@ object DialogUtils {
         builder.setCancelable(false)
         builder.setPositiveButton(context.getString(R.string.become_a_member), null)
         builder.setNegativeButton(context.getString(R.string.cancel), null)
+
         val dialog = builder.create()
         dialog.show()
+
         val becomeMember = dialog.getButton(android.app.AlertDialog.BUTTON_POSITIVE)
         val cancel = dialog.getButton(android.app.AlertDialog.BUTTON_NEGATIVE)
         becomeMember.contentDescription = context.getString(R.string.confirm_membership)
         cancel.contentDescription = context.getString(R.string.cancel)
+
         becomeMember.setOnClickListener {
             val guest = true
             val intent = Intent(context, BecomeMemberActivity::class.java)
             intent.putExtra("username", profileDbHandler.userModel?.name)
             intent.putExtra("guest", guest)
             context.startActivity(intent)
+        }
         cancel.setOnClickListener {
             dialog.dismiss()
+        }
+    }
+
+    @JvmStatic
     fun showError(prgDialog: CustomProgressDialog?, message: String?) {
         prgDialog?.setTitle(message)
         prgDialog?.disableNegativeButton()
+    }
+
+    @JvmStatic
     fun showWifiSettingDialog(context: Context) {
         if (!networkUtils.isWifiBluetoothEnabled()) return
         showDialog(context)
+    }
+
     private fun showDialog(context: Context) {
         if (MainApplication.syncFailedCount > 3) {
             val pd = AlertDialog.Builder(context, R.style.AlertDialogTheme)
@@ -72,6 +88,7 @@ object DialogUtils {
             message += context.getString(R.string.is_on_please_turn_of_to_save_battery)
             } else {
             message = context.getString(R.string.is_on_please_turn_of_to_save_battery)
+            }
             pd.setMessage(message)
             pd.setPositiveButton(context.getString(R.string.go_to_settings)) { _, _ ->
                 MainApplication.syncFailedCount = 0
@@ -81,9 +98,17 @@ object DialogUtils {
             pd.setCancelable(false)
             val d = pd.create()
             d.show()
+        }
+    }
+
+    @JvmStatic
     fun showSnack(v: View?, s: String?) {
         if (v != null) {
             s?.let { Snackbar.make(v, it, Snackbar.LENGTH_LONG).show() }
+        }
+    }
+
+    @JvmStatic
     fun showAlert(context: Context?, title: String?, message: String?) {
         if (context is Activity && !context.isFinishing) {
             AlertDialog.Builder(context, R.style.AlertDialogTheme)
@@ -95,6 +120,10 @@ object DialogUtils {
                     }
                 }
                 .show()
+        }
+    }
+
+    @JvmStatic
     fun getAlertDialog(context: Context, message: String, pos: String, listener: DialogInterface.OnClickListener?): AlertDialog {
         return AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialog))
             .setMessage(message)
@@ -102,38 +131,66 @@ object DialogUtils {
             .setPositiveButton(pos, listener)
             .setNegativeButton(R.string.button_cancel, null)
             .show()
+    }
+
+    @JvmStatic
     fun showCloseAlert(context: Context, title: String?, message: String) {
         AlertDialog.Builder(context, R.style.CustomAlertDialog)
             .setTitle(title)
+            .setMessage(message)
             .setPositiveButton(R.string.close, null)
+            .show()
+    }
+
+    @JvmStatic
     fun getAlertDialog(context: Context, title: String, v: View): AlertDialog {
+        return AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialog))
+            .setTitle(title)
             .setIcon(R.drawable.ic_edit)
             .setView(v)
             .setPositiveButton(R.string.submit, null)
             .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    @JvmStatic
     fun getUpdateDialog(context: Context, info: MyPlanet?, progressDialog: CustomProgressDialog?): AlertDialog.Builder {
         return AlertDialog.Builder(context, R.style.CustomAlertDialog)
             .setTitle(R.string.new_version_of_my_planet_available)
             .setMessage(R.string.download_first_to_continue)
             .setNeutralButton(R.string.upgrade_local) { _, _ ->
                 startDownloadUpdate(context, Utilities.getApkUpdateUrl(info?.localapkpath), progressDialog)
+            }
             .setPositiveButton(R.string.upgrade) { _, _ ->
                 info?.apkpath?.let { startDownloadUpdate(context, it, progressDialog) }
+            }
+    }
+
+    @JvmStatic
     fun startDownloadUpdate(context: Context, path: String, progressDialog: CustomProgressDialog?) {
         Service(MainApplication.context).checkCheckSum(object : Service.ChecksumCallback {
             override fun onMatch() {
                 Utilities.toast(MainApplication.context, context.getString(R.string.apk_already_exists))
                 FileUtils.installApk(context, path)
+            }
+
             override fun onFail() {
                 val urls = arrayListOf(path)
                 if (progressDialog != null) {
                     progressDialog.setText(context.getString(R.string.downloading_file))
                     progressDialog.setCancelable(false)
                     progressDialog.show()
+                }
                 MyDownloadService.startService(context, "$urls", false)
+            }
         }, path)
+    }
+
+    @JvmStatic
     fun getCustomProgressDialog(context: Context): CustomProgressDialog {
         return CustomProgressDialog(context)
+    }
+
     class CustomProgressDialog(context: Context) {
         private val binding: DialogProgressBinding = DialogProgressBinding.inflate(LayoutInflater.from(context))
         private val dialogBuilder: AlertDialog.Builder = AlertDialog.Builder(context, R.style.CustomAlertDialog)
@@ -143,45 +200,74 @@ object DialogUtils {
         private var dialog: AlertDialog? = null
         private var positiveButtonAction: (() -> Unit)? = null
         private var negativeButtonAction: (() -> Unit)? = null
+
         init {
             dialogBuilder.setView(binding.root)
             dialogBuilder.setCancelable(false)
             binding.buttonPositive.setOnClickListener {
                 positiveButtonAction?.invoke()
+            }
             binding.buttonNegative.setOnClickListener {
                 negativeButtonAction?.invoke()
+            }
+        }
         fun setPositiveButton(text: String, isVisible: Boolean = true, listener: () -> Unit) {
             binding.buttonPositive.text = text
             positiveButtonAction = listener
             binding.buttonPositive.visibility = if (isVisible) View.VISIBLE else View.GONE
+        }
+
         fun setNegativeButton(text: String = "Cancel", isVisible: Boolean = true, listener: () -> Unit) {
             binding.buttonNegative.text = text
             negativeButtonAction = listener
             binding.buttonNegative.visibility = if (isVisible) View.VISIBLE else View.GONE
+        }
+
         fun show() {
             if (dialog == null) {
                 dialog = dialogBuilder.create()
+            }
             if (dialog?.isShowing == false) {
                 dialog?.show()
+            }
+        }
+
         fun dismiss() {
             dialog?.dismiss()
+        }
+
         fun setCancelable(state: Boolean) {
             dialog?.setCancelable(state)
+        }
+
         private fun setIndeterminate() {
             progressBar.isIndeterminate = false
+        }
+
         fun setMax(maxValue: Int) {
             progressBar.max = maxValue
+        }
+
         fun setProgress(value: Int) {
             setIndeterminate()
             progressBar.progress = value
+        }
+
         fun setText(text: String) {
             progressText.text = text
             progressText.visibility = View.VISIBLE
+        }
+
         fun setTitle(text: String?) {
             progressTitle.visibility = View.VISIBLE
             progressTitle.text = text
+        }
         fun isShowing(): Boolean {
             return dialog?.isShowing == true
+        }
+
         fun disableNegativeButton() {
             binding.buttonNegative.isEnabled = false
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/NetworkUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/NetworkUtils.kt
@@ -16,15 +16,9 @@ import androidx.core.net.toUri
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.*
-import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
-object NetworkUtils {
-    lateinit var coroutineScope: CoroutineScope
-
-    fun initialize(coroutineScope: CoroutineScope) {
-        this.coroutineScope = coroutineScope
-    }
+class NetworkUtils(private val context: Context, private val coroutineScope: CoroutineScope) {
 
     private val connectivityManager: ConnectivityManager by lazy {
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -103,32 +97,27 @@ object NetworkUtils {
         else -> false
     }
 
-    @JvmStatic
     fun isWifiEnabled(): Boolean {
         val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
         return wifiManager.isWifiEnabled
     }
 
-    @JvmStatic
     fun isWifiConnected(): Boolean {
         val network = connectivityManager.activeNetwork
         val capabilities = connectivityManager.getNetworkCapabilities(network)
         return capabilities != null && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
     }
 
-    @JvmStatic
     fun isWifiBluetoothEnabled(): Boolean {
         return isBluetoothEnabled() || isWifiEnabled()
     }
 
-    @JvmStatic
     fun isBluetoothEnabled(): Boolean {
         val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
         val adapter: BluetoothAdapter? = bluetoothManager.adapter
         return adapter != null && adapter.isEnabled
     }
 
-    @JvmStatic
     fun getCurrentNetworkId(context: Context): Int {
         var ssid = -1
         val connManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -144,14 +133,12 @@ object NetworkUtils {
         return ssid
     }
 
-    @JvmStatic
     fun getUniqueIdentifier(): String {
         val androidId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
         val buildId = Build.ID
         return androidId + "_" + buildId
     }
 
-    @JvmStatic
     fun getDeviceName(): String {
         val manufacturer = Build.MANUFACTURER
         val model = Build.MODEL
@@ -162,7 +149,6 @@ object NetworkUtils {
         }
     }
 
-    @JvmStatic
     fun getCustomDeviceName(context: Context): String {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .getString("customDeviceName", "") ?: ""

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/NetworkUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/NetworkUtils.kt
@@ -49,7 +49,7 @@ class NetworkUtils(private val context: Context, private val coroutineScope: Cor
         connectivityManager.registerDefaultNetworkCallback(networkCallback)
     }
 
-    private class NetworkCallback : ConnectivityManager.NetworkCallback() {
+    private inner class NetworkCallback : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
             _currentNetwork.update {
                 it.copy(isAvailable = true)


### PR DESCRIPTION
## Summary
- refactor `NetworkUtils` into a class that requires a context and scope
- initialize `networkUtils` instance in `MainApplication`
- migrate `CourseRatingUtils` to a class
- adapt callers like `AdapterCourses`, `AdapterResource` and fragments to use the new injected utilities
- update imports across the codebase

## Testing
- `./gradlew test --no-daemon` *(fails: unable to fetch remote Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_687df8d7be2c832baa804f3553c1d858