### PR TITLE
dashboard: smoother activity realm handling (fixes #7170)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3001
-        versionName = "0.30.1"
+        versionCode = 3008
+        versionName = "0.30.8"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/MyActivityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/MyActivityFragment.kt
@@ -12,7 +12,6 @@ import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarEntry
 import com.github.mikephil.charting.formatter.ValueFormatter
 import dagger.hilt.android.AndroidEntryPoint
-import io.realm.Realm
 import java.text.DateFormatSymbols
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -29,7 +28,6 @@ class MyActivityFragment : Fragment() {
     private val binding get() = _binding!!
     @Inject
     lateinit var databaseService: DatabaseService
-    lateinit var realm: Realm
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentMyActivityBinding.inflate(inflater, container, false)
         return binding.root
@@ -38,62 +36,63 @@ class MyActivityFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val userModel = UserProfileDbHandler(requireActivity()).userModel
-        realm = databaseService.realmInstance
         val calendar = Calendar.getInstance()
-        val daynight_textColor = ResourcesCompat.getColor(getResources(), R.color.daynight_textColor, null);
+        val daynight_textColor = ResourcesCompat.getColor(getResources(), R.color.daynight_textColor, null)
 
         calendar.set(Calendar.YEAR, calendar.get(Calendar.YEAR) - 1)
-        val resourceActivity = realm.where(RealmOfflineActivity::class.java).equalTo("userId", userModel?.id)
-            .between("loginTime", calendar.timeInMillis, Calendar.getInstance().timeInMillis)
-            .findAll()
+        databaseService.withRealm { realm ->
+            val resourceActivity = realm.where(RealmOfflineActivity::class.java).equalTo("userId", userModel?.id)
+                .between("loginTime", calendar.timeInMillis, Calendar.getInstance().timeInMillis)
+                .findAll()
 
-        val countMap = HashMap<String, Int>()
-        val format = SimpleDateFormat("MMM")
-        resourceActivity.forEach {
-            val d = format.format(it.loginTime)
-            if (countMap.containsKey(d)) {
-                countMap[d] = countMap[d]!!.plus(1)
-            } else {
-                countMap[d] = 1
-            }
-        }
-        val entries = ArrayList<BarEntry>()
-        var i = 0
-        for (entry in countMap.keys) {
-            val key = format.parse(entry)
-            val calendar = Calendar.getInstance()
-            key?.let {
-                calendar.time = it
-                val month = calendar.get(Calendar.MONTH)
-                val en = countMap[entry]?.toFloat()
-                    ?.let { it1 -> BarEntry(month.toFloat(), it1) }
-                if (en != null) {
-                    entries.add(en)
+            val countMap = HashMap<String, Int>()
+            val format = SimpleDateFormat("MMM")
+            resourceActivity.forEach {
+                val d = format.format(it.loginTime)
+                if (countMap.containsKey(d)) {
+                    countMap[d] = countMap[d]!!.plus(1)
+                } else {
+                    countMap[d] = 1
                 }
             }
-            i = i.plus(1)
-        }
-        var label = getString(R.string.chart_label)
-        val dataSet = BarDataSet(entries, label)
-
-        val lineData = BarData(dataSet)
-        binding.chart.data = lineData
-        val d = Description()
-        d.text = getString(R.string.chart_description)
-        d.textColor = daynight_textColor
-        binding.chart.description = d
-        binding.chart.xAxis.valueFormatter = object : ValueFormatter() {
-            override fun getFormattedValue(value: Float): String {
-                return getMonth(value.toInt())
+            val entries = ArrayList<BarEntry>()
+            var i = 0
+            for (entry in countMap.keys) {
+                val key = format.parse(entry)
+                val calendar = Calendar.getInstance()
+                key?.let {
+                    calendar.time = it
+                    val month = calendar.get(Calendar.MONTH)
+                    val en = countMap[entry]?.toFloat()
+                        ?.let { it1 -> BarEntry(month.toFloat(), it1) }
+                    if (en != null) {
+                        entries.add(en)
+                    }
+                }
+                i = i.plus(1)
             }
+            var label = getString(R.string.chart_label)
+            val dataSet = BarDataSet(entries, label)
+
+            val lineData = BarData(dataSet)
+            binding.chart.data = lineData
+            val d = Description()
+            d.text = getString(R.string.chart_description)
+            d.textColor = daynight_textColor
+            binding.chart.description = d
+            binding.chart.xAxis.valueFormatter = object : ValueFormatter() {
+                override fun getFormattedValue(value: Float): String {
+                    return getMonth(value.toInt())
+                }
+            }
+            binding.chart.xAxis.textColor = daynight_textColor
+            binding.chart.axisLeft.textColor = daynight_textColor
+            binding.chart.axisRight.textColor = daynight_textColor
+            binding.chart.legend.textColor = daynight_textColor
+            binding.chart.description.setPosition(850f, 830f)
+            binding.chart.data.setValueTextColor(daynight_textColor)
+            binding.chart.invalidate()
         }
-        binding.chart.xAxis.textColor = daynight_textColor
-        binding.chart.axisLeft.textColor = daynight_textColor
-        binding.chart.axisRight.textColor = daynight_textColor
-        binding.chart.legend.textColor = daynight_textColor
-        binding.chart.description.setPosition(850f,830f)
-        binding.chart.data.setValueTextColor(daynight_textColor)
-        binding.chart.invalidate()
     }
 
     fun getMonth(month: Int): String {
@@ -101,9 +100,6 @@ class MyActivityFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        if (::realm.isInitialized && !realm.isClosed) {
-            realm.close()
-        }
         _binding = null
         super.onDestroyView()
     }


### PR DESCRIPTION
## Summary
- avoid keeping Realm instance in `MyActivityFragment`
- run activity query inside `databaseService.withRealm`
- drop manual Realm close in `onDestroyView`

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b025a5d43c832b8d2ae67df41aad0e