### PR TITLE
refactor: extract server availability repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -31,7 +31,7 @@ import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.datamanager.MyDownloadService
 import org.ole.planet.myplanet.datamanager.Service
-import org.ole.planet.myplanet.datamanager.Service.PlanetAvailableListener
+import org.ole.planet.myplanet.repository.ServerAvailabilityRepository.PlanetAvailableListener
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.RealmMyCourse

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -5,13 +5,11 @@ import android.content.SharedPreferences
 import android.net.Uri
 import android.text.TextUtils
 import androidx.core.content.edit
-import androidx.core.net.toUri
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import dagger.hilt.android.EntryPointAccessors
 import io.realm.Realm
 import java.io.IOException
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -21,7 +19,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.SecurityDataCallback
 import org.ole.planet.myplanet.callback.SuccessListener
@@ -41,29 +38,38 @@ import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.NetworkUtils
-import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.Sha256Utils
 import org.ole.planet.myplanet.utilities.UrlUtils
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.VersionUtils
+import org.ole.planet.myplanet.repository.ServerAvailabilityRepository
+import org.ole.planet.myplanet.repository.ServerAvailabilityRepositoryImpl
+import org.ole.planet.myplanet.repository.ServerAvailabilityRepository.PlanetAvailableListener
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
 class Service @Inject constructor(
     private val context: Context,
-    private val retrofitInterface: ApiInterface
+    private val retrofitInterface: ApiInterface,
+    private val serverAvailabilityRepository: ServerAvailabilityRepository
 ) {
     constructor(context: Context) : this(
         context,
         EntryPointAccessors.fromApplication(
             context.applicationContext,
             ApiInterfaceEntryPoint::class.java
-        ).apiInterface()
+        ).apiInterface(),
+        ServerAvailabilityRepositoryImpl(
+            context,
+            EntryPointAccessors.fromApplication(
+                context.applicationContext,
+                ApiInterfaceEntryPoint::class.java
+            ).apiInterface()
+        )
     )
     private val preferences: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private val serverAvailabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
     private val configurationManager = ConfigurationManager(context, preferences, retrofitInterface)
 
     fun healthAccess(listener: SuccessListener) {
@@ -153,53 +159,7 @@ class Service @Inject constructor(
     }
 
     fun isPlanetAvailable(callback: PlanetAvailableListener?) {
-        val updateUrl = "${preferences.getString("serverURL", "")}"
-        serverAvailabilityCache[updateUrl]?.let { (available, timestamp) ->
-            if (System.currentTimeMillis() - timestamp < 30000) {
-                if (available) {
-                    callback?.isAvailable()
-                } else {
-                    callback?.notAvailable()
-                }
-                return
-            }
-        }
-
-        val serverUrlMapper = ServerUrlMapper()
-        val mapping = serverUrlMapper.processUrl(updateUrl)
-
-        CoroutineScope(Dispatchers.IO).launch {
-            val primaryAvailable = isServerReachable(mapping.primaryUrl)
-            val alternativeAvailable = mapping.alternativeUrl?.let { isServerReachable(it) } == true
-
-            if (!primaryAvailable && alternativeAvailable) {
-                mapping.alternativeUrl.let { alternativeUrl ->
-                    val uri = updateUrl.toUri()
-                    val editor = preferences.edit()
-
-                    serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, preferences)
-                }
-            }
-
-            withContext(Dispatchers.Main) {
-                retrofitInterface.isPlanetAvailable(UrlUtils.getUpdateUrl(preferences))?.enqueue(object : Callback<ResponseBody?> {
-                    override fun onResponse(call: Call<ResponseBody?>, response: Response<ResponseBody?>) {
-                        val isAvailable = callback != null && response.code() == 200
-                        serverAvailabilityCache[updateUrl] = Pair(isAvailable, System.currentTimeMillis())
-                        if (isAvailable) {
-                            callback.isAvailable()
-                        } else {
-                            callback?.notAvailable()
-                        }
-                    }
-
-                    override fun onFailure(call: Call<ResponseBody?>, t: Throwable) {
-                        serverAvailabilityCache[updateUrl] = Pair(false, System.currentTimeMillis())
-                        callback?.notAvailable()
-                    }
-                })
-            }
-        }
+        serverAvailabilityRepository.isPlanetAvailable(callback)
     }
 
     fun becomeMember(realm: Realm, obj: JsonObject, callback: CreateUserCallback, securityCallback: SecurityDataCallback? = null) {
@@ -434,11 +394,6 @@ class Service @Inject constructor(
     interface ChecksumCallback {
         fun onMatch()
         fun onFail()
-    }
-
-    interface PlanetAvailableListener {
-        fun isAvailable()
-        fun notAvailable()
     }
 
     interface ConfigurationIdListener {

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -15,6 +15,8 @@ import org.ole.planet.myplanet.repository.LibraryRepository
 import org.ole.planet.myplanet.repository.LibraryRepositoryImpl
 import org.ole.planet.myplanet.repository.NotificationRepository
 import org.ole.planet.myplanet.repository.NotificationRepositoryImpl
+import org.ole.planet.myplanet.repository.ServerAvailabilityRepository
+import org.ole.planet.myplanet.repository.ServerAvailabilityRepositoryImpl
 import org.ole.planet.myplanet.repository.RatingRepository
 import org.ole.planet.myplanet.repository.RatingRepositoryImpl
 import org.ole.planet.myplanet.repository.SearchRepository
@@ -69,4 +71,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindNotificationRepository(impl: NotificationRepositoryImpl): NotificationRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindServerAvailabilityRepository(
+        impl: ServerAvailabilityRepositoryImpl
+    ): ServerAvailabilityRepository
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ServerAvailabilityRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ServerAvailabilityRepository.kt
@@ -1,0 +1,11 @@
+package org.ole.planet.myplanet.repository
+
+interface ServerAvailabilityRepository {
+    fun isPlanetAvailable(callback: PlanetAvailableListener?)
+
+    interface PlanetAvailableListener {
+        fun isAvailable()
+        fun notAvailable()
+    }
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ServerAvailabilityRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ServerAvailabilityRepositoryImpl.kt
@@ -1,0 +1,80 @@
+package org.ole.planet.myplanet.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.net.toUri
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.ResponseBody
+import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.datamanager.ApiInterface
+import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
+import org.ole.planet.myplanet.utilities.ServerUrlMapper
+import org.ole.planet.myplanet.utilities.UrlUtils
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class ServerAvailabilityRepositoryImpl @Inject constructor(
+    private val context: Context,
+    private val retrofitInterface: ApiInterface
+) : ServerAvailabilityRepository {
+
+    private val preferences: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val serverAvailabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
+
+    override fun isPlanetAvailable(callback: ServerAvailabilityRepository.PlanetAvailableListener?) {
+        val updateUrl = "${preferences.getString("serverURL", "")}"
+        serverAvailabilityCache[updateUrl]?.let { (available, timestamp) ->
+            if (System.currentTimeMillis() - timestamp < 30000) {
+                if (available) {
+                    callback?.isAvailable()
+                } else {
+                    callback?.notAvailable()
+                }
+                return
+            }
+        }
+
+        val serverUrlMapper = ServerUrlMapper()
+        val mapping = serverUrlMapper.processUrl(updateUrl)
+
+        CoroutineScope(Dispatchers.IO).launch {
+            val primaryAvailable = isServerReachable(mapping.primaryUrl)
+            val alternativeAvailable = mapping.alternativeUrl?.let { isServerReachable(it) } == true
+
+            if (!primaryAvailable && alternativeAvailable) {
+                mapping.alternativeUrl.let { alternativeUrl ->
+                    val uri = updateUrl.toUri()
+                    val editor = preferences.edit()
+
+                    serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, preferences)
+                }
+            }
+
+            withContext(Dispatchers.Main) {
+                retrofitInterface.isPlanetAvailable(UrlUtils.getUpdateUrl(preferences))?.enqueue(object : Callback<ResponseBody?> {
+                    override fun onResponse(call: Call<ResponseBody?>, response: Response<ResponseBody?>) {
+                        val isAvailable = callback != null && response.code() == 200
+                        serverAvailabilityCache[updateUrl] = Pair(isAvailable, System.currentTimeMillis())
+                        if (isAvailable) {
+                            callback.isAvailable()
+                        } else {
+                            callback?.notAvailable()
+                        }
+                    }
+
+                    override fun onFailure(call: Call<ResponseBody?>, t: Throwable) {
+                        serverAvailabilityCache[updateUrl] = Pair(false, System.currentTimeMillis())
+                        callback?.notAvailable()
+                    }
+                })
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -66,7 +66,7 @@ import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.Service
 import org.ole.planet.myplanet.datamanager.Service.CheckVersionCallback
 import org.ole.planet.myplanet.datamanager.Service.ConfigurationIdListener
-import org.ole.planet.myplanet.datamanager.Service.PlanetAvailableListener
+import org.ole.planet.myplanet.repository.ServerAvailabilityRepository.PlanetAvailableListener
 import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.ServerAddressesModel


### PR DESCRIPTION
## Summary
- add `ServerAvailabilityRepository` for server health checks
- delegate availability checks from `Service` to the new repository
- bind `ServerAvailabilityRepository` in `RepositoryModule`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeddea3738832ba75ec621c5161982