### PR TITLE
teams: smoother tasks binding and realm closing (fixes #7128)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2987
-        versionName = "0.29.87"
+        versionCode = 2996
+        versionName = "0.29.96"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
@@ -40,7 +40,8 @@ import org.ole.planet.myplanet.utilities.TimeUtils.formatDateTZ
 import org.ole.planet.myplanet.utilities.Utilities
 
 class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
-    private lateinit var fragmentTeamTaskBinding: FragmentTeamTaskBinding
+    private var _binding: FragmentTeamTaskBinding? = null
+    private val binding get() = _binding!!
     private var deadline: Calendar? = null
     private var datePicker: TextView? = null
     var list: List<RealmTeamTask>? = null
@@ -72,12 +73,16 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
         timePickerDialog.show()
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentTeamTaskBinding = FragmentTeamTaskBinding.inflate(inflater, container, false)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentTeamTaskBinding.inflate(inflater, container, false)
         if (!isMember()) {
-            fragmentTeamTaskBinding.fab.visibility = View.GONE
+            binding.fab.visibility = View.GONE
         }
-        fragmentTeamTaskBinding.fab.setOnClickListener { showTaskAlert(null) }
+        binding.fab.setOnClickListener { showTaskAlert(null) }
         teamTaskList = mRealm.where(RealmTeamTask::class.java).equalTo("teamId", teamId)
             .notEqualTo("status", "archived").findAllAsync()
 
@@ -85,7 +90,7 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
             updatedTeamTaskList(results)
         }
 
-        return fragmentTeamTaskBinding.root
+        return binding.root
     }
 
     private fun showTaskAlert(t: RealmTeamTask?) {
@@ -157,20 +162,20 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
         obSync.addProperty("planetCode", user?.planetCode)
         realmTeamTask?.sync = Gson().toJson(obSync)
         mRealm.commitTransaction()
-        if (fragmentTeamTaskBinding.rvTask.adapter != null) {
-            fragmentTeamTaskBinding.rvTask.adapter?.notifyDataSetChanged()
-            showNoData(fragmentTeamTaskBinding.tvNodata, fragmentTeamTaskBinding.rvTask.adapter?.itemCount, "tasks")
+        if (binding.rvTask.adapter != null) {
+            binding.rvTask.adapter?.notifyDataSetChanged()
+            showNoData(binding.tvNodata, binding.rvTask.adapter?.itemCount, "tasks")
         }
         Utilities.toast(activity, String.format(getString(R.string.task_s_successfully), if (isCreate) getString(R.string.added) else getString(R.string.updated)))
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        fragmentTeamTaskBinding.rvTask.layoutManager = LinearLayoutManager(activity)
+        binding.rvTask.layoutManager = LinearLayoutManager(activity)
         list = mRealm.where(RealmTeamTask::class.java).equalTo("teamId", teamId).findAll()
         setAdapter()
-        showNoData(fragmentTeamTaskBinding.tvNodata, list?.size,"tasks")
-        fragmentTeamTaskBinding.taskToggle.setOnCheckedChangeListener { _: SingleSelectToggleGroup?, checkedId: Int ->
+        showNoData(binding.tvNodata, list?.size, "tasks")
+        binding.taskToggle.setOnCheckedChangeListener { _: SingleSelectToggleGroup?, checkedId: Int ->
             currentTab = checkedId
             when (checkedId) {
                 R.id.btn_my -> {
@@ -224,14 +229,14 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
                 }
             }
             if (list!!.isEmpty()){
-                showNoData(fragmentTeamTaskBinding.tvNodata, list?.size, "tasks")
+                showNoData(binding.tvNodata, list?.size, "tasks")
             }
             else {
-                showNoData(fragmentTeamTaskBinding.tvNodata, list?.size, "")
+                showNoData(binding.tvNodata, list?.size, "")
             }
             adapterTask = AdapterTask(requireContext(), mRealm, list, !isMember())
             adapterTask.setListener(this)
-            fragmentTeamTaskBinding.rvTask.adapter = adapterTask
+            binding.rvTask.adapter = adapterTask
         }
     }
 
@@ -256,7 +261,7 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
         Utilities.toast(activity, getString(R.string.task_deleted_successfully))
         mRealm.commitTransaction()
         setAdapter()
-        showNoData(fragmentTeamTaskBinding.tvNodata, fragmentTeamTaskBinding.rvTask.adapter?.itemCount, "tasks")
+        showNoData(binding.tvNodata, binding.rvTask.adapter?.itemCount, "tasks")
     }
 
     override fun onClickMore(realmTeamTask: RealmTeamTask?) {
@@ -295,7 +300,7 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
         activity?.runOnUiThread {
             adapterTask = AdapterTask(requireContext(), mRealm, updatedList, !isMember())
             adapterTask.setListener(this)
-            fragmentTeamTaskBinding.rvTask.adapter = adapterTask
+            binding.rvTask.adapter = adapterTask
             adapterTask.notifyDataSetChanged()
         }
     }
@@ -304,10 +309,11 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
         teamTaskList?.removeAllChangeListeners()
         teamTaskList = null
         list = null
-        fragmentTeamTaskBinding.rvTask.adapter = null
+        binding.rvTask.adapter = null
         if (isRealmInitialized()) {
             mRealm.close()
         }
+        _binding = null
         super.onDestroyView()
     }
 }


### PR DESCRIPTION
## Summary
- refactor TeamTaskFragment to hold view binding as nullable `_binding` with non-nullable `binding` accessor
- clear `_binding` in `onDestroyView`

## Testing
- `./gradlew :app:compileDefaultDebugKotlin --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aedb0513b0832baa6cc2db172a31f8