### PR TITLE
Refactor team member requests with repository and ViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -22,6 +22,8 @@ import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.repository.SubmissionRepositoryImpl
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.UserRepositoryImpl
+import org.ole.planet.myplanet.repository.TeamRepository
+import org.ole.planet.myplanet.repository.TeamRepositoryImpl
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -82,5 +84,13 @@ object RepositoryModule {
         databaseService: DatabaseService
     ): SubmissionRepository {
         return SubmissionRepositoryImpl(databaseService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideTeamRepository(
+        databaseService: DatabaseService,
+    ): TeamRepository {
+        return TeamRepositoryImpl(databaseService)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -1,0 +1,7 @@
+package org.ole.planet.myplanet.repository
+
+interface TeamRepository {
+    suspend fun acceptRequest(teamId: String, userId: String)
+    suspend fun rejectRequest(teamId: String, userId: String)
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package org.ole.planet.myplanet.repository
+
+import javax.inject.Inject
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyTeam
+
+class TeamRepositoryImpl @Inject constructor(
+    private val databaseService: DatabaseService
+) : TeamRepository {
+
+    override suspend fun acceptRequest(teamId: String, userId: String) {
+        databaseService.executeTransactionAsync { realm ->
+            realm.where(RealmMyTeam::class.java)
+                .equalTo("teamId", teamId)
+                .equalTo("userId", userId)
+                .findFirst()
+                ?.apply {
+                    docType = "membership"
+                    updated = true
+                }
+        }
+    }
+
+    override suspend fun rejectRequest(teamId: String, userId: String) {
+        databaseService.executeTransactionAsync { realm ->
+            realm.where(RealmMyTeam::class.java)
+                .equalTo("teamId", teamId)
+                .equalTo("userId", userId)
+                .findFirst()
+                ?.deleteFromRealm()
+        }
+    }
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterMemberRequest.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterMemberRequest.kt
@@ -4,25 +4,20 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import io.realm.Realm
-import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.callback.MemberChangeListener
 import org.ole.planet.myplanet.databinding.RowMemberRequestBinding
-import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMember
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
-import org.ole.planet.myplanet.utilities.Utilities
 
-class AdapterMemberRequest(private val context: Context, private val list: MutableList<RealmUserModel>, private val mRealm: Realm, private val currentUser: RealmUserModel, private val listener: MemberChangeListener, private val uploadManager: UploadManager) : RecyclerView.Adapter<AdapterMemberRequest.ViewHolderUser>() {
+class AdapterMemberRequest(
+    private val context: Context,
+    private val list: MutableList<RealmUserModel>,
+    private val teamId: String?,
+    private val currentUser: RealmUserModel,
+    private val isTeamLeader: Boolean,
+    private val members: Int,
+    private val viewModel: MemberRequestViewModel
+) : RecyclerView.Adapter<AdapterMemberRequest.ViewHolderUser>() {
+
     private lateinit var rowMemberRequestBinding: RowMemberRequestBinding
-    private var teamId: String? = null
-    private lateinit var team: RealmMyTeam
-
-    fun setTeamId(teamId: String?) {
-        this.teamId = teamId
-    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderUser {
         rowMemberRequestBinding = RowMemberRequestBinding.inflate(LayoutInflater.from(context), parent, false)
@@ -33,32 +28,14 @@ class AdapterMemberRequest(private val context: Context, private val list: Mutab
         val currentItem = list.getOrNull(position) ?: return
         rowMemberRequestBinding.tvName.text = currentItem.name ?: currentItem.toString()
 
-        team = try {
-            mRealm.where(RealmMyTeam::class.java).equalTo("_id", teamId).findFirst()
-                ?: throw IllegalArgumentException("Team not found for ID: $teamId")
-        } catch (e: IllegalArgumentException) {
-            e.printStackTrace()
-            try {
-                mRealm.where(RealmMyTeam::class.java).equalTo("teamId", teamId).findFirst()
-                    ?: throw IllegalArgumentException("Team not found for ID: $teamId")
-            } catch (e: IllegalArgumentException) {
-                e.printStackTrace()
-                return
-            }
-        }
-
         with(rowMemberRequestBinding) {
-            val members = getJoinedMember("$teamId", mRealm).size
-
-            if (members >= 12){
+            if (members >= 12) {
                 btnAccept.isEnabled = false
             }
-
-            if(isGuestUser() || !isTeamLeader()){
+            if (isGuestUser() || !isTeamLeader) {
                 btnReject.isEnabled = false
                 btnAccept.isEnabled = false
             }
-
             btnAccept.setOnClickListener { handleClick(holder, true) }
             btnReject.setOnClickListener { handleClick(holder, false) }
         }
@@ -66,52 +43,26 @@ class AdapterMemberRequest(private val context: Context, private val list: Mutab
 
     private fun isGuestUser() = currentUser.id?.startsWith("guest") == true
 
-    fun isTeamLeader(): Boolean {
-        if(teamId==null)return false
-        return team.userId == currentUser._id
-    }
-
     private fun handleClick(holder: RecyclerView.ViewHolder, isAccepted: Boolean) {
-        val adapterPosition = holder.bindingAdapterPosition
-        if (adapterPosition != RecyclerView.NO_POSITION && adapterPosition < list.size) {
-            acceptReject(list[adapterPosition], isAccepted, adapterPosition)
-        }
-        listener.onMemberChanged()
-    }
-
-    private fun acceptReject(userModel: RealmUserModel, isAccept: Boolean, position: Int) {
-        val userId = userModel.id
-
-        list.removeAt(position)
-        notifyItemRemoved(position)
-        notifyItemRangeChanged(position, list.size)
-
-        mRealm.executeTransactionAsync({ realm: Realm ->
-            val team = realm.where(RealmMyTeam::class.java)
-                .equalTo("teamId", teamId)
-                .equalTo("userId", userId)
-                .findFirst()
-            if (team != null) {
-                if (isAccept) {
-                    team.docType = "membership"
-                    team.updated = true
+        val position = holder.bindingAdapterPosition
+        if (position != RecyclerView.NO_POSITION && position < list.size) {
+            val userModel = list[position]
+            val userId = userModel.id
+            list.removeAt(position)
+            notifyItemRemoved(position)
+            notifyItemRangeChanged(position, list.size)
+            if (teamId != null && userId != null) {
+                if (isAccepted) {
+                    viewModel.acceptRequest(teamId, userId)
                 } else {
-                    team.deleteFromRealm()
+                    viewModel.rejectRequest(teamId, userId)
                 }
             }
-        }, {
-            syncTeamActivities(context, uploadManager)
-            listener.onMemberChanged()
-        }, { error ->
-            list.add(position, userModel)
-            notifyItemInserted(position)
-            Utilities.toast(context, context.getString(R.string.request_failed_please_retry))
-        })
+        }
     }
 
-    override fun getItemCount(): Int {
-        return list.size
-    }
+    override fun getItemCount(): Int = list.size
 
-    class ViewHolderUser(rowMemberRequestBinding: RowMemberRequestBinding) : RecyclerView.ViewHolder(rowMemberRequestBinding.root)
+    class ViewHolderUser(binding: RowMemberRequestBinding) : RecyclerView.ViewHolder(binding.root)
 }
+

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MemberRequestViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MemberRequestViewModel.kt
@@ -1,0 +1,44 @@
+package org.ole.planet.myplanet.ui.team.teamMember
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.MainApplication
+import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.repository.TeamRepository
+import org.ole.planet.myplanet.service.UploadManager
+
+@HiltViewModel
+class MemberRequestViewModel @Inject constructor(
+    private val teamRepository: TeamRepository,
+    private val uploadManager: UploadManager
+) : ViewModel() {
+
+    private val _result = MutableLiveData<Result<Unit>>()
+    val result: LiveData<Result<Unit>> = _result
+
+    fun acceptRequest(teamId: String, userId: String) {
+        viewModelScope.launch {
+            val res = runCatching {
+                teamRepository.acceptRequest(teamId, userId)
+                RealmMyTeam.syncTeamActivities(MainApplication.context, uploadManager)
+            }
+            _result.postValue(res)
+        }
+    }
+
+    fun rejectRequest(teamId: String, userId: String) {
+        viewModelScope.launch {
+            val res = runCatching {
+                teamRepository.rejectRequest(teamId, userId)
+                RealmMyTeam.syncTeamActivities(MainApplication.context, uploadManager)
+            }
+            _result.postValue(res)
+        }
+    }
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MembersFragment.kt
@@ -2,18 +2,22 @@ package org.ole.planet.myplanet.ui.team.teamMember
 
 import android.content.Context
 import android.content.res.Configuration
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
+import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseMemberFragment
 import org.ole.planet.myplanet.callback.MemberChangeListener
 import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMemberCount
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getRequestedMember
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
 class MembersFragment : BaseMemberFragment() {
@@ -21,8 +25,7 @@ class MembersFragment : BaseMemberFragment() {
     private lateinit var currentUser: RealmUserModel
     private lateinit var memberChangeListener: MemberChangeListener
 
-    @Inject
-    lateinit var uploadManager: UploadManager
+    private val viewModel: MemberRequestViewModel by viewModels()
 
     fun setMemberChangeListener(listener: MemberChangeListener) {
         this.memberChangeListener = listener
@@ -31,6 +34,18 @@ class MembersFragment : BaseMemberFragment() {
     override fun onAttach(context: Context) {
         super.onAttach(context)
         currentUser = UserProfileDbHandler(context).userModel!!
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.result.observe(viewLifecycleOwner) { result ->
+            result.onSuccess {
+                memberChangeListener.onMemberChanged()
+            }
+            result.onFailure {
+                Utilities.toast(requireContext(), getString(R.string.request_failed_please_retry))
+            }
+        }
     }
 
     override fun onNewsItemClick(news: RealmNews?) {}
@@ -43,8 +58,18 @@ class MembersFragment : BaseMemberFragment() {
         get() = getRequestedMember(teamId, mRealm)
 
     override val adapter: RecyclerView.Adapter<*>
-        get() = AdapterMemberRequest(requireActivity(), list.toMutableList(),
-            mRealm, currentUser, memberChangeListener, uploadManager).apply { setTeamId(teamId) }
+        get() {
+            val memberCount = getJoinedMemberCount(teamId, mRealm)
+            return AdapterMemberRequest(
+                requireActivity(),
+                list.toMutableList(),
+                teamId,
+                currentUser,
+                isTeamLeader(),
+                memberCount,
+                viewModel
+            )
+        }
 
     override val layoutManager: RecyclerView.LayoutManager
         get() {


### PR DESCRIPTION
## Summary
- Introduce `TeamRepository` and `TeamRepositoryImpl` to accept or reject team member requests using Realm transactions.
- Add `MemberRequestViewModel` to handle requests, trigger sync, and expose result state.
- Register the new repository in `RepositoryModule` and refactor `MembersFragment`/`AdapterMemberRequest` to use the ViewModel instead of direct Realm operations.

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6893832894d0832b82e295ea8cc19d43