### PR TITLE
Remove Realm listeners before closing in MyPersonalsFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
@@ -87,6 +87,7 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
 
     override fun onDestroy() {
         if (::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.removeAllChangeListeners()
             mRealm.close()
         }
         super.onDestroy()


### PR DESCRIPTION
## Summary
- Ensure Realm change listeners are removed when `MyPersonalsFragment` is destroyed

## Testing
- `./gradlew assembleDebug` *(fails: did not complete in allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68a575cd5df8832bbffa089fc5efcb67