### PR TITLE
courses: smoother repository submission count (fixes #7013)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2942
-        versionName = "0.29.42"
+        versionCode = 2951
+        versionName = "0.29.51"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -4,6 +4,7 @@ import org.ole.planet.myplanet.model.RealmSubmission
 
 interface SubmissionRepository {
     suspend fun getPendingSurveys(userId: String?): List<RealmSubmission>
+    suspend fun getSurveyCountByUser(userId: String?): Int
     suspend fun getSurveyTitlesFromSubmissions(submissions: List<RealmSubmission>): List<String>
     suspend fun getSubmissionById(id: String): RealmSubmission?
     suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -4,7 +4,7 @@ import org.ole.planet.myplanet.model.RealmSubmission
 
 interface SubmissionRepository {
     suspend fun getPendingSurveys(userId: String?): List<RealmSubmission>
-    suspend fun getSurveyCountByUser(userId: String?): Int
+    suspend fun getSubmissionCountByUser(userId: String?): Int
     suspend fun getSurveyTitlesFromSubmissions(submissions: List<RealmSubmission>): List<String>
     suspend fun getSubmissionById(id: String): RealmSubmission?
     suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -19,7 +19,7 @@ class SubmissionRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getSurveyCountByUser(userId: String?): Int {
+    override suspend fun getSubmissionCountByUser(userId: String?): Int {
         return queryList(RealmSubmission::class.java) {
             equalTo("userId", userId)
             equalTo("type", "survey")

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -19,6 +19,14 @@ class SubmissionRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getSurveyCountByUser(userId: String?): Int {
+        return queryList(RealmSubmission::class.java) {
+            equalTo("userId", userId)
+            equalTo("type", "survey")
+            equalTo("status", "pending")
+        }.size
+    }
+
     override suspend fun getSurveyTitlesFromSubmissions(
         submissions: List<RealmSubmission>
     ): List<String> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -54,9 +54,7 @@ class DashboardViewModel @Inject constructor(
 
     private fun loadSurveyWarning(userId: String?) {
         viewModelScope.launch {
-            val count = databaseService.withRealmAsync { realm ->
-                RealmSubmission.getNoOfSurveySubmissionByUser(userId, realm)
-            }
+            val count = submissionRepository.getSurveyCountByUser(userId)
             _surveyWarning.value = count == 0
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -54,7 +54,7 @@ class DashboardViewModel @Inject constructor(
 
     private fun loadSurveyWarning(userId: String?) {
         viewModelScope.launch {
-            val count = submissionRepository.getSurveyCountByUser(userId)
+            val count = submissionRepository.getSubmissionCountByUser(userId)
             _surveyWarning.value = count == 0
         }
     }


### PR DESCRIPTION
## Summary
- add `getSurveyCountByUser` to `SubmissionRepository`
- implement survey count lookup in `SubmissionRepositoryImpl`
- use repository method in `DashboardViewModel.loadSurveyWarning`

## Testing
- ⚠️ `./gradlew assembleDebug` *(execution did not complete; last log lines show progress up to mergeExtDex task)*

------
https://chatgpt.com/codex/tasks/task_e_68a8682516bc832b9255e0bfef413cee