### PR TITLE
teams: smoother survey repository queries (fixes #6708)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2828
-        versionName = "0.28.28"
+        versionCode = 2833
+        versionName = "0.28.33"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -67,10 +67,14 @@ class SubmissionRepositoryImpl @Inject constructor(
     }
 
     override fun getPendingSurveys(userId: String?): List<RealmSubmission> {
-        return databaseService.realmInstance.where(RealmSubmission::class.java)
-            .equalTo("userId", userId)
-            .equalTo("status", "pending")
-            .equalTo("type", "survey")
-            .findAll()
+        return databaseService.withRealm { realm ->
+            realm.copyFromRealm(
+                realm.where(RealmSubmission::class.java)
+                    .equalTo("userId", userId)
+                    .equalTo("status", "pending")
+                    .equalTo("type", "survey")
+                    .findAll()
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure pending survey queries use `withRealm`

## Testing
- `./gradlew --no-daemon lint` *(fails: Task :app:mergeDefaultDebugResources FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6899fb1efa58832bbec35993342a0461