### PR TITLE
login: smoother register realm inheriting (fixes #6801)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,9 +9,9 @@ android {
     defaultConfig {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
-        targetSdk = 35
-        versionCode = 2855
-        versionName = "0.28.55"
+        targetSdk = 36
+        versionCode = 2861
+        versionName = "0.28.61"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/BecomeMemberActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/BecomeMemberActivity.kt
@@ -33,8 +33,7 @@ class BecomeMemberActivity : BaseActivity() {
     private lateinit var activityBecomeMemberBinding: ActivityBecomeMemberBinding
     var dob: String = ""
     var guest: Boolean = false
-
-
+    
     private data class MemberInfo(
         val username: String,
         var password: String,
@@ -168,7 +167,6 @@ class BecomeMemberActivity : BaseActivity() {
         EdgeToEdgeUtil.setupEdgeToEdge(this, activityBecomeMemberBinding.root)
         supportActionBar?.setHomeButtonEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        val mRealm: Realm = databaseService.realmInstance
         val languages = resources.getStringArray(R.array.language)
         val lnAadapter = ArrayAdapter(this, R.layout.become_a_member_spinner_layout, languages)
         activityBecomeMemberBinding.spnLang.adapter = lnAadapter
@@ -201,6 +199,13 @@ class BecomeMemberActivity : BaseActivity() {
                 addMember(info, mRealm)
             }
         }
+    }
+
+    override fun onDestroy() {
+        if (!mRealm.isClosed) {
+            mRealm.close()
+        }
+        super.onDestroy()
     }
 
     private fun autoLoginNewMember(username: String, password: String) {


### PR DESCRIPTION
## Summary
- Use inherited `mRealm` instance instead of local variable
- Close the Realm instance in `onDestroy` when open

## Testing
- `./gradlew lint`

------
https://chatgpt.com/codex/tasks/task_e_689db7c29b40832bb42cc353de454270