### PR TITLE
all: smoother fragments `DatabaseService` injection (fixes #6416)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2733
-        versionName = "0.27.33"
+        versionCode = 2735
+        versionName = "0.27.35"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -23,6 +23,7 @@ import java.util.Locale
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.createMyCourse
@@ -49,7 +50,8 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     var selectedItems: MutableList<LI>? = null
     var gradeLevel = ""
     var subjectLevel = ""
-    private lateinit var realmService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     lateinit var recyclerView: RecyclerView
     lateinit var tvMessage: TextView
     lateinit var tvFragmentInfo: TextView
@@ -90,8 +92,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         tvMessage = v.findViewById(R.id.tv_message)
         selectedItems = mutableListOf()
         list = mutableListOf()
-        realmService = DatabaseService(requireActivity())
-        mRealm = realmService.realmInstance
+        mRealm = databaseService.realmInstance
         profileDbHandler = UserProfileDbHandler(requireActivity())
         model = profileDbHandler.userModel!!
         val adapter = getAdapter()

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -22,8 +22,6 @@ import java.text.Normalizer
 import java.util.Locale
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
-import org.ole.planet.myplanet.datamanager.DatabaseService
-import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.createMyCourse
@@ -50,8 +48,6 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     var selectedItems: MutableList<LI>? = null
     var gradeLevel = ""
     var subjectLevel = ""
-    @Inject
-    lateinit var databaseService: DatabaseService
     lateinit var recyclerView: RecyclerView
     lateinit var tvMessage: TextView
     lateinit var tvFragmentInfo: TextView

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -27,6 +27,7 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.MyDownloadService
 import org.ole.planet.myplanet.datamanager.Service
 import org.ole.planet.myplanet.datamanager.Service.PlanetAvailableListener
@@ -63,6 +64,8 @@ abstract class BaseResourceFragment : Fragment() {
     var lv: CheckboxListView? = null
     var convertView: View? = null
     internal lateinit var prgDialog: DialogUtils.CustomProgressDialog
+    @Inject
+    lateinit var databaseService: DatabaseService
     private var resourceNotFoundDialog: AlertDialog? = null
 
     private fun isFragmentActive(): Boolean {
@@ -309,7 +312,7 @@ abstract class BaseResourceFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         prgDialog = getProgressDialog(requireActivity())
         settings = requireActivity().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         editor = settings?.edit()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -59,7 +59,10 @@ import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class ChatDetailFragment : Fragment() {
     lateinit var fragmentChatDetailBinding: FragmentChatDetailBinding
     private lateinit var mAdapter: ChatAdapter
@@ -74,6 +77,8 @@ class ChatDetailFragment : Fragment() {
     private var newsId: String? = null
     lateinit var settings: SharedPreferences
     lateinit var customProgressDialog: DialogUtils.CustomProgressDialog
+    @Inject
+    lateinit var databaseService: DatabaseService
     private val gson = Gson()
     private val serverUrlMapper = ServerUrlMapper()
     private val jsonMediaType = "application/json".toMediaTypeOrNull()
@@ -109,7 +114,7 @@ class ChatDetailFragment : Fragment() {
     }
 
     private fun initChatComponents() {
-        mRealm = DatabaseService(requireContext()).realmInstance
+        mRealm = databaseService.realmInstance
         user = UserProfileDbHandler(requireContext()).userModel
         mAdapter = ChatAdapter(ArrayList(), requireContext(), fragmentChatDetailBinding.recyclerGchat)
         fragmentChatDetailBinding.recyclerGchat.apply {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -56,6 +56,8 @@ class ChatHistoryListFragment : Fragment() {
     
     @Inject
     lateinit var syncManager: SyncManager
+    @Inject
+    lateinit var databaseService: DatabaseService
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
 
@@ -213,7 +215,7 @@ class ChatHistoryListFragment : Fragment() {
     }
 
     fun refreshChatHistoryList() {
-        val mRealm = DatabaseService(requireActivity()).realmInstance
+        val mRealm = databaseService.realmInstance
         val list = mRealm.where(RealmChatHistory::class.java).equalTo("user", user?.name)
             .sort("id", Sort.DESCENDING)
             .findAll()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
@@ -14,6 +14,8 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import io.realm.Realm
 import java.util.Locale
 import java.util.UUID
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentAddLinkBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
@@ -21,11 +23,14 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.ui.team.AdapterTeam
 import org.ole.planet.myplanet.utilities.Utilities
 
+@AndroidEntryPoint
 class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedListener {
     private lateinit var fragmentAddLinkBinding: FragmentAddLinkBinding
     override fun onNothingSelected(p0: AdapterView<*>?) {
     }
 
+    @Inject
+    lateinit var databaseService: DatabaseService
     lateinit var mRealm: Realm
     var selectedTeam: RealmMyTeam? = null
 
@@ -66,7 +71,7 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         fragmentAddLinkBinding.spnLink.onItemSelectedListener = this
         fragmentAddLinkBinding.btnSave.setOnClickListener {
             val type = fragmentAddLinkBinding.spnLink.selectedItem.toString()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
@@ -31,6 +31,8 @@ class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickLi
     
     @Inject
     lateinit var userProfileDbHandler: UserProfileDbHandler
+    @Inject
+    lateinit var databaseService: DatabaseService
     override fun addImage(llImage: LinearLayout?) {}
     override fun onNewsItemClick(news: RealmNews?) {}
     override fun clearImages() {}
@@ -58,7 +60,7 @@ class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickLi
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         user = UserProfileDbHandler(requireActivity()).userModel
         fragmentCommunityBinding.btnLibrary.setOnClickListener {
             homeItemClickListener?.openCallFragment(ResourcesFragment())

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
@@ -16,7 +16,6 @@ import io.realm.RealmResults
 import io.realm.Sort
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.databinding.FragmentCommunityBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
@@ -31,8 +30,6 @@ class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickLi
     
     @Inject
     lateinit var userProfileDbHandler: UserProfileDbHandler
-    @Inject
-    lateinit var databaseService: DatabaseService
     override fun addImage(llImage: LinearLayout?) {}
     override fun onNewsItemClick(news: RealmNews?) {}
     override fun clearImages() {}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/ServicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/ServicesFragment.kt
@@ -13,7 +13,6 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentServicesBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
@@ -25,8 +24,6 @@ import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 
 class ServicesFragment : BaseTeamFragment() {
     private lateinit var fragmentServicesBinding: FragmentServicesBinding
-    @Inject
-    lateinit var databaseService: DatabaseService
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentServicesBinding = FragmentServicesBinding.inflate(inflater, container, false)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/ServicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/ServicesFragment.kt
@@ -14,6 +14,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentServicesBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.service.UserProfileDbHandler
@@ -24,6 +25,8 @@ import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 
 class ServicesFragment : BaseTeamFragment() {
     private lateinit var fragmentServicesBinding: FragmentServicesBinding
+    @Inject
+    lateinit var databaseService: DatabaseService
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentServicesBinding = FragmentServicesBinding.inflate(inflater, container, false)
@@ -33,7 +36,7 @@ class ServicesFragment : BaseTeamFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 
         super.onViewCreated(view, savedInstanceState)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         user = UserProfileDbHandler(requireActivity()).userModel
 
         val links = mRealm.where(RealmMyTeam::class.java)?.equalTo("docType", "link")?.findAll()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
@@ -19,13 +19,15 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmRating.Companion.getRatingsById
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.getNoOfExam
 import org.ole.planet.myplanet.model.RealmUserModel
+import javax.inject.Inject
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
 
 class CourseDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     private lateinit var fragmentCourseDetailBinding: FragmentCourseDetailBinding
-    lateinit var dbService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var cRealm: Realm
     var courses: RealmMyCourse? = null
     var user: RealmUserModel? = null
@@ -39,8 +41,7 @@ class CourseDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentCourseDetailBinding = FragmentCourseDetailBinding.inflate(inflater, container, false)
-        dbService = DatabaseService(requireActivity())
-        cRealm = dbService.realmInstance
+        cRealm = databaseService.realmInstance
         courses = cRealm.where(RealmMyCourse::class.java).equalTo("courseId", id).findFirst()
         user = UserProfileDbHandler(requireContext()).userModel
         return fragmentCourseDetailBinding.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
@@ -12,7 +12,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.databinding.FragmentCourseDetailBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.getCourseSteps
 import org.ole.planet.myplanet.model.RealmMyLibrary
@@ -26,8 +25,6 @@ import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
 
 class CourseDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     private lateinit var fragmentCourseDetailBinding: FragmentCourseDetailBinding
-    @Inject
-    lateinit var databaseService: DatabaseService
     private lateinit var cRealm: Realm
     var courses: RealmMyCourse? = null
     var user: RealmUserModel? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -15,7 +15,6 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.databinding.FragmentCourseStepBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmExamQuestion
@@ -37,8 +36,6 @@ import javax.inject.Inject
 class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     private lateinit var fragmentCourseStepBinding: FragmentCourseStepBinding
     var stepId: String? = null
-    @Inject
-    lateinit var databaseService: DatabaseService
     private lateinit var cRealm: Realm
     private lateinit var step: RealmCourseStep
     private lateinit var resources: List<RealmMyLibrary>

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -32,11 +32,13 @@ import org.ole.planet.myplanet.utilities.CameraUtils.capturePhoto
 import org.ole.planet.myplanet.utilities.CustomClickableSpan
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
+import javax.inject.Inject
 
 class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     private lateinit var fragmentCourseStepBinding: FragmentCourseStepBinding
     var stepId: String? = null
-    private lateinit var dbService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var cRealm: Realm
     private lateinit var step: RealmCourseStep
     private lateinit var resources: List<RealmMyLibrary>
@@ -54,8 +56,7 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentCourseStepBinding = FragmentCourseStepBinding.inflate(inflater, container, false)
-        dbService = DatabaseService(requireActivity())
-        cRealm = dbService.realmInstance
+        cRealm = databaseService.realmInstance
         user = UserProfileDbHandler(requireContext()).userModel
         fragmentCourseStepBinding.btnTakeTest.visibility = View.VISIBLE
         fragmentCourseStepBinding.btnTakeSurvey.visibility = View.VISIBLE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/MyProgressFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/MyProgressFragment.kt
@@ -5,6 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.gson.Gson
 import com.google.gson.JsonArray
@@ -22,8 +24,11 @@ import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 
+@AndroidEntryPoint
 class MyProgressFragment : Fragment() {
     private lateinit var fragmentMyProgressBinding: FragmentMyProgressBinding
+    @Inject
+    lateinit var databaseService: DatabaseService
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentMyProgressBinding = FragmentMyProgressBinding.inflate(inflater, container, false)
@@ -36,7 +41,7 @@ class MyProgressFragment : Fragment() {
     }
 
     private fun initializeData() {
-        val realm = DatabaseService(requireActivity()).realmInstance
+        val realm = databaseService.realmInstance
         val user = UserProfileDbHandler(requireActivity()).userModel
         val courseData = fetchCourseData(realm, user?.id)
         fragmentMyProgressBinding.rvMyprogress.layoutManager = LinearLayoutManager(requireActivity())

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -38,10 +38,14 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.DialogUtils.getAlertDialog
 import org.ole.planet.myplanet.utilities.Utilities
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnClickListener {
     private lateinit var fragmentTakeCourseBinding: FragmentTakeCourseBinding
-    lateinit var dbService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     lateinit var mRealm: Realm
     private var currentCourse: RealmMyCourse? = null
     lateinit var steps: List<RealmCourseStep?>
@@ -60,8 +64,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentTakeCourseBinding = FragmentTakeCourseBinding.inflate(inflater, container, false)
-        dbService = DatabaseService(requireActivity())
-        mRealm = dbService.realmInstance
+        mRealm = databaseService.realmInstance
         userModel = UserProfileDbHandler(requireContext()).userModel
         currentCourse = mRealm.where(RealmMyCourse::class.java).equalTo("courseId", courseId).findFirst()
         return fragmentTakeCourseBinding.root
@@ -266,7 +269,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     }
 
     private fun getCourseProgress(): Int {
-        val realm = DatabaseService(requireActivity()).realmInstance
+        val realm = databaseService.realmInstance
         val user = UserProfileDbHandler(requireActivity()).userModel
         val courseProgressMap = RealmCourseProgress.getCourseProgress(realm, user?.id)
         val courseProgress = courseProgressMap[courseId]?.asJsonObject?.get("current")?.asInt

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -53,11 +53,9 @@ import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Utilities
-
 open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCallback,
     SyncListener {
     private var fullName: String? = null
-    lateinit var dbService: DatabaseService
     private var params = LinearLayout.LayoutParams(250, 100)
     private var di: DialogUtils.CustomProgressDialog? = null
     private lateinit var myCoursesResults: RealmResults<RealmMyCourse>
@@ -111,7 +109,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     override fun forceDownloadNewsImages() {
-        mRealm = DatabaseService(requireContext()).realmInstance
+        mRealm = databaseService.realmInstance
         Utilities.toast(activity, getString(R.string.please_select_starting_date))
         val now = Calendar.getInstance()
         val dpd = DatePickerDialog(requireActivity(), { _: DatePicker?, i: Int, i1: Int, i2: Int ->
@@ -254,7 +252,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     private fun setUpMyLife(userId: String?) {
-        val realm = DatabaseService(requireContext()).realmInstance
+        val realm = databaseService.realmInstance
         val realmObjects = RealmMyLife.getMyLifeByUserId(mRealm, settings)
         if (realmObjects.isEmpty()) {
             if (!realm.isInTransaction) {
@@ -326,8 +324,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
         view.findViewById<View>(R.id.txtFullName).setOnClickListener {
             homeItemClickListener?.openCallFragment(UserProfileFragment())
         }
-        dbService = DatabaseService(requireContext())
-        mRealm = dbService.realmInstance
+        mRealm = databaseService.realmInstance
         myLibraryDiv(view)
         initializeFlexBoxView(view, R.id.flexboxLayoutCourse, RealmMyCourse::class.java)
         initializeFlexBoxView(view, R.id.flexboxLayoutTeams, RealmMyTeam::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardFragment.kt
@@ -8,7 +8,6 @@ import androidx.appcompat.app.AppCompatActivity
 import io.realm.Realm
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentHomeBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmSubmission.Companion.getNoOfSurveySubmissionByUser
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
@@ -23,8 +22,6 @@ import javax.inject.Inject
 class DashboardFragment : BaseDashboardFragment() {
     private lateinit var fragmentHomeBinding: FragmentHomeBinding
     private lateinit var dRealm: Realm
-    @Inject
-    lateinit var databaseService: DatabaseService
     var user: RealmUserModel? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardFragment.kt
@@ -18,11 +18,13 @@ import org.ole.planet.myplanet.ui.submission.MySubmissionFragment
 import org.ole.planet.myplanet.ui.userprofile.AchievementFragment
 import org.ole.planet.myplanet.utilities.DialogUtils.guestDialog
 import org.ole.planet.myplanet.utilities.TimeUtils.currentDate
+import javax.inject.Inject
 
 class DashboardFragment : BaseDashboardFragment() {
     private lateinit var fragmentHomeBinding: FragmentHomeBinding
     private lateinit var dRealm: Realm
-    private lateinit var databaseService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     var user: RealmUserModel? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -41,7 +43,6 @@ class DashboardFragment : BaseDashboardFragment() {
         fragmentHomeBinding.cardProfile.tvAchievement.setOnClickListener {
             homeItemClickListener?.openCallFragment(AchievementFragment())
         }
-        databaseService = DatabaseService(requireActivity())
         dRealm = databaseService.realmInstance
         user = UserProfileDbHandler(requireContext()).userModel
         onLoaded(view)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/MyActivityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/MyActivityFragment.kt
@@ -20,9 +20,14 @@ import org.ole.planet.myplanet.databinding.FragmentMyActivityBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.service.UserProfileDbHandler
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class MyActivityFragment : Fragment() {
     private lateinit var fragmentMyActivityBinding : FragmentMyActivityBinding
+    @Inject
+    lateinit var databaseService: DatabaseService
     lateinit var realm: Realm
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentMyActivityBinding = FragmentMyActivityBinding.inflate(inflater, container, false)
@@ -32,7 +37,7 @@ class MyActivityFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val userModel = UserProfileDbHandler(requireActivity()).userModel
-        realm = DatabaseService(requireActivity()).realmInstance
+        realm = databaseService.realmInstance
         val calendar = Calendar.getInstance()
         val daynight_textColor = ResourcesCompat.getColor(getResources(), R.color.daynight_textColor, null);
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -29,10 +29,14 @@ import org.ole.planet.myplanet.ui.resources.ResourcesFragment
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
 import org.ole.planet.myplanet.ui.team.TeamDetailFragment
 import org.ole.planet.myplanet.ui.team.TeamPage
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class NotificationsFragment : Fragment() {
     private lateinit var fragmentNotificationsBinding: FragmentNotificationsBinding
-    private lateinit var databaseService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var mRealm: Realm
     private lateinit var adapter: AdapterNotification
     private lateinit var userId: String
@@ -52,7 +56,6 @@ class NotificationsFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentNotificationsBinding = FragmentNotificationsBinding.inflate(inflater, container, false)
-        databaseService = DatabaseService(requireActivity())
         mRealm = databaseService.realmInstance
         userId = arguments?.getString("userId") ?: ""
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
@@ -25,10 +25,13 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
 import org.ole.planet.myplanet.utilities.TimeUtils.formatDateTZ
 import org.ole.planet.myplanet.utilities.Utilities
+import javax.inject.Inject
 
 class FinanceFragment : BaseTeamFragment() {
     private lateinit var fragmentFinanceBinding: FragmentFinanceBinding
     private lateinit var addTransactionBinding: AddTransactionBinding
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var fRealm: Realm
     private var adapterFinance: AdapterFinance? = null
     var date: Calendar? = null
@@ -48,7 +51,7 @@ class FinanceFragment : BaseTeamFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentFinanceBinding = FragmentFinanceBinding.inflate(inflater, container, false)
-        fRealm = DatabaseService(requireActivity()).realmInstance
+        fRealm = databaseService.realmInstance
         date = Calendar.getInstance()
         fragmentFinanceBinding.tvFromDateCalendar.setOnClickListener {
             showDatePickerDialog(isFromDate = true)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
@@ -19,7 +19,6 @@ import java.util.UUID
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.AddTransactionBinding
 import org.ole.planet.myplanet.databinding.FragmentFinanceBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
@@ -30,8 +29,6 @@ import javax.inject.Inject
 class FinanceFragment : BaseTeamFragment() {
     private lateinit var fragmentFinanceBinding: FragmentFinanceBinding
     private lateinit var addTransactionBinding: AddTransactionBinding
-    @Inject
-    lateinit var databaseService: DatabaseService
     private lateinit var fRealm: Realm
     private var adapterFinance: AdapterFinance? = null
     var date: Calendar? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
@@ -31,9 +31,12 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.Utilities
+import javax.inject.Inject
 
 class ReportsFragment : BaseTeamFragment() {
     private lateinit var fragmentReportsBinding: FragmentReportsBinding
+    @Inject
+    lateinit var databaseService: DatabaseService
     var list: RealmResults<RealmMyTeam>? = null
     private lateinit var adapterReports: AdapterReports
     private var startTimeStamp: String? = null
@@ -43,7 +46,7 @@ class ReportsFragment : BaseTeamFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentReportsBinding = FragmentReportsBinding.inflate(inflater, container, false)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         prefData = SharedPrefManager(requireContext())
         if (!isMember()) {
             fragmentReportsBinding.addReports.visibility = View.GONE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
@@ -24,7 +24,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.databinding.DialogAddReportBinding
 import org.ole.planet.myplanet.databinding.FragmentReportsBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.insertReports
 import org.ole.planet.myplanet.model.RealmNews
@@ -35,8 +34,6 @@ import javax.inject.Inject
 
 class ReportsFragment : BaseTeamFragment() {
     private lateinit var fragmentReportsBinding: FragmentReportsBinding
-    @Inject
-    lateinit var databaseService: DatabaseService
     var list: RealmResults<RealmMyTeam>? = null
     private lateinit var adapterReports: AdapterReports
     private var startTimeStamp: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
@@ -38,11 +38,15 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.ui.survey.SurveyFragment
 import org.ole.planet.myplanet.utilities.CameraUtils.ImageCaptureCallback
 import org.ole.planet.myplanet.utilities.NetworkUtils.getUniqueIdentifier
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import org.ole.planet.myplanet.utilities.Utilities
 
+@AndroidEntryPoint
 abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
     var exam: RealmStepExam? = null
-    lateinit var db: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     lateinit var mRealm: Realm
     var stepId: String? = null
     var id: String? = ""
@@ -64,8 +68,7 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        db = DatabaseService(requireActivity())
-        mRealm = db.realmInstance
+        mRealm = databaseService.realmInstance
         if (arguments != null) {
             stepId = requireArguments().getString("stepId")
             stepNumber = requireArguments().getInt("stepNum")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -39,10 +39,15 @@ import org.ole.planet.myplanet.ui.team.TeamPage
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.Utilities
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
     private lateinit var fragmentUserInformationBinding: FragmentUserInformationBinding
     var dob: String? = ""
+    @Inject
+    lateinit var databaseService: DatabaseService
     lateinit var mRealm: Realm
     private var submissions: RealmSubmission? = null
     var userModel: RealmUserModel? = null
@@ -50,7 +55,7 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentUserInformationBinding = FragmentUserInformationBinding.inflate(inflater, container, false)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         userModel = UserProfileDbHandler(requireContext()).userModel
         if (!TextUtils.isEmpty(id)) {
             submissions = mRealm.where(RealmSubmission::class.java).equalTo("id", id).findFirst()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import io.realm.Realm
@@ -20,10 +22,12 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Utilities
 
+@AndroidEntryPoint
 class FeedbackFragment : DialogFragment(), View.OnClickListener {
     private lateinit var fragmentFeedbackBinding: FragmentFeedbackBinding
     private lateinit var mRealm: Realm
-    private lateinit var databaseService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     private var model: RealmUserModel ?= null
     var user: String? = ""
 
@@ -43,7 +47,6 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentFeedbackBinding = FragmentFeedbackBinding.inflate(inflater, container, false)
-        databaseService = DatabaseService(requireActivity())
         mRealm = databaseService.realmInstance
         model = UserProfileDbHandler(requireContext()).userModel
         user = model?.name

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -44,6 +44,8 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     lateinit var prefManager: SharedPrefManager
 
     lateinit var settings: SharedPreferences
+    @Inject
+    lateinit var databaseService: DatabaseService
     private val serverUrlMapper = ServerUrlMapper()
     
     @Inject
@@ -61,7 +63,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentFeedbackListBinding = FragmentFeedbackListBinding.inflate(inflater, container, false)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         userModel = UserProfileDbHandler(requireContext()).userModel
 
         fragmentFeedbackListBinding.fab.setOnClickListener {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
@@ -29,6 +29,8 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
     
     @Inject
     lateinit var uploadManager: UploadManager
+    @Inject
+    lateinit var databaseService: DatabaseService
     fun refreshFragment() {
         if (isAdded) {
             setAdapter()
@@ -41,7 +43,7 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentMyPersonalsBinding = FragmentMyPersonalsBinding.inflate(inflater, container, false)
         pg = DialogUtils.getCustomProgressDialog(requireContext())
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         fragmentMyPersonalsBinding.rvMypersonal.layoutManager = LinearLayoutManager(activity)
         fragmentMyPersonalsBinding.addMyPersonal.setOnClickListener {
             addResourceFragment = AddResourceFragment()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
@@ -34,14 +34,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
-import javax.inject.Inject
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.callback.SyncListener
 import org.ole.planet.myplanet.databinding.AlertHealthListBinding
 import org.ole.planet.myplanet.databinding.AlertMyPersonalBinding
 import org.ole.planet.myplanet.databinding.FragmentVitalSignBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmMyHealthPojo
 import org.ole.planet.myplanet.model.RealmUserModel
@@ -55,6 +53,8 @@ import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils.getFormatedDate
 import org.ole.planet.myplanet.utilities.Utilities
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MyHealthFragment : Fragment() {
@@ -64,6 +64,8 @@ class MyHealthFragment : Fragment() {
     
     @Inject
     lateinit var syncManager: SyncManager
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var fragmentVitalSignBinding: FragmentVitalSignBinding
     private lateinit var alertMyPersonalBinding: AlertMyPersonalBinding
     private lateinit var alertHealthListBinding: AlertHealthListBinding
@@ -90,7 +92,7 @@ class MyHealthFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentVitalSignBinding = FragmentVitalSignBinding.inflate(inflater, container, false)
-        mRealm = DatabaseService(requireContext()).realmInstance
+        mRealm = databaseService.realmInstance
         return fragmentVitalSignBinding.root
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mymeetup/MyMeetupDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mymeetup/MyMeetupDetailFragment.kt
@@ -19,10 +19,15 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
     private lateinit var fragmentMyMeetupDetailBinding: FragmentMyMeetupDetailBinding
     private var meetups: RealmMeetup? = null
+    @Inject
+    lateinit var databaseService: DatabaseService
     lateinit var mRealm: Realm
     private var meetUpId: String? = null
     var profileDbHandler: UserProfileDbHandler? = null
@@ -45,7 +50,7 @@ class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
         fragmentMyMeetupDetailBinding.btnInvite.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
         fragmentMyMeetupDetailBinding.btnLeave.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
         fragmentMyMeetupDetailBinding.btnLeave.setOnClickListener(this)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         profileDbHandler = UserProfileDbHandler(requireContext())
         user = profileDbHandler?.userModel?.let { mRealm.copyFromRealm(it) }
         return fragmentMyMeetupDetailBinding.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
@@ -18,7 +18,6 @@ import io.realm.Sort
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseNewsFragment
 import org.ole.planet.myplanet.databinding.FragmentNewsBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNews.Companion.createNews
@@ -38,8 +37,6 @@ class NewsFragment : BaseNewsFragment() {
     
     @Inject
     lateinit var userProfileDbHandler: UserProfileDbHandler
-    @Inject
-    lateinit var databaseService: DatabaseService
     private var updatedNewsList: RealmResults<RealmNews>? = null
     private var filteredNewsList: List<RealmNews?> = listOf()
     private val gson = Gson()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
@@ -38,6 +38,8 @@ class NewsFragment : BaseNewsFragment() {
     
     @Inject
     lateinit var userProfileDbHandler: UserProfileDbHandler
+    @Inject
+    lateinit var databaseService: DatabaseService
     private var updatedNewsList: RealmResults<RealmNews>? = null
     private var filteredNewsList: List<RealmNews?> = listOf()
     private val gson = Gson()
@@ -45,7 +47,7 @@ class NewsFragment : BaseNewsFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentNewsBinding = FragmentNewsBinding.inflate(inflater, container, false)
         llImage = fragmentNewsBinding.llImages
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         user = UserProfileDbHandler(requireContext()).userModel
         setupUI(fragmentNewsBinding.newsFragmentParentLayout, requireActivity())
         if (user?.id?.startsWith("guest") == true) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
@@ -9,6 +9,8 @@ import android.view.ViewGroup
 import android.widget.RatingBar
 import android.widget.RatingBar.OnRatingBarChangeListener
 import androidx.fragment.app.DialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import com.google.gson.Gson
 import io.realm.Realm
 import java.util.Date
@@ -22,9 +24,11 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.Utilities
 
+@AndroidEntryPoint
 class RatingFragment : DialogFragment() {
     private lateinit var fragmentRatingBinding: FragmentRatingBinding
-    private lateinit var databaseService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     lateinit var mRealm: Realm
     var model: RealmUserModel? = null
     var id: String? = ""
@@ -49,7 +53,6 @@ class RatingFragment : DialogFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentRatingBinding = FragmentRatingBinding.inflate(inflater, container, false)
-        databaseService = DatabaseService(requireActivity())
         mRealm = databaseService.realmInstance
         settings = requireActivity().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         return fragmentRatingBinding.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -8,6 +8,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton
 import androidx.fragment.app.DialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import io.realm.Realm
 import java.util.Locale
 import kotlin.collections.ArrayList
@@ -21,8 +23,11 @@ import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.utilities.KeyboardUtils
 
+@AndroidEntryPoint
 class CollectionsFragment : DialogFragment(), TagExpandableAdapter.OnClickTagItem, CompoundButton.OnCheckedChangeListener {
     private lateinit var fragmentCollectionsBinding: FragmentCollectionsBinding
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var mRealm: Realm
     private lateinit var list: List<RealmTag>
     private var filteredList: ArrayList<RealmTag> = ArrayList()
@@ -39,7 +44,7 @@ class CollectionsFragment : DialogFragment(), TagExpandableAdapter.OnClickTagIte
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentCollectionsBinding = FragmentCollectionsBinding.inflate(inflater, container, false)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         KeyboardUtils.hideSoftKeyboard(requireActivity())
         return fragmentCollectionsBinding.root
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -19,6 +19,7 @@ import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.databinding.FragmentLibraryDetailBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyLibrary.Companion.listToString
 import org.ole.planet.myplanet.model.RealmRating.Companion.getRatingsById
@@ -32,7 +33,8 @@ import org.ole.planet.myplanet.utilities.Utilities
 class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     private lateinit var fragmentLibraryDetailBinding: FragmentLibraryDetailBinding
     private var libraryId: String? = null
-    private lateinit var dbService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var lRealm: Realm
     private lateinit var library: RealmMyLibrary
     var userModel: RealmUserModel? = null
@@ -80,8 +82,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         super.onCreateView(inflater, container, savedInstanceState)
         fragmentLibraryDetailBinding = FragmentLibraryDetailBinding.inflate(inflater, container, false)
-        dbService = DatabaseService(requireActivity())
-        lRealm = dbService.realmInstance
+        lRealm = databaseService.realmInstance
         userModel = UserProfileDbHandler(requireContext()).userModel!!
         library = lRealm.where(RealmMyLibrary::class.java).equalTo("resourceId", libraryId).findFirst()!!
         return fragmentLibraryDetailBinding.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -18,7 +18,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.databinding.FragmentLibraryDetailBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyLibrary.Companion.listToString
@@ -33,8 +32,6 @@ import org.ole.planet.myplanet.utilities.Utilities
 class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     private lateinit var fragmentLibraryDetailBinding: FragmentLibraryDetailBinding
     private var libraryId: String? = null
-    @Inject
-    lateinit var databaseService: DatabaseService
     private lateinit var lRealm: Realm
     private lateinit var library: RealmMyLibrary
     var userModel: RealmUserModel? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submission/MySubmissionFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submission/MySubmissionFragment.kt
@@ -18,6 +18,8 @@ import io.realm.Sort
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.databinding.FragmentMySubmissionBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.getIds
 import org.ole.planet.myplanet.model.RealmSubmission
@@ -25,9 +27,12 @@ import org.ole.planet.myplanet.model.RealmSubmission.Companion.getExamMap
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 
+@AndroidEntryPoint
 class MySubmissionFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
     private lateinit var fragmentMySubmissionBinding: FragmentMySubmissionBinding
     lateinit var mRealm: Realm
+    @Inject
+    lateinit var databaseService: DatabaseService
     var type: String? = ""
     var exams: HashMap<String?, RealmStepExam>? = null
     private var submissions: List<RealmSubmission>? = null
@@ -47,7 +52,7 @@ class MySubmissionFragment : Fragment(), CompoundButton.OnCheckedChangeListener 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
         fragmentMySubmissionBinding.rvMysurvey.layoutManager = LinearLayoutManager(activity)
         fragmentMySubmissionBinding.rvMysurvey.addItemDecoration(
             DividerItemDecoration(activity, DividerItemDecoration.VERTICAL)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SendSurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SendSurveyFragment.kt
@@ -19,18 +19,21 @@ import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmSubmission.Companion.createSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.utilities.Utilities
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class SendSurveyFragment : BaseDialogFragment() {
     private lateinit var fragmentSendSurveyBinding: FragmentSendSurveyBinding
     lateinit var mRealm: Realm
-    lateinit var dbService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     override val key: String
         get() = "surveyId"
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentSendSurveyBinding = FragmentSendSurveyBinding.inflate(inflater, container, false)
-        dbService = DatabaseService(requireActivity())
-        mRealm = dbService.realmInstance
+        mRealm = databaseService.realmInstance
         if (TextUtils.isEmpty(id)) {
             dismiss()
             return fragmentSendSurveyBinding.root
@@ -40,7 +43,7 @@ class SendSurveyFragment : BaseDialogFragment() {
     }
 
     private fun createSurveySubmission(userId: String?) {
-        val mRealm = DatabaseService(requireActivity()).realmInstance
+        val mRealm = databaseService.realmInstance
         val exam = mRealm.where(RealmStepExam::class.java).equalTo("id", id).findFirst()
         mRealm.beginTransaction()
         var sub = mRealm.where(RealmSubmission::class.java).equalTo("userId", userId)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
@@ -4,16 +4,12 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
 import org.ole.planet.myplanet.base.BaseNewsFragment
-import org.ole.planet.myplanet.datamanager.DatabaseService
-import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
 abstract class BaseTeamFragment : BaseNewsFragment() {
-    @Inject
-    lateinit var databaseService: DatabaseService
     var user: RealmUserModel? = null
     lateinit var teamId: String
     var team: RealmMyTeam? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
@@ -5,13 +5,15 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import org.ole.planet.myplanet.base.BaseNewsFragment
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
 abstract class BaseTeamFragment : BaseNewsFragment() {
-    lateinit var dbService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     var user: RealmUserModel? = null
     lateinit var teamId: String
     var team: RealmMyTeam? = null
@@ -22,8 +24,7 @@ abstract class BaseTeamFragment : BaseNewsFragment() {
         val sParentCode = settings?.getString("parentCode", "")
         val communityName = settings?.getString("communityName", "")
         teamId = requireArguments().getString("id", "") ?: "$communityName@$sParentCode"
-        dbService = DatabaseService(requireActivity())
-        mRealm = dbService.realmInstance
+        mRealm = databaseService.realmInstance
         user = profileDbHandler.userModel?.let { mRealm.copyFromRealm(it) }
 
         if (shouldQueryTeamFromRealm()) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
@@ -59,7 +59,8 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
     var team: RealmMyTeam? = null
     lateinit var listContent: ListView
     private lateinit var tabLayout: TabLayout
-    lateinit var dbService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var rvDiscussion: RecyclerView
     lateinit var llRv: LinearLayout
     private var isMyTeam = false
@@ -77,8 +78,7 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
         fragmentMyTeamsDetailBinding = FragmentMyTeamsDetailBinding.inflate(inflater, container, false)
         val v: View = fragmentMyTeamsDetailBinding.root
         initializeViews(v)
-        dbService = DatabaseService(requireActivity())
-        mRealm = dbService.realmInstance
+        mRealm = databaseService.realmInstance
         user = profileDbHandler.userModel?.let { mRealm.copyFromRealm(it) }
         team = mRealm.where(RealmMyTeam::class.java).equalTo("_id", teamId).findFirst()
         return fragmentMyTeamsDetailBinding.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
@@ -27,7 +27,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseNewsFragment
 import org.ole.planet.myplanet.databinding.AlertInputBinding
 import org.ole.planet.myplanet.databinding.FragmentMyTeamsDetailBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
@@ -59,8 +58,6 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
     var team: RealmMyTeam? = null
     lateinit var listContent: ListView
     private lateinit var tabLayout: TabLayout
-    @Inject
-    lateinit var databaseService: DatabaseService
     private lateinit var rvDiscussion: RecyclerView
     lateinit var llRv: LinearLayout
     private var isMyTeam = false

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -25,7 +25,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.MemberChangeListener
 import org.ole.planet.myplanet.callback.SyncListener
 import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMemberCount
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
@@ -48,8 +47,6 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     
     @Inject
     lateinit var syncManager: SyncManager
-    @Inject
-    lateinit var databaseService: DatabaseService
     
     private lateinit var fragmentTeamDetailBinding: FragmentTeamDetailBinding
     private var directTeamName: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -48,6 +48,8 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     
     @Inject
     lateinit var syncManager: SyncManager
+    @Inject
+    lateinit var databaseService: DatabaseService
     
     private lateinit var fragmentTeamDetailBinding: FragmentTeamDetailBinding
     private var directTeamName: String? = null
@@ -76,7 +78,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
         val teamId = requireArguments().getString("id" ) ?: ""
         val isMyTeam = requireArguments().getBoolean("isMyTeam", false)
         val user = UserProfileDbHandler(requireContext()).userModel
-        mRealm = DatabaseService(requireActivity()).realmInstance
+        mRealm = databaseService.realmInstance
 
         if (shouldQueryRealm(teamId)) {
             if (teamId.isNotEmpty()) {
@@ -314,7 +316,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
         val teamType = getEffectiveTeamType()
 
         CoroutineScope(Dispatchers.IO).launch {
-            val realm = DatabaseService(requireActivity()).realmInstance
+            val realm = databaseService.realmInstance
 
             realm.executeTransaction { r ->
                 val log = r.createObject(RealmTeamLog::class.java, "${UUID.randomUUID()}")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -21,6 +21,8 @@ import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.databinding.AlertCreateTeamBinding
 import org.ole.planet.myplanet.databinding.FragmentTeamBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getMyTeamsByUserId
 import org.ole.planet.myplanet.model.RealmUserModel
@@ -29,10 +31,13 @@ import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Utilities
 
+@AndroidEntryPoint
 class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private lateinit var fragmentTeamBinding: FragmentTeamBinding
     private lateinit var alertCreateTeamBinding: AlertCreateTeamBinding
     private lateinit var mRealm: Realm
+    @Inject
+    lateinit var databaseService: DatabaseService
     var type: String? = null
     private var fromDashboard: Boolean = false
     var user: RealmUserModel? = null
@@ -56,7 +61,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentTeamBinding = FragmentTeamBinding.inflate(inflater, container, false)
-        mRealm = DatabaseService(requireContext()).realmInstance
+        mRealm = databaseService.realmInstance
         user = UserProfileDbHandler(requireActivity()).userModel
 
         if (user?.isGuest() == true) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
@@ -37,7 +37,6 @@ import org.ole.planet.myplanet.databinding.EditOtherInfoBinding
 import org.ole.planet.myplanet.databinding.FragmentEditAchievementBinding
 import org.ole.planet.myplanet.databinding.MyLibraryAlertdialogBinding
 import org.ole.planet.myplanet.databinding.RowlayoutBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmAchievement
 import org.ole.planet.myplanet.model.RealmAchievement.Companion.createReference
@@ -56,8 +55,6 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
     private lateinit var alertReferenceBinding: AlertReferenceBinding
     private lateinit var alertAddAttachmentBinding: AlertAddAttachmentBinding
     private lateinit var myLibraryAlertdialogBinding: MyLibraryAlertdialogBinding
-    @Inject
-    lateinit var databaseService: DatabaseService
     private lateinit var aRealm: Realm
     var user: RealmUserModel? = null
     private var achievement: RealmAchievement? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
@@ -38,6 +38,7 @@ import org.ole.planet.myplanet.databinding.FragmentEditAchievementBinding
 import org.ole.planet.myplanet.databinding.MyLibraryAlertdialogBinding
 import org.ole.planet.myplanet.databinding.RowlayoutBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmAchievement
 import org.ole.planet.myplanet.model.RealmAchievement.Companion.createReference
 import org.ole.planet.myplanet.model.RealmMyLibrary
@@ -55,6 +56,8 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
     private lateinit var alertReferenceBinding: AlertReferenceBinding
     private lateinit var alertAddAttachmentBinding: AlertAddAttachmentBinding
     private lateinit var myLibraryAlertdialogBinding: MyLibraryAlertdialogBinding
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var aRealm: Realm
     var user: RealmUserModel? = null
     private var achievement: RealmAchievement? = null
@@ -64,7 +67,7 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentEditAchievementBinding = FragmentEditAchievementBinding.inflate(inflater, container, false)
-        aRealm = DatabaseService(requireActivity()).realmInstance
+        aRealm = databaseService.realmInstance
         user = UserProfileDbHandler(requireContext()).userModel
         achievementArray = JsonArray()
         achievement = aRealm.where(RealmAchievement::class.java).equalTo("_id", user?.id + "@" + user?.planetCode).findFirst()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserDetailFragment.kt
@@ -5,6 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
@@ -16,11 +18,14 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.TimeUtils.getFormatedDate
 import org.ole.planet.myplanet.utilities.Utilities
 
+@AndroidEntryPoint
 class UserDetailFragment : Fragment() {
     private lateinit var fragmentUserDetailBinding: FragmentUserDetailBinding
     lateinit var itemTitleDescBinding: ItemTitleDescBinding
     private var userId: String? = null
     private var user: RealmUserModel? = null
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var db: UserProfileDbHandler
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -33,7 +38,7 @@ class UserDetailFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentUserDetailBinding = FragmentUserDetailBinding.inflate(inflater, container, false)
         fragmentUserDetailBinding.rvUserDetail.layoutManager = GridLayoutManager(activity, 2)
-        val mRealm = DatabaseService(requireActivity()).realmInstance
+        val mRealm = databaseService.realmInstance
         db = UserProfileDbHandler(requireActivity())
         user = mRealm.where(RealmUserModel::class.java).equalTo("id", userId).findFirst()
         return fragmentUserDetailBinding.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
@@ -30,6 +30,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.view.children
 import androidx.fragment.app.Fragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -61,12 +63,14 @@ import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
+@AndroidEntryPoint
 class UserProfileFragment : Fragment() {
     private lateinit var fragmentUserProfileBinding: FragmentUserProfileBinding
     private lateinit var rowStatBinding: RowStatBinding
     private lateinit var handler: UserProfileDbHandler
     private lateinit var settings: SharedPreferences
-    private lateinit var realmService: DatabaseService
+    @Inject
+    lateinit var databaseService: DatabaseService
     private lateinit var mRealm: Realm
     private var model: RealmUserModel? = null
     private var imageUrl = ""
@@ -151,8 +155,7 @@ class UserProfileFragment : Fragment() {
     private fun initializeDependencies() {
         settings = requireContext().getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         handler = UserProfileDbHandler(requireContext())
-        realmService = DatabaseService(requireContext())
-        mRealm = realmService.realmInstance
+        mRealm = databaseService.realmInstance
         fragmentUserProfileBinding.rvStat.layoutManager = LinearLayoutManager(activity)
         fragmentUserProfileBinding.rvStat.isNestedScrollingEnabled = false
     }


### PR DESCRIPTION
## Summary
- inject `DatabaseService` in fragments using Hilt
- remove manual `DatabaseService(requireActivity())` instantiation

## Testing
- `./gradlew test` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687f57d14e88832b8f632f5acf85f7ce