### PR TITLE
resources: smoother user handling (fixes #6977)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2938
-        versionName = "0.29.38"
+        versionCode = 2939
+        versionName = "0.29.39"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2927
-        versionName = "0.29.27"
+        versionCode = 2938
+        versionName = "0.29.38"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -46,7 +46,6 @@ import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmTag.Companion.getTagsArray
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils
@@ -206,7 +205,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         isMyCourseLib = arguments?.getBoolean("isMyCourseLib", false) ?: false
-        userModel = UserProfileDbHandler(requireContext()).userModel
+        userModel = profileDbHandler.userModel
         searchTags = ArrayList()
         config = Utilities.getCloudConfig().showClose(R.color.black_overlay)
 


### PR DESCRIPTION
## Summary
- Use existing `profileDbHandler` to retrieve `userModel` instead of creating a new `UserProfileDbHandler` instance
- Remove obsolete `UserProfileDbHandler` import

## Testing
- `./gradlew :app:compileDebugKotlin --console=plain` *(fails: Preparing "Install Android SDK Build-Tools 35 v.35.0.0")*

------
https://chatgpt.com/codex/tasks/task_e_68a72e4af34c832ba4446898432e458a