### PR TITLE
dashboard: smoother `DashboardViewModel.kt` (fixes #6704)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2790
-        versionName = "0.27.90"
+        versionCode = 2829
+        versionName = "0.28.29"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2829
-        versionName = "0.28.29"
+        versionCode = 2830
+        versionName = "0.28.30"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -1,7 +1,6 @@
 package org.ole.planet.myplanet.ui.dashboard
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.Realm
 import java.util.Date
@@ -40,34 +39,31 @@ class DashboardViewModel @Inject constructor(
         return total.coerceAtMost(11)
     }
 
-    fun updateResourceNotification(userId: String?, onComplete: () -> Unit = {}) {
-        viewModelScope.launch {
-            try {
-                databaseService.executeTransactionAsync { realm ->
-                    val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
-                    if (resourceCount > 0) {
-                        val existingNotification = realm.where(RealmNotification::class.java)
-                            .equalTo("userId", userId)
-                            .equalTo("type", "resource")
-                            .findFirst()
+    suspend fun updateResourceNotification(userId: String?) {
+        try {
+            databaseService.executeTransactionAsync { realm ->
+                val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
+                if (resourceCount > 0) {
+                    val existingNotification = realm.where(RealmNotification::class.java)
+                        .equalTo("userId", userId)
+                        .equalTo("type", "resource")
+                        .findFirst()
 
-                        if (existingNotification != null) {
-                            existingNotification.message = "$resourceCount"
-                            existingNotification.relatedId = "$resourceCount"
-                        } else {
-                            createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
-                        }
+                    if (existingNotification != null) {
+                        existingNotification.message = "$resourceCount"
+                        existingNotification.relatedId = "$resourceCount"
                     } else {
-                        realm.where(RealmNotification::class.java)
-                            .equalTo("userId", userId)
-                            .equalTo("type", "resource")
-                            .findFirst()?.deleteFromRealm()
+                        createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
                     }
+                } else {
+                    realm.where(RealmNotification::class.java)
+                        .equalTo("userId", userId)
+                        .equalTo("type", "resource")
+                        .findFirst()?.deleteFromRealm()
                 }
-                onComplete()
-            } catch (e: Exception) {
-                e.printStackTrace()
             }
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
     }
 
@@ -118,51 +114,6 @@ class DashboardViewModel @Inject constructor(
                 .equalTo("isRead", false)
                 .count()
                 .toInt()
-        }
-    }
-
-    @Deprecated("Use async version without realm parameter", ReplaceWith("getUnreadNotificationsSize(userId)"))
-    fun getUnreadNotificationsSize(realm: Realm, userId: String?): Int {
-        return realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("isRead", false)
-            .count()
-            .toInt()
-    }
-    
-    @Deprecated("Use async version", ReplaceWith("getSurveyTitlesFromSubmissions(submissions)"))
-    fun getSurveyTitlesFromSubmissions(realm: Realm, submissions: List<RealmSubmission>): List<String> {
-        val titles = mutableListOf<String>()
-        submissions.forEach { submission ->
-            val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
-            val exam = realm.where(RealmStepExam::class.java)
-                .equalTo("id", examId)
-                .findFirst()
-            exam?.name?.let { titles.add(it) }
-        }
-        return titles
-    }
-    
-    @Deprecated("Use async version", ReplaceWith("updateResourceNotification(userId)"))
-    fun updateResourceNotification(realm: Realm, userId: String?) {
-        val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
-        if (resourceCount > 0) {
-            val existingNotification = realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()
-
-            if (existingNotification != null) {
-                existingNotification.message = "$resourceCount"
-                existingNotification.relatedId = "$resourceCount"
-            } else {
-                createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
-            }
-        } else {
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()?.deleteFromRealm()
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove deprecated synchronous DashboardViewModel methods
- call asynchronous notification helpers from DashboardActivity
- await resource notification updates before building notification list

## Testing
- `./gradlew --version`


------
https://chatgpt.com/codex/tasks/task_e_68915fee47f4832ba8eca31a675f4124