### PR TITLE
dashboard: smoother view model (fixes #6873)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2909
-        versionName = "0.29.9"
+        versionCode = 2925
+        versionName = "0.29.25"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -1,11 +1,16 @@
 package org.ole.planet.myplanet.ui.dashboard
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.Realm
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseResourceFragment
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmNotification
@@ -24,6 +29,11 @@ class DashboardViewModel @Inject constructor(
     private val courseRepository: CourseRepository,
     private val submissionRepository: SubmissionRepository
 ) : ViewModel() {
+    private val _surveyWarning = MutableStateFlow(false)
+    val surveyWarning: StateFlow<Boolean> = _surveyWarning.asStateFlow()
+
+    private val _unreadNotifications = MutableStateFlow(0)
+    val unreadNotifications: StateFlow<Int> = _unreadNotifications.asStateFlow()
     fun calculateIndividualProgress(voiceCount: Int, hasUnfinishedSurvey: Boolean): Int {
         val earnedDollarsVoice = minOf(voiceCount, 5) * 2
         val earnedDollarsSurvey = if (!hasUnfinishedSurvey) 1 else 0
@@ -36,6 +46,26 @@ class DashboardViewModel @Inject constructor(
         val earnedDollarsSurvey = if (!hasUnfinishedSurvey) 1 else 0
         val total = earnedDollarsVoice + earnedDollarsSurvey
         return total.coerceAtMost(11)
+    }
+
+    fun loadDashboardData(userId: String?) {
+        loadSurveyWarning(userId)
+        loadUnreadNotifications(userId)
+    }
+
+    private fun loadSurveyWarning(userId: String?) {
+        viewModelScope.launch {
+            val count = databaseService.withRealmAsync { realm ->
+                RealmSubmission.getNoOfSurveySubmissionByUser(userId, realm)
+            }
+            _surveyWarning.value = count == 0
+        }
+    }
+
+    private fun loadUnreadNotifications(userId: String?) {
+        viewModelScope.launch {
+            _unreadNotifications.value = getUnreadNotificationsSize(userId)
+        }
     }
 
     suspend fun updateResourceNotification(userId: String?) {


### PR DESCRIPTION
## Summary
- retrieve DashboardViewModel in DashboardFragment via `by viewModels`
- compute survey warning and notification counts inside DashboardViewModel and expose as flows
- observe survey warning state from fragment to update UI

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68a5767efa1c832baea29292f1b64654