### PR TITLE
teams: smoother mine detail binding (fixes #7173)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3001
-        versionName = "0.30.1"
+        versionCode = 3011
+        versionName = "0.30.11"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/MyTeamsDetailFragment.kt
@@ -47,7 +47,8 @@ import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
 class MyTeamsDetailFragment : BaseNewsFragment() {
-    private lateinit var fragmentMyTeamsDetailBinding: FragmentMyTeamsDetailBinding
+    private var _binding: FragmentMyTeamsDetailBinding? = null
+    private val binding get() = _binding!!
     lateinit var tvDescription: TextView
     var user: RealmUserModel? = null
     
@@ -71,13 +72,13 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentMyTeamsDetailBinding = FragmentMyTeamsDetailBinding.inflate(inflater, container, false)
-        val v: View = fragmentMyTeamsDetailBinding.root
+        _binding = FragmentMyTeamsDetailBinding.inflate(inflater, container, false)
+        val v: View = binding.root
         initializeViews(v)
         mRealm = databaseService.realmInstance
         user = profileDbHandler.userModel?.let { mRealm.copyFromRealm(it) }
         team = mRealm.where(RealmMyTeam::class.java).equalTo("_id", teamId).findFirst()
-        return fragmentMyTeamsDetailBinding.root
+        return binding.root
     }
 
     private fun initializeViews(v: View) {
@@ -86,12 +87,12 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
         tvDescription = v.findViewById(R.id.description)
         tabLayout = v.findViewById(R.id.tab_layout)
         listContent = v.findViewById(R.id.list_content)
-        fragmentMyTeamsDetailBinding.btnInvite.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) {
+        binding.btnInvite.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) {
             View.VISIBLE
         } else {
             View.GONE
         }
-        fragmentMyTeamsDetailBinding.btnLeave.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) {
+        binding.btnLeave.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) {
             View.VISIBLE
         } else {
             View.GONE
@@ -126,9 +127,14 @@ class MyTeamsDetailFragment : BaseNewsFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        fragmentMyTeamsDetailBinding.title.text = team?.name
+        binding.title.text = team?.name
         tvDescription.text = team?.description
         setTeamList()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onNewsItemClick(news: RealmNews?) {}


### PR DESCRIPTION
## Summary
- use nullable view binding with non-null getter in `MyTeamsDetailFragment`
- clear binding reference in `onDestroyView`

## Testing
- `./gradlew :app:assembleDebug` *(fails: command did not complete in time in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b029179db0832b9e1997090cf72538