### PR TITLE
community: include shared replies in community feed (fixes #6667)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityFragment.kt
@@ -48,7 +48,7 @@ class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickLi
         fragmentCommunityBinding = FragmentCommunityBinding.inflate(inflater, container, false)
         newList = mRealm.where(RealmNews::class.java).equalTo("docType", "message", Case.INSENSITIVE)
             .equalTo("viewableBy", "community", Case.INSENSITIVE)
-            .equalTo("createdOn", user?.planetCode, Case.INSENSITIVE).isEmpty("replyTo")
+            .equalTo("createdOn", user?.planetCode, Case.INSENSITIVE)
             .sort("time", Sort.DESCENDING).findAll()
         newsListChangeListener = RealmChangeListener { results ->
             updatedNewsList(results)
@@ -66,7 +66,7 @@ class CommunityFragment : BaseContainerFragment(), AdapterNews.OnNewsItemClickLi
         }
         newList = mRealm.where(RealmNews::class.java).equalTo("docType", "message", Case.INSENSITIVE)
             .equalTo("viewableBy", "community", Case.INSENSITIVE)
-            .equalTo("createdOn", user?.planetCode, Case.INSENSITIVE).isEmpty("replyTo")
+            .equalTo("createdOn", user?.planetCode, Case.INSENSITIVE)
             .sort("time", Sort.DESCENDING).findAll()
         val orientation = resources.configuration.orientation
         changeLayoutManager(orientation)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
@@ -234,8 +234,15 @@ class AdapterNews(var context: Context, private val list: MutableList<RealmNews?
     }
 
     private fun setMessageAndDate(holder: ViewHolderNews, news: RealmNews, sharedTeamName: String) {
+        var message = news.message ?: ""
+        if (!news.replyTo.isNullOrEmpty()) {
+            val parent = mRealm.where(RealmNews::class.java).equalTo("id", news.replyTo, Case.INSENSITIVE).findFirst()
+            val parentUser = parent?.userName ?: ""
+            val prefix = if (parentUser.isNotEmpty()) "Reply to $parentUser:\n" else "Reply:\n"
+            message = prefix + message
+        }
         val markdownContentWithLocalPaths = prependBaseUrlToImages(
-            news.message,
+            message,
             "file://" + context.getExternalFilesDir(null) + "/ole/",
             600,
             350


### PR DESCRIPTION
fixes #6667


## Summary
- show replies shared to community by removing `replyTo` filter
- display parent context for shared replies in news feed

------
https://chatgpt.com/codex/tasks/task_e_68acbf69b4ec832bb69e1c87080b0f5b