### PR TITLE
Ensure streams closed with use

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
@@ -17,7 +17,6 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
-import java.io.OutputStream
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.util.UUID
@@ -142,25 +141,19 @@ object FileUtils {
     @JvmStatic
     fun copyAssets(context: Context) {
         val tiles = arrayOf("dhulikhel.mbtiles", "somalia.mbtiles")
-        val assetManager = context.assets
         try {
-            for (s in tiles) {
-                var out: OutputStream
-                val `in`: InputStream = assetManager.open(s)
-                val outFile = File(Environment.getExternalStorageDirectory().toString() + "/osmdroid", s)
-                out = FileOutputStream(outFile)
-                copyFile(`in`, out)
-                out.close()
-                `in`.close()
+            for (name in tiles) {
+                context.assets.open(name).use { input ->
+                    FileOutputStream(
+                        File(Environment.getExternalStorageDirectory().toString() + "/osmdroid", name)
+                    ).use { out ->
+                        input.copyTo(out)
+                    }
+                }
             }
         } catch (e: Exception) {
             e.printStackTrace()
         }
-    }
-
-    @Throws(IOException::class)
-    private fun copyFile(`in`: InputStream, out: OutputStream) {
-        `in`.copyTo(out)
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary
- rewrite asset copy loop using Kotlin's `use`
- remove unused `copyFile` helper
- drop the `OutputStream` import

## Testing
- `./gradlew test` *(fails: Fetch remote repository)*

------
https://chatgpt.com/codex/tasks/task_e_688ca69bbe44832b8abf00d8067d1221