### PR TITLE
all: smoother destroy super calls last (fixes #6800)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,9 +9,9 @@ android {
     defaultConfig {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
-        targetSdk = 35
-        versionCode = 2855
-        versionName = "0.28.55"
+        targetSdk = 36
+        versionCode = 2860
+        versionName = "0.28.60"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
@@ -365,7 +365,7 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         dismissProgressDialog()
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseMemberFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseMemberFragment.kt
@@ -28,7 +28,7 @@ abstract class BaseMemberFragment : BaseTeamFragment() {
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         _binding = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -389,7 +389,6 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.removeAllChangeListeners()
             if (mRealm.isInTransaction) {
@@ -397,6 +396,7 @@ abstract class BaseResourceFragment : Fragment() {
             }
             mRealm.close()
         }
+        super.onDestroy()
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/service/NetworkConnectivityService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/NetworkConnectivityService.kt
@@ -57,7 +57,7 @@ class NetworkConnectivityService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
-        super.onDestroy()
         serviceScope.cancel()
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
@@ -249,10 +249,10 @@ class SettingActivity : AppCompatActivity() {
         }
 
         override fun onDestroy() {
-            super.onDestroy()
             if (this::profileDbHandler.isInitialized) {
                 profileDbHandler.onDestroy()
             }
+            super.onDestroy()
         }
 
         companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -550,7 +550,6 @@ class ChatDetailFragment : Fragment() {
         if (::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
-        super.onDestroyView()
         val editor = settings.edit()
         if (settings.getBoolean("isAlternativeUrl", false)) {
             editor.putString("alternativeUrl", "")
@@ -558,5 +557,6 @@ class ChatDetailFragment : Fragment() {
             editor.putBoolean("isAlternativeUrl", false)
             editor.apply()
         }
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -249,9 +249,9 @@ class ChatHistoryListFragment : Fragment() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         customProgressDialog?.dismiss()
         customProgressDialog = null
+        super.onDestroy()
     }
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
@@ -95,9 +95,9 @@ class CourseDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         if (this::cRealm.isInitialized && !cRealm.isClosed) {
             cRealm.close()
         }
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
@@ -90,9 +90,9 @@ class CourseProgressActivity : BaseActivity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::realm.isInitialized && !realm.isClosed) {
             realm.close()
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -79,10 +79,10 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::cRealm.isInitialized && !cRealm.isClosed) {
             cRealm.close()
         }
+        super.onDestroy()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -603,9 +603,9 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         customProgressDialog?.dismiss()
         customProgressDialog = null
+        super.onDestroy()
     }
 
     private fun recreateFragment(fragment: Fragment) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -325,10 +325,10 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     override fun onDestroyView() {
         fragmentTakeCourseBinding.courseProgress.setOnSeekBarChangeListener(null)
         lifecycleScope.coroutineContext.cancelChildren()
-        super.onDestroyView()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroyView()
     }
 
     private val isValidClickRight: Boolean get() = fragmentTakeCourseBinding.viewPager2.adapter != null && fragmentTakeCourseBinding.viewPager2.currentItem < fragmentTakeCourseBinding.viewPager2.adapter?.itemCount!!

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -992,7 +992,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         profileDbHandler.onDestroy()
         realmListeners.forEach { it.removeListener() }
         realmListeners.clear()
@@ -1001,6 +1000,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             unregisterReceiver(it)
             systemNotificationReceiver = null
         }
+        super.onDestroy()
     }
 
     override fun openCallFragment(f: Fragment) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/MyActivityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/MyActivityFragment.kt
@@ -96,10 +96,10 @@ class MyActivityFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         if (::realm.isInitialized && !realm.isClosed) {
             realm.close()
         }
+        super.onDestroyView()
     }
 
     fun getMonth(month: Int): String {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -265,9 +265,9 @@ class NotificationsFragment : Fragment() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (::mRealm.isInitialized) {
             mRealm.close()
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -56,10 +56,10 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroy()
     }
 
     override fun onClick(view: View) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -206,9 +206,9 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         customProgressDialog?.dismiss()
         customProgressDialog = null
+        super.onDestroy()
     }
 
     override fun onFeedbackSubmitted() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
