### PR TITLE
Refactor realm writes off UI thread

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -5,6 +5,8 @@ import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.log.LogLevel
 import io.realm.log.RealmLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class DatabaseService(context: Context) {
     init {
@@ -14,17 +16,24 @@ class DatabaseService(context: Context) {
             .name(Realm.DEFAULT_REALM_NAME)
             .deleteRealmIfMigrationNeeded()
             .schemaVersion(4)
-            .allowWritesOnUiThread(true)
             .build()
         Realm.setDefaultConfiguration(config)
     }
 
     val realmInstance: Realm
         get() = Realm.getDefaultInstance()
-    
-    fun <T> withRealm(operation: (Realm) -> T): T {
+
+    fun <T> withRealmSync(operation: (Realm) -> T): T {
         return Realm.getDefaultInstance().use { realm ->
             operation(realm)
+        }
+    }
+
+    suspend fun <T> withRealm(operation: suspend (Realm) -> T): T {
+        return withContext(Dispatchers.IO) {
+            Realm.getDefaultInstance().use { realm ->
+                operation(realm)
+            }
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
@@ -32,7 +32,6 @@ object DatabaseModule {
             .name(Realm.DEFAULT_REALM_NAME)
             .deleteRealmIfMigrationNeeded()
             .schemaVersion(4)
-            .allowWritesOnUiThread(true)
             .build()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -289,12 +289,9 @@ open class RealmMyTeam : RealmObject() {
         private fun uploadTeamActivities(context: Context, uploadManager: UploadManager) {
             MainApplication.applicationScope.launch {
                 try {
-                    withContext(Dispatchers.IO) {
-                        uploadManager.uploadTeams()
-                    }
-                    withContext(Dispatchers.IO) {
-                        val apiInterface = client?.create(ApiInterface::class.java)
-                        val realm = DatabaseService(context).realmInstance
+                    withContext(Dispatchers.IO) { uploadManager.uploadTeams() }
+                    val apiInterface = client?.create(ApiInterface::class.java)
+                    DatabaseService(context).withRealm { realm ->
                         realm.executeTransaction { transactionRealm ->
                             uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
                         }

--- a/app/src/main/java/org/ole/planet/myplanet/service/TaskNotificationWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/TaskNotificationWorker.kt
@@ -12,24 +12,25 @@ import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 
 class TaskNotificationWorker(private val context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
     override fun doWork(): Result {
-        val mRealm = DatabaseService(context).realmInstance
-        val current = Calendar.getInstance().timeInMillis
-        val tomorrow = Calendar.getInstance()
-        tomorrow.add(Calendar.DAY_OF_YEAR, 1)
-        val user = UserProfileDbHandler(context).userModel
-        if (user != null) {
-            val tasks: List<RealmTeamTask> = mRealm.where(RealmTeamTask::class.java)
-                .equalTo("completed", false)
-                .equalTo("assignee", user.id)
-                .equalTo("isNotified", false)
-                .between("deadline", current, tomorrow.timeInMillis)
-                .findAll()
-            mRealm.beginTransaction()
-            for (`in` in tasks) {
-                create(context, R.drawable.ole_logo, `in`.title, "Task expires on " + formatDate(`in`.deadline, ""))
-                `in`.isNotified = true
+        DatabaseService(context).withRealmSync { mRealm ->
+            val current = Calendar.getInstance().timeInMillis
+            val tomorrow = Calendar.getInstance()
+            tomorrow.add(Calendar.DAY_OF_YEAR, 1)
+            val user = UserProfileDbHandler(context).userModel
+            if (user != null) {
+                val tasks: List<RealmTeamTask> = mRealm.where(RealmTeamTask::class.java)
+                    .equalTo("completed", false)
+                    .equalTo("assignee", user.id)
+                    .equalTo("isNotified", false)
+                    .between("deadline", current, tomorrow.timeInMillis)
+                    .findAll()
+                mRealm.executeTransaction { realm ->
+                    for (task in tasks) {
+                        create(context, R.drawable.ole_logo, task.title, "Task expires on " + formatDate(task.deadline, ""))
+                        task.isNotified = true
+                    }
+                }
             }
-            mRealm.commitTransaction()
         }
         return Result.success()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/NotificationUtil.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/NotificationUtil.kt
@@ -502,17 +502,15 @@ class NotificationActionReceiver : BroadcastReceiver() {
         if (notificationId == null) return
 
         try {
-            val realm = databaseService.realmInstance
-            
-            realm.executeTransaction { r ->
-                val notification = r.where(RealmNotification::class.java)
-                    .contains("id", notificationId)
-                    .findFirst()
-                
-                notification?.isRead = true
+            databaseService.withRealmSync { realm ->
+                realm.executeTransaction { r ->
+                    val notification = r.where(RealmNotification::class.java)
+                        .contains("id", notificationId)
+                        .findFirst()
+
+                    notification?.isRead = true
+                }
             }
-            
-            realm.close()
         } catch (e: Exception) {
             e.printStackTrace()
         }


### PR DESCRIPTION
## Summary
- remove `.allowWritesOnUiThread(true)` from Realm configuration
- add suspend `withRealm` helper and sync `withRealmSync`
- move some writes to the new helpers

## Testing
- `./gradlew --version`
- `./gradlew tasks --all` *(failed: Calculating task graph)*

------
https://chatgpt.com/codex/tasks/task_e_6887d80cb67c832bb386b86366141364