### PR TITLE
all: smoother realm instance loops (fixes #6392)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2724
-        versionName = "0.27.24"
+        versionCode = 2726
+        versionName = "0.27.26"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
@@ -119,15 +119,16 @@ class UserProfileDbHandler(context: Context) {
     }
 
     fun getLastVisit(m: RealmUserModel): String {
-        val realm = Realm.getDefaultInstance()
-        val lastLogoutTimestamp = realm.where(RealmOfflineActivity::class.java)
-            .equalTo("userName", m.name)
-            .max("loginTime") as Long?
-        return if (lastLogoutTimestamp != null) {
-            val date = Date(lastLogoutTimestamp)
-            SimpleDateFormat("MMMM dd, yyyy hh:mm a", Locale.getDefault()).format(date)
-        } else {
-            "No logout record found"
+        Realm.getDefaultInstance().use { realm ->
+            val lastLogoutTimestamp = realm.where(RealmOfflineActivity::class.java)
+                .equalTo("userName", m.name)
+                .max("loginTime") as Long?
+            return if (lastLogoutTimestamp != null) {
+                val date = Date(lastLogoutTimestamp)
+                SimpleDateFormat("MMMM dd, yyyy hh:mm a", Locale.getDefault()).format(date)
+            } else {
+                "No logout record found"
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -435,22 +435,16 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         lifecycleScope.launch(Dispatchers.IO) {
             try {
                 var attempt = 0
-                while (true) {
-                    val realm = Realm.getDefaultInstance()
-                    var dataInserted = false
-
-                    try {
+                Realm.getDefaultInstance().use { realm ->
+                    while (true) {
                         realm.refresh()
                         val realmResults = realm.where(RealmUserModel::class.java).findAll()
-                        if (!realmResults.isEmpty()) {
-                            dataInserted = true
+                        if (realmResults.isNotEmpty()) {
                             break
                         }
-                    } finally {
-                        realm.close()
+                        attempt++
+                        delay(1000)
                     }
-                    attempt++
-                    delay(1000)
                 }
 
                 withContext(Dispatchers.Main) {


### PR DESCRIPTION
## Summary
- ensure `Realm` instance is closed in `getLastVisit`
- create and reuse one `Realm` inside the sync completion loop

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687df6b7798c832b9a8a09f5b8c97d68