### PR TITLE
teams: smoother navigation with helper (fixes #6754)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2845
-        versionName = "0.28.45"
+        versionCode = 2847
+        versionName = "0.28.47"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -15,7 +15,6 @@ import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.RecyclerView
 import io.realm.Realm
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.ItemTeamListBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
@@ -24,6 +23,7 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
+import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
 
@@ -67,23 +67,21 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
             showActionButton(isMyTeam, team, user)
 
             root.setOnClickListener {
-                if (context is OnHomeItemClickListener) {
-                    val fragmentManager = (context as AppCompatActivity).supportFragmentManager
-                    val existingFragment = fragmentManager.findFragmentByTag("TeamDetailFragment")
-
-                    val f = TeamDetailFragment.newInstance(
-                        teamId = "${team._id}",
-                        teamName = "${team.name}",
-                        teamType = "${team.type}",
-                        isMyTeam = isMyTeam
-                    )
-                    if (existingFragment is TeamDetailFragment) {
-                        existingFragment.arguments?.clear()
-                        existingFragment.arguments = f.arguments
-                    }
-                    (context as OnHomeItemClickListener).openCallFragment(f)
-                    prefData.setTeamName(team.name)
-                }
+                val activity = context as? AppCompatActivity ?: return@setOnClickListener
+                val fragment = TeamDetailFragment.newInstance(
+                    teamId = "${team._id}",
+                    teamName = "${team.name}",
+                    teamType = "${team.type}",
+                    isMyTeam = isMyTeam
+                )
+                NavigationHelper.replaceFragment(
+                    activity.supportFragmentManager,
+                    R.id.fragment_container,
+                    fragment,
+                    addToBackStack = true,
+                    tag = "TeamDetailFragment"
+                )
+                prefData.setTeamName(team.name)
             }
 
             btnFeedback.setOnClickListener {


### PR DESCRIPTION
## Summary
- Navigate to `TeamDetailFragment` using `NavigationHelper` to centralize fragment transactions
- Preserve existing `TeamDetailFragment` tag when replacing fragments

## Testing
- ⚠️ `./gradlew assembleDebug` *(aborted: took too long to complete in this environment)*
- ✅ `./gradlew -version`


------
https://chatgpt.com/codex/tasks/task_e_689c427561b0832b9259cf45e5a34141