### PR TITLE
Use nullable binding pattern in RatingFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
@@ -26,7 +26,8 @@ import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
 class RatingFragment : DialogFragment() {
-    private lateinit var fragmentRatingBinding: FragmentRatingBinding
+    private var _binding: FragmentRatingBinding? = null
+    private val binding get() = _binding!!
     @Inject
     lateinit var databaseService: DatabaseService
     lateinit var mRealm: Realm
@@ -52,10 +53,10 @@ class RatingFragment : DialogFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentRatingBinding = FragmentRatingBinding.inflate(inflater, container, false)
+        _binding = FragmentRatingBinding.inflate(inflater, container, false)
         mRealm = databaseService.realmInstance
         settings = requireActivity().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        return fragmentRatingBinding.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -65,20 +66,20 @@ class RatingFragment : DialogFragment() {
         previousRating = mRealm.where(RealmRating::class.java).equalTo("type", type)
             .equalTo("userId", settings.getString("userId", "")).equalTo("item", id).findFirst()
         if (previousRating != null) {
-            fragmentRatingBinding.ratingBar.rating = previousRating?.rate?.toFloat() ?: 0.0f
-            fragmentRatingBinding.etComment.setText(previousRating?.comment)
+            binding.ratingBar.rating = previousRating?.rate?.toFloat() ?: 0.0f
+            binding.etComment.setText(previousRating?.comment)
         }
-        fragmentRatingBinding.ratingBar.onRatingBarChangeListener =
+        binding.ratingBar.onRatingBarChangeListener =
             OnRatingBarChangeListener { _: RatingBar?, _: Float, fromUser: Boolean ->
                 if (fromUser) {
-                    fragmentRatingBinding.ratingError.visibility = View.GONE
+                    binding.ratingError.visibility = View.GONE
                 }
             }
-        fragmentRatingBinding.btnCancel.setOnClickListener { dismiss() }
-        fragmentRatingBinding.btnSubmit.setOnClickListener {
-            if (fragmentRatingBinding.ratingBar.rating.toDouble() == 0.0) {
-                fragmentRatingBinding.ratingError.visibility = View.VISIBLE
-                fragmentRatingBinding.ratingError.text = getString(R.string.kindly_give_a_rating)
+        binding.btnCancel.setOnClickListener { dismiss() }
+        binding.btnSubmit.setOnClickListener {
+            if (binding.ratingBar.rating.toDouble() == 0.0) {
+                binding.ratingError.visibility = View.VISIBLE
+                binding.ratingError.text = getString(R.string.kindly_give_a_rating)
             } else {
                 saveRating()
             }
@@ -89,12 +90,13 @@ class RatingFragment : DialogFragment() {
         if (::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        _binding = null
         super.onDestroyView()
     }
 
     private fun saveRating() {
-        val comment = fragmentRatingBinding.etComment.text.toString()
-        val rating = fragmentRatingBinding.ratingBar.rating
+        val comment = binding.etComment.text.toString()
+        val rating = binding.ratingBar.rating
         mRealm.executeTransactionAsync(Realm.Transaction { realm: Realm ->
             var ratingObject = realm.where(RealmRating::class.java)
                 .equalTo("type", type)


### PR DESCRIPTION
## Summary
- migrate RatingFragment to nullable view binding with a safe accessor
- clear binding reference in onDestroyView to avoid leaks

## Testing
- `./gradlew lint --console=plain --no-configuration-cache` *(fails: Timeout waiting to lock Configuration Cache / terminated)*
- `./gradlew -q help`


------
https://chatgpt.com/codex/tasks/task_e_689db8935228832b86eddabde7da172a