### PR TITLE
Add TeamViewModel for team operations

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -36,7 +36,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private lateinit var fragmentTeamBinding: FragmentTeamBinding
     private lateinit var alertCreateTeamBinding: AlertCreateTeamBinding
     private lateinit var mRealm: Realm
-    private val teamViewModel: TeamViewModel by viewModels()
+    private val teamViewModel: TeamViewModel by viewModels { defaultViewModelProviderFactory }
     @Inject
     lateinit var databaseService: DatabaseService
     var type: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Case
@@ -36,7 +36,13 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private lateinit var fragmentTeamBinding: FragmentTeamBinding
     private lateinit var alertCreateTeamBinding: AlertCreateTeamBinding
     private lateinit var mRealm: Realm
-    private val teamViewModel: TeamViewModel by activityViewModels()
+    private val teamViewModel: TeamViewModel by lazy {
+        ViewModelProvider(
+            requireActivity(),
+            defaultViewModelProviderFactory,
+            requireActivity().defaultViewModelCreationExtras
+        )[TeamViewModel::class.java]
+    }
     @Inject
     lateinit var databaseService: DatabaseService
     var type: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -36,7 +36,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private lateinit var fragmentTeamBinding: FragmentTeamBinding
     private lateinit var alertCreateTeamBinding: AlertCreateTeamBinding
     private lateinit var mRealm: Realm
-    private val teamViewModel: TeamViewModel by viewModels { defaultViewModelProviderFactory }
+    private val teamViewModel: TeamViewModel by viewModels()
     @Inject
     lateinit var databaseService: DatabaseService
     var type: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Case
@@ -36,13 +36,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private lateinit var fragmentTeamBinding: FragmentTeamBinding
     private lateinit var alertCreateTeamBinding: AlertCreateTeamBinding
     private lateinit var mRealm: Realm
-    private val teamViewModel: TeamViewModel by lazy {
-        ViewModelProvider(
-            requireActivity(),
-            defaultViewModelProviderFactory,
-            requireActivity().defaultViewModelCreationExtras
-        )[TeamViewModel::class.java]
-    }
+    private val teamViewModel: TeamViewModel by viewModels()
     @Inject
     lateinit var databaseService: DatabaseService
     var type: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Case
@@ -36,7 +36,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private lateinit var fragmentTeamBinding: FragmentTeamBinding
     private lateinit var alertCreateTeamBinding: AlertCreateTeamBinding
     private lateinit var mRealm: Realm
-    private val teamViewModel: TeamViewModel by viewModels()
+    private val teamViewModel: TeamViewModel by activityViewModels()
     @Inject
     lateinit var databaseService: DatabaseService
     var type: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamViewModel.kt
@@ -1,0 +1,79 @@
+package org.ole.planet.myplanet.ui.team
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import io.realm.Realm
+import java.util.Date
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.utilities.AndroidDecrypter
+
+@HiltViewModel
+class TeamViewModel @Inject constructor(
+    private val databaseService: DatabaseService
+) : ViewModel() {
+
+    private val realm: Realm
+        get() = databaseService.realmInstance
+
+    fun createTeam(
+        currentUser: RealmUserModel,
+        name: String?,
+        fragmentType: String?,
+        teamType: String?,
+        details: Map<String, String>,
+        isPublic: Boolean
+    ) {
+        if (!realm.isInTransaction) realm.beginTransaction()
+        val teamId = AndroidDecrypter.generateIv()
+        val team = realm.createObject(RealmMyTeam::class.java, teamId)
+        team.status = "active"
+        team.createdDate = Date().time
+        if (fragmentType == "enterprise") {
+            team.type = "enterprise"
+            team.services = details["services"]
+            team.rules = details["rules"]
+        } else {
+            team.type = "team"
+            team.teamType = teamType
+        }
+        team.name = name
+        team.description = details["desc"]
+        team.createdBy = currentUser._id
+        team.teamId = ""
+        team.isPublic = isPublic
+        team.userId = currentUser.id
+        team.parentCode = currentUser.parentCode
+        team.teamPlanetCode = currentUser.planetCode
+        team.updated = true
+
+        val teamMemberObj = realm.createObject(RealmMyTeam::class.java, AndroidDecrypter.generateIv())
+        teamMemberObj.userId = currentUser._id
+        teamMemberObj.teamId = teamId
+        teamMemberObj.teamPlanetCode = currentUser.planetCode
+        teamMemberObj.userPlanetCode = currentUser.planetCode
+        teamMemberObj.docType = "membership"
+        teamMemberObj.isLeader = true
+        teamMemberObj.teamType = teamType
+        teamMemberObj.updated = true
+
+        realm.commitTransaction()
+    }
+
+    fun updateTeam(team: RealmMyTeam, name: String, details: Map<String, String>, userId: String?) {
+        val r = team.realm
+        if (!r.isInTransaction) {
+            r.beginTransaction()
+        }
+        team.name = name
+        team.services = details["services"]
+        team.rules = details["rules"]
+        team.limit = 12
+        team.description = details["desc"]
+        team.createdBy = userId
+        team.updated = true
+        r.commitTransaction()
+    }
+}


### PR DESCRIPTION
## Summary
- add `TeamViewModel` with `createTeam` and `updateTeam`
- use `TeamViewModel` in `TeamFragment`

## Testing
- `./gradlew test --no-daemon` *(fails: `kaptGenerateStubsDefaultReleaseKotlin`)*

------
https://chatgpt.com/codex/tasks/task_e_6887d8bb0a08832b8f6e8ef4832be4d3