### PR TITLE
Switch Retrofit calls to suspend

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiInterface.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiInterface.kt
@@ -6,7 +6,7 @@ import okhttp3.ResponseBody
 import org.ole.planet.myplanet.model.ChatModel
 import org.ole.planet.myplanet.model.DocumentResponse
 import org.ole.planet.myplanet.model.MyPlanet
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -19,47 +19,47 @@ import retrofit2.http.Url
 interface ApiInterface {
     @Streaming
     @GET
-    fun downloadFile(@Header("Authorization") header: String?, @Url fileUrl: String?): Call<ResponseBody>
+    suspend fun downloadFile(@Header("Authorization") header: String?, @Url fileUrl: String?): Response<ResponseBody>
 
     @GET
-    fun getDocuments(@Header("Authorization") header: String?, @Url url: String?): Call<DocumentResponse>
+    suspend fun getDocuments(@Header("Authorization") header: String?, @Url url: String?): Response<DocumentResponse>
 
     @GET
-    fun getJsonObject(@Header("Authorization") header: String?, @Url url: String?): Call<JsonObject>
+    suspend fun getJsonObject(@Header("Authorization") header: String?, @Url url: String?): Response<JsonObject>
 
     @POST
-    fun findDocs(@Header("Authorization") header: String?, @Header("Content-Type") c: String?, @Url url: String?, @Body s: JsonObject?): Call<JsonObject>
+    suspend fun findDocs(@Header("Authorization") header: String?, @Header("Content-Type") c: String?, @Url url: String?, @Body s: JsonObject?): Response<JsonObject>
 
     @POST
-    fun postDoc(@Header("Authorization") header: String?, @Header("Content-Type") c: String?, @Url url: String?, @Body s: JsonObject?): Call<JsonObject>
+    suspend fun postDoc(@Header("Authorization") header: String?, @Header("Content-Type") c: String?, @Url url: String?, @Body s: JsonObject?): Response<JsonObject>
 
     @PUT
-    fun uploadResource(@HeaderMap headerMap: Map<String, String>, @Url url: String?, @Body body: RequestBody?): Call<JsonObject>
+    suspend fun uploadResource(@HeaderMap headerMap: Map<String, String>, @Url url: String?, @Body body: RequestBody?): Response<JsonObject>
 
     @PUT
-    fun putDoc(@Header("Authorization") header: String?, @Header("Content-Type") c: String?, @Url url: String?, @Body s: JsonObject?): Call<JsonObject>
+    suspend fun putDoc(@Header("Authorization") header: String?, @Header("Content-Type") c: String?, @Url url: String?, @Body s: JsonObject?): Response<JsonObject>
 
     @GET
-    fun checkVersion(@Url serverUrl: String?): Call<MyPlanet>
+    suspend fun checkVersion(@Url serverUrl: String?): Response<MyPlanet>
 
     @GET
-    fun getApkVersion(@Url url: String?): Call<ResponseBody>
+    suspend fun getApkVersion(@Url url: String?): Response<ResponseBody>
 
     @GET
-    fun healthAccess(@Url url: String?): Call<ResponseBody>
+    suspend fun healthAccess(@Url url: String?): Response<ResponseBody>
 
     @GET
-    fun getChecksum(@Url url: String?): Call<ResponseBody>
+    suspend fun getChecksum(@Url url: String?): Response<ResponseBody>
 
     @GET
-    fun isPlanetAvailable(@Url serverUrl: String?): Call<ResponseBody>
+    suspend fun isPlanetAvailable(@Url serverUrl: String?): Response<ResponseBody>
 
     @POST
-    fun chatGpt(@Url url: String?, @Body requestBody: RequestBody?): Call<ChatModel>
+    suspend fun chatGpt(@Url url: String?, @Body requestBody: RequestBody?): Response<ChatModel>
 
     @GET
-    fun checkAiProviders(@Url url: String?): Call<ResponseBody>
+    suspend fun checkAiProviders(@Url url: String?): Response<ResponseBody>
 
     @GET
-    fun getConfiguration(@Url url: String?): Call<JsonObject>
+    suspend fun getConfiguration(@Url url: String?): Response<JsonObject>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -572,8 +572,8 @@ class SyncManager private constructor(private val context: Context) {
             val realmInstance = backgroundRealm ?: mRealm
             val newIds: MutableList<String?> = ArrayList()
             var totalRows = 0
-            ApiClient.executeWithRetry {
-                apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?limit=0").execute()
+            ApiClient.executeWithRetrySuspend {
+                apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?limit=0")
             }?.let { response ->
                 response.body()?.let { body ->
                     if (body.has("total_rows")) {
@@ -591,8 +591,8 @@ class SyncManager private constructor(private val context: Context) {
 
                 try {
                     var response: JsonObject? = null
-                    ApiClient.executeWithRetry {
-                        apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?include_docs=true&limit=$batchSize&skip=$skip").execute()
+                    ApiClient.executeWithRetrySuspend {
+                        apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?include_docs=true&limit=$batchSize&skip=$skip")
                     }?.let {
                         response = it.body()
                     }
@@ -722,8 +722,8 @@ class SyncManager private constructor(private val context: Context) {
             val newIds = ConcurrentHashMap.newKeySet<String>()
 
             var totalRows = 0
-            ApiClient.executeWithRetry {
-                apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?limit=0").execute()
+            ApiClient.executeWithRetrySuspend {
+                apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?limit=0")
             }?.let { response ->
                 response.body()?.let { body ->
                     if (body.has("total_rows")) {
@@ -766,8 +766,8 @@ class SyncManager private constructor(private val context: Context) {
 
         try {
             var response: JsonObject? = null
-            ApiClient.executeWithRetry {
-                apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?include_docs=true&limit=$batchSize&skip=$skip").execute()
+            ApiClient.executeWithRetrySuspend {
+                apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?include_docs=true&limit=$batchSize&skip=$skip")
             }?.let {
                 response = it.body()
             }

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
@@ -7,6 +7,7 @@ import com.google.gson.*
 import io.realm.*
 import java.io.*
 import java.util.Date
+import kotlinx.coroutines.runBlocking
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.MainApplication
@@ -61,7 +62,14 @@ class UploadManager(var context: Context) : FileUploadService() {
 
             newsLog.processInBatches { news ->
                     try {
-                        val `object` = apiInterface?.postDoc(Utilities.header, "application/json", "${Utilities.getUrl()}/myplanet_activities", RealmNewsLog.serialize(news))?.execute()?.body()
+                        val `object` = runBlocking {
+                            apiInterface?.postDoc(
+                                Utilities.header,
+                                "application/json",
+                                "${Utilities.getUrl()}/myplanet_activities",
+                                RealmNewsLog.serialize(news)
+                            )
+                        }?.body()
 
                         if (`object` != null) {
                             news._id = getString("id", `object`)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -326,7 +326,7 @@ abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
             try {
                 val apiInterface = client?.create(ApiInterface::class.java)
                 val userDocUrl = "${getUrl()}/tablet_users/org.couchdb.user:$name"
-                val response = apiInterface?.getJsonObject(Utilities.header, userDocUrl)?.execute()
+                val response = apiInterface?.getJsonObject(Utilities.header, userDocUrl)
 
                 if (response?.isSuccessful == true && response.body() != null) {
                     val userDoc = response.body()


### PR DESCRIPTION
## Summary
- refactor `ApiInterface` methods to return `suspend` `Response`
- add coroutine aware retry helpers in `ApiClient`
- update `Service`, `ProcessUserDataActivity`, `UploadManager` and `SyncManager` to use suspend API

## Testing
- `./gradlew --no-daemon tasks --all`
- `./gradlew --no-daemon test`


------
https://chatgpt.com/codex/tasks/task_e_687df6788430832b834d71d4fba0c815