### PR TITLE
all: smoother `NetworkUtils.kt` (fixes #6623)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2790
-        versionName = "0.27.90"
+        versionCode = 2794
+        versionName = "0.27.94"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/NetworkUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/NetworkUtils.kt
@@ -10,7 +10,6 @@ import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
 import android.os.Build
 import android.provider.Settings
-import android.text.TextUtils
 import androidx.core.net.toUri
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
@@ -141,7 +140,7 @@ object NetworkUtils {
         if (capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true) {
             val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager?
             val connectionInfo: WifiInfo? = wifiManager?.connectionInfo
-            if (connectionInfo != null && !TextUtils.isEmpty(connectionInfo.ssid)) {
+            if (!connectionInfo?.ssid.isNullOrEmpty()) {
                 ssid = connectionInfo.networkId
             }
         }


### PR DESCRIPTION
## Summary
- Replace `TextUtils.isEmpty` with Kotlin's safe `isNullOrEmpty` check in `NetworkUtils.getCurrentNetworkId`
- Remove `android.text.TextUtils` import

## Testing
- `./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68915cd918dc832b812529c294189c2c