### PR TITLE
all: smoother profiles realm closing (fixes #6758)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2845
-        versionName = "0.28.45"
+        versionCode = 2851
+        versionName = "0.28.51"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -314,6 +314,13 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
         dpd.show()
     }
 
+    override fun onDestroyView() {
+        if (this::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.close()
+        }
+        super.onDestroyView()
+    }
+
     override val key: String
         get() = "sub_id"
 


### PR DESCRIPTION
## Summary
- Close Realm instance in `UserInformationFragment` when view is destroyed

## Testing
- `./gradlew assembleDebug` *(fails: terminated due to environment timeout)*

------
https://chatgpt.com/codex/tasks/task_e_689c430ceb9c832bab5c99871445d652