### PR TITLE
Refactor feedback submission with ViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentFeedbackBinding
@@ -19,7 +19,7 @@ import org.ole.planet.myplanet.utilities.Utilities
 class FeedbackFragment : DialogFragment(), View.OnClickListener {
     private var _binding: FragmentFeedbackBinding? = null
     private val binding get() = _binding!!
-    private val viewModel: SubmitFeedbackViewModel by viewModels()
+    private val viewModel: SubmitFeedbackViewModel by activityViewModels()
     private var model: RealmUserModel? = null
     var user: String? = ""
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentFeedbackBinding
@@ -19,7 +19,7 @@ import org.ole.planet.myplanet.utilities.Utilities
 class FeedbackFragment : DialogFragment(), View.OnClickListener {
     private var _binding: FragmentFeedbackBinding? = null
     private val binding get() = _binding!!
-    private val viewModel: SubmitFeedbackViewModel by activityViewModels()
+    private val viewModel: SubmitFeedbackViewModel by viewModels()
     private var model: RealmUserModel? = null
     var user: String? = ""
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentFeedbackBinding
@@ -19,7 +19,7 @@ import org.ole.planet.myplanet.utilities.Utilities
 class FeedbackFragment : DialogFragment(), View.OnClickListener {
     private var _binding: FragmentFeedbackBinding? = null
     private val binding get() = _binding!!
-    private val viewModel: SubmitFeedbackViewModel by viewModels()
+    private val viewModel: SubmitFeedbackViewModel by activityViewModels()
     private var model: RealmUserModel? = null
     var user: String? = ""
 
@@ -46,7 +46,7 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
 
         viewModel.submitStatus.observe(viewLifecycleOwner) { result ->
             result.onSuccess {
-                Utilities.toast(activity, R.string.feedback_saved.toString())
+                Utilities.toast(activity, getString(R.string.feedback_saved))
                 Toast.makeText(
                     activity,
                     R.string.thank_you_your_feedback_has_been_submitted,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/SubmitFeedbackViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/SubmitFeedbackViewModel.kt
@@ -1,0 +1,38 @@
+package org.ole.planet.myplanet.ui.feedback
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.repository.FeedbackRepository
+
+@HiltViewModel
+class SubmitFeedbackViewModel @Inject constructor(
+    private val feedbackRepository: FeedbackRepository,
+) : ViewModel() {
+
+    private val _submitStatus = MutableLiveData<Result<Unit>>()
+    val submitStatus: LiveData<Result<Unit>> = _submitStatus
+
+    fun submitFeedback(
+        user: String?,
+        urgent: String,
+        type: String,
+        message: String,
+        item: String? = null,
+        state: String? = null,
+    ) {
+        viewModelScope.launch {
+            runCatching {
+                feedbackRepository.submitFeedback(user, urgent, type, message, item, state)
+            }.onSuccess {
+                _submitStatus.postValue(Result.success(Unit))
+            }.onFailure { error ->
+                _submitStatus.postValue(Result.failure(error))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SubmitFeedbackViewModel with FeedbackRepository
- route feedback saving through repository from FeedbackFragment
- support repository-based feedback persistence

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68b02aad503c832b8e08a8ad60e44fb0