### PR TITLE
all: less repository constructor commas is more (fixes #7018)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2942
-        versionName = "0.29.42"
+        versionCode = 2954
+        versionName = "0.29.54"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -5,7 +5,7 @@ import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyCourse
 
 class CourseRepositoryImpl @Inject constructor(
-    databaseService: DatabaseService,
+    databaseService: DatabaseService
 ) : RealmRepository(databaseService), CourseRepository {
 
     override suspend fun getAllCourses(): List<RealmMyCourse> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -8,7 +8,7 @@ import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 
 class SubmissionRepositoryImpl @Inject constructor(
-    databaseService: DatabaseService,
+    databaseService: DatabaseService
 ) : RealmRepository(databaseService), SubmissionRepository {
 
     override suspend fun getPendingSurveys(userId: String?): List<RealmSubmission> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -8,7 +8,7 @@ import org.ole.planet.myplanet.model.RealmUserModel
 
 class UserRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
-    @AppPreferences private val preferences: SharedPreferences,
+    @AppPreferences private val preferences: SharedPreferences
 ) : RealmRepository(databaseService), UserRepository {
 
     override suspend fun getUserProfile(): String? {


### PR DESCRIPTION
## Summary
- tidy CourseRepositoryImpl constructor parameters by dropping trailing comma
- tidy SubmissionRepositoryImpl constructor parameters by dropping trailing comma
- tidy UserRepositoryImpl constructor parameters by dropping trailing comma

## Testing
- ⚠️ `./gradlew --no-daemon --console=plain lint` *(failed: Gradle build did not proceed beyond task graph calculation)*

------
https://chatgpt.com/codex/tasks/task_e_68a867de6cc8832ba0735f0a7c745a38