### PR TITLE
all: less synchronous `CourseRepository.kt` is more (fixes #6628)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2806
-        versionName = "0.28.6"
+        versionCode = 2811
+        versionName = "0.28.11"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
@@ -10,10 +10,4 @@ interface CourseRepository {
     suspend fun saveCourse(course: RealmMyCourse)
     suspend fun updateCourse(id: String, updater: (RealmMyCourse) -> Unit)
     suspend fun deleteCourse(id: String)
-    @Deprecated("Use async version", ReplaceWith("getAllCourses()"))
-    fun getAllCoursesSync(): List<RealmMyCourse>
-    @Deprecated("Use async version", ReplaceWith("getCourseById(id)"))
-    fun getCourseByIdSync(id: String): RealmMyCourse?
-    @Deprecated("Use async version", ReplaceWith("getEnrolledCourses()"))
-    fun getEnrolledCoursesSync(): List<RealmMyCourse>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -64,36 +64,8 @@ class CourseRepositoryImpl @Inject constructor(
         }
     }
 
-    private suspend fun getCurrentUserId(): String {
-        return databaseService.withRealmAsync { realm ->
-            getCurrentUserId(realm)
-        }
-    }
-
     private fun getCurrentUserId(realm: io.realm.Realm): String {
         return realm.where(RealmUserModel::class.java)
-            .findFirst()?.id ?: ""
-    }
-
-    // Deprecated methods for backward compatibility
-    override fun getAllCoursesSync(): List<RealmMyCourse> {
-        return databaseService.realmInstance.where(RealmMyCourse::class.java).findAll()
-    }
-
-    override fun getCourseByIdSync(id: String): RealmMyCourse? {
-        return databaseService.realmInstance.where(RealmMyCourse::class.java)
-            .equalTo("courseId", id)
-            .findFirst()
-    }
-
-    override fun getEnrolledCoursesSync(): List<RealmMyCourse> {
-        return databaseService.realmInstance.where(RealmMyCourse::class.java)
-            .equalTo("userId", getCurrentUserIdSync())
-            .findAll()
-    }
-
-    private fun getCurrentUserIdSync(): String {
-        return databaseService.realmInstance.where(RealmUserModel::class.java)
             .findFirst()?.id ?: ""
     }
 }


### PR DESCRIPTION
## Summary
- remove deprecated synchronous methods from CourseRepository and CourseRepositoryImpl
- drop unused synchronous helper getCurrentUserIdSync

## Testing
- `./gradlew -p app compileDefaultDebugKotlin --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68931a2b46b4832b9db80f0c7c73f69f