### PR TITLE
Introduce repositories for chat and team

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/chat/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/chat/ChatRepository.kt
@@ -1,8 +1,8 @@
 package org.ole.planet.myplanet.data.chat
 
+import io.realm.Sort
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import io.realm.Sort
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmChatHistory
 

--- a/app/src/main/java/org/ole/planet/myplanet/data/chat/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/chat/ChatRepository.kt
@@ -1,0 +1,25 @@
+package org.ole.planet.myplanet.data.chat
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import io.realm.Sort
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmChatHistory
+
+interface ChatRepository {
+    suspend fun getChatHistoryForUser(userName: String?): List<RealmChatHistory>
+}
+
+class ChatRepositoryImpl(private val databaseService: DatabaseService) : ChatRepository {
+    override suspend fun getChatHistoryForUser(userName: String?): List<RealmChatHistory> {
+        return withContext(Dispatchers.IO) {
+            databaseService.realmInstance.use { realm ->
+                val results = realm.where(RealmChatHistory::class.java)
+                    .equalTo("user", userName)
+                    .sort("id", Sort.DESCENDING)
+                    .findAll()
+                realm.copyFromRealm(results)
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/team/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/team/TeamRepository.kt
@@ -1,0 +1,55 @@
+package org.ole.planet.myplanet.data.team
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import io.realm.Case
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getMyTeamsByUserId
+
+interface TeamRepository {
+    suspend fun getTeams(fromDashboard: Boolean, type: String?, settings: SharedPreferences?): List<RealmMyTeam>
+    suspend fun searchTeams(query: String, type: String?): List<RealmMyTeam>
+}
+
+class TeamRepositoryImpl(private val databaseService: DatabaseService) : TeamRepository {
+    override suspend fun getTeams(fromDashboard: Boolean, type: String?, settings: SharedPreferences?): List<RealmMyTeam> {
+        return withContext(Dispatchers.IO) {
+            databaseService.realmInstance.use { realm ->
+                val results = if (fromDashboard) {
+                    getMyTeamsByUserId(realm, settings)
+                } else {
+                    var queryRealm = realm.where(RealmMyTeam::class.java)
+                        .isEmpty("teamId")
+                        .notEqualTo("status", "archived")
+                    queryRealm = if (type.isNullOrEmpty() || type == "team") {
+                        queryRealm.notEqualTo("type", "enterprise")
+                    } else {
+                        queryRealm.equalTo("type", "enterprise")
+                    }
+                    queryRealm.findAll()
+                }
+                realm.copyFromRealm(results)
+            }
+        }
+    }
+
+    override suspend fun searchTeams(query: String, type: String?): List<RealmMyTeam> {
+        return withContext(Dispatchers.IO) {
+            databaseService.realmInstance.use { realm ->
+                var queryRealm = realm.where(RealmMyTeam::class.java)
+                    .isEmpty("teamId")
+                    .notEqualTo("status", "archived")
+                    .contains("name", query, Case.INSENSITIVE)
+                queryRealm = if (type.isNullOrEmpty() || type == "team") {
+                    queryRealm.notEqualTo("type", "enterprise")
+                } else {
+                    queryRealm.equalTo("type", "enterprise")
+                }
+                val results = queryRealm.findAll()
+                realm.copyFromRealm(results)
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/team/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/team/TeamRepository.kt
@@ -1,9 +1,9 @@
 package org.ole.planet.myplanet.data.team
 
 import android.content.SharedPreferences
+import io.realm.Case
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import io.realm.Case
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getMyTeamsByUserId

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -14,7 +14,6 @@ class DatabaseService(context: Context) {
             .name(Realm.DEFAULT_REALM_NAME)
             .deleteRealmIfMigrationNeeded()
             .schemaVersion(4)
-            .allowWritesOnUiThread(true)
             .build()
         Realm.setDefaultConfiguration(config)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
@@ -32,7 +32,6 @@ object DatabaseModule {
             .name(Realm.DEFAULT_REALM_NAME)
             .deleteRealmIfMigrationNeeded()
             .schemaVersion(4)
-            .allowWritesOnUiThread(true)
             .build()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -6,14 +6,14 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.realm.Realm
+import javax.inject.Singleton
 import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.RealmMyCourse
+import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -46,6 +46,22 @@ object RepositoryModule {
     ): CourseRepository {
         return CourseRepositoryImpl(databaseService, apiInterface)
     }
+
+    @Provides
+    @Singleton
+    fun provideChatRepository(
+        databaseService: DatabaseService
+    ): org.ole.planet.myplanet.data.chat.ChatRepository {
+        return org.ole.planet.myplanet.data.chat.ChatRepositoryImpl(databaseService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideTeamRepository(
+        databaseService: DatabaseService
+    ): org.ole.planet.myplanet.data.team.TeamRepository {
+        return org.ole.planet.myplanet.data.team.TeamRepositoryImpl(databaseService)
+    }
 }
 
 // User Repository

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -13,6 +13,7 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.slidingpanelayout.widget.SlidingPaneLayout
@@ -34,12 +35,11 @@ import org.ole.planet.myplanet.model.Conversation
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.ui.chat.ChatHistoryViewModel
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.SharedPrefManager
-import androidx.fragment.app.viewModels
-import org.ole.planet.myplanet.ui.chat.ChatHistoryViewModel
 
 @AndroidEntryPoint
 class ChatHistoryListFragment : Fragment() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -45,7 +45,7 @@ import org.ole.planet.myplanet.utilities.SharedPrefManager
 class ChatHistoryListFragment : Fragment() {
     private lateinit var fragmentChatHistoryListBinding: FragmentChatHistoryListBinding
     private lateinit var sharedViewModel: ChatViewModel
-    private val chatHistoryViewModel: ChatHistoryViewModel by viewModels()
+    private val chatHistoryViewModel: ChatHistoryViewModel by viewModels({ requireActivity() })
     var user: RealmUserModel? = null
     private var isFullSearch: Boolean = false
     private var isQuestion: Boolean = false

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryViewModel.kt
@@ -1,0 +1,27 @@
+package org.ole.planet.myplanet.ui.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.data.chat.ChatRepository
+import org.ole.planet.myplanet.model.RealmChatHistory
+
+@HiltViewModel
+class ChatHistoryViewModel @Inject constructor(
+    private val chatRepository: ChatRepository
+) : ViewModel() {
+
+    private val _chatHistory = MutableStateFlow<List<RealmChatHistory>>(emptyList())
+    val chatHistory: StateFlow<List<RealmChatHistory>> = _chatHistory.asStateFlow()
+
+    fun loadChatHistory(userName: String?) {
+        viewModelScope.launch {
+            _chatHistory.value = chatRepository.getChatHistoryForUser(userName)
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -11,13 +11,14 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Case
 import io.realm.Realm
 import java.util.Date
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.databinding.AlertCreateTeamBinding
@@ -25,12 +26,12 @@ import org.ole.planet.myplanet.databinding.FragmentTeamBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.ui.team.TeamViewModel
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Utilities
-import org.ole.planet.myplanet.ui.team.TeamViewModel
 
 @AndroidEntryPoint
 class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -40,7 +40,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private lateinit var mRealm: Realm
     @Inject
     lateinit var databaseService: DatabaseService
-    private val teamViewModel: TeamViewModel by viewModels()
+    private val teamViewModel: TeamViewModel by viewModels({ requireActivity() })
     var type: String? = null
     private var fromDashboard: Boolean = false
     var user: RealmUserModel? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamViewModel.kt
@@ -1,0 +1,32 @@
+package org.ole.planet.myplanet.ui.team
+
+import android.content.SharedPreferences
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.data.team.TeamRepository
+import org.ole.planet.myplanet.model.RealmMyTeam
+
+@HiltViewModel
+class TeamViewModel @Inject constructor(
+    private val teamRepository: TeamRepository
+) : ViewModel() {
+
+    private val _teams = MutableStateFlow<List<RealmMyTeam>>(emptyList())
+    val teams: StateFlow<List<RealmMyTeam>> = _teams.asStateFlow()
+
+    fun loadTeams(fromDashboard: Boolean, type: String?, settings: SharedPreferences?) {
+        viewModelScope.launch {
+            _teams.value = teamRepository.getTeams(fromDashboard, type, settings)
+        }
+    }
+
+    suspend fun searchTeams(query: String, type: String?): List<RealmMyTeam> {
+        return teamRepository.searchTeams(query, type)
+    }
+}


### PR DESCRIPTION
## Summary
- move Realm queries into new ChatRepository and TeamRepository
- fetch data using ChatHistoryViewModel and TeamViewModel
- update fragments to consume repository data
- remove `allowWritesOnUiThread` from Realm configuration

## Testing
- `./gradlew help --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6881ee022f54832bb31a590566e68eba