### PR TITLE
feat: unify date formatting utilities

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMeetup.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMeetup.kt
@@ -8,6 +8,7 @@ import io.realm.Case
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
+import java.time.ZoneId
 import org.json.JSONArray
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.TimeUtils
@@ -86,8 +87,10 @@ open class RealmMeetup : RealmObject() {
             map["Created By"] = checkNull(meetups.creator)
             map["Category"] = checkNull(meetups.category)
             try {
-                map["Meetup Date"] = TimeUtils.getFormattedDate(meetups.startDate) +
-                        " - " + TimeUtils.getFormattedDate(meetups.endDate)
+                map["Meetup Date"] =
+                    TimeUtils.format(meetups.startDate, "EEEE, MMM dd, yyyy", ZoneId.of("UTC")) +
+                        " - " +
+                        TimeUtils.format(meetups.endDate, "EEEE, MMM dd, yyyy", ZoneId.of("UTC"))
             } catch (e: Exception) {
                 e.printStackTrace()
             }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
@@ -247,7 +247,9 @@ open class RealmSubmission : RealmObject() {
                 .equalTo("userId", userId)
                 .sort("startTime", Sort.DESCENDING)
                 .findFirst()
-            return recentSubmission?.startTime?.let { TimeUtils.getFormattedDateWithTime(it) } ?: ""
+            return recentSubmission?.startTime?.let {
+                TimeUtils.format(it, "EEE dd, MMMM yyyy , hh:mm a")
+            } ?: ""
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/service/TaskNotificationWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/TaskNotificationWorker.kt
@@ -8,7 +8,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.utilities.NotificationUtil.create
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 
 class TaskNotificationWorker(private val context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
     override fun doWork(): Result {
@@ -26,7 +26,12 @@ class TaskNotificationWorker(private val context: Context, workerParams: WorkerP
                     .findAll()
                 realm.executeTransaction {
                     for (task in tasks) {
-                        create(context, R.drawable.ole_logo, task.title, "Task expires on " + formatDate(task.deadline, ""))
+                        create(
+                            context,
+                            R.drawable.ole_logo,
+                            task.title,
+                            "Task expires on " + TimeUtils.format(task.deadline, "EEE dd, MMMM yyyy"),
+                        )
                         task.isNotified = true
                     }
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -32,7 +32,7 @@ import org.ole.planet.myplanet.utilities.CourseRatingUtils
 import org.ole.planet.myplanet.utilities.JsonUtils.getInt
 import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 class AdapterCourses(
@@ -204,7 +204,7 @@ class AdapterCourses(
             holder.rowCourseBinding.tvDate2.visibility = View.VISIBLE
             holder.rowCourseBinding.tvDate.visibility = View.GONE
             try {
-                holder.rowCourseBinding.tvDate2.text = formatDate(course.createdDate, "MMM dd, yyyy")
+                holder.rowCourseBinding.tvDate2.text = TimeUtils.format(course.createdDate, "MMM dd, yyyy")
             } catch (e: Exception) {
                 throw RuntimeException(e)
             }
@@ -213,7 +213,7 @@ class AdapterCourses(
             holder.rowCourseBinding.tvDate2.visibility = View.GONE
             holder.rowCourseBinding.holder.visibility = View.GONE
             try {
-                holder.rowCourseBinding.tvDate.text = formatDate(course.createdDate, "MMM dd, yyyy")
+                holder.rowCourseBinding.tvDate.text = TimeUtils.format(course.createdDate, "MMM dd, yyyy")
             } catch (e: Exception) {
                 throw RuntimeException(e)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -72,7 +72,8 @@ class BellDashboardFragment : BaseDashboardFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        fragmentHomeBellBinding.cardProfileBell.txtDate.text = TimeUtils.formatDate(Date().time, "")
+        fragmentHomeBellBinding.cardProfileBell.txtDate.text =
+            TimeUtils.format(Date().time, "EEE dd, MMMM yyyy")
         fragmentHomeBellBinding.cardProfileBell.txtCommunityName.text = model?.planetCode
         setupNetworkStatusMonitoring()
         (activity as DashboardActivity?)?.supportActionBar?.hide()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -93,7 +93,7 @@ import org.ole.planet.myplanet.utilities.FileUtils.totalAvailableMemoryRatio
 import org.ole.planet.myplanet.utilities.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utilities.LocaleHelper
 import org.ole.planet.myplanet.utilities.NotificationUtil
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities.toast
 
 @AndroidEntryPoint  
@@ -681,7 +681,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             dashboardViewModel.createNotificationIfNotExists(
                 realm,
                 "task",
-                "${task.title} ${formatDate(task.deadline)}",
+                "${task.title} ${TimeUtils.format(task.deadline, "EEE dd, MMMM yyyy")}",
                 task.id,
                 userId
             )

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardFragment.kt
@@ -16,7 +16,7 @@ import org.ole.planet.myplanet.ui.resources.AddResourceFragment
 import org.ole.planet.myplanet.ui.submission.MySubmissionFragment
 import org.ole.planet.myplanet.ui.userprofile.AchievementFragment
 import org.ole.planet.myplanet.utilities.DialogUtils.guestDialog
-import org.ole.planet.myplanet.utilities.TimeUtils.currentDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 
 class DashboardFragment : BaseDashboardFragment() {
     private lateinit var fragmentHomeBinding: FragmentHomeBinding
@@ -43,7 +43,8 @@ class DashboardFragment : BaseDashboardFragment() {
         user = UserProfileDbHandler(requireContext()).userModel
         onLoaded(view)
         initView(view)
-        (activity as AppCompatActivity?)?.supportActionBar?.subtitle = currentDate()
+        (activity as AppCompatActivity?)?.supportActionBar?.subtitle =
+            TimeUtils.format(System.currentTimeMillis(), "EEE dd, MMMM yyyy")
         return fragmentHomeBinding.root
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterCalendar.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterCalendar.kt
@@ -8,7 +8,8 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowTeamCalendarBinding
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.ui.enterprises.AdapterCalendar.ViewHolderCalendar
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
+import java.time.ZoneId
 
 class AdapterCalendar(private val context: Context, private val list: List<RealmMeetup>) : RecyclerView.Adapter<ViewHolderCalendar>() {
     private lateinit var rowTeamCalendarBinding: RowTeamCalendarBinding
@@ -22,9 +23,17 @@ class AdapterCalendar(private val context: Context, private val list: List<Realm
         rowTeamCalendarBinding.tvTitle.text = meetup.title
         rowTeamCalendarBinding.tvDescription.text = meetup.description
         if (meetup.startDate == meetup.endDate) {
-            rowTeamCalendarBinding.tvDate.text = formatDate(meetup.startDate,"")
+            rowTeamCalendarBinding.tvDate.text = TimeUtils.format(
+                meetup.startDate,
+                "EEE dd, MMMM yyyy",
+                ZoneId.of("UTC"),
+            )
         } else {
-            rowTeamCalendarBinding.tvDate.text = context.getString(R.string.date_range, formatDate(meetup.startDate, ""), formatDate(meetup.endDate, ""))
+            rowTeamCalendarBinding.tvDate.text = context.getString(
+                R.string.date_range,
+                TimeUtils.format(meetup.startDate, "EEE dd, MMMM yyyy", ZoneId.of("UTC")),
+                TimeUtils.format(meetup.endDate, "EEE dd, MMMM yyyy", ZoneId.of("UTC")),
+            )
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterFinance.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterFinance.kt
@@ -17,7 +17,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowFinanceBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.ui.enterprises.AdapterFinance.ViewHolderFinance
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 
 class AdapterFinance(private val context: Context, private val list: RealmResults<RealmMyTeam>) : RecyclerView.Adapter<ViewHolderFinance>() {
     private lateinit var rowFinanceBinding: RowFinanceBinding
@@ -28,7 +28,7 @@ class AdapterFinance(private val context: Context, private val list: RealmResult
 
     override fun onBindViewHolder(holder: ViewHolderFinance, position: Int) {
         list[position]?.let {
-            rowFinanceBinding.date.text = formatDate(it.date, "MMM dd, yyyy")
+            rowFinanceBinding.date.text = TimeUtils.format(it.date, "MMM dd, yyyy")
             rowFinanceBinding.note.text = it.description
             if (TextUtils.equals(it.type?.lowercase(Locale.getDefault()), "debit")) {
                 rowFinanceBinding.debit.text = context.getString(R.string.number_placeholder, it.amount)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterReports.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/AdapterReports.kt
@@ -49,7 +49,11 @@ class AdapterReports(private val context: Context, private var list: RealmResult
                 val totalExpenses = report.wages + report.otherExpenses
                 val profitLoss = totalIncome - totalExpenses
 
-                date.text = context.getString(R.string.string_range, TimeUtils.formatDate(it.startDate, " MMM dd, yyyy"), TimeUtils.formatDate(it.endDate, "MMM dd, yyyy"))
+                date.text = context.getString(
+                    R.string.string_range,
+                    TimeUtils.format(it.startDate, " MMM dd, yyyy"),
+                    TimeUtils.format(it.endDate, "MMM dd, yyyy"),
+                )
                 beginningBalanceValue.text = context.getString(R.string.number_placeholder, it.beginningBalance)
                 salesValue.text = context.getString(R.string.number_placeholder, it.sales)
                 otherValue.text = context.getString(R.string.number_placeholder, it.otherIncome)
@@ -60,7 +64,11 @@ class AdapterReports(private val context: Context, private var list: RealmResult
                 profitLossValue.text = context.getString(R.string.number_placeholder, profitLoss)
                 endingBalanceValue.text = context.getString(R.string.number_placeholder, profitLoss + it.beginningBalance)
                 tvReportDetails.text = context.getString(R.string.message_placeholder, it.description)
-                createUpdate.text = context.getString(R.string.report_date_details, TimeUtils.formatDate(it.createdDate, "MMM dd, yyyy"), TimeUtils.formatDate(it.updatedDate, "MMM dd, yyyy"))
+                createUpdate.text = context.getString(
+                    R.string.report_date_details,
+                    TimeUtils.format(it.createdDate, "MMM dd, yyyy"),
+                    TimeUtils.format(it.updatedDate, "MMM dd, yyyy"),
+                )
             }
         }
 
@@ -80,8 +88,14 @@ class AdapterReports(private val context: Context, private var list: RealmResult
             val calendar = Calendar.getInstance()
             calendar.set(Calendar.DAY_OF_MONTH, 1)
 
-            dialogAddReportBinding.startDate.text = context.getString(R.string.message_placeholder, report?.let { it1 -> TimeUtils.formatDate(it1.startDate, " MMM dd, yyyy") })
-            dialogAddReportBinding.endDate.text = context.getString(R.string.message_placeholder, report?.let { it1 -> TimeUtils.formatDate(it1.endDate, " MMM dd, yyyy") })
+            dialogAddReportBinding.startDate.text = context.getString(
+                R.string.message_placeholder,
+                report?.let { it1 -> TimeUtils.format(it1.startDate, " MMM dd, yyyy") },
+            )
+            dialogAddReportBinding.endDate.text = context.getString(
+                R.string.message_placeholder,
+                report?.let { it1 -> TimeUtils.format(it1.endDate, " MMM dd, yyyy") },
+            )
             dialogAddReportBinding.summary.setText(context.getString(R.string.message_placeholder, report?.description))
             dialogAddReportBinding.beginningBalance.setText(context.getString(R.string.number_placeholder, report?.beginningBalance))
             dialogAddReportBinding.sales.setText(context.getString(R.string.number_placeholder, report?.sales))

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
@@ -22,7 +22,7 @@ import org.ole.planet.myplanet.databinding.FragmentFinanceBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDateTZ
+import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 class FinanceFragment : BaseTeamFragment() {
@@ -40,7 +40,9 @@ class FinanceFragment : BaseTeamFragment() {
             date?.set(Calendar.MONTH, monthOfYear)
             date?.set(Calendar.DAY_OF_MONTH, dayOfMonth)
             if (date != null) {
-                addTransactionBinding.tvSelectDate.text = date?.timeInMillis?.let { formatDateTZ(it) }
+                addTransactionBinding.tvSelectDate.text = date?.timeInMillis?.let {
+                    TimeUtils.format(it, "yyyy-MM-dd HH:mm:ss")
+                }
             }
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/AdapterFeedback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/AdapterFeedback.kt
@@ -10,7 +10,8 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowFeedbackBinding
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.ui.feedback.AdapterFeedback.ViewHolderFeedback
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
+import org.ole.planet.myplanet.utilities.TimeUtils
+import java.time.ZoneId
 
 class AdapterFeedback(private val context: Context, private var list: List<RealmFeedback>?) : RecyclerView.Adapter<ViewHolderFeedback>() {
     private lateinit var rowFeedbackBinding: RowFeedbackBinding
@@ -25,9 +26,12 @@ class AdapterFeedback(private val context: Context, private var list: List<Realm
         rowFeedbackBinding.tvType.text = list?.get(position)?.type
         rowFeedbackBinding.tvPriority.text = list?.get(position)?.priority
         rowFeedbackBinding.tvStatus.text = list?.get(position)?.status
+        val formattedOpenDate = list?.get(position)?.openTime?.let {
+            TimeUtils.format(it, "EEEE, MMM dd, yyyy", ZoneId.of("UTC"))
+        } ?: "N/A"
         val contentDescription = "${list?.get(position)?.title}, ${list?.get(position)?.type}, " +
                 "${context.getString(R.string.status)}: ${list?.get(position)?.status}, ${context.getString(R.string.priority)}: ${list?.get(position)?.priority}, " +
-                "${context.getString(R.string.open_date)}: ${getFormattedDate(list?.get(position)?.openTime)}"
+                "${context.getString(R.string.open_date)}: $formattedOpenDate"
         rowFeedbackBinding.feedbackCardView.contentDescription = contentDescription
 
         if ("yes".equals(list?.get(position)?.priority, ignoreCase = true)) {
@@ -41,7 +45,7 @@ class AdapterFeedback(private val context: Context, private var list: List<Realm
             } else {
                 R.drawable.bg_grey
             }, null)
-        rowFeedbackBinding.tvOpenDate.text = getFormattedDate(list?.get(position)?.openTime)
+        rowFeedbackBinding.tvOpenDate.text = formattedOpenDate
         rowFeedbackBinding.root.setOnClickListener {
             rowFeedbackBinding.root.contentDescription = list?.get(position)?.title
             context.startActivity(Intent(context, FeedbackDetailActivity::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
@@ -27,7 +27,7 @@ import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.feedback.FeedbackDetailActivity.RvFeedbackAdapter.ReplyViewHolder
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtil
 import org.ole.planet.myplanet.utilities.LocaleHelper
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDateWithTime
+import org.ole.planet.myplanet.utilities.TimeUtils
 
 @AndroidEntryPoint
 class FeedbackDetailActivity : AppCompatActivity() {
@@ -54,7 +54,8 @@ class FeedbackDetailActivity : AppCompatActivity() {
         setTitle(R.string.feedback)
         realm = databaseService.realmInstance
         feedback = realm.where(RealmFeedback::class.java).equalTo("id", intent.getStringExtra("id")).findFirst()!!
-        activityFeedbackDetailBinding.tvDate.text = getFormattedDateWithTime(feedback.openTime)
+        activityFeedbackDetailBinding.tvDate.text =
+            TimeUtils.format(feedback.openTime, "EEE dd, MMMM yyyy , hh:mm a")
         activityFeedbackDetailBinding.tvMessage.text = if (TextUtils.isEmpty(feedback.message))
             "N/A"
         else
@@ -138,7 +139,7 @@ class FeedbackDetailActivity : AppCompatActivity() {
 
         override fun onBindViewHolder(holder: ReplyViewHolder, position: Int) {
             rowFeedbackReplyBinding.tvDate.text = replyList?.get(position)?.date?.let {
-                getFormattedDateWithTime(it.toLong())
+                TimeUtils.format(it.toLong(), "EEE dd, MMMM yyyy , hh:mm a")
             }
             rowFeedbackReplyBinding.tvUser.text = replyList?.get(position)?.user
             rowFeedbackReplyBinding.tvMessage.text = replyList?.get(position)?.message

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/AdapterMyPersonal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/AdapterMyPersonal.kt
@@ -21,7 +21,8 @@ import org.ole.planet.myplanet.ui.viewer.ImageViewerActivity
 import org.ole.planet.myplanet.ui.viewer.PDFReaderActivity
 import org.ole.planet.myplanet.ui.viewer.VideoPlayerActivity
 import org.ole.planet.myplanet.utilities.IntentUtils.openAudioFile
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
+import org.ole.planet.myplanet.utilities.TimeUtils
+import java.time.ZoneId
 import org.ole.planet.myplanet.utilities.Utilities
 
 class AdapterMyPersonal(private val context: Context, private val list: List<RealmMyPersonal>) : RecyclerView.Adapter<ViewHolderMyPersonal>() {
@@ -41,7 +42,11 @@ class AdapterMyPersonal(private val context: Context, private val list: List<Rea
     override fun onBindViewHolder(holder: ViewHolderMyPersonal, position: Int) {
         rowMyPersonalBinding.title.text = list[position].title
         rowMyPersonalBinding.description.text = list[position].description
-        rowMyPersonalBinding.date.text = getFormattedDate(list[position].date)
+        rowMyPersonalBinding.date.text = TimeUtils.format(
+            list[position].date,
+            "EEEE, MMM dd, yyyy",
+            ZoneId.of("UTC"),
+        )
         rowMyPersonalBinding.imgDelete.setOnClickListener {
             AlertDialog.Builder(context, R.style.AlertDialogTheme)
                 .setMessage(R.string.delete_record)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AdapterHealthExamination.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/AdapterHealthExamination.kt
@@ -22,7 +22,7 @@ import org.ole.planet.myplanet.model.RealmMyHealthPojo
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.ui.myhealth.AdapterHealthExamination.ViewHolderMyHealthExamination
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 class AdapterHealthExamination(private val context: Context, private val list: List<RealmMyHealthPojo>?, private val mh: RealmMyHealthPojo, private val userModel: RealmUserModel?) : RecyclerView.Adapter<ViewHolderMyHealthExamination>() {
@@ -44,7 +44,9 @@ class AdapterHealthExamination(private val context: Context, private val list: L
     override fun onBindViewHolder(holder: ViewHolderMyHealthExamination, position: Int) {
             rowExaminationBinding.txtTemp.text = list?.get(position)?.temperature.toString()
             rowExaminationBinding.txtTemp.text = list?.get(position)?.let { checkEmpty(it.temperature) }
-            rowExaminationBinding.txtDate.text = list?.get(position)?.let { formatDate(it.date, "MMM dd, yyyy") }
+            rowExaminationBinding.txtDate.text = list?.get(position)?.let {
+                TimeUtils.format(it.date, "MMM dd, yyyy")
+            }
             val encrypted = userModel?.let { it1 -> list?.get(position)?.getEncryptedDataAsJson(it1) }
 
 
@@ -91,7 +93,7 @@ class AdapterHealthExamination(private val context: Context, private val list: L
         showConditions(alertExaminationBinding.tvCondition, realmExamination)
         showEncryptedData(alertExaminationBinding.tvOtherNotes, encrypted)
         val dialog = AlertDialog.Builder(context, R.style.CustomAlertDialog)
-            .setTitle(realmExamination?.let { formatDate(it.date, "MMM dd, yyyy") })
+            .setTitle(realmExamination?.let { TimeUtils.format(it.date, "MMM dd, yyyy") })
             .setView(alertExaminationBinding.root)
             .setPositiveButton("OK", null).create()
         val backgroundColor = ContextCompat.getColor(context, R.color.multi_select_grey)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/UserListArrayAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/UserListArrayAdapter.kt
@@ -38,7 +38,10 @@ class UserListArrayAdapter(activity: Activity, val view: Int, var list: List<Rea
         val um = getItem(position)
         holder.tvName?.text = context.getString(R.string.two_strings, um?.getFullName(), "(${um?.name})")
         if (um != null) {
-            holder.joined?.text = context.getString(R.string.joined_colon, TimeUtils.formatDate(um.joinDate))
+            holder.joined?.text = context.getString(
+                R.string.joined_colon,
+                TimeUtils.format(um.joinDate, "EEE dd, MMMM yyyy"),
+            )
         }
 
         if (!TextUtils.isEmpty(um?.userImage)) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mymeetup/AdapterMeetup.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mymeetup/AdapterMeetup.kt
@@ -7,7 +7,7 @@ import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemMeetupBinding
 import org.ole.planet.myplanet.model.RealmMeetup
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 
 class AdapterMeetup(private val list: List<RealmMeetup>) : RecyclerView.Adapter<AdapterMeetup.ViewHolderMeetup>() {
     private lateinit var itemMeetupBinding: ItemMeetupBinding
@@ -21,8 +21,8 @@ class AdapterMeetup(private val list: List<RealmMeetup>) : RecyclerView.Adapter<
         val meetup = list[position]
         itemMeetupBinding.tvTitle.text = context.getString(R.string.message_placeholder, meetup.title)
         itemMeetupBinding.tvDescription.text = context.getString(R.string.message_placeholder, meetup.description)
-        itemMeetupBinding.tvDateFrom.text = formatDate(meetup.startDate)
-        itemMeetupBinding.tvDateTo.text = formatDate(meetup.endDate)
+        itemMeetupBinding.tvDateFrom.text = TimeUtils.format(meetup.startDate, "EEE dd, MMMM yyyy")
+        itemMeetupBinding.tvDateTo.text = TimeUtils.format(meetup.endDate, "EEE dd, MMMM yyyy")
         itemMeetupBinding.tvTime.text = "${meetup.startTime} - ${meetup.endTime}"
         itemMeetupBinding.tvLocation.text = context.getString(R.string.message_placeholder, meetup.meetupLocation)
         itemMeetupBinding.tvLink.text = context.getString(R.string.message_placeholder, meetup.meetupLink)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
@@ -48,7 +48,7 @@ import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 import org.ole.planet.myplanet.utilities.SharedPrefManager
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.makeExpandable
 
@@ -231,9 +231,9 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
         )
         holder.rowNewsBinding.tvDate.text =
             if (sharedTeamName.isEmpty() || teamName.isNotEmpty()) {
-                formatDate(news.time)
+                TimeUtils.format(news.time, "EEE dd, MMMM yyyy")
             } else {
-                "${formatDate(news.time)} | Shared from $sharedTeamName"
+                "${TimeUtils.format(news.time, "EEE dd, MMMM yyyy")} | Shared from $sharedTeamName"
             }
         holder.rowNewsBinding.tvEdited.visibility = if (news.isEdited) View.VISIBLE else View.GONE
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
@@ -25,7 +25,7 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.CourseRatingUtils
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 class AdapterResource(private val context: Context, private var libraryList: List<RealmMyLibrary?>, private var ratingMap: HashMap<String?, JsonObject>, private val realm: Realm) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -85,7 +85,9 @@ class AdapterResource(private val context: Context, private var libraryList: Lis
                 } else {
                     String.format(Locale.getDefault(), "%.1f", libraryList[position]?.averageRating?.toDouble())
                 }
-            holder.rowLibraryBinding.tvDate.text = libraryList[position]?.createdDate?.let { formatDate(it, "MMM dd, yyyy") }
+            holder.rowLibraryBinding.tvDate.text = libraryList[position]?.createdDate?.let {
+                TimeUtils.format(it, "MMM dd, yyyy")
+            }
             displayTagCloud(holder.rowLibraryBinding.flexboxDrawable, position)
             holder.itemView.setOnClickListener { openLibrary(libraryList[position]) }
             userModel = UserProfileDbHandler(context).userModel

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submission/AdapterMySubmission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submission/AdapterMySubmission.kt
@@ -20,7 +20,8 @@ import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.ui.exam.TakeExamFragment
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission.ViewHolderMySurvey
-import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
+import org.ole.planet.myplanet.utilities.TimeUtils
+import java.time.ZoneId
 
 class AdapterMySubmission(private val context: Context, private val list: List<RealmSubmission>?, private val examHashMap: HashMap<String?, RealmStepExam>?) : RecyclerView.Adapter<ViewHolderMySurvey>() {
     private lateinit var rowMySurveyBinding: RowMysurveyBinding
@@ -48,7 +49,10 @@ class AdapterMySubmission(private val context: Context, private val list: List<R
 
     override fun onBindViewHolder(holder: ViewHolderMySurvey, position: Int) {
         rowMySurveyBinding.status.text = list?.get(position)?.status
-        rowMySurveyBinding.date.text = getFormattedDate(list?.get(position)?.startTime)
+        val formattedDate = list?.get(position)?.startTime?.let {
+            TimeUtils.format(it, "EEEE, MMM dd, yyyy", ZoneId.of("UTC"))
+        } ?: "N/A"
+        rowMySurveyBinding.date.text = formattedDate
         showSubmittedBy(rowMySurveyBinding.submittedBy, position)
         if (examHashMap?.containsKey(list?.get(position)?.parentId) == true)
             rowMySurveyBinding.title.text = examHashMap[list?.get(position)?.parentId]?.name

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
@@ -24,7 +24,7 @@ import org.ole.planet.myplanet.model.RealmSubmission.Companion.getNoOfSubmission
 import org.ole.planet.myplanet.model.RealmSubmission.Companion.getRecentSubmissionDate
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 
 class AdapterSurvey(
     private val context: Context,
@@ -168,7 +168,10 @@ class AdapterSurvey(
                     else -> getNoOfSubmissionByUser(exam.id, exam.courseId, userId, mRealm)
                 }
                 tvDateCompleted.text = getRecentSubmissionDate(exam.id, exam.courseId, userId, mRealm)
-                tvDate.text = formatDate(RealmStepExam.getSurveyCreationTime(exam.id!!, mRealm)!!, "MMM dd, yyyy")
+                tvDate.text = TimeUtils.format(
+                    RealmStepExam.getSurveyCreationTime(exam.id!!, mRealm)!!,
+                    "MMM dd, yyyy",
+                )
             }
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -26,6 +26,7 @@ import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
+import java.time.ZoneId
 
 class AdapterTeamList(private val context: Context, private val list: List<RealmMyTeam>, private val mRealm: Realm, private val fragmentManager: FragmentManager, private val uploadManager: UploadManager) : RecyclerView.Adapter<AdapterTeamList.ViewHolderTeam>() {
     private lateinit var itemTeamListBinding: ItemTeamListBinding
@@ -57,7 +58,11 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
         val user: RealmUserModel? = UserProfileDbHandler(context).userModel
 
         with(holder.binding) {
-            created.text = TimeUtils.getFormattedDate(team.createdDate)
+            created.text = TimeUtils.format(
+                team.createdDate,
+                "EEEE, MMM dd, yyyy",
+                ZoneId.of("UTC"),
+            )
             type.text = team.teamType
             type.visibility = if (team.teamType == null) View.GONE else View.VISIBLE
             name.text = team.name

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/PlanFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/PlanFragment.kt
@@ -16,7 +16,7 @@ import org.ole.planet.myplanet.databinding.FragmentPlanBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.service.UserProfileDbHandler
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 class PlanFragment : BaseTeamFragment() {
@@ -157,7 +157,7 @@ class PlanFragment : BaseTeamFragment() {
         fragmentPlanBinding.tvDate.text = getString(
             R.string.two_strings,
             getString(R.string.created_on),
-            updatedTeam.createdDate?.let { formatDate(it) }
+            updatedTeam.createdDate?.let { TimeUtils.format(it, "EEE dd, MMMM yyyy") }
         )
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamCalendarFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamCalendarFragment.kt
@@ -163,14 +163,14 @@ class TeamCalendarFragment : BaseTeamFragment() {
     private fun setDatePickerListener(view: TextView, date: Calendar?, endDate: Calendar?) {
         val initCal = date ?: Calendar.getInstance()
         if (date != null && endDate != null) {
-            view.text = date.timeInMillis.let { it1 -> TimeUtils.formatDate(it1, "yyyy-MM-dd") }
+            view.text = date.timeInMillis.let { it1 -> TimeUtils.format(it1, "yyyy-MM-dd") }
         }
         view.setOnClickListener {
             DatePickerDialog(requireActivity(), { _, year, monthOfYear, dayOfMonth ->
                 date?.set(Calendar.YEAR, year)
                 date?.set(Calendar.MONTH, monthOfYear)
                 date?.set(Calendar.DAY_OF_MONTH, dayOfMonth)
-                view.text = date?.timeInMillis?.let { it1 -> TimeUtils.formatDate(it1, "yyyy-MM-dd") }
+                view.text = date?.timeInMillis?.let { it1 -> TimeUtils.format(it1, "yyyy-MM-dd") }
             }, initCal.get(Calendar.YEAR),
                 initCal.get(Calendar.MONTH),
                 initCal.get(Calendar.DAY_OF_MONTH)).show()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/AdapterTask.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/AdapterTask.kt
@@ -14,7 +14,7 @@ import org.ole.planet.myplanet.databinding.RowTaskBinding
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.ui.team.teamTask.AdapterTask.ViewHolderTask
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
+import org.ole.planet.myplanet.utilities.TimeUtils
 
 class AdapterTask(private val context: Context, private val realm: Realm, private val list: List<RealmTeamTask>?, private val nonTeamMember: Boolean) : RecyclerView.Adapter<ViewHolderTask>() {
     private lateinit var rowTaskBinding: RowTaskBinding
@@ -32,10 +32,23 @@ class AdapterTask(private val context: Context, private val realm: Realm, privat
             rowTaskBinding.checkbox.text = it.title
             rowTaskBinding.checkbox.isChecked = it.completed
             if (!it.completed) {
-                rowTaskBinding.deadline.text = context.getString(R.string.deadline_colon, formatDate(it.deadline))
+                rowTaskBinding.deadline.text =
+                    context.getString(
+                        R.string.deadline_colon,
+                        TimeUtils.format(it.deadline, "EEE dd, MMMM yyyy"),
+                    )
             } else {
-                rowTaskBinding.deadline.text =context.getString(R.string.two_strings,
-                    context.getString(R.string.deadline_colon, formatDate(it.deadline)), context.getString(R.string.completed_colon, formatDate(it.deadline)))
+                rowTaskBinding.deadline.text = context.getString(
+                    R.string.two_strings,
+                    context.getString(
+                        R.string.deadline_colon,
+                        TimeUtils.format(it.deadline, "EEE dd, MMMM yyyy"),
+                    ),
+                    context.getString(
+                        R.string.completed_colon,
+                        TimeUtils.format(it.deadline, "EEE dd, MMMM yyyy"),
+                    ),
+                )
             }
             showAssignee(it)
             rowTaskBinding.icMore.setOnClickListener {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
@@ -35,8 +35,6 @@ import org.ole.planet.myplanet.ui.myhealth.UserListArrayAdapter
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
 import org.ole.planet.myplanet.ui.team.teamTask.AdapterTask.OnCompletedListener
 import org.ole.planet.myplanet.utilities.TimeUtils
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
-import org.ole.planet.myplanet.utilities.TimeUtils.formatDateTZ
 import org.ole.planet.myplanet.utilities.Utilities
 
 class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
@@ -54,7 +52,9 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
             deadline?.set(Calendar.MONTH, monthOfYear)
             deadline?.set(Calendar.DAY_OF_MONTH, dayOfMonth)
             if (datePicker != null) {
-                datePicker?.text = deadline?.timeInMillis?.let { formatDateTZ(it) }
+                datePicker?.text = deadline?.timeInMillis?.let {
+                    TimeUtils.format(it, "yyyy-MM-dd HH:mm:ss")
+                }
             }
             timePicker()
         }
@@ -65,7 +65,7 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
             deadline?.set(Calendar.MINUTE, minute)
             if (datePicker != null) {
                 datePicker?.text = deadline?.timeInMillis?.let {
-                    TimeUtils.getFormattedDateWithTime(it)
+                    TimeUtils.format(it, "EEE dd, MMMM yyyy , hh:mm a")
                 }
             }
         }, deadline!![Calendar.HOUR_OF_DAY], deadline!![Calendar.MINUTE], true)
@@ -94,7 +94,7 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
         if (t != null) {
             alertTaskBinding.etTask.setText(t.title)
             alertTaskBinding.etDescription.setText(t.description)
-            datePicker?.text = formatDate(t.deadline)
+            datePicker?.text = TimeUtils.format(t.deadline, "EEE dd, MMMM yyyy")
             deadline = Calendar.getInstance()
             deadline?.time = Date(t.deadline)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
@@ -43,6 +43,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Realm
 import java.lang.String.format
 import java.time.Instant
+import java.time.ZoneId
 import java.util.ArrayList
 import java.util.Calendar
 import java.util.LinkedHashMap
@@ -293,7 +294,11 @@ class UserProfileFragment : Fragment() {
                     val calendar = Calendar.getInstance()
                     calendar.set(year, monthOfYear, dayOfMonth)
                     val dobMillis = calendar.timeInMillis
-                    val dobFormatted = TimeUtils.getFormattedDate(dobMillis)
+                    val dobFormatted = TimeUtils.format(
+                        dobMillis,
+                        "EEEE, MMM dd, yyyy",
+                        ZoneId.of("UTC"),
+                    )
 
                     date = format(Locale.US, "%04d-%02d-%02dT00:00:00.000Z", year, monthOfYear + 1, dayOfMonth)
                     binding.dateOfBirth.text = dobFormatted

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/TimeUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/TimeUtils.kt
@@ -14,50 +14,31 @@ object TimeUtils {
 
     private val utcZone: ZoneId = ZoneId.of("UTC")
 
-    private val defaultDateFormatter by lazy {
-        DateTimeFormatter.ofPattern("EEEE, MMM dd, yyyy", defaultLocale).withZone(utcZone)
-    }
+    private const val DEFAULT_DATE_PATTERN = "EEE dd, MMMM yyyy"
+    private const val DEFAULT_DATE_WITH_DAY_PATTERN = "EEEE, MMM dd, yyyy"
+    private const val DEFAULT_DATE_TIME_PATTERN = "EEE dd, MMMM yyyy , hh:mm a"
+    private const val TZ_DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm:ss"
 
-    private val dateTimeFormatter by lazy {
-        DateTimeFormatter
-            .ofPattern("EEE dd, MMMM yyyy , hh:mm a", defaultLocale)
-            .withZone(ZoneId.systemDefault())
-    }
-
-    private val tzFormatter by lazy {
-        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault())
-    }
-
-    private val dateOnlyFormatter by lazy {
-        DateTimeFormatter.ofPattern("EEE dd, MMMM yyyy", defaultLocale).withZone(ZoneId.systemDefault())
-    }
-
-    fun getFormattedDate(date: Long?): String =
+    fun format(dateMillis: Long, pattern: String, zone: ZoneId = ZoneId.systemDefault()): String =
         try {
-            val instant = date?.let { Instant.ofEpochMilli(it) } ?: Instant.now()
-            defaultDateFormatter.format(instant)
-        } catch (e: Exception) {
-            e.printStackTrace()
-            "N/A"
-        }
-
-    fun getFormattedDateWithTime(date: Long): String =
-        try {
-            val instant = Instant.ofEpochMilli(date)
-            dateTimeFormatter.format(instant)
-        } catch (e: Exception) {
-            e.printStackTrace()
-            "N/A"
-        }
-
-    fun formatDateTZ(data: Long): String =
-        try {
-            val instant = Instant.ofEpochMilli(data)
-            tzFormatter.format(instant)
+            val formatter = DateTimeFormatter.ofPattern(pattern, defaultLocale).withZone(zone)
+            formatter.format(Instant.ofEpochMilli(dateMillis))
         } catch (e: Exception) {
             e.printStackTrace()
             ""
         }
+
+    fun getFormattedDate(date: Long?): String {
+        val result = format(date ?: Instant.now().toEpochMilli(), DEFAULT_DATE_WITH_DAY_PATTERN, utcZone)
+        return if (result.isNotEmpty()) result else "N/A"
+    }
+
+    fun getFormattedDateWithTime(date: Long): String {
+        val result = format(date, DEFAULT_DATE_TIME_PATTERN)
+        return if (result.isNotEmpty()) result else "N/A"
+    }
+
+    fun formatDateTZ(data: Long): String = format(data, TZ_DATE_TIME_PATTERN)
 
     fun getAge(date: String): Int =
         try {
@@ -85,44 +66,30 @@ object TimeUtils {
             if (stringDate.isNullOrBlank() || pattern.isNullOrBlank()) return "N/A"
             val formatter = DateTimeFormatter.ofPattern(pattern, defaultLocale).withZone(utcZone)
             val instant = LocalDate.parse(stringDate, formatter).atStartOfDay(utcZone).toInstant()
-            getFormattedDate(instant.toEpochMilli())
+            val result = format(instant.toEpochMilli(), DEFAULT_DATE_WITH_DAY_PATTERN, utcZone)
+            if (result.isNotEmpty()) result else "N/A"
         } catch (e: Exception) {
             e.printStackTrace()
             "N/A"
         }
     }
 
-    fun currentDate(): String =
-        try {
-            dateOnlyFormatter.format(Instant.now())
-        } catch (e: Exception) {
-            e.printStackTrace()
-            "N/A"
-        }
-
-    fun formatDate(date: Long): String =
-        try {
-            dateOnlyFormatter.format(Instant.ofEpochMilli(date))
-        } catch (e: Exception) {
-            e.printStackTrace()
-            ""
-        }
+    fun formatDate(date: Long): String = format(date, DEFAULT_DATE_PATTERN)
 
     fun formatDate(
         date: Long,
         format: String?,
     ): String =
-        try {
-            val formatter = DateTimeFormatter.ofPattern(format ?: "", defaultLocale).withZone(ZoneId.systemDefault())
-            formatter.format(Instant.ofEpochMilli(date))
-        } catch (e: Exception) {
-            e.printStackTrace()
-            ""
+        if (format.isNullOrBlank()) {
+            formatDate(date)
+        } else {
+            format(date, format)
         }
 
     fun parseDate(dateString: String): Long? =
         try {
-            val localDate = LocalDate.parse(dateString, dateOnlyFormatter)
+            val formatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_PATTERN, defaultLocale)
+            val localDate = LocalDate.parse(dateString, formatter)
             localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
## Summary
- add generic `TimeUtils.format` for pattern-based date rendering
- update legacy helpers to wrap the new function
- replace direct calls with `TimeUtils.format` across the app

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68a44dbe8f00832ba7d7d4b62ee1aab3