### PR TITLE
all: smoother base recycler fragment realm closing (fixes #6932)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2909
-        versionName = "0.29.9"
+        versionCode = 2919
+        versionName = "0.29.19"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -287,6 +287,21 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         return sub && lev && lan && med
     }
 
+    override fun onDestroy() {
+        if (isRealmInitialized()) {
+            mRealm.removeAllChangeListeners()
+            if (mRealm.isInTransaction) {
+                try {
+                    mRealm.commitTransaction()
+                } catch (e: Exception) {
+                    mRealm.cancelTransaction()
+                }
+            }
+            mRealm.close()
+        }
+        super.onDestroy()
+    }
+
     companion object {
         private val noDataMessages = mapOf(
             "courses" to R.string.no_courses,


### PR DESCRIPTION
## Summary
- add onDestroy override in BaseRecyclerFragment to clean up Realm instances

## Testing
- `./gradlew assembleDebug` *(interrupted: build timed out in environment)*
- `./gradlew app:compileDefaultDebugKotlin` *(interrupted: build timed out in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a57653ab18832ba419d4c9fb629e66