### PR TITLE
Use coroutine delays for retry and watchdog

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -212,7 +212,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                 }
             }
         })
-        anrWatchdog.start()
+        anrWatchdog.start(applicationScope)
     }
 
     private fun scheduleWorkersOnStart() {

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
@@ -5,6 +5,7 @@ import java.io.IOException
 import java.lang.reflect.Modifier
 import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.delay
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.utilities.RetryUtils
 import retrofit2.Response
@@ -68,7 +69,7 @@ object ApiClient {
         return enhancedRetrofit.create(ApiInterface::class.java)
     }
 
-    fun <T> executeWithRetry(operation: () -> Response<T>?): Response<T>? {
+    suspend fun <T> executeWithRetry(operation: suspend () -> Response<T>?): Response<T>? {
         return RetryUtils.retry(
             maxAttempts = 3,
             delayMs = 2000L,
@@ -77,7 +78,7 @@ object ApiClient {
         )
     }
 
-    fun <T> executeWithResult(operation: () -> Response<T>?): NetworkResult<T> {
+    suspend fun <T> executeWithResult(operation: suspend () -> Response<T>?): NetworkResult<T> {
         var retryCount = 0
         var lastException: Exception? = null
 
@@ -93,7 +94,7 @@ object ApiClient {
                         return NetworkResult.Error(response.code(), null)
                     } else if (retryCount < 2) {
                         retryCount++
-                        Thread.sleep(2000L * (retryCount + 1))
+                        delay(2000L * (retryCount + 1))
                         continue
                     } else {
                         val errorBody = try { response.errorBody()?.string() } catch (_: Exception) { null }
@@ -110,7 +111,7 @@ object ApiClient {
 
             if (retryCount < 2) {
                 retryCount++
-                Thread.sleep(2000L * (retryCount + 1))
+                delay(2000L * (retryCount + 1))
             } else {
                 break
             }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -264,7 +264,9 @@ class Service(private val context: Context) {
                 if (res?.body() != null) {
                     val model = populateUsersTable(res.body(), realm1, settings)
                     if (model != null) {
-                        UploadToShelfService(MainApplication.context).saveKeyIv(retrofitInterface, model, obj)
+                        MainApplication.applicationScope.launch {
+                            UploadToShelfService(MainApplication.context).saveKeyIv(retrofitInterface, model, obj)
+                        }
                     }
                 }
             } catch (e: IOException) {

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -216,7 +216,7 @@ class SyncManager private constructor(private val context: Context) {
             logger.endProcess("admin_sync")
 
             logger.startProcess("resource_sync")
-            resourceTransactionSync()
+            runBlocking { resourceTransactionSync() }
             logger.endProcess("resource_sync")
 
             logger.startProcess("on_synced")
@@ -562,7 +562,7 @@ class SyncManager private constructor(private val context: Context) {
         }
     }
 
-    private fun resourceTransactionSync(backgroundRealm: Realm? = null) {
+    private suspend fun resourceTransactionSync(backgroundRealm: Realm? = null) {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("resource_sync")
         var processedItems = 0
@@ -712,7 +712,7 @@ class SyncManager private constructor(private val context: Context) {
         }
     }
 
-    private fun fastResourceTransactionSync() {
+    private suspend fun fastResourceTransactionSync() {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("resource_sync")
         var processedItems = 0
@@ -998,7 +998,7 @@ class SyncManager private constructor(private val context: Context) {
         return processedItems
     }
 
-    private fun processShelfDataOptimizedSync(shelfId: String?, shelfData: Constants.ShelfData, shelfDoc: JsonObject?, apiInterface: ApiInterface): Int {
+    private suspend fun processShelfDataOptimizedSync(shelfId: String?, shelfData: Constants.ShelfData, shelfDoc: JsonObject?, apiInterface: ApiInterface): Int {
         var processedCount = 0
 
         try {
@@ -1075,7 +1075,7 @@ class SyncManager private constructor(private val context: Context) {
         return processedCount
     }
 
-    private fun fastMyLibraryTransactionSync() {
+    private suspend fun fastMyLibraryTransactionSync() {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("library_sync")
         var processedItems = 0
@@ -1179,7 +1179,7 @@ class SyncManager private constructor(private val context: Context) {
             val results = validIds.chunked(batchSize).map { batch ->
                 withContext(Dispatchers.IO) {
                     safeRealmOperation { threadRealm ->
-                        processBatchForShelfData(batch, shelfData, shelfId, apiInterface, threadRealm)
+                        runBlocking { processBatchForShelfData(batch, shelfData, shelfId, apiInterface, threadRealm) }
                     } ?: 0
                 }
             }
@@ -1214,7 +1214,7 @@ class SyncManager private constructor(private val context: Context) {
         }
     }
 
-    private fun processBatchForShelfData(batch: List<String>, shelfData: Constants.ShelfData, shelfId: String?, apiInterface: ApiInterface, realmInstance: Realm): Int {
+    private suspend fun processBatchForShelfData(batch: List<String>, shelfData: Constants.ShelfData, shelfId: String?, apiInterface: ApiInterface, realmInstance: Realm): Int {
         var processedCount = 0
 
         try {

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadToShelfService.kt
@@ -15,6 +15,7 @@ import java.util.Date
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.callback.SuccessListener
 import org.ole.planet.myplanet.datamanager.ApiClient.client
+import kotlinx.coroutines.runBlocking
 import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMeetup.Companion.getMyMeetUpIds
@@ -146,7 +147,8 @@ class UploadToShelfService(context: Context) {
                 model.salt = getString("salt", fetchDataResponse.body())
                 model.iterations = getString("iterations", fetchDataResponse.body())
 
-                if (saveKeyIv(apiInterface, model, obj)) {
+                val saved = runBlocking { saveKeyIv(apiInterface, model, obj) }
+                if (saved) {
                     updateHealthData(realm, model)
                 }
             }
@@ -200,7 +202,7 @@ class UploadToShelfService(context: Context) {
     }
 
     @Throws(IOException::class)
-    fun saveKeyIv(apiInterface: ApiInterface?, model: RealmUserModel, obj: JsonObject): Boolean {
+    suspend fun saveKeyIv(apiInterface: ApiInterface?, model: RealmUserModel, obj: JsonObject): Boolean {
         val table = "userdb-${Utilities.toHex(model.planetCode)}-${Utilities.toHex(model.name)}"
         val header = "Basic ${Base64.encodeToString(("${obj["name"].asString}:${obj["password"].asString}").toByteArray(), Base64.NO_WRAP)}"
         val ob = JsonObject()

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/ANRWatchdog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/ANRWatchdog.kt
@@ -1,6 +1,11 @@
 package org.ole.planet.myplanet.utilities
 
 import android.os.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class ANRWatchdog(private val timeout: Long = DEFAULT_ANR_TIMEOUT, private val listener: ANRListener? = null) {
     companion object {
@@ -10,6 +15,7 @@ class ANRWatchdog(private val timeout: Long = DEFAULT_ANR_TIMEOUT, private val l
     private val mainHandler = Handler(Looper.getMainLooper())
     private var isWatching = false
     private var tick = 0L
+    private var watchJob: Job? = null
 
     private val ticker = Runnable {
         tick = SystemClock.elapsedRealtime()
@@ -19,7 +25,7 @@ class ANRWatchdog(private val timeout: Long = DEFAULT_ANR_TIMEOUT, private val l
         fun onAppNotResponding(message: String, blockedThread: Thread, duration: Long)
     }
 
-    fun start() {
+    fun start(scope: CoroutineScope) {
         if (isWatching) {
             return
         }
@@ -28,49 +34,44 @@ class ANRWatchdog(private val timeout: Long = DEFAULT_ANR_TIMEOUT, private val l
         tick = SystemClock.elapsedRealtime()
         mainHandler.post(ticker)
 
-        Thread({
+        watchJob = scope.launch(Dispatchers.Default) {
             val threadName = Thread.currentThread().name
             Thread.currentThread().name = "ANRWatchdog"
 
-            while (isWatching) {
-                val lastTick = tick
-                val currentTime = SystemClock.elapsedRealtime()
-                mainHandler.post(ticker)
+            try {
+                while (isWatching) {
+                    val lastTick = tick
+                    val currentTime = SystemClock.elapsedRealtime()
+                    mainHandler.post(ticker)
 
-                try {
-                    Thread.sleep(timeout / 2)
-                } catch (e: InterruptedException) {
-                    e.printStackTrace()
-                }
+                    delay(timeout / 2)
 
-                if (isWatching && lastTick == tick) {
-                    val duration = currentTime - lastTick
-                    val mainThread = Looper.getMainLooper().thread
+                    if (isWatching && lastTick == tick) {
+                        val duration = currentTime - lastTick
+                        val mainThread = Looper.getMainLooper().thread
 
-                    val message = StringBuilder("ANR detected on thread ")
-                        .append(mainThread.name)
-                        .append(" (")
-                        .append(mainThread.id)
-                        .append(")\n")
+                        val message = StringBuilder("ANR detected on thread ")
+                            .append(mainThread.name)
+                            .append(" (")
+                            .append(mainThread.id)
+                            .append(")\n")
 
-                    for (element in mainThread.stackTrace) {
-                        message.append("\tat ").append(element.toString()).append('\n')
-                    }
+                        for (element in mainThread.stackTrace) {
+                            message.append("\tat ").append(element.toString()).append('\n')
+                        }
 
-                    listener?.onAppNotResponding(message.toString(), mainThread, duration)
-                    try {
-                        Thread.sleep(timeout)
-                    } catch (e: InterruptedException) {
-                        e.printStackTrace()
+                        listener?.onAppNotResponding(message.toString(), mainThread, duration)
+                        delay(timeout)
                     }
                 }
+            } finally {
+                Thread.currentThread().name = threadName
             }
-
-            Thread.currentThread().name = threadName
-        }, "ANRWatchdog").start()
+        }
     }
 
     fun stop() {
         isWatching = false
+        watchJob?.cancel()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
@@ -1,11 +1,14 @@
 package org.ole.planet.myplanet.utilities
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+
 object RetryUtils {
-    fun <T> retry(
+    suspend fun <T> retry(
         maxAttempts: Int = 3,
         delayMs: Long = 2000L,
         shouldRetry: (T?) -> Boolean = { it == null },
-        block: () -> T?
+        block: suspend () -> T?
     ): T? {
         var attempt = 0
         var result: T? = null
@@ -24,9 +27,11 @@ object RetryUtils {
             attempt++
             if (attempt < maxAttempts) {
                 try {
-                    Thread.sleep(delayMs)
-                } catch (ie: InterruptedException) {
-                    // ignore
+                    delay(delayMs)
+                } catch (ce: CancellationException) {
+                    throw ce
+                } catch (_: Exception) {
+                    // ignore other exceptions
                 }
             }
         }


### PR DESCRIPTION
## Summary
- implement `RetryUtils.retry` with coroutine delay
- replace blocking sleep calls in `ApiClient` and `ANRWatchdog`
- launch ANR watchdog from `MainApplication`
- adapt service functions to new suspend APIs

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_687df6563dfc832b99a6dfc128119bf0