### PR TITLE
refactor: use RealmRepository helper in TeamRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -7,11 +7,11 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 
 class TeamRepositoryImpl @Inject constructor(
-    private val databaseService: DatabaseService,
-) : TeamRepository {
+    databaseService: DatabaseService,
+) : RealmRepository(databaseService), TeamRepository {
 
     override suspend fun getTeamResources(teamId: String): List<RealmMyLibrary> {
-        return databaseService.withRealmAsync { realm ->
+        return withRealm { realm ->
             val resourceIds = RealmMyTeam.getResourceIds(teamId, realm)
             if (resourceIds.isEmpty()) emptyList() else
                 realm.queryList(RealmMyLibrary::class.java) {


### PR DESCRIPTION
## Summary
- refactor TeamRepositoryImpl to extend RealmRepository and use withRealm

## Testing
- `./gradlew --console=plain app:compileLiteDebugKotlin`


------
https://chatgpt.com/codex/tasks/task_e_68a867f05638832ba835b7ac1c61c397