### PR TITLE
refactor: remove unused api interface dependency

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -6,7 +6,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
-import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.repository.CourseRepository
@@ -26,28 +25,25 @@ object RepositoryModule {
     @Singleton
     fun provideUserRepository(
         databaseService: DatabaseService,
-        @AppPreferences preferences: SharedPreferences,
-        apiInterface: ApiInterface
+        @AppPreferences preferences: SharedPreferences
     ): UserRepository {
-        return UserRepositoryImpl(databaseService, preferences, apiInterface)
+        return UserRepositoryImpl(databaseService, preferences)
     }
 
     @Provides
     @Singleton
     fun provideLibraryRepository(
-        databaseService: DatabaseService,
-        apiInterface: ApiInterface
+        databaseService: DatabaseService
     ): LibraryRepository {
-        return LibraryRepositoryImpl(databaseService, apiInterface)
+        return LibraryRepositoryImpl(databaseService)
     }
 
     @Provides
     @Singleton
     fun provideCourseRepository(
-        databaseService: DatabaseService,
-        apiInterface: ApiInterface
+        databaseService: DatabaseService
     ): CourseRepository {
-        return CourseRepositoryImpl(databaseService, apiInterface)
+        return CourseRepositoryImpl(databaseService)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -1,14 +1,12 @@
 package org.ole.planet.myplanet.repository
 
 import javax.inject.Inject
-import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmUserModel
 
 class CourseRepositoryImpl @Inject constructor(
-    private val databaseService: DatabaseService,
-    private val apiInterface: ApiInterface,
+    private val databaseService: DatabaseService
 ) : CourseRepository {
 
     override fun getAllCourses(): List<RealmMyCourse> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -2,13 +2,11 @@ package org.ole.planet.myplanet.repository
 
 import io.realm.RealmResults
 import javax.inject.Inject
-import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 
 class LibraryRepositoryImpl @Inject constructor(
-    private val databaseService: DatabaseService,
-    private val apiInterface: ApiInterface,
+    private val databaseService: DatabaseService
 ) : LibraryRepository {
 
     override fun getAllLibraryItems(): List<RealmMyLibrary> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -3,14 +3,12 @@ package org.ole.planet.myplanet.repository
 import android.content.SharedPreferences
 import io.realm.Realm
 import javax.inject.Inject
-import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmUserModel
 
 class UserRepositoryImpl @Inject constructor(
     private val databaseService: DatabaseService,
-    private val preferences: SharedPreferences,
-    private val apiInterface: ApiInterface,
+    private val preferences: SharedPreferences
 ) : UserRepository {
 
     override suspend fun getUserProfile(): String? {


### PR DESCRIPTION
## Summary
- drop `ApiInterface` from repository implementations
- simplify `RepositoryModule` providers to match new constructors

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_6890806cfff8832bb0187fcd2ea26677