### PR TITLE
Refactor SD path and Play Store intent

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ConfigurationManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ConfigurationManager.kt
@@ -21,7 +21,7 @@ import org.ole.planet.myplanet.utilities.LocaleHelper
 import org.ole.planet.myplanet.utilities.NetworkUtils.extractProtocol
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.UrlUtils
-import org.ole.planet.myplanet.utilities.Utilities
+import org.ole.planet.myplanet.utilities.IntentUtils
 
 class ConfigurationManager(
     private val context: Context,
@@ -225,7 +225,7 @@ class ConfigurationManager(
             builder.setCancelable(true)
             builder.setNegativeButton(R.string.okay) { dialog: DialogInterface, _: Int ->
                 if (playStoreRedirect) {
-                    Utilities.openPlayStore()
+                    IntentUtils.openPlayStore(context)
                 }
                 dialog.cancel()
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
@@ -47,6 +47,7 @@ import org.ole.planet.myplanet.utilities.EdgeToEdgeUtil
 import org.ole.planet.myplanet.utilities.FileUtils.availableOverTotalMemoryFormattedString
 import org.ole.planet.myplanet.utilities.LocaleHelper
 import org.ole.planet.myplanet.utilities.ThemeManager
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -190,7 +191,7 @@ class SettingActivity : AppCompatActivity() {
                                         library.resourceOffline = false
                                     }
                                 }, {
-                                    val f = File(Utilities.SD_PATH)
+                                    val f = File(FileUtils.SD_PATH)
                                     deleteRecursive(f)
                                     Utilities.toast(requireActivity(), R.string.data_cleared.toString())
                                 }) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
@@ -22,6 +22,7 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtil
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.NetworkUtils
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -73,7 +74,7 @@ class NewsDetailActivity : BaseActivity() {
                 val library = realm.where(RealmMyLibrary::class.java).equalTo("_id", resourceId).findFirst()
                 msg = msg?.replace(
                     markDown,
-                    "<img style=\"float: right; padding: 10px 10px 10px 10px;\"  width=\"200px\" src=\"file://" + Utilities.SD_PATH + "/" + library?.id + "/" + library?.resourceLocalAddress + "\"/>",
+                    "<img style=\"float: right; padding: 10px 10px 10px 10px;\"  width=\"200px\" src=\"file://" + FileUtils.SD_PATH + "/" + library?.id + "/" + library?.resourceLocalAddress + "\"/>",
                     false
                 )
             }
@@ -120,7 +121,7 @@ class NewsDetailActivity : BaseActivity() {
                 realm.where(RealmMyLibrary::class.java).equalTo("_id", resourceId).findFirst()
             if (library != null) {
                 Glide.with(this)
-                    .load(File(Utilities.SD_PATH, library.id + "/" + library.resourceLocalAddress))
+                    .load(File(FileUtils.SD_PATH, library.id + "/" + library.resourceLocalAddress))
                     .into(binding.img)
                 binding.img.visibility = View.VISIBLE
                 return

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -94,6 +94,7 @@ import org.ole.planet.myplanet.utilities.NotificationUtil.cancelAll
 import org.ole.planet.myplanet.utilities.ServerConfigUtils
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.UrlUtils
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.Utilities.getRelativeTime
 
@@ -234,7 +235,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
     }
 
     private fun clearInternalStorage() {
-        val myDir = File(Utilities.SD_PATH)
+        val myDir = File(FileUtils.SD_PATH)
         if (myDir.isDirectory) {
             val children = myDir.list()
             if (children != null) {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
@@ -87,7 +87,7 @@ object CameraUtils {
 
     @JvmStatic
     private fun savePicture(data: ByteArray, callback: ImageCaptureCallback) {
-        val pictureFileDir = File("${Utilities.SD_PATH}/userimages")
+        val pictureFileDir = File("${FileUtils.SD_PATH}/userimages")
         if (!pictureFileDir.exists() && !pictureFileDir.mkdirs()) {
             pictureFileDir.mkdirs()
         }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
@@ -23,6 +23,10 @@ import java.util.UUID
 import org.ole.planet.myplanet.MainApplication.Companion.context
 
 object FileUtils {
+    val SD_PATH: String by lazy {
+        context.getExternalFilesDir(null)?.let { "${it}/ole/" } ?: ""
+    }
+
     @JvmStatic
     @Throws(IOException::class)
     fun fullyReadFileToBytes(f: File): ByteArray = f.readBytes()
@@ -200,7 +204,7 @@ object FileUtils {
     @JvmStatic
     fun openOleFolder(): Intent {
         val intent = Intent(Intent.ACTION_GET_CONTENT)
-        val uri = Utilities.SD_PATH.toUri()  // Ensure org.ole.planet.myplanet.utilities.Utilities.SD_PATH is the correct path
+        val uri = SD_PATH.toUri()
         intent.setDataAndType(uri, "*/*")
         return Intent.createChooser(intent, "Open folder")
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/IntentUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/IntentUtils.kt
@@ -1,7 +1,9 @@
 package org.ole.planet.myplanet.utilities
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import androidx.core.net.toUri
 import org.ole.planet.myplanet.ui.viewer.AudioPlayerActivity
 
 object IntentUtils {
@@ -13,5 +15,22 @@ object IntentUtils {
             putExtra("RESOURCE_TITLE", resourceTitle)
         }
         context.startActivity(intent)
+    }
+
+    @JvmStatic
+    fun openPlayStore(context: Context) {
+        val appPackageName = context.packageName
+        val intent = Intent(Intent.ACTION_VIEW, "market://details?id=$appPackageName".toUri()).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        try {
+            context.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            val webIntent = Intent(
+                Intent.ACTION_VIEW,
+                "https://play.google.com/store/apps/details?id=$appPackageName".toUri(),
+            ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+            context.startActivity(webIntent)
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
@@ -1,7 +1,6 @@
 package org.ole.planet.myplanet.utilities
 
 import android.content.Context
-import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Handler
 import android.os.Looper
@@ -22,9 +21,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
 object Utilities {
-    val SD_PATH: String by lazy {
-        context.getExternalFilesDir(null)?.let { "$it/ole/" } ?: ""
-    }
 
     @JvmStatic
     fun log(message: String) {
@@ -125,21 +121,5 @@ object Utilities {
     fun getMimeType(url: String?): String? {
         val extension = FileUtils.getFileExtension(url)
         return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
-    }
-
-    fun openPlayStore() {
-        val appPackageName = context.packageName
-        val intent = Intent(Intent.ACTION_VIEW, "market://details?id=$appPackageName".toUri()).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-        try {
-            context.startActivity(intent)
-        } catch (e: android.content.ActivityNotFoundException) {
-            val webIntent = Intent(Intent.ACTION_VIEW,
-                "https://play.google.com/store/apps/details?id=$appPackageName".toUri()).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-            context.startActivity(webIntent)
-        }
     }
 }


### PR DESCRIPTION
## Summary
- centralize SD card path handling in FileUtils and update callers
- expose Play Store intent via IntentUtils and remove legacy logic
- drop obsolete Utilities entries and adjust imports

## Testing
- `./gradlew assemble` *(fails: command terminated without completion)*

------
https://chatgpt.com/codex/tasks/task_e_68ac428081dc832b8c488aed33fd71b0