### PR TITLE
teams: smoother survey diff callback (fixes #6861)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2881
-        versionName = "0.28.81"
+        versionCode = 2891
+        versionName = "0.28.91"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
@@ -264,18 +264,6 @@ class AdapterSurvey(
     }
 }
 
-class SurveyDiffCallback(private val oldList: List<RealmStepExam>, private val newList: List<RealmStepExam>) : DiffUtil.Callback() {
-    override fun getOldListSize(): Int = oldList.size
-    override fun getNewListSize(): Int = newList.size
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return oldList[oldItemPosition].id == newList[newItemPosition].id
-    }
-
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return oldList[oldItemPosition] == newList[newItemPosition]
-    }
-}
-
 enum class SurveySortType {
     DATE_DESC,
     DATE_ASC,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyDiffCallback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyDiffCallback.kt
@@ -1,0 +1,20 @@
+package org.ole.planet.myplanet.ui.survey
+
+import androidx.recyclerview.widget.DiffUtil
+import org.ole.planet.myplanet.model.RealmStepExam
+
+class SurveyDiffCallback(
+    private val oldList: List<RealmStepExam>,
+    private val newList: List<RealmStepExam>
+) : DiffUtil.Callback() {
+    override fun getOldListSize(): Int = oldList.size
+    override fun getNewListSize(): Int = newList.size
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return oldList[oldItemPosition].id == newList[newItemPosition].id
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return oldList[oldItemPosition] == newList[newItemPosition]
+    }
+}
+


### PR DESCRIPTION
## Summary
- move SurveyDiffCallback into its own `SurveyDiffCallback.kt`
- reference new class from AdapterSurvey

## Testing
- `./gradlew :app:compileLiteDebugKotlin` *(fails: build did not complete within time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68a307220708832b87fe9f4988b29368