### PR TITLE
teams: smoother details binding and realm closing (fixes #7126)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2987
-        versionName = "0.29.87"
+        versionCode = 2993
+        versionName = "0.29.93"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2993
-        versionName = "0.29.93"
+        versionCode = 2994
+        versionName = "0.29.94"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -63,8 +63,9 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
 
     @Inject
     lateinit var uploadManager: UploadManager
-    
-    private lateinit var fragmentTeamDetailBinding: FragmentTeamDetailBinding
+
+    private var _binding: FragmentTeamDetailBinding? = null
+    private val binding get() = _binding!!
     private var directTeamName: String? = null
     private var directTeamType: String? = null
     private var directTeamId: String? = null
@@ -83,7 +84,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     }
 
     private fun selectPage(pageId: String?, smoothScroll: Boolean = false) {
-        pageIndexById(pageId)?.let { fragmentTeamDetailBinding.viewPager2.setCurrentItem(it, smoothScroll) }
+        pageIndexById(pageId)?.let { binding.viewPager2.setCurrentItem(it, smoothScroll) }
     }
 
     private fun buildPages(isMyTeam: Boolean): List<TeamPageConfig> {
@@ -114,7 +115,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentTeamDetailBinding = FragmentTeamDetailBinding.inflate(inflater, container, false)
+        _binding = FragmentTeamDetailBinding.inflate(inflater, container, false)
         directTeamId = requireArguments().getString("teamId")
         directTeamName = requireArguments().getString("teamName")
         directTeamType = requireArguments().getString("teamType")
@@ -138,7 +139,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
 
         setupTeamDetails(isMyTeam, user)
 
-        return fragmentTeamDetailBinding.root
+        return binding.root
     }
 
     private fun startTeamSync() {
@@ -188,7 +189,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
                         customProgressDialog?.dismiss()
                         customProgressDialog = null
 
-                        Snackbar.make(fragmentTeamDetailBinding.root, "Sync failed: ${msg ?: "Unknown error"}", Snackbar.LENGTH_LONG)
+                        Snackbar.make(binding.root, "Sync failed: ${msg ?: "Unknown error"}", Snackbar.LENGTH_LONG)
                             .setAction("Retry") { startTeamSync() }
                             .show()
                     }
