### PR TITLE
community: smoother voices binding and realm closing (fixes #7125)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2987
-        versionName = "0.29.87"
+        versionCode = 2993
+        versionName = "0.29.93"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- replace lateinit view binding with nullable backing property and cleanup in onDestroyView
- use databaseService.withRealm for community news queries

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeda970cc8832bac21befe955092a2