### PR TITLE
Inject Service and ManagerSync via Hilt

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ManagerSync.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ManagerSync.kt
@@ -20,7 +20,7 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
-class ManagerSync private constructor(context: Context) {
+class ManagerSync constructor(context: Context) {
     private val settings: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val dbService: DatabaseService = DatabaseService(context)
     private val mRealm: Realm = dbService.realmInstance
@@ -95,12 +95,14 @@ class ManagerSync private constructor(context: Context) {
     }
 
     companion object {
-        private var ourInstance: ManagerSync? = null
-        @JvmStatic
-        val instance: ManagerSync?
+        @Deprecated("Use dependency injection instead", ReplaceWith("Inject ManagerSync"))
+        var instance: ManagerSync? = null
             get() {
-                ourInstance = ManagerSync(MainApplication.context)
-                return ourInstance
+                if (field == null) {
+                    field = ManagerSync(MainApplication.context)
+                }
+                return field
             }
+            private set
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -9,6 +9,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
+import org.ole.planet.myplanet.datamanager.ManagerSync
+import org.ole.planet.myplanet.datamanager.Service
 import org.ole.planet.myplanet.service.SyncManager
 import org.ole.planet.myplanet.service.UploadManager
 import javax.inject.Singleton
@@ -35,5 +37,21 @@ object ServiceModule {
         @AppPreferences preferences: SharedPreferences
     ): UploadManager {
         return UploadManager(context, databaseService, preferences)
+    }
+
+    @Provides
+    @Singleton
+    fun provideService(
+        @ApplicationContext context: Context
+    ): Service {
+        return Service(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideManagerSync(
+        @ApplicationContext context: Context
+    ): ManagerSync {
+        return ManagerSync(context)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.kt
@@ -24,9 +24,10 @@ import org.ole.planet.myplanet.utilities.DialogUtils.startDownloadUpdate
 import org.ole.planet.myplanet.utilities.Utilities
 
 class AutoSyncWorker @AssistedInject constructor(
-    @Assisted private val context: Context, 
+    @Assisted private val context: Context,
     @Assisted workerParams: WorkerParameters,
-    private val uploadManager: UploadManager
+    private val uploadManager: UploadManager,
+    private val service: Service
 ) : Worker(context, workerParams), SyncListener, CheckVersionCallback, SuccessListener {
     
     @AssistedFactory
@@ -44,7 +45,7 @@ class AutoSyncWorker @AssistedInject constructor(
             if (isAppInForeground(context)) {
                 Utilities.toast(context, "Syncing started...")
             }
-            Service(context).checkVersion(this, preferences)
+            service.checkVersion(this, preferences)
         }
         return Result.success()
     }
@@ -70,7 +71,7 @@ class AutoSyncWorker @AssistedInject constructor(
         if (!blockSync) {
             SyncManager.instance?.start(this, "upload")
             UploadToShelfService.instance?.uploadUserData {
-                Service(MainApplication.context).healthAccess {
+                service.healthAccess {
                     UploadToShelfService.instance?.uploadHealth()
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -47,7 +47,10 @@ import org.ole.planet.myplanet.utilities.*
 import org.ole.planet.myplanet.utilities.FileUtils.availableOverTotalMemoryFormattedString
 import org.ole.planet.myplanet.utilities.Utilities.getUrl
 import org.ole.planet.myplanet.utilities.Utilities.toast
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
     private lateinit var activityLoginBinding: ActivityLoginBinding
     private var guest = false
@@ -57,6 +60,9 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
     private val backPressedInterval: Long = 2000
     private var teamList = java.util.ArrayList<String?>()
     private var teamAdapter: ArrayAdapter<String?>? = null
+
+    @Inject
+    lateinit var managerSync: ManagerSync
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -455,7 +461,7 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
     }
 
     private fun submitForm(name: String?, password: String?) {
-        AuthHelper.login(this, name, password)
+        AuthHelper.login(this, name, password, managerSync)
     }
 
     internal fun showGuestDialog(username: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/AuthHelper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/AuthHelper.kt
@@ -47,7 +47,7 @@ object AuthHelper {
         }
     }
 
-    fun login(activity: LoginActivity, name: String?, password: String?) {
+    fun login(activity: LoginActivity, name: String?, password: String?, managerSync: ManagerSync) {
         if (activity.forceSyncTrigger()) return
 
         val settings = activity.settings
@@ -64,7 +64,7 @@ object AuthHelper {
             return
         }
 
-        ManagerSync.instance?.login(name, password, object : SyncListener {
+        managerSync.login(name, password, object : SyncListener {
             override fun onSyncStarted() {
                 activity.customProgressDialog.setText(activity.getString(R.string.please_wait))
                 activity.customProgressDialog.show()


### PR DESCRIPTION
## Summary
- add DI providers for `Service` and `ManagerSync`
- allow `ManagerSync` construction by DI
- inject `Service` into `AutoSyncWorker`
- inject `ManagerSync` into `AuthHelper` and `LoginActivity`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f580f7ffc832b8267d66a6c980505