### PR TITLE
all: smoother feedback realm flowing and closing (fixes #7129)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2987
-        versionName = "0.29.87"
+        versionCode = 2997
+        versionName = "0.29.97"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2997
-        versionName = "0.29.97"
+        versionCode = 3002
+        versionName = "0.30.2"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- Acquire Realm instance within callbackFlow when fetching feedback
- Remove `withRealm` wrapper and close Realm in `awaitClose`

## Testing
- ⚠️ `./gradlew lint` *(incomplete: command terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68aed975271c832ba1b6db2b0069d15c