### PR TITLE
Refactor Realm usage for team uploads

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -294,9 +294,10 @@ open class RealmMyTeam : RealmObject() {
                     }
                     withContext(Dispatchers.IO) {
                         val apiInterface = client?.create(ApiInterface::class.java)
-                        val realm = DatabaseService(context).realmInstance
-                        realm.executeTransaction { transactionRealm ->
-                            uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
+                        DatabaseService(context).withRealm { realm ->
+                            realm.executeTransaction { transactionRealm ->
+                                uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
+                            }
                         }
                     }
                 } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- use `DatabaseService.withRealm` to handle Realm access during team activity uploads

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_6899fbb40560832bb7515731c26cec22