### PR TITLE
teams: smoother member details binding (fixes #7022)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2942
-        versionName = "0.29.42"
+        versionCode = 2958
+        versionName = "0.29.58"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MemberDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MemberDetailFragment.kt
@@ -11,10 +11,11 @@ import org.ole.planet.myplanet.databinding.FragmentMemberDetailBinding
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 
 class MemberDetailFragment : Fragment() {
-    private lateinit var binding: FragmentMemberDetailBinding
+    private var _binding: FragmentMemberDetailBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        binding = FragmentMemberDetailBinding.inflate(inflater, container, false)
+        _binding = FragmentMemberDetailBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -45,6 +46,11 @@ class MemberDetailFragment : Fragment() {
         binding.btnClose.setOnClickListener {
             activity?.supportFragmentManager?.let { NavigationHelper.popBackStack(it) }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun setFieldOrHide(view: View, value: String?) {


### PR DESCRIPTION
## Summary
- use nullable backing property for MemberDetailFragment view binding
- clear binding in onDestroyView to avoid leaks

## Testing
- ⚠️ `./gradlew assembleDebug --console=plain` *(partial: cancelled after long download)*
- ⚠️ `./gradlew -q help` *(partial output, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68a869d79ec0832bb29a6d22efd5b16f