### PR TITLE
Refactor Realm usage in MainApplication

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -15,7 +15,6 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import dagger.hilt.android.HiltAndroidApp
-import io.realm.Realm
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.Date
@@ -74,7 +73,6 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
         private const val STAY_ONLINE_WORK_TAG = "stayOnlineWork"
         private const val TASK_NOTIFICATION_WORK_TAG = "taskNotificationWork"
         lateinit var context: Context
-        lateinit var mRealm: Realm
         lateinit var service: DatabaseService
         var preferences: SharedPreferences? = null
         var syncFailedCount = 0
@@ -206,7 +204,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
     private fun setupPreferences() {
         preferences = appPreferences
         service = databaseService
-        mRealm = service.realmInstance
+        service.withRealm { }
         defaultPref = defaultPreferences
     }
 
@@ -265,7 +263,12 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                             isServerReachable(serverUrl)
                         }
                         if (canReachServer && defaultPref.getBoolean("beta_auto_download", false)) {
-                            backgroundDownload(downloadAllFiles(getAllLibraryList(mRealm)), applicationContext)
+                            service.withRealm { realm ->
+                                backgroundDownload(
+                                    downloadAllFiles(getAllLibraryList(realm)),
+                                    applicationContext
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- eliminate global Realm instance in MainApplication
- scope Realm usage to withRealm calls for setup and auto-download

## Testing
- `./gradlew :app:lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68931b596fa0832b849bb1c1f85cbc59