### PR TITLE
all: less `TimeUtils.kt` is more (fixes #6711)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2828
-        versionName = "0.28.28"
+        versionCode = 2838
+        versionName = "0.28.38"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/TimeUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/TimeUtils.kt
@@ -42,12 +42,6 @@ object TimeUtils {
         }
     }
 
-    @Deprecated("Use getFormattedDate", ReplaceWith("getFormattedDate(date)"))
-    @JvmStatic
-    fun getFormatedDate(date: Long?): String {
-        return getFormattedDate(date)
-    }
-
     @JvmStatic
     fun getFormattedDateWithTime(date: Long): String {
         return try {
@@ -57,12 +51,6 @@ object TimeUtils {
             e.printStackTrace()
             "N/A"
         }
-    }
-
-    @Deprecated("Use getFormattedDateWithTime", ReplaceWith("getFormattedDateWithTime(date)"))
-    @JvmStatic
-    fun getFormatedDateWithTime(date: Long): String {
-        return getFormattedDateWithTime(date)
     }
 
     @JvmStatic
@@ -105,12 +93,6 @@ object TimeUtils {
             e.printStackTrace()
             "N/A"
         }
-    }
-
-    @Deprecated("Use getFormattedDate", ReplaceWith("getFormattedDate(stringDate, pattern)"))
-    @JvmStatic
-    fun getFormatedDate(stringDate: String?, pattern: String?): String {
-        return getFormattedDate(stringDate, pattern)
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary
- clean up TimeUtils by dropping deprecated `getFormatedDate*` helpers
- ensure callers rely on `getFormattedDate*` utilities

## Testing
- `./gradlew -version`


------
https://chatgpt.com/codex/tasks/task_e_6899fde2ba84832ba6ee058662b31bce