### PR TITLE
Add AuthHelper username validation tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,6 +176,7 @@ repositories {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
+    testImplementation "io.mockk:mockk:1.13.11"
     implementation fileTree(include: ['*.jar', '*.aar'], dir: 'libs')
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/app/src/test/java/org/ole/planet/myplanet/utilities/AuthHelperTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utilities/AuthHelperTest.kt
@@ -1,0 +1,64 @@
+package org.ole.planet.myplanet.utilities
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.realm.Realm
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.model.RealmUserModel
+
+class AuthHelperTest {
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = mockk()
+        every { context.getString(R.string.username_cannot_be_empty) } returns "Username cannot be empty"
+        every { context.getString(R.string.invalid_username) } returns "Invalid username"
+        every { context.getString(R.string.must_start_with_letter_or_number) } returns "Must start with letter or number"
+        every { context.getString(R.string.only_letters_numbers_and_are_allowed) } returns "Only letters numbers and _ . - are allowed"
+        every { context.getString(R.string.username_taken) } returns "Username taken"
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun validateUsername_allowsValidUsernames() {
+        listOf("user1", "User_2", "user-3", "user.4").forEach { username ->
+            assertNull(AuthHelper.validateUsername(context, username))
+        }
+    }
+
+    @Test
+    fun validateUsername_rejectsInvalidCharacters() {
+        val result = AuthHelper.validateUsername(context, "invalid\$user")
+        assertEquals("Only letters numbers and _ . - are allowed", result)
+    }
+
+    @Test
+    fun validateUsername_rejectsUsernamesStartingWithNonAlphanumeric() {
+        val result = AuthHelper.validateUsername(context, "_start")
+        assertEquals("Must start with letter or number", result)
+    }
+
+    @Test
+    fun validateUsername_rejectsDuplicateUsername() {
+        mockkObject(RealmUserModel.Companion)
+        every { RealmUserModel.isUserExists(any(), "existing") } returns true
+        val realm = mockk<Realm>()
+
+        val result = AuthHelper.validateUsername(context, "existing", realm)
+
+        assertEquals("Username taken", result)
+    }
+}


### PR DESCRIPTION
## Summary
- add JVM unit tests for AuthHelper username validation covering valid names, invalid chars, leading symbol checks, and duplicate detection
- include MockK dependency for mocking Realm interactions

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68b59ce744b8832b8c7be1b99eedace3