### PR TITLE
all: smoother feedback realm closing (fixes #6969)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2927
-        versionName = "0.29.27"
+        versionCode = 2932
+        versionName = "0.29.32"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
@@ -130,6 +130,13 @@ class FeedbackDetailActivity : AppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
+    override fun onDestroy() {
+        if (::realm.isInitialized && !realm.isClosed) {
+            realm.close()
+        }
+        super.onDestroy()
+    }
+
     inner class RvFeedbackAdapter(private val replyList: List<FeedbackReply>?, var context: Context) : RecyclerView.Adapter<ReplyViewHolder>() {
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReplyViewHolder {
             rowFeedbackReplyBinding = RowFeedbackReplyBinding.inflate(layoutInflater, parent, false)


### PR DESCRIPTION
## Summary
- close Realm in FeedbackDetailActivity's onDestroy

## Testing
- `./gradlew lint` *(fails: Installed Build Tools revision 35.0.0 is corrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a72ca17280832bb0e3cacf8fe2b2dd