### PR TITLE
 Enabled minification

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled = false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled = true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         debug {
             minifyEnabled = false


### PR DESCRIPTION
app's release version isn't using Proguard/R8 (minifyEnabled = false). This makes it larger than necessary and, more critically, easier to reverse engineer, potentially exposing sensitive information.