### PR TITLE
teams: smoother voices updates (fixes #6670)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2790
-        versionName = "0.27.90"
+        versionCode = 2816
+        versionName = "0.28.16"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
@@ -77,12 +77,13 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
 
     fun addItem(news: RealmNews?) {
         val newList = list.toMutableList()
-        newList.add(news)
+        newList.add(0, news)
         val diffCallback = RealmNewsDiffCallback(list, newList)
         val diffResult = DiffUtil.calculateDiff(diffCallback)
         list.clear()
         list.addAll(newList)
         diffResult.dispatchUpdatesTo(this)
+        recyclerView?.scrollToPosition(0)
     }
 
     fun setFromLogin(fromLogin: Boolean) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
@@ -19,6 +19,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toDrawable
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -75,8 +76,13 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
     }
 
     fun addItem(news: RealmNews?) {
-        list.add(news)
-        notifyDataSetChanged()
+        val newList = list.toMutableList()
+        newList.add(news)
+        val diffCallback = RealmNewsDiffCallback(list, newList)
+        val diffResult = DiffUtil.calculateDiff(diffCallback)
+        list.clear()
+        list.addAll(newList)
+        diffResult.dispatchUpdatesTo(this)
     }
 
     fun setFromLogin(fromLogin: Boolean) {
@@ -321,9 +327,11 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
     }
 
     fun updateList(newList: List<RealmNews?>) {
+        val diffCallback = RealmNewsDiffCallback(list, newList)
+        val diffResult = DiffUtil.calculateDiff(diffCallback)
         list.clear()
         list.addAll(newList)
-        notifyDataSetChanged()
+        diffResult.dispatchUpdatesTo(this)
     }
 
     private fun setMemberClickListeners(holder: ViewHolderNews, userModel: RealmUserModel?, currentLeader: RealmUserModel?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/RealmNewsDiffCallback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/RealmNewsDiffCallback.kt
@@ -1,0 +1,25 @@
+package org.ole.planet.myplanet.ui.news
+
+import androidx.recyclerview.widget.DiffUtil
+import org.ole.planet.myplanet.model.RealmNews
+
+class RealmNewsDiffCallback(
+    private val oldList: List<RealmNews?>,
+    private val newList: List<RealmNews?>
+) : DiffUtil.Callback() {
+    override fun getOldListSize(): Int = oldList.size
+
+    override fun getNewListSize(): Int = newList.size
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val oldItem = oldList[oldItemPosition]
+        val newItem = newList[newItemPosition]
+        return oldItem?.id == newItem?.id
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val oldItem = oldList[oldItemPosition]
+        val newItem = newList[newItemPosition]
+        return oldItem == newItem
+    }
+}


### PR DESCRIPTION
## Summary
- add RealmNewsDiffCallback for fine-grained list updates
- apply DiffUtil in AdapterNews.addItem and updateList instead of notifyDataSetChanged

## Testing
- `./gradlew --no-daemon --console=plain assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_689161199264832bad88aa08bf8363a3