### PR TITLE
all: smoother user repository realm handling (fixes #6736)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2838
-        versionName = "0.28.38"
+        versionCode = 2843
+        versionName = "0.28.43"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -22,7 +22,9 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun getCurrentUser(): RealmUserModel? {
         return databaseService.withRealmAsync { realm ->
-            realm.where(RealmUserModel::class.java).findFirst()
+            realm.where(RealmUserModel::class.java)
+                .findFirst()
+                ?.let { realm.copyFromRealm(it) }
         }
     }
 
@@ -31,6 +33,7 @@ class UserRepositoryImpl @Inject constructor(
             realm.where(RealmUserModel::class.java)
                 .equalTo("id", userId)
                 .findFirst()
+                ?.let { realm.copyFromRealm(it) }
         }
     }
 
@@ -39,12 +42,15 @@ class UserRepositoryImpl @Inject constructor(
             realm.where(RealmUserModel::class.java)
                 .equalTo("name", username)
                 .findFirst()
+                ?.let { realm.copyFromRealm(it) }
         }
     }
 
     override suspend fun getAllUsers(): List<RealmUserModel> {
         return databaseService.withRealmAsync { realm ->
-            realm.where(RealmUserModel::class.java).findAll()
+            realm.where(RealmUserModel::class.java)
+                .findAll()
+                .let { realm.copyFromRealm(it) }
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure Realm objects are copied to unmanaged instances before leaving withRealmAsync
- copy lists of RealmUserModel from Realm results

## Testing
- `./gradlew --version`
- `./gradlew app:compileDefaultDebugKotlin`

------
https://chatgpt.com/codex/tasks/task_e_689af58f83d0832b940ae27bfd23ab37