### PR TITLE
chat: smoother history lists (fixes #7130)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2987
-        versionName = "0.29.87"
+        versionCode = 2996
+        versionName = "0.29.96"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
@@ -7,7 +7,9 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toDrawable
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.google.gson.Gson
 import io.realm.Case
@@ -35,10 +37,9 @@ class ChatHistoryListAdapter(
     private val fragment: ChatHistoryListFragment,
     private val databaseService: DatabaseService,
     private val settings: SharedPreferences
-) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+) : ListAdapter<RealmChatHistory, ChatHistoryListAdapter.ViewHolderChat>(DIFF_CALLBACK) {
     private lateinit var rowChatHistoryBinding: RowChatHistoryBinding
     private var chatHistoryItemClickListener: ChatHistoryItemClickListener? = null
-    private var filteredChatHistory: List<RealmChatHistory> = chatHistory
     private var chatTitle: String? = ""
     private lateinit var expandableListAdapter: ExpandableListAdapter
     private lateinit var expandableTitleList: List<String>
@@ -48,7 +49,7 @@ class ChatHistoryListAdapter(
 
     init {
         chatHistory = chatHistory.sortedByDescending { it.lastUsed }
-        filteredChatHistory = chatHistory
+        submitList(chatHistory)
     }
 
     interface ChatHistoryItemClickListener {
@@ -60,14 +61,14 @@ class ChatHistoryListAdapter(
     }
 
     fun filter(query: String) {
-        filteredChatHistory = chatHistory.filter { chat ->
+        val filteredChatHistory = chatHistory.filter { chat ->
             if (chat.conversations != null && chat.conversations?.isNotEmpty() == true) {
                 chat.conversations?.get(0)?.query?.contains(query, ignoreCase = true) == true
             } else {
-                chat.title?.contains(query, ignoreCase = true) ==true
+                chat.title?.contains(query, ignoreCase = true) == true
             }
         }
-        notifyDataSetChanged()
+        submitList(filteredChatHistory)
     }
 
     private fun normalizeText(str: String): String {
@@ -75,16 +76,16 @@ class ChatHistoryListAdapter(
             .replace(Regex("\\p{InCombiningDiacriticalMarks}+"), "")
     }
 
-    fun search(s: String, isFullSearch: Boolean, isQuestion: Boolean){
-        if(isFullSearch){
+    fun search(s: String, isFullSearch: Boolean, isQuestion: Boolean) {
+        val results = if (isFullSearch) {
             FullConvoSearch(s, isQuestion)
         } else {
             searchByTitle(s)
         }
-        notifyDataSetChanged()
+        submitList(results)
     }
 
-    private fun FullConvoSearch(s: String, isQuestion: Boolean){
+    private fun FullConvoSearch(s: String, isQuestion: Boolean): List<RealmChatHistory> {
         var conversation: String?
         val queryParts = s.split(" ").filterNot { it.isEmpty() }
         val normalizedQuery = normalizeText(s)
@@ -94,30 +95,28 @@ class ChatHistoryListAdapter(
         val containsQuery = mutableListOf<RealmChatHistory>()
 
         for (chat in chatHistory) {
-            if(chat.conversations != null && chat.conversations?.isNotEmpty() == true) {
+            if (chat.conversations != null && chat.conversations?.isNotEmpty() == true) {
                 for (i in 0 until chat.conversations!!.size) {
-                    conversation = if(isQuestion){
+                    conversation = if (isQuestion) {
                         chat.conversations?.get(i)?.query?.let { normalizeText(it) }
-                    } else{
+                    } else {
                         chat.conversations?.get(i)?.response?.let { normalizeText(it) }
                     }
-                    if(conversation == null) continue
+                    if (conversation == null) continue
                     if (conversation.startsWith(normalizedQuery, ignoreCase = true)) {
-                        if(i == 0) inTitleStartQuery.add(chat)
-                        else startsWithQuery.add(chat)
+                        if (i == 0) inTitleStartQuery.add(chat) else startsWithQuery.add(chat)
                         break
                     } else if (queryParts.all { conversation.contains(normalizeText(it), ignoreCase = true) }) {
-                        if(i == 0) inTitleContainsQuery.add(chat)
-                        else containsQuery.add(chat)
+                        if (i == 0) inTitleContainsQuery.add(chat) else containsQuery.add(chat)
                         break
                     }
                 }
             }
         }
-        filteredChatHistory = inTitleStartQuery+ inTitleContainsQuery + startsWithQuery + containsQuery
+        return inTitleStartQuery + inTitleContainsQuery + startsWithQuery + containsQuery
     }
 
-    private fun searchByTitle(s: String) {
+    private fun searchByTitle(s: String): List<RealmChatHistory> {
         var title: String?
         val queryParts = s.split(" ").filterNot { it.isEmpty() }
         val normalizedQuery = normalizeText(s)
@@ -125,22 +124,22 @@ class ChatHistoryListAdapter(
         val containsQuery = mutableListOf<RealmChatHistory>()
 
         for (chat in chatHistory) {
-            if(chat.conversations != null && chat.conversations?.isNotEmpty() == true) {
+            if (chat.conversations != null && chat.conversations?.isNotEmpty() == true) {
                 title = chat.conversations?.get(0)?.query?.let { normalizeText(it) }
             } else {
                 title = chat.title?.let { normalizeText(it) }
             }
-            if(title == null) continue
+            if (title == null) continue
             if (title.startsWith(normalizedQuery, ignoreCase = true)) {
                 startsWithQuery.add(chat)
             } else if (queryParts.all { title.contains(normalizeText(it), ignoreCase = true) }) {
                 containsQuery.add(chat)
             }
         }
-        filteredChatHistory = startsWithQuery + containsQuery
+        return startsWithQuery + containsQuery
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderChat {
         rowChatHistoryBinding = RowChatHistoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         databaseService.withRealm { realm ->
             val userId = settings.getString("userId", "")
@@ -160,47 +159,42 @@ class ChatHistoryListAdapter(
         return ViewHolderChat(rowChatHistoryBinding)
     }
 
-    override fun getItemCount(): Int {
-        return filteredChatHistory.size
-    }
-
     fun updateChatHistory(newChatHistory: List<RealmChatHistory>) {
         chatHistory = newChatHistory.sortedByDescending { it.lastUsed }
-        filteredChatHistory = chatHistory
-        notifyDataSetChanged()
+        submitList(chatHistory)
     }
 
-    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        val viewHolderChat = holder as ViewHolderChat
-        if (filteredChatHistory[position].conversations != null && filteredChatHistory[position].conversations?.isNotEmpty() == true) {
-            viewHolderChat.rowChatHistoryBinding.chatTitle.text = filteredChatHistory[position].conversations?.get(0)?.query
-            viewHolderChat.rowChatHistoryBinding.chatTitle.contentDescription = filteredChatHistory[position].conversations?.get(0)?.query
-            chatTitle = filteredChatHistory[position].conversations?.get(0)?.query
+    override fun onBindViewHolder(holder: ViewHolderChat, position: Int) {
+        val item = getItem(position)
+        if (item.conversations != null && item.conversations?.isNotEmpty() == true) {
+            holder.rowChatHistoryBinding.chatTitle.text = item.conversations?.get(0)?.query
+            holder.rowChatHistoryBinding.chatTitle.contentDescription = item.conversations?.get(0)?.query
+            chatTitle = item.conversations?.get(0)?.query
         } else {
-            viewHolderChat.rowChatHistoryBinding.chatTitle.text = filteredChatHistory[position].title
-            viewHolderChat.rowChatHistoryBinding.chatTitle.contentDescription = filteredChatHistory[position].title
-            chatTitle = filteredChatHistory[position].title
+            holder.rowChatHistoryBinding.chatTitle.text = item.title
+            holder.rowChatHistoryBinding.chatTitle.contentDescription = item.title
+            chatTitle = item.title
         }
 
-        viewHolderChat.rowChatHistoryBinding.root.setOnClickListener {
-            viewHolderChat.rowChatHistoryBinding.chatCardView.contentDescription = chatTitle
+        holder.rowChatHistoryBinding.root.setOnClickListener {
+            holder.rowChatHistoryBinding.chatCardView.contentDescription = chatTitle
             chatHistoryItemClickListener?.onChatHistoryItemClicked(
-                filteredChatHistory[position].conversations?.toList(),
-                "${filteredChatHistory[position]._id}",
-                filteredChatHistory[position]._rev,
-                filteredChatHistory[position].aiProvider
+                item.conversations?.toList(),
+                "${item._id}",
+                item._rev,
+                item.aiProvider
             )
         }
 
         val isInNewsList = newsList.any { newsItem ->
-            newsItem.newsId == filteredChatHistory[position]._id
+            newsItem.newsId == item._id
         }
 
         if (isInNewsList) {
-            viewHolderChat.rowChatHistoryBinding.shareChat.setImageResource(R.drawable.baseline_check_24)
+            holder.rowChatHistoryBinding.shareChat.setImageResource(R.drawable.baseline_check_24)
         } else {
-            viewHolderChat.rowChatHistoryBinding.shareChat.setImageResource(R.drawable.baseline_share_24)
-            viewHolderChat.rowChatHistoryBinding.shareChat.setOnClickListener {
+            holder.rowChatHistoryBinding.shareChat.setImageResource(R.drawable.baseline_share_24)
+            holder.rowChatHistoryBinding.shareChat.setOnClickListener {
                 val chatShareDialogBinding = ChatShareDialogBinding.inflate(LayoutInflater.from(context))
                 var dialog: AlertDialog? = null
 
@@ -225,9 +219,9 @@ class ChatHistoryListAdapter(
                             )
 
                             if (expandableDetailList[expandableTitleList[groupPosition]]?.get(childPosition) == context.getString(R.string.teams)) {
-                                showGrandChildRecyclerView(teamList, context.getString(R.string.teams), filteredChatHistory[position])
+                                showGrandChildRecyclerView(teamList, context.getString(R.string.teams), item)
                             } else {
-                                showGrandChildRecyclerView(enterpriseList, context.getString(R.string.enterprises), filteredChatHistory[position])
+                                showGrandChildRecyclerView(enterpriseList, context.getString(R.string.enterprises), item)
                             }
                         }
                     } else {
@@ -238,7 +232,7 @@ class ChatHistoryListAdapter(
                             val community = realm.where(RealmMyTeam::class.java)
                                 .equalTo("_id", teamId)
                                 .findFirst()?.let { realm.copyFromRealm(it) }
-                            showEditTextAndShareButton(community, context.getString(R.string.community), filteredChatHistory[position])
+                            showEditTextAndShareButton(community, context.getString(R.string.community), item)
                         }
                     }
                     dialog?.dismiss()
@@ -346,6 +340,18 @@ class ChatHistoryListAdapter(
         expandableListDetail[context.getString(R.string.share_with_community)] = community
         expandableListDetail[context.getString(R.string.share_with_team_enterprise)] = teams
         return expandableListDetail
+    }
+
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<RealmChatHistory>() {
+            override fun areItemsTheSame(oldItem: RealmChatHistory, newItem: RealmChatHistory): Boolean {
+                return oldItem._id == newItem._id
+            }
+
+            override fun areContentsTheSame(oldItem: RealmChatHistory, newItem: RealmChatHistory): Boolean {
+                return oldItem == newItem
+            }
+        }
     }
 
     class ViewHolderChat(val rowChatHistoryBinding: RowChatHistoryBinding) : RecyclerView.ViewHolder(rowChatHistoryBinding.root)


### PR DESCRIPTION
## Summary
- use ListAdapter with DiffUtil for chat history
- submit list updates for filtering and searching

## Testing
- ⚠️ `./gradlew assembleDebug` (timed out; see partial task output)


------
https://chatgpt.com/codex/tasks/task_e_68aeda09464c832b9165ab34298775c5