### PR TITLE
all: smoother `JsonUtils.kt` (fixes #6624)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2790
-        versionName = "0.27.90"
+        versionCode = 2795
+        versionName = "0.27.95"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/JsonUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/JsonUtils.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.utilities
 
-import android.text.TextUtils
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonNull
@@ -64,7 +63,7 @@ object JsonUtils {
 
     @JvmStatic
     fun addString(`object`: JsonObject, fieldName: String, value: String?) {
-        if (!TextUtils.isEmpty(value)) `object`.addProperty(fieldName, value)
+        if (!value.isNullOrEmpty()) `object`.addProperty(fieldName, value)
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary
- use `isNullOrEmpty` for string checks in `JsonUtils`
- drop deprecated `TextUtils` import

## Testing
- `./gradlew :app:lint --console=plain` *(hangs after task `lintAnalyzeDefaultDebug`)*

------
https://chatgpt.com/codex/tasks/task_e_68915d0481f8832b8bef97bc41505896