### PR TITLE
Use nullable binding in CommunityTabFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
@@ -12,10 +12,11 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
 class CommunityTabFragment : Fragment() {
-    private lateinit var fragmentTeamDetailBinding: FragmentTeamDetailBinding
+    private var _binding: FragmentTeamDetailBinding? = null
+    private val binding get() = _binding!!
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentTeamDetailBinding = FragmentTeamDetailBinding.inflate(inflater, container, false)
-        return fragmentTeamDetailBinding.root
+        _binding = FragmentTeamDetailBinding.inflate(inflater, container, false)
+        return binding.root
     }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -23,12 +24,16 @@ class CommunityTabFragment : Fragment() {
         val sParentcode = settings.getString("parentCode", "")
         val communityName = settings.getString("communityName", "")
         val user = UserProfileDbHandler(requireActivity()).userModel
-        fragmentTeamDetailBinding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), user?.planetCode + "@" + sParentcode, false, settings)
-        TabLayoutMediator(fragmentTeamDetailBinding.tabLayout, fragmentTeamDetailBinding.viewPager2) { tab, position ->
-            tab.text = (fragmentTeamDetailBinding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
+        binding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), user?.planetCode + "@" + sParentcode, false, settings)
+        TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->
+            tab.text = (binding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
         }.attach()
-        fragmentTeamDetailBinding.title.text = if (user?.planetCode == "") communityName else user?.planetCode
-        fragmentTeamDetailBinding.subtitle.text = settings.getString("planetType", "")
-        fragmentTeamDetailBinding.llActionButtons.visibility = View.GONE
+        binding.title.text = if (user?.planetCode == "") communityName else user?.planetCode
+        binding.subtitle.text = settings.getString("planetType", "")
+        binding.llActionButtons.visibility = View.GONE
+    }
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }


### PR DESCRIPTION
## Summary
- refactor `CommunityTabFragment` to use nullable backing field for view binding
- clear binding reference in `onDestroyView`

## Testing
- `./gradlew lint` *(fails: command terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_689db89b86d8832b8881deee37652d76