### PR TITLE
all: smoother profile realm handling (fixes #7090)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2976
-        versionName = "0.29.76"
+        versionCode = 2977
+        versionName = "0.29.77"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -373,26 +373,27 @@ abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
 
     private fun updateRealmUserSecurityData(name: String, userId: String?, rev: String?, derivedKey: String?, salt: String?, passwordScheme: String?, iterations: String?, securityCallback: SecurityDataCallback? = null) {
         try {
-            val realm = databaseService.realmInstance
-            realm.executeTransactionAsync({ transactionRealm ->
-                val user = transactionRealm.where(RealmUserModel::class.java)
-                    .equalTo("name", name)
-                    .findFirst()
+            databaseService.withRealm { realm ->
+                realm.executeTransactionAsync({ transactionRealm ->
+                    val user = transactionRealm.where(RealmUserModel::class.java)
+                        .equalTo("name", name)
+                        .findFirst()
 
-                if (user != null) {
-                    user._id = userId
-                    user._rev = rev
-                    user.derived_key = derivedKey
-                    user.salt = salt
-                    user.password_scheme = passwordScheme
-                    user.iterations = iterations
-                    user.isUpdated = false
+                    if (user != null) {
+                        user._id = userId
+                        user._rev = rev
+                        user.derived_key = derivedKey
+                        user.salt = salt
+                        user.password_scheme = passwordScheme
+                        user.iterations = iterations
+                        user.isUpdated = false
+                    }
+                }, {
+                    securityCallback?.onSecurityDataUpdated()
+                }) { error ->
+                    error.printStackTrace()
+                    securityCallback?.onSecurityDataUpdated()
                 }
-            }, {
-                securityCallback?.onSecurityDataUpdated()
-            }) { error ->
-                error.printStackTrace()
-                securityCallback?.onSecurityDataUpdated()
             }
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
## Summary
- refactor user security update logic to use `databaseService.withRealm`
- ensure callbacks still notify security updates after async transactions

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68ad96c6fc18832b8cc41f0df796c430