### PR TITLE
Refactor team upload to use DatabaseService.withRealm

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -294,9 +294,10 @@ open class RealmMyTeam : RealmObject() {
                     }
                     withContext(Dispatchers.IO) {
                         val apiInterface = client?.create(ApiInterface::class.java)
-                        val realm = DatabaseService(context).realmInstance
-                        realm.executeTransaction { transactionRealm ->
-                            uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
+                        DatabaseService(context).withRealm { realm ->
+                            realm.executeTransaction { transactionRealm ->
+                                uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
+                            }
                         }
                     }
                 } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- Use `DatabaseService.withRealm` in `uploadTeamActivities` for scoped Realm access

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_6899fc714e64832bbaf451571e09ba8c