### PR TITLE
Make Realm access suspendable

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -6,6 +6,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.realm.Realm
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Singleton
 import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
@@ -50,8 +52,8 @@ object RepositoryModule {
 interface UserRepository {
     suspend fun getUserProfile(): String?
     suspend fun saveUserData(data: String)
-    fun getRealm(): Realm
-    fun getCurrentUser(): RealmUserModel?
+    suspend fun getRealm(): Realm
+    suspend fun getCurrentUser(): RealmUserModel?
 }
 
 class UserRepositoryImpl(
@@ -68,12 +70,16 @@ class UserRepositoryImpl(
         preferences.edit().putString("user_profile", data).apply()
     }
 
-    override fun getRealm(): Realm {
-        return databaseService.realmInstance
+    override suspend fun getRealm(): Realm {
+        return withContext(Dispatchers.IO) {
+            databaseService.realmInstance
+        }
     }
 
-    override fun getCurrentUser(): RealmUserModel? {
-        return databaseService.realmInstance.where(RealmUserModel::class.java).findFirst()
+    override suspend fun getCurrentUser(): RealmUserModel? {
+        return withContext(Dispatchers.IO) {
+            databaseService.realmInstance.where(RealmUserModel::class.java).findFirst()
+        }
     }
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -514,9 +514,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                         newNotifications.addAll(createdNotifications)
                     }
 
-                    unreadCount = runBlocking {
-                        dashboardViewModel.getUnreadNotificationsSize(userId)
-                    }
+                    unreadCount = dashboardViewModel.getUnreadNotificationsSize(userId)
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -542,7 +540,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     private fun createNotifications(realm: Realm, userId: String?): List<NotificationUtil.NotificationConfig> {
         val newNotifications = mutableListOf<NotificationUtil.NotificationConfig>()
 
-        lifecycleScope.launch {
+        lifecycleScope.launch(Dispatchers.IO) {
             dashboardViewModel.updateResourceNotification(userId)
         }
 
@@ -556,7 +554,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
     private fun createSurveyNotifications(realm: Realm, userId: String?): List<NotificationUtil.NotificationConfig> {
         val newNotifications = mutableListOf<NotificationUtil.NotificationConfig>()
-        val pendingSurveys = runBlocking {
+        val pendingSurveys = runBlocking(Dispatchers.IO) {
             dashboardViewModel.getPendingSurveys(userId)
         }
         val surveyTitles = dashboardViewModel.getSurveyTitlesFromSubmissions(realm, pendingSurveys)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -46,6 +46,7 @@ import kotlin.math.ceil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.ole.planet.myplanet.BuildConfig
 import org.ole.planet.myplanet.MainApplication
@@ -513,7 +514,9 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                         newNotifications.addAll(createdNotifications)
                     }
 
-                    unreadCount = dashboardViewModel.getUnreadNotificationsSize(backgroundRealm, userId)
+                    unreadCount = runBlocking {
+                        dashboardViewModel.getUnreadNotificationsSize(userId)
+                    }
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -539,7 +542,9 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     private fun createNotifications(realm: Realm, userId: String?): List<NotificationUtil.NotificationConfig> {
         val newNotifications = mutableListOf<NotificationUtil.NotificationConfig>()
 
-        dashboardViewModel.updateResourceNotification(realm, userId)
+        lifecycleScope.launch {
+            dashboardViewModel.updateResourceNotification(userId)
+        }
 
         newNotifications.addAll(createSurveyNotifications(realm, userId))
         newNotifications.addAll(createTaskNotifications(realm, userId))
@@ -551,7 +556,9 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
     private fun createSurveyNotifications(realm: Realm, userId: String?): List<NotificationUtil.NotificationConfig> {
         val newNotifications = mutableListOf<NotificationUtil.NotificationConfig>()
-        val pendingSurveys = dashboardViewModel.getPendingSurveys(realm, userId)
+        val pendingSurveys = runBlocking {
+            dashboardViewModel.getPendingSurveys(userId)
+        }
         val surveyTitles = dashboardViewModel.getSurveyTitlesFromSubmissions(realm, pendingSurveys)
 
         surveyTitles.forEach { title ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -18,6 +18,7 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import io.realm.Realm
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
@@ -48,7 +49,7 @@ class DashboardViewModel @Inject constructor(
         return total.coerceAtMost(11)
     }
 
-    suspend fun updateResourceNotification(userId: String?) {
+    suspend fun updateResourceNotification(userId: String?) = withContext(Dispatchers.IO) {
         val realm = userRepository.getRealm()
         val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
         if (resourceCount > 0) {
@@ -89,9 +90,9 @@ class DashboardViewModel @Inject constructor(
         }
     }
 
-    suspend fun getPendingSurveys(userId: String?): List<RealmSubmission> {
+    suspend fun getPendingSurveys(userId: String?): List<RealmSubmission> = withContext(Dispatchers.IO) {
         val realm = userRepository.getRealm()
-        return realm.where(RealmSubmission::class.java)
+        realm.where(RealmSubmission::class.java)
             .equalTo("userId", userId)
             .equalTo("type", "survey")
             .equalTo("status", "pending", Case.INSENSITIVE)
@@ -110,9 +111,9 @@ class DashboardViewModel @Inject constructor(
         return titles
     }
 
-    suspend fun getUnreadNotificationsSize(userId: String?): Int {
+    suspend fun getUnreadNotificationsSize(userId: String?): Int = withContext(Dispatchers.IO) {
         val realm = userRepository.getRealm()
-        return realm.where(RealmNotification::class.java)
+        realm.where(RealmNotification::class.java)
             .equalTo("userId", userId)
             .equalTo("isRead", false)
             .count()


### PR DESCRIPTION
## Summary
- update `UserRepository` to expose suspend functions
- run Realm operations via `Dispatchers.IO`
- call suspend repository methods in `DashboardViewModel`
- adapt dashboard activity to invoke updated suspend functions

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6887d503eed8832b9b8c5b3ed68cc8bb