### PR TITLE
courses: smoother repositories (fixes #6627)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2790
-        versionName = "0.27.90"
+        versionCode = 2801
+        versionName = "0.28.1"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -10,8 +10,14 @@ import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.repository.CourseRepository
 import org.ole.planet.myplanet.repository.CourseRepositoryImpl
+import org.ole.planet.myplanet.repository.CourseProgressRepository
+import org.ole.planet.myplanet.repository.CourseProgressRepositoryImpl
 import org.ole.planet.myplanet.repository.LibraryRepository
 import org.ole.planet.myplanet.repository.LibraryRepositoryImpl
+import org.ole.planet.myplanet.repository.RatingRepository
+import org.ole.planet.myplanet.repository.RatingRepositoryImpl
+import org.ole.planet.myplanet.repository.SearchRepository
+import org.ole.planet.myplanet.repository.SearchRepositoryImpl
 import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.repository.SubmissionRepositoryImpl
 import org.ole.planet.myplanet.repository.UserRepository
@@ -44,6 +50,30 @@ object RepositoryModule {
         databaseService: DatabaseService
     ): CourseRepository {
         return CourseRepositoryImpl(databaseService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideCourseProgressRepository(
+        databaseService: DatabaseService
+    ): CourseProgressRepository {
+        return CourseProgressRepositoryImpl(databaseService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRatingRepository(
+        databaseService: DatabaseService
+    ): RatingRepository {
+        return RatingRepositoryImpl(databaseService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSearchRepository(
+        databaseService: DatabaseService
+    ): SearchRepository {
+        return SearchRepositoryImpl(databaseService)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseProgressRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseProgressRepository.kt
@@ -1,0 +1,7 @@
+package org.ole.planet.myplanet.repository
+
+import org.ole.planet.myplanet.model.RealmCourseProgress
+
+interface CourseProgressRepository {
+    suspend fun getCourseProgress(userId: String?): Map<String, RealmCourseProgress>
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseProgressRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package org.ole.planet.myplanet.repository
+
+import javax.inject.Inject
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmCourseProgress
+
+class CourseProgressRepositoryImpl @Inject constructor(
+    private val databaseService: DatabaseService
+) : CourseProgressRepository {
+
+    override suspend fun getCourseProgress(userId: String?): Map<String, RealmCourseProgress> {
+        return databaseService.withRealmAsync { realm ->
+            val progressList = realm.where(RealmCourseProgress::class.java)
+                .equalTo("userId", userId)
+                .findAll()
+
+            progressList.associate { (it.courseId ?: "") to it }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
@@ -8,6 +8,7 @@ interface LibraryRepository {
     suspend fun getOfflineLibraryItemsAsync(): List<RealmMyLibrary>
     suspend fun getLibraryListForUserAsync(userId: String?): List<RealmMyLibrary>
     suspend fun getAllLibraryListAsync(): List<RealmMyLibrary>
+    suspend fun getCourseLibraryItems(courseIds: List<String>): List<RealmMyLibrary>
     suspend fun saveLibraryItem(item: RealmMyLibrary)
     suspend fun deleteLibraryItem(id: String)
     suspend fun updateLibraryItem(id: String, updater: (RealmMyLibrary) -> Unit)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -49,6 +49,16 @@ class LibraryRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getCourseLibraryItems(courseIds: List<String>): List<RealmMyLibrary> {
+        return databaseService.withRealmAsync { realm ->
+            realm.where(RealmMyLibrary::class.java)
+                .`in`("courseId", courseIds.toTypedArray())
+                .equalTo("resourceOffline", false)
+                .isNotNull("resourceLocalAddress")
+                .findAll()
+        }
+    }
+
     override suspend fun saveLibraryItem(item: RealmMyLibrary) {
         databaseService.executeTransactionAsync { realm ->
             realm.copyToRealmOrUpdate(item)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingRepository.kt
@@ -1,0 +1,7 @@
+package org.ole.planet.myplanet.repository
+
+import org.ole.planet.myplanet.model.RealmRating
+
+interface RatingRepository {
+    suspend fun getRatings(type: String, userId: String?): Map<String, Int>
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package org.ole.planet.myplanet.repository
+
+import javax.inject.Inject
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmRating
+
+class RatingRepositoryImpl @Inject constructor(
+    private val databaseService: DatabaseService
+) : RatingRepository {
+
+    override suspend fun getRatings(type: String, userId: String?): Map<String, Int> {
+        return databaseService.withRealmAsync { realm ->
+            val ratings = realm.where(RealmRating::class.java)
+                .equalTo("type", type)
+                .equalTo("userId", userId)
+                .findAll()
+
+            ratings.associate { (it.item ?: "") to (it.rate?.toInt() ?: 0) }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SearchRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SearchRepository.kt
@@ -1,0 +1,15 @@
+package org.ole.planet.myplanet.repository
+
+import org.ole.planet.myplanet.model.RealmTag
+
+interface SearchRepository {
+    suspend fun saveSearchActivity(
+        userId: String?,
+        userPlanetCode: String?,
+        userParentCode: String?,
+        searchText: String,
+        tags: List<RealmTag>,
+        gradeLevel: String,
+        subjectLevel: String
+    )
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SearchRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package org.ole.planet.myplanet.repository
+
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import java.util.Calendar
+import java.util.UUID
+import javax.inject.Inject
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.RealmTag
+
+class SearchRepositoryImpl @Inject constructor(
+    private val databaseService: DatabaseService
+) : SearchRepository {
+
+    override suspend fun saveSearchActivity(
+        userId: String?,
+        userPlanetCode: String?,
+        userParentCode: String?,
+        searchText: String,
+        tags: List<RealmTag>,
+        gradeLevel: String,
+        subjectLevel: String
+    ) {
+        databaseService.executeTransactionAsync { realm ->
+            val activity = realm.createObject(RealmSearchActivity::class.java, UUID.randomUUID().toString())
+            activity.user = userId ?: ""
+            activity.time = Calendar.getInstance().timeInMillis
+            activity.createdOn = userPlanetCode ?: ""
+            activity.parentCode = userParentCode ?: ""
+            activity.text = searchText
+            activity.type = "courses"
+
+            val filter = JsonObject()
+            val tagsArray = JsonArray()
+            tags.forEach { tag ->
+                tagsArray.add(tag.name)
+            }
+            filter.add("tags", tagsArray)
+            filter.addProperty("doc.gradeLevel", gradeLevel)
+            filter.addProperty("doc.subjectLevel", subjectLevel)
+
+            activity.filter = Gson().toJson(filter)
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
@@ -3,30 +3,30 @@ package org.ole.planet.myplanet.ui.courses
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.util.Calendar
-import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmRating
-import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.repository.CourseProgressRepository
 import org.ole.planet.myplanet.repository.CourseRepository
 import org.ole.planet.myplanet.repository.LibraryRepository
+import org.ole.planet.myplanet.repository.RatingRepository
+import org.ole.planet.myplanet.repository.SearchRepository
 import org.ole.planet.myplanet.repository.UserRepository
 
 @HiltViewModel
 class CoursesViewModel @Inject constructor(
-    private val databaseService: DatabaseService,
     private val courseRepository: CourseRepository,
     private val libraryRepository: LibraryRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val ratingRepository: RatingRepository,
+    private val courseProgressRepository: CourseProgressRepository,
+    private val searchRepository: SearchRepository
 ) : ViewModel() {
 
     private val _coursesState = MutableStateFlow<CoursesUiState>(CoursesUiState.Loading)
@@ -64,8 +64,8 @@ class CoursesViewModel @Inject constructor(
                     courses
                 }
                 
-                val ratings = getRatings("course", userId)
-                val progress = getCourseProgress(userId)
+                val ratings = ratingRepository.getRatings("course", userId)
+                val progress = courseProgressRepository.getCourseProgress(userId)
                 
                 _coursesState.value = CoursesUiState.Success(
                     courses = filteredCourses,
@@ -106,46 +106,13 @@ class CoursesViewModel @Inject constructor(
 
     suspend fun getCourseLibraryItems(courseIds: List<String>): List<RealmMyLibrary> {
         return try {
-            databaseService.withRealmAsync { realm ->
-                realm.where(RealmMyLibrary::class.java)
-                    .`in`("courseId", courseIds.toTypedArray())
-                    .equalTo("resourceOffline", false)
-                    .isNotNull("resourceLocalAddress")
-                    .findAll()
-            }
+            libraryRepository.getCourseLibraryItems(courseIds)
         } catch (e: Exception) {
             emptyList()
         }
     }
 
-    private suspend fun getRatings(type: String, userId: String?): Map<String, Int> {
-        return try {
-            databaseService.withRealmAsync { realm ->
-                val ratings = realm.where(RealmRating::class.java)
-                    .equalTo("type", type)
-                    .equalTo("userId", userId)
-                    .findAll()
-                
-                ratings.associate { (it.item ?: "") to (it.rate?.toInt() ?: 0) }
-            }
-        } catch (e: Exception) {
-            emptyMap()
-        }
-    }
-
-    private suspend fun getCourseProgress(userId: String?): Map<String, RealmCourseProgress> {
-        return try {
-            databaseService.withRealmAsync { realm ->
-                val progressList = realm.where(RealmCourseProgress::class.java)
-                    .equalTo("userId", userId)
-                    .findAll()
-                
-                progressList.associate { (it.courseId ?: "") to it }
-            }
-        } catch (e: Exception) {
-            emptyMap()
-        }
-    }
+    // Ratings and course progress retrieval are handled by repositories
 
     suspend fun saveSearchActivity(
         userId: String?,
@@ -157,27 +124,15 @@ class CoursesViewModel @Inject constructor(
         subjectLevel: String
     ) {
         try {
-            databaseService.executeTransactionAsync { realm ->
-                val activity = realm.createObject(RealmSearchActivity::class.java, UUID.randomUUID().toString())
-                activity.user = userId ?: ""
-                activity.time = Calendar.getInstance().timeInMillis
-                activity.createdOn = userPlanetCode ?: ""
-                activity.parentCode = userParentCode ?: ""
-                activity.text = searchText
-                activity.type = "courses"
-                
-                // Create filter object
-                val filter = com.google.gson.JsonObject()
-                val tagsArray = com.google.gson.JsonArray()
-                tags.forEach { tag ->
-                    tagsArray.add(tag.name)
-                }
-                filter.add("tags", tagsArray)
-                filter.addProperty("doc.gradeLevel", gradeLevel)
-                filter.addProperty("doc.subjectLevel", subjectLevel)
-                
-                activity.filter = com.google.gson.Gson().toJson(filter)
-            }
+            searchRepository.saveSearchActivity(
+                userId,
+                userPlanetCode,
+                userParentCode,
+                searchText,
+                tags,
+                gradeLevel,
+                subjectLevel
+            )
         } catch (e: Exception) {
             e.printStackTrace()
         }


### PR DESCRIPTION
## Summary
- add repository methods for course library items
- introduce repositories for ratings, course progress and search activity
- inject new repositories into `CoursesViewModel` and remove direct `DatabaseService` use

## Testing
- `./gradlew lint`

------
https://chatgpt.com/codex/tasks/task_e_68915d3cf8a8832b8f76bb7f3fe361e2