### PR TITLE
teams: smoother discussion list realm handling (fixes #7092)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2976
-        versionName = "0.29.76"
+        versionCode = 2979
+        versionName = "0.29.79"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamDiscussion/DiscussionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamDiscussion/DiscussionListFragment.kt
@@ -255,6 +255,15 @@ class DiscussionListFragment : BaseTeamFragment() {
         showRecyclerView(list)
     }
 
+    override fun onDestroyView() {
+        updatedNewsList?.removeAllChangeListeners()
+        updatedNewsList = null
+        if (isRealmInitialized()) {
+            mRealm.close()
+        }
+        super.onDestroyView()
+    }
+
     private fun shouldQueryTeamFromRealm(): Boolean {
         val hasDirectData = requireArguments().containsKey("teamName") &&
                 requireArguments().containsKey("teamType") &&


### PR DESCRIPTION
## Summary
- Release Realm news listeners and close Realm in `DiscussionListFragment`

## Testing
- `./gradlew :app:compileLiteDebugKotlin --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68ad9750fe48832b8c33385b273008d5