### PR TITLE
Refactor courses sync into ViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -52,7 +52,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
 
     private val viewModel: CoursesViewModel by lazy {
         ViewModelProvider(
-            this,
+            viewModelStore,
             defaultViewModelProviderFactory,
             defaultViewModelCreationExtras
         )[CoursesViewModel::class.java]

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -17,7 +17,7 @@ import android.widget.TextView
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -50,7 +50,13 @@ import org.ole.planet.myplanet.utilities.SharedPrefManager
 @AndroidEntryPoint
 class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSelected, TagClickListener {
 
-    private val viewModel: CoursesViewModel by viewModels()
+    private val viewModel: CoursesViewModel by lazy {
+        ViewModelProvider(
+            this,
+            defaultViewModelProviderFactory,
+            defaultViewModelCreationExtras
+        )[CoursesViewModel::class.java]
+    }
 
     companion object {
         fun newInstance(isMyCourseLib: Boolean): CoursesFragment {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -48,7 +48,7 @@ import org.ole.planet.myplanet.utilities.SharedPrefManager
 @AndroidEntryPoint
 class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSelected, TagClickListener {
 
-    private val viewModel: CoursesViewModel by viewModels()
+    private val viewModel: CoursesViewModel by viewModels { defaultViewModelProviderFactory }
 
     companion object {
         fun newInstance(isMyCourseLib: Boolean): CoursesFragment {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -48,7 +48,7 @@ import org.ole.planet.myplanet.utilities.SharedPrefManager
 @AndroidEntryPoint
 class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSelected, TagClickListener {
 
-    private val viewModel: CoursesViewModel by viewModels { defaultViewModelProviderFactory }
+    private val viewModel: CoursesViewModel by viewModels()
 
     companion object {
         fun newInstance(isMyCourseLib: Boolean): CoursesFragment {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
@@ -1,0 +1,116 @@
+package org.ole.planet.myplanet.ui.courses
+
+import android.content.SharedPreferences
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.gson.JsonObject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.callback.SyncListener
+import org.ole.planet.myplanet.di.CourseRepository
+import org.ole.planet.myplanet.di.LibraryRepository
+import org.ole.planet.myplanet.di.UserRepository
+import org.ole.planet.myplanet.model.RealmCourseProgress.Companion.getCourseProgress
+import org.ole.planet.myplanet.model.RealmMyCourse
+import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmRating.Companion.getRatings
+import org.ole.planet.myplanet.service.SyncManager
+import org.ole.planet.myplanet.utilities.ServerUrlMapper
+import org.ole.planet.myplanet.utilities.SharedPrefManager
+
+@HiltViewModel
+class CoursesViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val libraryRepository: LibraryRepository,
+    private val courseRepository: CourseRepository,
+    private val syncManager: SyncManager,
+) : ViewModel() {
+
+    private val serverUrlMapper = ServerUrlMapper()
+
+    private val _courses = MutableStateFlow<List<RealmMyCourse>>(emptyList())
+    val courses: StateFlow<List<RealmMyCourse>> = _courses.asStateFlow()
+
+    private val _progressMap = MutableStateFlow<HashMap<String?, JsonObject>>(hashMapOf())
+    val progressMap: StateFlow<HashMap<String?, JsonObject>> = _progressMap.asStateFlow()
+
+    private val _ratingMap = MutableStateFlow<HashMap<String?, JsonObject>>(hashMapOf())
+    val ratingMap: StateFlow<HashMap<String?, JsonObject>> = _ratingMap.asStateFlow()
+
+    private val _libraryResources = MutableStateFlow<List<RealmMyLibrary>>(emptyList())
+    val libraryResources: StateFlow<List<RealmMyLibrary>> = _libraryResources.asStateFlow()
+
+    private val _isSyncing = MutableStateFlow(false)
+    val isSyncing: StateFlow<Boolean> = _isSyncing.asStateFlow()
+
+    private val _syncError = MutableStateFlow<String?>(null)
+    val syncError: StateFlow<String?> = _syncError.asStateFlow()
+
+    fun startCoursesSync(serverUrl: String, settings: SharedPreferences, prefManager: SharedPrefManager, isMyCourseLib: Boolean) {
+        val isFastSync = settings.getBoolean("fastSync", false)
+        if (isFastSync && !prefManager.isCoursesSynced()) {
+            checkServerAndStartSync(serverUrl, settings, prefManager, isMyCourseLib)
+        }
+    }
+
+    private fun checkServerAndStartSync(serverUrl: String, settings: SharedPreferences, prefManager: SharedPrefManager, isMyCourseLib: Boolean) {
+        val mapping = serverUrlMapper.processUrl(serverUrl)
+        viewModelScope.launch {
+            updateServerIfNecessary(mapping, settings)
+            startSyncManager(prefManager, isMyCourseLib)
+        }
+    }
+
+    private fun startSyncManager(prefManager: SharedPrefManager, isMyCourseLib: Boolean) {
+        syncManager.start(object : SyncListener {
+            override fun onSyncStarted() { _isSyncing.value = true }
+            override fun onSyncComplete() {
+                _isSyncing.value = false
+                prefManager.setCoursesSynced(true)
+                refreshCoursesData(isMyCourseLib)
+            }
+            override fun onSyncFailed(msg: String?) {
+                _isSyncing.value = false
+                _syncError.value = msg
+            }
+        }, "full", listOf("courses"))
+    }
+
+    private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping, settings: SharedPreferences) {
+        withContext(Dispatchers.IO) {
+            serverUrlMapper.updateServerIfNecessary(mapping, settings) { url ->
+                isServerReachable(url)
+            }
+        }
+    }
+
+    fun refreshCoursesData(isMyCourseLib: Boolean) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val realm = userRepository.getRealm()
+            val userId = userRepository.getCurrentUser()?.id
+            val rating = getRatings(realm, "course", userId)
+            val progress = getCourseProgress(realm, userId)
+            val courses = courseRepository.getAllCourses()
+            val sortedCourses = courses.sortedWith(compareBy({ it.isMyCourse }, { it.courseTitle }))
+            val libs = if (isMyCourseLib) {
+                val courseIds = courses.mapNotNull { it.id }
+                libraryRepository.getAllLibraryItems()
+                    .filter { !it.resourceOffline && it.resourceLocalAddress != null && it.courseId in courseIds }
+            } else emptyList()
+            withContext(Dispatchers.Main) {
+                _courses.value = sortedCourses
+                _ratingMap.value = rating
+                _progressMap.value = progress
+                if (isMyCourseLib) _libraryResources.value = libs
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- extract courses sync logic and progress calculation into `CoursesViewModel`
- update `CoursesFragment` to use the new ViewModel and observe state

## Testing
- `./gradlew test --no-daemon` *(fails: could not finish due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887d31dcfa4832bad23382f244dd982