### PR TITLE
Close Realm instance in RatingFragment on view destruction

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
@@ -85,6 +85,13 @@ class RatingFragment : DialogFragment() {
         }
     }
 
+    override fun onDestroyView() {
+        if (::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.close()
+        }
+        super.onDestroyView()
+    }
+
     private fun saveRating() {
         val comment = fragmentRatingBinding.etComment.text.toString()
         val rating = fragmentRatingBinding.ratingBar.rating


### PR DESCRIPTION
## Summary
- add onDestroyView override in RatingFragment
- ensure Realm instance is closed before calling super

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899fc0fadfc832b9d306b9918cee60c