### PR TITLE
all: smoother feedback adapter item callback (fixes #7134)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2987
-        versionName = "0.29.87"
+        versionCode = 3001
+        versionName = "0.30.1"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/AdapterFeedback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/AdapterFeedback.kt
@@ -4,29 +4,30 @@ import android.content.Intent
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.res.ResourcesCompat
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowFeedbackBinding
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.ui.feedback.AdapterFeedback.ViewHolderFeedback
+import org.ole.planet.myplanet.utilities.DiffUtils
 import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
 
 class AdapterFeedback :
-    ListAdapter<RealmFeedback, ViewHolderFeedback>(DiffCallback) {
-
-    companion object DiffCallback : DiffUtil.ItemCallback<RealmFeedback>() {
-        override fun areItemsTheSame(oldItem: RealmFeedback, newItem: RealmFeedback) =
-            oldItem.id == newItem.id
-
-        override fun areContentsTheSame(oldItem: RealmFeedback, newItem: RealmFeedback) =
-            oldItem.title == newItem.title &&
-                oldItem.type == newItem.type &&
-                oldItem.priority == newItem.priority &&
-                oldItem.status == newItem.status &&
-                oldItem.openTime == newItem.openTime
-    }
+    ListAdapter<RealmFeedback, ViewHolderFeedback>(
+        DiffUtils.itemCallback(
+            { oldItem, newItem ->
+                oldItem.id == newItem.id
+            },
+            { oldItem, newItem ->
+                oldItem.title == newItem.title &&
+                    oldItem.type == newItem.type &&
+                    oldItem.priority == newItem.priority &&
+                    oldItem.status == newItem.status &&
+                    oldItem.openTime == newItem.openTime
+            }
+        )
+    ) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderFeedback {
         val binding = RowFeedbackBinding.inflate(LayoutInflater.from(parent.context), parent, false)


### PR DESCRIPTION
## Summary
- replace companion DiffCallback object with DiffUtils.itemCallback
- inline areItemsTheSame and areContentsTheSame comparisons

## Testing
- `./gradlew assembleDebug --no-daemon --console=plain` *(fails: command did not complete in allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68aedc27938c832bbcde374f3dbce157