### PR TITLE
fix: avoid crash removing member (fixes #6961)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.kt
@@ -178,19 +178,16 @@ class AdapterJoinedMember(
     }
 
     private fun getNextOfKin(): RealmUserModel? {
-        val members: List<RealmMyTeam> = mRealm.where(RealmMyTeam::class.java)
+        val successor = mRealm.where(RealmMyTeam::class.java)
             .equalTo("teamId", teamId)
             .equalTo("isLeader", false)
-            .notEqualTo("status","archived")
+            .notEqualTo("status", "archived")
             .sort("createdDate", Sort.DESCENDING)
-            .findAll()
-        val successor =  if (members.isNotEmpty()) members?.first() else null
-        if(successor==null){
-            return null
-        }
-        else{
-            val user= mRealm.where(RealmUserModel::class.java).equalTo("id", successor.userId).findFirst()
-            return user
+            .findFirst()
+        return successor?.let {
+            mRealm.where(RealmUserModel::class.java)
+                .equalTo("id", it.userId)
+                .findFirst()
         }
     }
 


### PR DESCRIPTION
#6961 

## Summary
- avoid NoSuchElementException in getNextOfKin when removing a team member

## Testing
- `./gradlew lint` *(fails: Gradle process did not complete in the environment)*
- `./gradlew -q help`
- `./gradlew -q tasks`

------
https://chatgpt.com/codex/tasks/task_e_68a831398f50832b97668927588082cf