### PR TITLE
all: smoother resources repository realm handling (fixes #6738)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2838
-        versionName = "0.28.38"
+        versionCode = 2845
+        versionName = "0.28.45"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -11,7 +11,9 @@ class LibraryRepositoryImpl @Inject constructor(
 
     override suspend fun getAllLibraryItemsAsync(): List<RealmMyLibrary> {
         return databaseService.withRealmAsync { realm ->
-            realm.where(RealmMyLibrary::class.java).findAll()
+            realm.copyFromRealm(
+                realm.where(RealmMyLibrary::class.java).findAll()
+            )
         }
     }
 
@@ -20,14 +22,17 @@ class LibraryRepositoryImpl @Inject constructor(
             realm.where(RealmMyLibrary::class.java)
                 .equalTo("id", id)
                 .findFirst()
+                ?.let { realm.copyFromRealm(it) }
         }
     }
 
     override suspend fun getOfflineLibraryItemsAsync(): List<RealmMyLibrary> {
         return databaseService.withRealmAsync { realm ->
-            realm.where(RealmMyLibrary::class.java)
-                .equalTo("resourceOffline", true)
-                .findAll()
+            realm.copyFromRealm(
+                realm.where(RealmMyLibrary::class.java)
+                    .equalTo("resourceOffline", true)
+                    .findAll()
+            )
         }
     }
 
@@ -36,7 +41,9 @@ class LibraryRepositoryImpl @Inject constructor(
             val results = realm.where(RealmMyLibrary::class.java)
                 .equalTo("isPrivate", false)
                 .findAll()
-            filterLibrariesNeedingUpdate(results).filter { it.userId?.contains(userId) == true }
+            val filteredList =
+                filterLibrariesNeedingUpdate(results).filter { it.userId?.contains(userId) == true }
+            realm.copyFromRealm(filteredList)
         }
     }
 
@@ -45,17 +52,20 @@ class LibraryRepositoryImpl @Inject constructor(
             val results = realm.where(RealmMyLibrary::class.java)
                 .equalTo("resourceOffline", false)
                 .findAll()
-            filterLibrariesNeedingUpdate(results)
+            val filteredList = filterLibrariesNeedingUpdate(results)
+            realm.copyFromRealm(filteredList)
         }
     }
 
     override suspend fun getCourseLibraryItems(courseIds: List<String>): List<RealmMyLibrary> {
         return databaseService.withRealmAsync { realm ->
-            realm.where(RealmMyLibrary::class.java)
-                .`in`("courseId", courseIds.toTypedArray())
-                .equalTo("resourceOffline", false)
-                .isNotNull("resourceLocalAddress")
-                .findAll()
+            realm.copyFromRealm(
+                realm.where(RealmMyLibrary::class.java)
+                    .`in`("courseId", courseIds.toTypedArray())
+                    .equalTo("resourceOffline", false)
+                    .isNotNull("resourceLocalAddress")
+                    .findAll()
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- detach asynchronous library queries from Realm using `copyFromRealm`
- copy filtered results for user-specific and offline library lists

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_689af57ce3dc832bb6cf684c739daa7a