### PR TITLE
Secure login prefs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -187,6 +187,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation "androidx.core:core-ktx:1.16.0"
+    implementation "androidx.security:security-crypto:1.1.0-alpha06"
     implementation "androidx.work:work-runtime:2.10.2"
     implementation "androidx.slidingpanelayout:slidingpanelayout:1.2.0"
     implementation 'androidx.preference:preference-ktx:1.2.1'

--- a/app/src/main/java/org/ole/planet/myplanet/service/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/TransactionSyncManager.kt
@@ -25,6 +25,7 @@ import org.ole.planet.myplanet.utilities.JsonUtils.getJsonArray
 import org.ole.planet.myplanet.utilities.JsonUtils.getJsonObject
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
 import org.ole.planet.myplanet.utilities.Utilities
+import org.ole.planet.myplanet.utilities.SecurePrefs
 import retrofit2.Response
 
 object TransactionSyncManager {
@@ -43,8 +44,8 @@ object TransactionSyncManager {
 
     fun syncAllHealthData(mRealm: Realm, settings: SharedPreferences, listener: SyncListener) {
         listener.onSyncStarted()
-        val userName = settings.getString("loginUserName", "")
-        val password = settings.getString("loginUserPassword", "")
+        val userName = SecurePrefs.getUserName(MainApplication.context, settings) ?: ""
+        val password = SecurePrefs.getPassword(MainApplication.context, settings) ?: ""
         val header = "Basic ${Base64.encodeToString("$userName:$password".toByteArray(), Base64.NO_WRAP)}"
         mRealm.executeTransactionAsync({ realm: Realm ->
             val users = realm.where(RealmUserModel::class.java).isNotEmpty("_id").findAll()
@@ -78,8 +79,8 @@ object TransactionSyncManager {
     fun syncKeyIv(mRealm: Realm, settings: SharedPreferences, listener: SyncListener) {
         listener.onSyncStarted()
         val model = UserProfileDbHandler(MainApplication.context).userModel
-        val userName = settings.getString("loginUserName", "")
-        val password = settings.getString("loginUserPassword", "")
+        val userName = SecurePrefs.getUserName(MainApplication.context, settings) ?: ""
+        val password = SecurePrefs.getPassword(MainApplication.context, settings) ?: ""
 //        val table = "userdb-" + model?.planetCode?.let { Utilities.toHex(it) } + "-" + model?.name?.let { Utilities.toHex(it) }
         val header = "Basic " + Base64.encodeToString("$userName:$password".toByteArray(), Base64.NO_WRAP)
         val id = model?.id

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadToShelfService.kt
@@ -29,6 +29,7 @@ import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.removedIds
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.utilities.AndroidDecrypter.Companion.generateIv
 import org.ole.planet.myplanet.utilities.AndroidDecrypter.Companion.generateKey
+import org.ole.planet.myplanet.utilities.SecurePrefs
 import org.ole.planet.myplanet.utilities.JsonUtils.getJsonArray
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
 import org.ole.planet.myplanet.utilities.RetryUtils
@@ -54,7 +55,7 @@ class UploadToShelfService @Inject constructor(
             if (userModels.isEmpty()) {
                 return@executeTransactionAsync
             }
-            val password = sharedPreferences.getString("loginUserPassword", "")
+            val password = SecurePrefs.getPassword(context, sharedPreferences) ?: ""
             userModels.forEachIndexed { index, model ->
                 try {
                     val header = "Basic ${Base64.encodeToString(("${model.name}:${password}").toByteArray(), Base64.NO_WRAP)}"
@@ -91,7 +92,7 @@ class UploadToShelfService @Inject constructor(
 
             if (userModel != null) {
                 try {
-                    val password = sharedPreferences.getString("loginUserPassword", "")
+                    val password = SecurePrefs.getPassword(context, sharedPreferences) ?: ""
                     val header = "Basic ${Base64.encodeToString(("${userModel.name}:${password}").toByteArray(), Base64.NO_WRAP)}"
 
                     val userExists = checkIfUserExists(apiInterface, header, userModel)
@@ -142,7 +143,7 @@ class UploadToShelfService @Inject constructor(
 
     private fun processUserAfterCreation(apiInterface: ApiInterface?, realm: Realm, model: RealmUserModel, obj: JsonObject) {
         try {
-            val password = sharedPreferences.getString("loginUserPassword", "")
+            val password = SecurePrefs.getPassword(context, sharedPreferences) ?: ""
             val header = "Basic ${Base64.encodeToString(("${model.name}:${password}").toByteArray(), Base64.NO_WRAP)}"
             val fetchDataResponse = apiInterface?.getJsonObject(header, "${replacedUrl(model)}/_users/${model._id}")?.execute()
             if (fetchDataResponse?.isSuccessful == true) {
@@ -190,7 +191,7 @@ class UploadToShelfService @Inject constructor(
 
     private fun replacedUrl(model: RealmUserModel): String {
         val url = Utilities.getUrl()
-        val password = sharedPreferences.getString("loginUserPassword", "")
+        val password = SecurePrefs.getPassword(context, sharedPreferences) ?: ""
         val replacedUrl = url.replaceFirst("[^:]+:[^@]+@".toRegex(), "${model.name}:${password}@")
         val protocolIndex = url.indexOf("://")
         val protocol = url.substring(0, protocolIndex)

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/AuthHelper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/AuthHelper.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.utilities
 import android.content.Context
 import android.widget.Toast
 import androidx.core.content.edit
+import org.ole.planet.myplanet.utilities.SecurePrefs
 import io.realm.Realm
 import java.text.Normalizer
 import java.util.regex.Pattern
@@ -51,10 +52,7 @@ object AuthHelper {
         if (activity.forceSyncTrigger()) return
 
         val settings = activity.settings
-        settings.edit {
-            putString("loginUserName", name)
-            putString("loginUserPassword", password)
-        }
+        SecurePrefs.saveCredentials(activity, settings, name, password)
 
         val isLoggedIn = activity.authenticateUser(settings, name, password, false)
         if (isLoggedIn) {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/SecurePrefs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/SecurePrefs.kt
@@ -1,0 +1,67 @@
+package org.ole.planet.myplanet.utilities
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+object SecurePrefs {
+    private const val FILE_NAME = "secure_prefs"
+
+    private fun prefs(context: Context): SharedPreferences {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        return EncryptedSharedPreferences.create(
+            context,
+            FILE_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    fun saveCredentials(
+        context: Context,
+        plainPrefs: SharedPreferences,
+        username: String?,
+        password: String?
+    ) {
+        val enc = prefs(context)
+        enc.edit {
+            putString("loginUserName", username)
+            putString("loginUserPassword", password)
+        }
+        plainPrefs.edit {
+            remove("loginUserName")
+            remove("loginUserPassword")
+        }
+    }
+
+    fun getUserName(context: Context, plainPrefs: SharedPreferences): String? {
+        val enc = prefs(context)
+        var name = enc.getString("loginUserName", null)
+        if (name.isNullOrEmpty()) {
+            name = plainPrefs.getString("loginUserName", null)
+            if (!name.isNullOrEmpty()) {
+                enc.edit { putString("loginUserName", name) }
+                plainPrefs.edit { remove("loginUserName") }
+            }
+        }
+        return name
+    }
+
+    fun getPassword(context: Context, plainPrefs: SharedPreferences): String? {
+        val enc = prefs(context)
+        var pwd = enc.getString("loginUserPassword", null)
+        if (pwd.isNullOrEmpty()) {
+            pwd = plainPrefs.getString("loginUserPassword", null)
+            if (!pwd.isNullOrEmpty()) {
+                enc.edit { putString("loginUserPassword", pwd) }
+                plainPrefs.edit { remove("loginUserPassword") }
+            }
+        }
+        return pwd
+    }
+}


### PR DESCRIPTION
## Summary
- add Jetpack Security dependency
- store login credentials using `EncryptedSharedPreferences`
- migrate plaintext `loginUserName` and `loginUserPassword` to encrypted storage

## Testing
- `./gradlew assembleDebug --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688a60199b40832bbd1913fe556179d5