### PR TITLE
sync: smoother realm handling (fixes #7202)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -473,7 +473,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         lifecycleScope.launch(Dispatchers.IO) {
             try {
                 var attempt = 0
-                Realm.getDefaultInstance().use { realm ->
+                databaseService.withRealm { realm ->
                     while (true) {
                         realm.refresh()
                         val realmResults = realm.where(RealmUserModel::class.java).findAll()
@@ -531,11 +531,11 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                     val betaAutoDownload = defaultPref.getBoolean("beta_auto_download", false)
                     if (betaAutoDownload) {
                         withContext(Dispatchers.IO) {
-                            val downloadRealm = Realm.getDefaultInstance()
-                            try {
-                                backgroundDownload(downloadAllFiles(getAllLibraryList(downloadRealm)), activityContext)
-                            } finally {
-                                downloadRealm.close()
+                            databaseService.withRealm { realm ->
+                                backgroundDownload(
+                                    downloadAllFiles(getAllLibraryList(realm)),
+                                    activityContext
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -473,16 +473,15 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
         lifecycleScope.launch(Dispatchers.IO) {
             try {
                 var attempt = 0
-                databaseService.withRealm { realm ->
-                    while (true) {
-                        realm.refresh()
-                        val realmResults = realm.where(RealmUserModel::class.java).findAll()
-                        if (realmResults.isNotEmpty()) {
-                            break
-                        }
-                        attempt++
-                        delay(1000)
+                while (true) {
+                    val hasUser = databaseService.withRealm { realm ->
+                        realm.where(RealmUserModel::class.java).findAll().isNotEmpty()
                     }
+                    if (hasUser) {
+                        break
+                    }
+                    attempt++
+                    delay(1000)
                 }
 
                 withContext(Dispatchers.Main) {


### PR DESCRIPTION
## Summary
- replace direct Realm instance with databaseService.withRealm in SyncActivity
- use databaseService.withRealm for background download realm access

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68b1b546e548832ba42051947f536af8