### PR TITLE
Use nullable binding in community fragments

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
@@ -12,23 +12,31 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
 class CommunityTabFragment : Fragment() {
-    private lateinit var fragmentTeamDetailBinding: FragmentTeamDetailBinding
+    private var _binding: FragmentTeamDetailBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentTeamDetailBinding = FragmentTeamDetailBinding.inflate(inflater, container, false)
-        return fragmentTeamDetailBinding.root
+        _binding = FragmentTeamDetailBinding.inflate(inflater, container, false)
+        return _binding!!.root
     }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val settings = requireActivity().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val sParentcode = settings.getString("parentCode", "")
         val communityName = settings.getString("communityName", "")
         val user = UserProfileDbHandler(requireActivity()).userModel
-        fragmentTeamDetailBinding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), user?.planetCode + "@" + sParentcode, false, settings)
-        TabLayoutMediator(fragmentTeamDetailBinding.tabLayout, fragmentTeamDetailBinding.viewPager2) { tab, position ->
-            tab.text = (fragmentTeamDetailBinding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
+        binding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), user?.planetCode + "@" + sParentcode, false, settings)
+        TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->
+            tab.text = (binding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
         }.attach()
-        fragmentTeamDetailBinding.title.text = if (user?.planetCode == "") communityName else user?.planetCode
-        fragmentTeamDetailBinding.subtitle.text = settings.getString("planetType", "")
-        fragmentTeamDetailBinding.llActionButtons.visibility = View.GONE
+        binding.title.text = if (user?.planetCode == "") communityName else user?.planetCode
+        binding.subtitle.text = settings.getString("planetType", "")
+        binding.llActionButtons.visibility = View.GONE
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
@@ -15,12 +15,13 @@ import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
 class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
-    private lateinit var fragmentTeamDetailBinding: FragmentTeamDetailBinding
+    private var _binding: FragmentTeamDetailBinding? = null
+    private val binding get() = _binding!!
     private var bottomSheetBehavior: BottomSheetBehavior<View>? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentTeamDetailBinding = FragmentTeamDetailBinding.inflate(inflater, container, false)
-        return fragmentTeamDetailBinding.root
+        _binding = FragmentTeamDetailBinding.inflate(inflater, container, false)
+        return _binding!!.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -75,18 +76,23 @@ class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
     }
 
     private fun initCommunityTab() {
-        fragmentTeamDetailBinding.llActionButtons.visibility = View.GONE
+        binding.llActionButtons.visibility = View.GONE
         val settings = requireActivity().getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         val sParentcode = settings.getString("parentCode", "")
         val communityName = settings.getString("communityName", "")
-        fragmentTeamDetailBinding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), "$communityName@$sParentcode", true, settings)
-        TabLayoutMediator(fragmentTeamDetailBinding.tabLayout, fragmentTeamDetailBinding.viewPager2) { tab, position ->
-            tab.text = (fragmentTeamDetailBinding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
+        binding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), "$communityName@$sParentcode", true, settings)
+        TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->
+            tab.text = (binding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
         }.attach()
-        fragmentTeamDetailBinding.title.text = communityName
-        fragmentTeamDetailBinding.title.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
-        fragmentTeamDetailBinding.subtitle.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
-        fragmentTeamDetailBinding.subtitle.text = settings.getString("planetType", "")
-        fragmentTeamDetailBinding.appBar.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.secondary_bg))
+        binding.title.text = communityName
+        binding.title.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
+        binding.subtitle.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
+        binding.subtitle.text = settings.getString("planetType", "")
+        binding.appBar.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.secondary_bg))
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }


### PR DESCRIPTION
## Summary
- make CommunityTabFragment use nullable binding and clean up in onDestroyView
- use nullable binding pattern for HomeCommunityDialogFragment

## Testing
- `./gradlew assembleDebug --console=plain` *(fails: Cannot access output property 'outputDir' of task ':app:mergeDefaultDebugNativeLibs')*


------
https://chatgpt.com/codex/tasks/task_e_68b57d858f38832b88d3659929ed8470