### PR TITLE
Use withRealm to auto-close Realm instance

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -285,19 +285,28 @@ class AddResourceFragment : BottomSheetDialogFragment() {
                         return@setPositiveButton
                     }
                     val desc = etDesc.text.toString().trim { it <= ' ' }
-                    val realm = databaseService.realmInstance
-                    realm.executeTransactionAsync(
-                        Realm.Transaction { realm1: Realm -> val myPersonal = realm1.createObject(RealmMyPersonal::class.java, UUID.randomUUID().toString())
-                            myPersonal.title = title
-                            myPersonal.userId = userId
-                            myPersonal.userName = userName
-                            myPersonal.path = path
-                            myPersonal.date = Date().time
-                            myPersonal.description = desc
-                        },
-                        Realm.Transaction.OnSuccess {
-                            Utilities.toast(MainApplication.context, context.getString(R.string.resource_saved_to_my_personal))
-                        })
+                    databaseService.withRealm { realm ->
+                        realm.executeTransactionAsync(
+                            Realm.Transaction { realm1: Realm ->
+                                val myPersonal = realm1.createObject(
+                                    RealmMyPersonal::class.java,
+                                    UUID.randomUUID().toString()
+                                )
+                                myPersonal.title = title
+                                myPersonal.userId = userId
+                                myPersonal.userName = userName
+                                myPersonal.path = path
+                                myPersonal.date = Date().time
+                                myPersonal.description = desc
+                            },
+                            Realm.Transaction.OnSuccess {
+                                Utilities.toast(
+                                    MainApplication.context,
+                                    context.getString(R.string.resource_saved_to_my_personal)
+                                )
+                            }
+                        )
+                    }
                     if (type == 1) {
                         myPersonalsFragment?.refreshFragment()
                     }


### PR DESCRIPTION
## Summary
- replace manual `realmInstance` management with `databaseService.withRealm` when saving resources to ensure Realm closes automatically

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68aed91de398832b8e999351c9049ddc