### PR TITLE
courses: smoother progress realm handling (fixes #7169)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3001
-        versionName = "0.30.1"
+        versionCode = 3007
+        versionName = "0.30.7"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/MyProgressFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/MyProgressFragment.kt
@@ -42,14 +42,11 @@ class MyProgressFragment : Fragment() {
     }
 
     private fun initializeData() {
-        val realm = databaseService.realmInstance
-        try {
+        databaseService.withRealm { realm ->
             val user = UserProfileDbHandler(requireActivity()).userModel
             val courseData = fetchCourseData(realm, user?.id)
             binding.rvMyprogress.layoutManager = LinearLayoutManager(requireActivity())
             binding.rvMyprogress.adapter = AdapterMyProgress(requireActivity(), courseData)
-        } finally {
-            realm.close()
         }
     }
 


### PR DESCRIPTION
## Summary
- simplify MyProgressFragment's Realm handling by using `databaseService.withRealm`

## Testing
- ⚠️ `./gradlew app:assembleDebug` *(build timed out but processed initial tasks)*

------
https://chatgpt.com/codex/tasks/task_e_68b025593dfc832b8d107bdf829dbb78