### PR TITLE
Replace TextUtils isEmpty with Kotlin isNullOrEmpty

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
@@ -8,7 +8,6 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
-import android.text.TextUtils
 import android.text.format.DateUtils
 import android.util.Base64
 import android.util.Log
@@ -56,7 +55,7 @@ object Utilities {
     }
 
     fun isValidEmail(target: CharSequence): Boolean {
-        return !TextUtils.isEmpty(target) && Patterns.EMAIL_ADDRESS.matcher(target).matches()
+        return !target.isNullOrEmpty() && Patterns.EMAIL_ADDRESS.matcher(target).matches()
     }
 
     fun getUrl(id: String?, file: String?): String {
@@ -180,7 +179,7 @@ object Utilities {
     }
 
     fun loadImage(userImage: String?, imageView: ImageView) {
-        if (!TextUtils.isEmpty(userImage)) {
+        if (!userImage.isNullOrEmpty()) {
             Glide.with(context)
                 .load(userImage)
                 .placeholder(R.drawable.profile)


### PR DESCRIPTION
## Summary
- Simplify email validation to use Kotlin `isNullOrEmpty`
- Use Kotlin `isNullOrEmpty` when loading user images
- Remove unused `TextUtils` import

## Testing
- `./gradlew test` *(fails: build stopped after processing resources)*
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_68915cc3eaa8832b8af583c3e3cf2919