### PR TITLE
dashboard: smoother survey submissions (fixes #6561)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2778
-        versionName = "0.27.78"
+        versionCode = 2779
+        versionName = "0.27.79"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -650,7 +650,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     }
 
     private fun createSurveyDatabaseNotifications(realm: Realm, userId: String?) {
-        val pendingSurveys = dashboardViewModel.getPendingSurveys(realm, userId)
+        val pendingSurveys = dashboardViewModel.getPendingSurveys(userId)
         val surveyTitles = dashboardViewModel.getSurveyTitlesFromSubmissions(realm, pendingSurveys)
 
         surveyTitles.forEach { title ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.ui.dashboard
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.realm.Case
 import io.realm.Realm
 import java.util.Date
 import java.util.UUID
@@ -11,6 +10,7 @@ import org.ole.planet.myplanet.base.BaseResourceFragment
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.di.CourseRepository
 import org.ole.planet.myplanet.di.LibraryRepository
+import org.ole.planet.myplanet.di.SubmissionRepository
 import org.ole.planet.myplanet.di.UserRepository
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmStepExam
@@ -21,7 +21,8 @@ class DashboardViewModel @Inject constructor(
     private val databaseService: DatabaseService,
     private val userRepository: UserRepository,
     private val libraryRepository: LibraryRepository,
-    private val courseRepository: CourseRepository
+    private val courseRepository: CourseRepository,
+    private val submissionRepository: SubmissionRepository
 ) : ViewModel() {
     fun calculateIndividualProgress(voiceCount: Int, hasUnfinishedSurvey: Boolean): Int {
         val earnedDollarsVoice = minOf(voiceCount, 5) * 2
@@ -77,12 +78,8 @@ class DashboardViewModel @Inject constructor(
         }
     }
 
-    fun getPendingSurveys(realm: Realm, userId: String?): List<RealmSubmission> {
-        return realm.where(RealmSubmission::class.java)
-            .equalTo("userId", userId)
-            .equalTo("type", "survey")
-            .equalTo("status", "pending", Case.INSENSITIVE)
-            .findAll()
+    fun getPendingSurveys(userId: String?): List<RealmSubmission> {
+        return submissionRepository.getPendingSurveys(userId)
     }
 
     fun getSurveyTitlesFromSubmissions(realm: Realm, submissions: List<RealmSubmission>): List<String> {


### PR DESCRIPTION
## Summary
- use `SubmissionRepository` in `DashboardViewModel`
- call updated `getPendingSurveys` from `DashboardActivity`

## Testing
- `./gradlew tasks --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_688c074e97c4832b8b8a504e167f5bbd