### PR TITLE
courses: smoother list diffing (fixes #7025)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2942
-        versionName = "0.29.42"
+        versionCode = 2961
+        versionName = "0.29.61"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -11,7 +11,6 @@ import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.flexbox.FlexboxLayout
 import com.google.gson.JsonObject
@@ -29,6 +28,7 @@ import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.CourseRatingUtils
+import org.ole.planet.myplanet.utilities.DiffUtils
 import org.ole.planet.myplanet.utilities.JsonUtils.getInt
 import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
@@ -73,27 +73,20 @@ class AdapterCourses(
     }
 
     private fun dispatchDiff(newList: List<RealmMyCourse?>) {
-        val diffResult = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
-            override fun getOldListSize() = courseList.size
-
-            override fun getNewListSize() = newList.size
-
-            override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-                return courseList[oldItemPosition]?.id == newList[newItemPosition]?.id
+        val diffResult = DiffUtils.calculateDiff(
+            courseList,
+            newList,
+            areItemsTheSame = { old, new -> old?.id == new?.id },
+            areContentsTheSame = { old, new ->
+                old?.courseTitle == new?.courseTitle &&
+                    old?.description == new?.description &&
+                    old?.gradeLevel == new?.gradeLevel &&
+                    old?.subjectLevel == new?.subjectLevel &&
+                    old?.createdDate == new?.createdDate &&
+                    old?.isMyCourse == new?.isMyCourse &&
+                    old?.getNumberOfSteps() == new?.getNumberOfSteps()
             }
-
-            override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-                val oldItem = courseList[oldItemPosition]
-                val newItem = newList[newItemPosition]
-                return oldItem?.courseTitle == newItem?.courseTitle &&
-                        oldItem?.description == newItem?.description &&
-                        oldItem?.gradeLevel == newItem?.gradeLevel &&
-                        oldItem?.subjectLevel == newItem?.subjectLevel &&
-                        oldItem?.createdDate == newItem?.createdDate &&
-                        oldItem?.isMyCourse == newItem?.isMyCourse &&
-                        oldItem?.getNumberOfSteps() == newItem?.getNumberOfSteps()
-            }
-        })
+        )
         courseList = newList
         diffResult.dispatchUpdatesTo(this)
     }


### PR DESCRIPTION
## Summary
- replace inline DiffUtil.Callback with DiffUtils.calculateDiff using lambdas
- keep list reassignment and update dispatch logic

## Testing
- `./gradlew assembleDebug` *(fails: missing Android dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a867a656f4832bbc04aafe86508f6d