### PR TITLE
Fix AutoSyncWorker creation and sort imports

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.kt
@@ -32,6 +32,14 @@ class AutoSyncWorker @AssistedInject constructor(
     private val uploadManager: UploadManager,
     private val uploadToShelfService: UploadToShelfService
 ) : Worker(context, workerParams), SyncListener, CheckVersionCallback, SuccessListener {
+
+    constructor(context: Context, workerParams: WorkerParameters) : this(
+        context,
+        workerParams,
+        SyncManager(context),
+        UploadManager(context),
+        UploadToShelfService(context)
+    )
     
     @AssistedFactory
     interface Factory {


### PR DESCRIPTION
## Summary
- add fallback constructor for `AutoSyncWorker`
- keep imports sorted

## Testing
- `./gradlew assembleDefaultDebug -x test` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68826ca36844832badd2826356ac83b6