### PR TITLE
Rename survey sort functions

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
@@ -56,19 +56,19 @@ class AdapterSurvey(
     }
 
     fun updateDataAfterSearch(newList: List<RealmStepExam>) {
-        if(examList.isEmpty()){
-            SortSurveyList(false, newList)
-        } else{
-            when (sortType){
-                SurveySortType.DATE_DESC -> SortSurveyList(false, newList)
-                SurveySortType.DATE_ASC ->  SortSurveyList(true, newList)
-                SurveySortType.TITLE -> SortSurveyListByName(isTitleAscending, newList)
+        if (examList.isEmpty()) {
+            sortSurveyList(false, newList)
+        } else {
+            when (sortType) {
+                SurveySortType.DATE_DESC -> sortSurveyList(false, newList)
+                SurveySortType.DATE_ASC -> sortSurveyList(true, newList)
+                SurveySortType.TITLE -> sortSurveyListByName(isTitleAscending, newList)
             }
         }
         notifyDataSetChanged()
     }
 
-    private fun SortSurveyList(isAscend: Boolean, list: List<RealmStepExam> = examList){
+    private fun sortSurveyList(isAscend: Boolean, list: List<RealmStepExam> = examList) {
         val list = list.toList()
         Collections.sort(list) { survey1, survey2 ->
             if (isAscend) {
@@ -80,13 +80,13 @@ class AdapterSurvey(
         examList = list
     }
 
-    fun SortByDate(isAscend: Boolean){
+    fun sortByDate(isAscend: Boolean) {
         sortType = if (isAscend) SurveySortType.DATE_DESC else SurveySortType.DATE_ASC
-        SortSurveyList(isAscend)
+        sortSurveyList(isAscend)
         notifyDataSetChanged()
     }
 
-    private fun SortSurveyListByName(isAscend: Boolean, list: List<RealmStepExam> = examList){
+    private fun sortSurveyListByName(isAscend: Boolean, list: List<RealmStepExam> = examList) {
         examList = if (isAscend) {
             list.sortedBy { it.name?.lowercase() }
         } else {
@@ -97,7 +97,7 @@ class AdapterSurvey(
     fun toggleTitleSortOrder() {
         sortType = SurveySortType.TITLE
         isTitleAscending = !isTitleAscending
-        SortSurveyListByName(isTitleAscending)
+        sortSurveyListByName(isTitleAscending)
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
@@ -184,8 +184,8 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), SurveyAdoptListen
         spn.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(adapterView: AdapterView<*>?, view: View?, i: Int, l: Long) {
                 when (i) {
-                    0 -> adapter.SortByDate(false)
-                    1 -> adapter.SortByDate(true)
+                    0 -> adapter.sortByDate(false)
+                    1 -> adapter.sortByDate(true)
                     2 -> adapter.toggleTitleSortOrder()
                 }
             }


### PR DESCRIPTION
## Summary
- rename sorting methods in `AdapterSurvey`
- update calls in `SurveyFragment`

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_688bd50904ec832bb9841a2ea35ea794