### PR TITLE
Use async Realm writes

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -97,7 +97,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                 val realm = Realm.getDefaultInstance()
                 val settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
                 try {
-                    realm.executeTransaction { r ->
+                    realm.executeTransactionAsync { r ->
                         val log = r.createObject(RealmApkLog::class.java, "${UUID.randomUUID()}")
                         val model = UserProfileDbHandler(context).userModel
                         log.parentCode = settings.getString("parentCode", "")

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -14,7 +14,6 @@ class DatabaseService(context: Context) {
             .name(Realm.DEFAULT_REALM_NAME)
             .deleteRealmIfMigrationNeeded()
             .schemaVersion(4)
-            .allowWritesOnUiThread(true)
             .build()
         Realm.setDefaultConfiguration(config)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -310,7 +310,7 @@ class Service @Inject constructor(
                     Executors.newSingleThreadExecutor().execute {
                         Realm.getDefaultInstance().use { backgroundRealm ->
                             try {
-                                backgroundRealm.executeTransaction { realm1 ->
+                                backgroundRealm.executeTransactionAsync { realm1 ->
                                     realm1.delete(RealmCommunity::class.java)
                                     for (j in arr) {
                                         var jsonDoc = j.asJsonObject

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseActivity.kt
@@ -29,7 +29,7 @@ open class RealmCourseActivity : RealmObject() {
             withContext(Dispatchers.IO) {
                 try {
                     if (!realm.isInTransaction) {
-                        realm.executeTransaction { realmInstance ->
+                        realm.executeTransactionAsync { realmInstance ->
                             val activity = realmInstance.createObject(RealmCourseActivity::class.java, UUID.randomUUID().toString())
                             activity.type = "visit"
                             activity.title = course?.courseTitle

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
@@ -193,7 +193,7 @@ open class RealmMyLibrary : RealmObject() {
         fun removeDeletedResource(newIds: List<String?>, mRealm: Realm) {
             val ids = getIds(mRealm)
             ids.filterNot { it in newIds }.forEach { id ->
-                mRealm.executeTransaction { realm ->
+                mRealm.executeTransactionAsync { realm ->
                     realm.where(RealmMyLibrary::class.java).equalTo("resourceId", id).findAll()
                         .deleteAllFromRealm()
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLife.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLife.kt
@@ -42,7 +42,7 @@ open class RealmMyLife : RealmObject {
             executor.execute {
                 val backgroundRealm = Realm.getDefaultInstance()
                 try {
-                    backgroundRealm.executeTransaction { mRealm ->
+                    backgroundRealm.executeTransactionAsync { mRealm ->
                         val targetItem = mRealm.where(RealmMyLife::class.java).equalTo("_id", id)
                             .findFirst()
 
@@ -70,7 +70,7 @@ open class RealmMyLife : RealmObject {
             executor.execute {
                 val backgroundRealm = Realm.getDefaultInstance()
                 try {
-                    backgroundRealm.executeTransaction { mRealm ->
+                    backgroundRealm.executeTransactionAsync { mRealm ->
                         mRealm.where(RealmMyLife::class.java).equalTo("_id", id).findFirst()
                             ?.isVisible = isVisible
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -295,7 +295,7 @@ open class RealmMyTeam : RealmObject() {
                     withContext(Dispatchers.IO) {
                         val apiInterface = client?.create(ApiInterface::class.java)
                         val realm = DatabaseService(context).realmInstance
-                        realm.executeTransaction { transactionRealm ->
+                        realm.executeTransactionAsync { transactionRealm ->
                             uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
                         }
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
@@ -75,7 +75,7 @@ open class RealmStepExam : RealmObject() {
             if (isInTransaction) {
                 performInsert()
             } else {
-                mRealm.executeTransaction { performInsert() }
+                mRealm.executeTransactionAsync { performInsert() }
             }
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmUserChallengeActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmUserChallengeActions.kt
@@ -15,7 +15,7 @@ open class RealmUserChallengeActions : RealmObject() {
 
     companion object {
         fun createAction(realm: Realm, userId: String, resourceId: String?, actionType: String) {
-            realm.executeTransaction { transactionRealm ->
+            realm.executeTransactionAsync { transactionRealm ->
                 val action = transactionRealm.createObject(
                     RealmUserChallengeActions::class.java, UUID.randomUUID().toString()
                 )

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
@@ -215,7 +215,7 @@ open class RealmUserModel : RealmObject() {
                 var user: RealmUserModel? = null
 
                 if (!mRealm.isInTransaction) {
-                    mRealm.executeTransaction { realm ->
+                    mRealm.executeTransactionAsync { realm ->
                         user = realm.where(RealmUserModel::class.java)
                             .equalTo("_id", id)
                             .findFirst()
@@ -471,7 +471,7 @@ open class RealmUserModel : RealmObject() {
 
         @JvmStatic
         fun cleanupDuplicateUsers(realm: Realm) {
-            realm.executeTransaction { mRealm ->
+            realm.executeTransactionAsync { mRealm ->
                 val allUsers = mRealm.where(RealmUserModel::class.java).findAll()
                 val usersByName = allUsers.groupBy { it.name }
 

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -640,7 +640,7 @@ class SyncManager @Inject constructor(
 
                             val savedIds = mutableListOf<String>()
                             for ((_, chunk) in chunks.withIndex()) {
-                                realmInstance.executeTransaction { realm ->
+                                realmInstance.executeTransactionAsync { realm ->
                                     val chunkDocuments = JsonArray()
                                     chunk.forEach { (doc, _) -> chunkDocuments.add(doc) }
 
@@ -667,7 +667,7 @@ class SyncManager @Inject constructor(
 
                             for ((doc, _) in validDocuments) {
                                 try {
-                                    realmInstance.executeTransaction { realm ->
+                                    realmInstance.executeTransactionAsync { realm ->
                                         val singleDocArray = JsonArray()
                                         singleDocArray.add(doc)
                                         val singleIds = save(singleDocArray, realm)
@@ -756,7 +756,7 @@ class SyncManager @Inject constructor(
             }
 
             safeRealmOperation { realmInstance ->
-                realmInstance.executeTransaction { realm ->
+                realmInstance.executeTransactionAsync { realm ->
                     removeDeletedResource(newIds.toList(), realm)
                 }
             }
@@ -803,7 +803,7 @@ class SyncManager @Inject constructor(
             if (validDocs.isEmpty()) return 0
 
             safeRealmOperation { realmInstance ->
-                realmInstance.executeTransaction { realm ->
+                realmInstance.executeTransactionAsync { realm ->
                     val bulkArray = JsonArray()
                     validDocs.forEach { doc -> bulkArray.add(doc) }
 
@@ -1055,7 +1055,7 @@ class SyncManager @Inject constructor(
 
                 if (documentsToProcess.isNotEmpty()) {
                     safeRealmOperation { realm ->
-                        realm.executeTransaction { realmTx ->
+                        realm.executeTransactionAsync { realmTx ->
                             documentsToProcess.forEach { doc ->
                                 try {
                                     when (shelfData.type) {
@@ -1237,7 +1237,7 @@ class SyncManager @Inject constructor(
             }
 
             if (documentsToProcess.isNotEmpty()) {
-                realmInstance.executeTransaction { realm ->
+                realmInstance.executeTransactionAsync { realm ->
                     documentsToProcess.forEach { doc ->
                         try {
                             when (shelfData.type) {

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
@@ -663,7 +663,7 @@ class UploadManager @Inject constructor(
                     uploadCrashLogData(realm, apiInterface)
                 }
             } else {
-                realm.executeTransaction { realm: Realm ->
+                realm.executeTransactionAsync { realm: Realm ->
                     uploadCrashLogData(realm, apiInterface)
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -483,7 +483,7 @@ class ChatDetailFragment : Fragment() {
     private fun saveNewChat(query: String, chatResponse: String, responseBody: ChatModel) {
         val jsonObject = buildChatHistoryObject(query, chatResponse, responseBody)
 
-        mRealm.executeTransaction { realm ->
+        mRealm.executeTransactionAsync { realm ->
             RealmChatHistory.insert(realm, jsonObject)
         }
         (requireActivity() as? DashboardActivity)?.refreshChatHistoryList()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
@@ -85,7 +85,7 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
                 return@setOnClickListener
             }
 
-            mRealm.executeTransaction {
+            mRealm.executeTransactionAsync {
                 val team = it.createObject(RealmMyTeam::class.java, UUID.randomUUID().toString())
                 team.docType = "link"
                 team.updated = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -508,7 +508,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
             try {
                 databaseService.realmInstance.use { backgroundRealm ->
-                    backgroundRealm.executeTransaction { realm ->
+                    backgroundRealm.executeTransactionAsync { realm ->
                         val createdNotifications = createNotifications(realm, userId)
                         newNotifications.addAll(createdNotifications)
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -195,7 +195,7 @@ class NotificationsFragment : Fragment() {
 
     private fun markAsRead(position: Int) {
         val notification = adapter.notificationList[position]
-        mRealm.executeTransaction {
+        mRealm.executeTransactionAsync {
             notification.isRead = true
         }
         adapter.notifyItemChanged(position)
@@ -204,7 +204,7 @@ class NotificationsFragment : Fragment() {
     }
 
     private fun markAllAsRead() {
-        mRealm.executeTransaction { realm ->
+        mRealm.executeTransactionAsync { realm ->
             realm.where(RealmNotification::class.java)
                 .equalTo("userId", userId)
                 .equalTo("isRead", false)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterReports.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterReports.kt
@@ -169,7 +169,7 @@ class AdapterReports(private val context: Context, private var list: RealmResult
                     .setMessage(R.string.delete_record)
                     .setPositiveButton(R.string.ok) { _, _ ->
                         Realm.getDefaultInstance().use { realm ->
-                            realm.executeTransaction { realmTx ->
+                            realm.executeTransactionAsync { realmTx ->
                                 realmTx.where(RealmMyTeam::class.java)
                                     .equalTo("_id", reportId)
                                     .findFirst()?.apply {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamSubmissionUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamSubmissionUtils.kt
@@ -22,7 +22,7 @@ object ExamSubmissionUtils {
         total: Int
     ): Boolean {
         var isCorrect = true
-        realm.executeTransaction { r ->
+        realm.executeTransactionAsync { r ->
             val answer = createOrRetrieveAnswer(r, submission, question)
             populateAnswer(answer, question, ans, listAns, otherText, otherVisible)
             if (type == "exam") {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
@@ -162,7 +162,7 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
     }
 
     private fun createSubmission() {
-        mRealm.executeTransaction { realm ->
+        mRealm.executeTransactionAsync { realm ->
             sub = createSubmission(null, realm)
             setParentId()
             sub?.userId = user?.id

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mymeetup/MyMeetupDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mymeetup/MyMeetupDetailFragment.kt
@@ -94,7 +94,7 @@ class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
     }
 
     private fun leaveJoinMeetUp() {
-        mRealm.executeTransaction {
+        mRealm.executeTransactionAsync {
             if (meetups?.userId?.isEmpty() == true) {
                 meetups?.userId = user?.id
                 fragmentMyMeetupDetailBinding.btnLeave.setText(R.string.leave)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
@@ -222,7 +222,7 @@ class AdapterSurvey(
 
             val adoptionId = "${UUID.randomUUID()}"
 
-            mRealm.executeTransaction { realm ->
+            mRealm.executeTransactionAsync { realm ->
                 val existingAdoption = realm.where(RealmSubmission::class.java)
                     .equalTo("userId", userModel?.id)
                     .equalTo("parentId", exam.id)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -850,7 +850,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
             withContext(Dispatchers.IO) {
                 val realm = Realm.getDefaultInstance()
                 try {
-                    realm.executeTransaction { transactionRealm ->
+                    realm.executeTransactionAsync { transactionRealm ->
                         transactionRealm.deleteAll()
                     }
                 } finally {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/PlanFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/PlanFragment.kt
@@ -105,7 +105,7 @@ class PlanFragment : BaseTeamFragment() {
         }
 
         val userId = UserProfileDbHandler(activity).userModel?._id
-        realm.executeTransaction {
+        realm.executeTransactionAsync {
             team.name = name
             team.services = binding.etServices.text.toString()
             team.rules = binding.etRules.text.toString()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -314,7 +314,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
         CoroutineScope(Dispatchers.IO).launch {
             val realm = databaseService.realmInstance
 
-            realm.executeTransaction { r ->
+            realm.executeTransactionAsync { r ->
                 val log = r.createObject(RealmTeamLog::class.java, "${UUID.randomUUID()}")
                 log.teamId = getEffectiveTeamId()
                 log.user = userName

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.kt
@@ -209,7 +209,7 @@ class AdapterJoinedMember(
     }
 
     private fun makeLeader(userModel: RealmUserModel) {
-        mRealm.executeTransaction { realm ->
+        mRealm.executeTransactionAsync { realm ->
             val currentLeader = realm.where(RealmMyTeam::class.java)
                 .equalTo("teamId", teamId)
                 .equalTo("isLeader", true)
@@ -228,7 +228,7 @@ class AdapterJoinedMember(
     }
 
     private fun reject(userModel: RealmUserModel, position: Int) {
-        mRealm.executeTransaction {
+        mRealm.executeTransactionAsync {
             val team = it.where(RealmMyTeam::class.java)
                 .equalTo("teamId", teamId)
                 .equalTo("userId", userModel.id)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamResource/AdapterTeamResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamResource/AdapterTeamResource.kt
@@ -72,7 +72,7 @@ class AdapterTeamResource(
             .findFirst()
 
         if (itemToDelete != null) {
-            mRealm.executeTransaction {
+            mRealm.executeTransactionAsync {
                 itemToDelete.resourceId = ""
                 itemToDelete.updated = true
             }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DownloadUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DownloadUtils.kt
@@ -157,7 +157,7 @@ object DownloadUtils {
         try {
             val backgroundRealm = Realm.getDefaultInstance()
             backgroundRealm.use { realm ->
-                realm.executeTransaction {
+                realm.executeTransactionAsync {
                     realm.where(RealmMyLibrary::class.java)
                         .equalTo("resourceLocalAddress", currentFileName)
                         .findAll()?.forEach {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/NotificationUtil.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/NotificationUtil.kt
@@ -504,7 +504,7 @@ class NotificationActionReceiver : BroadcastReceiver() {
         try {
             val realm = databaseService.realmInstance
             
-            realm.executeTransaction { r ->
+            realm.executeTransactionAsync { r ->
                 val notification = r.where(RealmNotification::class.java)
                     .contains("id", notificationId)
                     .findFirst()


### PR DESCRIPTION
## Summary
- swap synchronous Realm transactions for `executeTransactionAsync` throughout the project
- drop `allowWritesOnUiThread(true)` from `DatabaseService`

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug -x lint -x test` *(failed: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688918d7ec7c8329856cb1069810f762