### PR TITLE
Convert retry utility to coroutine

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
@@ -68,7 +68,7 @@ object ApiClient {
         return enhancedRetrofit.create(ApiInterface::class.java)
     }
 
-    fun <T> executeWithRetry(operation: () -> Response<T>?): Response<T>? {
+    suspend fun <T> executeWithRetry(operation: () -> Response<T>?): Response<T>? {
         return RetryUtils.retry(
             maxAttempts = 3,
             delayMs = 2000L,

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -216,7 +216,7 @@ class SyncManager private constructor(private val context: Context) {
             logger.endProcess("admin_sync")
 
             logger.startProcess("resource_sync")
-            resourceTransactionSync()
+            runBlocking { resourceTransactionSync() }
             logger.endProcess("resource_sync")
 
             logger.startProcess("on_synced")
@@ -562,7 +562,7 @@ class SyncManager private constructor(private val context: Context) {
         }
     }
 
-    private fun resourceTransactionSync(backgroundRealm: Realm? = null) {
+    private suspend fun resourceTransactionSync(backgroundRealm: Realm? = null) {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("resource_sync")
         var processedItems = 0
@@ -712,7 +712,7 @@ class SyncManager private constructor(private val context: Context) {
         }
     }
 
-    private fun fastResourceTransactionSync() {
+    private suspend fun fastResourceTransactionSync() {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("resource_sync")
         var processedItems = 0
@@ -998,7 +998,7 @@ class SyncManager private constructor(private val context: Context) {
         return processedItems
     }
 
-    private fun processShelfDataOptimizedSync(shelfId: String?, shelfData: Constants.ShelfData, shelfDoc: JsonObject?, apiInterface: ApiInterface): Int {
+    private suspend fun processShelfDataOptimizedSync(shelfId: String?, shelfData: Constants.ShelfData, shelfDoc: JsonObject?, apiInterface: ApiInterface): Int {
         var processedCount = 0
 
         try {
@@ -1075,7 +1075,7 @@ class SyncManager private constructor(private val context: Context) {
         return processedCount
     }
 
-    private fun fastMyLibraryTransactionSync() {
+    private suspend fun fastMyLibraryTransactionSync() {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("library_sync")
         var processedItems = 0
@@ -1222,8 +1222,15 @@ class SyncManager private constructor(private val context: Context) {
             keysObject.add("keys", Gson().fromJson(Gson().toJson(batch), JsonArray::class.java))
 
             var response: JsonObject? = null
-            ApiClient.executeWithRetry {
-                apiInterface.findDocs(Utilities.header, "application/json", "${Utilities.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject).execute()
+            runBlocking {
+                ApiClient.executeWithRetry {
+                    apiInterface.findDocs(
+                        Utilities.header,
+                        "application/json",
+                        "${Utilities.getUrl()}/${shelfData.type}/_all_docs?include_docs=true",
+                        keysObject
+                    ).execute()
+                }
             }?.let {
                 response = it.body()
             }

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadToShelfService.kt
@@ -31,6 +31,7 @@ import org.ole.planet.myplanet.utilities.JsonUtils.getJsonArray
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.RetryUtils
+import kotlinx.coroutines.runBlocking
 import retrofit2.Response
 
 class UploadToShelfService(context: Context) {
@@ -218,12 +219,14 @@ class UploadToShelfService(context: Context) {
         val maxAttempts = 3
         val retryDelayMs = 2000L
 
-        val response = RetryUtils.retry(
-            maxAttempts = maxAttempts,
-            delayMs = retryDelayMs,
-            shouldRetry = { resp -> resp == null || !resp.isSuccessful || resp.body() == null }
-        ) {
-            apiInterface?.postDoc(header, "application/json", "${Utilities.getUrl()}/$table", ob)?.execute()
+        val response = runBlocking {
+            RetryUtils.retry(
+                maxAttempts = maxAttempts,
+                delayMs = retryDelayMs,
+                shouldRetry = { resp -> resp == null || !resp.isSuccessful || resp.body() == null }
+            ) {
+                apiInterface?.postDoc(header, "application/json", "${Utilities.getUrl()}/$table", ob)?.execute()
+            }
         }
 
         if (response?.isSuccessful == true && response.body() != null) {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
@@ -1,7 +1,9 @@
 package org.ole.planet.myplanet.utilities
 
+import kotlinx.coroutines.delay
+
 object RetryUtils {
-    fun <T> retry(
+    suspend fun <T> retry(
         maxAttempts: Int = 3,
         delayMs: Long = 2000L,
         shouldRetry: (T?) -> Boolean = { it == null },
@@ -23,11 +25,7 @@ object RetryUtils {
             }
             attempt++
             if (attempt < maxAttempts) {
-                try {
-                    Thread.sleep(delayMs)
-                } catch (ie: InterruptedException) {
-                    // ignore
-                }
+                delay(delayMs)
             }
         }
         lastException?.printStackTrace()


### PR DESCRIPTION
## Summary
- make `RetryUtils.retry` a suspend function and delay with `kotlinx.coroutines.delay`
- update `ApiClient.executeWithRetry` to be suspend
- adjust UploadToShelfService and SyncManager to call the suspend retry from coroutine scopes

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew testDefaultDebugUnitTest --no-daemon` *(fails: Process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687df8274ee4832bab80bb1d51e93c34