### PR TITLE
Use scoped Realm instance in RealmMyTeam

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -294,9 +294,10 @@ open class RealmMyTeam : RealmObject() {
                     }
                     withContext(Dispatchers.IO) {
                         val apiInterface = client?.create(ApiInterface::class.java)
-                        val realm = DatabaseService(context).realmInstance
-                        realm.executeTransaction { transactionRealm ->
-                            uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
+                        DatabaseService(context).withRealm { realm ->
+                            realm.executeTransaction { transactionRealm ->
+                                uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
+                            }
                         }
                     }
                 } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- use DatabaseService.withRealm in RealmMyTeam to automatically close Realm instance

## Testing
- `./gradlew assemble -x test` *(fails: Gradle build daemon disappeared unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68ad96a106d4832b86254a22336346e2