### PR TITLE
Ensure proper resource cleanup

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
@@ -95,9 +95,9 @@ object CameraUtils {
         val filename = "${pictureFileDir.path}${File.separator}$photoFile"
         val mainPicture = File(filename)
         try {
-            val fos = FileOutputStream(mainPicture)
-            fos.write(data)
-            fos.close()
+            FileOutputStream(mainPicture).use { fos ->
+                fos.write(data)
+            }
             callback.onImageCapture(mainPicture.absolutePath)
         } catch (error: Exception) {
             error.printStackTrace()

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/MapTileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/MapTileUtils.kt
@@ -15,13 +15,12 @@ object MapTileUtils {
         val assetManager = context.assets
         try {
             for (s in tiles) {
-                var out: OutputStream
-                val `in`: InputStream = assetManager.open(s)
                 val outFile = File(Environment.getExternalStorageDirectory().toString() + "/osmdroid", s)
-                out = FileOutputStream(outFile)
-                copyFile(`in`, out)
-                out.close()
-                `in`.close()
+                assetManager.open(s).use { input ->
+                    FileOutputStream(outFile).use { output ->
+                        copyFile(input, output)
+                    }
+                }
             }
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
## Summary
- use structured streams to close asset copy resources automatically
- write camera image files with use to avoid leaking handles
- wrap download streams in use blocks for consistent cleanup
- streamline worker file writes with use and auto closure

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c4f24320832e9ef59ab0309334f9