### PR TITLE
teams: smoother tabbing (fixes #6685)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2806
-        versionName = "0.28.6"
+        versionCode = 2827
+        versionName = "0.28.27"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -81,7 +81,9 @@ import org.ole.planet.myplanet.ui.survey.SurveyFragment
 import org.ole.planet.myplanet.ui.sync.DashboardElementActivity
 import org.ole.planet.myplanet.ui.team.TeamDetailFragment
 import org.ole.planet.myplanet.ui.team.TeamFragment
-import org.ole.planet.myplanet.ui.team.TeamPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.JoinRequestsPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.TasksPage
 import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
@@ -426,7 +428,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                     teamName = teamObject?.name ?: "",
                     teamType = teamObject?.type ?: "",
                     isMyTeam = true,
-                    navigateToPage = TeamPage.TASKS
+                    navigateToPage = TasksPage
                 )
 
                 openCallFragment(f)
@@ -453,7 +455,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                 val b = Bundle()
                 b.putString("id", teamId)
                 b.putBoolean("isMyTeam", true)
-                b.putInt("navigateToPage", TeamPage.JOIN_REQUESTS.ordinal)
+                b.putString("navigateToPage", JoinRequestsPage.id)
                 f.arguments = b
                 openCallFragment(f)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -30,7 +30,9 @@ import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.resources.ResourcesFragment
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
 import org.ole.planet.myplanet.ui.team.TeamDetailFragment
