### PR TITLE
all: smoother notification realm handling and closing (fixes #7124)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2987
-        versionName = "0.29.87"
+        versionCode = 2991
+        versionName = "0.29.91"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2991
-        versionName = "0.29.91"
+        versionCode = 2992
+        versionName = "0.29.92"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -311,7 +311,7 @@ class NotificationsFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         _binding = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -16,8 +16,8 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Sort
 import java.util.ArrayList
-import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import org.json.JSONObject
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.R.array.status_options

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -10,12 +10,13 @@ import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
-import io.realm.Realm
 import io.realm.Sort
 import java.util.ArrayList
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import org.json.JSONObject
 import org.ole.planet.myplanet.R
@@ -36,10 +37,10 @@ import org.ole.planet.myplanet.ui.team.TeamPageConfig.TasksPage
 
 @AndroidEntryPoint
 class NotificationsFragment : Fragment() {
-    private lateinit var fragmentNotificationsBinding: FragmentNotificationsBinding
+    private var _binding: FragmentNotificationsBinding? = null
+    private val binding get() = _binding!!
     @Inject
     lateinit var databaseService: DatabaseService
-    private lateinit var mRealm: Realm
     private lateinit var adapter: AdapterNotification
     private lateinit var userId: String
     private var notificationUpdateListener: NotificationListener? = null
@@ -57,8 +58,7 @@ class NotificationsFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentNotificationsBinding = FragmentNotificationsBinding.inflate(inflater, container, false)
-        mRealm = databaseService.realmInstance
+        _binding = FragmentNotificationsBinding.inflate(inflater, container, false)
         userId = arguments?.getString("userId") ?: ""
 
         val notifications = loadNotifications(userId, "all")
@@ -67,25 +67,21 @@ class NotificationsFragment : Fragment() {
         val optionsList: MutableList<String?> = ArrayList(listOf(*options))
         val spinnerAdapter = ArrayAdapter(requireContext(), R.layout.spinner_item, optionsList)
         spinnerAdapter.setDropDownViewResource(R.layout.spinner_item)
-        fragmentNotificationsBinding.status.adapter = spinnerAdapter
-        fragmentNotificationsBinding.status.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        binding.status.adapter = spinnerAdapter
+        binding.status.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
                 val selectedOption = parent.getItemAtPosition(position).toString().lowercase()
                 val filteredNotifications = loadNotifications(userId, selectedOption)
                 adapter.updateNotifications(filteredNotifications)
 
-                if (filteredNotifications.isEmpty()) {
-                    fragmentNotificationsBinding.emptyData.visibility = View.VISIBLE
-                } else {
-                    fragmentNotificationsBinding.emptyData.visibility = View.GONE
-                }
+                binding.emptyData.visibility = if (filteredNotifications.isEmpty()) View.VISIBLE else View.GONE
             }
 
             override fun onNothingSelected(parent: AdapterView<*>) {}
         }
 
         if (notifications.isEmpty()) {
-            fragmentNotificationsBinding.emptyData.visibility = View.VISIBLE
+            binding.emptyData.visibility = View.VISIBLE
         }
 
         adapter = AdapterNotification(
@@ -98,14 +94,14 @@ class NotificationsFragment : Fragment() {
                 handleNotificationClick(notification)
             }
         )
-        fragmentNotificationsBinding.rvNotifications.adapter = adapter
-        fragmentNotificationsBinding.rvNotifications.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvNotifications.adapter = adapter
+        binding.rvNotifications.layoutManager = LinearLayoutManager(requireContext())
 
-        fragmentNotificationsBinding.btnMarkAllAsRead.setOnClickListener {
+        binding.btnMarkAllAsRead.setOnClickListener {
             markAllAsRead()
         }
         updateMarkAllAsReadButtonVisibility()
-        return fragmentNotificationsBinding.root
+        return binding.root
     }
 
     private fun handleNotificationClick(notification: RealmNotification) {
@@ -115,29 +111,40 @@ class NotificationsFragment : Fragment() {
                 startActivity(intent)
             }
             "survey" -> {
-                val currentStepExam = mRealm.where(RealmStepExam::class.java).equalTo("name", notification.relatedId)
-                    .findFirst()
-                if (currentStepExam != null && activity is OnHomeItemClickListener) {
-                    AdapterMySubmission.openSurvey(activity as OnHomeItemClickListener, currentStepExam.id, false, false, "")
+                databaseService.withRealm { realm ->
+                    val currentStepExam = realm.where(RealmStepExam::class.java)
+                        .equalTo("name", notification.relatedId)
+                        .findFirst()
+                    if (currentStepExam != null && activity is OnHomeItemClickListener) {
+                        AdapterMySubmission.openSurvey(
+                            activity as OnHomeItemClickListener,
+                            currentStepExam.id,
+                            false,
+                            false,
+                            "",
+                        )
+                    }
                 }
             }
             "task" -> {
-                val taskId = notification.relatedId
-                val task = mRealm.where(RealmTeamTask::class.java)
-                    .equalTo("id", taskId)
-                    .findFirst()
+                databaseService.withRealm { realm ->
+                    val taskId = notification.relatedId
+                    val task = realm.where(RealmTeamTask::class.java)
+                        .equalTo("id", taskId)
+                        .findFirst()
 
-                val linkJson = JSONObject(task?.link ?: "{}")
-                val teamId = linkJson.optString("teams")
-                if (teamId.isNotEmpty()) {
-                    if (activity is OnHomeItemClickListener) {
-                        val teamObject = mRealm.where(RealmMyTeam::class.java)?.equalTo("_id", teamId)?.findFirst()
+                    val linkJson = JSONObject(task?.link ?: "{}")
+                    val teamId = linkJson.optString("teams")
+                    if (teamId.isNotEmpty() && activity is OnHomeItemClickListener) {
+                        val teamObject = realm.where(RealmMyTeam::class.java)
+                            .equalTo("_id", teamId)
+                            .findFirst()
                         val f = TeamDetailFragment.newInstance(
                             teamId = teamId,
                             teamName = teamObject?.name ?: "",
                             teamType = teamObject?.type ?: "",
                             isMyTeam = true,
-                            navigateToPage = TasksPage
+                            navigateToPage = TasksPage,
                         )
 
                         (activity as OnHomeItemClickListener).openCallFragment(f)
@@ -152,20 +159,22 @@ class NotificationsFragment : Fragment() {
                     } else {
                         joinRequestId
                     }
-                    val joinRequest = mRealm.where(RealmMyTeam::class.java)
-                        .equalTo("_id", actualJoinRequestId)
-                        .equalTo("docType", "request")
-                        .findFirst()
+                    databaseService.withRealm { realm ->
+                        val joinRequest = realm.where(RealmMyTeam::class.java)
+                            .equalTo("_id", actualJoinRequestId)
+                            .equalTo("docType", "request")
+                            .findFirst()
 
-                    val teamId = joinRequest?.teamId
-                    if (teamId?.isNotEmpty() == true) {
-                        val f = TeamDetailFragment()
-                        val b = Bundle()
-                        b.putString("id", teamId)
-                        b.putBoolean("isMyTeam", true)
-                        b.putString("navigateToPage", JoinRequestsPage.id)
-                        f.arguments = b
-                        (activity as OnHomeItemClickListener).openCallFragment(f)
+                        val teamId = joinRequest?.teamId
+                        if (teamId?.isNotEmpty() == true) {
+                            val f = TeamDetailFragment()
+                            val b = Bundle()
+                            b.putString("id", teamId)
+                            b.putBoolean("isMyTeam", true)
+                            b.putString("navigateToPage", JoinRequestsPage.id)
+                            f.arguments = b
+                            (activity as OnHomeItemClickListener).openCallFragment(f)
+                        }
                     }
                 }
             }
@@ -185,95 +194,103 @@ class NotificationsFragment : Fragment() {
     }
 
     private fun loadNotifications(userId: String, filter: String): List<RealmNotification> {
-        val query = mRealm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
+        return databaseService.withRealm { realm ->
+            val query = realm.where(RealmNotification::class.java)
+                .equalTo("userId", userId)
 
-        when (filter) {
-            "read" -> query.equalTo("isRead", true)
-            "unread" -> query.equalTo("isRead", false)
-            "all" -> {}
-        }
+            when (filter) {
+                "read" -> query.equalTo("isRead", true)
+                "unread" -> query.equalTo("isRead", false)
+                "all" -> {}
+            }
 
-        val results = query.sort("createdAt", Sort.DESCENDING).findAll()
-        return mRealm.copyFromRealm(results).filter {
-            it.message.isNotEmpty() && it.message != "INVALID"
+            val results = query.sort("createdAt", Sort.DESCENDING).findAll()
+            realm.copyFromRealm(results).filter {
+                it.message.isNotEmpty() && it.message != "INVALID"
+            }
         }
     }
 
     private fun markAsRead(position: Int) {
         val notification = adapter.currentList[position]
         val notificationId = notification.id
-        mRealm.executeTransactionAsync({ realm ->
-            val realmNotification = realm.where(RealmNotification::class.java)
-                .equalTo("id", notificationId)
-                .findFirst()
-            realmNotification?.isRead = true
-        }, {
-            activity?.runOnUiThread {
-                adapter.updateNotifications(
-                    loadNotifications(
-                        userId,
-                        fragmentNotificationsBinding.status.selectedItem.toString().lowercase()
-                    )
-                )
-                updateUnreadCount()
-                updateMarkAllAsReadButtonVisibility()
+        viewLifecycleOwner.lifecycleScope.launch {
+            databaseService.executeTransactionAsync { realm ->
+                val realmNotification = realm.where(RealmNotification::class.java)
+                    .equalTo("id", notificationId)
+                    .findFirst()
+                realmNotification?.isRead = true
             }
-        }, {})
+            adapter.updateNotifications(
+                loadNotifications(
+                    userId,
+                    binding.status.selectedItem.toString().lowercase(),
+                ),
+            )
+            updateUnreadCount()
+            updateMarkAllAsReadButtonVisibility()
+        }
     }
 
     private fun markAsReadById(notificationId: String) {
-        mRealm.executeTransaction { realm ->
-            val realmNotification = realm.where(RealmNotification::class.java)
-                .equalTo("id", notificationId)
-                .findFirst()
-            realmNotification?.isRead = true
-        }
-        val currentList = adapter.currentList.toMutableList()
-        val index = currentList.indexOfFirst { it.id == notificationId }
-        if (index != -1) {
-            val notification = currentList[index]
-            val updatedNotification = mRealm.copyFromRealm(notification)
-            updatedNotification.isRead = true
-            currentList[index] = updatedNotification
-            adapter.submitList(currentList)
-            adapter.notifyItemChanged(index)
-            updateUnreadCount()
-            updateMarkAllAsReadButtonVisibility()
-        } else {
-            refreshNotificationsList()
+        viewLifecycleOwner.lifecycleScope.launch {
+            databaseService.executeTransactionAsync { realm ->
+                val realmNotification = realm.where(RealmNotification::class.java)
+                    .equalTo("id", notificationId)
+                    .findFirst()
+                realmNotification?.isRead = true
+            }
+            val currentList = adapter.currentList.toMutableList()
+            val index = currentList.indexOfFirst { it.id == notificationId }
+            if (index != -1) {
+                currentList[index].isRead = true
+                adapter.submitList(currentList)
+                adapter.notifyItemChanged(index)
+                updateUnreadCount()
+                updateMarkAllAsReadButtonVisibility()
+            } else {
+                refreshNotificationsList()
+            }
         }
     }
 
     private fun markAllAsRead() {
-        mRealm.executeTransactionAsync({ realm ->
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("isRead", false)
-                .findAll()
-                .forEach { it.isRead = true }
-        }, {
-            activity?.runOnUiThread {
-                adapter.updateNotifications(loadNotifications(userId, fragmentNotificationsBinding.status.selectedItem.toString().lowercase()))
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                databaseService.executeTransactionAsync { realm ->
+                    realm.where(RealmNotification::class.java)
+                        .equalTo("userId", userId)
+                        .equalTo("isRead", false)
+                        .findAll()
+                        .forEach { it.isRead = true }
+                }
+                adapter.updateNotifications(
+                    loadNotifications(
+                        userId,
+                        binding.status.selectedItem.toString().lowercase(),
+                    ),
+                )
                 updateMarkAllAsReadButtonVisibility()
                 updateUnreadCount()
+            } catch (e: Exception) {
+                Snackbar.make(binding.root, getString(R.string.failed_to_mark_as_read), Snackbar.LENGTH_LONG).show()
             }
-        }, {
-            Snackbar.make(fragmentNotificationsBinding.root, getString(R.string.failed_to_mark_as_read), Snackbar.LENGTH_LONG).show()
-        })
+        }
     }
 
     private fun updateMarkAllAsReadButtonVisibility() {
         val unreadCount = getUnreadNotificationsSize()
-        fragmentNotificationsBinding.btnMarkAllAsRead.visibility = if (unreadCount > 0) View.VISIBLE else View.GONE
+        binding.btnMarkAllAsRead.visibility = if (unreadCount > 0) View.VISIBLE else View.GONE
     }
 
     private fun getUnreadNotificationsSize(): Int {
-        return mRealm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("isRead", false)
-            .count()
-            .toInt()
+        return databaseService.withRealm { realm ->
+            realm.where(RealmNotification::class.java)
+                .equalTo("userId", userId)
+                .equalTo("isRead", false)
+                .count()
+                .toInt()
+        }
     }
 
     private fun updateUnreadCount() {
@@ -282,25 +299,19 @@ class NotificationsFragment : Fragment() {
     }
 
     fun refreshNotificationsList() {
-        if (::adapter.isInitialized && ::fragmentNotificationsBinding.isInitialized) {
-            val selectedFilter = fragmentNotificationsBinding.status.selectedItem.toString().lowercase()
+        if (::adapter.isInitialized && _binding != null) {
+            val selectedFilter = binding.status.selectedItem.toString().lowercase()
             val notifications = loadNotifications(userId, selectedFilter)
             adapter.updateNotifications(notifications)
             updateMarkAllAsReadButtonVisibility()
             updateUnreadCount()
 
-            if (notifications.isEmpty()) {
-                fragmentNotificationsBinding.emptyData.visibility = View.VISIBLE
-            } else {
-                fragmentNotificationsBinding.emptyData.visibility = View.GONE
-            }
+            binding.emptyData.visibility = if (notifications.isEmpty()) View.VISIBLE else View.GONE
         }
     }
 
-    override fun onDestroy() {
-        if (::mRealm.isInitialized) {
-            mRealm.close()
-        }
-        super.onDestroy()
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }


### PR DESCRIPTION
## Summary
- switch NotificationsFragment to nullable view binding and clear it in `onDestroyView`
- replace long-lived Realm instance with `databaseService.withRealm` and `executeTransactionAsync`

## Testing
- ⚠️ `./gradlew app:lintDefaultDebug` *(incomplete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda88a0cc832bb494dd278698fcb8