### PR TITLE
Refactor news adapter to use ListAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
@@ -85,13 +85,12 @@ abstract class BaseNewsFragment : BaseContainerFragment(), OnNewsItemClickListen
             if (result.resultCode == Activity.RESULT_OK) {
                 val newsId = result.data?.getStringExtra("newsId")
                 newsId.let { adapterNews?.updateReplyBadge(it) }
-                adapterNews?.notifyDataSetChanged()
             }
         }
     }
 
     override fun onDataChanged() {
-        adapterNews?.notifyDataSetChanged()
+        adapterNews?.currentList?.let { adapterNews?.submitList(it.toList()) }
     }
 
     override fun onAttach(context: Context) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
@@ -87,14 +87,14 @@ class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickLi
 
     private fun updatedNewsList(updatedList: RealmResults<RealmNews>?) {
         activity?.runOnUiThread {
-            val updatedListAsMutable: MutableList<RealmNews> = updatedList?.filterNotNull()?.toMutableList() ?: mutableListOf()
-            val adapter = activity?.let { AdapterNews(it, updatedListAsMutable, user, null, "", null, userProfileDbHandler) }
+            val updatedListFiltered = updatedList?.filterNotNull() ?: emptyList()
+            val adapter = activity?.let { AdapterNews(it, user, null, "", null, userProfileDbHandler) }
             adapter?.setListener(this)
             adapter?.setFromLogin(requireArguments().getBoolean("fromLogin", false))
             adapter?.setmRealm(mRealm)
             fragmentCommunityBinding.rvCommunity.adapter = adapter
             fragmentCommunityBinding.llEditDelete.visibility = if (user?.isManager() == true) View.VISIBLE else View.GONE
-            adapter?.submitList(updatedListAsMutable)
+            adapter?.submitList(updatedListFiltered)
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
@@ -87,14 +87,14 @@ class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickLi
 
     private fun updatedNewsList(updatedList: RealmResults<RealmNews>?) {
         activity?.runOnUiThread {
-            val updatedListAsMutable: MutableList<RealmNews?> = updatedList?.toMutableList() ?: mutableListOf()
+            val updatedListAsMutable: MutableList<RealmNews> = updatedList?.filterNotNull()?.toMutableList() ?: mutableListOf()
             val adapter = activity?.let { AdapterNews(it, updatedListAsMutable, user, null, "", null, userProfileDbHandler) }
             adapter?.setListener(this)
             adapter?.setFromLogin(requireArguments().getBoolean("fromLogin", false))
             adapter?.setmRealm(mRealm)
             fragmentCommunityBinding.rvCommunity.adapter = adapter
             fragmentCommunityBinding.llEditDelete.visibility = if (user?.isManager() == true) View.VISIBLE else View.GONE
-            adapter?.notifyDataSetChanged()
+            adapter?.submitList(updatedListAsMutable)
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsActions.kt
@@ -158,22 +158,20 @@ object NewsActions {
     fun deletePost(
         context: Context,
         realm: Realm,
-        news: RealmNews?,
-        list: MutableList<RealmNews?>,
+        news: RealmNews,
+        list: MutableList<RealmNews>,
         teamName: String,
         listener: AdapterNews.OnNewsItemClickListener? = null
     ) {
-        val ar = Gson().fromJson(news?.viewIn, JsonArray::class.java)
+        val ar = Gson().fromJson(news.viewIn, JsonArray::class.java)
         if (!realm.isInTransaction) realm.beginTransaction()
         val position = list.indexOf(news)
         if (position != -1) {
             list.removeAt(position)
         }
         if (teamName.isNotEmpty() || ar.size() < 2) {
-            news?.let {
-                deleteChildPosts(realm, it.id, list)
-                it.deleteFromRealm()
-            }
+            deleteChildPosts(realm, news.id, list)
+            news.deleteFromRealm()
         } else {
             val filtered = JsonArray().apply {
                 ar.forEach { elem ->
@@ -182,7 +180,7 @@ object NewsActions {
                     }
                 }
             }
-            news?.viewIn = Gson().toJson(filtered)
+            news.viewIn = Gson().toJson(filtered)
         }
         realm.commitTransaction()
         listener?.onDataChanged()
@@ -191,7 +189,7 @@ object NewsActions {
     private fun deleteChildPosts(
         realm: Realm,
         parentId: String?,
-        list: MutableList<RealmNews?>
+        list: MutableList<RealmNews>
     ) {
         if (parentId == null) return
         val children = realm.where(RealmNews::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsActions.kt
@@ -159,18 +159,13 @@ object NewsActions {
         context: Context,
         realm: Realm,
         news: RealmNews,
-        list: MutableList<RealmNews>,
         teamName: String,
         listener: AdapterNews.OnNewsItemClickListener? = null
     ) {
         val ar = Gson().fromJson(news.viewIn, JsonArray::class.java)
         if (!realm.isInTransaction) realm.beginTransaction()
-        val position = list.indexOf(news)
-        if (position != -1) {
-            list.removeAt(position)
-        }
         if (teamName.isNotEmpty() || ar.size() < 2) {
-            deleteChildPosts(realm, news.id, list)
+            deleteChildPosts(realm, news.id)
             news.deleteFromRealm()
         } else {
             val filtered = JsonArray().apply {
@@ -188,17 +183,14 @@ object NewsActions {
 
     private fun deleteChildPosts(
         realm: Realm,
-        parentId: String?,
-        list: MutableList<RealmNews>
+        parentId: String?
     ) {
         if (parentId == null) return
         val children = realm.where(RealmNews::class.java)
             .equalTo("replyTo", parentId)
             .findAll()
         children.forEach { child ->
-            deleteChildPosts(realm, child.id, list)
-            val idx = list.indexOf(child)
-            if (idx != -1) list.removeAt(idx)
+            deleteChildPosts(realm, child.id)
             child.deleteFromRealm()
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
@@ -210,7 +210,7 @@ class NewsFragment : BaseNewsFragment() {
                 getSortDate(news)
             })
             if (fragmentNewsBinding.rvNews.adapter == null) {
-                adapterNews = AdapterNews(requireActivity(), sortedList.toMutableList(), user, null, "", null, userProfileDbHandler)
+                adapterNews = AdapterNews(requireActivity(), user, null, "", null, userProfileDbHandler)
 
                 adapterNews?.setmRealm(mRealm)
                 adapterNews?.setFromLogin(requireArguments().getBoolean("fromLogin"))

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
@@ -206,24 +206,26 @@ class NewsFragment : BaseNewsFragment() {
                 .`in`("_id", resourceIds.toTypedArray())
                 .findAll()
             getUrlsAndStartDownload(lib, ArrayList())
-            val updatedListAsMutable: MutableList<RealmNews?> = list.toMutableList()
-            val sortedList = updatedListAsMutable.sortedWith(compareByDescending { news ->
+            val sortedList = list.filterNotNull().sortedWith(compareByDescending { news ->
                 getSortDate(news)
             })
-            adapterNews = AdapterNews(requireActivity(), sortedList.toMutableList(), user, null, "", null, userProfileDbHandler)
+            if (fragmentNewsBinding.rvNews.adapter == null) {
+                adapterNews = AdapterNews(requireActivity(), sortedList.toMutableList(), user, null, "", null, userProfileDbHandler)
 
-            adapterNews?.setmRealm(mRealm)
-            adapterNews?.setFromLogin(requireArguments().getBoolean("fromLogin"))
-            adapterNews?.setListener(this)
-            adapterNews?.registerAdapterDataObserver(observer)
+                adapterNews?.setmRealm(mRealm)
+                adapterNews?.setFromLogin(requireArguments().getBoolean("fromLogin"))
+                adapterNews?.setListener(this)
+                adapterNews?.registerAdapterDataObserver(observer)
 
-            fragmentNewsBinding.rvNews.adapter = adapterNews
-        } else {
-            (fragmentNewsBinding.rvNews.adapter as? AdapterNews)?.updateList(list)
+                fragmentNewsBinding.rvNews.adapter = adapterNews
+            } else {
+                adapterNews = fragmentNewsBinding.rvNews.adapter as? AdapterNews
+            }
+            adapterNews?.submitList(sortedList)
+            adapterNews?.let { showNoData(fragmentNewsBinding.tvMessage, it.itemCount, "news") }
+            fragmentNewsBinding.llAddNews.visibility = View.GONE
+            fragmentNewsBinding.btnNewVoice.text = getString(R.string.new_voice)
         }
-        adapterNews?.let { showNoData(fragmentNewsBinding.tvMessage, it.itemCount, "news") }
-        fragmentNewsBinding.llAddNews.visibility = View.GONE
-        fragmentNewsBinding.btnNewVoice.text = getString(R.string.new_voice)
     }
 
     override fun onNewsItemClick(news: RealmNews?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/RealmNewsDiffCallback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/RealmNewsDiffCallback.kt
@@ -3,31 +3,21 @@ package org.ole.planet.myplanet.ui.news
 import androidx.recyclerview.widget.DiffUtil
 import org.ole.planet.myplanet.model.RealmNews
 
-class RealmNewsDiffCallback(
-    private val oldList: List<RealmNews?>,
-    private val newList: List<RealmNews?>
-) : DiffUtil.Callback() {
-
-    override fun getOldListSize() = oldList.size
-    override fun getNewListSize() = newList.size
-
+object RealmNewsDiffCallback : DiffUtil.ItemCallback<RealmNews>() {
     private fun safeId(n: RealmNews?): String? = if (n?.isValid == true) n.id else null
 
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        val oId = safeId(oldList[oldItemPosition])
-        val nId = safeId(newList[newItemPosition])
+    override fun areItemsTheSame(oldItem: RealmNews, newItem: RealmNews): Boolean {
+        val oId = safeId(oldItem)
+        val nId = safeId(newItem)
         return oId != null && oId == nId
     }
 
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        val o = oldList[oldItemPosition]
-        val n = newList[newItemPosition]
+    override fun areContentsTheSame(oldItem: RealmNews, newItem: RealmNews): Boolean {
+        if (oldItem.isValid != true || newItem.isValid != true) return false
 
-        if (o?.isValid != true || n?.isValid != true) return false
-
-        return o.id == n.id &&
-                o.time == n.time &&
-                o.isEdited == n.isEdited &&
-                o.message == n.message
+        return oldItem.id == newItem.id &&
+            oldItem.time == newItem.time &&
+            oldItem.isEdited == newItem.isEdited &&
+            oldItem.message == newItem.message
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/ReplyActivity.kt
@@ -83,9 +83,9 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
     private fun showData(id: String?) {
         val news = mRealm.where(RealmNews::class.java).equalTo("id", id).findFirst()
         val list: List<RealmNews?> = mRealm.where(RealmNews::class.java).sort("time", Sort.DESCENDING).equalTo("replyTo", id, Case.INSENSITIVE).findAll()
-        val mutable = list.filterNotNull().toMutableList()
-        newsAdapter = AdapterNews(this, mutable, user, news, "", null, userProfileDbHandler)
-        newsAdapter.submitList(mutable)
+        val items = list.filterNotNull()
+        newsAdapter = AdapterNews(this, user, news, "", null, userProfileDbHandler)
+        newsAdapter.submitList(items)
         newsAdapter.setListener(this)
         newsAdapter.setmRealm(mRealm)
         newsAdapter.setFromLogin(intent.getBooleanExtra("fromLogin", false))

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/ReplyActivity.kt
@@ -83,7 +83,9 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
     private fun showData(id: String?) {
         val news = mRealm.where(RealmNews::class.java).equalTo("id", id).findFirst()
         val list: List<RealmNews?> = mRealm.where(RealmNews::class.java).sort("time", Sort.DESCENDING).equalTo("replyTo", id, Case.INSENSITIVE).findAll()
-        newsAdapter = AdapterNews(this, list.toMutableList(), user, news, "", null, userProfileDbHandler)
+        val mutable = list.filterNotNull().toMutableList()
+        newsAdapter = AdapterNews(this, mutable, user, news, "", null, userProfileDbHandler)
+        newsAdapter.submitList(mutable)
         newsAdapter.setListener(this)
         newsAdapter.setmRealm(mRealm)
         newsAdapter.setFromLogin(intent.getBooleanExtra("fromLogin", false))

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
@@ -183,7 +183,7 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
     private fun showRecyclerView(realmNewsList: List<RealmNews?>?) {
         val list = realmNewsList?.filterNotNull()?.toMutableList() ?: mutableListOf()
         adapterNews = activity?.let {
-            AdapterNews(it, list, user, null, team?.name.toString(), teamId, userProfileDbHandler)
+            AdapterNews(it, user, null, team?.name.toString(), teamId, userProfileDbHandler)
         }
         adapterNews?.setmRealm(mRealm)
         adapterNews?.setListener(this)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
@@ -181,14 +181,14 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
     }
 
     private fun showRecyclerView(realmNewsList: List<RealmNews?>?) {
+        val list = realmNewsList?.filterNotNull()?.toMutableList() ?: mutableListOf()
         adapterNews = activity?.let {
-            realmNewsList?.let { it1 ->
-                AdapterNews(it, it1.toMutableList(), user, null, team?.name.toString(), teamId, userProfileDbHandler)
-            }
+            AdapterNews(it, list, user, null, team?.name.toString(), teamId, userProfileDbHandler)
         }
         adapterNews?.setmRealm(mRealm)
         adapterNews?.setListener(this)
         rvDiscussion.adapter = adapterNews
+        adapterNews?.submitList(list)
         llRv.visibility = View.VISIBLE
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamDiscussion/DiscussionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamDiscussion/DiscussionListFragment.kt
@@ -169,21 +169,22 @@ class DiscussionListFragment : BaseTeamFragment() {
         val existingAdapter = fragmentDiscussionListBinding.rvDiscussion.adapter
         if (existingAdapter == null) {
             val adapterNews = activity?.let {
-                realmNewsList?.let { list ->
-                    AdapterNews(it, list.toMutableList(), user, null, getEffectiveTeamName(), teamId, userProfileDbHandler)
+                realmNewsList?.filterNotNull()?.toMutableList()?.let { list ->
+                    AdapterNews(it, list, user, null, getEffectiveTeamName(), teamId, userProfileDbHandler)
                 }
             }
             adapterNews?.setmRealm(mRealm)
             adapterNews?.setListener(this)
             if (!isMember()) adapterNews?.setNonTeamMember(true)
             fragmentDiscussionListBinding.rvDiscussion.adapter = adapterNews
+            adapterNews?.submitList(realmNewsList?.filterNotNull())
             adapterNews?.let {
                 showNoData(fragmentDiscussionListBinding.tvNodata, it.itemCount, "discussions")
             }
         } else {
             (existingAdapter as? AdapterNews)?.let { adapter ->
                 realmNewsList?.let {
-                    adapter.updateList(it)
+                    adapter.submitList(it.filterNotNull())
                     showNoData(fragmentDiscussionListBinding.tvNodata, adapter.itemCount, "discussions")
                 }
             }
@@ -219,7 +220,6 @@ class DiscussionListFragment : BaseTeamFragment() {
                 map["messagePlanetCode"] = team?.teamPlanetCode ?: ""
                 map["name"] = getEffectiveTeamName()
                 user?.let { createNews(map, mRealm, it, imageList) }
-                fragmentDiscussionListBinding.rvDiscussion.adapter?.notifyDataSetChanged()
                 setData(news)
                 layout.editText?.text?.clear()
                 imageList.clear()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamDiscussion/DiscussionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamDiscussion/DiscussionListFragment.kt
@@ -169,9 +169,7 @@ class DiscussionListFragment : BaseTeamFragment() {
         val existingAdapter = fragmentDiscussionListBinding.rvDiscussion.adapter
         if (existingAdapter == null) {
             val adapterNews = activity?.let {
-                realmNewsList?.filterNotNull()?.toMutableList()?.let { list ->
-                    AdapterNews(it, list, user, null, getEffectiveTeamName(), teamId, userProfileDbHandler)
-                }
+                AdapterNews(it, user, null, getEffectiveTeamName(), teamId, userProfileDbHandler)
             }
             adapterNews?.setmRealm(mRealm)
             adapterNews?.setListener(this)


### PR DESCRIPTION
## Summary
- replace RealmNewsDiffCallback with a DiffUtil.ItemCallback object
- convert AdapterNews to ListAdapter and remove manual diffing
- use submitList for news updates across fragments and activities

## Testing
- `./gradlew assembleDebug -x test`


------
https://chatgpt.com/codex/tasks/task_e_689f05095eb0832baf1c79c642fe9bb5