### PR TITLE
Fix auto-download Realm usage to close automatically

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
@@ -139,7 +139,12 @@ class SettingActivity : AppCompatActivity() {
             autoDownload?.onPreferenceChangeListener = OnPreferenceChangeListener { _: Preference?, _: Any? ->
                 if (autoDownload.isChecked == true) {
                     defaultPref.edit { putBoolean("beta_auto_download", true) }
-                    backgroundDownload(downloadAllFiles(getAllLibraryList((requireActivity() as SettingActivity).databaseService.realmInstance)), requireContext())
+                    (requireActivity() as SettingActivity).databaseService.withRealm { realm ->
+                        backgroundDownload(
+                            downloadAllFiles(getAllLibraryList(realm)),
+                            requireContext()
+                        )
+                    }
                 } else {
                     defaultPref.edit { putBoolean("beta_auto_download", false) }
                 }


### PR DESCRIPTION
## Summary
- Wrap auto-download Realm access in `withRealm` so the Realm instance closes automatically

## Testing
- `./gradlew assembleDebug --no-daemon --console=plain` *(fails: took too long to progress beyond SDK install)*

------
https://chatgpt.com/codex/tasks/task_e_68a72b680758832b8044fc0028700afb