### PR TITLE
Add view models and domain classes

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/domain/ChallengeEvaluator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/domain/ChallengeEvaluator.kt
@@ -1,0 +1,118 @@
+package org.ole.planet.myplanet.domain
+
+import android.content.SharedPreferences
+import io.realm.Realm
+import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.util.Date
+import java.util.Locale
+import org.json.JSONArray
+import org.ole.planet.myplanet.BuildConfig
+import org.ole.planet.myplanet.model.RealmMyCourse
+import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.model.RealmStepExam
+import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.ui.courses.MyProgressFragment
+import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
+
+class ChallengeEvaluator(
+    private val realm: Realm,
+    private val user: RealmUserModel?,
+    private val settings: SharedPreferences,
+    private val editor: SharedPreferences.Editor
+) {
+    data class Result(
+        val voiceCount: Int,
+        val courseProgress: com.google.gson.JsonObject?,
+        val courseName: String?,
+        val allVoiceCount: Int,
+        val hasUnfinishedSurvey: Boolean,
+        val shouldShow: Boolean
+    )
+
+    fun evaluate(): Result? {
+        val startTime = 1730419200000
+        val endTime = 1734307200000
+
+        val uniqueDates = fetchVoiceDates(startTime, endTime, user?.id)
+        val allUniqueDates = fetchVoiceDates(startTime, endTime, null)
+
+        val courseId = "4e6b78800b6ad18b4e8b0e1e38a98cac"
+        val courseData = MyProgressFragment.fetchCourseData(realm, user?.id)
+        val progress = MyProgressFragment.getCourseProgress(courseData, courseId)
+        val courseName = realm.where(RealmMyCourse::class.java)
+            .equalTo("courseId", courseId)
+            .findFirst()?.courseTitle
+
+        val hasUnfinishedSurvey = hasPendingSurvey(courseId)
+
+        val validUrls = listOf(
+            "https://${BuildConfig.PLANET_GUATEMALA_URL}",
+            "http://${BuildConfig.PLANET_XELA_URL}",
+            "http://${BuildConfig.PLANET_URIUR_URL}",
+            "http://${BuildConfig.PLANET_SANPABLO_URL}",
+            "http://${BuildConfig.PLANET_EMBAKASI_URL}",
+            "https://${BuildConfig.PLANET_VI_URL}"
+        )
+
+        val today = LocalDate.now()
+        return if (user?.id?.startsWith("guest") == false && shouldPromptChallenge(today, validUrls)) {
+            Result(uniqueDates.size, progress, courseName, allUniqueDates.size, hasUnfinishedSurvey, true)
+        } else {
+            null
+        }
+    }
+
+    private fun fetchVoiceDates(start: Long, end: Long, userId: String?): List<String> {
+        val query = realm.where(RealmNews::class.java)
+            .greaterThanOrEqualTo("time", start)
+            .lessThanOrEqualTo("time", end)
+        if (userId != null) query.equalTo("userId", userId)
+        val results = query.findAll()
+        return results.filter { isCommunitySection(it) }
+            .map { getDateFromTimestamp(it.time) }
+            .distinct()
+    }
+
+    private fun isCommunitySection(news: RealmNews): Boolean {
+        news.viewIn?.let { viewInStr ->
+            try {
+                val viewInArray = JSONArray(viewInStr)
+                for (i in 0 until viewInArray.length()) {
+                    val viewInObj = viewInArray.getJSONObject(i)
+                    if (viewInObj.optString("section") == "community") {
+                        return true
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+        return false
+    }
+
+    private fun getDateFromTimestamp(timestamp: Long): String {
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        return dateFormat.format(Date(timestamp))
+    }
+
+    private fun hasPendingSurvey(courseId: String): Boolean {
+        return realm.where(RealmStepExam::class.java)
+            .equalTo("courseId", courseId)
+            .equalTo("type", "survey")
+            .findAll()
+            .any { survey -> !TakeCourseFragment.existsSubmission(realm, survey.id, "survey") }
+    }
+
+    private fun shouldPromptChallenge(today: LocalDate, validUrls: List<String>): Boolean {
+        val endDate = LocalDate.of(2025, 1, 16)
+        return today.isAfter(LocalDate.of(2024, 11, 30)) &&
+            today.isBefore(endDate) &&
+            settings.getString("serverURL", "") in validUrls
+    }
+
+    fun markCongratsShown() {
+        editor.putBoolean("has_shown_congrats", true).apply()
+    }
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/domain/NotificationCreator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/domain/NotificationCreator.kt
@@ -1,0 +1,137 @@
+package org.ole.planet.myplanet.domain
+
+import io.realm.Realm
+import io.realm.Sort
+import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.model.RealmSubmission
+import org.ole.planet.myplanet.model.RealmStepExam
+import org.ole.planet.myplanet.ui.dashboard.DashboardViewModel
+import org.ole.planet.myplanet.utilities.FileUtils
+import org.ole.planet.myplanet.utilities.NotificationUtil
+import org.ole.planet.myplanet.utilities.TimeUtils
+
+class NotificationCreator(
+    private val viewModel: DashboardViewModel,
+    private val notificationManager: NotificationUtil.NotificationManager
+) {
+    fun createNotifications(realm: Realm, userId: String?): List<NotificationUtil.NotificationConfig> {
+        val newNotifications = mutableListOf<NotificationUtil.NotificationConfig>()
+
+        viewModel.updateResourceNotification(realm, userId)
+
+        newNotifications += createSurveyNotifications(realm, userId)
+        newNotifications += createTaskNotifications(realm, userId)
+        newNotifications += createStorageNotification(realm, userId)
+        newNotifications += createJoinRequestNotifications(realm, userId)
+
+        return newNotifications
+    }
+
+    private fun createSurveyNotifications(realm: Realm, userId: String?): List<NotificationUtil.NotificationConfig> {
+        val notifications = mutableListOf<NotificationUtil.NotificationConfig>()
+        val pendingSurveys = viewModel.getPendingSurveys(realm, userId)
+        val surveyTitles = viewModel.getSurveyTitlesFromSubmissions(realm, pendingSurveys)
+
+        surveyTitles.forEach { title ->
+            val notificationKey = "survey-$title"
+            if (!notificationManager.hasNotificationBeenShown(notificationKey)) {
+                viewModel.createNotificationIfNotExists(realm, "survey", title, title, userId)
+                val config = notificationManager.createSurveyNotification(title, title)
+                notifications.add(config)
+            }
+        }
+        return notifications
+    }
+
+    private fun createTaskNotifications(realm: Realm, userId: String?): List<NotificationUtil.NotificationConfig> {
+        val notifications = mutableListOf<NotificationUtil.NotificationConfig>()
+        val tasks = realm.where(RealmTeamTask::class.java)
+            .notEqualTo("status", "archived")
+            .equalTo("completed", false)
+            .equalTo("assignee", userId)
+            .sort("deadline", Sort.ASCENDING)
+            .findAll()
+
+        tasks.forEach { task ->
+            val notificationKey = "task-${task.id}"
+            if (!notificationManager.hasNotificationBeenShown(notificationKey)) {
+                viewModel.createNotificationIfNotExists(
+                    realm,
+                    "task",
+                    "${task.title} ${TimeUtils.formatDate(task.deadline)}",
+                    task.id,
+                    userId
+                )
+                val config = notificationManager.createTaskNotification(
+                    task.id ?: "task",
+                    task.title ?: "New Task",
+                    TimeUtils.formatDate(task.deadline)
+                )
+                notifications.add(config)
+            }
+        }
+        return notifications
+    }
+
+    private fun createStorageNotification(realm: Realm, userId: String?): List<NotificationUtil.NotificationConfig> {
+        val notifications = mutableListOf<NotificationUtil.NotificationConfig>()
+        val storageRatio = FileUtils.totalAvailableMemoryRatio
+        val notificationKey = "storage-critical"
+
+        if (storageRatio > 85 && !notificationManager.hasNotificationBeenShown(notificationKey)) {
+            viewModel.createNotificationIfNotExists(realm, "storage", "$storageRatio%", "storage", userId)
+            val config = notificationManager.createStorageWarningNotification(storageRatio.toInt())
+            notifications.add(config)
+        }
+        return notifications
+    }
+
+    private fun createJoinRequestNotifications(realm: Realm, userId: String?): List<NotificationUtil.NotificationConfig> {
+        val notifications = mutableListOf<NotificationUtil.NotificationConfig>()
+        val teamLeaderMemberships = realm.where(RealmMyTeam::class.java)
+            .equalTo("userId", userId)
+            .equalTo("docType", "membership")
+            .equalTo("isLeader", true)
+            .findAll()
+
+        teamLeaderMemberships.forEach { leadership ->
+            val pendingJoinRequests = realm.where(RealmMyTeam::class.java)
+                .equalTo("teamId", leadership.teamId)
+                .equalTo("docType", "request")
+                .findAll()
+
+            pendingJoinRequests.forEach { joinRequest ->
+                val notificationKey = "join_request-${joinRequest._id}"
+                if (!notificationManager.hasNotificationBeenShown(notificationKey)) {
+                    val team = realm.where(RealmMyTeam::class.java)
+                        .equalTo("_id", leadership.teamId)
+                        .findFirst()
+                    val requester = realm.where(RealmUserModel::class.java)
+                        .equalTo("id", joinRequest.userId)
+                        .findFirst()
+                    val requesterName = requester?.name ?: "Unknown User"
+                    val teamName = team?.name ?: "Unknown Team"
+                    val message = "$requesterName has requested to join $teamName"
+
+                    viewModel.createNotificationIfNotExists(
+                        realm,
+                        "join_request",
+                        message,
+                        joinRequest._id,
+                        userId
+                    )
+                    val config = notificationManager.createJoinRequestNotification(
+                        joinRequest._id!!,
+                        requesterName,
+                        teamName
+                    )
+                    notifications.add(config)
+                }
+            }
+        }
+        return notifications
+    }
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/model/SyncViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/SyncViewModel.kt
@@ -1,0 +1,43 @@
+package org.ole.planet.myplanet.model
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.ole.planet.myplanet.callback.SyncListener
+import org.ole.planet.myplanet.service.SyncManager
+
+@HiltViewModel
+class SyncViewModel @Inject constructor(
+    private val syncManager: SyncManager
+) : ViewModel() {
+
+    private val _syncState = MutableStateFlow<SyncState>(SyncState.Idle)
+    val syncState: StateFlow<SyncState> = _syncState.asStateFlow()
+
+    fun startSync(type: String = "full", tables: List<String>? = null) {
+        syncManager.start(object : SyncListener {
+            override fun onSyncStarted() {
+                _syncState.value = SyncState.Syncing
+            }
+
+            override fun onSyncComplete() {
+                _syncState.value = SyncState.Success
+            }
+
+            override fun onSyncFailed(msg: String?) {
+                _syncState.value = SyncState.Failed(msg)
+            }
+        }, type, tables)
+    }
+
+    sealed class SyncState {
+        object Idle : SyncState()
+        object Syncing : SyncState()
+        object Success : SyncState()
+        data class Failed(val message: String?) : SyncState()
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `SyncViewModel` to manage sync progress
- extract notification creation to `NotificationCreator`
- move challenge evaluation logic to `ChallengeEvaluator`
- update dashboard to use new domain classes
- observe sync state from `SyncActivity`

## Testing
- `./gradlew test` *(fails: Downloading gradle)*

------
https://chatgpt.com/codex/tasks/task_e_6881f19559b0832b9c30f3a7e1d6af7f