### PR TITLE
all: smoother retry logic (fixes #6391)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2724
-        versionName = "0.27.24"
+        versionCode = 2725
+        versionName = "0.27.25"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
@@ -7,6 +7,7 @@ import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.utilities.RetryUtils
+import kotlinx.coroutines.delay
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -77,7 +78,7 @@ object ApiClient {
         )
     }
 
-    fun <T> executeWithResult(operation: () -> Response<T>?): NetworkResult<T> {
+    suspend fun <T> executeWithResult(operation: suspend () -> Response<T>?): NetworkResult<T> {
         var retryCount = 0
         var lastException: Exception? = null
 
@@ -93,7 +94,7 @@ object ApiClient {
                         return NetworkResult.Error(response.code(), null)
                     } else if (retryCount < 2) {
                         retryCount++
-                        Thread.sleep(2000L * (retryCount + 1))
+                        delay(2000L * (retryCount + 1))
                         continue
                     } else {
                         val errorBody = try { response.errorBody()?.string() } catch (_: Exception) { null }
@@ -110,7 +111,7 @@ object ApiClient {
 
             if (retryCount < 2) {
                 retryCount++
-                Thread.sleep(2000L * (retryCount + 1))
+                delay(2000L * (retryCount + 1))
             } else {
                 break
             }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiInterface.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiInterface.kt
@@ -6,6 +6,7 @@ import okhttp3.ResponseBody
 import org.ole.planet.myplanet.model.ChatModel
 import org.ole.planet.myplanet.model.DocumentResponse
 import org.ole.planet.myplanet.model.MyPlanet
+import retrofit2.Response
 import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -40,10 +41,10 @@ interface ApiInterface {
     fun putDoc(@Header("Authorization") header: String?, @Header("Content-Type") c: String?, @Url url: String?, @Body s: JsonObject?): Call<JsonObject>
 
     @GET
-    fun checkVersion(@Url serverUrl: String?): Call<MyPlanet>
+    suspend fun checkVersion(@Url serverUrl: String?): Response<MyPlanet>
 
     @GET
-    fun getApkVersion(@Url url: String?): Call<ResponseBody>
+    suspend fun getApkVersion(@Url url: String?): Response<ResponseBody>
 
     @GET
     fun healthAccess(@Url url: String?): Call<ResponseBody>

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -362,7 +362,7 @@ class Service(private val context: Context) {
     private suspend fun fetchVersionInfo(settings: SharedPreferences): MyPlanet? =
         withContext(Dispatchers.IO) {
             val result = ApiClient.executeWithResult {
-                retrofitInterface?.checkVersion(Utilities.getUpdateUrl(settings))?.execute()
+                retrofitInterface?.checkVersion(Utilities.getUpdateUrl(settings))
             }
             when (result) {
                 is NetworkResult.Success -> result.data
@@ -373,7 +373,7 @@ class Service(private val context: Context) {
     private suspend fun fetchApkVersionString(settings: SharedPreferences): String? =
         withContext(Dispatchers.IO) {
             val result = ApiClient.executeWithResult {
-                retrofitInterface?.getApkVersion(Utilities.getApkVersionUrl(settings))?.execute()
+                retrofitInterface?.getApkVersion(Utilities.getApkVersionUrl(settings))
             }
             when (result) {
                 is NetworkResult.Success -> result.data.string()


### PR DESCRIPTION
## Summary
- make `executeWithResult` a suspend function
- pause retries using `delay` instead of `Thread.sleep`
- use Retrofit suspend API for version checks

## Testing
- `./gradlew assembleDebug -x lint`

------
https://chatgpt.com/codex/tasks/task_e_687df82f7010832b8f9e130ba56a2271