### PR TITLE
all: smoother `ReplyActivity.kt` realm closing (fixes #6677)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2815
-        versionName = "0.28.15"
+        versionCode = 2819
+        versionName = "0.28.19"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/ReplyActivity.kt
@@ -166,4 +166,12 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
         if (item.itemId == android.R.id.home) finish()
         return super.onOptionsItemSelected(item)
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.removeAllChangeListeners()
+            mRealm.close()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Close Realm in ReplyActivity on destruction
- Remove Realm change listeners prior to closing the instance

## Testing
- `./gradlew --no-daemon --console=plain lint`

------
https://chatgpt.com/codex/tasks/task_e_6894aba8cc08832baecc4c8b963dec42