### PR TITLE
Inject AuthSessionUpdater via Hilt

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/AuthSessionUpdaterModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/AuthSessionUpdaterModule.kt
@@ -1,0 +1,17 @@
+package org.ole.planet.myplanet.di
+
+import android.app.Activity
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import org.ole.planet.myplanet.utilities.AuthSessionUpdater
+
+@Module
+@InstallIn(ActivityComponent::class)
+object AuthSessionUpdaterModule {
+    @Provides
+    fun provideAuthCallback(activity: Activity): AuthSessionUpdater.AuthCallback {
+        return activity as AuthSessionUpdater.AuthCallback
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -8,6 +8,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
@@ -48,5 +51,11 @@ object ServiceModule {
         @AppPreferences preferences: SharedPreferences
     ): UploadToShelfService {
         return UploadToShelfService(context, databaseService, preferences)
+    }
+
+    @Provides
+    @Singleton
+    fun provideApplicationScope(): CoroutineScope {
+        return CoroutineScope(SupervisorJob() + Dispatchers.IO)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/VideoPlayerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/VideoPlayerActivity.kt
@@ -4,7 +4,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.SharedPreferences
 import android.media.AudioManager
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
@@ -27,19 +26,24 @@ import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ActivityExoPlayerVideoBinding
 import org.ole.planet.myplanet.utilities.AuthSessionUpdater
-import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtil
 import org.ole.planet.myplanet.utilities.Utilities
 
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import javax.inject.Provider
+
+@AndroidEntryPoint
 class VideoPlayerActivity : AppCompatActivity(), AuthSessionUpdater.AuthCallback {
     private lateinit var binding: ActivityExoPlayerVideoBinding
     private var exoPlayer: ExoPlayer? = null
     private var auth: String = ""
     private var videoURL: String = ""
-    private lateinit var settings: SharedPreferences
     private var playWhenReady = true
     private var currentPosition = 0L
     private var isActivityVisible = false
+    @Inject
+    lateinit var authSessionUpdaterProvider: Provider<AuthSessionUpdater>
     private var authSessionUpdater: AuthSessionUpdater? = null
 
     private val audioBecomingNoisyReceiver = object : BroadcastReceiver() {
@@ -55,8 +59,6 @@ class VideoPlayerActivity : AppCompatActivity(), AuthSessionUpdater.AuthCallback
         binding = ActivityExoPlayerVideoBinding.inflate(layoutInflater)
         setContentView(binding.root)
         EdgeToEdgeUtil.setupEdgeToEdge(this, binding.root)
-        settings = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-
         val extras = intent.extras
         val videoType = extras?.getString("videoType")
         videoURL = extras?.getString("videoURL") ?: ""
@@ -67,7 +69,7 @@ class VideoPlayerActivity : AppCompatActivity(), AuthSessionUpdater.AuthCallback
         when (videoType) {
             "offline" -> prepareExoPlayerFromFileUri(videoURL)
             "online" -> {
-                authSessionUpdater = AuthSessionUpdater(this, settings)
+                authSessionUpdater = authSessionUpdaterProvider.get()
             }
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/AuthSessionUpdater.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/AuthSessionUpdater.kt
@@ -12,11 +12,13 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import javax.inject.Inject
+import org.ole.planet.myplanet.di.AppPreferences
 
-class AuthSessionUpdater(
+class AuthSessionUpdater @Inject constructor(
     private val callback: AuthCallback,
-    private val settings: SharedPreferences,
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+    @AppPreferences private val settings: SharedPreferences,
+    private val scope: CoroutineScope
 ) {
 
     interface AuthCallback {


### PR DESCRIPTION
## Summary
- convert AuthSessionUpdater to an @Inject-able class and remove the default coroutine scope
- provide an application coroutine scope and Hilt callback binding
- obtain AuthSessionUpdater through Hilt in VideoPlayerActivity

## Testing
- `./gradlew assembleDebug` *(fails to display completion within allotted time but executed build tasks)*

------
https://chatgpt.com/codex/tasks/task_e_6890817ed784832b9e2f42a2433c9b77