### PR TITLE
Refactor viewmodels to use repositories

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -5,15 +5,27 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import io.realm.Case
 import io.realm.Realm
+import io.realm.RealmList
+import java.util.Date
+import java.util.UUID
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.ole.planet.myplanet.MainApplication
+import org.ole.planet.myplanet.base.BaseResourceFragment
 import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.model.Conversation
+import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.RealmMyCourse
+import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.model.RealmStepExam
+import org.ole.planet.myplanet.model.RealmSubmission
+import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
-import javax.inject.Singleton
+import org.ole.planet.myplanet.utilities.NetworkUtils.isNetworkConnectedFlow
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -45,6 +57,26 @@ object RepositoryModule {
         apiInterface: ApiInterface
     ): CourseRepository {
         return CourseRepositoryImpl(databaseService, apiInterface)
+    }
+
+    @Provides
+    @Singleton
+    fun provideDashboardRepository(
+        databaseService: DatabaseService
+    ): DashboardRepository {
+        return DashboardRepositoryImpl(databaseService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideNetworkRepository(): NetworkRepository {
+        return NetworkRepositoryImpl()
+    }
+
+    @Provides
+    @Singleton
+    fun provideChatRepository(): ChatRepository {
+        return ChatRepositoryImpl()
     }
 }
 
@@ -140,4 +172,134 @@ class CourseRepositoryImpl(
         return databaseService.realmInstance.where(RealmUserModel::class.java)
             .findFirst()?.id ?: ""
     }
+}
+
+// Dashboard Repository
+interface DashboardRepository {
+    fun updateResourceNotification(userId: String?)
+    fun createNotificationIfNotExists(type: String, message: String, relatedId: String?, userId: String?)
+    fun getPendingSurveys(userId: String?): List<RealmSubmission>
+    fun getSurveyTitlesFromSubmissions(submissions: List<RealmSubmission>): List<String>
+    fun getUnreadNotificationsSize(userId: String?): Int
+}
+
+class DashboardRepositoryImpl(
+    private val databaseService: DatabaseService
+) : DashboardRepository {
+
+    override fun updateResourceNotification(userId: String?) {
+        databaseService.withRealm { realm ->
+            val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
+            if (resourceCount > 0) {
+                val existingNotification = realm.where(RealmNotification::class.java)
+                    .equalTo("userId", userId)
+                    .equalTo("type", "resource")
+                    .findFirst()
+                if (existingNotification != null) {
+                    existingNotification.message = "$resourceCount"
+                    existingNotification.relatedId = "$resourceCount"
+                } else {
+                    createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
+                }
+            } else {
+                realm.where(RealmNotification::class.java)
+                    .equalTo("userId", userId)
+                    .equalTo("type", "resource")
+                    .findFirst()?.deleteFromRealm()
+            }
+        }
+    }
+
+    private fun createNotificationIfNotExists(
+        realm: Realm,
+        type: String,
+        message: String,
+        relatedId: String?,
+        userId: String?
+    ) {
+        val existingNotification = realm.where(RealmNotification::class.java)
+            .equalTo("userId", userId)
+            .equalTo("type", type)
+            .equalTo("relatedId", relatedId)
+            .findFirst()
+
+        if (existingNotification == null) {
+            realm.createObject(RealmNotification::class.java, "${UUID.randomUUID()}").apply {
+                this.userId = userId ?: ""
+                this.type = type
+                this.message = message
+                this.relatedId = relatedId
+                this.createdAt = Date()
+            }
+        }
+    }
+
+    override fun createNotificationIfNotExists(type: String, message: String, relatedId: String?, userId: String?) {
+        databaseService.withRealm { realm ->
+            createNotificationIfNotExists(realm, type, message, relatedId, userId)
+        }
+    }
+
+    override fun getPendingSurveys(userId: String?): List<RealmSubmission> {
+        return databaseService.withRealm { realm ->
+            val pending = realm.where(RealmSubmission::class.java)
+                .equalTo("userId", userId)
+                .equalTo("type", "survey")
+                .equalTo("status", "pending", Case.INSENSITIVE)
+                .findAll()
+            realm.copyFromRealm(pending)
+        }
+    }
+
+    override fun getSurveyTitlesFromSubmissions(submissions: List<RealmSubmission>): List<String> {
+        return databaseService.withRealm { realm ->
+            val titles = mutableListOf<String>()
+            submissions.forEach { submission ->
+                val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
+                val exam = realm.where(RealmStepExam::class.java)
+                    .equalTo("id", examId)
+                    .findFirst()
+                exam?.name?.let { titles.add(it) }
+            }
+            titles
+        }
+    }
+
+    override fun getUnreadNotificationsSize(userId: String?): Int {
+        return databaseService.withRealm { realm ->
+            realm.where(RealmNotification::class.java)
+                .equalTo("userId", userId)
+                .equalTo("isRead", false)
+                .count()
+                .toInt()
+        }
+    }
+}
+
+// Network Repository
+interface NetworkRepository {
+    val isNetworkConnectedFlow: kotlinx.coroutines.flow.Flow<Boolean>
+    suspend fun isServerReachable(url: String): Boolean
+}
+
+class NetworkRepositoryImpl : NetworkRepository {
+    override val isNetworkConnectedFlow: kotlinx.coroutines.flow.Flow<Boolean> = org.ole.planet.myplanet.utilities.NetworkUtils.isNetworkConnectedFlow
+    override suspend fun isServerReachable(url: String): Boolean {
+        return MainApplication.isServerReachable(url)
+    }
+}
+
+// Chat Repository
+interface ChatRepository {
+    val selectedChatHistory: MutableStateFlow<RealmList<Conversation>?>
+    val selectedId: MutableStateFlow<String>
+    val selectedRev: MutableStateFlow<String>
+    val selectedAiProvider: MutableStateFlow<String?>
+}
+
+class ChatRepositoryImpl : ChatRepository {
+    override val selectedChatHistory: MutableStateFlow<RealmList<Conversation>?> = MutableStateFlow(null)
+    override val selectedId: MutableStateFlow<String> = MutableStateFlow("")
+    override val selectedRev: MutableStateFlow<String> = MutableStateFlow("")
+    override val selectedAiProvider: MutableStateFlow<String?> = MutableStateFlow(null)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ChatViewModel.kt
@@ -1,38 +1,42 @@
 package org.ole.planet.myplanet.model
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.realm.RealmList
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import io.realm.RealmList
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.di.ChatRepository
 
-class ChatViewModel : ViewModel() {
-    private val _selectedChatHistory = MutableStateFlow<RealmList<Conversation>?>(null)
-    val selectedChatHistory: StateFlow<RealmList<Conversation>?> = _selectedChatHistory.asStateFlow()
-
-    private val _selectedId = MutableStateFlow("")
-    val selectedId: StateFlow<String> = _selectedId.asStateFlow()
-
-    private val _selectedRev = MutableStateFlow("")
-    val selectedRev: StateFlow<String> = _selectedRev.asStateFlow()
-
-    private val _selectedAiProvider = MutableStateFlow<String?>(null)
-    val selectedAiProvider: StateFlow<String?> = _selectedAiProvider.asStateFlow()
+@HiltViewModel
+class ChatViewModel @Inject constructor(
+    private val chatRepository: ChatRepository
+) : ViewModel() {
+    val selectedChatHistory: StateFlow<RealmList<Conversation>?> = chatRepository.selectedChatHistory.asStateFlow()
+    val selectedId: StateFlow<String> = chatRepository.selectedId.asStateFlow()
+    val selectedRev: StateFlow<String> = chatRepository.selectedRev.asStateFlow()
+    val selectedAiProvider: StateFlow<String?> = chatRepository.selectedAiProvider.asStateFlow()
 
     fun setSelectedChatHistory(conversations: RealmList<Conversation>) {
-        _selectedChatHistory.value = conversations
+        viewModelScope.launch(Dispatchers.IO) {
+            chatRepository.selectedChatHistory.value = conversations
+        }
     }
 
     fun setSelectedId(id: String) {
-        _selectedId.value = id
+        viewModelScope.launch(Dispatchers.IO) { chatRepository.selectedId.value = id }
     }
 
     fun setSelectedRev(rev: String) {
-        _selectedRev.value = rev
+        viewModelScope.launch(Dispatchers.IO) { chatRepository.selectedRev.value = rev }
     }
 
     fun setSelectedAiProvider(aiProvider: String?) {
-        _selectedAiProvider.value = aiProvider
+        viewModelScope.launch(Dispatchers.IO) { chatRepository.selectedAiProvider.value = aiProvider }
     }
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -17,29 +17,31 @@ import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.view.isNotEmpty
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.reflect.TypeToken
+import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Realm
 import java.util.Date
 import java.util.Locale
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.databinding.FragmentChatDetailBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.databinding.FragmentChatDetailBinding
 import org.ole.planet.myplanet.model.AiProvider
 import org.ole.planet.myplanet.model.ChatModel
 import org.ole.planet.myplanet.model.ChatRequestModel
@@ -59,14 +61,12 @@ import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class ChatDetailFragment : Fragment() {
     lateinit var fragmentChatDetailBinding: FragmentChatDetailBinding
     private lateinit var mAdapter: ChatAdapter
-    private lateinit var sharedViewModel: ChatViewModel
+    private val sharedViewModel: ChatViewModel by activityViewModels()
     private var _id: String = ""
     private var _rev: String = ""
     private var currentID: String = ""
@@ -87,7 +87,6 @@ class ChatDetailFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        sharedViewModel = ViewModelProvider(requireActivity())[ChatViewModel::class.java]
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -13,7 +13,7 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.slidingpanelayout.widget.SlidingPaneLayout
 import com.google.android.material.snackbar.Snackbar
@@ -28,8 +28,8 @@ import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.SyncListener
-import org.ole.planet.myplanet.databinding.FragmentChatHistoryListBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.databinding.FragmentChatHistoryListBinding
 import org.ole.planet.myplanet.model.ChatViewModel
 import org.ole.planet.myplanet.model.Conversation
 import org.ole.planet.myplanet.model.RealmChatHistory
@@ -45,7 +45,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class ChatHistoryListFragment : Fragment() {
     private lateinit var fragmentChatHistoryListBinding: FragmentChatHistoryListBinding
-    private lateinit var sharedViewModel: ChatViewModel
+    private val sharedViewModel: ChatViewModel by activityViewModels()
     var user: RealmUserModel? = null
     private var isFullSearch: Boolean = false
     private var isQuestion: Boolean = false
@@ -63,7 +63,6 @@ class ChatHistoryListFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        sharedViewModel = ViewModelProvider(requireActivity())[ChatViewModel::class.java]
         prefManager = SharedPrefManager(requireContext())
         settings = requireActivity().getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         startChatHistorySync()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardViewModel.kt
@@ -2,22 +2,26 @@ package org.ole.planet.myplanet.ui.dashboard
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
-import org.ole.planet.myplanet.utilities.NetworkUtils.isNetworkConnectedFlow
+import org.ole.planet.myplanet.di.NetworkRepository
+import javax.inject.Inject
 
-class BellDashboardViewModel : ViewModel() {
+@HiltViewModel
+class BellDashboardViewModel @Inject constructor(
+    private val networkRepository: NetworkRepository
+) : ViewModel() {
     private val _networkStatus = MutableStateFlow<NetworkStatus>(NetworkStatus.Disconnected)
     val networkStatus: StateFlow<NetworkStatus> = _networkStatus.asStateFlow()
 
     init {
         viewModelScope.launch {
-            isNetworkConnectedFlow.collect { isConnected ->
+            networkRepository.isNetworkConnectedFlow.collect { isConnected ->
                 updateNetworkStatus(isConnected)
             }
         }
@@ -34,7 +38,7 @@ class BellDashboardViewModel : ViewModel() {
 
     suspend fun checkServerConnection(serverUrl: String): Boolean {
         return withContext(Dispatchers.IO) {
-            isServerReachable(serverUrl)
+            networkRepository.isServerReachable(serverUrl)
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -1,27 +1,18 @@
 package org.ole.planet.myplanet.ui.dashboard
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.realm.Case
-import io.realm.Realm
-import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.di.UserRepository
-import org.ole.planet.myplanet.di.LibraryRepository
-import org.ole.planet.myplanet.di.CourseRepository
-import javax.inject.Inject
-import java.util.Date
-import java.util.UUID
-import org.ole.planet.myplanet.base.BaseResourceFragment
-import org.ole.planet.myplanet.model.RealmNotification
-import org.ole.planet.myplanet.model.RealmStepExam
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.ole.planet.myplanet.di.DashboardRepository
 import org.ole.planet.myplanet.model.RealmSubmission
+import javax.inject.Inject
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
-    private val databaseService: DatabaseService,
-    private val userRepository: UserRepository,
-    private val libraryRepository: LibraryRepository,
-    private val courseRepository: CourseRepository
+    private val dashboardRepository: DashboardRepository
 ) : ViewModel() {
     fun calculateIndividualProgress(voiceCount: Int, hasUnfinishedSurvey: Boolean): Int {
         val earnedDollarsVoice = minOf(voiceCount, 5) * 2
@@ -37,72 +28,28 @@ class DashboardViewModel @Inject constructor(
         return total.coerceAtMost(11)
     }
 
-    fun updateResourceNotification(realm: Realm, userId: String?) {
-        val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
-        if (resourceCount > 0) {
-            val existingNotification = realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()
-
-            if (existingNotification != null) {
-                existingNotification.message = "$resourceCount"
-                existingNotification.relatedId = "$resourceCount"
-            } else {
-                createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
-            }
-        } else {
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()?.deleteFromRealm()
+    fun updateResourceNotification(userId: String?) {
+        viewModelScope.launch(Dispatchers.IO) {
+            dashboardRepository.updateResourceNotification(userId)
         }
     }
 
-    fun createNotificationIfNotExists(realm: Realm, type: String, message: String, relatedId: String?, userId: String?) {
-        val existingNotification = realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("type", type)
-            .equalTo("relatedId", relatedId)
-            .findFirst()
-
-        if (existingNotification == null) {
-            realm.createObject(RealmNotification::class.java, "${UUID.randomUUID()}").apply {
-                this.userId = userId ?: ""
-                this.type = type
-                this.message = message
-                this.relatedId = relatedId
-                this.createdAt = Date()
-            }
+    fun createNotificationIfNotExists(type: String, message: String, relatedId: String?, userId: String?) {
+        viewModelScope.launch(Dispatchers.IO) {
+            dashboardRepository.createNotificationIfNotExists(type, message, relatedId, userId)
         }
     }
 
-    fun getPendingSurveys(realm: Realm, userId: String?): List<RealmSubmission> {
-        return realm.where(RealmSubmission::class.java)
-            .equalTo("userId", userId)
-            .equalTo("type", "survey")
-            .equalTo("status", "pending", Case.INSENSITIVE)
-            .findAll()
+    fun getPendingSurveys(userId: String?): List<RealmSubmission> {
+        return dashboardRepository.getPendingSurveys(userId)
     }
 
-    fun getSurveyTitlesFromSubmissions(realm: Realm, submissions: List<RealmSubmission>): List<String> {
-        val titles = mutableListOf<String>()
-        submissions.forEach { submission ->
-            val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
-            val exam = realm.where(RealmStepExam::class.java)
-                .equalTo("id", examId)
-                .findFirst()
-            exam?.name?.let { titles.add(it) }
-        }
-        return titles
+    fun getSurveyTitlesFromSubmissions(submissions: List<RealmSubmission>): List<String> {
+        return dashboardRepository.getSurveyTitlesFromSubmissions(submissions)
     }
 
-    fun getUnreadNotificationsSize(realm: Realm, userId: String?): Int {
-        return realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("isRead", false)
-            .count()
-            .toInt()
+    fun getUnreadNotificationsSize(userId: String?): Int {
+        return dashboardRepository.getUnreadNotificationsSize(userId)
     }
 }
 


### PR DESCRIPTION
## Summary
- move viewmodel data logic into repositories
- inject ChatRepository, DashboardRepository, and NetworkRepository
- adapt Chat fragments to use Hilt viewmodel
- update DashboardActivity calls
- compile with new repository structure
- sort imports for easier merging

## Testing
- `./gradlew assembleDebug --console=plain -x lint` *(fails: tasks start but build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68805e50aed0832b81104bcab48fb303