### PR TITLE
all: smoother notification repository unread counting (fixes #7014)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2942
-        versionName = "0.29.42"
+        versionCode = 2952
+        versionName = "0.29.52"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -11,6 +11,8 @@ import org.ole.planet.myplanet.repository.CourseRepository
 import org.ole.planet.myplanet.repository.CourseRepositoryImpl
 import org.ole.planet.myplanet.repository.LibraryRepository
 import org.ole.planet.myplanet.repository.LibraryRepositoryImpl
+import org.ole.planet.myplanet.repository.NotificationRepository
+import org.ole.planet.myplanet.repository.NotificationRepositoryImpl
 import org.ole.planet.myplanet.repository.RatingRepository
 import org.ole.planet.myplanet.repository.RatingRepositoryImpl
 import org.ole.planet.myplanet.repository.SearchRepository
@@ -57,4 +59,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindNotificationRepository(impl: NotificationRepositoryImpl): NotificationRepository
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -1,0 +1,6 @@
+package org.ole.planet.myplanet.repository
+
+interface NotificationRepository {
+    suspend fun getUnreadCount(userId: String?): Int
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -3,4 +3,3 @@ package org.ole.planet.myplanet.repository
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
 }
-

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package org.ole.planet.myplanet.repository
+
+import javax.inject.Inject
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmNotification
+
+class NotificationRepositoryImpl @Inject constructor(
+    databaseService: DatabaseService,
+) : RealmRepository(databaseService), NotificationRepository {
+
+    override suspend fun getUnreadCount(userId: String?): Int {
+        return withRealm { realm ->
+            realm.where(RealmNotification::class.java)
+                .equalTo("userId", userId)
+                .equalTo("isRead", false)
+                .count()
+                .toInt()
+        }
+    }
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -18,4 +18,3 @@ class NotificationRepositoryImpl @Inject constructor(
         }
     }
 }
-

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -17,6 +17,7 @@ import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.repository.CourseRepository
 import org.ole.planet.myplanet.repository.LibraryRepository
+import org.ole.planet.myplanet.repository.NotificationRepository
 import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.repository.UserRepository
 
@@ -26,7 +27,8 @@ class DashboardViewModel @Inject constructor(
     private val userRepository: UserRepository,
     private val libraryRepository: LibraryRepository,
     private val courseRepository: CourseRepository,
-    private val submissionRepository: SubmissionRepository
+    private val submissionRepository: SubmissionRepository,
+    private val notificationRepository: NotificationRepository
 ) : ViewModel() {
     private val _surveyWarning = MutableStateFlow(false)
     val surveyWarning: StateFlow<Boolean> = _surveyWarning.asStateFlow()
@@ -63,7 +65,7 @@ class DashboardViewModel @Inject constructor(
 
     private fun loadUnreadNotifications(userId: String?) {
         viewModelScope.launch {
-            _unreadNotifications.value = getUnreadNotificationsSize(userId)
+            _unreadNotifications.value = notificationRepository.getUnreadCount(userId)
         }
     }
 
@@ -122,12 +124,6 @@ class DashboardViewModel @Inject constructor(
     }
 
     suspend fun getUnreadNotificationsSize(userId: String?): Int {
-        return databaseService.withRealmAsync { realm ->
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("isRead", false)
-                .count()
-                .toInt()
-        }
+        return notificationRepository.getUnreadCount(userId)
     }
 }


### PR DESCRIPTION
## Summary
- create `NotificationRepository` and its implementation to provide unread notification counts
- bind `NotificationRepository` in `RepositoryModule`
- update `DashboardViewModel` to use `NotificationRepository` for unread counts

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68a8683837e0832b81178e8d549daae0