### PR TITLE
all: smoother `NetworkUtils.kt` scope (fixes #6802)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 35
-        versionCode = 2855
-        versionName = "0.28.55"
+        versionCode = 2862
+        versionName = "0.28.62"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -46,9 +46,9 @@ import org.ole.planet.myplanet.utilities.ANRWatchdog
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DownloadUtils.downloadAllFiles
 import org.ole.planet.myplanet.utilities.LocaleHelper
-import org.ole.planet.myplanet.utilities.NetworkUtils.initialize
 import org.ole.planet.myplanet.utilities.NetworkUtils.isNetworkConnectedFlow
 import org.ole.planet.myplanet.utilities.NetworkUtils.startListenNetworkState
+import org.ole.planet.myplanet.utilities.NetworkUtils.stopListenNetworkState
 import org.ole.planet.myplanet.utilities.NotificationUtil.cancelAll
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.ThemeMode
@@ -201,7 +201,6 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
 
     private fun initApp() {
         context = this
-        initialize(applicationScope)
         startListenNetworkState()
     }
 
@@ -382,6 +381,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
         }
         super.onTerminate()
         onAppClosed()
+        stopListenNetworkState()
         applicationScope.cancel()
     }
 }


### PR DESCRIPTION
## Summary
- Inject `CoroutineScope` using Hilt `@ApplicationScope` in `NetworkUtils`
- Add `stopListenNetworkState` to unregister network callback
- Clean up network listener in `MainApplication.onTerminate`

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_689db85980c8832b9f3406554171dba6