### PR TITLE
Remove direct Realm access

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -83,9 +83,9 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         tvMessage = v.findViewById(R.id.tv_message)
         selectedItems = mutableListOf()
         list = mutableListOf()
-        mRealm = userRepository.getRealm()
         profileDbHandler = UserProfileDbHandler(requireActivity())
-        model = profileDbHandler.userModel!!
+        mRealm = profileDbHandler.mRealm
+        model = profileDbHandler.userModel
         val adapter = getAdapter()
         recyclerView.adapter = adapter
         if (isMyCourseLib && adapter.itemCount != 0 && courseLib == "courses") {

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -323,7 +323,9 @@ abstract class BaseResourceFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        mRealm = userRepository.getRealm()
+        profileDbHandler = UserProfileDbHandler(requireActivity())
+        mRealm = profileDbHandler.mRealm
+        model = profileDbHandler.userModel
         prgDialog = getProgressDialog(requireActivity())
         editor = settings.edit()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import io.realm.Realm
 import org.ole.planet.myplanet.model.RealmUserModel
 
 interface UserRepository {
@@ -10,6 +9,4 @@ interface UserRepository {
     suspend fun getUserById(userId: String): RealmUserModel?
     suspend fun getUserByName(username: String): RealmUserModel?
     suspend fun getAllUsers(): List<RealmUserModel>
-    @Deprecated("Use async version", ReplaceWith("getCurrentUser()"))
-    fun getRealm(): Realm
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package org.ole.planet.myplanet.repository
 
 import android.content.SharedPreferences
-import io.realm.Realm
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
@@ -46,9 +45,5 @@ class UserRepositoryImpl @Inject constructor(
         return databaseService.withRealmAsync { realm ->
             realm.where(RealmUserModel::class.java).findAll()
         }
-    }
-
-    override fun getRealm(): Realm {
-        return databaseService.realmInstance
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
@@ -80,13 +80,9 @@ class UploadManager @Inject constructor(
 
     private val gson = Gson()
 
-    private fun getRealm(): Realm {
-        return databaseService.realmInstance
-    }
-
     private fun uploadNewsActivities() {
         val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         realm.executeTransactionAsync { realm: Realm ->
             val newsLog: List<RealmNewsLog> = realm.where(RealmNewsLog::class.java)
                 .isNull("_id").or().isEmpty("_id")
@@ -170,7 +166,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadExamResult(listener: SuccessListener) {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
 
         realm.executeTransactionAsync({ realm: Realm ->
@@ -213,7 +209,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadAchievement() {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         realm.executeTransactionAsync { realm: Realm ->
             val list: List<RealmAchievement> = realm.where(RealmAchievement::class.java).findAll()
             list.processInBatches { sub ->
@@ -231,7 +227,7 @@ class UploadManager @Inject constructor(
 
     private fun uploadCourseProgress() {
         val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         realm.executeTransactionAsync { realm: Realm ->
             val data: List<RealmCourseProgress> = realm.where(RealmCourseProgress::class.java).isNull("_id").findAll()
             var successCount = 0
@@ -264,7 +260,7 @@ class UploadManager @Inject constructor(
 
     fun uploadFeedback(listener: SuccessListener) {
         val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         realm.executeTransactionAsync(Realm.Transaction { realm: Realm ->
             val feedbacks: List<RealmFeedback> = realm.where(RealmFeedback::class.java).findAll()
 
@@ -307,7 +303,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadSubmitPhotos(listener: SuccessListener?) {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
         realm.executeTransactionAsync { realm: Realm ->
             val data: List<RealmSubmitPhotos> = realm.where(RealmSubmitPhotos::class.java).equalTo("uploaded", false).findAll()
@@ -333,7 +329,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadResource(listener: SuccessListener?) {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
 
         realm.executeTransactionAsync({ realm: Realm ->
@@ -377,7 +373,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadMyPersonal(personal: RealmMyPersonal, listener: SuccessListener) {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
 
         if (!personal.isUploaded) {
@@ -418,7 +414,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadTeamTask() {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
         realm.executeTransactionAsync { realm: Realm ->
             val list: List<RealmTeamTask> = realm.where(RealmTeamTask::class.java).findAll()
@@ -444,7 +440,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadSubmissions() {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
 
         realm.executeTransactionAsync { realm: Realm ->
@@ -473,7 +469,7 @@ class UploadManager @Inject constructor(
 
     fun uploadTeams() {
         val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
 
         realm.executeTransactionAsync { realm: Realm ->
             val teams: List<RealmMyTeam> = realm.where(RealmMyTeam::class.java).equalTo("updated", true).findAll()
@@ -503,7 +499,7 @@ class UploadManager @Inject constructor(
             return
         }
 
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         realm.executeTransactionAsync({ transactionRealm: Realm ->
             val activities = transactionRealm.where(RealmOfflineActivity::class.java).isNull("_rev").equalTo("type", "login").findAll()
 
@@ -546,7 +542,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadRating() {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
 
         realm.executeTransactionAsync { realm: Realm ->
@@ -576,7 +572,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadNews() {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
 
         realm.executeTransactionAsync { realm: Realm ->
@@ -652,7 +648,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadCrashLog() {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
 
         try {
@@ -689,7 +685,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadSearchActivity() {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
         realm.executeTransactionAsync { realm: Realm ->
             val logs: RealmResults<RealmSearchActivity> = realm.where(RealmSearchActivity::class.java).isEmpty("_rev").findAll()
@@ -708,7 +704,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadResourceActivities(type: String) {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
 
         val db = if (type == "sync") {
@@ -740,7 +736,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadCourseActivities() {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
 
         realm.executeTransactionAsync { realm: Realm ->
@@ -761,7 +757,7 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadMeetups() {
-        val realm = getRealm()
+        val realm = databaseService.realmInstance
         val apiInterface = client?.create(ApiInterface::class.java)
         realm.executeTransactionAsync { realm: Realm ->
             val meetups: List<RealmMeetup> = realm.where(RealmMeetup::class.java).findAll()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
@@ -57,8 +57,7 @@ class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickLi
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        mRealm = userRepository.getRealm()
-        user = UserProfileDbHandler(requireActivity()).userModel
+        user = profileDbHandler.userModel
         fragmentCommunityBinding.btnLibrary.setOnClickListener {
             homeItemClickListener?.openCallFragment(ResourcesFragment())
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/ServicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/ServicesFragment.kt
@@ -14,7 +14,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentServicesBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
 import org.ole.planet.myplanet.ui.team.TeamDetailFragment
 import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
@@ -31,8 +30,7 @@ class ServicesFragment : BaseTeamFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 
         super.onViewCreated(view, savedInstanceState)
-        mRealm = userRepository.getRealm()
-        user = UserProfileDbHandler(requireActivity()).userModel
+        user = profileDbHandler.userModel
 
         val links = mRealm.where(RealmMyTeam::class.java)?.equalTo("docType", "link")?.findAll()
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
@@ -18,7 +18,6 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmRating.Companion.getRatingsById
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.getNoOfExam
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 
@@ -37,9 +36,9 @@ class CourseDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentCourseDetailBinding = FragmentCourseDetailBinding.inflate(inflater, container, false)
-        cRealm = userRepository.getRealm()
+        cRealm = mRealm
         courses = cRealm.where(RealmMyCourse::class.java).equalTo("courseId", id).findFirst()
-        user = UserProfileDbHandler(requireContext()).userModel
+        user = profileDbHandler.userModel
         return fragmentCourseDetailBinding.root
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -23,7 +23,6 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.exam.TakeExamFragment
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
 import org.ole.planet.myplanet.utilities.CameraUtils.ImageCaptureCallback
@@ -52,8 +51,8 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentCourseStepBinding = FragmentCourseStepBinding.inflate(inflater, container, false)
-        cRealm = userRepository.getRealm()
-        user = UserProfileDbHandler(requireContext()).userModel
+        cRealm = mRealm
+        user = profileDbHandler.userModel
         fragmentCourseStepBinding.btnTakeTest.visibility = View.VISIBLE
         fragmentCourseStepBinding.btnTakeSurvey.visibility = View.VISIBLE
         return fragmentCourseStepBinding.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -109,7 +109,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     override fun forceDownloadNewsImages() {
-        mRealm = userRepository.getRealm()
+        mRealm = profileDbHandler.mRealm
         Utilities.toast(activity, getString(R.string.please_select_starting_date))
         val now = Calendar.getInstance()
         val dpd = DatePickerDialog(requireActivity(), { _: DatePicker?, i: Int, i1: Int, i2: Int ->
@@ -253,7 +253,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     private fun setUpMyLife(userId: String?) {
-        val realm = userRepository.getRealm()
+        val realm = mRealm
         val realmObjects = RealmMyLife.getMyLifeByUserId(mRealm, settings)
         if (realmObjects.isEmpty()) {
             if (!realm.isInTransaction) {
@@ -324,7 +324,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
         view.findViewById<View>(R.id.txtFullName).setOnClickListener {
             homeItemClickListener?.openCallFragment(UserProfileFragment())
         }
-        mRealm = userRepository.getRealm()
+        mRealm = profileDbHandler.mRealm
         myLibraryDiv(view)
         initializeFlexBoxView(view, R.id.flexboxLayoutCourse, RealmMyCourse::class.java)
         initializeFlexBoxView(view, R.id.flexboxLayoutTeams, RealmMyTeam::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardFragment.kt
@@ -10,7 +10,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentHomeBinding
 import org.ole.planet.myplanet.model.RealmSubmission.Companion.getNoOfSurveySubmissionByUser
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.news.NewsFragment
 import org.ole.planet.myplanet.ui.resources.AddResourceFragment
 import org.ole.planet.myplanet.ui.submission.MySubmissionFragment
@@ -39,8 +38,8 @@ class DashboardFragment : BaseDashboardFragment() {
         fragmentHomeBinding.cardProfile.tvAchievement.setOnClickListener {
             homeItemClickListener?.openCallFragment(AchievementFragment())
         }
-        dRealm = userRepository.getRealm()
-        user = UserProfileDbHandler(requireContext()).userModel
+        dRealm = mRealm
+        user = profileDbHandler.userModel
         onLoaded(view)
         initView(view)
         (activity as AppCompatActivity?)?.supportActionBar?.subtitle = currentDate()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
@@ -47,7 +47,7 @@ class FinanceFragment : BaseTeamFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentFinanceBinding = FragmentFinanceBinding.inflate(inflater, container, false)
-        fRealm = userRepository.getRealm()
+        fRealm = mRealm
         date = Calendar.getInstance()
         fragmentFinanceBinding.tvFromDateCalendar.setOnClickListener {
             showDatePickerDialog(isFromDate = true)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
@@ -42,7 +42,6 @@ class ReportsFragment : BaseTeamFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentReportsBinding = FragmentReportsBinding.inflate(inflater, container, false)
-        mRealm = userRepository.getRealm()
         prefData = SharedPrefManager(requireContext())
         if (!isMember()) {
             fragmentReportsBinding.addReports.visibility = View.GONE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
@@ -54,7 +54,6 @@ class NewsFragment : BaseNewsFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentNewsBinding = FragmentNewsBinding.inflate(inflater, container, false)
         llImage = fragmentNewsBinding.llImages
-        mRealm = userRepository.getRealm()
         user = UserProfileDbHandler(requireContext()).userModel
         setupUI(fragmentNewsBinding.newsFragmentParentLayout, requireActivity())
         if (user?.id?.startsWith("guest") == true) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -25,7 +25,6 @@ import org.ole.planet.myplanet.model.RealmRating.Companion.getRatingsById
 import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.onAdd
 import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.onRemove
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.FileUtils.getFileExtension
 import org.ole.planet.myplanet.utilities.Utilities
 
@@ -78,8 +77,8 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         super.onCreateView(inflater, container, savedInstanceState)
         fragmentLibraryDetailBinding = FragmentLibraryDetailBinding.inflate(inflater, container, false)
-        lRealm = userRepository.getRealm()
-        userModel = UserProfileDbHandler(requireContext()).userModel!!
+        lRealm = mRealm
+        userModel = profileDbHandler.userModel!!
         library = lRealm.where(RealmMyLibrary::class.java).equalTo("resourceId", libraryId).findFirst()!!
         return fragmentLibraryDetailBinding.root
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
@@ -19,7 +19,6 @@ abstract class BaseTeamFragment : BaseNewsFragment() {
         val sParentCode = settings.getString("parentCode", "")
         val communityName = settings.getString("communityName", "")
         teamId = requireArguments().getString("id", "") ?: "$communityName@$sParentCode"
-        mRealm = userRepository.getRealm()
         user = profileDbHandler.userModel?.let { mRealm.copyFromRealm(it) }
 
         if (shouldQueryTeamFromRealm()) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
@@ -74,7 +74,6 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
         fragmentMyTeamsDetailBinding = FragmentMyTeamsDetailBinding.inflate(inflater, container, false)
         val v: View = fragmentMyTeamsDetailBinding.root
         initializeViews(v)
-        mRealm = userRepository.getRealm()
         user = profileDbHandler.userModel?.let { mRealm.copyFromRealm(it) }
         team = mRealm.where(RealmMyTeam::class.java).equalTo("_id", teamId).findFirst()
         return fragmentMyTeamsDetailBinding.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -32,6 +32,7 @@ import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
 import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.team.TeamPageConfig.ApplicantsPage
 import org.ole.planet.myplanet.ui.team.TeamPageConfig.CalendarPage
 import org.ole.planet.myplanet.ui.team.TeamPageConfig.ChatPage

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
@@ -33,7 +33,6 @@ import org.ole.planet.myplanet.model.RealmAchievement
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
@@ -69,8 +68,8 @@ class AchievementFragment : BaseContainerFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentAchievementBinding = FragmentAchievementBinding.inflate(inflater, container, false)
-        aRealm = userRepository.getRealm()
-        user = UserProfileDbHandler(MainApplication.context).userModel
+        aRealm = mRealm
+        user = profileDbHandler.userModel
         fragmentAchievementBinding.btnEdit.setOnClickListener {
             if (listener != null) listener?.openCallFragment(EditAchievementFragment())
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
@@ -39,7 +39,6 @@ import org.ole.planet.myplanet.model.RealmAchievement
 import org.ole.planet.myplanet.model.RealmAchievement.Companion.createReference
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.CheckboxListView
 import org.ole.planet.myplanet.utilities.DialogUtils.getAlertDialog
 import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
@@ -61,8 +60,8 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentEditAchievementBinding = FragmentEditAchievementBinding.inflate(inflater, container, false)
-        aRealm = userRepository.getRealm()
-        user = UserProfileDbHandler(requireContext()).userModel
+        aRealm = mRealm
+        user = profileDbHandler.userModel
         achievementArray = JsonArray()
         achievement = aRealm.where(RealmAchievement::class.java).equalTo("_id", user?.id + "@" + user?.planetCode).findFirst()
         initializeData()


### PR DESCRIPTION
## Summary
- drop getRealm from UserRepository and its implementation
- replace getRealm calls with profileDbHandler realm instances
- remove UploadManager helper and use DatabaseService realm directly

## Testing
- `./gradlew :app:compileDefaultDebugKotlin`


------
https://chatgpt.com/codex/tasks/task_e_689b15b56738832bb7e8abb8b9b3e5a8