### PR TITLE
Use image view context for Glide and remove unused Utilities context

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -52,7 +52,6 @@ import org.ole.planet.myplanet.utilities.NetworkUtils.stopListenNetworkState
 import org.ole.planet.myplanet.utilities.NotificationUtil.cancelAll
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.ThemeMode
-import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils.getVersionName
 
 @HiltAndroidApp
@@ -311,7 +310,6 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
 
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(LocaleHelper.onAttach(base))
-        Utilities.setContext(base)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
@@ -16,7 +16,6 @@ import androidx.core.graphics.toColorInt
 import androidx.core.net.toUri
 import com.bumptech.glide.Glide
 import fisk.chipcloud.ChipCloudConfig
-import java.lang.ref.WeakReference
 import java.math.BigInteger
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.R
@@ -24,12 +23,6 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
 object Utilities {
-    private var contextRef: WeakReference<Context>? = null
-
-    fun setContext(ctx: Context) {
-        contextRef = WeakReference(ctx.applicationContext)
-    }
-
     val SD_PATH: String by lazy {
         context.getExternalFilesDir(null)?.let { "$it/ole/" } ?: ""
     }
@@ -89,7 +82,7 @@ object Utilities {
 
     fun loadImage(userImage: String?, imageView: ImageView) {
         if (!userImage.isNullOrEmpty()) {
-            Glide.with(context)
+            Glide.with(imageView.context)
                 .load(userImage)
                 .placeholder(R.drawable.profile)
                 .error(R.drawable.profile)


### PR DESCRIPTION
## Summary
- Avoid using global context in `Utilities.loadImage` by using `imageView.context`
- Drop unused `contextRef` and `setContext` from `Utilities`
- Remove now-unnecessary `Utilities.setContext` call in `MainApplication`

## Testing
- `./gradlew --console=plain assembleDebug` *(fails: Could not determine the dependencies of task ':app:compileDefaultDebugJavaWithJavac'. Failed to install the following SDK components: platforms;android-36 Android SDK Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_689f04639efc832bb50468a1ee144fe7