### PR TITLE
all: smoother feedback repository realm handling (fixes #7091)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2976
-        versionName = "0.29.76"
+        versionCode = 2978
+        versionName = "0.29.78"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import io.realm.Realm
 import io.realm.RealmChangeListener
 import io.realm.RealmResults
 import javax.inject.Inject
@@ -16,25 +15,29 @@ interface FeedbackRepository {
 }
 
 class FeedbackRepositoryImpl @Inject constructor(
-    private val databaseService: DatabaseService
+    private val databaseService: DatabaseService,
 ) : FeedbackRepository {
-    override fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>> = callbackFlow {
-        val mRealm = databaseService.realmInstance
-        val feedbackList: RealmResults<RealmFeedback> = if (userModel?.isManager() == true) {
-            mRealm.where(RealmFeedback::class.java).findAllAsync()
-        } else {
-            mRealm.where(RealmFeedback::class.java).equalTo("owner", userModel?.name).findAllAsync()
-        }
+    override fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>> =
+        databaseService.withRealm { realm ->
+            callbackFlow {
+                val feedbackList: RealmResults<RealmFeedback> =
+                    if (userModel?.isManager() == true) {
+                        realm.where(RealmFeedback::class.java).findAllAsync()
+                    } else {
+                        realm.where(RealmFeedback::class.java).equalTo("owner", userModel?.name)
+                            .findAllAsync()
+                    }
 
-        val listener = RealmChangeListener<RealmResults<RealmFeedback>> { results ->
-            trySend(mRealm.copyFromRealm(results))
-        }
+                val listener = RealmChangeListener<RealmResults<RealmFeedback>> { results ->
+                    trySend(realm.copyFromRealm(results))
+                }
 
-        feedbackList.addChangeListener(listener)
+                feedbackList.addChangeListener(listener)
 
-        awaitClose {
-            feedbackList.removeChangeListener(listener)
-            mRealm.close()
+                awaitClose {
+                    feedbackList.removeChangeListener(listener)
+                    realm.close()
+                }
+            }
         }
-    }
 }


### PR DESCRIPTION
## Summary
- replace deprecated `realmInstance` with `databaseService.withRealm` in `FeedbackRepository`
- wrap `callbackFlow` inside `withRealm` and close the instance via `awaitClose`

## Testing
- `./gradlew lint` *(fails: Preparing "Install Android SDK Build-Tools 35 v.35.0.0")*

------
https://chatgpt.com/codex/tasks/task_e_68ad9898d7e0832b97378b9b69c6f074