### PR TITLE
Fix team leader assignment crash

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.kt
@@ -212,7 +212,7 @@ class AdapterJoinedMember(
     }
 
     private fun makeLeader(userModel: RealmUserModel) {
-        mRealm.executeTransaction { realm ->
+        mRealm.executeTransactionAsync({ realm ->
             val currentLeader = realm.where(RealmMyTeam::class.java)
                 .equalTo("teamId", teamId)
                 .equalTo("isLeader", true)
@@ -224,23 +224,29 @@ class AdapterJoinedMember(
             currentLeader?.isLeader = false
             newLeader?.isLeader = true
             teamLeaderId = newLeader?.userId
-        }
-        notifyDataSetChanged()
-        Utilities.toast(context, context.getString(R.string.leader_selected))
-        refreshList()
+        }, {
+            notifyDataSetChanged()
+            Utilities.toast(context, context.getString(R.string.leader_selected))
+            refreshList()
+        }, { error ->
+            Utilities.toast(context, error.message)
+        })
     }
 
     private fun reject(userModel: RealmUserModel, position: Int) {
-        mRealm.executeTransaction {
-            val team = it.where(RealmMyTeam::class.java)
+        mRealm.executeTransactionAsync({ realm ->
+            val team = realm.where(RealmMyTeam::class.java)
                 .equalTo("teamId", teamId)
                 .equalTo("userId", userModel.id)
                 .findFirst()
             team?.deleteFromRealm()
-        }
-        list.removeAt(position)
-        notifyItemRemoved(position)
-        notifyItemRangeChanged(position, list.size)
+        }, {
+            list.removeAt(position)
+            notifyItemRemoved(position)
+            notifyItemRangeChanged(position, list.size)
+        }, { error ->
+            Utilities.toast(context, error.message)
+        })
     }
 
     override fun getItemCount(): Int = list.size


### PR DESCRIPTION
## Summary
- avoid Realm UI thread crash when promoting team leader by running the transaction asynchronously
- make member removal asynchronous as well

## Testing
- `./gradlew assembleDebug --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68950b325028832b8f1da3cfe69eddf0