### PR TITLE
mylife: smoother `AchievementFragment.kt` realm closing (fixes #6681)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2815
-        versionName = "0.28.15"
+        versionCode = 2823
+        versionName = "0.28.23"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
@@ -276,5 +276,8 @@ class AchievementFragment : BaseContainerFragment() {
         super.onDestroy()
         customProgressDialog?.dismiss()
         customProgressDialog = null
+        if (::aRealm.isInitialized && !aRealm.isClosed) {
+            aRealm.close()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure AchievementFragment closes Realm instance on destruction

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_6894ab901364832b86e518f5d1d8d34e