### PR TITLE
feedrepo

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -21,12 +21,18 @@ import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.repository.SubmissionRepositoryImpl
 import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.repository.TeamRepositoryImpl
+import org.ole.planet.myplanet.repository.FeedbackRepository
+import org.ole.planet.myplanet.repository.FeedbackRepositoryImpl
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.UserRepositoryImpl
 
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindFeedbackRepository(impl: FeedbackRepositoryImpl): FeedbackRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
@@ -1,0 +1,41 @@
+package org.ole.planet.myplanet.repository
+
+import javax.inject.Inject
+import org.ole.planet.myplanet.datamanager.DatabaseService
+
+import io.realm.Realm
+import io.realm.RealmChangeListener
+import io.realm.RealmResults
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.RealmUserModel
+
+interface FeedbackRepository {
+    fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>>
+}
+
+class FeedbackRepositoryImpl @Inject constructor(
+    private val databaseService: DatabaseService
+) : FeedbackRepository {
+    override fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>> = callbackFlow {
+        val mRealm = databaseService.realmInstance
+        val feedbackList: RealmResults<RealmFeedback> = if (userModel?.isManager() == true) {
+            mRealm.where(RealmFeedback::class.java).findAllAsync()
+        } else {
+            mRealm.where(RealmFeedback::class.java).equalTo("owner", userModel?.name).findAllAsync()
+        }
+
+        val listener = RealmChangeListener<RealmResults<RealmFeedback>> { results ->
+            trySend(mRealm.copyFromRealm(results))
+        }
+
+        feedbackList.addChangeListener(listener)
+
+        awaitClose {
+            feedbackList.removeChangeListener(listener)
+            mRealm.close()
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -10,11 +10,9 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
-import io.realm.Realm
-import io.realm.RealmChangeListener
-import io.realm.RealmResults
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
@@ -22,10 +20,10 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.SyncListener
 import org.ole.planet.myplanet.databinding.FragmentFeedbackListBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.service.SyncManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment.OnFeedbackSubmittedListener
@@ -37,13 +35,7 @@ import org.ole.planet.myplanet.utilities.SharedPrefManager
 class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     private var _binding: FragmentFeedbackListBinding? = null
     private val binding get() = _binding!!
-    private lateinit var mRealm: Realm
     var userModel: RealmUserModel? = null
-    private var feedbackList: RealmResults<RealmFeedback>? = null
-    private val feedbackChangeListener =
-        RealmChangeListener<RealmResults<RealmFeedback>> { results ->
-            updatedFeedbackList(results)
-        }
     private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
     lateinit var prefManager: SharedPrefManager
 
@@ -51,7 +43,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     @AppPreferences
     lateinit var settings: SharedPreferences
     @Inject
-    lateinit var databaseService: DatabaseService
+    lateinit var feedbackRepository: FeedbackRepository
     private val serverUrlMapper = ServerUrlMapper()
     
     @Inject
@@ -68,7 +60,6 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentFeedbackListBinding.inflate(inflater, container, false)
-        mRealm = databaseService.realmInstance
         userModel = UserProfileDbHandler(requireContext()).userModel
 
         binding.fab.setOnClickListener {
@@ -78,8 +69,6 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
                 feedbackFragment.show(childFragmentManager, "")
             }
         }
-
-        setupFeedbackListener()
 
         return binding.root
     }
@@ -119,8 +108,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
                     if (isAdded) {
                         customProgressDialog?.dismiss()
                         customProgressDialog = null
-                        refreshFeedbackData()
-
+                        onFeedbackSubmitted()
                         prefManager.setFeedbackSynced(true)
                     }
                 }
@@ -146,63 +134,13 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
         }
     }
 
