### PR TITLE
all: smoother realm initialization (fixes #6562)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2771
-        versionName = "0.27.71"
+        versionCode = 2780
+        versionName = "0.27.80"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -94,9 +94,8 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
 
         fun createLog(type: String, error: String = "") {
             applicationScope.launch(Dispatchers.IO) {
-                val realm = Realm.getDefaultInstance()
                 val settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-                try {
+                service.withRealm { realm ->
                     realm.executeTransaction { r ->
                         val log = r.createObject(RealmApkLog::class.java, "${UUID.randomUUID()}")
                         val model = UserProfileDbHandler(context).userModel
@@ -111,10 +110,6 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                             log.error = error
                         }
                     }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                } finally {
-                    realm.close()
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -308,7 +308,7 @@ class Service @Inject constructor(
                     val arr = JsonUtils.getJsonArray("rows", response.body())
 
                     Executors.newSingleThreadExecutor().execute {
-                        Realm.getDefaultInstance().use { backgroundRealm ->
+                        MainApplication.service.withRealm { backgroundRealm ->
                             try {
                                 backgroundRealm.executeTransaction { realm1 ->
                                     realm1.delete(RealmCommunity::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
@@ -6,10 +6,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import io.realm.Realm
-import io.realm.RealmConfiguration
-import io.realm.log.LogLevel
-import io.realm.log.RealmLog
 import javax.inject.Singleton
 import org.ole.planet.myplanet.datamanager.DatabaseService
 
@@ -23,22 +19,5 @@ object DatabaseModule {
         return DatabaseService(context)
     }
 
-    @Provides
-    @Singleton
-    fun provideRealmConfiguration(@ApplicationContext context: Context): RealmConfiguration {
-        Realm.init(context)
-        RealmLog.setLevel(LogLevel.DEBUG)
-        return RealmConfiguration.Builder()
-            .name(Realm.DEFAULT_REALM_NAME)
-            .deleteRealmIfMigrationNeeded()
-            .schemaVersion(4)
-            .allowWritesOnUiThread(true)
-            .build()
-    }
-
-    @Provides
-    fun provideRealm(realmConfiguration: RealmConfiguration): Realm {
-        Realm.setDefaultConfiguration(realmConfiguration)
-        return Realm.getDefaultInstance()
-    }
+    // Realm initialization is handled in DatabaseService
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLife.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLife.kt
@@ -5,6 +5,7 @@ import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import java.util.concurrent.Executors
+import org.ole.planet.myplanet.MainApplication
 
 open class RealmMyLife : RealmObject {
     @PrimaryKey
@@ -40,8 +41,7 @@ open class RealmMyLife : RealmObject {
         fun updateWeight(weight: Int, id: String?, userId: String?) {
             val executor = Executors.newSingleThreadExecutor()
             executor.execute {
-                val backgroundRealm = Realm.getDefaultInstance()
-                try {
+                MainApplication.service.withRealm { backgroundRealm ->
                     backgroundRealm.executeTransaction { mRealm ->
                         val targetItem = mRealm.where(RealmMyLife::class.java).equalTo("_id", id)
                             .findFirst()
@@ -57,10 +57,8 @@ open class RealmMyLife : RealmObject {
                             otherItem?.weight = currentWeight
                         }
                     }
-                } finally {
-                    backgroundRealm.close()
-                    executor.shutdown()
                 }
+                executor.shutdown()
             }
         }
 
@@ -68,16 +66,13 @@ open class RealmMyLife : RealmObject {
         fun updateVisibility(isVisible: Boolean, id: String?) {
             val executor = Executors.newSingleThreadExecutor()
             executor.execute {
-                val backgroundRealm = Realm.getDefaultInstance()
-                try {
+                MainApplication.service.withRealm { backgroundRealm ->
                     backgroundRealm.executeTransaction { mRealm ->
                         mRealm.where(RealmMyLife::class.java).equalTo("_id", id).findFirst()
                             ?.isVisible = isVisible
                     }
-                } finally {
-                    backgroundRealm.close()
-                    executor.shutdown()
                 }
+                executor.shutdown()
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -1199,7 +1199,7 @@ class SyncManager @Inject constructor(
 
     private fun <T> safeRealmOperation(operation: (Realm) -> T): T? {
         return try {
-            Realm.getDefaultInstance().use { realm ->
+            databaseService.realmInstance.use { realm ->
                 operation(realm)
             }
         } catch (e: Exception) {

--- a/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
@@ -128,11 +128,11 @@ class UserProfileDbHandler @Inject constructor(
     }
 
     fun getLastVisit(m: RealmUserModel): String {
-        Realm.getDefaultInstance().use { realm ->
+        return realmService.withRealm { realm ->
             val lastLogoutTimestamp = realm.where(RealmOfflineActivity::class.java)
                 .equalTo("userName", m.name)
                 .max("loginTime") as Long?
-            return if (lastLogoutTimestamp != null) {
+            if (lastLogoutTimestamp != null) {
                 val date = Date(lastLogoutTimestamp)
                 SimpleDateFormat("MMMM dd, yyyy hh:mm a", Locale.getDefault()).format(date)
             } else {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -162,12 +162,13 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
             val detachedCurrentCourse = currentCourse?.let { mRealm.copyFromRealm(it) }
 
             withContext(Dispatchers.IO) {
+                val backgroundRealm = databaseService.realmInstance
                 try {
-                    Realm.getDefaultInstance().use { backgroundRealm ->
-                        createActivity(backgroundRealm, detachedUserModel, detachedCurrentCourse)
-                    }
+                    createActivity(backgroundRealm, detachedUserModel, detachedCurrentCourse)
                 } catch (e: Exception) {
                     e.printStackTrace()
+                } finally {
+                    backgroundRealm.close()
                 }
             }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterReports.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterReports.kt
@@ -9,7 +9,6 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.RecyclerView
 import com.google.gson.JsonObject
-import io.realm.Realm
 import io.realm.RealmResults
 import java.util.Calendar
 import org.ole.planet.myplanet.R
@@ -18,6 +17,7 @@ import org.ole.planet.myplanet.databinding.ReportListItemBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
+import org.ole.planet.myplanet.MainApplication
 
 class AdapterReports(private val context: Context, private var list: RealmResults<RealmMyTeam>) : RecyclerView.Adapter<AdapterReports.ViewHolderReports>() {
     private lateinit var reportListItemBinding: ReportListItemBinding
@@ -152,7 +152,7 @@ class AdapterReports(private val context: Context, private var list: RealmResult
                         addProperty("updatedDate", System.currentTimeMillis())
                         addProperty("updated", true)
                     }
-                    Realm.getDefaultInstance().use { realm ->
+                    MainApplication.service.withRealm { realm ->
                         RealmMyTeam.updateReports(doc, realm)
                     }
                     dialog.dismiss()
@@ -168,7 +168,7 @@ class AdapterReports(private val context: Context, private var list: RealmResult
                 builder.setTitle("Delete Report")
                     .setMessage(R.string.delete_record)
                     .setPositiveButton(R.string.ok) { _, _ ->
-                        Realm.getDefaultInstance().use { realm ->
+                        MainApplication.service.withRealm { realm ->
                             realm.executeTransaction { realmTx ->
                                 realmTx.where(RealmMyTeam::class.java)
                                     .equalTo("_id", reportId)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -18,6 +18,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.databinding.FragmentLibraryDetailBinding
+import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyLibrary.Companion.listToString
 import org.ole.planet.myplanet.model.RealmRating.Companion.getRatingsById
@@ -46,23 +47,19 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
         super.onDownloadComplete()
         fragmentScope.launch {
             withContext(Dispatchers.IO) {
-                val backgroundRealm = Realm.getDefaultInstance()
                 try {
-                    val backgroundLibrary = backgroundRealm.where(RealmMyLibrary::class.java)
-                        .equalTo("resourceId", libraryId).findFirst()
-                    if (backgroundLibrary != null && !backgroundLibrary.userId?.contains(profileDbHandler.userModel?.id)!!) {
-                        if (!backgroundRealm.isInTransaction) backgroundRealm.beginTransaction()
-                        backgroundLibrary.setUserId(profileDbHandler.userModel?.id)
-                        onAdd(backgroundRealm, "resources", profileDbHandler.userModel?.id, libraryId)
-                        backgroundRealm.commitTransaction()
+                    MainApplication.service.withRealm { backgroundRealm ->
+                        val backgroundLibrary = backgroundRealm.where(RealmMyLibrary::class.java)
+                            .equalTo("resourceId", libraryId).findFirst()
+                        if (backgroundLibrary != null && !backgroundLibrary.userId?.contains(profileDbHandler.userModel?.id)!!) {
+                            if (!backgroundRealm.isInTransaction) backgroundRealm.beginTransaction()
+                            backgroundLibrary.setUserId(profileDbHandler.userModel?.id)
+                            onAdd(backgroundRealm, "resources", profileDbHandler.userModel?.id, libraryId)
+                            backgroundRealm.commitTransaction()
+                        }
                     }
                 } catch (e: Exception) {
-                    if (backgroundRealm.isInTransaction) {
-                        backgroundRealm.cancelTransaction()
-                    }
                     e.printStackTrace()
-                } finally {
-                    backgroundRealm.close()
                 }
             }
             withContext(Dispatchers.Main) {
@@ -181,29 +178,25 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             val userId = profileDbHandler.userModel?.id
             fragmentScope.launch {
                 withContext(Dispatchers.IO) {
-                    val backgroundRealm = Realm.getDefaultInstance()
                     try {
-                        val backgroundLibrary = backgroundRealm.where(RealmMyLibrary::class.java)
-                            .equalTo("resourceId", libraryId).findFirst()
+                        MainApplication.service.withRealm { backgroundRealm ->
+                            val backgroundLibrary = backgroundRealm.where(RealmMyLibrary::class.java)
+                                .equalTo("resourceId", libraryId).findFirst()
 
-                        if (backgroundLibrary != null) {
-                            if (!backgroundRealm.isInTransaction) backgroundRealm.beginTransaction()
-                            if (isAdd) {
-                                backgroundLibrary.setUserId(userId)
-                                onAdd(backgroundRealm, "resources", userId, libraryId)
-                            } else {
-                                backgroundLibrary.removeUserId(userId)
-                                onRemove(backgroundRealm, "resources", userId, libraryId)
+                            if (backgroundLibrary != null) {
+                                if (!backgroundRealm.isInTransaction) backgroundRealm.beginTransaction()
+                                if (isAdd) {
+                                    backgroundLibrary.setUserId(userId)
+                                    onAdd(backgroundRealm, "resources", userId, libraryId)
+                                } else {
+                                    backgroundLibrary.removeUserId(userId)
+                                    onRemove(backgroundRealm, "resources", userId, libraryId)
+                                }
+                                backgroundRealm.commitTransaction()
                             }
-                            backgroundRealm.commitTransaction()
                         }
                     } catch (e: Exception) {
-                        if (backgroundRealm.isInTransaction) {
-                            backgroundRealm.cancelTransaction()
-                        }
                         e.printStackTrace()
-                    } finally {
-                        backgroundRealm.close()
                     }
                 }
                 withContext(Dispatchers.Main) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/GuestLoginExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/GuestLoginExtensions.kt
@@ -5,7 +5,7 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AlertDialog
-import io.realm.Realm
+import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.AlertGuestLoginBinding
 import org.ole.planet.myplanet.model.RealmUserModel
@@ -13,7 +13,7 @@ import org.ole.planet.myplanet.utilities.AuthHelper
 import org.ole.planet.myplanet.utilities.Utilities.toast
 
 fun LoginActivity.showGuestLoginDialog() {
-    Realm.getDefaultInstance().use { realm ->
+    MainApplication.service.withRealm { realm ->
         realm.refresh()
         val binding = AlertGuestLoginBinding.inflate(LayoutInflater.from(this))
         val view: View = binding.root
@@ -47,7 +47,7 @@ fun LoginActivity.showGuestLoginDialog() {
         val login = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
         val cancel = dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
         login.setOnClickListener {
-            Realm.getDefaultInstance().use { loginRealm ->
+            MainApplication.service.withRealm { loginRealm ->
                 val username = binding.etUserName.text.toString().trim { it <= ' ' }
                 val error = AuthHelper.validateUsername(this@showGuestLoginDialog, username)
                 if (error == null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -474,7 +474,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         val activityContext = this@SyncActivity
         lifecycleScope.launch(Dispatchers.Main) {
             try {
-                val realm = Realm.getDefaultInstance()
+                val realm = databaseService.realmInstance
                 val results = realm.where(RealmUserModel::class.java).findAllAsync()
                 val listener = object : RealmChangeListener<RealmResults<RealmUserModel>> {
                     override fun onChange(t: RealmResults<RealmUserModel>) {
@@ -538,7 +538,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         val betaAutoDownload = defaultPref.getBoolean("beta_auto_download", false)
         if (betaAutoDownload) {
             lifecycleScope.launch(Dispatchers.IO) {
-                val downloadRealm = Realm.getDefaultInstance()
+                val downloadRealm = databaseService.realmInstance
                 try {
                     backgroundDownload(downloadAllFiles(getAllLibraryList(downloadRealm)), activityContext)
                 } finally {
@@ -674,7 +674,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                                 startUpload("login")
                             }
                             withContext(Dispatchers.Default) {
-                                val backgroundRealm = Realm.getDefaultInstance()
+                                val backgroundRealm = databaseService.realmInstance
                                 try {
                                     TransactionSyncManager.syncDb(backgroundRealm, "login_activities")
                                 } finally {
@@ -848,13 +848,10 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
 
         suspend fun clearRealmDb() {
             withContext(Dispatchers.IO) {
-                val realm = Realm.getDefaultInstance()
-                try {
+                MainApplication.service.withRealm { realm ->
                     realm.executeTransaction { transactionRealm ->
                         transactionRealm.deleteAll()
                     }
-                } finally {
-                    realm.close()
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamCalendarFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamCalendarFragment.kt
@@ -42,6 +42,7 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.mymeetup.AdapterMeetup
 import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
+import org.ole.planet.myplanet.MainApplication
 
 class TeamCalendarFragment : BaseTeamFragment() {
     private lateinit var fragmentEnterpriseCalendarBinding: FragmentEnterpriseCalendarBinding
@@ -308,7 +309,7 @@ class TeamCalendarFragment : BaseTeamFragment() {
         viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
             var meetupList = mutableListOf<RealmMeetup>()
             val newDates = mutableListOf<Calendar>()
-            val realm = Realm.getDefaultInstance()
+            val realm = MainApplication.service.realmInstance
             try {
                 meetupList = realm.where(RealmMeetup::class.java).equalTo("teamId", teamId).findAll()
                 val calendarInstance = Calendar.getInstance()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
@@ -316,7 +316,7 @@ class UserProfileFragment : Fragment() {
                 binding.rbFemale.isChecked -> "female"
                 else -> selectedGender
             }
-            val realm = Realm.getDefaultInstance()
+            val realm = databaseService.realmInstance
             val userId = settings.getString("userId", "")
             RealmUserModel.updateUserDetails(
                 realm,

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DownloadUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DownloadUtils.kt
@@ -6,12 +6,12 @@ import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
 import androidx.core.app.NotificationCompat
-import io.realm.Realm
 import java.util.regex.Pattern
 import kotlin.text.isNotEmpty
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.utilities.FileUtils
+import org.ole.planet.myplanet.MainApplication
 
 object DownloadUtils {
     private const val DOWNLOAD_CHANNEL = "DownloadChannel"
@@ -155,8 +155,7 @@ object DownloadUtils {
     fun updateResourceOfflineStatus(url: String) {
         val currentFileName = FileUtils.getFileNameFromUrl(url)
         try {
-            val backgroundRealm = Realm.getDefaultInstance()
-            backgroundRealm.use { realm ->
+            MainApplication.service.withRealm { realm ->
                 realm.executeTransaction {
                     realm.where(RealmMyLibrary::class.java)
                         .equalTo("resourceLocalAddress", currentFileName)


### PR DESCRIPTION
## Summary
- remove Realm config from `DatabaseModule`
- let `DatabaseService` manage Realm setup
- open Realm instances through `DatabaseService`
- clean up various calls to `Realm.getDefaultInstance`

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_688bd51dfa68832b86263a72fcffdf71