### PR TITLE
courses: smoother realm closing (fixes #6641)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2806
-        versionName = "0.28.6"
+        versionCode = 2808
+        versionName = "0.28.8"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
@@ -93,4 +93,11 @@ class CourseDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
         super.onDownloadComplete()
         setCourseData()
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if (this::cRealm.isInitialized && !cRealm.isClosed) {
+            cRealm.close()
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/MyProgressFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/MyProgressFragment.kt
@@ -42,10 +42,14 @@ class MyProgressFragment : Fragment() {
 
     private fun initializeData() {
         val realm = databaseService.realmInstance
-        val user = UserProfileDbHandler(requireActivity()).userModel
-        val courseData = fetchCourseData(realm, user?.id)
-        fragmentMyProgressBinding.rvMyprogress.layoutManager = LinearLayoutManager(requireActivity())
-        fragmentMyProgressBinding.rvMyprogress.adapter = AdapterMyProgress(requireActivity(), courseData)
+        try {
+            val user = UserProfileDbHandler(requireActivity()).userModel
+            val courseData = fetchCourseData(realm, user?.id)
+            fragmentMyProgressBinding.rvMyprogress.layoutManager = LinearLayoutManager(requireActivity())
+            fragmentMyProgressBinding.rvMyprogress.adapter = AdapterMyProgress(requireActivity(), courseData)
+        } finally {
+            realm.close()
+        }
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -18,6 +18,7 @@ import java.util.Locale
 import javax.inject.Inject
 import kotlin.collections.isNotEmpty
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
@@ -319,6 +320,15 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
             fragmentTakeCourseBinding.finishStep.visibility = View.GONE
         }
 
+    }
+
+    override fun onDestroyView() {
+        fragmentTakeCourseBinding.courseProgress.setOnSeekBarChangeListener(null)
+        lifecycleScope.coroutineContext.cancelChildren()
+        super.onDestroyView()
+        if (this::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.close()
+        }
     }
 
     private val isValidClickRight: Boolean get() = fragmentTakeCourseBinding.viewPager2.adapter != null && fragmentTakeCourseBinding.viewPager2.currentItem < fragmentTakeCourseBinding.viewPager2.adapter?.itemCount!!


### PR DESCRIPTION
## Summary
- Close `Realm` instances in course-related fragments to prevent leaks
- Cancel pending coroutines and listeners before closing database in `TakeCourseFragment`
- Ensure progress screen uses and closes a short-lived realm instance

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_6893207e3ca4832b864c368b76e4eb37