### PR TITLE
Refactor data access into repositories

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -6,13 +6,13 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.realm.Realm
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import javax.inject.Singleton
 
 @Module
@@ -45,6 +45,25 @@ object RepositoryModule {
         apiInterface: ApiInterface
     ): CourseRepository {
         return CourseRepositoryImpl(databaseService, apiInterface)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSyncRepository(
+        databaseService: DatabaseService,
+        @AppPreferences settings: SharedPreferences,
+        @DefaultPreferences defaultPreferences: SharedPreferences
+    ): SyncRepository {
+        return SyncRepositoryImpl(databaseService, settings, defaultPreferences)
+    }
+
+    @Provides
+    @Singleton
+    fun provideDashboardRepository(
+        databaseService: DatabaseService,
+        @AppPreferences settings: SharedPreferences
+    ): DashboardRepository {
+        return DashboardRepositoryImpl(databaseService, settings)
     }
 }
 
@@ -139,5 +158,152 @@ class CourseRepositoryImpl(
     private fun getCurrentUserId(): String {
         return databaseService.realmInstance.where(RealmUserModel::class.java)
             .findFirst()?.id ?: ""
+    }
+}
+
+// Sync Repository
+interface SyncRepository {
+    suspend fun authenticateUser(username: String?, password: String?, isManagerMode: Boolean): RealmUserModel?
+    suspend fun isAutoSyncEnabled(): Boolean
+    suspend fun getAutoSyncPosition(): Int
+}
+
+class SyncRepositoryImpl(
+    private val databaseService: DatabaseService,
+    @AppPreferences private val settings: SharedPreferences,
+    @DefaultPreferences private val defaultPreferences: SharedPreferences
+) : SyncRepository {
+    override suspend fun authenticateUser(
+        username: String?,
+        password: String?,
+        isManagerMode: Boolean
+    ): RealmUserModel? = withContext(Dispatchers.IO) {
+        val realm = databaseService.realmInstance
+        val user = realm.where(RealmUserModel::class.java)
+            .equalTo("name", username)
+            .findFirst()
+        user?.let {
+            if (it._id?.isEmpty() == true) {
+                if (username == it.name && password == it.password) it else null
+            } else {
+                if (org.ole.planet.myplanet.utilities.AndroidDecrypter.androidDecrypter(
+                    username,
+                    password,
+                    it.derived_key,
+                    it.salt
+                ) && (!isManagerMode || it.isManager())) {
+                    it
+                } else null
+            }
+        }
+    }
+
+    override suspend fun isAutoSyncEnabled(): Boolean = withContext(Dispatchers.IO) {
+        settings.getBoolean("autoSync", true)
+    }
+
+    override suspend fun getAutoSyncPosition(): Int = withContext(Dispatchers.IO) {
+        settings.getInt("autoSyncPosition", 0)
+    }
+}
+
+// Dashboard Repository
+interface DashboardRepository {
+    suspend fun updateResourceNotification(userId: String?)
+    suspend fun getUnreadNotificationsSize(userId: String?): Int
+    suspend fun getPendingSurveyTitles(userId: String?): List<String>
+    suspend fun createNotificationIfNotExists(type: String, message: String, relatedId: String?, userId: String?)
+    suspend fun getMyLibraryByUser(): List<RealmMyLibrary>
+}
+
+class DashboardRepositoryImpl(
+    private val databaseService: DatabaseService,
+    @AppPreferences private val settings: SharedPreferences
+) : DashboardRepository {
+    override suspend fun updateResourceNotification(userId: String?) {
+        withContext(Dispatchers.IO) {
+            val realm = databaseService.realmInstance
+            realm.executeTransaction { r ->
+                val resourceCount = org.ole.planet.myplanet.base.BaseResourceFragment.getLibraryList(r, userId).size
+                val existing = r.where(org.ole.planet.myplanet.model.RealmNotification::class.java)
+                    .equalTo("userId", userId)
+                    .equalTo("type", "resource")
+                    .findFirst()
+                if (resourceCount > 0) {
+                    if (existing != null) {
+                        existing.message = "$resourceCount"
+                        existing.relatedId = "$resourceCount"
+                    } else {
+                        createNotificationIfNotExists(r, "resource", "$resourceCount", "$resourceCount", userId)
+                    }
+                } else {
+                    existing?.deleteFromRealm()
+                }
+            }
+        }
+    }
+
+    private fun createNotificationIfNotExists(
+        realm: Realm,
+        type: String,
+        message: String,
+        relatedId: String?,
+        userId: String?
+    ) {
+        val existing = realm.where(org.ole.planet.myplanet.model.RealmNotification::class.java)
+            .equalTo("userId", userId)
+            .equalTo("type", type)
+            .equalTo("relatedId", relatedId)
+            .findFirst()
+        if (existing == null) {
+            realm.createObject(org.ole.planet.myplanet.model.RealmNotification::class.java, java.util.UUID.randomUUID().toString()).apply {
+                this.userId = userId ?: ""
+                this.type = type
+                this.message = message
+                this.relatedId = relatedId
+                this.createdAt = java.util.Date()
+            }
+        }
+    }
+
+    override suspend fun getUnreadNotificationsSize(userId: String?): Int = withContext(Dispatchers.IO) {
+        val realm = databaseService.realmInstance
+        realm.where(org.ole.planet.myplanet.model.RealmNotification::class.java)
+            .equalTo("userId", userId)
+            .equalTo("isRead", false)
+            .count()
+            .toInt()
+    }
+
+    override suspend fun getPendingSurveyTitles(userId: String?): List<String> = withContext(Dispatchers.IO) {
+        val realm = databaseService.realmInstance
+        val submissions = realm.where(org.ole.planet.myplanet.model.RealmSubmission::class.java)
+            .equalTo("userId", userId)
+            .equalTo("type", "survey")
+            .equalTo("status", "pending", io.realm.Case.INSENSITIVE)
+            .findAll()
+        val titles = mutableListOf<String>()
+        submissions.forEach { submission ->
+            val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
+            val exam = realm.where(org.ole.planet.myplanet.model.RealmStepExam::class.java)
+                .equalTo("id", examId)
+                .findFirst()
+            exam?.name?.let { titles.add(it) }
+        }
+        titles
+    }
+
+    override suspend fun getMyLibraryByUser(): List<RealmMyLibrary> = withContext(Dispatchers.IO) {
+        val realm = databaseService.realmInstance
+        RealmMyLibrary.getMyLibraryByUserId(realm, settings)
+    }
+
+    override suspend fun createNotificationIfNotExists(type: String, message: String, relatedId: String?, userId: String?) {
+        withContext(Dispatchers.IO) {
+            val realm = databaseService.realmInstance
+            realm.executeTransaction { r ->
+                createNotificationIfNotExists(r, type, message, relatedId, userId)
+            }
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -53,11 +53,15 @@ import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Utilities
+import kotlinx.coroutines.runBlocking
+import androidx.fragment.app.viewModels
+import org.ole.planet.myplanet.ui.dashboard.DashboardViewModel
 
 open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCallback,
     SyncListener {
     private var fullName: String? = null
     lateinit var dbService: DatabaseService
+    private val dashboardViewModel: DashboardViewModel by viewModels()
     private var params = LinearLayout.LayoutParams(250, 100)
     private var di: DialogUtils.CustomProgressDialog? = null
     private lateinit var myCoursesResults: RealmResults<RealmMyCourse>
@@ -142,7 +146,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
 
     private fun myLibraryDiv(view: View) {
         view.findViewById<FlexboxLayout>(R.id.flexboxLayout).flexDirection = FlexDirection.ROW
-        val dbMylibrary = RealmMyLibrary.getMyLibraryByUserId(mRealm, settings)
+        val dbMylibrary = runBlocking { dashboardViewModel.getMyLibraryByUser() }
         if (dbMylibrary.isEmpty()) {
             view.findViewById<TextView>(R.id.count_library).visibility = View.GONE
         } else {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -2,26 +2,12 @@ package org.ole.planet.myplanet.ui.dashboard
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.realm.Case
-import io.realm.Realm
-import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.di.UserRepository
-import org.ole.planet.myplanet.di.LibraryRepository
-import org.ole.planet.myplanet.di.CourseRepository
 import javax.inject.Inject
-import java.util.Date
-import java.util.UUID
-import org.ole.planet.myplanet.base.BaseResourceFragment
-import org.ole.planet.myplanet.model.RealmNotification
-import org.ole.planet.myplanet.model.RealmStepExam
-import org.ole.planet.myplanet.model.RealmSubmission
+import org.ole.planet.myplanet.di.DashboardRepository
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
-    private val databaseService: DatabaseService,
-    private val userRepository: UserRepository,
-    private val libraryRepository: LibraryRepository,
-    private val courseRepository: CourseRepository
+    private val repository: DashboardRepository
 ) : ViewModel() {
     fun calculateIndividualProgress(voiceCount: Int, hasUnfinishedSurvey: Boolean): Int {
         val earnedDollarsVoice = minOf(voiceCount, 5) * 2
@@ -37,72 +23,22 @@ class DashboardViewModel @Inject constructor(
         return total.coerceAtMost(11)
     }
 
-    fun updateResourceNotification(realm: Realm, userId: String?) {
-        val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
-        if (resourceCount > 0) {
-            val existingNotification = realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()
-
-            if (existingNotification != null) {
-                existingNotification.message = "$resourceCount"
-                existingNotification.relatedId = "$resourceCount"
-            } else {
-                createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
-            }
-        } else {
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()?.deleteFromRealm()
-        }
+    suspend fun updateResourceNotification(userId: String?) {
+        repository.updateResourceNotification(userId)
     }
 
-    fun createNotificationIfNotExists(realm: Realm, type: String, message: String, relatedId: String?, userId: String?) {
-        val existingNotification = realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("type", type)
-            .equalTo("relatedId", relatedId)
-            .findFirst()
-
-        if (existingNotification == null) {
-            realm.createObject(RealmNotification::class.java, "${UUID.randomUUID()}").apply {
-                this.userId = userId ?: ""
-                this.type = type
-                this.message = message
-                this.relatedId = relatedId
-                this.createdAt = Date()
-            }
-        }
+    suspend fun getPendingSurveyTitles(userId: String?): List<String> {
+        return repository.getPendingSurveyTitles(userId)
     }
 
-    fun getPendingSurveys(realm: Realm, userId: String?): List<RealmSubmission> {
-        return realm.where(RealmSubmission::class.java)
-            .equalTo("userId", userId)
-            .equalTo("type", "survey")
-            .equalTo("status", "pending", Case.INSENSITIVE)
-            .findAll()
+    suspend fun getUnreadNotificationsSize(userId: String?): Int {
+        return repository.getUnreadNotificationsSize(userId)
     }
 
-    fun getSurveyTitlesFromSubmissions(realm: Realm, submissions: List<RealmSubmission>): List<String> {
-        val titles = mutableListOf<String>()
-        submissions.forEach { submission ->
-            val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
-            val exam = realm.where(RealmStepExam::class.java)
-                .equalTo("id", examId)
-                .findFirst()
-            exam?.name?.let { titles.add(it) }
-        }
-        return titles
+    suspend fun createNotificationIfNotExists(type: String, message: String, relatedId: String?, userId: String?) {
+        repository.createNotificationIfNotExists(type, message, relatedId, userId)
     }
 
-    fun getUnreadNotificationsSize(realm: Realm, userId: String?): Int {
-        return realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("isRead", false)
-            .count()
-            .toInt()
-    }
+    suspend fun getMyLibraryByUser() = repository.getMyLibraryByUser()
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncViewModel.kt
@@ -1,0 +1,30 @@
+package org.ole.planet.myplanet.ui.sync
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.di.SyncRepository
+
+@HiltViewModel
+class SyncViewModel @Inject constructor(
+    private val repository: SyncRepository
+) : ViewModel() {
+
+    private val _autoSyncEnabled = MutableStateFlow(true)
+    val autoSyncEnabled: StateFlow<Boolean> = _autoSyncEnabled.asStateFlow()
+
+    fun loadAutoSyncSettings() {
+        viewModelScope.launch {
+            _autoSyncEnabled.value = repository.isAutoSyncEnabled()
+        }
+    }
+
+    suspend fun authenticateUser(username: String?, password: String?, isManagerMode: Boolean) =
+        repository.authenticateUser(username, password, isManagerMode)
+    }
+}


### PR DESCRIPTION
## Summary
- provide new repository APIs for sync and dashboard features
- add SyncViewModel for `SyncActivity`
- move Realm queries to repository layer
- adjust dashboard notifications to use ViewModel operations
- fetch library data from repository in BaseDashboardFragment

## Testing
- `./gradlew test` *(fails: Installed Build Tools revision 35.0.0 is corrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687f5c9823ec832b843a3c8b1863699b