### PR TITLE
fix: rename TimeUtils date helpers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMeetup.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMeetup.kt
@@ -86,8 +86,8 @@ open class RealmMeetup : RealmObject() {
             map["Created By"] = checkNull(meetups.creator)
             map["Category"] = checkNull(meetups.category)
             try {
-                map["Meetup Date"] = TimeUtils.getFormatedDate(meetups.startDate) +
-                        " - " + TimeUtils.getFormatedDate(meetups.endDate)
+                map["Meetup Date"] = TimeUtils.getFormattedDate(meetups.startDate) +
+                        " - " + TimeUtils.getFormattedDate(meetups.endDate)
             } catch (e: Exception) {
                 e.printStackTrace()
             }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
@@ -247,7 +247,7 @@ open class RealmSubmission : RealmObject() {
                 .equalTo("userId", userId)
                 .sort("startTime", Sort.DESCENDING)
                 .findFirst()
-            return recentSubmission?.startTime?.let { TimeUtils.getFormatedDateWithTime(it) } ?: ""
+            return recentSubmission?.startTime?.let { TimeUtils.getFormattedDateWithTime(it) } ?: ""
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/AdapterFeedback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/AdapterFeedback.kt
@@ -10,7 +10,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowFeedbackBinding
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.ui.feedback.AdapterFeedback.ViewHolderFeedback
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormatedDate
+import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
 
 class AdapterFeedback(private val context: Context, private var list: List<RealmFeedback>?) : RecyclerView.Adapter<ViewHolderFeedback>() {
     private lateinit var rowFeedbackBinding: RowFeedbackBinding
@@ -27,7 +27,7 @@ class AdapterFeedback(private val context: Context, private var list: List<Realm
         rowFeedbackBinding.tvStatus.text = list?.get(position)?.status
         val contentDescription = "${list?.get(position)?.title}, ${list?.get(position)?.type}, " +
                 "${context.getString(R.string.status)}: ${list?.get(position)?.status}, ${context.getString(R.string.priority)}: ${list?.get(position)?.priority}, " +
-                "${context.getString(R.string.open_date)}: ${getFormatedDate(list?.get(position)?.openTime)}"
+                "${context.getString(R.string.open_date)}: ${getFormattedDate(list?.get(position)?.openTime)}"
         rowFeedbackBinding.feedbackCardView.contentDescription = contentDescription
 
         if ("yes".equals(list?.get(position)?.priority, ignoreCase = true)) {
@@ -41,7 +41,7 @@ class AdapterFeedback(private val context: Context, private var list: List<Realm
             } else {
                 R.drawable.bg_grey
             }, null)
-        rowFeedbackBinding.tvOpenDate.text = getFormatedDate(list?.get(position)?.openTime)
+        rowFeedbackBinding.tvOpenDate.text = getFormattedDate(list?.get(position)?.openTime)
         rowFeedbackBinding.root.setOnClickListener {
             rowFeedbackBinding.root.contentDescription = list?.get(position)?.title
             context.startActivity(Intent(context, FeedbackDetailActivity::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
@@ -27,7 +27,7 @@ import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.feedback.FeedbackDetailActivity.RvFeedbackAdapter.ReplyViewHolder
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtil
 import org.ole.planet.myplanet.utilities.LocaleHelper
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormatedDateWithTime
+import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDateWithTime
 
 @AndroidEntryPoint
 class FeedbackDetailActivity : AppCompatActivity() {
@@ -54,7 +54,7 @@ class FeedbackDetailActivity : AppCompatActivity() {
         setTitle(R.string.feedback)
         realm = databaseService.realmInstance
         feedback = realm.where(RealmFeedback::class.java).equalTo("id", intent.getStringExtra("id")).findFirst()!!
-        activityFeedbackDetailBinding.tvDate.text = getFormatedDateWithTime(feedback.openTime)
+        activityFeedbackDetailBinding.tvDate.text = getFormattedDateWithTime(feedback.openTime)
         activityFeedbackDetailBinding.tvMessage.text = if (TextUtils.isEmpty(feedback.message))
             "N/A"
         else
@@ -138,7 +138,7 @@ class FeedbackDetailActivity : AppCompatActivity() {
 
         override fun onBindViewHolder(holder: ReplyViewHolder, position: Int) {
             rowFeedbackReplyBinding.tvDate.text = replyList?.get(position)?.date?.let {
-                getFormatedDateWithTime(it.toLong())
+                getFormattedDateWithTime(it.toLong())
             }
             rowFeedbackReplyBinding.tvUser.text = replyList?.get(position)?.user
             rowFeedbackReplyBinding.tvMessage.text = replyList?.get(position)?.message

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/AdapterMyPersonal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/AdapterMyPersonal.kt
@@ -21,7 +21,7 @@ import org.ole.planet.myplanet.ui.viewer.ImageViewerActivity
 import org.ole.planet.myplanet.ui.viewer.PDFReaderActivity
 import org.ole.planet.myplanet.ui.viewer.VideoPlayerActivity
 import org.ole.planet.myplanet.utilities.IntentUtils.openAudioFile
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormatedDate
+import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
 import org.ole.planet.myplanet.utilities.Utilities
 
 class AdapterMyPersonal(private val context: Context, private val list: List<RealmMyPersonal>) : RecyclerView.Adapter<ViewHolderMyPersonal>() {
@@ -41,7 +41,7 @@ class AdapterMyPersonal(private val context: Context, private val list: List<Rea
     override fun onBindViewHolder(holder: ViewHolderMyPersonal, position: Int) {
         rowMyPersonalBinding.title.text = list[position].title
         rowMyPersonalBinding.description.text = list[position].description
-        rowMyPersonalBinding.date.text = getFormatedDate(list[position].date)
+        rowMyPersonalBinding.date.text = getFormattedDate(list[position].date)
         rowMyPersonalBinding.imgDelete.setOnClickListener {
             AlertDialog.Builder(context, R.style.AlertDialogTheme)
                 .setMessage(R.string.delete_record)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
@@ -55,7 +55,7 @@ import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.SharedPrefManager
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormatedDate
+import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -222,7 +222,7 @@ class MyHealthFragment : Fragment() {
             startActivity(Intent(activity, AddMyHealthActivity::class.java).putExtra("userId", userId))
         }
 
-        fragmentVitalSignBinding.txtDob.text = if (TextUtils.isEmpty(userModel?.dob)) getString(R.string.birth_date) else getFormatedDate(userModel?.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+        fragmentVitalSignBinding.txtDob.text = if (TextUtils.isEmpty(userModel?.dob)) getString(R.string.birth_date) else getFormattedDate(userModel?.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     }
 
     private fun getHealthRecords(memberId: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submission/AdapterMySubmission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submission/AdapterMySubmission.kt
@@ -20,7 +20,7 @@ import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.ui.exam.TakeExamFragment
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission.ViewHolderMySurvey
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormatedDate
+import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
 
 class AdapterMySubmission(private val context: Context, private val list: List<RealmSubmission>?, private val examHashMap: HashMap<String?, RealmStepExam>?) : RecyclerView.Adapter<ViewHolderMySurvey>() {
     private lateinit var rowMySurveyBinding: RowMysurveyBinding
@@ -48,7 +48,7 @@ class AdapterMySubmission(private val context: Context, private val list: List<R
 
     override fun onBindViewHolder(holder: ViewHolderMySurvey, position: Int) {
         rowMySurveyBinding.status.text = list?.get(position)?.status
-        rowMySurveyBinding.date.text = getFormatedDate(list?.get(position)?.startTime)
+        rowMySurveyBinding.date.text = getFormattedDate(list?.get(position)?.startTime)
         showSubmittedBy(rowMySurveyBinding.submittedBy, position)
         if (examHashMap?.containsKey(list?.get(position)?.parentId) == true)
             rowMySurveyBinding.title.text = examHashMap[list?.get(position)?.parentId]?.name

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -57,7 +57,7 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
         val user: RealmUserModel? = UserProfileDbHandler(context).userModel
 
         with(holder.binding) {
-            created.text = TimeUtils.getFormatedDate(team.createdDate)
+            created.text = TimeUtils.getFormattedDate(team.createdDate)
             type.text = team.teamType
             type.visibility = if (team.teamType == null) View.GONE else View.VISIBLE
             name.text = team.name

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
@@ -65,7 +65,7 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
             deadline?.set(Calendar.MINUTE, minute)
             if (datePicker != null) {
                 datePicker?.text = deadline?.timeInMillis?.let {
-                    TimeUtils.getFormatedDateWithTime(it)
+                    TimeUtils.getFormattedDateWithTime(it)
                 }
             }
         }, deadline!![Calendar.HOUR_OF_DAY], deadline!![Calendar.MINUTE], true)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
@@ -42,7 +42,7 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.CheckboxListView
 import org.ole.planet.myplanet.utilities.DialogUtils.getAlertDialog
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormatedDate
+import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
 import org.ole.planet.myplanet.utilities.Utilities
 
 class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDateSetListener {
@@ -282,7 +282,7 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
             fragmentEditAchievementBinding.etGoals.setText(achievement?.goals)
             fragmentEditAchievementBinding.cbSendToNation.isChecked = achievement?.sendToNation.toBoolean()
         }
-        fragmentEditAchievementBinding.txtDob.text = if (TextUtils.isEmpty(user?.dob)) getString(R.string.birth_date) else getFormatedDate(user?.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+        fragmentEditAchievementBinding.txtDob.text = if (TextUtils.isEmpty(user?.dob)) getString(R.string.birth_date) else getFormattedDate(user?.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
         resourceArray = JsonArray()
         fragmentEditAchievementBinding.etFname.setText(user?.firstName)
         fragmentEditAchievementBinding.etMname.setText(user?.middleName)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserDetailFragment.kt
@@ -15,7 +15,7 @@ import org.ole.planet.myplanet.databinding.ItemTitleDescBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormatedDate
+import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -72,7 +72,7 @@ class UserDetailFragment : Fragment() {
     private fun getList(user: RealmUserModel, db: UserProfileDbHandler?): List<Detail> {
         val list: MutableList<Detail> = ArrayList()
         list.add(Detail("Full Name", user.getFullName()))
-        list.add(Detail("DOB", getFormatedDate(user.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")))
+        list.add(Detail("DOB", getFormattedDate(user.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")))
         list.add(Detail("Email", user.email!!))
         list.add(Detail("Phone", user.phoneNumber!!))
         list.add(Detail("Language", user.language!!))

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
@@ -170,7 +170,7 @@ class UserProfileFragment : Fragment() {
             model?.name ?: ""
         }
         fragmentUserProfileBinding.txtEmail.text = getString(R.string.two_strings, getString(R.string.email_colon), Utilities.checkNA(model?.email))
-        val dob = if (TextUtils.isEmpty(model?.dob)) getString(R.string.n_a) else TimeUtils.getFormatedDate(model?.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+        val dob = if (TextUtils.isEmpty(model?.dob)) getString(R.string.n_a) else TimeUtils.getFormattedDate(model?.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
         fragmentUserProfileBinding.txtDob.text = getString(R.string.two_strings, getString(R.string.date_of_birth), dob)
         fragmentUserProfileBinding.txtGender.text = getString(R.string.gender_colon, Utilities.checkNA(model?.gender))
         fragmentUserProfileBinding.txtLanguage.text = getString(R.string.two_strings, getString(R.string.language_colon), Utilities.checkNA(model?.language))
@@ -223,7 +223,7 @@ class UserProfileFragment : Fragment() {
         val dobText = if (TextUtils.isEmpty(model?.dob)) {
             getString(R.string.n_a)
         } else {
-            TimeUtils.getFormatedDate(model?.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+            TimeUtils.getFormattedDate(model?.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
         }
         binding.dateOfBirth.text = dobText
     }
@@ -293,7 +293,7 @@ class UserProfileFragment : Fragment() {
                     val calendar = Calendar.getInstance()
                     calendar.set(year, monthOfYear, dayOfMonth)
                     val dobMillis = calendar.timeInMillis
-                    val dobFormatted = TimeUtils.getFormatedDate(dobMillis)
+                    val dobFormatted = TimeUtils.getFormattedDate(dobMillis)
 
                     date = format(Locale.US, "%04d-%02d-%02dT00:00:00.000Z", year, monthOfYear + 1, dayOfMonth)
                     binding.dateOfBirth.text = dobFormatted
@@ -475,7 +475,7 @@ class UserProfileFragment : Fragment() {
         model?.let {
             fragmentUserProfileBinding.txtName.text = String.format("%s %s %s", it.firstName, it.middleName, it.lastName)
             fragmentUserProfileBinding.txtEmail.text = getString(R.string.two_strings, getString(R.string.email_colon), Utilities.checkNA(it.email))
-            val dob = if (TextUtils.isEmpty(it.dob)) "N/A" else TimeUtils.getFormatedDate(it.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+            val dob = if (TextUtils.isEmpty(it.dob)) "N/A" else TimeUtils.getFormattedDate(it.dob, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
             fragmentUserProfileBinding.txtDob.text = getString(R.string.two_strings, getString(R.string.date_of_birth), dob)
             fragmentUserProfileBinding.txtGender.text = getString(R.string.gender_colon, Utilities.checkNA(it.gender))
             fragmentUserProfileBinding.txtLanguage.text = getString(R.string.two_strings, getString(R.string.language_colon), Utilities.checkNA(it.language))

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/TimeUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/TimeUtils.kt
@@ -32,7 +32,7 @@ object TimeUtils {
     }
 
     @JvmStatic
-    fun getFormatedDate(date: Long?): String {
+    fun getFormattedDate(date: Long?): String {
         return try {
             val instant = date?.let { Instant.ofEpochMilli(it) } ?: Instant.now()
             defaultDateFormatter.format(instant)
@@ -42,8 +42,14 @@ object TimeUtils {
         }
     }
 
+    @Deprecated("Use getFormattedDate", ReplaceWith("getFormattedDate(date)"))
     @JvmStatic
-    fun getFormatedDateWithTime(date: Long): String {
+    fun getFormatedDate(date: Long?): String {
+        return getFormattedDate(date)
+    }
+
+    @JvmStatic
+    fun getFormattedDateWithTime(date: Long): String {
         return try {
             val instant = Instant.ofEpochMilli(date)
             dateTimeFormatter.format(instant)
@@ -51,6 +57,12 @@ object TimeUtils {
             e.printStackTrace()
             "N/A"
         }
+    }
+
+    @Deprecated("Use getFormattedDateWithTime", ReplaceWith("getFormattedDateWithTime(date)"))
+    @JvmStatic
+    fun getFormatedDateWithTime(date: Long): String {
+        return getFormattedDateWithTime(date)
     }
 
     @JvmStatic
@@ -83,16 +95,22 @@ object TimeUtils {
     }
 
     @JvmStatic
-    fun getFormatedDate(stringDate: String?, pattern: String?): String {
+    fun getFormattedDate(stringDate: String?, pattern: String?): String {
         return try {
             if (stringDate.isNullOrBlank() || pattern.isNullOrBlank()) return "N/A"
             val formatter = DateTimeFormatter.ofPattern(pattern, defaultLocale).withZone(utcZone)
             val instant = LocalDate.parse(stringDate, formatter).atStartOfDay(utcZone).toInstant()
-            getFormatedDate(instant.toEpochMilli())
+            getFormattedDate(instant.toEpochMilli())
         } catch (e: Exception) {
             e.printStackTrace()
             "N/A"
         }
+    }
+
+    @Deprecated("Use getFormattedDate", ReplaceWith("getFormattedDate(stringDate, pattern)"))
+    @JvmStatic
+    fun getFormatedDate(stringDate: String?, pattern: String?): String {
+        return getFormattedDate(stringDate, pattern)
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary
- rename TimeUtils date helpers to `getFormattedDate` and `getFormattedDateWithTime`
- update references to new helper names

## Testing
- `./gradlew assembleDebug` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68915e794664832b9afc22b021a5479a