### PR TITLE
teams: smoother voices diff callback (fixes #6862)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2881
-        versionName = "0.28.81"
+        versionCode = 2892
+        versionName = "0.28.92"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
@@ -78,7 +78,7 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
     fun addItem(news: RealmNews?) {
         val newList = list.toMutableList()
         newList.add(0, news)
-        val diffCallback = RealmNewsDiffCallback(list, newList)
+        val diffCallback = NewsDiffCallback(list, newList)
         val diffResult = DiffUtil.calculateDiff(diffCallback)
         list.clear()
         list.addAll(newList)
@@ -328,7 +328,7 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
     }
 
     fun updateList(newList: List<RealmNews?>) {
-        val diffCallback = RealmNewsDiffCallback(list, newList)
+        val diffCallback = NewsDiffCallback(list, newList)
         val diffResult = DiffUtil.calculateDiff(diffCallback)
         list.clear()
         list.addAll(newList)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDiffCallback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDiffCallback.kt
@@ -3,7 +3,7 @@ package org.ole.planet.myplanet.ui.news
 import androidx.recyclerview.widget.DiffUtil
 import org.ole.planet.myplanet.model.RealmNews
 
-class RealmNewsDiffCallback(
+class NewsDiffCallback(
     private val oldList: List<RealmNews?>,
     private val newList: List<RealmNews?>
 ) : DiffUtil.Callback() {


### PR DESCRIPTION
## Summary
- rename RealmNewsDiffCallback to NewsDiffCallback
- update AdapterNews to use the new NewsDiffCallback

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68a30702c10c832ba08ae11c256a3c57