### PR TITLE
refactor: use withRealm in NewsDetailActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
@@ -41,16 +41,19 @@ class NewsDetailActivity : BaseActivity() {
         initActionBar()
         databaseService.withRealm { realm ->
             val id = intent.getStringExtra("newsId")
-            news = realm.where(RealmNews::class.java).equalTo("id", id).findFirst()
-            if (news == null) {
+            val managedNews =
+                realm.where(RealmNews::class.java).equalTo("id", id).findFirst()
+            if (managedNews == null) {
                 Utilities.toast(this, getString(R.string.new_not_available))
                 finish()
                 return@withRealm
             }
+            news = realm.copyFromRealm(managedNews)
             val user = userProfileDbHandler.userModel!!
             val userId = user.id
             realm.executeTransactionAsync {
-                val newsLog: RealmNewsLog = it.createObject(RealmNewsLog::class.java, UUID.randomUUID().toString())
+                val newsLog: RealmNewsLog =
+                    it.createObject(RealmNewsLog::class.java, UUID.randomUUID().toString())
                 newsLog.androidId = NetworkUtils.getUniqueIdentifier()
                 newsLog.type = "news"
                 newsLog.time = Date().time


### PR DESCRIPTION
## Summary
- use `databaseService.withRealm` instead of a manual Realm instance in `NewsDetailActivity`
- remove explicit Realm field and cleanup

## Testing
- `./gradlew assembleDebug` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b025979038832b8cb6b7ded88f718a