### PR TITLE
all: less repository suffix is more (fixes #6919)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2909
-        versionName = "0.29.9"
+        versionCode = 2912
+        versionName = "0.29.12"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -109,7 +109,7 @@ abstract class BaseResourceFragment : Fragment() {
     private var receiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             this@BaseResourceFragment.lifecycleScope.launch {
-                val list = libraryRepository.getLibraryListForUserAsync(
+                val list = libraryRepository.getLibraryListForUser(
                     settings.getString("userId", "--")
                 )
                 showDownloadDialog(list)
@@ -193,7 +193,7 @@ abstract class BaseResourceFragment : Fragment() {
     fun showPendingSurveyDialog() {
         model = UserProfileDbHandler(requireContext()).userModel
         viewLifecycleOwner.lifecycleScope.launch {
-            val list = submissionRepository.getPendingSurveysAsync(model?.id)
+            val list = submissionRepository.getPendingSurveys(model?.id)
             if (list.isEmpty()) return@launch
             val exams = getExamMap(mRealm, list)
             val arrayAdapter = createSurveyAdapter(list, exams)
@@ -327,7 +327,7 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     suspend fun getLibraryList(mRealm: Realm): List<RealmMyLibrary> {
-        return libraryRepository.getLibraryListForUserAsync(
+        return libraryRepository.getLibraryListForUser(
             settings.getString("userId", "--")
         )
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
@@ -3,11 +3,11 @@ package org.ole.planet.myplanet.repository
 import org.ole.planet.myplanet.model.RealmMyLibrary
 
 interface LibraryRepository {
-    suspend fun getAllLibraryItemsAsync(): List<RealmMyLibrary>
-    suspend fun getLibraryItemByIdAsync(id: String): RealmMyLibrary?
-    suspend fun getOfflineLibraryItemsAsync(): List<RealmMyLibrary>
-    suspend fun getLibraryListForUserAsync(userId: String?): List<RealmMyLibrary>
-    suspend fun getAllLibraryListAsync(): List<RealmMyLibrary>
+    suspend fun getAllLibraryItems(): List<RealmMyLibrary>
+    suspend fun getLibraryItemById(id: String): RealmMyLibrary?
+    suspend fun getOfflineLibraryItems(): List<RealmMyLibrary>
+    suspend fun getLibraryListForUser(userId: String?): List<RealmMyLibrary>
+    suspend fun getAllLibraryList(): List<RealmMyLibrary>
     suspend fun getCourseLibraryItems(courseIds: List<String>): List<RealmMyLibrary>
     suspend fun saveLibraryItem(item: RealmMyLibrary)
     suspend fun deleteLibraryItem(id: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -11,19 +11,19 @@ class LibraryRepositoryImpl @Inject constructor(
     private val databaseService: DatabaseService
 ) : LibraryRepository {
 
-    override suspend fun getAllLibraryItemsAsync(): List<RealmMyLibrary> {
+    override suspend fun getAllLibraryItems(): List<RealmMyLibrary> {
         return databaseService.withRealmAsync { realm ->
             realm.queryList(RealmMyLibrary::class.java)
         }
     }
 
-    override suspend fun getLibraryItemByIdAsync(id: String): RealmMyLibrary? {
+    override suspend fun getLibraryItemById(id: String): RealmMyLibrary? {
         return databaseService.withRealmAsync { realm ->
             realm.findCopyByField(RealmMyLibrary::class.java, "id", id)
         }
     }
 
-    override suspend fun getOfflineLibraryItemsAsync(): List<RealmMyLibrary> {
+    override suspend fun getOfflineLibraryItems(): List<RealmMyLibrary> {
         return databaseService.withRealmAsync { realm ->
             realm.queryList(RealmMyLibrary::class.java) {
                 equalTo("resourceOffline", true)
@@ -31,7 +31,7 @@ class LibraryRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getLibraryListForUserAsync(userId: String?): List<RealmMyLibrary> {
+    override suspend fun getLibraryListForUser(userId: String?): List<RealmMyLibrary> {
         return databaseService.withRealmAsync { realm ->
             val results = realm.where(RealmMyLibrary::class.java)
                 .equalTo("isPrivate", false)
@@ -42,7 +42,7 @@ class LibraryRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getAllLibraryListAsync(): List<RealmMyLibrary> {
+    override suspend fun getAllLibraryList(): List<RealmMyLibrary> {
         return databaseService.withRealmAsync { realm ->
             val results = realm.where(RealmMyLibrary::class.java)
                 .equalTo("resourceOffline", false)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -3,7 +3,7 @@ package org.ole.planet.myplanet.repository
 import org.ole.planet.myplanet.model.RealmSubmission
 
 interface SubmissionRepository {
-    suspend fun getPendingSurveysAsync(userId: String?): List<RealmSubmission>
+    suspend fun getPendingSurveys(userId: String?): List<RealmSubmission>
     suspend fun getSubmissionById(id: String): RealmSubmission?
     suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission>
     suspend fun getSubmissionsByType(type: String): List<RealmSubmission>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -10,7 +10,7 @@ class SubmissionRepositoryImpl @Inject constructor(
     private val databaseService: DatabaseService,
 ) : SubmissionRepository {
 
-    override suspend fun getPendingSurveysAsync(userId: String?): List<RealmSubmission> {
+    override suspend fun getPendingSurveys(userId: String?): List<RealmSubmission> {
         return databaseService.withRealmAsync { realm ->
             realm.queryList(RealmSubmission::class.java) {
                 equalTo("userId", userId)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -84,8 +84,8 @@ class DashboardViewModel @Inject constructor(
         }
     }
 
-    suspend fun getPendingSurveysAsync(userId: String?): List<RealmSubmission> {
-        return submissionRepository.getPendingSurveysAsync(userId)
+    suspend fun getPendingSurveys(userId: String?): List<RealmSubmission> {
+        return submissionRepository.getPendingSurveys(userId)
     }
 
     suspend fun getSurveyTitlesFromSubmissions(submissions: List<RealmSubmission>): List<String> {


### PR DESCRIPTION
## Summary
- rename repository methods to drop Async suffix
- update BaseResourceFragment and DashboardViewModel to use new names

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a573df9ca8832bac852e37510eea38