### PR TITLE
Fix chat detail crash when fragment detached

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -40,8 +40,8 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.databinding.FragmentChatDetailBinding
+import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.AiProvider
 import org.ole.planet.myplanet.model.ChatModel
 import org.ole.planet.myplanet.model.ChatRequestModel
@@ -487,7 +487,9 @@ class ChatDetailFragment : Fragment() {
         mRealm.executeTransaction { realm ->
             RealmChatHistory.insert(realm, jsonObject)
         }
-        (requireActivity() as? DashboardActivity)?.refreshChatHistoryList()
+        if (isAdded) {
+            (activity as? DashboardActivity)?.refreshChatHistoryList()
+        }
     }
 
     private fun buildChatHistoryObject(query: String, chatResponse: String, responseBody: ChatModel): JsonObject =


### PR DESCRIPTION
## Summary
- prevent crash in `ChatDetailFragment` when saving chat by checking the fragment is added before calling `DashboardActivity.refreshChatHistoryList`
- sort imports in `ChatDetailFragment` to avoid duplication

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDefaultDebug`


------
https://chatgpt.com/codex/tasks/task_e_688271c281c4832ba47eb5424200982b