### PR TITLE
teams: smoother calendar realm (fixes #6936)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2909
-        versionName = "0.29.9"
+        versionCode = 2923
+        versionName = "0.29.23"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamCalendarFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamCalendarFragment.kt
@@ -307,22 +307,20 @@ class TeamCalendarFragment : BaseTeamFragment() {
             return
         }
         viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-            var meetupList = mutableListOf<RealmMeetup>()
             val newDates = mutableListOf<Calendar>()
-            val realm = databaseService.realmInstance
-            try {
-                meetupList = realm.where(RealmMeetup::class.java).equalTo("teamId", teamId).findAll()
-                val calendarInstance = Calendar.getInstance()
+            databaseService.withRealm { realm ->
+                try {
+                    val meetupList = realm.where(RealmMeetup::class.java).equalTo("teamId", teamId).findAll()
+                    val calendarInstance = Calendar.getInstance()
 
-                for (meetup in meetupList) {
-                    val startDateMillis = meetup.startDate
-                    calendarInstance.timeInMillis = startDateMillis
-                    newDates.add(calendarInstance.clone() as Calendar)
+                    for (meetup in meetupList) {
+                        val startDateMillis = meetup.startDate
+                        calendarInstance.timeInMillis = startDateMillis
+                        newDates.add(calendarInstance.clone() as Calendar)
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            } finally {
-                realm.close()
             }
             withContext(Dispatchers.Main) {
                 if (isAdded && activity != null) {


### PR DESCRIPTION
## Summary
- use databaseService.withRealm in TeamCalendarFragment to handle Realm instances safely

## Testing
- `./gradlew :app:compileDefaultDebugKotlin`


------
https://chatgpt.com/codex/tasks/task_e_68a576060c64832ba598015c88e4370b