### PR TITLE
fix: guard NewsFragment binding

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
@@ -83,6 +83,7 @@ class NewsFragment : BaseNewsFragment() {
             .findAllAsync()
 
         updatedNewsList?.addChangeListener { results ->
+            if (_binding == null) return@addChangeListener
             filteredNewsList = filterNewsList(results)
             updateLabelSpinner()
             labelFilteredList = applyLabelFilter(filteredNewsList)
@@ -331,6 +332,7 @@ class NewsFragment : BaseNewsFragment() {
     }
     
     private fun updateLabelSpinner() {
+        val binding = _binding ?: return
         val labels = collectAllLabels(filteredNewsList)
         val themedContext = androidx.appcompat.view.ContextThemeWrapper(requireContext(), R.style.ResourcePopupMenu)
         val adapter = ArrayAdapter(themedContext, android.R.layout.simple_spinner_item, labels)
@@ -423,6 +425,7 @@ class NewsFragment : BaseNewsFragment() {
     }
 
     override fun onDestroyView() {
+        updatedNewsList?.removeAllChangeListeners()
         _binding = null
         super.onDestroyView()
     }


### PR DESCRIPTION
## Summary
- avoid NPE when news updates arrive after view is destroyed
- skip label spinner work if binding is unavailable
- clear change listeners on destroy

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8312a5690832b92454b1ab0aadb7e