### PR TITLE
Replace RealmList with List for chat history flow

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ChatViewModel.kt
@@ -1,14 +1,13 @@
 package org.ole.planet.myplanet.model
 
 import androidx.lifecycle.ViewModel
-import io.realm.RealmList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class ChatViewModel : ViewModel() {
-    private val _selectedChatHistory = MutableStateFlow<RealmList<Conversation>?>(null)
-    val selectedChatHistory: StateFlow<RealmList<Conversation>?> = _selectedChatHistory.asStateFlow()
+    private val _selectedChatHistory = MutableStateFlow<List<Conversation>?>(null)
+    val selectedChatHistory: StateFlow<List<Conversation>?> = _selectedChatHistory.asStateFlow()
 
     private val _selectedId = MutableStateFlow("")
     val selectedId: StateFlow<String> = _selectedId.asStateFlow()
@@ -19,7 +18,7 @@ class ChatViewModel : ViewModel() {
     private val _selectedAiProvider = MutableStateFlow<String?>(null)
     val selectedAiProvider: StateFlow<String?> = _selectedAiProvider.asStateFlow()
 
-    fun setSelectedChatHistory(conversations: RealmList<Conversation>) {
+    fun setSelectedChatHistory(conversations: List<Conversation>) {
         _selectedChatHistory.value = conversations
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -204,7 +204,7 @@ class ChatDetailFragment : Fragment() {
                         mAdapter.clearData()
                         fragmentChatDetailBinding.editGchatMessage.text.clear()
                         fragmentChatDetailBinding.textGchatIndicator.visibility = View.GONE
-                        if (conversations != null && conversations.isValid && conversations.isNotEmpty()) {
+                        if (!conversations.isNullOrEmpty()) {
                             for (conversation in conversations) {
                                 conversation.query?.let { mAdapter.addQuery(it) }
                                 mAdapter.responseSource = ChatAdapter.RESPONSE_SOURCE_SHARED_VIEW_MODEL

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
@@ -12,7 +12,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.gson.Gson
 import io.realm.Case
 import io.realm.Realm
-import io.realm.RealmList
 import io.realm.RealmResults
 import java.text.Normalizer
 import java.util.Date
@@ -57,7 +56,7 @@ class ChatHistoryListAdapter(
     }
 
     interface ChatHistoryItemClickListener {
-        fun onChatHistoryItemClicked(conversations: RealmList<Conversation>?, id: String, rev: String?, aiProvider: String?)
+        fun onChatHistoryItemClicked(conversations: List<Conversation>?, id: String, rev: String?, aiProvider: String?)
     }
 
     fun setChatHistoryItemClickListener(listener: ChatHistoryItemClickListener) {
@@ -181,7 +180,7 @@ class ChatHistoryListAdapter(
         viewHolderChat.rowChatHistoryBinding.root.setOnClickListener {
             viewHolderChat.rowChatHistoryBinding.chatCardView.contentDescription = chatTitle
             chatHistoryItemClickListener?.onChatHistoryItemClicked(
-                filteredChatHistory[position].conversations,
+                filteredChatHistory[position].conversations?.toList(),
                 "${filteredChatHistory[position]._id}",
                 filteredChatHistory[position]._rev,
                 filteredChatHistory[position].aiProvider

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -17,7 +17,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.slidingpanelayout.widget.SlidingPaneLayout
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
-import io.realm.RealmList
 import io.realm.Sort
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
@@ -223,7 +222,7 @@ class ChatHistoryListFragment : Fragment() {
         if (adapter == null) {
             val newAdapter = ChatHistoryListAdapter(requireContext(), list, this, databaseService, settings)
             newAdapter.setChatHistoryItemClickListener(object : ChatHistoryListAdapter.ChatHistoryItemClickListener {
-                override fun onChatHistoryItemClicked(conversations: RealmList<Conversation>?, id: String, rev: String?, aiProvider: String?) {
+                override fun onChatHistoryItemClicked(conversations: List<Conversation>?, id: String, rev: String?, aiProvider: String?) {
                     conversations?.let { sharedViewModel.setSelectedChatHistory(it) }
                     sharedViewModel.setSelectedId(id)
                     rev?.let { sharedViewModel.setSelectedRev(it) }


### PR DESCRIPTION
## Summary
- switch chat history state to use regular `List<Conversation>`
- convert Realm lists to Kotlin lists when selecting chat history
- update chat UI to handle `List<Conversation>`

## Testing
- `./gradlew :app:compileLiteDebugKotlin`

------
https://chatgpt.com/codex/tasks/task_e_689080feb690832b83b5e052a74eca57