### PR TITLE
all: smoother feedback detail view model (fixes #7133)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2987
-        versionName = "0.29.87"
+        versionCode = 2999
+        versionName = "0.29.99"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
@@ -1,5 +1,8 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import io.realm.RealmChangeListener
 import io.realm.RealmResults
 import javax.inject.Inject
@@ -12,6 +15,9 @@ import org.ole.planet.myplanet.model.RealmUserModel
 
 interface FeedbackRepository {
     fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>>
+    suspend fun getFeedbackById(id: String?): RealmFeedback?
+    suspend fun closeFeedback(id: String?)
+    suspend fun addReply(id: String?, obj: JsonObject)
 }
 
 class FeedbackRepositoryImpl @Inject constructor(
@@ -40,4 +46,34 @@ class FeedbackRepositoryImpl @Inject constructor(
                 }
             }
         }
+
+    override suspend fun getFeedbackById(id: String?): RealmFeedback? =
+        databaseService.withRealmAsync { realm ->
+            realm.where(RealmFeedback::class.java)
+                .equalTo("id", id)
+                .findFirst()
+                ?.let { realm.copyFromRealm(it) }
+        }
+
+    override suspend fun closeFeedback(id: String?) {
+        databaseService.executeTransactionAsync { realm ->
+            realm.where(RealmFeedback::class.java)
+                .equalTo("id", id)
+                .findFirst()?.status = "Closed"
+        }
+    }
+
+    override suspend fun addReply(id: String?, obj: JsonObject) {
+        databaseService.executeTransactionAsync { realm ->
+            val feedback = realm.where(RealmFeedback::class.java)
+                .equalTo("id", id)
+                .findFirst()
+            if (feedback != null) {
+                val con = Gson()
+                val msgArray = con.fromJson(feedback.messages, JsonArray::class.java)
+                msgArray.add(obj)
+                feedback.setMessages(msgArray)
+            }
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
@@ -7,20 +7,19 @@ import android.text.TextUtils
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.google.gson.Gson
-import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import dagger.hilt.android.AndroidEntryPoint
-import io.realm.Realm
 import java.util.Date
-import javax.inject.Inject
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ActivityFeedbackDetailBinding
 import org.ole.planet.myplanet.databinding.RowFeedbackReplyBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.FeedbackReply
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
@@ -34,11 +33,10 @@ class FeedbackDetailActivity : AppCompatActivity() {
     private lateinit var activityFeedbackDetailBinding: ActivityFeedbackDetailBinding
     private var mAdapter: RecyclerView.Adapter<*>? = null
     private var layoutManager: RecyclerView.LayoutManager? = null
-    private lateinit var feedback: RealmFeedback
-    @Inject
-    lateinit var databaseService: DatabaseService
-    lateinit var realm: Realm
+    private var feedback: RealmFeedback? = null
     private lateinit var rowFeedbackReplyBinding: RowFeedbackReplyBinding
+    private lateinit var feedbackId: String
+    private val viewModel: FeedbackDetailViewModel by viewModels()
 
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(LocaleHelper.onAttach(base))
@@ -52,49 +50,54 @@ class FeedbackDetailActivity : AppCompatActivity() {
         supportActionBar?.setHomeButtonEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         setTitle(R.string.feedback)
-        realm = databaseService.realmInstance
-        feedback = realm.where(RealmFeedback::class.java).equalTo("id", intent.getStringExtra("id")).findFirst()!!
-        activityFeedbackDetailBinding.tvDate.text = getFormattedDateWithTime(feedback.openTime)
-        activityFeedbackDetailBinding.tvMessage.text = if (TextUtils.isEmpty(feedback.message))
-            "N/A"
-        else
-            feedback.message
+        feedbackId = intent.getStringExtra("id")!!
         setUpReplies()
+
+        lifecycleScope.launch {
+            viewModel.feedback.collectLatest { fb ->
+                fb?.let {
+                    feedback = it
+                    activityFeedbackDetailBinding.tvDate.text = getFormattedDateWithTime(it.openTime)
+                    activityFeedbackDetailBinding.tvMessage.text =
+                        if (TextUtils.isEmpty(it.message)) "N/A" else it.message
+                    mAdapter = RvFeedbackAdapter(it.messageList, applicationContext)
+                    activityFeedbackDetailBinding.rvFeedbackReply.adapter = mAdapter
+                    updateForClosed()
+                }
+            }
+        }
+
+        activityFeedbackDetailBinding.closeFeedback.setOnClickListener {
+            viewModel.closeFeedback(feedbackId)
+        }
+        activityFeedbackDetailBinding.replyFeedback.setOnClickListener {
+            if (TextUtils.isEmpty(activityFeedbackDetailBinding.feedbackReplyEditText.text.toString().trim { it <= ' ' })) {
+                activityFeedbackDetailBinding.feedbackReplyEditText.error =
+                    getString(R.string.kindly_enter_reply_message)
+            } else {
+                val message = activityFeedbackDetailBinding.feedbackReplyEditText.text.toString().trim { it <= ' ' }
+                val obj = JsonObject().apply {
+                    addProperty("message", message)
+                    addProperty("time", Date().time.toString())
+                    addProperty("user", feedback?.owner ?: "")
+                }
+                viewModel.addReply(feedbackId, obj)
+                activityFeedbackDetailBinding.feedbackReplyEditText.setText(R.string.empty_text)
+                activityFeedbackDetailBinding.feedbackReplyEditText.clearFocus()
+            }
+        }
+
+        viewModel.loadFeedback(feedbackId)
     }
 
     private fun setUpReplies() {
         activityFeedbackDetailBinding.rvFeedbackReply.setHasFixedSize(true)
         layoutManager = LinearLayoutManager(this)
         activityFeedbackDetailBinding.rvFeedbackReply.layoutManager = layoutManager
-        mAdapter = RvFeedbackAdapter(feedback.messageList, applicationContext)
-        activityFeedbackDetailBinding.rvFeedbackReply.adapter = mAdapter
-        activityFeedbackDetailBinding.closeFeedback.setOnClickListener {
-            realm.executeTransactionAsync(Realm.Transaction { realm1: Realm ->
-                val feedback1 = realm1.where(RealmFeedback::class.java).equalTo("id", intent.getStringExtra("id")).findFirst()
-                feedback1?.status = "Closed" },
-                Realm.Transaction.OnSuccess { updateForClosed() })
-        }
-        activityFeedbackDetailBinding.replyFeedback.setOnClickListener {
-            if (TextUtils.isEmpty(activityFeedbackDetailBinding.feedbackReplyEditText.text.toString().trim { it <= ' ' })) {
-                activityFeedbackDetailBinding.feedbackReplyEditText.error = getString(R.string.kindly_enter_reply_message)
-            } else {
-                val message = activityFeedbackDetailBinding.feedbackReplyEditText.text.toString().trim { it <= ' ' }
-                val `object` = JsonObject()
-                `object`.addProperty("message", message)
-                `object`.addProperty("time", Date().time.toString() + "")
-                `object`.addProperty("user", feedback.owner + "")
-                val id = feedback.id
-                addReply(`object`, id)
-                mAdapter = RvFeedbackAdapter(feedback.messageList, applicationContext)
-                activityFeedbackDetailBinding.rvFeedbackReply.adapter = mAdapter
-                activityFeedbackDetailBinding.feedbackReplyEditText.setText(R.string.empty_text)
-                activityFeedbackDetailBinding.feedbackReplyEditText.clearFocus()
-            }
-        }
     }
 
     private fun updateForClosed() {
-        if (feedback.status.equals("Closed", ignoreCase = true)) {
+        if (feedback?.status.equals("Closed", ignoreCase = true)) {
             activityFeedbackDetailBinding.closeFeedback.isEnabled = false
             activityFeedbackDetailBinding.replyFeedback.isEnabled = false
             activityFeedbackDetailBinding.feedbackReplyEditText.visibility = View.INVISIBLE
@@ -109,32 +112,9 @@ class FeedbackDetailActivity : AppCompatActivity() {
         finish()
     }
 
-    private fun addReply(obj: JsonObject?, id: String?) {
-        realm.executeTransactionAsync(Realm.Transaction { realm: Realm ->
-            val feedback = realm.where(RealmFeedback::class.java).equalTo("id", id).findFirst()
-            if (feedback != null) {
-                val con = Gson()
-                val msgArray = con.fromJson(feedback.messages, JsonArray::class.java)
-                msgArray.add(obj)
-                feedback.setMessages(msgArray)
-            }
-        }, Realm.Transaction.OnSuccess {
-            updateForClosed()
-            mAdapter = RvFeedbackAdapter(feedback.messageList, applicationContext)
-            activityFeedbackDetailBinding.rvFeedbackReply.adapter = mAdapter
-        })
-    }
-
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) finish()
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onDestroy() {
-        if (::realm.isInitialized && !realm.isClosed) {
-            realm.close()
-        }
-        super.onDestroy()
     }
 
     inner class RvFeedbackAdapter(private val replyList: List<FeedbackReply>?, var context: Context) : RecyclerView.Adapter<ReplyViewHolder>() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailViewModel.kt
@@ -1,0 +1,43 @@
+package org.ole.planet.myplanet.ui.feedback
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.gson.JsonObject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.repository.FeedbackRepository
+
+@HiltViewModel
+class FeedbackDetailViewModel @Inject constructor(
+    private val feedbackRepository: FeedbackRepository
+) : ViewModel() {
+
+    private val _feedback = MutableStateFlow<RealmFeedback?>(null)
+    val feedback: StateFlow<RealmFeedback?> = _feedback.asStateFlow()
+
+    fun loadFeedback(id: String?) {
+        viewModelScope.launch {
+            _feedback.value = feedbackRepository.getFeedbackById(id)
+        }
+    }
+
+    fun closeFeedback(id: String?) {
+        viewModelScope.launch {
+            feedbackRepository.closeFeedback(id)
+            _feedback.value = feedbackRepository.getFeedbackById(id)
+        }
+    }
+
+    fun addReply(id: String?, obj: JsonObject) {
+        viewModelScope.launch {
+            feedbackRepository.addReply(id, obj)
+            _feedback.value = feedbackRepository.getFeedbackById(id)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Extend `FeedbackRepository` with methods to fetch feedback by id, close feedback, and add replies
- Add `FeedbackDetailViewModel` to coordinate feedback loading and updates
- Refactor `FeedbackDetailActivity` to use injected ViewModel instead of direct Realm access

## Testing
- `./gradlew :app:compileDebugKotlin --console=plain` *(fails: process interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68aedba45100832ba22499af0c4ae812