### PR TITLE
community: smoother service links realm closing (fixes #6756)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2845
-        versionName = "0.28.45"
+        versionCode = 2849
+        versionName = "0.28.49"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
@@ -96,4 +96,11 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
             }
         }
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if (this::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.close()
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
@@ -98,9 +98,9 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroyView()
     }
 }


### PR DESCRIPTION
## Summary
- Close Realm instance in AddLinkFragment when its view is destroyed to prevent leaks

## Testing
- `./gradlew lint`

------
https://chatgpt.com/codex/tasks/task_e_689c42e59698832b932c92dabaf51be7