### PR TITLE
all: smoother courses repository user injection (fixes #6761)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2845
-        versionName = "0.28.45"
+        versionCode = 2855
+        versionName = "0.28.55"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -3,10 +3,10 @@ package org.ole.planet.myplanet.repository
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmUserModel
 
 class CourseRepositoryImpl @Inject constructor(
-    private val databaseService: DatabaseService
+    private val databaseService: DatabaseService,
+    private val userRepository: UserRepository,
 ) : CourseRepository {
 
     override suspend fun getAllCourses(): List<RealmMyCourse> {
@@ -27,8 +27,8 @@ class CourseRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getEnrolledCourses(): List<RealmMyCourse> {
+        val userId = userRepository.getCurrentUser()?.id ?: ""
         return databaseService.withRealmAsync { realm ->
-            val userId = getCurrentUserId(realm)
             realm.copyFromRealm(
                 realm.where(RealmMyCourse::class.java)
                     .equalTo("userId", userId)
@@ -69,10 +69,5 @@ class CourseRepositoryImpl @Inject constructor(
                 .findFirst()
                 ?.deleteFromRealm()
         }
-    }
-
-    private fun getCurrentUserId(realm: io.realm.Realm): String {
-        return realm.where(RealmUserModel::class.java)
-            .findFirst()?.id ?: ""
     }
 }


### PR DESCRIPTION
## Summary
- Inject `UserRepository` into `CourseRepositoryImpl`
- Use the current user's ID from `UserRepository` when loading enrolled courses
- Remove redundant helper for getting current user ID

## Testing
- ⚠️ `./gradlew assemble` *(terminated early; see tail output for progress)*


------
https://chatgpt.com/codex/tasks/task_e_689c4488c4b8832ba2b01315514e5d0c