### PR TITLE
all: smoother repository realm comparisons (fixes #7012)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2942
-        versionName = "0.29.42"
+        versionCode = 2950
+        versionName = "0.29.50"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -68,20 +68,25 @@ fun <T : RealmModel> Realm.queryList(
     return where(clazz).apply(builder).findAll().let { copyFromRealm(it) }
 }
 
-fun <T : RealmModel, V> Realm.findCopyByField(
+fun <T : RealmModel, V : Any> Realm.findCopyByField(
     clazz: Class<T>,
     fieldName: String,
     value: V,
 ): T? {
-    val query = where(clazz)
-    when (value) {
-        is String -> query.equalTo(fieldName, value)
-        is Boolean -> query.equalTo(fieldName, value)
-        is Int -> query.equalTo(fieldName, value)
-        is Long -> query.equalTo(fieldName, value)
-        is Float -> query.equalTo(fieldName, value)
-        is Double -> query.equalTo(fieldName, value)
+    return where(clazz)
+        .applyEqualTo(fieldName, value)
+        .findFirst()
+        ?.let { copyFromRealm(it) }
+}
+
+fun <T : RealmModel> RealmQuery<T>.applyEqualTo(field: String, value: Any): RealmQuery<T> {
+    return when (value) {
+        is String -> equalTo(field, value)
+        is Boolean -> equalTo(field, value)
+        is Int -> equalTo(field, value)
+        is Long -> equalTo(field, value)
+        is Float -> equalTo(field, value)
+        is Double -> equalTo(field, value)
         else -> throw IllegalArgumentException("Unsupported value type")
     }
-    return query.findFirst()?.let { copyFromRealm(it) }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -4,6 +4,7 @@ import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.RealmQuery
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.datamanager.applyEqualTo
 import org.ole.planet.myplanet.datamanager.findCopyByField
 import org.ole.planet.myplanet.datamanager.queryList
 
@@ -16,7 +17,7 @@ open class RealmRepository(private val databaseService: DatabaseService) {
         realm.queryList(clazz, builder)
     }
 
-    protected suspend fun <T : RealmObject, V> findByField(
+    protected suspend fun <T : RealmObject, V : Any> findByField(
         clazz: Class<T>,
         fieldName: String,
         value: V
@@ -30,44 +31,28 @@ open class RealmRepository(private val databaseService: DatabaseService) {
         }
     }
 
-    protected suspend fun <T : RealmObject, V> update(
+    protected suspend fun <T : RealmObject, V : Any> update(
         clazz: Class<T>,
         fieldName: String,
         value: V,
         updater: (T) -> Unit
     ) {
         executeTransaction { realm ->
-            val query = realm.where(clazz)
-            when (value) {
-                is String -> query.equalTo(fieldName, value)
-                is Boolean -> query.equalTo(fieldName, value)
-                is Int -> query.equalTo(fieldName, value)
-                is Long -> query.equalTo(fieldName, value)
-                is Float -> query.equalTo(fieldName, value)
-                is Double -> query.equalTo(fieldName, value)
-                else -> throw IllegalArgumentException("Unsupported value type")
-            }
-            query.findFirst()?.let { updater(it) }
+            realm.where(clazz)
+                .applyEqualTo(fieldName, value)
+                .findFirst()?.let { updater(it) }
         }
     }
 
-    protected suspend fun <T : RealmObject, V> delete(
+    protected suspend fun <T : RealmObject, V : Any> delete(
         clazz: Class<T>,
         fieldName: String,
         value: V
     ) {
         executeTransaction { realm ->
-            val query = realm.where(clazz)
-            when (value) {
-                is String -> query.equalTo(fieldName, value)
-                is Boolean -> query.equalTo(fieldName, value)
-                is Int -> query.equalTo(fieldName, value)
-                is Long -> query.equalTo(fieldName, value)
-                is Float -> query.equalTo(fieldName, value)
-                is Double -> query.equalTo(fieldName, value)
-                else -> throw IllegalArgumentException("Unsupported value type")
-            }
-            query.findFirst()?.deleteFromRealm()
+            realm.where(clazz)
+                .applyEqualTo(fieldName, value)
+                .findFirst()?.deleteFromRealm()
         }
     }
 


### PR DESCRIPTION
## Summary
- add RealmQuery.applyEqualTo to centralize type-safe equality filtering
- use applyEqualTo in repository operations to avoid repeated when blocks

## Testing
- `./gradlew --console=plain assembleDebug` *(failed: Gradle download stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68a866c9ee00832b913cf822539e77e0