### PR TITLE
Refactor notifications adapter to use ListAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/AdapterNotification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/AdapterNotification.kt
@@ -5,35 +5,40 @@ import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import java.util.regex.Pattern
-import org.ole.planet.myplanet.MainApplication.Companion.service
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowNotificationsBinding
+import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmTeamTask
 
 class AdapterNotification(
-    var notificationList: List<RealmNotification>,
+    private val databaseService: DatabaseService,
+    notifications: List<RealmNotification>,
     private val onMarkAsReadClick: (Int) -> Unit,
     private val onNotificationClick: (RealmNotification) -> Unit
-) : RecyclerView.Adapter<AdapterNotification.ViewHolderNotifications>() {
+) : ListAdapter<RealmNotification, AdapterNotification.ViewHolderNotifications>(DIFF_CALLBACK) {
+
+    init {
+        submitList(notifications)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderNotifications {
         val rowNotificationsBinding = RowNotificationsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return ViewHolderNotifications(rowNotificationsBinding)
     }
 
     override fun onBindViewHolder(holder: ViewHolderNotifications, position: Int) {
-        val notification = notificationList[position]
+        val notification = getItem(position)
         holder.bind(notification, position)
     }
 
-    override fun getItemCount(): Int = notificationList.size
-
     fun updateNotifications(newNotifications: List<RealmNotification>) {
-        notificationList = newNotifications
-        notifyDataSetChanged()
+        submitList(newNotifications)
     }
 
     inner class ViewHolderNotifications(private val rowNotificationsBinding: RowNotificationsBinding) :
@@ -92,7 +97,7 @@ class AdapterNotification(
                 }
                 "join_request" -> {
                     val teamId = notification.relatedId
-                    val teamName = service.withRealm { realm ->
+                    val teamName = databaseService.withRealm { realm ->
                         realm.where(RealmMyTeam::class.java)
                             .equalTo("_id", teamId)
                             .findFirst()?.name
@@ -109,7 +114,7 @@ class AdapterNotification(
         }
 
         private fun formatTaskNotification(context: Context, taskTitle: String, dateValue: String): String {
-            return service.withRealm { realm ->
+            return databaseService.withRealm { realm ->
                 val taskObj = realm.where(RealmTeamTask::class.java)
                     .equalTo("title", taskTitle)
                     .findFirst()
@@ -121,6 +126,18 @@ class AdapterNotification(
                 } else {
                     context.getString(R.string.task_notification, taskTitle, dateValue)
                 }
+            }
+        }
+    }
+
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<RealmNotification>() {
+            override fun areItemsTheSame(oldItem: RealmNotification, newItem: RealmNotification): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(oldItem: RealmNotification, newItem: RealmNotification): Boolean {
+                return oldItem == newItem
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -92,9 +92,12 @@ class NotificationsFragment : Fragment() {
              notification.message.isNotEmpty() && notification.message != "INVALID"
         }
 
-        adapter = AdapterNotification(filteredNotifications,
+        adapter = AdapterNotification(
+            databaseService,
+            filteredNotifications,
             onMarkAsReadClick = { position ->
-                markAsRead(position) },
+                markAsRead(position)
+            },
             onNotificationClick = { notification ->
                 handleNotificationClick(notification)
             }
@@ -178,7 +181,7 @@ class NotificationsFragment : Fragment() {
         }
 
         if (!notification.isRead) {
-            markAsRead(adapter.notificationList.indexOf(notification))
+            markAsRead(adapter.currentList.indexOf(notification))
         }
     }
 
@@ -196,7 +199,7 @@ class NotificationsFragment : Fragment() {
     }
 
     private fun markAsRead(position: Int) {
-        val notification = adapter.notificationList[position]
+        val notification = adapter.currentList[position]
         val notificationId = notification.id
         mRealm.executeTransactionAsync({ realm ->
             val realmNotification = realm.where(RealmNotification::class.java)


### PR DESCRIPTION
## Summary
- Use ListAdapter with DiffUtil for notifications
- Inject DatabaseService instead of static service
- Update fragment to submit lists and use currentList

## Testing
- `./gradlew lint` *(incomplete: build did not complete)*
- `./gradlew :app:lintDebug` *(fails: task ambiguous)*

------
https://chatgpt.com/codex/tasks/task_e_68a72d8cbd28832bb09fb5635da9fedf