### PR TITLE
teams: smoother detail scope (fixes #6799)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2845
-        versionName = "0.28.45"
+        versionCode = 2859
+        versionName = "0.28.59"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -14,7 +14,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -366,7 +365,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
         val userParentCode = userModel.parentCode
         val teamType = getEffectiveTeamType()
 
-        CoroutineScope(Dispatchers.IO).launch {
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
             val realm = userRepository.getRealm()
 
             realm.executeTransaction { r ->


### PR DESCRIPTION
## Summary
- replace manual `CoroutineScope` with `viewLifecycleOwner.lifecycleScope`
- drop redundant coroutine scope import

## Testing
- `./gradlew --no-daemon --console=plain test` *(fails: command terminated due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_689cc7bc6fb8832bb8cd881770eea8be