### PR TITLE
refactor: use DiffUtils helper for server updates

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerAddressAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerAddressAdapter.kt
@@ -4,8 +4,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import org.ole.planet.myplanet.utilities.DiffUtils
 import com.google.android.material.button.MaterialButton
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.R
@@ -20,19 +20,12 @@ class ServerAddressAdapter(private var serverList: List<ServerAddressesModel>,
     private var lastSelectedPosition: Int = -1
 
     fun updateList(newList: List<ServerAddressesModel>) {
-        val diffCallback = object : DiffUtil.Callback() {
-            override fun getOldListSize() = serverList.size
-            override fun getNewListSize() = newList.size
-
-            override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-                return serverList[oldItemPosition].url == newList[newItemPosition].url
-            }
-
-            override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-                return serverList[oldItemPosition] == newList[newItemPosition]
-            }
-        }
-        val diffResult = DiffUtil.calculateDiff(diffCallback)
+        val diffResult = DiffUtils.calculateDiff(
+            serverList,
+            newList,
+            areItemsTheSame = { old, new -> old.url == new.url },
+            areContentsTheSame = { old, new -> old == new }
+        )
         serverList = newList
         diffResult.dispatchUpdatesTo(this)
     }


### PR DESCRIPTION
## Summary
- replace inlined DiffUtil with utilities DiffUtils.calculateDiff in ServerAddressAdapter
- compare items by URL and contents by equality

## Testing
- `./gradlew assembleDebug` *(fails: requires Android SDK Platform 36 installation)*

------
https://chatgpt.com/codex/tasks/task_e_68a867933540832b9c40ec0b0feff168