@@ -86,10 +86,10 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroy()
     }
 
     override fun onUpload(personal: RealmMyPersonal?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddExaminationActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddExaminationActivity.kt
@@ -394,9 +394,9 @@ class AddExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedChan
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddMyHealthActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AddMyHealthActivity.kt
@@ -148,9 +148,9 @@ class AddMyHealthActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::realm.isInitialized && !realm.isClosed) {
             realm.close()
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
@@ -416,8 +416,8 @@ class MyHealthFragment : Fragment() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         customProgressDialog?.dismiss()
         customProgressDialog = null
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mylife/LifeFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mylife/LifeFragment.kt
@@ -53,8 +53,8 @@ class LifeFragment : BaseRecyclerFragment<RealmMyLife?>(), OnStartDragListener {
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         _binding = null
+        super.onDestroyView()
     }
 
     override fun onStartDrag(viewHolder: RecyclerView.ViewHolder?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
@@ -130,10 +130,10 @@ class NewsDetailActivity : BaseActivity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (::realm.isInitialized && !realm.isClosed) {
             realm.removeAllChangeListeners()
             realm.close()
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/ReplyActivity.kt
@@ -168,10 +168,10 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.removeAllChangeListeners()
             mRealm.close()
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -68,10 +68,10 @@ class AddResourceActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroy()
     }
 
     private fun initializeViews() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -131,10 +131,10 @@ class CollectionsFragment : DialogFragment(), TagExpandableAdapter.OnClickTagIte
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         if (::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroyView()
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -225,7 +225,6 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
         setRatings(`object`)
     }
     override fun onDestroy() {
-        super.onDestroy()
         fragmentScope.cancel()
         if (this::lRealm.isInitialized && !lRealm.isClosed) {
             lRealm.close()
@@ -236,5 +235,6 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             }
         } catch (_: UninitializedPropertyAccessException) {
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -555,9 +555,9 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         customProgressDialog?.dismiss()
         customProgressDialog = null
+        super.onDestroy()
     }
 
     private fun recreateFragment(fragment: Fragment) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -582,9 +582,9 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (!mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -858,13 +858,13 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::bManager.isInitialized) {
             bManager.unregisterReceiver(broadcastReceiver)
         }
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroy()
     }
     companion object {
         lateinit var cal_today: Calendar

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamCalendarFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamCalendarFragment.kt
@@ -334,12 +334,12 @@ class TeamCalendarFragment : BaseTeamFragment() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         try {
             if (!mRealm.isClosed) {
                 mRealm.close()
             }
         } catch (_: UninitializedPropertyAccessException) {
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -389,9 +389,9 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         customProgressDialog?.dismiss()
         customProgressDialog = null
+        super.onDestroy()
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -208,10 +208,10 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        super.onDestroy()
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
@@ -273,7 +273,6 @@ class AchievementFragment : BaseContainerFragment() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         customProgressDialog?.dismiss()
         customProgressDialog = null
         if (this::aRealm.isInitialized && !aRealm.isClosed) {
@@ -285,5 +284,6 @@ class AchievementFragment : BaseContainerFragment() {
             }
         } catch (_: UninitializedPropertyAccessException) {
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
@@ -324,7 +324,6 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::aRealm.isInitialized && !aRealm.isClosed) {
             aRealm.close()
         }
@@ -334,5 +333,6 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
             }
         } catch (_: UninitializedPropertyAccessException) {
         }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
@@ -86,10 +86,10 @@ class UserProfileFragment : Fragment() {
     private lateinit var requestCameraLauncher: ActivityResultLauncher<String>
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::mRealm.isInitialized) {
             mRealm.close()
         }
+        super.onDestroy()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/AudioPlayerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/AudioPlayerActivity.kt
@@ -168,9 +168,9 @@ class AudioPlayerActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         binding.playerView.player = null
         exoPlayer?.release()
         exoPlayer = null
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
@@ -111,7 +111,6 @@ class PDFReaderActivity : AppCompatActivity(), OnPageChangeListener, OnLoadCompl
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (this::audioRecorderService.isInitialized && audioRecorderService.isRecording()) {
             audioRecorderService.stopRecording()
         }
@@ -125,6 +124,7 @@ class PDFReaderActivity : AppCompatActivity(), OnPageChangeListener, OnLoadCompl
             }
             mRealm.close()
         }
+        super.onDestroy()
     }
 
     override fun onError(error: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/VideoPlayerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/VideoPlayerActivity.kt
@@ -225,12 +225,12 @@ class VideoPlayerActivity : AppCompatActivity(), AuthSessionUpdater.AuthCallback
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         authSessionUpdater?.stop()
         try {
             unregisterReceiver(audioBecomingNoisyReceiver)
         } catch (e: IllegalArgumentException) {
             e.printStackTrace()
         }
+        super.onDestroy()
     }
 }


### PR DESCRIPTION
## Summary
- Move cleanup logic before superclass calls in all `onDestroy` and `onDestroyView` overrides

## Testing
- `./gradlew lint` *(fails: Daemon compilation failed - Could not close incremental caches)*

------
https://chatgpt.com/codex/tasks/task_e_689c69048058832bb50688f344fcfc03