### PR TITLE
Add suspending retry utility and update API client

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
@@ -15,8 +15,8 @@ object ApiClient {
         return enhancedRetrofit.create(ApiInterface::class.java)
     }
 
-    fun <T> executeWithRetry(operation: () -> Response<T>?): Response<T>? {
-        return RetryUtils.retry(
+    suspend fun <T> executeWithRetry(operation: suspend () -> Response<T>?): Response<T>? {
+        return RetryUtils.retrySuspending(
             maxAttempts = 3,
             delayMs = 2000L,
             shouldRetry = { resp -> resp == null || !resp.isSuccessful },

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -225,7 +225,7 @@ class SyncManager @Inject constructor(
             logger.endProcess("admin_sync")
 
             logger.startProcess("resource_sync")
-            resourceTransactionSync()
+            runBlocking { resourceTransactionSync() }
             logger.endProcess("resource_sync")
 
             logger.startProcess("on_synced")

--- a/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/SyncManager.kt
@@ -571,7 +571,7 @@ class SyncManager @Inject constructor(
         }
     }
 
-    private fun resourceTransactionSync(backgroundRealm: Realm? = null) {
+    private suspend fun resourceTransactionSync(backgroundRealm: Realm? = null) {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("resource_sync")
         var processedItems = 0
@@ -720,7 +720,7 @@ class SyncManager @Inject constructor(
         }
     }
 
-    private fun fastResourceTransactionSync() {
+    private suspend fun fastResourceTransactionSync() {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("resource_sync")
         var processedItems = 0
@@ -1003,7 +1003,7 @@ class SyncManager @Inject constructor(
         return processedItems
     }
 
-    private fun processShelfDataOptimizedSync(shelfId: String?, shelfData: Constants.ShelfData, shelfDoc: JsonObject?, apiInterface: ApiInterface): Int {
+    private suspend fun processShelfDataOptimizedSync(shelfId: String?, shelfData: Constants.ShelfData, shelfDoc: JsonObject?, apiInterface: ApiInterface): Int {
         var processedCount = 0
 
         try {
@@ -1080,7 +1080,7 @@ class SyncManager @Inject constructor(
         return processedCount
     }
 
-    private fun fastMyLibraryTransactionSync() {
+    private suspend fun fastMyLibraryTransactionSync() {
         val logger = SyncTimeLogger.getInstance()
         logger.startProcess("library_sync")
         var processedItems = 0
@@ -1197,18 +1197,19 @@ class SyncManager @Inject constructor(
         return processedCount
     }
 
-    private fun <T> safeRealmOperation(operation: (Realm) -> T): T? {
+    private suspend fun <T> safeRealmOperation(operation: suspend (Realm) -> T): T? {
+        val realm = databaseService.realmInstance
         return try {
-            databaseService.realmInstance.use { realm ->
-                operation(realm)
-            }
+            operation(realm)
         } catch (e: Exception) {
             e.printStackTrace()
             null
+        } finally {
+            realm.close()
         }
     }
 
-    private fun processBatchForShelfData(batch: List<String>, shelfData: Constants.ShelfData, shelfId: String?, apiInterface: ApiInterface, realmInstance: Realm): Int {
+    private suspend fun processBatchForShelfData(batch: List<String>, shelfData: Constants.ShelfData, shelfId: String?, apiInterface: ApiInterface, realmInstance: Realm): Int {
         var processedCount = 0
 
         try {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
@@ -1,5 +1,7 @@
 package org.ole.planet.myplanet.utilities
 
+import kotlinx.coroutines.delay
+
 object RetryUtils {
     fun <T> retry(
         maxAttempts: Int = 3,
@@ -26,6 +28,39 @@ object RetryUtils {
                 try {
                     Thread.sleep(delayMs)
                 } catch (ie: InterruptedException) {
+                    // ignore
+                }
+            }
+        }
+        lastException?.printStackTrace()
+        return result
+    }
+
+    suspend fun <T> retrySuspending(
+        maxAttempts: Int = 3,
+        delayMs: Long = 2000L,
+        shouldRetry: (T?) -> Boolean = { it == null },
+        block: suspend () -> T?,
+    ): T? {
+        var attempt = 0
+        var result: T? = null
+        var lastException: Exception? = null
+
+        while (attempt < maxAttempts) {
+            try {
+                result = block()
+            } catch (e: Exception) {
+                lastException = e
+                result = null
+            }
+            if (!shouldRetry(result)) {
+                return result
+            }
+            attempt++
+            if (attempt < maxAttempts) {
+                try {
+                    delay(delayMs)
+                } catch (_: Exception) {
                     // ignore
                 }
             }


### PR DESCRIPTION
## Summary
- add `retrySuspending` using `kotlinx.coroutines.delay`
- use suspending retry in `ApiClient.executeWithRetry`
- mark SyncManager resource sync helpers as `suspend`

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f04223ae0832ba50d0044893430d5