### PR TITLE
Add Realm query helper and refactor team repo

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -17,6 +17,20 @@ open class RealmRepository(private val databaseService: DatabaseService) {
         realm.queryList(clazz, builder)
     }
 
+    protected suspend fun <T : RealmObject> queryInList(
+        clazz: Class<T>,
+        fieldName: String,
+        ids: List<String>,
+    ): List<T> {
+        if (ids.isEmpty()) return emptyList()
+        return databaseService.withRealmAsync { realm ->
+            realm.queryList(clazz) {
+                `in`(fieldName, ids.toTypedArray())
+            }
+        }
+    }
+
+
     protected suspend fun <T : RealmObject, V : Any> findByField(
         clazz: Class<T>,
         fieldName: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.repository
 
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.datamanager.queryList
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 
@@ -11,13 +10,10 @@ class TeamRepositoryImpl @Inject constructor(
 ) : RealmRepository(databaseService), TeamRepository {
 
     override suspend fun getTeamResources(teamId: String): List<RealmMyLibrary> {
-        return withRealm { realm ->
-            val resourceIds = RealmMyTeam.getResourceIds(teamId, realm)
-            if (resourceIds.isEmpty()) emptyList() else
-                realm.queryList(RealmMyLibrary::class.java) {
-                    `in`("id", resourceIds.toTypedArray())
-                }
+        val resourceIds = withRealm { realm ->
+            RealmMyTeam.getResourceIds(teamId, realm)
         }
+        return queryInList(RealmMyLibrary::class.java, "id", resourceIds)
     }
 }
 


### PR DESCRIPTION
## Summary
- add generic `queryInList` helper to abstract Realm `in` queries
- refactor `TeamRepositoryImpl` to use new `queryInList` for resource lookups

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68b1b6ce1fcc832b8c50c0465a892d13