### PR TITLE
Refactor adapters to use ListAdapter diffing

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -31,13 +31,12 @@ import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
-import org.ole.planet.myplanet.utilities.JsonUtils.getInt
-import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
-import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
 import org.ole.planet.myplanet.utilities.CourseRatingUtils
+import org.ole.planet.myplanet.utilities.JsonUtils.getInt
+import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
+import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import org.ole.planet.myplanet.utilities.Utilities
-
 class AdapterCourses(
     private val context: Context,
     currentList: List<RealmMyCourse?>,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -293,22 +293,27 @@ class AdapterCourses(
     private fun showProgressAndRating(position: Int, holder: RecyclerView.ViewHolder) {
         val viewHolder = holder as ViewHoldercourse
         showProgress(viewHolder.rowCourseBinding, position)
-        if (map.containsKey(currentList[position].courseId)) {
-            val `object` = map[currentList[position].courseId]
-            CourseRatingUtils.showRating(
-                `object`,
-                viewHolder.rowCourseBinding.rating,
-                viewHolder.rowCourseBinding.timesRated,
-                viewHolder.rowCourseBinding.ratingBar
-            )
-        } else {
+        currentList[position]?.courseId?.let { courseId ->
+            if (map.containsKey(courseId)) {
+                val ratingObj = map[courseId]
+                CourseRatingUtils.showRating(
+                    ratingObj,
+                    viewHolder.rowCourseBinding.rating,
+                    viewHolder.rowCourseBinding.timesRated,
+                    viewHolder.rowCourseBinding.ratingBar
+                )
+            } else {
+                viewHolder.rowCourseBinding.ratingBar.rating = 0f
+            }
+        } ?: run {
             viewHolder.rowCourseBinding.ratingBar.rating = 0f
         }
     }
 
     private fun showProgress(binding: RowCourseBinding, position: Int) {
-        if (progressMap?.containsKey(currentList[position].courseId) == true) {
-            val ob = progressMap!![currentList[position].courseId]
+        val courseId = currentList[position]?.courseId
+        if (courseId != null && progressMap?.containsKey(courseId) == true) {
+            val ob = progressMap!![courseId]
             binding.courseProgress.max = getInt("max", ob)
             binding.courseProgress.progress = getInt("current", ob)
             if (getInt("current", ob) < getInt("max", ob)) {
@@ -357,11 +362,13 @@ class AdapterCourses(
                 override fun onProgressChanged(seekBar: SeekBar, i: Int, b: Boolean) {
                     val position = bindingAdapterPosition
                     if (position != RecyclerView.NO_POSITION && position < currentList.size) {
-                        if (progressMap?.containsKey(currentList[bindingAdapterPosition].courseId) == true) {
-                            val ob = progressMap!![currentList[bindingAdapterPosition].courseId]
-                            val current = getInt("current", ob)
-                            if (b && i <= current + 1) {
-                                openCourse(currentList[bindingAdapterPosition], seekBar.progress)
+                        currentList[bindingAdapterPosition]?.courseId?.let { courseId ->
+                            if (progressMap?.containsKey(courseId) == true) {
+                                val ob = progressMap!![courseId]
+                                val current = getInt("current", ob)
+                                if (b && i <= current + 1) {
+                                    openCourse(currentList[bindingAdapterPosition], seekBar.progress)
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -11,6 +11,7 @@ import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.AsyncDifferConfig
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -36,12 +37,15 @@ import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import org.ole.planet.myplanet.utilities.Utilities
+
 class AdapterCourses(
     private val context: Context,
     currentList: List<RealmMyCourse>,
     private val map: HashMap<String?, JsonObject>,
     private val userProfileDbHandler: UserProfileDbHandler
-) : ListAdapter<RealmMyCourse, RecyclerView.ViewHolder>(CourseDiffCallback()) {
+) : ListAdapter<RealmMyCourse, RecyclerView.ViewHolder>(
+    AsyncDifferConfig.Builder(CourseDiffCallback()).setBackgroundThreadExecutor { it.run() }.build()
+) {
     private val selectedItems: MutableList<RealmMyCourse> = ArrayList()
     private var listener: OnCourseItemSelected? = null
     private var homeItemClickListener: OnHomeItemClickListener? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -38,11 +38,11 @@ import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import org.ole.planet.myplanet.utilities.Utilities
 class AdapterCourses(
     private val context: Context,
-    currentList: List<RealmMyCourse?>,
+    currentList: List<RealmMyCourse>,
     private val map: HashMap<String?, JsonObject>,
     private val userProfileDbHandler: UserProfileDbHandler
-) : ListAdapter<RealmMyCourse?, RecyclerView.ViewHolder>(CourseDiffCallback()) {
-    private val selectedItems: MutableList<RealmMyCourse?> = ArrayList()
+) : ListAdapter<RealmMyCourse, RecyclerView.ViewHolder>(CourseDiffCallback()) {
+    private val selectedItems: MutableList<RealmMyCourse> = ArrayList()
     private var listener: OnCourseItemSelected? = null
     private var homeItemClickListener: OnHomeItemClickListener? = null
     private var progressMap: HashMap<String?, JsonObject>? = null
@@ -70,31 +70,31 @@ class AdapterCourses(
         this.ratingChangeListener = ratingChangeListener
     }
 
-    fun getCourseList(): List<RealmMyCourse?> {
+    fun getCourseList(): List<RealmMyCourse> {
         return currentList
     }
 
-    fun setOriginalCourseList(currentList: List<RealmMyCourse?>){
+    fun setOriginalCourseList(currentList: List<RealmMyCourse>){
         submitList(currentList)
     }
 
-    fun setCourseList(currentList: List<RealmMyCourse?>) {
+    fun setCourseList(currentList: List<RealmMyCourse>) {
         submitList(currentList)
     }
 
-    private fun sortCourseListByTitle(): List<RealmMyCourse?> {
+    private fun sortCourseListByTitle(): List<RealmMyCourse> {
         return if (isTitleAscending) {
-            currentList.sortedBy { it?.courseTitle?.lowercase() }
+            currentList.sortedBy { it.courseTitle?.lowercase() }
         } else {
-            currentList.sortedByDescending { it?.courseTitle?.lowercase() }
+            currentList.sortedByDescending { it.courseTitle?.lowercase() }
         }
     }
 
-    private fun sortCourseList(): List<RealmMyCourse?> {
+    private fun sortCourseList(): List<RealmMyCourse> {
         return if (isAscending) {
-            currentList.sortedBy { it?.createdDate }
+            currentList.sortedBy { it.createdDate }
         } else {
-            currentList.sortedByDescending { it?.createdDate }
+            currentList.sortedByDescending { it.createdDate }
         }
     }
 
@@ -125,7 +125,7 @@ class AdapterCourses(
         if (holder !is ViewHoldercourse) return
 
         holder.bind(position)
-        val course = currentList[position] ?: return
+        val course = currentList[position]
 
         updateVisibilityForMyCourse(holder, course)
         holder.rowCourseBinding.title.text = course.courseTitle
@@ -232,8 +232,8 @@ class AdapterCourses(
             holder.rowCourseBinding.checkbox.setOnClickListener { view: View ->
                 holder.rowCourseBinding.checkbox.contentDescription =
                     context.getString(R.string.select_res_course, course.courseTitle)
-                Utilities.handleCheck((view as CheckBox).isChecked, position, selectedItems, currentList)
-                listener?.onSelectedListChange(selectedItems)
+                Utilities.handleCheck((view as CheckBox).isChecked, position, selectedItems as MutableList<RealmMyCourse?>, currentList as List<RealmMyCourse?>)
+                listener?.onSelectedListChange(selectedItems as MutableList<RealmMyCourse?>)
             }
         } else {
             holder.rowCourseBinding.checkbox.visibility = View.GONE
@@ -258,17 +258,17 @@ class AdapterCourses(
         selectedItems.clear()
         if (selectAll) {
             selectedItems.addAll(currentList.filter { course ->
-                course != null && !course.isMyCourse
+                !course.isMyCourse
             })
         }
         submitList(currentList.toList())
-        listener?.onSelectedListChange(selectedItems)
+        listener?.onSelectedListChange(selectedItems as MutableList<RealmMyCourse?>)
     }
 
     private fun displayTagCloud(flexboxDrawable: FlexboxLayout, position: Int) {
         flexboxDrawable.removeAllViews()
         val chipCloud = ChipCloud(context, flexboxDrawable, config)
-        val tags: List<RealmTag>? = mRealm?.where(RealmTag::class.java)?.equalTo("db", "courses")?.equalTo("linkId", currentList[position]!!.id)?.findAll()
+        val tags: List<RealmTag>? = mRealm?.where(RealmTag::class.java)?.equalTo("db", "courses")?.equalTo("linkId", currentList[position].id)?.findAll()
         showTags(tags, chipCloud)
     }
 
@@ -293,7 +293,7 @@ class AdapterCourses(
     private fun showProgressAndRating(position: Int, holder: RecyclerView.ViewHolder) {
         val viewHolder = holder as ViewHoldercourse
         showProgress(viewHolder.rowCourseBinding, position)
-        currentList[position]?.courseId?.let { courseId ->
+        currentList[position].courseId?.let { courseId ->
             if (map.containsKey(courseId)) {
                 val ratingObj = map[courseId]
                 CourseRatingUtils.showRating(
@@ -311,7 +311,7 @@ class AdapterCourses(
     }
 
     private fun showProgress(binding: RowCourseBinding, position: Int) {
-        val courseId = currentList[position]?.courseId
+        val courseId = currentList[position].courseId
         if (courseId != null && progressMap?.containsKey(courseId) == true) {
             val ob = progressMap!![courseId]
             binding.courseProgress.max = getInt("max", ob)
@@ -325,18 +325,18 @@ class AdapterCourses(
         }
     }
 
-    private fun openCourse(realmMyCourses: RealmMyCourse?, step: Int) {
+    private fun openCourse(realmMyCourses: RealmMyCourse, step: Int) {
         if (homeItemClickListener != null) {
             val f: Fragment = TakeCourseFragment()
             val b = Bundle()
-            b.putString("id", realmMyCourses?.courseId)
+            b.putString("id", realmMyCourses.courseId)
             b.putInt("position", step)
             f.arguments = b
             homeItemClickListener?.openCallFragment(f)
         }
     }
 
-    fun updateCourseList(newCourseList: List<RealmMyCourse?>) {
+    fun updateCourseList(newCourseList: List<RealmMyCourse>) {
         selectedItems.clear()
         submitList(newCourseList)
     }
@@ -362,7 +362,7 @@ class AdapterCourses(
                 override fun onProgressChanged(seekBar: SeekBar, i: Int, b: Boolean) {
                     val position = bindingAdapterPosition
                     if (position != RecyclerView.NO_POSITION && position < currentList.size) {
-                        currentList[bindingAdapterPosition]?.courseId?.let { courseId ->
+                        currentList[bindingAdapterPosition].courseId?.let { courseId ->
                             if (progressMap?.containsKey(courseId) == true) {
                                 val ob = progressMap!![courseId]
                                 val current = getInt("current", ob)
@@ -384,12 +384,12 @@ class AdapterCourses(
     }
 }
 
-class CourseDiffCallback : DiffUtil.ItemCallback<RealmMyCourse?>() {
-    override fun areItemsTheSame(oldItem: RealmMyCourse?, newItem: RealmMyCourse?): Boolean {
-        return oldItem?.id == newItem?.id
+class CourseDiffCallback : DiffUtil.ItemCallback<RealmMyCourse>() {
+    override fun areItemsTheSame(oldItem: RealmMyCourse, newItem: RealmMyCourse): Boolean {
+        return oldItem.id == newItem.id
     }
 
-    override fun areContentsTheSame(oldItem: RealmMyCourse?, newItem: RealmMyCourse?): Boolean {
+    override fun areContentsTheSame(oldItem: RealmMyCourse, newItem: RealmMyCourse): Boolean {
         return oldItem == newItem
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -19,7 +19,6 @@ import com.google.gson.JsonObject
 import fisk.chipcloud.ChipCloud
 import fisk.chipcloud.ChipCloudConfig
 import io.realm.Realm
-import java.util.Collections
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.R
@@ -39,11 +38,11 @@ import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import org.ole.planet.myplanet.utilities.Utilities
 class AdapterCourses(
     private val context: Context,
-    currentList: List<RealmMyCourse>,
+    currentList: List<RealmMyCourse?>,
     private val map: HashMap<String?, JsonObject>,
     private val userProfileDbHandler: UserProfileDbHandler
-) : ListAdapter<RealmMyCourse, RecyclerView.ViewHolder>(CourseDiffCallback()) {
-    private val selectedItems: MutableList<RealmMyCourse> = ArrayList()
+) : ListAdapter<RealmMyCourse?, RecyclerView.ViewHolder>(CourseDiffCallback()) {
+    private val selectedItems: MutableList<RealmMyCourse?> = ArrayList()
     private var listener: OnCourseItemSelected? = null
     private var homeItemClickListener: OnHomeItemClickListener? = null
     private var progressMap: HashMap<String?, JsonObject>? = null
@@ -71,31 +70,31 @@ class AdapterCourses(
         this.ratingChangeListener = ratingChangeListener
     }
 
-    fun getCourseList(): List<RealmMyCourse> {
+    fun getCourseList(): List<RealmMyCourse?> {
         return currentList
     }
 
-    fun setOriginalCourseList(currentList: List<RealmMyCourse>){
+    fun setOriginalCourseList(currentList: List<RealmMyCourse?>){
         submitList(currentList)
     }
 
-    fun setCourseList(currentList: List<RealmMyCourse>) {
+    fun setCourseList(currentList: List<RealmMyCourse?>) {
         submitList(currentList)
     }
 
-    private fun sortCourseListByTitle(): List<RealmMyCourse> {
+    private fun sortCourseListByTitle(): List<RealmMyCourse?> {
         return if (isTitleAscending) {
-            currentList.sortedBy { it.courseTitle?.lowercase() }
+            currentList.sortedBy { it?.courseTitle?.lowercase() }
         } else {
-            currentList.sortedByDescending { it.courseTitle?.lowercase() }
+            currentList.sortedByDescending { it?.courseTitle?.lowercase() }
         }
     }
 
-    private fun sortCourseList(): List<RealmMyCourse> {
+    private fun sortCourseList(): List<RealmMyCourse?> {
         return if (isAscending) {
-            currentList.sortedBy { it.createdDate }
+            currentList.sortedBy { it?.createdDate }
         } else {
-            currentList.sortedByDescending { it.createdDate }
+            currentList.sortedByDescending { it?.createdDate }
         }
     }
 
@@ -321,18 +320,18 @@ class AdapterCourses(
         }
     }
 
-    private fun openCourse(realmMyCourses: RealmMyCourse, step: Int) {
+    private fun openCourse(realmMyCourses: RealmMyCourse?, step: Int) {
         if (homeItemClickListener != null) {
             val f: Fragment = TakeCourseFragment()
             val b = Bundle()
-            b.putString("id", realmMyCourses.courseId)
+            b.putString("id", realmMyCourses?.courseId)
             b.putInt("position", step)
             f.arguments = b
             homeItemClickListener?.openCallFragment(f)
         }
     }
 
-    fun updateCourseList(newCourseList: List<RealmMyCourse>) {
+    fun updateCourseList(newCourseList: List<RealmMyCourse?>) {
         selectedItems.clear()
         submitList(newCourseList)
     }
@@ -378,12 +377,12 @@ class AdapterCourses(
     }
 }
 
-class CourseDiffCallback : DiffUtil.ItemCallback<RealmMyCourse>() {
-    override fun areItemsTheSame(oldItem: RealmMyCourse, newItem: RealmMyCourse): Boolean {
-        return oldItem.id == newItem.id
+class CourseDiffCallback : DiffUtil.ItemCallback<RealmMyCourse?>() {
+    override fun areItemsTheSame(oldItem: RealmMyCourse?, newItem: RealmMyCourse?): Boolean {
+        return oldItem?.id == newItem?.id
     }
 
-    override fun areContentsTheSame(oldItem: RealmMyCourse, newItem: RealmMyCourse): Boolean {
+    override fun areContentsTheSame(oldItem: RealmMyCourse?, newItem: RealmMyCourse?): Boolean {
         return oldItem == newItem
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -39,11 +39,11 @@ import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import org.ole.planet.myplanet.utilities.Utilities
 class AdapterCourses(
     private val context: Context,
-    currentList: List<RealmMyCourse?>,
+    currentList: List<RealmMyCourse>,
     private val map: HashMap<String?, JsonObject>,
     private val userProfileDbHandler: UserProfileDbHandler
-) : ListAdapter<RealmMyCourse?, RecyclerView.ViewHolder>(CourseDiffCallback()) {
-    private val selectedItems: MutableList<RealmMyCourse?> = ArrayList()
+) : ListAdapter<RealmMyCourse, RecyclerView.ViewHolder>(CourseDiffCallback()) {
+    private val selectedItems: MutableList<RealmMyCourse> = ArrayList()
     private var listener: OnCourseItemSelected? = null
     private var homeItemClickListener: OnHomeItemClickListener? = null
     private var progressMap: HashMap<String?, JsonObject>? = null
@@ -71,31 +71,31 @@ class AdapterCourses(
         this.ratingChangeListener = ratingChangeListener
     }
 
-    fun getCourseList(): List<RealmMyCourse?> {
+    fun getCourseList(): List<RealmMyCourse> {
         return currentList
     }
 
-    fun setOriginalCourseList(currentList: List<RealmMyCourse?>){
+    fun setOriginalCourseList(currentList: List<RealmMyCourse>){
         submitList(currentList)
     }
 
-    fun setCourseList(currentList: List<RealmMyCourse?>) {
+    fun setCourseList(currentList: List<RealmMyCourse>) {
         submitList(currentList)
     }
 
-    private fun sortCourseListByTitle(): List<RealmMyCourse?> {
+    private fun sortCourseListByTitle(): List<RealmMyCourse> {
         return if (isTitleAscending) {
-            currentList.sortedBy { it?.courseTitle?.lowercase() }
+            currentList.sortedBy { it.courseTitle?.lowercase() }
         } else {
-            currentList.sortedByDescending { it?.courseTitle?.lowercase() }
+            currentList.sortedByDescending { it.courseTitle?.lowercase() }
         }
     }
 
-    private fun sortCourseList(): List<RealmMyCourse?> {
+    private fun sortCourseList(): List<RealmMyCourse> {
         return if (isAscending) {
-            currentList.sortedBy { it?.createdDate }
+            currentList.sortedBy { it.createdDate }
         } else {
-            currentList.sortedByDescending { it?.createdDate }
+            currentList.sortedByDescending { it.createdDate }
         }
     }
 
@@ -294,8 +294,8 @@ class AdapterCourses(
     private fun showProgressAndRating(position: Int, holder: RecyclerView.ViewHolder) {
         val viewHolder = holder as ViewHoldercourse
         showProgress(viewHolder.rowCourseBinding, position)
-        if (map.containsKey(currentList[position]!!.courseId)) {
-            val `object` = map[currentList[position]!!.courseId]
+        if (map.containsKey(currentList[position].courseId)) {
+            val `object` = map[currentList[position].courseId]
             CourseRatingUtils.showRating(
                 `object`,
                 viewHolder.rowCourseBinding.rating,
@@ -308,8 +308,8 @@ class AdapterCourses(
     }
 
     private fun showProgress(binding: RowCourseBinding, position: Int) {
-        if (progressMap?.containsKey(currentList[position]?.courseId) == true) {
-            val ob = progressMap!![currentList[position]?.courseId]
+        if (progressMap?.containsKey(currentList[position].courseId) == true) {
+            val ob = progressMap!![currentList[position].courseId]
             binding.courseProgress.max = getInt("max", ob)
             binding.courseProgress.progress = getInt("current", ob)
             if (getInt("current", ob) < getInt("max", ob)) {
@@ -321,18 +321,18 @@ class AdapterCourses(
         }
     }
 
-    private fun openCourse(realmMyCourses: RealmMyCourse?, step: Int) {
+    private fun openCourse(realmMyCourses: RealmMyCourse, step: Int) {
         if (homeItemClickListener != null) {
             val f: Fragment = TakeCourseFragment()
             val b = Bundle()
-            b.putString("id", realmMyCourses?.courseId)
+            b.putString("id", realmMyCourses.courseId)
             b.putInt("position", step)
             f.arguments = b
             homeItemClickListener?.openCallFragment(f)
         }
     }
 
-    fun updateCourseList(newCourseList: List<RealmMyCourse?>) {
+    fun updateCourseList(newCourseList: List<RealmMyCourse>) {
         selectedItems.clear()
         submitList(newCourseList)
     }
@@ -358,8 +358,8 @@ class AdapterCourses(
                 override fun onProgressChanged(seekBar: SeekBar, i: Int, b: Boolean) {
                     val position = bindingAdapterPosition
                     if (position != RecyclerView.NO_POSITION && position < currentList.size) {
-                        if (progressMap?.containsKey(currentList[bindingAdapterPosition]?.courseId) == true) {
-                            val ob = progressMap!![currentList[bindingAdapterPosition]?.courseId]
+                        if (progressMap?.containsKey(currentList[bindingAdapterPosition].courseId) == true) {
+                            val ob = progressMap!![currentList[bindingAdapterPosition].courseId]
                             val current = getInt("current", ob)
                             if (b && i <= current + 1) {
                                 openCourse(currentList[bindingAdapterPosition], seekBar.progress)
@@ -378,12 +378,12 @@ class AdapterCourses(
     }
 }
 
-class CourseDiffCallback : DiffUtil.ItemCallback<RealmMyCourse?>() {
-    override fun areItemsTheSame(oldItem: RealmMyCourse?, newItem: RealmMyCourse?): Boolean {
-        return oldItem?.id == newItem?.id
+class CourseDiffCallback : DiffUtil.ItemCallback<RealmMyCourse>() {
+    override fun areItemsTheSame(oldItem: RealmMyCourse, newItem: RealmMyCourse): Boolean {
+        return oldItem.id == newItem.id
     }
 
-    override fun areContentsTheSame(oldItem: RealmMyCourse?, newItem: RealmMyCourse?): Boolean {
+    override fun areContentsTheSame(oldItem: RealmMyCourse, newItem: RealmMyCourse): Boolean {
         return oldItem == newItem
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -262,8 +262,8 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                     val courseList = filterCourseByTag(query, searchTags)
                     val sortedCourseList = courseList.sortedWith(compareBy({ it?.isMyCourse }, { it?.courseTitle }))
                     adapterCourses.setOriginalCourseList(sortedCourseList)
-                }
-                else {
+                    showNoData(tvMessage, adapterCourses.itemCount, "courses")
+                } else {
                     adapterCourses.setCourseList(filterCourseByTag(etSearch.text.toString(), searchTags))
                     showNoData(tvMessage, adapterCourses.itemCount, "courses")
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -182,7 +182,6 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             adapterCourses.updateCourseList(sortedCourseList)
             adapterCourses.setProgressMap(progressMap)
             adapterCourses.setRatingMap(map)
-            adapterCourses.notifyDataSetChanged()
 
             if (isMyCourseLib) {
                 val courseIds = courseList.mapNotNull { it?.id }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -176,15 +176,15 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         try {
             val map = getRatings(mRealm, "course", model?.id)
             val progressMap = getCourseProgress(mRealm, model?.id)
-            val courseList: List<RealmMyCourse?> = getList(RealmMyCourse::class.java).filterIsInstance<RealmMyCourse?>()
-            val sortedCourseList = courseList.sortedWith(compareBy({ it?.isMyCourse }, { it?.courseTitle }))
+            val courseList: List<RealmMyCourse> = getList(RealmMyCourse::class.java).filterIsInstance<RealmMyCourse>()
+            val sortedCourseList = courseList.sortedWith(compareBy({ it.isMyCourse }, { it.courseTitle }))
 
             adapterCourses.updateCourseList(sortedCourseList)
             adapterCourses.setProgressMap(progressMap)
             adapterCourses.setRatingMap(map)
 
             if (isMyCourseLib) {
-                val courseIds = courseList.mapNotNull { it?.id }
+                val courseIds = courseList.map { it.id }
                 resources = mRealm.where(RealmMyLibrary::class.java)
                     .`in`("courseId", courseIds.toTypedArray())
                     .equalTo("resourceOffline", false)
@@ -203,8 +203,8 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     override fun getAdapter(): RecyclerView.Adapter<*> {
         val map = getRatings(mRealm, "course", model?.id)
         val progressMap = getCourseProgress(mRealm, model?.id)
-        val courseList: List<RealmMyCourse?> = getList(RealmMyCourse::class.java).filterIsInstance<RealmMyCourse?>()
-        val sortedCourseList = courseList.sortedWith(compareBy({ it?.isMyCourse }, { it?.courseTitle }))
+        val courseList: List<RealmMyCourse> = getList(RealmMyCourse::class.java).filterIsInstance<RealmMyCourse>()
+        val sortedCourseList = courseList.sortedWith(compareBy({ it.isMyCourse }, { it.courseTitle }))
         adapterCourses = AdapterCourses(requireActivity(), sortedCourseList, map, userProfileDbHandler)
         adapterCourses.setProgressMap(progressMap)
         adapterCourses.setmRealm(mRealm)
@@ -212,7 +212,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         adapterCourses.setRatingChangeListener(this)
 
         if (isMyCourseLib) {
-            val courseIds = courseList.mapNotNull { it?.id }
+            val courseIds = courseList.map { it.id }
             resources = mRealm.where(RealmMyLibrary::class.java)
                 .`in`("courseId", courseIds.toTypedArray())
                 .equalTo("resourceOffline", false)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/AdapterNotification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/AdapterNotification.kt
@@ -5,6 +5,8 @@ import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import java.util.regex.Pattern
 import org.ole.planet.myplanet.MainApplication.Companion.context
@@ -16,10 +18,14 @@ import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmTeamTask
 
 class AdapterNotification(
-    var notificationList: List<RealmNotification>,
+    notifications: List<RealmNotification>,
     private val onMarkAsReadClick: (Int) -> Unit,
     private val onNotificationClick: (RealmNotification) -> Unit
-) : RecyclerView.Adapter<AdapterNotification.ViewHolderNotifications>() {
+) : ListAdapter<RealmNotification, AdapterNotification.ViewHolderNotifications>(NotificationDiffCallback()) {
+
+    init {
+        submitList(notifications)
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderNotifications {
         val rowNotificationsBinding = RowNotificationsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -27,15 +33,12 @@ class AdapterNotification(
     }
 
     override fun onBindViewHolder(holder: ViewHolderNotifications, position: Int) {
-        val notification = notificationList[position]
+        val notification = currentList[position]
         holder.bind(notification, position)
     }
 
-    override fun getItemCount(): Int = notificationList.size
-
     fun updateNotifications(newNotifications: List<RealmNotification>) {
-        notificationList = newNotifications
-        notifyDataSetChanged()
+        submitList(newNotifications)
     }
 
     inner class ViewHolderNotifications(private val rowNotificationsBinding: RowNotificationsBinding) :
@@ -123,5 +126,15 @@ class AdapterNotification(
             }
             return formattedText
         }
+    }
+}
+
+class NotificationDiffCallback : DiffUtil.ItemCallback<RealmNotification>() {
+    override fun areItemsTheSame(oldItem: RealmNotification, newItem: RealmNotification): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: RealmNotification, newItem: RealmNotification): Boolean {
+        return oldItem == newItem
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/AdapterNotification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/AdapterNotification.kt
@@ -5,6 +5,7 @@ import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.AsyncDifferConfig
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -21,7 +22,9 @@ class AdapterNotification(
     notifications: List<RealmNotification>,
     private val onMarkAsReadClick: (Int) -> Unit,
     private val onNotificationClick: (RealmNotification) -> Unit
-) : ListAdapter<RealmNotification, AdapterNotification.ViewHolderNotifications>(NotificationDiffCallback()) {
+) : ListAdapter<RealmNotification, AdapterNotification.ViewHolderNotifications>(
+    AsyncDifferConfig.Builder(NotificationDiffCallback()).setBackgroundThreadExecutor { it.run() }.build()
+) {
 
     init {
         submitList(notifications)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -176,7 +176,7 @@ class NotificationsFragment : Fragment() {
         }
 
         if (!notification.isRead) {
-            markAsRead(adapter.notificationList.indexOf(notification))
+            markAsRead(adapter.currentList.indexOf(notification))
         }
     }
 
@@ -194,7 +194,7 @@ class NotificationsFragment : Fragment() {
     }
 
     private fun markAsRead(position: Int) {
-        val notification = adapter.notificationList[position]
+        val notification = adapter.currentList[position]
         mRealm.executeTransaction {
             notification.isRead = true
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
@@ -33,11 +33,11 @@ import org.ole.planet.myplanet.utilities.Utilities
 
 class AdapterResource(
     private val context: Context,
-    libraryList: List<RealmMyLibrary>,
+    libraryList: List<RealmMyLibrary?>,
     private var ratingMap: HashMap<String?, JsonObject>,
     private val realm: Realm
-) : ListAdapter<RealmMyLibrary, RecyclerView.ViewHolder>(ResourceDiffCallback()) {
-    private val selectedItems: MutableList<RealmMyLibrary> = ArrayList()
+) : ListAdapter<RealmMyLibrary?, RecyclerView.ViewHolder>(ResourceDiffCallback()) {
+    private val selectedItems: MutableList<RealmMyLibrary?> = ArrayList()
     private var listener: OnLibraryItemSelected? = null
     private val config: ChipCloudConfig = Utilities.getCloudConfig().selectMode(ChipCloud.SelectMode.single)
     private var homeItemClickListener: OnHomeItemClickListener? = null
@@ -57,11 +57,11 @@ class AdapterResource(
         this.ratingChangeListener = ratingChangeListener
     }
 
-    fun getLibraryList(): List<RealmMyLibrary> {
+    fun getLibraryList(): List<RealmMyLibrary?> {
         return currentList
     }
 
-    fun setLibraryList(libraryList: List<RealmMyLibrary>) {
+    fun setLibraryList(libraryList: List<RealmMyLibrary?>) {
         submitList(libraryList)
     }
 
@@ -151,7 +151,7 @@ class AdapterResource(
         }
     }
 
-    private fun openLibrary(library: RealmMyLibrary) {
+    private fun openLibrary(library: RealmMyLibrary?) {
         homeItemClickListener?.openLibraryDetailFragment(library)
     }
 
@@ -186,7 +186,7 @@ class AdapterResource(
         submitList(sortLibraryList())
     }
 
-    private fun sortLibraryListByTitle(): List<RealmMyLibrary> {
+    private fun sortLibraryListByTitle(): List<RealmMyLibrary?> {
         return if (isTitleAscending) {
             currentList.sortedBy { it?.title?.lowercase(Locale.ROOT) }
         } else {
@@ -194,7 +194,7 @@ class AdapterResource(
         }
     }
 
-    private fun sortLibraryList(): List<RealmMyLibrary> {
+    private fun sortLibraryList(): List<RealmMyLibrary?> {
         return if (isAscending) {
             currentList.sortedBy { it?.createdDate }
         } else {
@@ -232,12 +232,12 @@ class AdapterResource(
     }
 }
 
-class ResourceDiffCallback : DiffUtil.ItemCallback<RealmMyLibrary>() {
-    override fun areItemsTheSame(oldItem: RealmMyLibrary, newItem: RealmMyLibrary): Boolean {
-        return oldItem.id == newItem.id
+class ResourceDiffCallback : DiffUtil.ItemCallback<RealmMyLibrary?>() {
+    override fun areItemsTheSame(oldItem: RealmMyLibrary?, newItem: RealmMyLibrary?): Boolean {
+        return oldItem?.id == newItem?.id
     }
 
-    override fun areContentsTheSame(oldItem: RealmMyLibrary, newItem: RealmMyLibrary): Boolean {
+    override fun areContentsTheSame(oldItem: RealmMyLibrary?, newItem: RealmMyLibrary?): Boolean {
         return oldItem == newItem
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
@@ -33,11 +33,11 @@ import org.ole.planet.myplanet.utilities.Utilities
 
 class AdapterResource(
     private val context: Context,
-    libraryList: List<RealmMyLibrary?>,
+    libraryList: List<RealmMyLibrary>,
     private var ratingMap: HashMap<String?, JsonObject>,
     private val realm: Realm
-) : ListAdapter<RealmMyLibrary?, RecyclerView.ViewHolder>(ResourceDiffCallback()) {
-    private val selectedItems: MutableList<RealmMyLibrary?> = ArrayList()
+) : ListAdapter<RealmMyLibrary, RecyclerView.ViewHolder>(ResourceDiffCallback()) {
+    private val selectedItems: MutableList<RealmMyLibrary> = ArrayList()
     private var listener: OnLibraryItemSelected? = null
     private val config: ChipCloudConfig = Utilities.getCloudConfig().selectMode(ChipCloud.SelectMode.single)
     private var homeItemClickListener: OnHomeItemClickListener? = null
@@ -57,11 +57,11 @@ class AdapterResource(
         this.ratingChangeListener = ratingChangeListener
     }
 
-    fun getLibraryList(): List<RealmMyLibrary?> {
+    fun getLibraryList(): List<RealmMyLibrary> {
         return currentList
     }
 
-    fun setLibraryList(libraryList: List<RealmMyLibrary?>) {
+    fun setLibraryList(libraryList: List<RealmMyLibrary>) {
         submitList(libraryList)
     }
 
@@ -151,7 +151,7 @@ class AdapterResource(
         }
     }
 
-    private fun openLibrary(library: RealmMyLibrary?) {
+    private fun openLibrary(library: RealmMyLibrary) {
         homeItemClickListener?.openLibraryDetailFragment(library)
     }
 
@@ -186,7 +186,7 @@ class AdapterResource(
         submitList(sortLibraryList())
     }
 
-    private fun sortLibraryListByTitle(): List<RealmMyLibrary?> {
+    private fun sortLibraryListByTitle(): List<RealmMyLibrary> {
         return if (isTitleAscending) {
             currentList.sortedBy { it?.title?.lowercase(Locale.ROOT) }
         } else {
@@ -194,7 +194,7 @@ class AdapterResource(
         }
     }
 
-    private fun sortLibraryList(): List<RealmMyLibrary?> {
+    private fun sortLibraryList(): List<RealmMyLibrary> {
         return if (isAscending) {
             currentList.sortedBy { it?.createdDate }
         } else {
@@ -232,12 +232,12 @@ class AdapterResource(
     }
 }
 
-class ResourceDiffCallback : DiffUtil.ItemCallback<RealmMyLibrary?>() {
-    override fun areItemsTheSame(oldItem: RealmMyLibrary?, newItem: RealmMyLibrary?): Boolean {
-        return oldItem?.id == newItem?.id
+class ResourceDiffCallback : DiffUtil.ItemCallback<RealmMyLibrary>() {
+    override fun areItemsTheSame(oldItem: RealmMyLibrary, newItem: RealmMyLibrary): Boolean {
+        return oldItem.id == newItem.id
     }
 
-    override fun areContentsTheSame(oldItem: RealmMyLibrary?, newItem: RealmMyLibrary?): Boolean {
+    override fun areContentsTheSame(oldItem: RealmMyLibrary, newItem: RealmMyLibrary): Boolean {
         return oldItem == newItem
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
@@ -7,6 +7,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
+import androidx.recyclerview.widget.AsyncDifferConfig
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -36,7 +37,9 @@ class AdapterResource(
     libraryList: List<RealmMyLibrary>,
     private var ratingMap: HashMap<String?, JsonObject>,
     private val realm: Realm
-) : ListAdapter<RealmMyLibrary, RecyclerView.ViewHolder>(ResourceDiffCallback()) {
+) : ListAdapter<RealmMyLibrary, RecyclerView.ViewHolder>(
+    AsyncDifferConfig.Builder(ResourceDiffCallback()).setBackgroundThreadExecutor { it.run() }.build()
+) {
     private val selectedItems: MutableList<RealmMyLibrary> = ArrayList()
     private var listener: OnLibraryItemSelected? = null
     private val config: ChipCloudConfig = Utilities.getCloudConfig().selectMode(ChipCloud.SelectMode.single)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -171,7 +171,6 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
             val libraryList: List<RealmMyLibrary?> = getList(RealmMyLibrary::class.java).filterIsInstance<RealmMyLibrary?>()
             adapterLibrary.setLibraryList(libraryList)
             adapterLibrary.setRatingMap(map!!)
-            adapterLibrary.notifyDataSetChanged()
             checkList()
             showNoData(tvMessage, adapterLibrary.itemCount, "resources")
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -168,7 +168,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
         try {
             map = getRatings(mRealm, "resource", model?.id)
-            val libraryList: List<RealmMyLibrary?> = getList(RealmMyLibrary::class.java).filterIsInstance<RealmMyLibrary?>()
+            val libraryList: List<RealmMyLibrary> = getList(RealmMyLibrary::class.java).filterIsInstance<RealmMyLibrary>()
             adapterLibrary.setLibraryList(libraryList)
             adapterLibrary.setRatingMap(map!!)
             checkList()
@@ -192,7 +192,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     override fun getAdapter(): RecyclerView.Adapter<*> {
         map = getRatings(mRealm, "resource", model?.id)
-        val libraryList: List<RealmMyLibrary?> = getList(RealmMyLibrary::class.java).filterIsInstance<RealmMyLibrary?>()
+        val libraryList: List<RealmMyLibrary> = getList(RealmMyLibrary::class.java).filterIsInstance<RealmMyLibrary>()
         adapterLibrary = AdapterResource(requireActivity(), libraryList, map!!, mRealm)
         adapterLibrary.setRatingChangeListener(this)
         adapterLibrary.setListener(this)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -12,6 +12,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.graphics.toColorInt
 import androidx.fragment.app.FragmentManager
+import androidx.recyclerview.widget.AsyncDifferConfig
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -28,13 +29,16 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
+
 class AdapterTeamList(
     private val context: Context,
     private val list: List<RealmMyTeam>,
     private val mRealm: Realm,
     private val fragmentManager: FragmentManager,
     private val uploadManager: UploadManager
-) : ListAdapter<RealmMyTeam, AdapterTeamList.ViewHolderTeam>(TeamDiffCallback()) {
+) : ListAdapter<RealmMyTeam, AdapterTeamList.ViewHolderTeam>(
+    AsyncDifferConfig.Builder(TeamDiffCallback()).setBackgroundThreadExecutor { it.run() }.build()
+) {
     private lateinit var itemTeamListBinding: ItemTeamListBinding
     private var type: String? = ""
     private var teamListener: OnClickTeamItem? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -21,14 +21,13 @@ import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.ItemTeamListBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
-
 class AdapterTeamList(
     private val context: Context,
     private val list: List<RealmMyTeam>,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -12,6 +12,8 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.graphics.toColorInt
 import androidx.fragment.app.FragmentManager
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import io.realm.Realm
 import org.ole.planet.myplanet.R
@@ -27,11 +29,16 @@ import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
 
-class AdapterTeamList(private val context: Context, private val list: List<RealmMyTeam>, private val mRealm: Realm, private val fragmentManager: FragmentManager, private val uploadManager: UploadManager) : RecyclerView.Adapter<AdapterTeamList.ViewHolderTeam>() {
+class AdapterTeamList(
+    private val context: Context,
+    private val list: List<RealmMyTeam>,
+    private val mRealm: Realm,
+    private val fragmentManager: FragmentManager,
+    private val uploadManager: UploadManager
+) : ListAdapter<RealmMyTeam, AdapterTeamList.ViewHolderTeam>(TeamDiffCallback()) {
     private lateinit var itemTeamListBinding: ItemTeamListBinding
     private var type: String? = ""
     private var teamListener: OnClickTeamItem? = null
-    private var filteredList: List<RealmMyTeam> = emptyList()
     private lateinit var prefData: SharedPrefManager
 
     interface OnClickTeamItem {
@@ -53,7 +60,7 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
     }
 
     override fun onBindViewHolder(holder: ViewHolderTeam, position: Int) {
-        val team = filteredList[position]
+        val team = currentList[position]
         val user: RealmUserModel? = UserProfileDbHandler(context).userModel
 
         with(holder.binding) {
@@ -172,7 +179,7 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
         val userId = user?.id
 
         val validTeams = list.filter { it.status?.isNotEmpty() == true }
-        filteredList = validTeams.sortedWith(compareByDescending<RealmMyTeam> { team ->
+        val sorted = validTeams.sortedWith(compareByDescending<RealmMyTeam> { team ->
             when {
                 userId != null && RealmMyTeam.isTeamLeader(team._id, userId, mRealm) -> 3
                 team.isMyTeam(userId, mRealm) -> 2
@@ -181,7 +188,7 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
         }.thenByDescending { team ->
             RealmTeamLog.getVisitByTeam(mRealm, team._id)
         })
-        notifyDataSetChanged()
+        submitList(sorted)
     }
 
     private fun getBundle(team: RealmMyTeam): Bundle {
@@ -196,7 +203,15 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
         this.type = type
     }
 
-    override fun getItemCount(): Int = filteredList.size
-
     class ViewHolderTeam(val binding: ItemTeamListBinding) : RecyclerView.ViewHolder(binding.root)
+}
+
+class TeamDiffCallback : DiffUtil.ItemCallback<RealmMyTeam>() {
+    override fun areItemsTheSame(oldItem: RealmMyTeam, newItem: RealmMyTeam): Boolean {
+        return oldItem._id == newItem._id
+    }
+
+    override fun areContentsTheSame(oldItem: RealmMyTeam, newItem: RealmMyTeam): Boolean {
+        return oldItem == newItem
+    }
 }


### PR DESCRIPTION
## Summary
- convert AdapterResource, AdapterCourses, AdapterTeamList and AdapterNotification to `ListAdapter`
- add `DiffUtil` callbacks for efficient updates
- call `submitList()` instead of `notifyDataSetChanged()`

## Testing
- `./gradlew test` *(failed: Fetch remote repository)*

------
https://chatgpt.com/codex/tasks/task_e_6881effcae0c832b8fb25363dcd475a4