### PR TITLE
Pass coroutine scope into AdapterReports

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterReports.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterReports.kt
@@ -13,7 +13,6 @@ import com.google.gson.JsonObject
 import io.realm.RealmResults
 import java.util.Calendar
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
@@ -23,7 +22,11 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
 
-class AdapterReports(private val context: Context, private var list: RealmResults<RealmMyTeam>) : RecyclerView.Adapter<AdapterReports.ViewHolderReports>() {
+class AdapterReports(
+    private val context: Context,
+    private var list: RealmResults<RealmMyTeam>,
+    private val scope: CoroutineScope
+) : RecyclerView.Adapter<AdapterReports.ViewHolderReports>() {
     private lateinit var reportListItemBinding: ReportListItemBinding
     private var startTimeStamp: String? = null
     private var endTimeStamp: String? = null
@@ -156,7 +159,7 @@ class AdapterReports(private val context: Context, private var list: RealmResult
                         addProperty("updatedDate", System.currentTimeMillis())
                         addProperty("updated", true)
                     }
-                    CoroutineScope(Dispatchers.Main).launch {
+                    scope.launch {
                         try {
                             MainApplication.service.executeTransactionAsync { realm ->
                                 RealmMyTeam.updateReports(doc, realm)
@@ -178,7 +181,7 @@ class AdapterReports(private val context: Context, private var list: RealmResult
                 builder.setTitle(context.getString(R.string.delete_report))
                     .setMessage(R.string.delete_record)
                     .setPositiveButton(R.string.ok) { _, _ ->
-                        CoroutineScope(Dispatchers.Main).launch {
+                        scope.launch {
                             try {
                                 MainApplication.service.executeTransactionAsync { realm ->
                                     realm.where(RealmMyTeam::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/ReportsFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.gson.JsonObject
 import io.realm.RealmResults
@@ -233,7 +234,7 @@ class ReportsFragment : BaseTeamFragment() {
 
     fun updatedReportsList(results: RealmResults<RealmMyTeam>) {
         activity?.runOnUiThread {
-            adapterReports = AdapterReports(requireContext(), results)
+            adapterReports = AdapterReports(requireContext(), results, viewLifecycleOwner.lifecycleScope)
             adapterReports.setNonTeamMember(!isMember())
             fragmentReportsBinding.rvReports.layoutManager = LinearLayoutManager(activity)
             fragmentReportsBinding.rvReports.adapter = adapterReports


### PR DESCRIPTION
## Summary
- Inject a CoroutineScope into AdapterReports and leverage it for report update/delete operations
- Provide fragment's `viewLifecycleOwner.lifecycleScope` when creating the adapter

## Testing
- `./gradlew test` *(fails: terminated while installing Android SDK components)*

------
https://chatgpt.com/codex/tasks/task_e_689cc7794df8832b9dff31dd476b4c6c