### PR TITLE
teams: smoother view binding (fixes #7171)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3001
-        versionName = "0.30.1"
+        versionCode = 3009
+        versionName = "0.30.9"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -33,7 +33,8 @@ import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
 class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
-    private lateinit var fragmentTeamBinding: FragmentTeamBinding
+    private var _binding: FragmentTeamBinding? = null
+    private val binding get() = _binding!!
     private lateinit var alertCreateTeamBinding: AlertCreateTeamBinding
     private lateinit var mRealm: Realm
     @Inject
@@ -62,18 +63,18 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentTeamBinding = FragmentTeamBinding.inflate(inflater, container, false)
+        _binding = FragmentTeamBinding.inflate(inflater, container, false)
         mRealm = databaseService.realmInstance
         user = UserProfileDbHandler(requireActivity()).userModel
 
         if (user?.isGuest() == true) {
-            fragmentTeamBinding.addTeam.visibility = View.GONE
+            binding.addTeam.visibility = View.GONE
         } else {
-            fragmentTeamBinding.addTeam.visibility = View.VISIBLE
+            binding.addTeam.visibility = View.VISIBLE
         }
 
-        fragmentTeamBinding.addTeam.setOnClickListener { createTeamAlert(null) }
-        fragmentTeamBinding.tvFragmentInfo.text = if (TextUtils.equals(type, "enterprise")) {
+        binding.addTeam.setOnClickListener { createTeamAlert(null) }
+        binding.tvFragmentInfo.text = if (TextUtils.equals(type, "enterprise")) {
             getString(R.string.enterprises)
         } else {
             getString(R.string.team)
@@ -96,7 +97,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
         teamList?.addChangeListener { _ ->
             updatedTeamList()
         }
-        return fragmentTeamBinding.root
+        return binding.root
     }
 
      fun createTeamAlert(team: RealmMyTeam?) {
@@ -155,8 +156,8 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                             team.updated = true
                             team.realm.commitTransaction()
                         }
-                        fragmentTeamBinding.etSearch.visibility = View.VISIBLE
-                        fragmentTeamBinding.tableTitle.visibility = View.VISIBLE
+                        binding.etSearch.visibility = View.VISIBLE
+                        binding.tableTitle.visibility = View.VISIBLE
                         Utilities.toast(activity, getString(R.string.team_created))
                         setTeamList()
                         // dialog won't close by default
@@ -214,9 +215,9 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        fragmentTeamBinding.rvTeamList.layoutManager = LinearLayoutManager(activity)
+        binding.rvTeamList.layoutManager = LinearLayoutManager(activity)
         setTeamList()
-        fragmentTeamBinding.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
             override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {
                 if (TextUtils.isEmpty(charSequence)) {
@@ -241,7 +242,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
 
                 if (list.isEmpty()) {
                     showNoResultsMessage(true, charSequence.toString())
-                    fragmentTeamBinding.rvTeamList.adapter = null
+                    binding.rvTeamList.adapter = null
                 } else {
                     showNoResultsMessage(false)
                     val sortedList = list.sortedWith(compareByDescending<RealmMyTeam> {
@@ -252,7 +253,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                         activity as Context, sortedList, mRealm, childFragmentManager, uploadManager
                     )
                     adapterTeamList.setTeamListener(this@TeamFragment)
-                    fragmentTeamBinding.rvTeamList.adapter = adapterTeamList
+                    binding.rvTeamList.adapter = adapterTeamList
                     listContentDescription(conditionApplied)
                 }
             }
@@ -286,7 +287,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
             } else {
                 View.VISIBLE
             }
-        fragmentTeamBinding.rvTeamList.adapter = adapterTeamList
+        binding.rvTeamList.adapter = adapterTeamList
         listContentDescription(conditionApplied)
         val itemCount = adapterTeamList.itemCount
 
@@ -320,22 +321,22 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                 setTeamListener(this@TeamFragment)
             }
 
-            fragmentTeamBinding.rvTeamList.adapter = adapterTeamList
+            binding.rvTeamList.adapter = adapterTeamList
             listContentDescription(conditionApplied)
         }
     }
 
     private fun listContentDescription(conditionApplied: Boolean) {
         if (conditionApplied) {
-            fragmentTeamBinding.rvTeamList.contentDescription = getString(R.string.enterprise_list)
+            binding.rvTeamList.contentDescription = getString(R.string.enterprise_list)
         } else {
-            fragmentTeamBinding.rvTeamList.contentDescription = getString(R.string.list_of_teams)
+            binding.rvTeamList.contentDescription = getString(R.string.list_of_teams)
         }
     }
 
     private fun showNoResultsMessage(show: Boolean, searchQuery: String = "") {
         if (show) {
-            fragmentTeamBinding.tvMessage.text = if (searchQuery.isNotEmpty()) {
+            binding.tvMessage.text = if (searchQuery.isNotEmpty()) {
                 if (TextUtils.equals(type, "enterprise")){
                     getString(R.string.no_enterprises_found_for_search, searchQuery)
                 } else {
@@ -348,13 +349,13 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                     getString(R.string.no_teams_found)
                 }
             }
-            fragmentTeamBinding.tvMessage.visibility = View.VISIBLE
-            fragmentTeamBinding.etSearch.visibility = View.VISIBLE
-            fragmentTeamBinding.tableTitle.visibility = View.GONE
+            binding.tvMessage.visibility = View.VISIBLE
+            binding.etSearch.visibility = View.VISIBLE
+            binding.tableTitle.visibility = View.GONE
         } else {
-            fragmentTeamBinding.tvMessage.visibility = View.GONE
-            fragmentTeamBinding.etSearch.visibility = View.VISIBLE
-            fragmentTeamBinding.tableTitle.visibility = View.VISIBLE
+            binding.tvMessage.visibility = View.GONE
+            binding.etSearch.visibility = View.VISIBLE
+            binding.tableTitle.visibility = View.VISIBLE
         }
     }
 
@@ -363,6 +364,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        _binding = null
         super.onDestroyView()
     }
 }


### PR DESCRIPTION
## Summary
- convert TeamFragment's binding to nullable with a safe getter
- clear the binding in onDestroyView

## Testing
- `./gradlew assemble` *(fails: Connection to the Kotlin daemon has been unexpectedly lost)*

------
https://chatgpt.com/codex/tasks/task_e_68b028a5f45c832b9de526d863389844