### PR TITLE
Refactor unsafe null assertions

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -87,7 +87,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         list = mutableListOf()
         mRealm = userRepository.getRealm()
         profileDbHandler = UserProfileDbHandler(requireActivity())
-        model = profileDbHandler.userModel!!
+        model = profileDbHandler.userModel
         val adapter = getAdapter()
         recyclerView.adapter = adapter
         if (isMyCourseLib && adapter.itemCount != 0 && courseLib == "courses") {
@@ -112,8 +112,8 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     }
 
     fun addToMyList() {
-        for (i in selectedItems?.indices!!) {
-            val `object` = selectedItems?.get(i) as RealmObject
+        selectedItems?.forEach { item ->
+            val `object` = item as RealmObject
             if (`object` is RealmMyLibrary) {
                 val myObject = mRealm.where(RealmMyLibrary::class.java)
                     .equalTo("resourceId", `object`.resourceId).findFirst()
@@ -132,9 +132,9 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     }
 
     fun deleteSelected(deleteProgress: Boolean) {
-        for (i in selectedItems?.indices!!) {
+        selectedItems?.forEach { item ->
             if (!mRealm.isInTransaction()) mRealm.beginTransaction()
-            val `object` = selectedItems?.get(i) as RealmObject
+            val `object` = item as RealmObject
             deleteCourseProgress(deleteProgress, `object`)
             removeFromShelf(`object`)
             recyclerView.adapter = getAdapter()
@@ -281,7 +281,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
 
     private fun isValidFilter(l: RealmMyLibrary): Boolean {
         val sub = subjects.isEmpty() || subjects.let { l.subject?.containsAll(it) } == true
-        val lev = levels.isEmpty() || l.level!!.containsAll(levels)
+        val lev = levels.isEmpty() || l.level?.containsAll(levels) == true
         val lan = languages.isEmpty() || languages.contains(l.language)
         val med = mediums.isEmpty() || mediums.contains(l.mediaType)
         return sub && lev && lan && med

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
@@ -141,7 +141,7 @@ open class RealmSubmission : RealmObject() {
             `object`.addProperty("parentCode", prefs.getString("parentCode", ""))
             val parent = Gson().fromJson(sub.parent, JsonObject::class.java)
             `object`.add("parent", parent)
-            `object`.add("answers", RealmAnswer.serializeRealmAnswer(sub.answers!!))
+            `object`.add("answers", RealmAnswer.serializeRealmAnswer(sub.answers ?: RealmList()))
             if (exam != null && parent == null) `object`.add("parent", RealmStepExam.serializeExam(mRealm, exam))
             if (TextUtils.isEmpty(sub.user)) {
                 `object`.add("user", user?.serialize())

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
@@ -199,10 +199,10 @@ class UploadManager @Inject constructor(
         `object`.addProperty("title", getString("fileName", imgObject))
         `object`.addProperty("createdDate", Date().time)
         `object`.addProperty("filename", getString("fileName", imgObject))
-        `object`.addProperty("addedBy", user!!.id)
         `object`.addProperty("private", true)
-        `object`.addProperty("resideOn", user.parentCode)
-        `object`.addProperty("sourcePlanet", user.planetCode)
+        user?.id?.let { `object`.addProperty("addedBy", it) }
+        user?.parentCode?.let { `object`.addProperty("resideOn", it) }
+        user?.planetCode?.let { `object`.addProperty("sourcePlanet", it) }
         val object1 = JsonObject()
         `object`.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
         `object`.addProperty("deviceName", NetworkUtils.getDeviceName())
@@ -320,7 +320,7 @@ class UploadManager @Inject constructor(
                             sub.uploaded = true
                             sub._rev = rev
                             sub._id = id
-                            uploadAttachment(id, rev, sub, listener!!)
+                            listener?.let { uploadAttachment(id, rev, sub, it) }
                         }
                     } catch (e: Exception) {
                         e.printStackTrace()
@@ -363,7 +363,7 @@ class UploadManager @Inject constructor(
                         val id = getString("id", `object`)
                         sub._rev = rev
                         sub._id = id
-                        uploadAttachment(id, rev, sub, listener!!)
+                        listener?.let { uploadAttachment(id, rev, sub, it) }
                     }
                 } catch (e: Exception) {
                     e.printStackTrace()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/AdapterSurvey.kt
@@ -168,7 +168,8 @@ class AdapterSurvey(
                     else -> getNoOfSubmissionByUser(exam.id, exam.courseId, userId, mRealm)
                 }
                 tvDateCompleted.text = getRecentSubmissionDate(exam.id, exam.courseId, userId, mRealm)
-                tvDate.text = formatDate(RealmStepExam.getSurveyCreationTime(exam.id!!, mRealm)!!, "MMM dd, yyyy")
+                val creationTime = exam.id?.let { RealmStepExam.getSurveyCreationTime(it, mRealm) }
+                tvDate.text = creationTime?.let { formatDate(it, "MMM dd, yyyy") } ?: ""
             }
         }
 


### PR DESCRIPTION
## Summary
- replace null assertion with safe user lookup when creating image metadata
- guard optional listener before uploading attachments
- remove null assertions in BaseRecyclerFragment loops and level filter
- use default empty answer list when serializing submission answers
- add per-field null checks when building image metadata
- safely format survey creation date from optional exam id

## Testing
- `./gradlew test` *(fails: Gradle distribution download stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68a457b4a040832e9e9911bc9bd784eb