### PR TITLE
teams: smoother finances realm closing (fixes #7094)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2976
-        versionName = "0.29.76"
+        versionCode = 2981
+        versionName = "0.29.81"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/FinanceFragment.kt
@@ -272,4 +272,13 @@ class FinanceFragment : BaseTeamFragment() {
             }
         }
     }
+
+    override fun onDestroyView() {
+        list?.removeAllChangeListeners()
+        list = null
+        if (isRealmInitialized()) {
+            mRealm.close()
+        }
+        super.onDestroyView()
+    }
 }


### PR DESCRIPTION
## Summary
- release FinanceFragment Realm resources in onDestroyView
- detach listeners and null out list when view is destroyed

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68ad976d1b9c832b8fc343c3e348251a