### PR TITLE
Add Realm change listener for sync completion

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -435,12 +435,12 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
 
     override fun onSyncComplete() {
         val activityContext = this@SyncActivity
-        lifecycleScope.launch(Dispatchers.IO) {
+        lifecycleScope.launch(Dispatchers.Main) {
             try {
                 userInsertRealm = Realm.getDefaultInstance()
                 userInsertResults = userInsertRealm!!.where(RealmUserModel::class.java).findAllAsync()
                 userInsertListener = RealmChangeListener { results ->
-                    if (!results.isEmpty()) {
+                    if (results.isLoaded && !results.isEmpty()) {
                         results.removeChangeListener(userInsertListener!!)
                         userInsertRealm?.close()
                         lifecycleScope.launch(Dispatchers.Main) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -110,6 +110,9 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
     var serverAddressAdapter: ServerAddressAdapter? = null
     lateinit var serverListAddresses: List<ServerAddressesModel>
     private var isProgressDialogShowing = false
+    private var userInsertResults: RealmResults<RealmUserModel>? = null
+    private var userInsertListener: RealmChangeListener<RealmResults<RealmUserModel>>? = null
+    private var userInsertRealm: Realm? = null
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -434,92 +437,82 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         val activityContext = this@SyncActivity
         lifecycleScope.launch(Dispatchers.IO) {
             try {
-                var attempt = 0
-                while (true) {
-                    val realm = Realm.getDefaultInstance()
-                    var dataInserted = false
+                userInsertRealm = Realm.getDefaultInstance()
+                userInsertResults = userInsertRealm!!.where(RealmUserModel::class.java).findAllAsync()
+                userInsertListener = RealmChangeListener { results ->
+                    if (!results.isEmpty()) {
+                        results.removeChangeListener(userInsertListener!!)
+                        userInsertRealm?.close()
+                        lifecycleScope.launch(Dispatchers.Main) {
+                            forceSyncTrigger()
+                            val syncedUrl = settings.getString("serverURL", null)?.let {
+                                ServerConfigUtils.removeProtocol(it) }
+                            if (syncedUrl != null && serverListAddresses.any { it.url.replace(Regex("^https?://"), "") == syncedUrl }) {
+                                editor.putString("pinnedServerUrl", syncedUrl).apply()
+                            }
 
-                    try {
-                        realm.refresh()
-                        val realmResults = realm.where(RealmUserModel::class.java).findAll()
-                        if (!realmResults.isEmpty()) {
-                            dataInserted = true
-                            break
-                        }
-                    } finally {
-                        realm.close()
-                    }
-                    attempt++
-                    delay(1000)
-                }
+                            customProgressDialog.dismiss()
 
-                withContext(Dispatchers.Main) {
-                    forceSyncTrigger()
-                    val syncedUrl = settings.getString("serverURL", null)?.let { ServerConfigUtils.removeProtocol(it) }
-                    if (syncedUrl != null && serverListAddresses.any { it.url.replace(Regex("^https?://"), "") == syncedUrl }) {
-                        editor.putString("pinnedServerUrl", syncedUrl).apply()
-                    }
+                            if (::syncIconDrawable.isInitialized) {
+                                syncIconDrawable = syncIcon.drawable as AnimationDrawable
+                                syncIconDrawable.stop()
+                                syncIconDrawable.selectDrawable(0)
+                                syncIcon.invalidateDrawable(syncIconDrawable)
+                            }
 
-                    customProgressDialog.dismiss()
+                            lifecycleScope.launch {
+                                createLog("synced successfully", "")
+                            }
 
-                    if (::syncIconDrawable.isInitialized) {
-                        syncIconDrawable = syncIcon.drawable as AnimationDrawable
-                        syncIconDrawable.stop()
-                        syncIconDrawable.selectDrawable(0)
-                        syncIcon.invalidateDrawable(syncIconDrawable)
-                    }
+                            lifecycleScope.launch(Dispatchers.IO) {
+                                val pendingLanguage = settings.getString("pendingLanguageChange", null)
+                                if (pendingLanguage != null) {
+                                    withContext(Dispatchers.Main) {
+                                        editor.remove("pendingLanguageChange").apply()
 
-                    lifecycleScope.launch {
-                        createLog("synced successfully", "")
-                    }
+                                        LocaleHelper.setLocale(this@SyncActivity, pendingLanguage)
+                                        updateUIWithNewLanguage()
+                                    }
+                                }
+                            }
 
-                    lifecycleScope.launch(Dispatchers.IO) {
-                        val pendingLanguage = settings.getString("pendingLanguageChange", null)
-                        if (pendingLanguage != null) {
-                            withContext(Dispatchers.Main) {
-                                editor.remove("pendingLanguageChange").apply()
+                            showSnack(activityContext.findViewById(android.R.id.content), getString(R.string.sync_completed))
 
-                                LocaleHelper.setLocale(this@SyncActivity, pendingLanguage)
-                                updateUIWithNewLanguage()
+                            if (settings.getBoolean("isAlternativeUrl", false)) {
+                                editor.putString("alternativeUrl", "")
+                                editor.putString("processedAlternativeUrl", "")
+                                editor.putBoolean("isAlternativeUrl", false)
+                                editor.apply()
+                            }
+
+                            downloadAdditionalResources()
+
+                            val betaAutoDownload = defaultPref.getBoolean("beta_auto_download", false)
+                            if (betaAutoDownload) {
+                                withContext(Dispatchers.IO) {
+                                    val downloadRealm = Realm.getDefaultInstance()
+                                    try {
+                                        backgroundDownload(downloadAllFiles(getAllLibraryList(downloadRealm)))
+                                    } finally {
+                                        downloadRealm.close()
+                                    }
+                                }
+                            }
+
+                            cancelAll(activityContext)
+
+                            if (activityContext is LoginActivity) {
+                                activityContext.updateTeamDropdown()
                             }
                         }
                     }
-
-                    showSnack(activityContext.findViewById(android.R.id.content), getString(R.string.sync_completed))
-
-                    if (settings.getBoolean("isAlternativeUrl", false)) {
-                        editor.putString("alternativeUrl", "")
-                        editor.putString("processedAlternativeUrl", "")
-                        editor.putBoolean("isAlternativeUrl", false)
-                        editor.apply()
-                    }
-
-                    downloadAdditionalResources()
-
-                    val betaAutoDownload = defaultPref.getBoolean("beta_auto_download", false)
-                    if (betaAutoDownload) {
-                        withContext(Dispatchers.IO) {
-                            val downloadRealm = Realm.getDefaultInstance()
-                            try {
-                                backgroundDownload(downloadAllFiles(getAllLibraryList(downloadRealm)))
-                            } finally {
-                                downloadRealm.close()
-                            }
-                        }
-                    }
-
-                    cancelAll(activityContext)
-
-                    if (activityContext is LoginActivity) {
-                        activityContext.updateTeamDropdown()
-                    }
                 }
+                userInsertResults!!.addChangeListener(userInsertListener!!)
             } catch (e: Exception) {
                 e.printStackTrace()
             }
         }
     }
-
     private fun updateUIWithNewLanguage() {
         try {
             if (::lblLastSyncDate.isInitialized) {
@@ -804,6 +797,10 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
 
     override fun onDestroy() {
         super.onDestroy()
+        userInsertResults?.let { listener ->
+            userInsertListener?.let { listener.removeChangeListener(it) }
+        }
+        userInsertRealm?.close()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }


### PR DESCRIPTION
## Summary
- observe `RealmUserModel` changes using `addChangeListener`
- trigger `forceSyncTrigger()` once user data is inserted
- close change listener and realm on activity destroy

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687df689f640832ba061f233395f41cf