### PR TITLE
community: smoother realm listeners closing (fixes #6935)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2909
-        versionName = "0.29.9"
+        versionCode = 2922
+        versionName = "0.29.22"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Case
+import io.realm.RealmChangeListener
 import io.realm.RealmResults
 import io.realm.Sort
 import javax.inject.Inject
@@ -27,6 +28,7 @@ import org.ole.planet.myplanet.ui.resources.ResourcesFragment
 class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickListener {
     private lateinit var fragmentCommunityBinding: FragmentCommunityBinding
     private var newList: RealmResults<RealmNews>? = null
+    private var newsListChangeListener: RealmChangeListener<RealmResults<RealmNews>>? = null
     
     @Inject
     lateinit var userProfileDbHandler: UserProfileDbHandler
@@ -48,10 +50,10 @@ class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickLi
             .equalTo("viewableBy", "community", Case.INSENSITIVE)
             .equalTo("createdOn", user?.planetCode, Case.INSENSITIVE).isEmpty("replyTo")
             .sort("time", Sort.DESCENDING).findAll()
-
-        newList?.addChangeListener { results ->
+        newsListChangeListener = RealmChangeListener { results ->
             updatedNewsList(results)
         }
+        newList?.addChangeListener(newsListChangeListener!!)
         return fragmentCommunityBinding.root
     }
 
@@ -96,5 +98,11 @@ class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickLi
             fragmentCommunityBinding.llEditDelete.visibility = if (user?.isManager() == true) View.VISIBLE else View.GONE
             adapter?.notifyDataSetChanged()
         }
+    }
+
+    override fun onDestroy() {
+        newList?.removeAllChangeListeners()
+        newsListChangeListener = null
+        super.onDestroy()
     }
 }


### PR DESCRIPTION
## Summary
- store RealmResults change listener in CommunityFragment
- clear RealmResults change listeners in onDestroy before closing Realm

## Testing
- `./gradlew :app:compileLiteDebugKotlin` *(fails: Calculating task graph only)*

------
https://chatgpt.com/codex/tasks/task_e_68a575e0a084832b9c9e06173733f206