### PR TITLE
Refactor dashboard notification helpers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -570,14 +570,16 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             val newNotifications = mutableListOf<NotificationUtil.NotificationConfig>()
 
             try {
-                databaseService.realmInstance.use { backgroundRealm ->
-                    backgroundRealm.executeTransaction { realm ->
-                        val createdNotifications = createNotifications(realm, userId)
-                        newNotifications.addAll(createdNotifications)
-                    }
+                val pendingSurveys = dashboardViewModel.getPendingSurveys(userId)
+                val surveyTitles = dashboardViewModel.getSurveyTitlesFromSubmissions(pendingSurveys)
+                dashboardViewModel.updateResourceNotification(userId)
 
-                    unreadCount = dashboardViewModel.getUnreadNotificationsSize(backgroundRealm, userId)
+                val createdNotifications = databaseService.executeTransactionWithResultAsync { realm ->
+                    createNotifications(realm, userId, surveyTitles)
                 }
+                newNotifications.addAll(createdNotifications)
+
+                unreadCount = dashboardViewModel.getUnreadNotificationsSize(userId)
             } catch (e: Exception) {
                 e.printStackTrace()
             }
@@ -599,9 +601,13 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-    private fun createNotifications(realm: Realm, userId: String?): List<NotificationUtil.NotificationConfig> {
+    private fun createNotifications(
+        realm: Realm,
+        userId: String?,
+        surveyTitles: List<String>
+    ): List<NotificationUtil.NotificationConfig> {
         val newNotifications = mutableListOf<NotificationUtil.NotificationConfig>()
-        createDatabaseNotificationsFromSources(realm, userId)
+        createDatabaseNotificationsFromSources(realm, userId, surveyTitles)
         val unreadNotifications = realm.where(RealmNotification::class.java)
             .equalTo("userId", userId)
             .equalTo("isRead", false)
@@ -616,9 +622,12 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         return newNotifications
     }
 
-    private fun createDatabaseNotificationsFromSources(realm: Realm, userId: String?) {
-        dashboardViewModel.updateResourceNotification(realm, userId)
-        createSurveyDatabaseNotifications(realm, userId)
+    private fun createDatabaseNotificationsFromSources(
+        realm: Realm,
+        userId: String?,
+        surveyTitles: List<String>
+    ) {
+        createSurveyDatabaseNotifications(realm, userId, surveyTitles)
         createTaskDatabaseNotifications(realm, userId)
         createStorageDatabaseNotifications(realm, userId)
         createJoinRequestDatabaseNotifications(realm, userId)
@@ -653,10 +662,11 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-    private fun createSurveyDatabaseNotifications(realm: Realm, userId: String?) {
-        val pendingSurveys = dashboardViewModel.getPendingSurveys(userId)
-        val surveyTitles = dashboardViewModel.getSurveyTitlesFromSubmissions(realm, pendingSurveys)
-
+    private fun createSurveyDatabaseNotifications(
+        realm: Realm,
+        userId: String?,
+        surveyTitles: List<String>
+    ) {
         surveyTitles.forEach { title ->
             dashboardViewModel.createNotificationIfNotExists(realm, "survey", title, title, userId)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -1,13 +1,11 @@
 package org.ole.planet.myplanet.ui.dashboard
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.Realm
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseResourceFragment
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmNotification
@@ -40,34 +38,37 @@ class DashboardViewModel @Inject constructor(
         return total.coerceAtMost(11)
     }
 
-    fun updateResourceNotification(userId: String?, onComplete: () -> Unit = {}) {
-        viewModelScope.launch {
-            try {
-                databaseService.executeTransactionAsync { realm ->
-                    val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
-                    if (resourceCount > 0) {
-                        val existingNotification = realm.where(RealmNotification::class.java)
-                            .equalTo("userId", userId)
-                            .equalTo("type", "resource")
-                            .findFirst()
+    suspend fun updateResourceNotification(userId: String?) {
+        try {
+            databaseService.executeTransactionAsync { realm ->
+                val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
+                if (resourceCount > 0) {
+                    val existingNotification = realm.where(RealmNotification::class.java)
+                        .equalTo("userId", userId)
+                        .equalTo("type", "resource")
+                        .findFirst()
 
-                        if (existingNotification != null) {
-                            existingNotification.message = "$resourceCount"
-                            existingNotification.relatedId = "$resourceCount"
-                        } else {
-                            createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
-                        }
+                    if (existingNotification != null) {
+                        existingNotification.message = "$resourceCount"
+                        existingNotification.relatedId = "$resourceCount"
                     } else {
-                        realm.where(RealmNotification::class.java)
-                            .equalTo("userId", userId)
-                            .equalTo("type", "resource")
-                            .findFirst()?.deleteFromRealm()
+                        createNotificationIfNotExists(
+                            realm,
+                            "resource",
+                            "$resourceCount",
+                            "$resourceCount",
+                            userId
+                        )
                     }
+                } else {
+                    realm.where(RealmNotification::class.java)
+                        .equalTo("userId", userId)
+                        .equalTo("type", "resource")
+                        .findFirst()?.deleteFromRealm()
                 }
-                onComplete()
-            } catch (e: Exception) {
-                e.printStackTrace()
             }
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
     }
 
@@ -121,48 +122,4 @@ class DashboardViewModel @Inject constructor(
         }
     }
 
-    @Deprecated("Use async version without realm parameter", ReplaceWith("getUnreadNotificationsSize(userId)"))
-    fun getUnreadNotificationsSize(realm: Realm, userId: String?): Int {
-        return realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("isRead", false)
-            .count()
-            .toInt()
-    }
-    
-    @Deprecated("Use async version", ReplaceWith("getSurveyTitlesFromSubmissions(submissions)"))
-    fun getSurveyTitlesFromSubmissions(realm: Realm, submissions: List<RealmSubmission>): List<String> {
-        val titles = mutableListOf<String>()
-        submissions.forEach { submission ->
-            val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
-            val exam = realm.where(RealmStepExam::class.java)
-                .equalTo("id", examId)
-                .findFirst()
-            exam?.name?.let { titles.add(it) }
-        }
-        return titles
-    }
-    
-    @Deprecated("Use async version", ReplaceWith("updateResourceNotification(userId)"))
-    fun updateResourceNotification(realm: Realm, userId: String?) {
-        val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
-        if (resourceCount > 0) {
-            val existingNotification = realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()
-
-            if (existingNotification != null) {
-                existingNotification.message = "$resourceCount"
-                existingNotification.relatedId = "$resourceCount"
-            } else {
-                createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
-            }
-        } else {
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "resource")
-                .findFirst()?.deleteFromRealm()
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- remove Realm-arg helpers in DashboardViewModel and expose suspend versions
- use lifecycle coroutines for notification, survey and unread count updates
- resolve survey titles and badge state via suspend APIs in fragments

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_6894a1327024832b83b5f43721340a37