### PR TITLE
survey: resolved autosync (fixes #6988)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import com.google.gson.JsonObject
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Realm
+import kotlinx.coroutines.CoroutineScope
 import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
@@ -258,7 +259,7 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
         val serverUrlMapper = ServerUrlMapper()
         val mapping = serverUrlMapper.processUrl(updateUrl)
 
-        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+        CoroutineScope(Dispatchers.IO).launch {
             val primaryAvailable = MainApplication.isServerReachable(mapping.primaryUrl)
             val alternativeAvailable =
                 mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -18,13 +18,13 @@ import androidx.lifecycle.lifecycleScope
 import com.google.gson.JsonObject
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Realm
-import kotlinx.coroutines.CoroutineScope
 import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseDialogFragment
@@ -259,21 +259,27 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
         val serverUrlMapper = ServerUrlMapper()
         val mapping = serverUrlMapper.processUrl(updateUrl)
 
-        CoroutineScope(Dispatchers.IO).launch {
-            val primaryAvailable = MainApplication.isServerReachable(mapping.primaryUrl)
-            val alternativeAvailable =
-                mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val primaryAvailable = withTimeoutOrNull(15000) {
+                    MainApplication.isServerReachable(mapping.primaryUrl)
+                } ?: false
+                
+                val alternativeAvailable = withTimeoutOrNull(15000) {
+                    mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
+                } ?: false
 
-            if (!primaryAvailable && alternativeAvailable) {
-                mapping.alternativeUrl.let { alternativeUrl ->
-                    val uri = updateUrl.toUri()
-                    val editor = settings.edit()
+                if (!primaryAvailable && alternativeAvailable) {
+                    mapping.alternativeUrl?.let { alternativeUrl ->
+                        val uri = updateUrl.toUri()
+                        val editor = settings.edit()
 
-                    serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, settings)
+                        serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, settings)
+                    }
                 }
-            }
 
-            withContext(Dispatchers.Main) {
+                uploadSubmissions()
+            } catch (_: Exception) {
                 uploadSubmissions()
             }
         }


### PR DESCRIPTION
fixes #6988
auto sync broke in https://github.com/open-learning-exchange/myplanet/pull/6794 
reasons:
- viewLifecycleOwner.lifecycleScope gets cancelled when the fragment's view is destroyed while previous code CoroutineScope(Dispatchers.IO) creates an independent scope that won't be cancelled by fragment lifecycle changes

current fix
- Automatic cancellation: When fragment is destroyed, viewLifecycleOwner.lifecycleScope cancels the coroutine
- Timeout protection: withTimeoutOrNull(15000) ensures operations don't run longer than 15 seconds
-  Graceful degradation: If cancelled or timed out, it defaults to false and continues with normal flow