### PR TITLE
Refactor repositories into separate package

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -30,9 +30,9 @@ import org.ole.planet.myplanet.datamanager.MyDownloadService
 import org.ole.planet.myplanet.datamanager.Service
 import org.ole.planet.myplanet.datamanager.Service.PlanetAvailableListener
 import org.ole.planet.myplanet.di.AppPreferences
-import org.ole.planet.myplanet.di.LibraryRepository
-import org.ole.planet.myplanet.di.SubmissionRepository
-import org.ole.planet.myplanet.di.UserRepository
+import org.ole.planet.myplanet.repository.LibraryRepository
+import org.ole.planet.myplanet.repository.SubmissionRepository
+import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.getMyCourse

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -5,15 +5,18 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import io.realm.Realm
-import io.realm.RealmResults
 import javax.inject.Singleton
 import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.model.RealmSubmission
+import org.ole.planet.myplanet.di.AppPreferences
+import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.repository.UserRepositoryImpl
+import org.ole.planet.myplanet.repository.LibraryRepository
+import org.ole.planet.myplanet.repository.LibraryRepositoryImpl
+import org.ole.planet.myplanet.repository.CourseRepository
+import org.ole.planet.myplanet.repository.CourseRepositoryImpl
+import org.ole.planet.myplanet.repository.SubmissionRepository
+import org.ole.planet.myplanet.repository.SubmissionRepositoryImpl
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -53,143 +56,5 @@ object RepositoryModule {
         databaseService: DatabaseService
     ): SubmissionRepository {
         return SubmissionRepositoryImpl(databaseService)
-    }
-}
-
-// User Repository
-interface UserRepository {
-    suspend fun getUserProfile(): String?
-    suspend fun saveUserData(data: String)
-    fun getRealm(): Realm
-    fun getCurrentUser(): RealmUserModel?
-}
-
-class UserRepositoryImpl(
-    private val databaseService: DatabaseService,
-    private val preferences: SharedPreferences,
-    private val apiInterface: ApiInterface
-) : UserRepository {
-
-    override suspend fun getUserProfile(): String? {
-        return preferences.getString("user_profile", null)
-    }
-
-    override suspend fun saveUserData(data: String) {
-        preferences.edit().putString("user_profile", data).apply()
-    }
-
-    override fun getRealm(): Realm {
-        return databaseService.realmInstance
-    }
-
-    override fun getCurrentUser(): RealmUserModel? {
-        return databaseService.realmInstance.where(RealmUserModel::class.java).findFirst()
-    }
-}
-
-// Library Repository
-interface LibraryRepository {
-    fun getAllLibraryItems(): List<RealmMyLibrary>
-    fun getLibraryItemById(id: String): RealmMyLibrary?
-    fun getOfflineLibraryItems(): List<RealmMyLibrary>
-    fun getLibraryListForUser(userId: String?): List<RealmMyLibrary>
-    fun getAllLibraryList(): List<RealmMyLibrary>
-}
-
-class LibraryRepositoryImpl(
-    private val databaseService: DatabaseService,
-    private val apiInterface: ApiInterface
-) : LibraryRepository {
-
-    override fun getAllLibraryItems(): List<RealmMyLibrary> {
-        return databaseService.realmInstance.where(RealmMyLibrary::class.java).findAll()
-    }
-
-    override fun getLibraryItemById(id: String): RealmMyLibrary? {
-        return databaseService.realmInstance.where(RealmMyLibrary::class.java)
-            .equalTo("id", id)
-            .findFirst()
-    }
-
-    override fun getOfflineLibraryItems(): List<RealmMyLibrary> {
-        return databaseService.realmInstance.where(RealmMyLibrary::class.java)
-            .equalTo("resourceOffline", true)
-            .findAll()
-    }
-
-    override fun getLibraryListForUser(userId: String?): List<RealmMyLibrary> {
-        val results = databaseService.realmInstance.where(RealmMyLibrary::class.java)
-            .equalTo("isPrivate", false)
-            .findAll()
-        return filterLibrariesNeedingUpdate(results).filter { it.userId?.contains(userId) == true }
-    }
-
-    override fun getAllLibraryList(): List<RealmMyLibrary> {
-        val results = databaseService.realmInstance.where(RealmMyLibrary::class.java)
-            .equalTo("resourceOffline", false)
-            .findAll()
-        return filterLibrariesNeedingUpdate(results)
-    }
-
-    private fun filterLibrariesNeedingUpdate(results: RealmResults<RealmMyLibrary>): List<RealmMyLibrary> {
-        val libraries = mutableListOf<RealmMyLibrary>()
-        for (lib in results) {
-            if (lib.needToUpdate()) {
-                libraries.add(lib)
-            }
-        }
-        return libraries
-    }
-}
-
-// Course Repository
-interface CourseRepository {
-    fun getAllCourses(): List<RealmMyCourse>
-    fun getCourseById(id: String): RealmMyCourse?
-    fun getEnrolledCourses(): List<RealmMyCourse>
-}
-
-class CourseRepositoryImpl(
-    private val databaseService: DatabaseService,
-    private val apiInterface: ApiInterface
-) : CourseRepository {
-
-    override fun getAllCourses(): List<RealmMyCourse> {
-        return databaseService.realmInstance.where(RealmMyCourse::class.java).findAll()
-    }
-
-    override fun getCourseById(id: String): RealmMyCourse? {
-        return databaseService.realmInstance.where(RealmMyCourse::class.java)
-            .equalTo("courseId", id)
-            .findFirst()
-    }
-
-    override fun getEnrolledCourses(): List<RealmMyCourse> {
-        return databaseService.realmInstance.where(RealmMyCourse::class.java)
-            .equalTo("userId", getCurrentUserId())
-            .findAll()
-    }
-
-    private fun getCurrentUserId(): String {
-        return databaseService.realmInstance.where(RealmUserModel::class.java)
-            .findFirst()?.id ?: ""
-    }
-}
-
-// Submission Repository
-interface SubmissionRepository {
-    fun getPendingSurveys(userId: String?): List<RealmSubmission>
-}
-
-class SubmissionRepositoryImpl(
-    private val databaseService: DatabaseService
-) : SubmissionRepository {
-
-    override fun getPendingSurveys(userId: String?): List<RealmSubmission> {
-        return databaseService.realmInstance.where(RealmSubmission::class.java)
-            .equalTo("userId", userId)
-            .equalTo("status", "pending")
-            .equalTo("type", "survey")
-            .findAll()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
@@ -1,0 +1,9 @@
+package org.ole.planet.myplanet.repository
+
+import org.ole.planet.myplanet.model.RealmMyCourse
+
+interface CourseRepository {
+    fun getAllCourses(): List<RealmMyCourse>
+    fun getCourseById(id: String): RealmMyCourse?
+    fun getEnrolledCourses(): List<RealmMyCourse>
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package org.ole.planet.myplanet.repository
+
+import javax.inject.Inject
+import org.ole.planet.myplanet.datamanager.ApiInterface
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyCourse
+import org.ole.planet.myplanet.model.RealmUserModel
+
+class CourseRepositoryImpl @Inject constructor(
+    private val databaseService: DatabaseService,
+    private val apiInterface: ApiInterface,
+) : CourseRepository {
+
+    override fun getAllCourses(): List<RealmMyCourse> {
+        return databaseService.realmInstance.where(RealmMyCourse::class.java).findAll()
+    }
+
+    override fun getCourseById(id: String): RealmMyCourse? {
+        return databaseService.realmInstance.where(RealmMyCourse::class.java)
+            .equalTo("courseId", id)
+            .findFirst()
+    }
+
+    override fun getEnrolledCourses(): List<RealmMyCourse> {
+        return databaseService.realmInstance.where(RealmMyCourse::class.java)
+            .equalTo("userId", getCurrentUserId())
+            .findAll()
+    }
+
+    private fun getCurrentUserId(): String {
+        return databaseService.realmInstance.where(RealmUserModel::class.java)
+            .findFirst()?.id ?: ""
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
@@ -1,0 +1,11 @@
+package org.ole.planet.myplanet.repository
+
+import org.ole.planet.myplanet.model.RealmMyLibrary
+
+interface LibraryRepository {
+    fun getAllLibraryItems(): List<RealmMyLibrary>
+    fun getLibraryItemById(id: String): RealmMyLibrary?
+    fun getOfflineLibraryItems(): List<RealmMyLibrary>
+    fun getLibraryListForUser(userId: String?): List<RealmMyLibrary>
+    fun getAllLibraryList(): List<RealmMyLibrary>
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -1,0 +1,53 @@
+package org.ole.planet.myplanet.repository
+
+import javax.inject.Inject
+import io.realm.RealmResults
+import org.ole.planet.myplanet.datamanager.ApiInterface
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyLibrary
+
+class LibraryRepositoryImpl @Inject constructor(
+    private val databaseService: DatabaseService,
+    private val apiInterface: ApiInterface,
+) : LibraryRepository {
+
+    override fun getAllLibraryItems(): List<RealmMyLibrary> {
+        return databaseService.realmInstance.where(RealmMyLibrary::class.java).findAll()
+    }
+
+    override fun getLibraryItemById(id: String): RealmMyLibrary? {
+        return databaseService.realmInstance.where(RealmMyLibrary::class.java)
+            .equalTo("id", id)
+            .findFirst()
+    }
+
+    override fun getOfflineLibraryItems(): List<RealmMyLibrary> {
+        return databaseService.realmInstance.where(RealmMyLibrary::class.java)
+            .equalTo("resourceOffline", true)
+            .findAll()
+    }
+
+    override fun getLibraryListForUser(userId: String?): List<RealmMyLibrary> {
+        val results = databaseService.realmInstance.where(RealmMyLibrary::class.java)
+            .equalTo("isPrivate", false)
+            .findAll()
+        return filterLibrariesNeedingUpdate(results).filter { it.userId?.contains(userId) == true }
+    }
+
+    override fun getAllLibraryList(): List<RealmMyLibrary> {
+        val results = databaseService.realmInstance.where(RealmMyLibrary::class.java)
+            .equalTo("resourceOffline", false)
+            .findAll()
+        return filterLibrariesNeedingUpdate(results)
+    }
+
+    private fun filterLibrariesNeedingUpdate(results: RealmResults<RealmMyLibrary>): List<RealmMyLibrary> {
+        val libraries = mutableListOf<RealmMyLibrary>()
+        for (lib in results) {
+            if (lib.needToUpdate()) {
+                libraries.add(lib)
+            }
+        }
+        return libraries
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -1,0 +1,7 @@
+package org.ole.planet.myplanet.repository
+
+import org.ole.planet.myplanet.model.RealmSubmission
+
+interface SubmissionRepository {
+    fun getPendingSurveys(userId: String?): List<RealmSubmission>
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package org.ole.planet.myplanet.repository
+
+import javax.inject.Inject
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmSubmission
+
+class SubmissionRepositoryImpl @Inject constructor(
+    private val databaseService: DatabaseService,
+) : SubmissionRepository {
+
+    override fun getPendingSurveys(userId: String?): List<RealmSubmission> {
+        return databaseService.realmInstance.where(RealmSubmission::class.java)
+            .equalTo("userId", userId)
+            .equalTo("status", "pending")
+            .equalTo("type", "survey")
+            .findAll()
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -1,0 +1,11 @@
+package org.ole.planet.myplanet.repository
+
+import io.realm.Realm
+import org.ole.planet.myplanet.model.RealmUserModel
+
+interface UserRepository {
+    suspend fun getUserProfile(): String?
+    suspend fun saveUserData(data: String)
+    fun getRealm(): Realm
+    fun getCurrentUser(): RealmUserModel?
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package org.ole.planet.myplanet.repository
+
+import android.content.SharedPreferences
+import io.realm.Realm
+import javax.inject.Inject
+import org.ole.planet.myplanet.datamanager.ApiInterface
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmUserModel
+
+class UserRepositoryImpl @Inject constructor(
+    private val databaseService: DatabaseService,
+    private val preferences: SharedPreferences,
+    private val apiInterface: ApiInterface,
+) : UserRepository {
+
+    override suspend fun getUserProfile(): String? {
+        return preferences.getString("user_profile", null)
+    }
+
+    override suspend fun saveUserData(data: String) {
+        preferences.edit().putString("user_profile", data).apply()
+    }
+
+    override fun getRealm(): Realm {
+        return databaseService.realmInstance
+    }
+
+    override fun getCurrentUser(): RealmUserModel? {
+        return databaseService.realmInstance.where(RealmUserModel::class.java).findFirst()
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -9,9 +9,9 @@ import java.util.UUID
 import javax.inject.Inject
 import org.ole.planet.myplanet.base.BaseResourceFragment
 import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.di.CourseRepository
-import org.ole.planet.myplanet.di.LibraryRepository
-import org.ole.planet.myplanet.di.UserRepository
+import org.ole.planet.myplanet.repository.CourseRepository
+import org.ole.planet.myplanet.repository.LibraryRepository
+import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission


### PR DESCRIPTION
## Summary
- move repository interfaces and implementations out of `RepositoryModule`
- create new repository package with Kotlin files
- update `RepositoryModule` to only provide implementations
- fix imports in classes using the repositories

## Testing
- `./gradlew -q help`

------
https://chatgpt.com/codex/tasks/task_e_688bd95c26cc832b9f3a7b3afaa135f5