### PR TITLE
Use nullable binding in MemberDetailFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MemberDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MemberDetailFragment.kt
@@ -10,11 +10,17 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentMemberDetailBinding
 
 class MemberDetailFragment : Fragment() {
-    private lateinit var binding: FragmentMemberDetailBinding
+    private var _binding: FragmentMemberDetailBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        binding = FragmentMemberDetailBinding.inflate(inflater, container, false)
+        _binding = FragmentMemberDetailBinding.inflate(inflater, container, false)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Summary
- replace lateinit binding with nullable backing property and non-null getter
- clear view binding in onDestroyView to prevent leaks

## Testing
- `./gradlew :app:compileLiteDebugKotlin` *(command timed out before completion)*

------
https://chatgpt.com/codex/tasks/task_e_689af3e19b6c832bb69521d808ecc3c8