### PR TITLE
refactor: use queryList for library retrieval

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import io.realm.RealmResults
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
@@ -24,24 +23,18 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getLibraryListForUser(userId: String?): List<RealmMyLibrary> {
-        return withRealm { realm ->
-            val results = realm.where(RealmMyLibrary::class.java)
-                .equalTo("isPrivate", false)
-                .findAll()
-            val filteredList =
-                filterLibrariesNeedingUpdate(results).filter { it.userId?.contains(userId) == true }
-            realm.copyFromRealm(filteredList)
+        val results = queryList(RealmMyLibrary::class.java) {
+            equalTo("isPrivate", false)
         }
+        return filterLibrariesNeedingUpdate(results)
+            .filter { it.userId?.contains(userId) == true }
     }
 
     override suspend fun getAllLibraryList(): List<RealmMyLibrary> {
-        return withRealm { realm ->
-            val results = realm.where(RealmMyLibrary::class.java)
-                .equalTo("resourceOffline", false)
-                .findAll()
-            val filteredList = filterLibrariesNeedingUpdate(results)
-            realm.copyFromRealm(filteredList)
+        val results = queryList(RealmMyLibrary::class.java) {
+            equalTo("resourceOffline", false)
         }
+        return filterLibrariesNeedingUpdate(results)
     }
 
     override suspend fun getCourseLibraryItems(courseIds: List<String>): List<RealmMyLibrary> {
@@ -64,7 +57,7 @@ class LibraryRepositoryImpl @Inject constructor(
         update(RealmMyLibrary::class.java, "id", id, updater)
     }
 
-    private fun filterLibrariesNeedingUpdate(results: RealmResults<RealmMyLibrary>): List<RealmMyLibrary> {
+    private fun filterLibrariesNeedingUpdate(results: Collection<RealmMyLibrary>): List<RealmMyLibrary> {
         return results.filter { it.needToUpdate() }
     }
 }


### PR DESCRIPTION
## Summary
- refactor library repository methods to use queryList instead of manual realm access
- filter libraries needing update via collection helper

## Testing
- `./gradlew lint` *(fails: Gradle hung in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a8687be128832b88ea66150165f88a