### PR TITLE
refactor: use DiffUtils in chat history adapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
@@ -345,7 +345,9 @@ class ChatHistoryListAdapter(
     companion object {
         private val DIFF_CALLBACK =
             DiffUtils.itemCallback<RealmChatHistory>(
-                areItemsTheSame = { old, new -> old._id == new._id },
+                areItemsTheSame = { old, new ->
+                    (old._id ?: old.id) == (new._id ?: new.id)
+                },
                 areContentsTheSame = { old, new -> old == new }
             )
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toDrawable
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -30,6 +29,7 @@ import org.ole.planet.myplanet.model.RealmNews.Companion.createNews
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.ui.news.ExpandableListAdapter
 import org.ole.planet.myplanet.ui.news.GrandChildAdapter
+import org.ole.planet.myplanet.utilities.DiffUtils
 
 class ChatHistoryListAdapter(
     var context: Context,
@@ -343,15 +343,11 @@ class ChatHistoryListAdapter(
     }
 
     companion object {
-        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<RealmChatHistory>() {
-            override fun areItemsTheSame(oldItem: RealmChatHistory, newItem: RealmChatHistory): Boolean {
-                return oldItem._id == newItem._id
-            }
-
-            override fun areContentsTheSame(oldItem: RealmChatHistory, newItem: RealmChatHistory): Boolean {
-                return oldItem == newItem
-            }
-        }
+        private val DIFF_CALLBACK =
+            DiffUtils.itemCallback<RealmChatHistory>(
+                idSelector = { it._id },
+                contentsComparator = { old, new -> old == new }
+            )
     }
 
     class ViewHolderChat(val rowChatHistoryBinding: RowChatHistoryBinding) : RecyclerView.ViewHolder(rowChatHistoryBinding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
@@ -345,8 +345,8 @@ class ChatHistoryListAdapter(
     companion object {
         private val DIFF_CALLBACK =
             DiffUtils.itemCallback<RealmChatHistory>(
-                idSelector = { it._id },
-                contentsComparator = { old, new -> old == new }
+                areItemsTheSame = { old, new -> old._id == new._id },
+                areContentsTheSame = { old, new -> old == new }
             )
     }
 


### PR DESCRIPTION
## Summary
- use `DiffUtils.itemCallback` for `ChatHistoryListAdapter`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b4ed3b88832b9a8a191b09260be7