### PR TITLE
Ensure Realm closed in BaseResourceFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
@@ -100,8 +100,8 @@ abstract class BaseNewsFragment : BaseContainerFragment(), OnNewsItemClickListen
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         profileDbHandler.onDestroy()
+        super.onDestroy()
     }
 
     override fun showReply(news: RealmNews?, fromLogin: Boolean, nonTeamMember: Boolean) {

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -154,11 +154,6 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         }
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        mRealm.close()
-    }
-
     private fun checkAndAddToList(course: RealmMyCourse?, courses: MutableList<RealmMyCourse>, tags: List<RealmTag>) {
         for (tg in tags) {
             val count = mRealm.where(RealmTag::class.java).equalTo("db", "courses").equalTo("tagId", tg.id)

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -387,6 +387,17 @@ abstract class BaseResourceFragment : Fragment() {
         Utilities.toast(activity, getString(R.string.added_to_my_library))
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        if (::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.removeAllChangeListeners()
+            if (mRealm.isInTransaction) {
+                mRealm.cancelTransaction()
+            }
+            mRealm.close()
+        }
+    }
+
     companion object {
         var auth = ""
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -283,7 +283,6 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         profileDbHandler.onDestroy()
         if (::myCoursesResults.isInitialized) {
             myCoursesResults.removeChangeListener(myCoursesChangeListener)
@@ -291,7 +290,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
         if (::myTeamsResults.isInitialized) {
             myTeamsResults.removeChangeListener(myTeamsChangeListener)
         }
-        mRealm.close()
+        super.onDestroy()
     }
 
     private fun setCountText(countText: Int, c: Class<*>, v: View) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
@@ -292,11 +292,6 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), SurveyAdoptListen
         return items.mapNotNull { it?.takeIf(clazz::isInstance)?.let(clazz::cast) }
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        mRealm.close()
-    }
-
     companion object {
         fun newInstance(): SurveyFragment = SurveyFragment()
     }


### PR DESCRIPTION
## Summary
- close Realm in `BaseResourceFragment.onDestroy` and clean up listeners/transactions
- rely on base cleanup in child fragments by removing redundant `mRealm.close()` calls
- reorder cleanup in `BaseDashboardFragment` and `BaseNewsFragment`

## Testing
- `./gradlew :app:compileLiteDebugKotlin --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68932054d624832b8678a3baced05b2b