### PR TITLE
refactor: simplify network utils entry point

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/NetworkUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/NetworkUtils.kt
@@ -11,10 +11,6 @@ import android.net.wifi.WifiManager
 import android.os.Build
 import android.provider.Settings
 import androidx.core.net.toUri
-import dagger.hilt.EntryPoint
-import dagger.hilt.InstallIn
-import dagger.hilt.android.EntryPointAccessors
-import dagger.hilt.components.SingletonComponent
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,22 +19,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import org.ole.planet.myplanet.MainApplication.Companion.applicationScope
 import org.ole.planet.myplanet.MainApplication.Companion.context
-import org.ole.planet.myplanet.di.ApplicationScope
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
 object NetworkUtils {
-    private val coroutineScope: CoroutineScope by lazy {
-        val entryPoint = EntryPointAccessors.fromApplication(context, NetworkUtilsEntryPoint::class.java)
-        entryPoint.applicationScope()
-    }
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface NetworkUtilsEntryPoint {
-        @ApplicationScope
-        fun applicationScope(): CoroutineScope
-    }
+    private val coroutineScope: CoroutineScope = applicationScope
 
     private val connectivityManager: ConnectivityManager by lazy {
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager


### PR DESCRIPTION
## Summary
- replace NetworkUtils EntryPoint usage with direct applicationScope import

## Testing
- `./gradlew lint`

------
https://chatgpt.com/codex/tasks/task_e_68a86964ac78832b9219953627b2d01c