### PR TITLE
Use withRealm to refresh chat history

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -217,34 +217,36 @@ class ChatHistoryListFragment : Fragment() {
     }
 
     fun refreshChatHistoryList() {
-        val mRealm = databaseService.realmInstance
-        val list = mRealm.where(RealmChatHistory::class.java).equalTo("user", user?.name)
-            .sort("id", Sort.DESCENDING)
-            .findAll()
+        databaseService.withRealm { realm ->
+            val list = realm.where(RealmChatHistory::class.java)
+                .equalTo("user", user?.name)
+                .sort("id", Sort.DESCENDING)
+                .findAll()
 
-        val adapter = fragmentChatHistoryListBinding.recyclerView.adapter as? ChatHistoryListAdapter
-        if (adapter == null) {
-            val newAdapter = ChatHistoryListAdapter(requireContext(), list, this, databaseService, settings)
-            newAdapter.setChatHistoryItemClickListener(object : ChatHistoryListAdapter.ChatHistoryItemClickListener {
-                override fun onChatHistoryItemClicked(conversations: List<Conversation>?, id: String, rev: String?, aiProvider: String?) {
-                    conversations?.let { sharedViewModel.setSelectedChatHistory(it) }
-                    sharedViewModel.setSelectedId(id)
-                    rev?.let { sharedViewModel.setSelectedRev(it) }
-                    aiProvider?.let { sharedViewModel.setSelectedAiProvider(it) }
-                    fragmentChatHistoryListBinding.slidingPaneLayout.openPane()
-                }
-            })
-            fragmentChatHistoryListBinding.recyclerView.adapter = newAdapter
-        } else {
-            adapter.updateChatHistory(list)
-            fragmentChatHistoryListBinding.searchBar.visibility = View.VISIBLE
-            fragmentChatHistoryListBinding.recyclerView.visibility = View.VISIBLE
-        }
+            val adapter = fragmentChatHistoryListBinding.recyclerView.adapter as? ChatHistoryListAdapter
+            if (adapter == null) {
+                val newAdapter = ChatHistoryListAdapter(requireContext(), list, this, databaseService, settings)
+                newAdapter.setChatHistoryItemClickListener(object : ChatHistoryListAdapter.ChatHistoryItemClickListener {
+                    override fun onChatHistoryItemClicked(conversations: List<Conversation>?, id: String, rev: String?, aiProvider: String?) {
+                        conversations?.let { sharedViewModel.setSelectedChatHistory(it) }
+                        sharedViewModel.setSelectedId(id)
+                        rev?.let { sharedViewModel.setSelectedRev(it) }
+                        aiProvider?.let { sharedViewModel.setSelectedAiProvider(it) }
+                        fragmentChatHistoryListBinding.slidingPaneLayout.openPane()
+                    }
+                })
+                fragmentChatHistoryListBinding.recyclerView.adapter = newAdapter
+            } else {
+                adapter.updateChatHistory(list)
+                fragmentChatHistoryListBinding.searchBar.visibility = View.VISIBLE
+                fragmentChatHistoryListBinding.recyclerView.visibility = View.VISIBLE
+            }
 
-        showNoData(fragmentChatHistoryListBinding.noChats, list.size, "chatHistory")
-        if (list.isEmpty()) {
-            fragmentChatHistoryListBinding.searchBar.visibility = View.GONE
-            fragmentChatHistoryListBinding.recyclerView.visibility = View.GONE
+            showNoData(fragmentChatHistoryListBinding.noChats, list.size, "chatHistory")
+            if (list.isEmpty()) {
+                fragmentChatHistoryListBinding.searchBar.visibility = View.GONE
+                fragmentChatHistoryListBinding.recyclerView.visibility = View.GONE
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Ensure chat history queries run inside `databaseService.withRealm` so Realm closes automatically

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689af31e52e0832baf1128b86866d956