### PR TITLE
Replace LibraryRepository with ResourceRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -44,7 +44,7 @@ import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmSubmission.Companion.getExamMap
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.repository.LibraryRepository
+import org.ole.planet.myplanet.repository.ResourceRepository
 import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.service.UserProfileDbHandler
@@ -72,7 +72,7 @@ abstract class BaseResourceFragment : Fragment() {
     @Inject
     lateinit var userRepository: UserRepository
     @Inject
-    lateinit var libraryRepository: LibraryRepository
+    lateinit var resourceRepository: ResourceRepository
     @Inject
     lateinit var submissionRepository: SubmissionRepository
     @Inject
@@ -109,7 +109,7 @@ abstract class BaseResourceFragment : Fragment() {
     private var receiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             this@BaseResourceFragment.lifecycleScope.launch {
-                val list = libraryRepository.getLibraryListForUser(
+                val list = resourceRepository.getLibraryListForUser(
                     settings.getString("userId", "--")
                 )
                 showDownloadDialog(list)
@@ -327,7 +327,7 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     suspend fun getLibraryList(mRealm: Realm): List<RealmMyLibrary> {
-        return libraryRepository.getLibraryListForUser(
+        return resourceRepository.getLibraryListForUser(
             settings.getString("userId", "--")
         )
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourceRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourceRepository.kt
@@ -1,6 +1,9 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.RealmTag
 
 interface ResourceRepository {
     suspend fun getAllLibraryItems(): List<RealmMyLibrary>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourceRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourceRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import javax.inject.Inject
 import com.google.gson.JsonObject
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
@@ -67,11 +66,19 @@ class ResourceRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getRatings(type: String, modelId: String?, userId: String?): HashMap<String?, JsonObject>? {
-        return RealmRating.getRatings(realm, type, modelId, userId)
+        return withRealm { realmInstance ->
+            if (modelId != null) {
+                RealmRating.getRatingsById(realmInstance, type, modelId, userId)?.let {
+                    hashMapOf(modelId to it)
+                }
+            } else {
+                RealmRating.getRatings(realmInstance, type, userId)
+            }
+        }
     }
 
     override suspend fun getLibraryList(): List<RealmMyLibrary?> {
-        return getList(RealmMyLibrary::class.java)
+        return queryList(RealmMyLibrary::class.java) as List<RealmMyLibrary?>
     }
 
     override suspend fun saveSearchActivity(activity: RealmSearchActivity) {
@@ -86,6 +93,6 @@ class ResourceRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getParentTag(tagId: String?): RealmTag? {
-        return findByField(RealmTag::class.java, "id", tagId)
+        return tagId?.let { findByField(RealmTag::class.java, "id", it) }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
@@ -14,7 +14,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.repository.CourseProgressRepository
 import org.ole.planet.myplanet.repository.CourseRepository
-import org.ole.planet.myplanet.repository.LibraryRepository
+import org.ole.planet.myplanet.repository.ResourceRepository
 import org.ole.planet.myplanet.repository.RatingRepository
 import org.ole.planet.myplanet.repository.SearchRepository
 import org.ole.planet.myplanet.repository.UserRepository
@@ -22,7 +22,7 @@ import org.ole.planet.myplanet.repository.UserRepository
 @HiltViewModel
 class CoursesViewModel @Inject constructor(
     private val courseRepository: CourseRepository,
-    private val libraryRepository: LibraryRepository,
+    private val resourceRepository: ResourceRepository,
     private val userRepository: UserRepository,
     private val ratingRepository: RatingRepository,
     private val courseProgressRepository: CourseProgressRepository,
@@ -98,7 +98,7 @@ class CoursesViewModel @Inject constructor(
 
     suspend fun getCourseLibraryItems(courseIds: List<String>): List<RealmMyLibrary> {
         return try {
-            libraryRepository.getCourseLibraryItems(courseIds)
+            resourceRepository.getCourseLibraryItems(courseIds)
         } catch (e: Exception) {
             emptyList()
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -16,8 +16,8 @@ import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.repository.CourseRepository
-import org.ole.planet.myplanet.repository.LibraryRepository
 import org.ole.planet.myplanet.repository.NotificationRepository
+import org.ole.planet.myplanet.repository.ResourceRepository
 import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.repository.UserRepository
 
@@ -25,7 +25,7 @@ import org.ole.planet.myplanet.repository.UserRepository
 class DashboardViewModel @Inject constructor(
     private val databaseService: DatabaseService,
     private val userRepository: UserRepository,
-    private val libraryRepository: LibraryRepository,
+    private val resourceRepository: ResourceRepository,
     private val courseRepository: CourseRepository,
     private val submissionRepository: SubmissionRepository,
     private val notificationRepository: NotificationRepository

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -45,7 +45,6 @@ import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmTag.Companion.getTagsArray
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.repository.ResourceRepository
 import org.ole.planet.myplanet.service.SyncManager
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
@@ -82,10 +81,6 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     @Inject
     lateinit var syncManager: SyncManager
-
-    @Inject
-    lateinit var resourceRepository: ResourceRepository
-
     private val serverUrlMapper = ServerUrlMapper()
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamResource/TeamResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamResource/TeamResourceFragment.kt
@@ -77,7 +77,7 @@ class TeamResourceFragment : BaseTeamFragment(), TeamPageListener, ResourceUpdat
         viewLifecycleOwner.lifecycleScope.launch {
             val existing = teamRepository.getTeamResources(teamId)
             val existingIds = existing.mapNotNull { it._id }
-            val availableLibraries = libraryRepository.getAllLibraryItems()
+            val availableLibraries = resourceRepository.getAllLibraryItems()
                 .filter { it._id !in existingIds }
 
             val titleView = TextView(safeActivity).apply {


### PR DESCRIPTION
## Summary
- use `ResourceRepository` instead of missing `LibraryRepository` across view models and fragments
- add required imports and implement missing methods in `ResourceRepository`
- simplify resource handling by removing redundant repository injection

## Testing
- `./gradlew assembleLiteDebug --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68ac2e18b2dc832ba319f115e62fd607