### PR TITLE
resources: smoother `PDFReaderActivity.kt` realm closing (fixes #6680)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2815
-        versionName = "0.28.15"
+        versionCode = 2822
+        versionName = "0.28.22"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
@@ -115,6 +115,16 @@ class PDFReaderActivity : AppCompatActivity(), OnPageChangeListener, OnLoadCompl
         if (this::audioRecorderService.isInitialized && audioRecorderService.isRecording()) {
             audioRecorderService.stopRecording()
         }
+        if (this::mRealm.isInitialized && !mRealm.isClosed) {
+            if (mRealm.isInTransaction) {
+                try {
+                    mRealm.commitTransaction()
+                } catch (e: Exception) {
+                    mRealm.cancelTransaction()
+                }
+            }
+            mRealm.close()
+        }
     }
 
     override fun onError(error: String?) {


### PR DESCRIPTION
## Summary
- Close `mRealm` in `PDFReaderActivity` when the activity is destroyed
- Commit or cancel pending Realm transactions before closing

## Testing
- `./gradlew lint` *(fails: exits early during Android SDK installation?)*

------
https://chatgpt.com/codex/tasks/task_e_6894abd73e90832ba16957506ffda24f