### PR TITLE
Refactor feedback flow realm usage

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
@@ -3,7 +3,6 @@ package org.ole.planet.myplanet.repository
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import io.realm.Realm
 import io.realm.RealmChangeListener
 import io.realm.RealmResults
 import io.realm.Sort
@@ -23,34 +22,34 @@ interface FeedbackRepository {
 }
 
 class FeedbackRepositoryImpl @Inject constructor(
-    databaseService: DatabaseService,
+    private val databaseService: DatabaseService,
     private val gson: Gson,
 ) : RealmRepository(databaseService), FeedbackRepository {
 
     override fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>> =
         callbackFlow {
-            val realm = Realm.getDefaultInstance()
-            val feedbackList: RealmResults<RealmFeedback> =
-                if (userModel?.isManager() == true) {
-                    realm.where(RealmFeedback::class.java)
-                        .sort("openTime", Sort.DESCENDING)
-                        .findAllAsync()
-                } else {
-                    realm.where(RealmFeedback::class.java)
-                        .equalTo("owner", userModel?.name)
-                        .sort("openTime", Sort.DESCENDING)
-                        .findAllAsync()
+            databaseService.withRealm { realm ->
+                val feedbackList: RealmResults<RealmFeedback> =
+                    if (userModel?.isManager() == true) {
+                        realm.where(RealmFeedback::class.java)
+                            .sort("openTime", Sort.DESCENDING)
+                            .findAllAsync()
+                    } else {
+                        realm.where(RealmFeedback::class.java)
+                            .equalTo("owner", userModel?.name)
+                            .sort("openTime", Sort.DESCENDING)
+                            .findAllAsync()
+                    }
+
+                val listener = RealmChangeListener<RealmResults<RealmFeedback>> { results ->
+                    trySend(realm.copyFromRealm(results))
                 }
 
-            val listener = RealmChangeListener<RealmResults<RealmFeedback>> { results ->
-                trySend(realm.copyFromRealm(results))
-            }
+                feedbackList.addChangeListener(listener)
 
-            feedbackList.addChangeListener(listener)
-
-            awaitClose {
-                feedbackList.removeChangeListener(listener)
-                realm.close()
+                awaitClose {
+                    feedbackList.removeChangeListener(listener)
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Replace manual Realm instance management in `FeedbackRepository` with `databaseService.withRealm`
- Register query and listener within `withRealm` and remove explicit `close`

## Testing
- `./gradlew assembleDebug` *(fails: command terminated early; partial output shows build starting)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b50d4084832b8fe47d83c7397c69