### PR TITLE
refactor notifications handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -1,5 +1,10 @@
 package org.ole.planet.myplanet.repository
 
+import org.ole.planet.myplanet.model.RealmNotification
+
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
+    suspend fun getNotifications(userId: String, filter: String): List<RealmNotification>
+    suspend fun markAsRead(notificationId: String)
+    suspend fun markAllAsRead(userId: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -47,7 +47,9 @@ class NotificationsFragment : Fragment() {
     private lateinit var userId: String
     private var notificationUpdateListener: NotificationListener? = null
     private lateinit var dashboardActivity: DashboardActivity
-    private val viewModel: NotificationsViewModel by viewModels()
+    private val viewModel: NotificationsViewModel by viewModels(
+        extrasProducer = { defaultViewModelCreationExtras }
+    )
 
     override fun onAttach(context: Context) {
         super.onAttach(context)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -47,9 +47,7 @@ class NotificationsFragment : Fragment() {
     private lateinit var userId: String
     private var notificationUpdateListener: NotificationListener? = null
     private lateinit var dashboardActivity: DashboardActivity
-    private val viewModel: NotificationsViewModel by viewModels(
-        extrasProducer = { defaultViewModelCreationExtras }
-    )
+    private val viewModel: NotificationsViewModel by viewModels()
 
     override fun onAttach(context: Context) {
         super.onAttach(context)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsViewModel.kt
@@ -1,0 +1,69 @@
+package org.ole.planet.myplanet.ui.dashboard.notification
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.repository.NotificationRepository
+
+@HiltViewModel
+class NotificationsViewModel @Inject constructor(
+    private val notificationRepository: NotificationRepository
+) : ViewModel() {
+    private val _notifications = MutableStateFlow<List<RealmNotification>>(emptyList())
+    val notifications: StateFlow<List<RealmNotification>> = _notifications.asStateFlow()
+
+    private val _unreadCount = MutableStateFlow(0)
+    val unreadCount: StateFlow<Int> = _unreadCount.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private var userId: String = ""
+    private var currentFilter: String = "all"
+
+    fun initialize(userId: String) {
+        this.userId = userId
+        loadNotifications("all")
+    }
+
+    fun loadNotifications(filter: String) {
+        currentFilter = filter
+        viewModelScope.launch {
+            _notifications.value = notificationRepository.getNotifications(userId, filter)
+            _unreadCount.value = notificationRepository.getUnreadCount(userId)
+        }
+    }
+
+    fun markAsRead(notificationId: String) {
+        viewModelScope.launch {
+            notificationRepository.markAsRead(notificationId)
+            loadNotifications(currentFilter)
+        }
+    }
+
+    fun markAllAsRead() {
+        viewModelScope.launch {
+            try {
+                notificationRepository.markAllAsRead(userId)
+            } catch (e: Exception) {
+                _error.value = e.message
+            } finally {
+                loadNotifications(currentFilter)
+            }
+        }
+    }
+
+    fun refresh() {
+        loadNotifications(currentFilter)
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+}


### PR DESCRIPTION
## Summary
- move notification database operations into NotificationRepository and add helper methods
- introduce NotificationsViewModel exposing notifications and unread counts
- update NotificationsFragment to observe ViewModel state and delegate actions to it

## Testing
- `./gradlew assembleDebug` *(fails: build timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68b029d20ddc832b857f86f1adff5ee0