### PR TITLE
resources: smoother local path opening (fixes #7021)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2942
-        versionName = "0.29.42"
+        versionCode = 2957
+        versionName = "0.29.57"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/ResourceOpener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/ResourceOpener.kt
@@ -19,6 +19,10 @@ import org.ole.planet.myplanet.ui.viewer.TextFileViewerActivity
 import org.ole.planet.myplanet.ui.viewer.VideoPlayerActivity
 
 object ResourceOpener {
+    private fun resourcePath(item: RealmMyLibrary): String {
+        return "${item.id}/${item.resourceLocalAddress}"
+    }
+
     fun openIntent(activity: Activity, items: RealmMyLibrary, typeClass: Class<*>) {
         val fileOpenIntent = Intent(activity, typeClass)
         if (items.resourceLocalAddress?.contains("ole/audio") == true ||
@@ -26,7 +30,7 @@ object ResourceOpener {
             fileOpenIntent.putExtra("TOUCHED_FILE", items.resourceLocalAddress)
             fileOpenIntent.putExtra("RESOURCE_TITLE", items.title)
         } else {
-            fileOpenIntent.putExtra("TOUCHED_FILE", items.id + "/" + items.resourceLocalAddress)
+            fileOpenIntent.putExtra("TOUCHED_FILE", resourcePath(items))
             fileOpenIntent.putExtra("RESOURCE_TITLE", items.title)
         }
         activity.startActivity(fileOpenIntent)
@@ -34,7 +38,7 @@ object ResourceOpener {
 
     fun openPdf(activity: Activity, item: RealmMyLibrary) {
         val fileOpenIntent = Intent(activity, PDFReaderActivity::class.java)
-        fileOpenIntent.putExtra("TOUCHED_FILE", item.id + "/" + item.resourceLocalAddress)
+        fileOpenIntent.putExtra("TOUCHED_FILE", resourcePath(item))
         fileOpenIntent.putExtra("resourceId", item.id)
         activity.startActivity(fileOpenIntent)
     }
@@ -70,15 +74,15 @@ object ResourceOpener {
         val bundle = Bundle()
         bundle.putString("videoType", videoType)
         if (videoType == "online") {
-            bundle.putString("videoURL", "" + UrlUtils.getUrl(items))
-            bundle.putString("Auth", "" + BaseResourceFragment.auth)
+            bundle.putString("videoURL", "${UrlUtils.getUrl(items)}")
+            bundle.putString("Auth", "${BaseResourceFragment.auth}")
         } else if (videoType == "offline") {
             if (items.resourceRemoteAddress == null && items.resourceLocalAddress != null) {
                 bundle.putString("videoURL", items.resourceLocalAddress)
             } else {
                 bundle.putString(
                     "videoURL",
-                    "" + Uri.fromFile(File("" + FileUtils.getSDPathFromUrl(items.resourceRemoteAddress)))
+                    Uri.fromFile(FileUtils.getSDPathFromUrl(items.resourceRemoteAddress)).toString()
                 )
             }
             bundle.putString("Auth", "")
@@ -88,7 +92,7 @@ object ResourceOpener {
     }
 
     fun openFileType(activity: Activity, items: RealmMyLibrary, videoType: String, profileDbHandler: UserProfileDbHandler) {
-        val mimetype = Utilities.getMimeType(items.resourceLocalAddress)
+        val mimetype = Utilities.getMimeType(resourcePath(items))
         if (mimetype == null) {
             Utilities.toast(activity, activity.getString(R.string.unable_to_open_resource))
             return


### PR DESCRIPTION
## Summary
- add private helper to build resource paths
- use the helper in openIntent, openPdf and openFileType
- replace string concatenations with Kotlin string templates

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68a8670527b0832bacd527ad1b69442d