### PR TITLE
refactor: close streams with use

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
@@ -17,7 +17,6 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
-import java.io.OutputStream
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.util.UUID
@@ -142,25 +141,21 @@ object FileUtils {
     @JvmStatic
     fun copyAssets(context: Context) {
         val tiles = arrayOf("dhulikhel.mbtiles", "somalia.mbtiles")
-        val assetManager = context.assets
         try {
-            for (s in tiles) {
-                var out: OutputStream
-                val `in`: InputStream = assetManager.open(s)
-                val outFile = File(Environment.getExternalStorageDirectory().toString() + "/osmdroid", s)
-                out = FileOutputStream(outFile)
-                copyFile(`in`, out)
-                out.close()
-                `in`.close()
+            for (name in tiles) {
+                context.assets.open(name).use { input ->
+                    val outFile = File(
+                        Environment.getExternalStorageDirectory().toString() + "/osmdroid",
+                        name
+                    )
+                    FileOutputStream(outFile).use { out ->
+                        input.copyTo(out)
+                    }
+                }
             }
         } catch (e: Exception) {
             e.printStackTrace()
         }
-    }
-
-    @Throws(IOException::class)
-    private fun copyFile(`in`: InputStream, out: OutputStream) {
-        `in`.copyTo(out)
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary
- ensure asset streams close automatically using Kotlin's `use`
- remove redundant `copyFile` helper

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68910c0bb85c832baa027c849f1109be