### PR TITLE
Preserve thread interrupt flag in RetryUtils sleep retry

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/RetryUtils.kt
@@ -26,7 +26,8 @@ object RetryUtils {
                 try {
                     Thread.sleep(delayMs)
                 } catch (ie: InterruptedException) {
-                    // ignore
+                    Thread.currentThread().interrupt()
+                    return result
                 }
             }
         }


### PR DESCRIPTION
## Summary
- preserve thread interrupted state when retry sleep is interrupted

## Testing
- `./gradlew app:compileDefaultDebugKotlin`


------
https://chatgpt.com/codex/tasks/task_e_68a44e54be70832b809c0728753c7873