### PR TITLE
Switch retry utils and ANR watchdog to coroutines

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -229,7 +229,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                 }
             }
         })
-        anrWatchdog.start()
+        anrWatchdog.start(applicationScope)
     }
 
     private fun scheduleWorkersOnStart() {

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
@@ -7,6 +7,7 @@ import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.utilities.RetryUtils
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import retrofit2.Response
 import retrofit2.Retrofit
@@ -69,8 +70,12 @@ object ApiClient {
         return enhancedRetrofit.create(ApiInterface::class.java)
     }
 
-    fun <T> executeWithRetry(operation: () -> Response<T>?): Response<T>? {
+    suspend fun <T> executeWithRetry(
+        scope: CoroutineScope,
+        operation: suspend () -> Response<T>?,
+    ): Response<T>? {
         return RetryUtils.retry(
+            scope = scope,
             maxAttempts = 3,
             delayMs = 2000L,
             shouldRetry = { resp -> resp == null || !resp.isSuccessful },

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runBlocking
 import okhttp3.ResponseBody
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
@@ -264,7 +265,9 @@ class Service(private val context: Context) {
                 if (res?.body() != null) {
                     val model = populateUsersTable(res.body(), realm1, settings)
                     if (model != null) {
-                        UploadToShelfService(MainApplication.context).saveKeyIv(retrofitInterface, model, obj)
+                        runBlocking {
+                            UploadToShelfService(MainApplication.context).saveKeyIv(retrofitInterface, model, obj)
+                        }
                     }
                 }
             } catch (e: IOException) {

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -1005,7 +1005,12 @@ class SyncManager @Inject constructor(
         return processedItems
     }
 
-    private fun processShelfDataOptimizedSync(shelfId: String?, shelfData: Constants.ShelfData, shelfDoc: JsonObject?, apiInterface: ApiInterface): Int {
+    private suspend fun processShelfDataOptimizedSync(
+        shelfId: String?,
+        shelfData: Constants.ShelfData,
+        shelfDoc: JsonObject?,
+        apiInterface: ApiInterface,
+    ): Int {
         var processedCount = 0
 
         try {
@@ -1200,7 +1205,7 @@ class SyncManager @Inject constructor(
         return processedCount
     }
 
-    private fun <T> safeRealmOperation(operation: (Realm) -> T): T? {
+    private suspend fun <T> safeRealmOperation(operation: suspend (Realm) -> T): T? {
         var realm: Realm? = null
         return try {
             realm = Realm.getDefaultInstance()

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -579,7 +579,7 @@ class SyncManager @Inject constructor(
             val realmInstance = backgroundRealm ?: mRealm
             val newIds: MutableList<String?> = ArrayList()
             var totalRows = 0
-            ApiClient.executeWithRetry(this) {
+            ApiClient.executeWithRetry(syncScope) {
                 apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?limit=0").execute()
             }?.let { response ->
                 response.body()?.let { body ->
@@ -598,7 +598,7 @@ class SyncManager @Inject constructor(
 
                 try {
                     var response: JsonObject? = null
-                    ApiClient.executeWithRetry(this) {
+                    ApiClient.executeWithRetry(syncScope) {
                         apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?include_docs=true&limit=$batchSize&skip=$skip").execute()
                     }?.let {
                         response = it.body()
@@ -719,7 +719,7 @@ class SyncManager @Inject constructor(
         }
     }
 
-    private fun fastResourceTransactionSync() {
+    private suspend fun fastResourceTransactionSync() {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("resource_sync")
         var processedItems = 0
@@ -729,7 +729,7 @@ class SyncManager @Inject constructor(
             val newIds = ConcurrentHashMap.newKeySet<String>()
 
             var totalRows = 0
-            ApiClient.executeWithRetry(this) {
+            ApiClient.executeWithRetry(syncScope) {
                 apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?limit=0").execute()
             }?.let { response ->
                 response.body()?.let { body ->
@@ -773,7 +773,7 @@ class SyncManager @Inject constructor(
 
         try {
             var response: JsonObject? = null
-            ApiClient.executeWithRetry(this) {
+            ApiClient.executeWithRetry(syncScope) {
                 apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?include_docs=true&limit=$batchSize&skip=$skip").execute()
             }?.let {
                 response = it.body()
@@ -852,7 +852,7 @@ class SyncManager @Inject constructor(
             return cachedShelves
         }
 
-        val allShelves = ApiClient.executeWithRetry(this) {
+        val allShelves = ApiClient.executeWithRetry(syncScope) {
             apiInterface.getDocuments(Utilities.header, "${Utilities.getUrl()}/shelf/_all_docs").execute()
         }?.body()?.rows ?: return emptyList()
 
@@ -882,7 +882,7 @@ class SyncManager @Inject constructor(
             add("keys", Gson().fromJson(Gson().toJson(shelfIds), JsonArray::class.java))
         }
 
-        val response = ApiClient.executeWithRetry(this) {
+        val response = ApiClient.executeWithRetry(syncScope) {
             apiInterface.findDocs(Utilities.header, "application/json", "${Utilities.getUrl()}/shelf/_all_docs?include_docs=true", keysObject).execute()
         }?.body()
 
@@ -976,7 +976,7 @@ class SyncManager @Inject constructor(
 
         try {
             var shelfDoc: JsonObject? = null
-            ApiClient.executeWithRetry(this) {
+            ApiClient.executeWithRetry(syncScope) {
                 apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/shelf/$shelfId").execute()
             }?.let {
                 shelfDoc = it.body()
@@ -1035,7 +1035,7 @@ class SyncManager @Inject constructor(
                 keysObject.add("keys", Gson().fromJson(Gson().toJson(batch), JsonArray::class.java))
 
                 var response: JsonObject? = null
-                ApiClient.executeWithRetry(this) {
+                ApiClient.executeWithRetry(syncScope) {
                     apiInterface.findDocs(Utilities.header, "application/json", "${Utilities.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject).execute()
                 }?.let {
                     response = it.body()
@@ -1082,7 +1082,7 @@ class SyncManager @Inject constructor(
         return processedCount
     }
 
-    private fun fastMyLibraryTransactionSync() {
+    private suspend fun fastMyLibraryTransactionSync() {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("library_sync")
         var processedItems = 0
@@ -1091,7 +1091,7 @@ class SyncManager @Inject constructor(
             val apiInterface = ApiClient.getEnhancedClient()
 
             var shelfResponse: DocumentResponse? = null
-            ApiClient.executeWithRetry(this) {
+            ApiClient.executeWithRetry(syncScope) {
                 apiInterface.getDocuments(Utilities.header, "${Utilities.getUrl()}/shelf/_all_docs?include_docs=true").execute()
             }?.let {
                 shelfResponse = it.body()
@@ -1130,7 +1130,7 @@ class SyncManager @Inject constructor(
 
         try {
             var shelfDoc: JsonObject? = null
-            ApiClient.executeWithRetry(this) {
+            ApiClient.executeWithRetry(syncScope) {
                 apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/shelf/$shelfId").execute()
             }?.let {
                 shelfDoc = it.body()
@@ -1221,7 +1221,7 @@ class SyncManager @Inject constructor(
         }
     }
 
-    private fun processBatchForShelfData(batch: List<String>, shelfData: Constants.ShelfData, shelfId: String?, apiInterface: ApiInterface, realmInstance: Realm): Int {
+    private suspend fun processBatchForShelfData(batch: List<String>, shelfData: Constants.ShelfData, shelfId: String?, apiInterface: ApiInterface, realmInstance: Realm): Int {
         var processedCount = 0
 
         try {
@@ -1229,7 +1229,7 @@ class SyncManager @Inject constructor(
             keysObject.add("keys", Gson().fromJson(Gson().toJson(batch), JsonArray::class.java))
 
             var response: JsonObject? = null
-            ApiClient.executeWithRetry(this) {
+            ApiClient.executeWithRetry(syncScope) {
                 apiInterface.findDocs(Utilities.header, "application/json", "${Utilities.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject).execute()
             }?.let {
                 response = it.body()

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -223,7 +223,7 @@ class SyncManager @Inject constructor(
             logger.endProcess("admin_sync")
 
             logger.startProcess("resource_sync")
-            resourceTransactionSync()
+            runBlocking { resourceTransactionSync() }
             logger.endProcess("resource_sync")
 
             logger.startProcess("on_synced")
@@ -569,7 +569,7 @@ class SyncManager @Inject constructor(
         }
     }
 
-    private fun resourceTransactionSync(backgroundRealm: Realm? = null) {
+    private suspend fun resourceTransactionSync(backgroundRealm: Realm? = null) {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("resource_sync")
         var processedItems = 0
@@ -579,7 +579,7 @@ class SyncManager @Inject constructor(
             val realmInstance = backgroundRealm ?: mRealm
             val newIds: MutableList<String?> = ArrayList()
             var totalRows = 0
-            ApiClient.executeWithRetry {
+            ApiClient.executeWithRetry(this) {
                 apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?limit=0").execute()
             }?.let { response ->
                 response.body()?.let { body ->
@@ -598,7 +598,7 @@ class SyncManager @Inject constructor(
 
                 try {
                     var response: JsonObject? = null
-                    ApiClient.executeWithRetry {
+                    ApiClient.executeWithRetry(this) {
                         apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?include_docs=true&limit=$batchSize&skip=$skip").execute()
                     }?.let {
                         response = it.body()
@@ -729,7 +729,7 @@ class SyncManager @Inject constructor(
             val newIds = ConcurrentHashMap.newKeySet<String>()
 
             var totalRows = 0
-            ApiClient.executeWithRetry {
+            ApiClient.executeWithRetry(this) {
                 apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?limit=0").execute()
             }?.let { response ->
                 response.body()?.let { body ->
@@ -773,7 +773,7 @@ class SyncManager @Inject constructor(
 
         try {
             var response: JsonObject? = null
-            ApiClient.executeWithRetry {
+            ApiClient.executeWithRetry(this) {
                 apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/resources/_all_docs?include_docs=true&limit=$batchSize&skip=$skip").execute()
             }?.let {
                 response = it.body()
@@ -852,7 +852,7 @@ class SyncManager @Inject constructor(
             return cachedShelves
         }
 
-        val allShelves = ApiClient.executeWithRetry {
+        val allShelves = ApiClient.executeWithRetry(this) {
             apiInterface.getDocuments(Utilities.header, "${Utilities.getUrl()}/shelf/_all_docs").execute()
         }?.body()?.rows ?: return emptyList()
 
@@ -882,7 +882,7 @@ class SyncManager @Inject constructor(
             add("keys", Gson().fromJson(Gson().toJson(shelfIds), JsonArray::class.java))
         }
 
-        val response = ApiClient.executeWithRetry {
+        val response = ApiClient.executeWithRetry(this) {
             apiInterface.findDocs(Utilities.header, "application/json", "${Utilities.getUrl()}/shelf/_all_docs?include_docs=true", keysObject).execute()
         }?.body()
 
@@ -976,7 +976,7 @@ class SyncManager @Inject constructor(
 
         try {
             var shelfDoc: JsonObject? = null
-            ApiClient.executeWithRetry {
+            ApiClient.executeWithRetry(this) {
                 apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/shelf/$shelfId").execute()
             }?.let {
                 shelfDoc = it.body()
@@ -1035,7 +1035,7 @@ class SyncManager @Inject constructor(
                 keysObject.add("keys", Gson().fromJson(Gson().toJson(batch), JsonArray::class.java))
 
                 var response: JsonObject? = null
-                ApiClient.executeWithRetry {
+                ApiClient.executeWithRetry(this) {
                     apiInterface.findDocs(Utilities.header, "application/json", "${Utilities.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject).execute()
                 }?.let {
                     response = it.body()
@@ -1091,7 +1091,7 @@ class SyncManager @Inject constructor(
             val apiInterface = ApiClient.getEnhancedClient()
 
             var shelfResponse: DocumentResponse? = null
-            ApiClient.executeWithRetry {
+            ApiClient.executeWithRetry(this) {
                 apiInterface.getDocuments(Utilities.header, "${Utilities.getUrl()}/shelf/_all_docs?include_docs=true").execute()
             }?.let {
                 shelfResponse = it.body()
@@ -1130,7 +1130,7 @@ class SyncManager @Inject constructor(
 
         try {
             var shelfDoc: JsonObject? = null
-            ApiClient.executeWithRetry {
+            ApiClient.executeWithRetry(this) {
                 apiInterface.getJsonObject(Utilities.header, "${Utilities.getUrl()}/shelf/$shelfId").execute()
             }?.let {
                 shelfDoc = it.body()
@@ -1229,7 +1229,7 @@ class SyncManager @Inject constructor(
             keysObject.add("keys", Gson().fromJson(Gson().toJson(batch), JsonArray::class.java))
 
             var response: JsonObject? = null
-            ApiClient.executeWithRetry {
+            ApiClient.executeWithRetry(this) {
                 apiInterface.findDocs(Utilities.header, "application/json", "${Utilities.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject).execute()
             }?.let {
                 response = it.body()

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
@@ -1,12 +1,17 @@
 package org.ole.planet.myplanet.utilities
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
 object RetryUtils {
-    fun <T> retry(
+    suspend fun <T> retry(
+        scope: CoroutineScope,
         maxAttempts: Int = 3,
         delayMs: Long = 2000L,
         shouldRetry: (T?) -> Boolean = { it == null },
-        block: () -> T?
-    ): T? {
+        block: suspend () -> T?,
+    ): T? = withContext(scope.coroutineContext) {
         var attempt = 0
         var result: T? = null
         var lastException: Exception? = null
@@ -18,20 +23,16 @@ object RetryUtils {
                 lastException = e
                 result = null
             }
+
             if (!shouldRetry(result)) {
-                return result
+                return@withContext result
             }
             attempt++
             if (attempt < maxAttempts) {
-                try {
-                    Thread.sleep(delayMs)
-                } catch (ie: InterruptedException) {
-                    // ignore
-                }
+                delay(delayMs)
             }
         }
         lastException?.printStackTrace()
-        return result
+        result
     }
 }
-


### PR DESCRIPTION
## Summary
- replace `Thread.sleep` retries with coroutine-based delay
- rework `ANRWatchdog` to schedule checks in a coroutine
- pass coroutine scope to `RetryUtils.retry`
- update callers to use suspending APIs

## Testing
- `./gradlew assembleDebug --dry-run`
- `./gradlew test --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_687f5bd7e380832b9c61cf1a1fa3ed08