### PR TITLE
teams: smoother realm listeners closing (fixes #6934)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2909
-        versionName = "0.29.9"
+        versionCode = 2921
+        versionName = "0.29.21"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -359,6 +359,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     }
 
     override fun onDestroyView() {
+        teamList?.removeAllChangeListeners()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }


### PR DESCRIPTION
## Summary
- remove TeamFragment Realm change listeners before closing `mRealm`

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68a575f59e74832b8b9de832b0b93243