### PR TITLE
teams: smoother discussion list binding (fixes #7132)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2987
-        versionName = "0.29.87"
+        versionCode = 3000
+        versionName = "0.30.0"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamDiscussion/DiscussionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamDiscussion/DiscussionListFragment.kt
@@ -40,7 +40,8 @@ import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
 class DiscussionListFragment : BaseTeamFragment() {
-    private lateinit var fragmentDiscussionListBinding: FragmentDiscussionListBinding
+    private var _binding: FragmentDiscussionListBinding? = null
+    private val binding get() = _binding!!
     private var updatedNewsList: RealmResults<RealmNews>? = null
     
     @Inject
@@ -48,8 +49,8 @@ class DiscussionListFragment : BaseTeamFragment() {
     private var filteredNewsList: List<RealmNews?> = listOf()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentDiscussionListBinding = FragmentDiscussionListBinding.inflate(inflater, container, false)
-        fragmentDiscussionListBinding.addMessage.setOnClickListener { showAddMessage() }
+        _binding = FragmentDiscussionListBinding.inflate(inflater, container, false)
+        binding.addMessage.setOnClickListener { showAddMessage() }
 
         if (shouldQueryTeamFromRealm()) {
             team = try {
@@ -68,11 +69,11 @@ class DiscussionListFragment : BaseTeamFragment() {
             }
         }
         if (user?.id?.startsWith("guest") == true) {
-            fragmentDiscussionListBinding.addMessage.visibility = View.GONE
-        }else if(isMember()) {
-            fragmentDiscussionListBinding.addMessage.visibility = View.VISIBLE
-        } else if(team?.isPublic == true && !isMember()) {
-            fragmentDiscussionListBinding.addMessage.visibility = View.VISIBLE
+            binding.addMessage.visibility = View.GONE
+        } else if (isMember()) {
+            binding.addMessage.visibility = View.VISIBLE
+        } else if (team?.isPublic == true && !isMember()) {
+            binding.addMessage.visibility = View.VISIBLE
         }
         updatedNewsList = mRealm.where(RealmNews::class.java).isEmpty("replyTo").sort("time", Sort.DESCENDING).findAllAsync()
 
@@ -80,7 +81,7 @@ class DiscussionListFragment : BaseTeamFragment() {
             filteredNewsList = filterNewsList(results)
             setData(filteredNewsList)
         }
-        return fragmentDiscussionListBinding.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -96,7 +97,7 @@ class DiscussionListFragment : BaseTeamFragment() {
             }
             notification?.lastCount = count
         }
-        changeLayoutManager(resources.configuration.orientation, fragmentDiscussionListBinding.rvDiscussion)
+        changeLayoutManager(resources.configuration.orientation, binding.rvDiscussion)
         showRecyclerView(realmNewsList)
     }
 
@@ -166,11 +167,11 @@ class DiscussionListFragment : BaseTeamFragment() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        changeLayoutManager(newConfig.orientation, fragmentDiscussionListBinding.rvDiscussion)
+        changeLayoutManager(newConfig.orientation, binding.rvDiscussion)
     }
 
     private fun showRecyclerView(realmNewsList: List<RealmNews?>?) {
-        val existingAdapter = fragmentDiscussionListBinding.rvDiscussion.adapter
+        val existingAdapter = binding.rvDiscussion.adapter
         if (existingAdapter == null) {
             val adapterNews = activity?.let {
                 realmNewsList?.let { list ->
@@ -180,35 +181,35 @@ class DiscussionListFragment : BaseTeamFragment() {
             adapterNews?.setmRealm(mRealm)
             adapterNews?.setListener(this)
             if (!isMember()) adapterNews?.setNonTeamMember(true)
-            fragmentDiscussionListBinding.rvDiscussion.adapter = adapterNews
+            binding.rvDiscussion.adapter = adapterNews
             adapterNews?.let {
-                showNoData(fragmentDiscussionListBinding.tvNodata, it.itemCount, "discussions")
+                showNoData(binding.tvNodata, it.itemCount, "discussions")
             }
         } else {
             (existingAdapter as? AdapterNews)?.let { adapter ->
                 realmNewsList?.let {
                     adapter.updateList(it)
-                    showNoData(fragmentDiscussionListBinding.tvNodata, adapter.itemCount, "discussions")
+                    showNoData(binding.tvNodata, adapter.itemCount, "discussions")
                 }
             }
         }
     }
 
     private fun showAddMessage() {
-        val binding = AlertInputBinding.inflate(layoutInflater)
-        val layout = binding.tlInput
-        binding.addNewsImage.setOnClickListener {
-            llImage = binding.llImage
+        val inputBinding = AlertInputBinding.inflate(layoutInflater)
+        val layout = inputBinding.tlInput
+        inputBinding.addNewsImage.setOnClickListener {
+            llImage = inputBinding.llImage
             val openFolderIntent = openOleFolder()
             openFolderLauncher.launch(openFolderIntent)
         }
-        binding.llImage.visibility = if (showBetaFeature(Constants.KEY_NEWSADDIMAGE, requireContext())) View.VISIBLE else View.GONE
+        inputBinding.llImage.visibility = if (showBetaFeature(Constants.KEY_NEWSADDIMAGE, requireContext())) View.VISIBLE else View.GONE
         layout.hint = getString(R.string.enter_message)
         layout.editText?.setHintTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
-        binding.custMsg.text = getString(R.string.add_message)
+        inputBinding.custMsg.text = getString(R.string.add_message)
 
         val dialog = AlertDialog.Builder(requireActivity(), R.style.CustomAlertDialog)
-            .setView(binding.root)
+            .setView(inputBinding.root)
             .setPositiveButton(getString(R.string.save)) { _: DialogInterface?, _: Int ->
                 val msg = "${layout.editText?.text}".trim { it <= ' ' }
                 if (msg.isEmpty()) {
@@ -222,20 +223,20 @@ class DiscussionListFragment : BaseTeamFragment() {
                 map["messageType"] = getEffectiveTeamType()
                 map["messagePlanetCode"] = team?.teamPlanetCode ?: ""
                 map["name"] = getEffectiveTeamName()
-                
+
                 lifecycleScope.launch(Dispatchers.IO) {
                     user?.let { userModel ->
                         databaseService.withRealmAsync { realm ->
                             createNews(map, realm, userModel, imageList)
                         }
                         withContext(Dispatchers.Main) {
-                            fragmentDiscussionListBinding.rvDiscussion.adapter?.notifyDataSetChanged()
+                            this@DiscussionListFragment.binding.rvDiscussion.adapter?.notifyDataSetChanged()
                             setData(news)
-                            fragmentDiscussionListBinding.rvDiscussion.scrollToPosition(0)
+                            this@DiscussionListFragment.binding.rvDiscussion.scrollToPosition(0)
                         }
                     }
                 }
-                
+
                 layout.editText?.text?.clear()
                 imageList.clear()
                 llImage?.removeAllViews()
@@ -261,6 +262,7 @@ class DiscussionListFragment : BaseTeamFragment() {
         if (isRealmInitialized()) {
             mRealm.close()
         }
+        _binding = null
         super.onDestroyView()
     }
 


### PR DESCRIPTION
## Summary
- refactor `DiscussionListFragment` to use a nullable `_binding` with a non-null `binding` accessor
- clear the binding reference in `onDestroyView` to avoid leaks

## Testing
- `./gradlew :app:compileDebugKotlin` *(terminated: process canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68aedb1bce14832bbc2d07d0e7222c5a