### PR TITLE
all: smoother `MyActivityFragment.kt` realm closing (fixes #6733)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2838
-        versionName = "0.28.38"
+        versionCode = 2839
+        versionName = "0.28.39"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/MyActivityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/MyActivityFragment.kt
@@ -95,6 +95,13 @@ class MyActivityFragment : Fragment() {
         fragmentMyActivityBinding.chart.invalidate()
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if (::realm.isInitialized && !realm.isClosed) {
+            realm.close()
+        }
+    }
+
     fun getMonth(month: Int): String {
         return DateFormatSymbols().months[month]
     }


### PR DESCRIPTION
## Summary
- Ensure `MyActivityFragment` closes its Realm instance when the view is destroyed to avoid leaking resources

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_689af2c59054832b9993f2d9170a9069