### PR TITLE
teams: smoother survey realm handling and closing (fixes #7123)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2987
-        versionName = "0.29.87"
+        versionCode = 2991
+        versionName = "0.29.91"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- use `withRealm` to load survey users without keeping a Realm instance
- wrap survey submission creation in `withRealm`
- clean up Realm in `onDestroy`

## Testing
- `./gradlew spotlessApply` *(fails: Task 'spotlessApply' not found)*
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68aed9f4a5e0832bb4022935f643e0c3