### PR TITLE
sync: smoother `SyncManager.kt` injections (fixes #6417)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2733
-        versionName = "0.27.33"
+        versionCode = 2736
+        versionName = "0.27.36"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.kt
@@ -18,15 +18,17 @@ import org.ole.planet.myplanet.datamanager.Service
 import org.ole.planet.myplanet.datamanager.Service.CheckVersionCallback
 import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.service.SyncManager
 import org.ole.planet.myplanet.ui.sync.LoginActivity
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils.startDownloadUpdate
 import org.ole.planet.myplanet.utilities.Utilities
 
 class AutoSyncWorker @AssistedInject constructor(
-    @Assisted private val context: Context, 
+    @Assisted private val context: Context,
     @Assisted workerParams: WorkerParameters,
-    private val uploadManager: UploadManager
+    private val uploadManager: UploadManager,
+    private val syncManager: SyncManager
 ) : Worker(context, workerParams), SyncListener, CheckVersionCallback, SuccessListener {
     
     @AssistedFactory
@@ -68,7 +70,7 @@ class AutoSyncWorker @AssistedInject constructor(
     override fun onCheckingVersion() {}
     override fun onError(msg: String, blockSync: Boolean) {
         if (!blockSync) {
-            SyncManager.instance?.start(this, "upload")
+            syncManager.start(this, "upload")
             UploadToShelfService.instance?.uploadUserData {
                 Service(MainApplication.context).healthAccess {
                     UploadToShelfService.instance?.uploadHealth()

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -90,7 +90,6 @@ class SyncManager @Inject constructor(
         cancelBackgroundSync()
         cancel(context, 111)
         isSyncing = false
-        ourInstance = null
         settings.edit { putLong("LastSync", Date().time) }
         listener?.onSyncComplete()
         try {
@@ -1285,15 +1284,5 @@ class SyncManager @Inject constructor(
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     )
 
-    companion object {
-        @Deprecated("Use dependency injection instead", ReplaceWith("Inject SyncManager"))
-        private var ourInstance: SyncManager? = null
-        @Deprecated("Use dependency injection instead", ReplaceWith("Inject SyncManager"))
-        val instance: SyncManager?
-            get() {
-                ourInstance = SyncManager(MainApplication.context)
-                return ourInstance
-            }
-    }
 }
 


### PR DESCRIPTION
## Summary
- remove deprecated `SyncManager.instance` singleton
- inject `SyncManager` into `AutoSyncWorker` and use it directly

## Testing
- `./gradlew test` *(fails: Fetch remote repository / network)*

------
https://chatgpt.com/codex/tasks/task_e_687f57dc3c9c832b8511837387d76fda