### PR TITLE
all: smoother `DownloadUtils.kt` (fixes #6676)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2809
-        versionName = "0.28.9"
+        versionCode = 2818
+        versionName = "0.28.18"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -51,6 +51,7 @@ import org.ole.planet.myplanet.utilities.CheckboxListView
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.DialogUtils.getProgressDialog
 import org.ole.planet.myplanet.utilities.DialogUtils.showError
+import org.ole.planet.myplanet.utilities.DownloadUtils
 import org.ole.planet.myplanet.utilities.DownloadUtils.downloadAllFiles
 import org.ole.planet.myplanet.utilities.DownloadUtils.downloadFiles
 import org.ole.planet.myplanet.utilities.Utilities
@@ -246,7 +247,7 @@ abstract class BaseResourceFragment : Fragment() {
                 if (urls.isNotEmpty()) {
                     try {
                         showProgressDialog()
-                        Utilities.openDownloadService(activity, urls, false)
+                        DownloadUtils.openDownloadService(activity, urls, false)
                     } catch (e: Exception) {
                         e.printStackTrace()
                     }
@@ -402,7 +403,7 @@ abstract class BaseResourceFragment : Fragment() {
             Service(context).isPlanetAvailable(object : PlanetAvailableListener {
                 override fun isAvailable() {
                     if (urls.isNotEmpty()) {
-                        Utilities.openDownloadService(context, urls, false)
+                        DownloadUtils.openDownloadService(context, urls, false)
                     }
                 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -28,7 +28,7 @@ import org.ole.planet.myplanet.utilities.DownloadUtils.extractLinks
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.Utilities.getUrl
-import org.ole.planet.myplanet.utilities.Utilities.openDownloadService
+import org.ole.planet.myplanet.utilities.DownloadUtils.openDownloadService
 
 open class RealmMyTeam : RealmObject() {
     @PrimaryKey

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -50,6 +50,7 @@ import org.ole.planet.myplanet.ui.userprofile.UserProfileFragment
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.FileUtils
+import org.ole.planet.myplanet.utilities.DownloadUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCallback,
@@ -131,7 +132,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
         list.add(Constants.DICTIONARY_URL)
         if (!FileUtils.checkFileExist(Constants.DICTIONARY_URL)) {
             Utilities.toast(activity, getString(R.string.downloading_started_please_check_notification))
-            Utilities.openDownloadService(activity, list, false)
+            DownloadUtils.openDownloadService(activity, list, false)
         } else {
             Utilities.toast(activity, getString(R.string.file_already_exists))
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
@@ -16,6 +16,7 @@ import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtil
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.JsonUtils
+import org.ole.planet.myplanet.utilities.DownloadUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -38,7 +39,7 @@ class DictionaryActivity : BaseActivity() {
             val list = ArrayList<String>()
             list.add(Constants.DICTIONARY_URL)
             Utilities.toast(this, getString(R.string.downloading_started_please_check_notificati))
-            Utilities.openDownloadService(this, list, false)
+            DownloadUtils.openDownloadService(this, list, false)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -98,7 +98,7 @@ import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.Utilities.getRelativeTime
 import org.ole.planet.myplanet.utilities.Utilities.getUrl
-import org.ole.planet.myplanet.utilities.Utilities.openDownloadService
+import org.ole.planet.myplanet.utilities.DownloadUtils.openDownloadService
 import org.ole.planet.myplanet.utilities.Utilities.toast
 
 @AndroidEntryPoint

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DownloadUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DownloadUtils.kt
@@ -1,15 +1,24 @@
 package org.ole.planet.myplanet.utilities
 
+import android.app.ActivityManager
+import android.app.AlarmManager
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
+import androidx.core.content.edit
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
 import java.util.regex.Pattern
 import kotlin.text.isNotEmpty
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.datamanager.DownloadWorker
+import org.ole.planet.myplanet.datamanager.MyDownloadService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.utilities.FileUtils
 
@@ -132,6 +141,87 @@ object DownloadUtils {
             urls.add(Utilities.getUrl(dbMyLibrary[selectedItems[i]]))
         }
         return urls
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    fun openDownloadService(context: Context?, urls: ArrayList<String>, fromSync: Boolean) {
+        context?.let { ctx ->
+            val preferences = ctx.getSharedPreferences(MyDownloadService.PREFS_NAME, Context.MODE_PRIVATE)
+            preferences.edit {
+                putStringSet("url_list_key", urls.toSet())
+            }
+            startDownloadServiceSafely(ctx, "url_list_key", fromSync)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun startDownloadServiceSafely(context: Context, urlsKey: String, fromSync: Boolean) {
+        if (canStartForegroundService(context)) {
+            try {
+                MyDownloadService.startService(context, urlsKey, fromSync)
+            } catch (e: Exception) {
+                e.printStackTrace()
+                handleForegroundServiceNotAllowed(context, urlsKey, fromSync)
+            }
+        } else {
+            handleForegroundServiceNotAllowed(context, urlsKey, fromSync)
+        }
+    }
+
+    private fun handleForegroundServiceNotAllowed(context: Context, urlsKey: String, fromSync: Boolean) {
+        if (!fromSync) {
+            Utilities.toast(context, context.getString(R.string.download_in_background))
+        }
+        startDownloadWork(context, urlsKey, fromSync)
+    }
+
+    private fun startDownloadWork(context: Context, urlsKey: String, fromSync: Boolean) {
+        val workRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
+            .setInputData(
+                workDataOf(
+                    "urls_key" to urlsKey,
+                    "fromSync" to fromSync
+                )
+            )
+            .addTag("download_work")
+            .build()
+
+        WorkManager.getInstance(context).enqueue(workRequest)
+    }
+
+    fun canStartForegroundService(context: Context): Boolean {
+        return when {
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.O -> true
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.S -> {
+                isAppInForeground(context)
+            }
+            else -> {
+                isAppInForeground(context) || hasSpecialForegroundPermissions(context)
+            }
+        }
+    }
+
+    private fun isAppInForeground(context: Context): Boolean {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val appProcesses = activityManager.runningAppProcesses ?: return false
+
+        val packageName = context.packageName
+        return appProcesses.any { processInfo ->
+            processInfo.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND &&
+                processInfo.processName == packageName
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun hasSpecialForegroundPermissions(context: Context): Boolean {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+        return when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                alarmManager.canScheduleExactAlarms()
+            }
+            else -> false
+        }
     }
 
     fun extractLinks(text: String?): ArrayList<String> {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
@@ -1,11 +1,8 @@
 package org.ole.planet.myplanet.utilities
 
-import android.app.ActivityManager
-import android.app.AlarmManager
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.text.format.DateUtils
@@ -15,21 +12,14 @@ import android.util.Patterns
 import android.webkit.MimeTypeMap
 import android.widget.ImageView
 import android.widget.Toast
-import androidx.annotation.RequiresApi
-import androidx.core.content.edit
 import androidx.core.graphics.toColorInt
 import androidx.core.net.toUri
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.WorkManager
-import androidx.work.workDataOf
 import com.bumptech.glide.Glide
 import fisk.chipcloud.ChipCloudConfig
 import java.lang.ref.WeakReference
 import java.math.BigInteger
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.datamanager.DownloadWorker
-import org.ole.planet.myplanet.datamanager.MyDownloadService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.UrlUtils
@@ -64,86 +54,6 @@ object Utilities {
 
     fun getUserImageUrl(userId: String?, imageName: String): String {
         return "${getUrl()}/_users/$userId/$imageName"
-    }
-
-    @RequiresApi(Build.VERSION_CODES.S)
-    fun openDownloadService(context: Context?, urls: ArrayList<String>, fromSync: Boolean) {
-        context?.let { ctx ->
-            val preferences = ctx.getSharedPreferences(MyDownloadService.PREFS_NAME, Context.MODE_PRIVATE)
-            preferences.edit {
-                putStringSet("url_list_key", urls.toSet())
-            }
-            startDownloadServiceSafely(ctx, "url_list_key", fromSync)
-        }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.S)
-    private fun startDownloadServiceSafely(context: Context, urlsKey: String, fromSync: Boolean) {
-        if (canStartForegroundService(context)) {
-            try {
-                MyDownloadService.startService(context, urlsKey, fromSync)
-            } catch (e: Exception) {
-                e.printStackTrace()
-                handleForegroundServiceNotAllowed(context, urlsKey, fromSync)
-            }
-        } else {
-            handleForegroundServiceNotAllowed(context, urlsKey, fromSync)
-        }
-    }
-
-    private fun handleForegroundServiceNotAllowed(context: Context, urlsKey: String, fromSync: Boolean) {
-        if (!fromSync) {
-            toast(context, context.getString(R.string.download_in_background))
-        }
-        startDownloadWork(context, urlsKey, fromSync)
-    }
-
-    private fun startDownloadWork(context: Context, urlsKey: String, fromSync: Boolean) {
-        val workRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
-            .setInputData(workDataOf(
-                "urls_key" to urlsKey,
-                "fromSync" to fromSync
-            ))
-            .addTag("download_work")
-            .build()
-
-        WorkManager.getInstance(context).enqueue(workRequest)
-    }
-
-    fun canStartForegroundService(context: Context): Boolean {
-        return when {
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.O -> true
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.S -> {
-                // Android 8-11: Check if app is in foreground or has special permissions
-                isAppInForeground(context)
-            }
-            else -> {
-                // Android 12+: More restrictions
-                isAppInForeground(context) || hasSpecialForegroundPermissions(context)
-            }
-        }
-    }
-
-    private fun isAppInForeground(context: Context): Boolean {
-        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        val appProcesses = activityManager.runningAppProcesses ?: return false
-
-        val packageName = context.packageName
-        return appProcesses.any { processInfo ->
-            processInfo.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND && processInfo.processName == packageName
-        }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.S)
-    private fun hasSpecialForegroundPermissions(context: Context): Boolean {
-        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-
-        return when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-                alarmManager.canScheduleExactAlarms()
-            }
-            else -> false
-        }
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary
- move download service helpers from Utilities to DownloadUtils
- update download invocations to use DownloadUtils
- clean up Utilities imports

## Testing
- `./gradlew assemble --console=plain` *(fails: Failed to store cache entry for task ':app:processLiteDebugResources')*

------
https://chatgpt.com/codex/tasks/task_e_689472e41990832b8a101e89fd8c5266