### PR TITLE
dashboard: smoother base fragment realm closing (fixes #6930)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2909
-        versionName = "0.29.9"
+        versionCode = 2917
+        versionName = "0.29.17"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -293,6 +293,13 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
         if (::myTeamsResults.isInitialized) {
             myTeamsResults.removeChangeListener(myTeamsChangeListener)
         }
+        if (isRealmInitialized()) {
+            mRealm.removeAllChangeListeners()
+            if (mRealm.isInTransaction) {
+                mRealm.cancelTransaction()
+            }
+            mRealm.close()
+        }
         super.onDestroy()
     }
 


### PR DESCRIPTION
## Summary
- ensure BaseDashboardFragment cancels any Realm transaction and closes the instance when destroyed

## Testing
- `./gradlew assembleDebug` *(fails: Starting a Gradle Daemon (subsequent builds will be faster))*

------
https://chatgpt.com/codex/tasks/task_e_68a57647bff0832bab73ab93718c03d9