@@ -204,7 +205,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     }
 
     private fun setupTeamDetails(isMyTeam: Boolean, user: RealmUserModel?) {
-        fragmentTeamDetailBinding.root.post {
+        binding.root.post {
             if (isAdded && !requireActivity().isFinishing) {
                 val targetPageId = arguments?.getString("navigateToPage")
                     ?: team?._id?.let { teamLastPage[it] }
@@ -212,8 +213,8 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
             }
         }
 
-        fragmentTeamDetailBinding.title.text = getEffectiveTeamName()
-        fragmentTeamDetailBinding.subtitle.text = getEffectiveTeamType()
+        binding.title.text = getEffectiveTeamName()
+        binding.subtitle.text = getEffectiveTeamType()
 
         if (!isMyTeam) {
             setupNonMyTeamButtons(user)
@@ -222,27 +223,27 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
         }
 
         if(getJoinedMemberCount(team!!._id.toString(), mRealm) <= 1 && isMyTeam){
-            fragmentTeamDetailBinding.btnLeave.visibility = View.GONE
+            binding.btnLeave.visibility = View.GONE
         }
     }
 
     private fun setupViewPager(isMyTeam: Boolean, restorePageId: String? = null) {
         pageConfigs = buildPages(isMyTeam)
-        fragmentTeamDetailBinding.viewPager2.isSaveEnabled = true
-        fragmentTeamDetailBinding.viewPager2.id = View.generateViewId()
-        fragmentTeamDetailBinding.viewPager2.adapter = TeamPagerAdapter(
+        binding.viewPager2.isSaveEnabled = true
+        binding.viewPager2.id = View.generateViewId()
+        binding.viewPager2.adapter = TeamPagerAdapter(
             requireActivity(),
             pageConfigs,
             team?._id,
             this
         )
-        TabLayoutMediator(fragmentTeamDetailBinding.tabLayout, fragmentTeamDetailBinding.viewPager2) { tab, position ->
-            tab.text = (fragmentTeamDetailBinding.viewPager2.adapter as TeamPagerAdapter).getPageTitle(position)
+        TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->
+            tab.text = (binding.viewPager2.adapter as TeamPagerAdapter).getPageTitle(position)
         }.attach()
 
         selectPage(restorePageId, false)
 
-        fragmentTeamDetailBinding.viewPager2.registerOnPageChangeCallback(
+        binding.viewPager2.registerOnPageChangeCallback(
             object : ViewPager2.OnPageChangeCallback() {
                 override fun onPageSelected(position: Int) {
                     team?._id?.let { teamId ->
@@ -256,28 +257,28 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     }
 
     private fun setupNonMyTeamButtons(user: RealmUserModel?) {
-        fragmentTeamDetailBinding.btnAddDoc.isEnabled = false
-        fragmentTeamDetailBinding.btnAddDoc.visibility = View.GONE
-        fragmentTeamDetailBinding.btnLeave.isEnabled = true
-        fragmentTeamDetailBinding.btnLeave.visibility = View.VISIBLE
+        binding.btnAddDoc.isEnabled = false
+        binding.btnAddDoc.visibility = View.GONE
+        binding.btnLeave.isEnabled = true
+        binding.btnLeave.visibility = View.VISIBLE
 
         if (user?.id?.startsWith("guest") == true){
-            fragmentTeamDetailBinding.btnLeave.isEnabled = false
-            fragmentTeamDetailBinding.btnLeave.visibility = View.GONE
+            binding.btnLeave.isEnabled = false
+            binding.btnLeave.visibility = View.GONE
         }
 
         val currentTeam = team
         if (currentTeam != null && !currentTeam._id.isNullOrEmpty()) {
             val isUserRequested = currentTeam.requested(user?.id, mRealm)
             if (isUserRequested) {
-                fragmentTeamDetailBinding.btnLeave.text = getString(R.string.requested)
-                fragmentTeamDetailBinding.btnLeave.isEnabled = false
+                binding.btnLeave.text = getString(R.string.requested)
+                binding.btnLeave.isEnabled = false
             } else {
-                fragmentTeamDetailBinding.btnLeave.text = getString(R.string.join)
-                fragmentTeamDetailBinding.btnLeave.setOnClickListener {
+                binding.btnLeave.text = getString(R.string.join)
+                binding.btnLeave.setOnClickListener {
                     RealmMyTeam.requestToJoin(currentTeam._id!!, user, mRealm, team?.teamType)
-                    fragmentTeamDetailBinding.btnLeave.text = getString(R.string.requested)
-                    fragmentTeamDetailBinding.btnLeave.isEnabled = false
+                    binding.btnLeave.text = getString(R.string.requested)
+                    binding.btnLeave.isEnabled = false
                     syncTeamActivities(requireContext(), uploadManager)
                 }
             }
@@ -287,23 +288,23 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     }
 
     private fun setupMyTeamButtons(user: RealmUserModel?) {
-        fragmentTeamDetailBinding.btnAddDoc.isEnabled = true
-        fragmentTeamDetailBinding.btnAddDoc.visibility = View.VISIBLE
-        fragmentTeamDetailBinding.btnLeave.isEnabled = true
-        fragmentTeamDetailBinding.btnLeave.visibility = View.VISIBLE
+        binding.btnAddDoc.isEnabled = true
+        binding.btnAddDoc.visibility = View.VISIBLE
+        binding.btnLeave.isEnabled = true
+        binding.btnLeave.visibility = View.VISIBLE
 
-        fragmentTeamDetailBinding.btnLeave.setOnClickListener {
+        binding.btnLeave.setOnClickListener {
             AlertDialog.Builder(requireContext()).setMessage(R.string.confirm_exit)
                 .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
                     team?.leave(user, mRealm)
                     Utilities.toast(activity, getString(R.string.left_team))
                     val lastPageId = team?._id?.let { teamLastPage[it] } ?: arguments?.getString("navigateToPage")
                     setupViewPager(false, lastPageId)
-                    fragmentTeamDetailBinding.llActionButtons.visibility = View.GONE
+                    binding.llActionButtons.visibility = View.GONE
                 }.setNegativeButton(R.string.no, null).show()
         }
 
-        fragmentTeamDetailBinding.btnAddDoc.setOnClickListener {
+        binding.btnAddDoc.setOnClickListener {
             MainApplication.showDownload = true
             selectPage(DocumentsPage.id)
             MainApplication.showDownload = false
@@ -325,13 +326,13 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
                     val lastPageId = team?._id?.let { teamLastPage[it] } ?: arguments?.getString("navigateToPage")
                     setupViewPager(isMyTeam, lastPageId)
 
-                    fragmentTeamDetailBinding.title.text = getEffectiveTeamName()
-                    fragmentTeamDetailBinding.subtitle.text = getEffectiveTeamType()
+                    binding.title.text = getEffectiveTeamName()
+                    binding.subtitle.text = getEffectiveTeamType()
 
                     if(getJoinedMemberCount(team!!._id.toString(), mRealm) <= 1 && isMyTeam){
-                        fragmentTeamDetailBinding.btnLeave.visibility = View.GONE
+                        binding.btnLeave.visibility = View.GONE
                     } else {
-                        fragmentTeamDetailBinding.btnLeave.visibility = View.VISIBLE
+                        binding.btnLeave.visibility = View.VISIBLE
                     }
                 }
             }
@@ -342,9 +343,9 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
 
     override fun onMemberChanged() {
         if(getJoinedMemberCount("${team?._id}", mRealm) <= 1){
-            fragmentTeamDetailBinding.btnLeave.visibility = View.GONE
+            binding.btnLeave.visibility = View.GONE
         } else{
-            fragmentTeamDetailBinding.btnLeave.visibility = View.VISIBLE
+            binding.btnLeave.visibility = View.VISIBLE
         }
     }
 
@@ -383,6 +384,11 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
 
     private fun shouldQueryRealm(teamId: String): Boolean {
         return teamId.isNotEmpty()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## Summary
- refactor TeamDetailFragment to use nullable view binding with a non-null getter
- clear view binding reference in onDestroyView to avoid leaks

## Testing
- `./gradlew :app:lintDefaultDebug` *(fails: command stalled while installing Android SDK components)*

------
https://chatgpt.com/codex/tasks/task_e_68aedaf1e398832b866eefd58a6bb523