### PR TITLE
Refactor PlanFragment binding handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/PlanFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/PlanFragment.kt
@@ -20,12 +20,13 @@ import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import org.ole.planet.myplanet.utilities.Utilities
 
 class PlanFragment : BaseTeamFragment() {
-    private lateinit var fragmentPlanBinding: FragmentPlanBinding
+    private var _binding: FragmentPlanBinding? = null
+    private val binding get() = _binding!!
     private var isEnterprise: Boolean = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentPlanBinding = FragmentPlanBinding.inflate(inflater, container, false)
-        return fragmentPlanBinding.root
+        _binding = FragmentPlanBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -35,16 +36,16 @@ class PlanFragment : BaseTeamFragment() {
         val isMyTeam = RealmMyTeam.isTeamLeader(team?._id, user?.id, mRealm)
         isEnterprise = team?.type?.equals("enterprise", ignoreCase = true) == true
 
-        fragmentPlanBinding.btnAddPlan.text = if (isEnterprise) {
+        binding.btnAddPlan.text = if (isEnterprise) {
             getString(R.string.edit_mission_and_services)
         } else {
             getString(R.string.edit_plan)
         }
 
-        fragmentPlanBinding.btnAddPlan.isVisible = isMyTeam
-        fragmentPlanBinding.btnAddPlan.isEnabled = isMyTeam
+        binding.btnAddPlan.isVisible = isMyTeam
+        binding.btnAddPlan.isEnabled = isMyTeam
 
-        fragmentPlanBinding.btnAddPlan.setOnClickListener {
+        binding.btnAddPlan.setOnClickListener {
             if (isMyTeam) {
                 editTeam()
             }
@@ -153,8 +154,8 @@ class PlanFragment : BaseTeamFragment() {
             missionText + servicesText + rulesText
         }
 
-        fragmentPlanBinding.tvDescription.text = Html.fromHtml(finalText, Html.FROM_HTML_MODE_LEGACY)
-        fragmentPlanBinding.tvDate.text = getString(
+        binding.tvDescription.text = Html.fromHtml(finalText, Html.FROM_HTML_MODE_LEGACY)
+        binding.tvDate.text = getString(
             R.string.two_strings,
             getString(R.string.created_on),
             updatedTeam.createdDate?.let { formatDate(it) }
@@ -170,5 +171,10 @@ class PlanFragment : BaseTeamFragment() {
     override fun clearImages() {
         imageList.clear()
         llImage?.removeAllViews()
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }


### PR DESCRIPTION
## Summary
- use nullable backing property for `FragmentPlanBinding` in `PlanFragment`
- clear view binding in `onDestroyView`

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68b028981b38832b9cdb2376989b2ac8