-    private fun setupFeedbackListener() {
-        feedbackList?.removeChangeListener(feedbackChangeListener)
-        feedbackList = mRealm.where(RealmFeedback::class.java)
-            .equalTo("owner", userModel?.name).findAllAsync()
-        feedbackList?.addChangeListener(feedbackChangeListener)
-    }
-
-    private fun refreshFeedbackData() {
-        if (!isAdded || requireActivity().isFinishing) return
-
-        try {
-            var list: List<RealmFeedback>? = mRealm.where(RealmFeedback::class.java)
-                .equalTo("owner", userModel?.name).findAll()
-
-            if (userModel?.isManager() == true) {
-                list = mRealm.where(RealmFeedback::class.java).findAll()
-            }
-
-            val adapterFeedback = AdapterFeedback(requireActivity(), list)
-            binding.rvFeedback.adapter = adapterFeedback
-
-            val itemCount = list?.size ?: 0
-            showNoData(binding.tvMessage, itemCount, "feedback")
-            updateTextViewsVisibility(itemCount)
-
-            setupFeedbackListener()
-
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.rvFeedback.layoutManager = LinearLayoutManager(activity)
-
-        loadInitialFeedbackData()
-    }
-
-    private fun loadInitialFeedbackData() {
-        var list: List<RealmFeedback>? = mRealm.where(RealmFeedback::class.java)
-            .equalTo("owner", userModel?.name).findAll()
-        if (userModel?.isManager() == true) list = mRealm.where(RealmFeedback::class.java).findAll()
-        val adapterFeedback = AdapterFeedback(requireActivity(), list)
-        binding.rvFeedback.adapter = adapterFeedback
-
-        val itemCount = feedbackList?.size ?: 0
-        showNoData(binding.tvMessage, itemCount, "feedback")
-
-        updateTextViewsVisibility(itemCount)
+        onFeedbackSubmitted()
     }
 
     override fun onDestroyView() {
-        feedbackList?.removeChangeListener(feedbackChangeListener)
-        if (this::mRealm.isInitialized && !mRealm.isClosed) {
-            mRealm.close()
-        }
         _binding = null
         super.onDestroyView()
     }
@@ -214,28 +152,20 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     }
 
     override fun onFeedbackSubmitted() {
-        mRealm.executeTransactionAsync(
-            Realm.Transaction { },
-            Realm.Transaction.OnSuccess {
-                var updatedList = mRealm.where(RealmFeedback::class.java)
-                    .equalTo("owner", userModel?.name).findAll()
-                if (userModel?.isManager() == true) {
-                    updatedList = mRealm.where(RealmFeedback::class.java).findAll()
-                }
-                updatedFeedbackList(updatedList)
-            })
+        lifecycleScope.launch {
+            feedbackRepository.getFeedback(userModel).collectLatest { feedbackList ->
+                updatedFeedbackList(feedbackList)
+            }
+        }
     }
 
-    private fun updatedFeedbackList(updatedList: RealmResults<RealmFeedback>?) {
-        activity?.runOnUiThread {
-            val adapterFeedback = updatedList?.let { AdapterFeedback(requireActivity(), it) }
-            binding.rvFeedback.adapter = adapterFeedback
-            adapterFeedback?.notifyDataSetChanged()
-
-            val itemCount = updatedList?.size ?: 0
-            showNoData(binding.tvMessage, itemCount, "feedback")
-            updateTextViewsVisibility(itemCount)
-        }
+    private fun updatedFeedbackList(updatedList: List<RealmFeedback>?) {
+        val adapterFeedback = updatedList?.let { AdapterFeedback(requireActivity(), it) }
+        binding.rvFeedback.adapter = adapterFeedback
+        adapterFeedback?.notifyDataSetChanged()
+        val itemCount = updatedList?.size ?: 0
+        showNoData(binding.tvMessage, itemCount, "feedback")
+        updateTextViewsVisibility(itemCount)
     }
 
     private fun updateTextViewsVisibility(itemCount: Int) {
@@ -246,5 +176,4 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
         binding.tvStatus.visibility = visibility
         binding.tvOpenDate.visibility = visibility
     }
-
 }


### PR DESCRIPTION
This commit refactors the FeedbackListFragment to use a modern Repository pattern.

- A new `FeedbackRepository` is introduced to encapsulate all Realm database logic, which was previously handled directly in the fragment.
- The repository exposes feedback data using Kotlin Flows, replacing the old `RealmChangeListener`.
- Dagger/Hilt is used to inject the `FeedbackRepository` into the fragment, promoting a cleaner, more decoupled architecture.

This change is part of a larger effort to clean up the data layer and improve the overall architecture of the application.