### PR TITLE
Use Hilt to share ChatViewModel across chat UI

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -16,7 +16,7 @@ import android.widget.TableRow
 import androidx.core.content.ContextCompat
 import androidx.core.view.isNotEmpty
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -64,7 +64,7 @@ import retrofit2.Response
 class ChatDetailFragment : Fragment() {
     lateinit var fragmentChatDetailBinding: FragmentChatDetailBinding
     private lateinit var mAdapter: ChatAdapter
-    private val sharedViewModel: ChatViewModel by activityViewModels()
+    private val sharedViewModel: ChatViewModel by viewModels({ requireActivity() })
     private var _id: String = ""
     private var _rev: String = ""
     private var currentID: String = ""

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -16,7 +16,7 @@ import android.widget.TableRow
 import androidx.core.content.ContextCompat
 import androidx.core.view.isNotEmpty
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -64,7 +64,7 @@ import retrofit2.Response
 class ChatDetailFragment : Fragment() {
     lateinit var fragmentChatDetailBinding: FragmentChatDetailBinding
     private lateinit var mAdapter: ChatAdapter
-    private val sharedViewModel: ChatViewModel by viewModels({ requireActivity() })
+    private val sharedViewModel: ChatViewModel by activityViewModels()
     private var _id: String = ""
     private var _rev: String = ""
     private var currentID: String = ""

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -16,8 +16,8 @@ import android.widget.TableRow
 import androidx.core.content.ContextCompat
 import androidx.core.view.isNotEmpty
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -44,7 +44,6 @@ import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.model.AiProvider
 import org.ole.planet.myplanet.model.ChatModel
 import org.ole.planet.myplanet.model.ChatRequestModel
-import org.ole.planet.myplanet.model.ChatViewModel
 import org.ole.planet.myplanet.model.ContentData
 import org.ole.planet.myplanet.model.ContinueChatModel
 import org.ole.planet.myplanet.model.Conversation
@@ -65,7 +64,7 @@ import retrofit2.Response
 class ChatDetailFragment : Fragment() {
     lateinit var fragmentChatDetailBinding: FragmentChatDetailBinding
     private lateinit var mAdapter: ChatAdapter
-    private lateinit var sharedViewModel: ChatViewModel
+    private val sharedViewModel: ChatViewModel by activityViewModels()
     private var _id: String = ""
     private var _rev: String = ""
     private var currentID: String = ""
@@ -87,11 +86,6 @@ class ChatDetailFragment : Fragment() {
     private val jsonMediaType = "application/json".toMediaTypeOrNull()
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        sharedViewModel = ViewModelProvider(requireActivity())[ChatViewModel::class.java]
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentChatDetailBinding = FragmentChatDetailBinding.inflate(inflater, container, false)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -12,7 +12,7 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.slidingpanelayout.widget.SlidingPaneLayout
 import com.google.android.material.snackbar.Snackbar
@@ -42,7 +42,7 @@ import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 @AndroidEntryPoint
 class ChatHistoryListFragment : Fragment() {
     private lateinit var fragmentChatHistoryListBinding: FragmentChatHistoryListBinding
-    private val sharedViewModel: ChatViewModel by activityViewModels()
+    private val sharedViewModel: ChatViewModel by viewModels({ requireActivity() })
     var user: RealmUserModel? = null
     private var isFullSearch: Boolean = false
     private var isQuestion: Boolean = false

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -12,7 +12,7 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.slidingpanelayout.widget.SlidingPaneLayout
 import com.google.android.material.snackbar.Snackbar
@@ -42,7 +42,7 @@ import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 @AndroidEntryPoint
 class ChatHistoryListFragment : Fragment() {
     private lateinit var fragmentChatHistoryListBinding: FragmentChatHistoryListBinding
-    private val sharedViewModel: ChatViewModel by viewModels({ requireActivity() })
+    private val sharedViewModel: ChatViewModel by activityViewModels()
     var user: RealmUserModel? = null
     private var isFullSearch: Boolean = false
     private var isQuestion: Boolean = false

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -12,7 +12,7 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.slidingpanelayout.widget.SlidingPaneLayout
 import com.google.android.material.snackbar.Snackbar
@@ -29,7 +29,6 @@ import org.ole.planet.myplanet.callback.SyncListener
 import org.ole.planet.myplanet.databinding.FragmentChatHistoryListBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
-import org.ole.planet.myplanet.model.ChatViewModel
 import org.ole.planet.myplanet.model.Conversation
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmUserModel
@@ -43,7 +42,7 @@ import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 @AndroidEntryPoint
 class ChatHistoryListFragment : Fragment() {
     private lateinit var fragmentChatHistoryListBinding: FragmentChatHistoryListBinding
-    private lateinit var sharedViewModel: ChatViewModel
+    private val sharedViewModel: ChatViewModel by activityViewModels()
     var user: RealmUserModel? = null
     private var isFullSearch: Boolean = false
     private var isQuestion: Boolean = false
@@ -63,7 +62,6 @@ class ChatHistoryListFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        sharedViewModel = ViewModelProvider(requireActivity())[ChatViewModel::class.java]
         prefManager = SharedPrefManager(requireContext())
         startChatHistorySync()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
@@ -1,11 +1,15 @@
-package org.ole.planet.myplanet.model
+package org.ole.planet.myplanet.ui.chat
 
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.ole.planet.myplanet.model.Conversation
 
-class ChatViewModel : ViewModel() {
+@HiltViewModel
+class ChatViewModel @Inject constructor() : ViewModel() {
     private val _selectedChatHistory = MutableStateFlow<List<Conversation>?>(null)
     val selectedChatHistory: StateFlow<List<Conversation>?> = _selectedChatHistory.asStateFlow()
 


### PR DESCRIPTION
## Summary
- Annotate `ChatViewModel` with `@HiltViewModel` and move it into `ui/chat`
- Replace `ViewModelProvider` with `activityViewModels()` in chat fragments

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_689144529214832b9d204cf4027275c2