### PR TITLE
chat: smoother `ChatAdapter.kt` coroutines (fixes #6703)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2816
-        versionName = "0.28.16"
+        versionCode = 2829
+        versionName = "0.28.29"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatAdapter.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.cancel
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemAiResponseMessageBinding
 import org.ole.planet.myplanet.databinding.ItemUserMessageBinding
@@ -164,6 +165,11 @@ class ChatAdapter(private val chatList: ArrayList<String>, val context: Context,
 
     override fun getItemCount(): Int {
         return chatList.size
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        super.onDetachedFromRecyclerView(recyclerView)
+        coroutineScope.cancel()
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatAdapter.kt
@@ -10,9 +10,9 @@ import android.widget.Toast
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.cancel
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemAiResponseMessageBinding
 import org.ole.planet.myplanet.databinding.ItemUserMessageBinding


### PR DESCRIPTION
## Summary
- cancel chat adapter coroutine scope when adapter is detached from RecyclerView to release pending coroutines

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68962fd224a0832bade8f90ccc34144a