### PR TITLE
courses: smoother progress realm closing (fixes #6762)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2845
-        versionName = "0.28.45"
+        versionCode = 2854
+        versionName = "0.28.54"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
@@ -88,4 +88,11 @@ class CourseProgressActivity : BaseActivity() {
             }
         }
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (this::realm.isInitialized && !realm.isClosed) {
+            realm.close()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- close Realm instance when CourseProgressActivity is destroyed

## Testing
- `./gradlew lint` *(fails: command did not complete within the time limit)*

------
https://chatgpt.com/codex/tasks/task_e_689c432bb728832ba645715b8b5a6d07