### PR TITLE
Handle Realm listener cleanup and incremental UI updates

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/AdapterMyPersonal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/AdapterMyPersonal.kt
@@ -51,7 +51,8 @@ class AdapterMyPersonal(private val context: Context, private val list: List<Rea
                         ?.equalTo("_id", list[position]._id)?.findFirst()
                     personal?.deleteFromRealm()
                     realm?.commitTransaction()
-                    notifyDataSetChanged()
+                    notifyItemRemoved(position)
+                    notifyItemRangeChanged(position, list.size - position)
                     listener?.onAddedResource()
                 }.setNegativeButton(R.string.cancel, null).show()
         }
@@ -110,7 +111,7 @@ class AdapterMyPersonal(private val context: Context, private val list: List<Rea
                 personal.description = desc
                 personal.title = title
                 realm?.commitTransaction()
-                notifyDataSetChanged()
+                notifyItemChanged(position)
                 listener?.onAddedResource()
             }
             .setNegativeButton(R.string.cancel, null)


### PR DESCRIPTION
## Summary
- Store Realm change listener for MyPersonals and remove it in `onDestroyView`
- Dismiss progress dialog when view is destroyed to avoid leaks
- Replace `notifyDataSetChanged` with fine-grained adapter notifications

## Testing
- `./gradlew assembleDebug` *(incomplete: build did not finish in time)*
- `./gradlew :app:compileDebugKotlin` *(failed: task name ambiguous)*

------
https://chatgpt.com/codex/tasks/task_e_689af394fa60832b99144668ff700d93