### PR TITLE
resources: smoother collections realm closing (fixes #6710)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2828
-        versionName = "0.28.28"
+        versionCode = 2836
+        versionName = "0.28.36"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -130,6 +130,13 @@ class CollectionsFragment : DialogFragment(), TagExpandableAdapter.OnClickTagIte
         fragmentCollectionsBinding.btnOk.visibility = if (b) View.VISIBLE else View.GONE
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if (::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.close()
+        }
+    }
+
     companion object {
         private lateinit var recentList: MutableList<RealmTag>
         @JvmStatic


### PR DESCRIPTION
## Summary
- ensure CollectionsFragment closes its Realm instance when view is destroyed

## Testing
- `./gradlew lint` *(fails: stuck installing Android SDK Platform 35 at 25%)*

------
https://chatgpt.com/codex/tasks/task_e_6899fc240428832b933534ca3914d97d