### PR TITLE
courses: smoother exams realm closing (fixes #6759)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2845
-        versionName = "0.28.45"
+        versionCode = 2852
+        versionName = "0.28.52"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
@@ -229,4 +229,11 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
         }
         etAnswer.setText(oldAnswer)
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.close()
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
@@ -231,9 +231,9 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
@@ -496,11 +496,6 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
         )
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        mRealm.close()
-    }
-
     override fun onCheckedChanged(compoundButton: CompoundButton, isChecked: Boolean) {
         if (isChecked) {
             handleChecked(compoundButton)


### PR DESCRIPTION
## Summary
- Close Realm instance in BaseExamFragment when the fragment is destroyed
- Rely on BaseExamFragment to handle Realm cleanup by removing extra closing in TakeExamFragment

## Testing
- `./gradlew assembleDebug` *(fails: build did not complete due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_689c431ca324832b9450b6d141111b85