### PR TITLE
all: smoother executors (fixes #6683)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2815
-        versionName = "0.28.15"
+        versionCode = 2824
+        versionName = "0.28.24"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -307,27 +307,29 @@ class Service @Inject constructor(
                 if (response.body() != null) {
                     val arr = JsonUtils.getJsonArray("rows", response.body())
 
-                    Executors.newSingleThreadExecutor().execute {
-                        MainApplication.service.withRealm { backgroundRealm ->
-                            try {
-                                backgroundRealm.executeTransaction { realm1 ->
-                                    realm1.delete(RealmCommunity::class.java)
-                                    for (j in arr) {
-                                        var jsonDoc = j.asJsonObject
-                                        jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
-                                        val id = JsonUtils.getString("_id", jsonDoc)
-                                        val community = realm1.createObject(RealmCommunity::class.java, id)
-                                        if (JsonUtils.getString("name", jsonDoc) == "learning") {
-                                            community.weight = 0
+                    Executors.newSingleThreadExecutor().use { executor ->
+                        executor.execute {
+                            MainApplication.service.withRealm { backgroundRealm ->
+                                try {
+                                    backgroundRealm.executeTransaction { realm1 ->
+                                        realm1.delete(RealmCommunity::class.java)
+                                        for (j in arr) {
+                                            var jsonDoc = j.asJsonObject
+                                            jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
+                                            val id = JsonUtils.getString("_id", jsonDoc)
+                                            val community = realm1.createObject(RealmCommunity::class.java, id)
+                                            if (JsonUtils.getString("name", jsonDoc) == "learning") {
+                                                community.weight = 0
+                                            }
+                                            community.localDomain = JsonUtils.getString("localDomain", jsonDoc)
+                                            community.name = JsonUtils.getString("name", jsonDoc)
+                                            community.parentDomain = JsonUtils.getString("parentDomain", jsonDoc)
+                                            community.registrationRequest = JsonUtils.getString("registrationRequest", jsonDoc)
                                         }
-                                        community.localDomain = JsonUtils.getString("localDomain", jsonDoc)
-                                        community.name = JsonUtils.getString("name", jsonDoc)
-                                        community.parentDomain = JsonUtils.getString("parentDomain", jsonDoc)
-                                        community.registrationRequest = JsonUtils.getString("registrationRequest", jsonDoc)
                                     }
+                                } catch (e: Exception) {
+                                    e.printStackTrace()
                                 }
-                            } catch (e: Exception) {
-                                e.printStackTrace()
                             }
                         }
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -307,7 +307,8 @@ class Service @Inject constructor(
                 if (response.body() != null) {
                     val arr = JsonUtils.getJsonArray("rows", response.body())
 
-                    Executors.newSingleThreadExecutor().use { executor ->
+                    val executor = Executors.newSingleThreadExecutor()
+                    try {
                         executor.execute {
                             MainApplication.service.withRealm { backgroundRealm ->
                                 try {
@@ -332,6 +333,8 @@ class Service @Inject constructor(
                                 }
                             }
                         }
+                    } finally {
+                        executor.shutdown()
                     }
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLife.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLife.kt
@@ -39,7 +39,8 @@ open class RealmMyLife : RealmObject {
 
         @JvmStatic
         fun updateWeight(weight: Int, id: String?, userId: String?) {
-            Executors.newSingleThreadExecutor().use { executor ->
+            val executor = Executors.newSingleThreadExecutor()
+            try {
                 executor.execute {
                     MainApplication.service.withRealm { backgroundRealm ->
                         backgroundRealm.executeTransaction { mRealm ->
@@ -59,12 +60,15 @@ open class RealmMyLife : RealmObject {
                         }
                     }
                 }
+            } finally {
+                executor.shutdown()
             }
         }
 
         @JvmStatic
         fun updateVisibility(isVisible: Boolean, id: String?) {
-            Executors.newSingleThreadExecutor().use { executor ->
+            val executor = Executors.newSingleThreadExecutor()
+            try {
                 executor.execute {
                     MainApplication.service.withRealm { backgroundRealm ->
                         backgroundRealm.executeTransaction { mRealm ->
@@ -73,6 +77,8 @@ open class RealmMyLife : RealmObject {
                         }
                     }
                 }
+            } finally {
+                executor.shutdown()
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLife.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLife.kt
@@ -39,40 +39,40 @@ open class RealmMyLife : RealmObject {
 
         @JvmStatic
         fun updateWeight(weight: Int, id: String?, userId: String?) {
-            val executor = Executors.newSingleThreadExecutor()
-            executor.execute {
-                MainApplication.service.withRealm { backgroundRealm ->
-                    backgroundRealm.executeTransaction { mRealm ->
-                        val targetItem = mRealm.where(RealmMyLife::class.java).equalTo("_id", id)
-                            .findFirst()
+            Executors.newSingleThreadExecutor().use { executor ->
+                executor.execute {
+                    MainApplication.service.withRealm { backgroundRealm ->
+                        backgroundRealm.executeTransaction { mRealm ->
+                            val targetItem = mRealm.where(RealmMyLife::class.java).equalTo("_id", id)
+                                .findFirst()
 
-                        targetItem?.let {
-                            val currentWeight = it.weight
-                            it.weight = weight
+                            targetItem?.let {
+                                val currentWeight = it.weight
+                                it.weight = weight
 
-                            val otherItem = mRealm.where(RealmMyLife::class.java)
-                                .equalTo("userId", userId).equalTo("weight", weight)
-                                .notEqualTo("_id", id).findFirst()
+                                val otherItem = mRealm.where(RealmMyLife::class.java)
+                                    .equalTo("userId", userId).equalTo("weight", weight)
+                                    .notEqualTo("_id", id).findFirst()
 
-                            otherItem?.weight = currentWeight
+                                otherItem?.weight = currentWeight
+                            }
                         }
                     }
                 }
-                executor.shutdown()
             }
         }
 
         @JvmStatic
         fun updateVisibility(isVisible: Boolean, id: String?) {
-            val executor = Executors.newSingleThreadExecutor()
-            executor.execute {
-                MainApplication.service.withRealm { backgroundRealm ->
-                    backgroundRealm.executeTransaction { mRealm ->
-                        mRealm.where(RealmMyLife::class.java).equalTo("_id", id).findFirst()
-                            ?.isVisible = isVisible
+            Executors.newSingleThreadExecutor().use { executor ->
+                executor.execute {
+                    MainApplication.service.withRealm { backgroundRealm ->
+                        backgroundRealm.executeTransaction { mRealm ->
+                            mRealm.where(RealmMyLife::class.java).equalTo("_id", id).findFirst()
+                                ?.isVisible = isVisible
+                        }
                     }
                 }
-                executor.shutdown()
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
@@ -22,6 +22,7 @@ import androidx.core.content.ContextCompat
 import java.io.File
 import java.io.FileOutputStream
 import java.util.Date
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import org.ole.planet.myplanet.MainApplication.Companion.context
 
@@ -31,6 +32,7 @@ object CameraUtils {
     private var imageReader: ImageReader? = null
     private var backgroundHandler: Handler
     private var backgroundThread: HandlerThread = HandlerThread("CameraBackground")
+    private var sessionExecutor: ExecutorService? = null
 
     @JvmStatic
     fun capturePhoto(callback: ImageCaptureCallback) {
@@ -79,6 +81,8 @@ object CameraUtils {
         cameraDevice = null
         imageReader?.close()
         imageReader = null
+        sessionExecutor?.shutdown()
+        sessionExecutor = null
     }
 
     @JvmStatic
@@ -135,7 +139,7 @@ object CameraUtils {
             captureRequestBuilder.addTarget(surface)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 val outputConfigurations = listOf(OutputConfiguration(surface))
-                val executor = Executors.newSingleThreadExecutor()
+                val executor = sessionExecutor ?: Executors.newSingleThreadExecutor().also { sessionExecutor = it }
                 val stateCallback = object : CameraCaptureSession.StateCallback() {
                     override fun onConfigured(session: CameraCaptureSession) {
                         if (cameraDevice == null) return


### PR DESCRIPTION
## Summary
- ensure planet server sync uses a single-thread executor within a `use` block
- wrap RealmMyLife updates in `use` blocks to automatically shut down executors
- reuse a dedicated executor for camera preview and shut it down when closing the camera

## Testing
- `./gradlew --console=plain test` *(partial output, build stopped around 25% during Android SDK installation)*

------
https://chatgpt.com/codex/tasks/task_e_6894e24910ec832ba83f595d938b3f14