### PR TITLE
resources: smoother shared preferences (fixes #6590)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2783
-        versionName = "0.27.83"
+        versionCode = 2789
+        versionName = "0.27.89"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -80,8 +80,10 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     var map: HashMap<String?, JsonObject>? = null
     private var confirmation: AlertDialog? = null
     private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
+
+    @Inject
     lateinit var prefManager: SharedPrefManager
-    
+
     @Inject
     lateinit var syncManager: SyncManager
 
@@ -91,7 +93,6 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        prefManager = SharedPrefManager(requireContext())
         settings = requireActivity().getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         startResourcesSync()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/SharedPrefManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/SharedPrefManager.kt
@@ -2,13 +2,15 @@ package org.ole.planet.myplanet.utilities
 
 import android.content.Context
 import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import org.ole.planet.myplanet.model.User
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
-class SharedPrefManager(context: Context) {
+class SharedPrefManager @Inject constructor(@ApplicationContext context: Context) {
     private var privateMode = 0
     private var pref: SharedPreferences = context.getSharedPreferences(PREFS_NAME, privateMode)
     private var editor: SharedPreferences.Editor = pref.edit()


### PR DESCRIPTION
## Summary
- annotate `SharedPrefManager` constructor with `@Inject` and `@ApplicationContext`
- inject `SharedPrefManager` into `ResourcesFragment` instead of manual instantiation

## Testing
- `./gradlew --console=plain assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_6890816b5064832b838e9c301c471396