### PR TITLE
Inject Gson dependency in SearchRepositoryImpl

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SearchRepositoryImpl.kt
@@ -11,7 +11,8 @@ import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmTag
 
 class SearchRepositoryImpl @Inject constructor(
-    private val databaseService: DatabaseService
+    private val databaseService: DatabaseService,
+    private val gson: Gson
 ) : SearchRepository {
 
     override suspend fun saveSearchActivity(
@@ -41,7 +42,7 @@ class SearchRepositoryImpl @Inject constructor(
             filter.addProperty("doc.gradeLevel", gradeLevel)
             filter.addProperty("doc.subjectLevel", subjectLevel)
 
-            activity.filter = Gson().toJson(filter)
+            activity.filter = gson.toJson(filter)
         }
     }
 }


### PR DESCRIPTION
## Summary
- inject Gson into SearchRepositoryImpl constructor
- use provided Gson for filter serialization

## Testing
- `GRADLE_OPTS="-Dorg.gradle.wrapper.download.no_pretty=true" ./gradlew -q lint 2>&1 | tail -n 20` *(fails: Install Android SDK Build-Tools 35 v.35.0.0 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c4472c9bc832b9127679afb5d7560