### PR TITLE
all: less synchronous `UserRepository.kt` is more (fixes #6646)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2806
-        versionName = "0.28.6"
+        versionCode = 2812
+        versionName = "0.28.12"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -10,8 +10,6 @@ interface UserRepository {
     suspend fun getUserById(userId: String): RealmUserModel?
     suspend fun getUserByName(username: String): RealmUserModel?
     suspend fun getAllUsers(): List<RealmUserModel>
-    @Deprecated("Use async version", ReplaceWith("getCurrentUser()"))    
-    fun getRealm(): Realm
     @Deprecated("Use async version", ReplaceWith("getCurrentUser()"))
-    fun getCurrentUserSync(): RealmUserModel?
+    fun getRealm(): Realm
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -50,8 +50,4 @@ class UserRepositoryImpl @Inject constructor(
     override fun getRealm(): Realm {
         return databaseService.realmInstance
     }
-
-    override fun getCurrentUserSync(): RealmUserModel? {
-        return databaseService.realmInstance.where(RealmUserModel::class.java).findFirst()
-    }
 }


### PR DESCRIPTION
## Summary
- remove deprecated synchronous user lookup from repository interface
- delete obsolete implementation

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68931a752c60832ba0a14199f970316e