### PR TITLE
login: smoother register realm handling (fixes #6729)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2838
-        versionName = "0.28.38"
+        versionCode = 2846
+        versionName = "0.28.46"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
@@ -470,8 +470,8 @@ open class RealmUserModel : RealmObject() {
         }
 
         @JvmStatic
-        fun cleanupDuplicateUsers(realm: Realm) {
-            realm.executeTransaction { mRealm ->
+        fun cleanupDuplicateUsers(realm: Realm, onSuccess: () -> Unit) {
+            realm.executeTransactionAsync({ mRealm: Realm ->
                 val allUsers = mRealm.where(RealmUserModel::class.java).findAll()
                 val usersByName = allUsers.groupBy { it.name }
 
@@ -492,6 +492,9 @@ open class RealmUserModel : RealmObject() {
                         }
                     }
                 }
+            }, {
+                onSuccess.invoke()
+            }) {
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/BecomeMemberActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/BecomeMemberActivity.kt
@@ -205,19 +205,20 @@ class BecomeMemberActivity : BaseActivity() {
 
     private fun autoLoginNewMember(username: String, password: String) {
         val mRealm = databaseService.realmInstance
-        RealmUserModel.cleanupDuplicateUsers(mRealm)
-        mRealm.close()
+        RealmUserModel.cleanupDuplicateUsers(mRealm) {
+            mRealm.close()
 
-        val intent = Intent(this, LoginActivity::class.java)
-        intent.putExtra("username", username)
-        intent.putExtra("password", password)
-        intent.putExtra("auto_login", true)
-        if (guest) {
-            intent.putExtra("guest", guest)
+            val intent = Intent(this, LoginActivity::class.java)
+            intent.putExtra("username", username)
+            intent.putExtra("password", password)
+            intent.putExtra("auto_login", true)
+            if (guest) {
+                intent.putExtra("guest", guest)
+            }
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(intent)
+            finish()
         }
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
-        startActivity(intent)
-        finish()
     }
 
     private fun setupTextWatchers(mRealm: Realm) {


### PR DESCRIPTION
## Summary
- prevent UI thread crash by running duplicate user cleanup asynchronously
- delay member auto-login until Realm cleanup completes

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_689b44337eec832b9a5507e417a0cef8