### PR TITLE
Ensure Realm instance is closed in BaseRecyclerFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -284,14 +284,10 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     }
 
     override fun onDestroy() {
-        super.onDestroy()
-        try {
-            if (!mRealm.isClosed) {
-                mRealm.close()
-            }
-        } catch (_: UninitializedPropertyAccessException) {
-            // Realm was not initialized
+        if (isRealmInitialized() && !mRealm.isClosed) {
+            mRealm.close()
         }
+        super.onDestroy()
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -285,8 +285,12 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
 
     override fun onDestroy() {
         super.onDestroy()
-        if (::mRealm.isInitialized && !mRealm.isClosed) {
-            mRealm.close()
+        try {
+            if (!mRealm.isClosed) {
+                mRealm.close()
+            }
+        } catch (_: UninitializedPropertyAccessException) {
+            // Realm was not initialized
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -283,6 +283,13 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         return sub && lev && lan && med
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        if (::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.close()
+        }
+    }
+
     companion object {
         private val noDataMessages = mapOf(
             "courses" to R.string.no_courses,

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -77,6 +77,8 @@ abstract class BaseResourceFragment : Fragment() {
     lateinit var settings: SharedPreferences
     private var resourceNotFoundDialog: AlertDialog? = null
 
+    protected fun isRealmInitialized() = this::mRealm.isInitialized
+
     private fun isFragmentActive(): Boolean {
         return isAdded && activity != null &&
             !requireActivity().isFinishing && !requireActivity().isDestroyed


### PR DESCRIPTION
## Summary
- Close Realm in `BaseRecyclerFragment` during destruction to avoid leaks
- Reviewed child fragments to ensure Realm isn't double-closed

## Testing
- `./gradlew --version --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_6899fb30e5d0832b98aea73015237947