### PR TITLE
Refactor library queries to use queryList

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import io.realm.RealmResults
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.datamanager.findCopyByField
@@ -32,23 +31,20 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getLibraryListForUser(userId: String?): List<RealmMyLibrary> {
+        if (userId == null) return emptyList()
         return databaseService.withRealmAsync { realm ->
-            val results = realm.where(RealmMyLibrary::class.java)
-                .equalTo("isPrivate", false)
-                .findAll()
-            val filteredList =
-                filterLibrariesNeedingUpdate(results).filter { it.userId?.contains(userId) == true }
-            realm.copyFromRealm(filteredList)
+            realm.queryList(RealmMyLibrary::class.java) {
+                equalTo("isPrivate", false)
+                contains("userId", userId)
+            }
         }
     }
 
     override suspend fun getAllLibraryList(): List<RealmMyLibrary> {
         return databaseService.withRealmAsync { realm ->
-            val results = realm.where(RealmMyLibrary::class.java)
-                .equalTo("resourceOffline", false)
-                .findAll()
-            val filteredList = filterLibrariesNeedingUpdate(results)
-            realm.copyFromRealm(filteredList)
+            realm.queryList(RealmMyLibrary::class.java) {
+                equalTo("resourceOffline", false)
+            }
         }
     }
 
@@ -84,9 +80,5 @@ class LibraryRepositoryImpl @Inject constructor(
                 .findFirst()
                 ?.let { updater(it) }
         }
-    }
-
-    private fun filterLibrariesNeedingUpdate(results: RealmResults<RealmMyLibrary>): List<RealmMyLibrary> {
-        return results.filter { it.needToUpdate() }
     }
 }


### PR DESCRIPTION
## Summary
- simplify library retrieval methods by using `queryList` within `withRealmAsync`
- drop manual `copyFromRealm` and update filters

## Testing
- `./gradlew lint` *(fails: Failed to install the following SDK components: platforms;android-36 Android SDK Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_68a73176ec00832b8d41ae2ef656fbeb