### PR TITLE
chat: smoother conversation continuing (fixes #6679)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2815
-        versionName = "0.28.15"
+        versionCode = 2821
+        versionName = "0.28.21"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -523,17 +523,17 @@ class ChatDetailFragment : Fragment() {
             add("conversations", conversationsArray)
         }
 
-    private fun continueConversationRealm(id:String, query:String, chatResponse:String) {
-        try {
-            addConversationToChatHistory(mRealm, id, query, chatResponse, _rev)
-            mRealm.commitTransaction()
-        } catch (e: Exception) {
-            e.printStackTrace()
-            if (mRealm.isInTransaction) {
-                mRealm.cancelTransaction()
+    private fun continueConversationRealm(id: String, query: String, chatResponse: String) {
+        databaseService.withRealm { realm ->
+            try {
+                addConversationToChatHistory(realm, id, query, chatResponse, _rev)
+                realm.commitTransaction()
+            } catch (e: Exception) {
+                e.printStackTrace()
+                if (realm.isInTransaction) {
+                    realm.cancelTransaction()
+                }
             }
-        } finally {
-            mRealm.close()
         }
     }
 
@@ -548,6 +548,9 @@ class ChatDetailFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        if (::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.close()
+        }
         super.onDestroyView()
         val editor = settings.edit()
         if (settings.getBoolean("isAlternativeUrl", false)) {


### PR DESCRIPTION
## Summary
- Use `DatabaseService.withRealm` for continuation transactions
- Close fragment Realm instance in `onDestroyView`

## Testing
- `./gradlew app:assembleDebug` *(fails: Calculating task graph as no cached configuration is available for tasks: app:assembleDebug)*
- `./gradlew -q help --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_6894ac2ee4e4832ba1fe336d0ae4dec9