-import org.ole.planet.myplanet.ui.team.TeamPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.JoinRequestsPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.TasksPage
 
 @AndroidEntryPoint
 class NotificationsFragment : Fragment() {
@@ -137,7 +139,7 @@ class NotificationsFragment : Fragment() {
                             teamName = teamObject?.name ?: "",
                             teamType = teamObject?.type ?: "",
                             isMyTeam = true,
-                            navigateToPage = TeamPage.TASKS
+                            navigateToPage = TasksPage
                         )
 
                         (context as OnHomeItemClickListener).openCallFragment(f)
@@ -164,7 +166,7 @@ class NotificationsFragment : Fragment() {
                         val b = Bundle()
                         b.putString("id", teamId)
                         b.putBoolean("isMyTeam", true)
-                        b.putInt("navigateToPage", TeamPage.JOIN_REQUESTS.ordinal)
+                        b.putString("navigateToPage", JoinRequestsPage.id)
                         f.arguments = b
                         (context as OnHomeItemClickListener).openCallFragment(f)
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamPage.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamPage.kt
@@ -1,7 +1,0 @@
-package org.ole.planet.myplanet.ui.team
-
-enum class TeamPage {
-    CHAT, PLAN, MISSION, TEAM, MEMBERS, TASKS, CALENDAR, SURVEY,
-    COURSES, FINANCES, REPORTS, DOCUMENTS, RESOURCES, APPLICANTS, JOIN_REQUESTS
-}
-

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamPageConfig.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamPageConfig.kt
@@ -1,0 +1,80 @@
+package org.ole.planet.myplanet.ui.team
+
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.ui.enterprises.FinanceFragment
+import org.ole.planet.myplanet.ui.enterprises.ReportsFragment
+import org.ole.planet.myplanet.ui.survey.SurveyFragment
+import org.ole.planet.myplanet.ui.team.teamCourse.TeamCourseFragment
+import org.ole.planet.myplanet.ui.team.teamDiscussion.DiscussionListFragment
+import org.ole.planet.myplanet.ui.team.teamMember.JoinedMemberFragment
+import org.ole.planet.myplanet.ui.team.teamMember.MembersFragment
+import org.ole.planet.myplanet.ui.team.TeamCalendarFragment
+import org.ole.planet.myplanet.ui.team.PlanFragment
+import org.ole.planet.myplanet.ui.team.teamResource.TeamResourceFragment
+import org.ole.planet.myplanet.ui.team.teamTask.TeamTaskFragment
+
+sealed class TeamPageConfig(val id: String, @StringRes val titleRes: Int) {
+    abstract fun createFragment(): Fragment
+
+    object ChatPage : TeamPageConfig("CHAT", R.string.chat) {
+        override fun createFragment() = DiscussionListFragment()
+    }
+
+    object PlanPage : TeamPageConfig("PLAN", R.string.plan) {
+        override fun createFragment() = PlanFragment()
+    }
+
+    object MissionPage : TeamPageConfig("MISSION", R.string.mission) {
+        override fun createFragment() = PlanFragment()
+    }
+
+    object TeamPage : TeamPageConfig("TEAM", R.string.team) {
+        override fun createFragment() = JoinedMemberFragment()
+    }
+
+    object MembersPage : TeamPageConfig("MEMBERS", R.string.members) {
+        override fun createFragment() = JoinedMemberFragment()
+    }
+
+    object TasksPage : TeamPageConfig("TASKS", R.string.tasks) {
+        override fun createFragment() = TeamTaskFragment()
+    }
+
+    object CalendarPage : TeamPageConfig("CALENDAR", R.string.calendar) {
+        override fun createFragment() = TeamCalendarFragment()
+    }
+
+    object SurveyPage : TeamPageConfig("SURVEY", R.string.survey) {
+        override fun createFragment() = SurveyFragment()
+    }
+
+    object CoursesPage : TeamPageConfig("COURSES", R.string.courses) {
+        override fun createFragment() = TeamCourseFragment()
+    }
+
+    object FinancesPage : TeamPageConfig("FINANCES", R.string.finances) {
+        override fun createFragment() = FinanceFragment()
+    }
+
+    object ReportsPage : TeamPageConfig("REPORTS", R.string.reports) {
+        override fun createFragment() = ReportsFragment()
+    }
+
+    object DocumentsPage : TeamPageConfig("DOCUMENTS", R.string.documents) {
+        override fun createFragment() = TeamResourceFragment()
+    }
+
+    object ResourcesPage : TeamPageConfig("RESOURCES", R.string.resources) {
+        override fun createFragment() = TeamResourceFragment()
+    }
+
+    object ApplicantsPage : TeamPageConfig("APPLICANTS", R.string.applicants) {
+        override fun createFragment() = MembersFragment()
+    }
+
+    object JoinRequestsPage : TeamPageConfig("JOIN_REQUESTS", R.string.join_requests) {
+        override fun createFragment() = MembersFragment()
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamPagerAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamPagerAdapter.kt
@@ -5,91 +5,75 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.MemberChangeListener
-import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.ui.enterprises.FinanceFragment
-import org.ole.planet.myplanet.ui.enterprises.ReportsFragment
-import org.ole.planet.myplanet.ui.survey.SurveyFragment
-import org.ole.planet.myplanet.ui.team.teamCourse.TeamCourseFragment
-import org.ole.planet.myplanet.ui.team.teamDiscussion.DiscussionListFragment
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.ApplicantsPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.CalendarPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.ChatPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.CoursesPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.DocumentsPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.FinancesPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.JoinRequestsPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.MembersPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.MissionPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.PlanPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.ReportsPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.ResourcesPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.SurveyPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.TasksPage
+import org.ole.planet.myplanet.ui.team.TeamPageConfig.TeamPage
 import org.ole.planet.myplanet.ui.team.teamMember.JoinedMemberFragment
 import org.ole.planet.myplanet.ui.team.teamMember.MembersFragment
 import org.ole.planet.myplanet.ui.team.teamResource.TeamResourceFragment
-import org.ole.planet.myplanet.ui.team.teamTask.TeamTaskFragment
 
 class TeamPagerAdapter(
     private val fm: FragmentActivity,
-    team: RealmMyTeam?,
-    isInMyTeam: Boolean,
+    private val pages: List<TeamPageConfig>,
+    private val teamId: String?,
     private val memberChangeListener: MemberChangeListener
 ) : FragmentStateAdapter(fm) {
-    private val teamId = team?._id
-    private val isEnterprise = team?.type == "enterprise"
 
-    private val pages = mutableListOf<TeamPage>()
-    private val fragments: List<Fragment>
-
-    init {
-        if (isInMyTeam || team?.isPublic == true) {
-            pages += TeamPage.CHAT
-            pages += if (isEnterprise) TeamPage.MISSION else TeamPage.PLAN
-            pages += if (isEnterprise) TeamPage.TEAM else TeamPage.MEMBERS
-            pages += TeamPage.TASKS
-            pages += TeamPage.CALENDAR
-            pages += TeamPage.SURVEY
-            pages += if (isEnterprise) TeamPage.FINANCES else TeamPage.COURSES
-            if (isEnterprise) pages += TeamPage.REPORTS
-            pages += if (isEnterprise) TeamPage.DOCUMENTS else TeamPage.RESOURCES
-            pages += if (isEnterprise) TeamPage.APPLICANTS else TeamPage.JOIN_REQUESTS
-        } else {
-            pages += if (isEnterprise) TeamPage.MISSION else TeamPage.PLAN
-            pages += if (isEnterprise) TeamPage.TEAM else TeamPage.MEMBERS
-        }
-
-        fragments = pages.map { page ->
-            when (page) {
-                TeamPage.CHAT -> DiscussionListFragment()
-                TeamPage.PLAN, TeamPage.MISSION -> PlanFragment()
-                TeamPage.MEMBERS, TeamPage.TEAM -> JoinedMemberFragment().apply { setMemberChangeListener(memberChangeListener) }
-                TeamPage.TASKS -> TeamTaskFragment()
-                TeamPage.CALENDAR -> TeamCalendarFragment()
-                TeamPage.SURVEY -> SurveyFragment().apply {
-                    arguments = Bundle().apply {
-                        putBoolean("isTeam", true)
-                        putString("teamId", teamId)
-                    }
-                }
-                TeamPage.COURSES -> TeamCourseFragment()
-                TeamPage.FINANCES -> FinanceFragment()
-                TeamPage.REPORTS -> ReportsFragment()
-                TeamPage.RESOURCES, TeamPage.DOCUMENTS -> TeamResourceFragment().apply {
-                    MainApplication.listener = this
-                }
-                TeamPage.JOIN_REQUESTS,
-                TeamPage.APPLICANTS -> MembersFragment().apply { setMemberChangeListener(memberChangeListener) }
-            }.apply {
-                if (arguments == null) {
-                    arguments = Bundle().apply { putString("id", teamId) }
-                }
-            }
-        }
-    }
-
-    override fun getItemCount(): Int = fragments.size
+    override fun getItemCount(): Int = pages.size
 
     fun getPageTitle(position: Int): CharSequence =
-        fm.getString(pages[position].getTitleRes())
+        fm.getString(pages[position].titleRes)
 
-    fun TeamPage.getTitleRes(): Int =
-        R.string::class.java.getDeclaredField(this.name.lowercase()).getInt(null)
-
-    override fun getItemId(position: Int): Long =
-        pages[position].ordinal.toLong()
+    override fun getItemId(position: Int): Long = position.toLong()
 
     override fun containsItem(itemId: Long): Boolean =
-        pages.any { it.ordinal.toLong() == itemId }
+        itemId in 0 until pages.size
 
-    override fun createFragment(position: Int): Fragment =
-        fragments[position]
+    override fun createFragment(position: Int): Fragment {
+        val page = pages[position]
+        val fragment = page.createFragment()
+
+        when (page) {
+            TeamPage -> if (fragment is JoinedMemberFragment) {
+                fragment.setMemberChangeListener(memberChangeListener)
+            }
+            MembersPage -> if (fragment is JoinedMemberFragment) {
+                fragment.setMemberChangeListener(memberChangeListener)
+            }
+            ApplicantsPage, JoinRequestsPage -> if (fragment is MembersFragment) {
+                fragment.setMemberChangeListener(memberChangeListener)
+            }
+            DocumentsPage, ResourcesPage -> if (fragment is TeamResourceFragment) {
+                MainApplication.listener = fragment
+            }
+            SurveyPage -> {
+                fragment.arguments = (fragment.arguments ?: Bundle()).apply {
+                    putBoolean("isTeam", true)
+                    putString("teamId", teamId)
+                }
+            }
+            else -> {}
+        }
+
+        if (fragment.arguments == null) {
+            fragment.arguments = Bundle().apply { putString("id", teamId) }
+        } else if (!fragment.arguments!!.containsKey("id")) {
+            fragment.arguments!!.putString("id", teamId)
+        }
+
+        return fragment
+    }
 }


### PR DESCRIPTION
## Summary
- replace TeamPage enum with a sealed `TeamPageConfig`
- refactor TeamPagerAdapter to use the new objects
- build page lists in TeamDetailFragment
- update DashboardActivity and NotificationsFragment
- use `DocumentsPage` id to switch to the documents tab

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688bd4e1dbf8832bb9b8fd5df723a577