### PR TITLE
all: smoother `NotificationUtil.kt` realm handling (fixes #6968)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2927
-        versionName = "0.29.27"
+        versionCode = 2931
+        versionName = "0.29.31"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -22,7 +22,7 @@ class DatabaseService(context: Context) {
         Realm.setDefaultConfiguration(config)
     }
 
-    val realmInstance: Realm
+    private val realmInstance: Realm
         get() = Realm.getDefaultInstance()
 
     private inline fun <T> withRealmInstance(block: (Realm) -> T): T {

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -22,7 +22,8 @@ class DatabaseService(context: Context) {
         Realm.setDefaultConfiguration(config)
     }
 
-    private val realmInstance: Realm
+    @Deprecated("Use withRealm/withRealmAsync instead")
+    val realmInstance: Realm
         get() = Realm.getDefaultInstance()
 
     private inline fun <T> withRealmInstance(block: (Realm) -> T): T {

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ManagerSync.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ManagerSync.kt
@@ -24,7 +24,6 @@ import retrofit2.Response
 class ManagerSync private constructor(context: Context) {
     private val settings: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val dbService: DatabaseService = DatabaseService(context)
-    private val mRealm: Realm = dbService.realmInstance
 
     fun login(userName: String?, password: String?, listener: SyncListener) {
         listener.onSyncStarted()
@@ -39,7 +38,9 @@ class ManagerSync private constructor(context: Context) {
                             val derivedKey = jsonDoc["derived_key"].asString
                             val salt = jsonDoc["salt"].asString
                             if (androidDecrypter(userName, password, derivedKey, salt)) {
-                                checkManagerAndInsert(jsonDoc, mRealm, listener)
+                                dbService.withRealm { realm ->
+                                    checkManagerAndInsert(jsonDoc, realm, listener)
+                                }
                             } else {
                                 listener.onSyncFailed("Name or password is incorrect.")
                             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
@@ -139,7 +139,13 @@ class SettingActivity : AppCompatActivity() {
             autoDownload?.onPreferenceChangeListener = OnPreferenceChangeListener { _: Preference?, _: Any? ->
                 if (autoDownload.isChecked == true) {
                     defaultPref.edit { putBoolean("beta_auto_download", true) }
-                    backgroundDownload(downloadAllFiles(getAllLibraryList((requireActivity() as SettingActivity).databaseService.realmInstance)), requireContext())
+                    val settingActivity = requireActivity() as SettingActivity
+                    settingActivity.databaseService.withRealm { realm ->
+                        backgroundDownload(
+                            downloadAllFiles(getAllLibraryList(realm)),
+                            requireContext(),
+                        )
+                    }
                 } else {
                     defaultPref.edit { putBoolean("beta_auto_download", false) }
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/NotificationUtil.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/NotificationUtil.kt
@@ -517,19 +517,17 @@ class NotificationActionReceiver : BroadcastReceiver() {
 
 
         try {
-            val realm = databaseService.realmInstance
-            
-            realm.executeTransaction { r ->
-                val notification = r.where(RealmNotification::class.java)
-                    .equalTo("id", notificationId)
-                    .findFirst()
-                
-                if (notification != null) {
-                    notification.isRead = true
+            databaseService.withRealm { realm ->
+                realm.executeTransaction { r ->
+                    val notification = r.where(RealmNotification::class.java)
+                        .equalTo("id", notificationId)
+                        .findFirst()
+
+                    if (notification != null) {
+                        notification.isRead = true
+                    }
                 }
             }
-
-            realm.close()
 
             android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
                 val broadcastIntent = Intent("org.ole.planet.myplanet.NOTIFICATION_READ_FROM_SYSTEM")


### PR DESCRIPTION
## Summary
- encapsulate realm access behind helper functions
- adjust some call sites to use `withRealm`

## Testing
- `./gradlew assembleDebug` *(fails: build interrupted, unresolved references may remain)*

------
https://chatgpt.com/codex/tasks/task_e_68a72b7949e4832b8ca488b34c183b7d