### PR TITLE
Cancel ChatAdapter coroutine scope on detachment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatAdapter.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemAiResponseMessageBinding
@@ -164,6 +165,11 @@ class ChatAdapter(private val chatList: ArrayList<String>, val context: Context,
 
     override fun getItemCount(): Int {
         return chatList.size
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        super.onDetachedFromRecyclerView(recyclerView)
+        coroutineScope.cancel()
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- Cancel ChatAdapter coroutine scope when adapter detaches from RecyclerView
- Import coroutine cancel extension

## Testing
- `./gradlew assembleDebug` *(fails: Failed to find target with hash string 'android-35' in: /usr/lib/android-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_6899fcc312d4832b9bbbf468c5cf2eab