### PR TITLE
community: smoother link realm handling (fixes #7270)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3039
-        versionName = "0.30.39"
+        versionCode = 3044
+        versionName = "0.30.44"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
@@ -12,7 +12,6 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import io.realm.Realm
 import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
@@ -32,24 +31,31 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
 
     @Inject
     lateinit var databaseService: DatabaseService
-    lateinit var mRealm: Realm
     var selectedTeam: RealmMyTeam? = null
 
     override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
-        val query = mRealm.where(RealmMyTeam::class.java).isEmpty("teamId").isNotEmpty("name").equalTo(             "type",
-            if (binding.spnLink.selectedItem.toString() == "Enterprises") "enterprise"
-            else ""
-        ).notEqualTo("status", "archived").findAll()
-        binding.rvList.layoutManager = LinearLayoutManager(requireActivity())
-        val adapter = AdapterTeam(requireActivity(), query, mRealm)
-        adapter.setTeamSelectedListener(object : AdapterTeam.OnTeamSelectedListener {
-            override fun onSelectedTeam(team: RealmMyTeam) {
-                this@AddLinkFragment.selectedTeam = team
-                Utilities.toast(requireActivity(), "Selected ${team.name}")
-            }
-        })
-
-        binding.rvList.adapter = adapter
+        databaseService.withRealm { realm ->
+            val teams = realm.copyFromRealm(
+                realm.where(RealmMyTeam::class.java)
+                    .isEmpty("teamId")
+                    .isNotEmpty("name")
+                    .equalTo(
+                        "type",
+                        if (binding.spnLink.selectedItem.toString() == "Enterprises") "enterprise" else ""
+                    )
+                    .notEqualTo("status", "archived")
+                    .findAll()
+            )
+            binding.rvList.layoutManager = LinearLayoutManager(requireActivity())
+            val adapter = AdapterTeam(requireActivity(), teams, databaseService)
+            adapter.setTeamSelectedListener(object : AdapterTeam.OnTeamSelectedListener {
+                override fun onSelectedTeam(team: RealmMyTeam) {
+                    this@AddLinkFragment.selectedTeam = team
+                    Utilities.toast(requireActivity(), "Selected ${team.name}")
+                }
+            })
+            binding.rvList.adapter = adapter
+        }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -72,7 +78,6 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        mRealm = databaseService.realmInstance
         binding.spnLink.onItemSelectedListener = this
         binding.btnSave.setOnClickListener {
             val type = binding.spnLink.selectedItem.toString()
@@ -86,22 +91,20 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
                 return@setOnClickListener
             }
 
-            mRealm.executeTransaction {
-                val team = it.createObject(RealmMyTeam::class.java, UUID.randomUUID().toString())
-                team.docType = "link"
-                team.updated = true
-                team.title = title
-                team.route = """/${type.lowercase(Locale.ROOT)}/view/${selectedTeam!!._id}"""
-                dismiss()
-
+            databaseService.withRealm { realm ->
+                realm.executeTransaction { r ->
+                    val team = r.createObject(RealmMyTeam::class.java, UUID.randomUUID().toString())
+                    team.docType = "link"
+                    team.updated = true
+                    team.title = title
+                    team.route = """/${type.lowercase(Locale.ROOT)}/view/${selectedTeam!!._id}"""
+                }
             }
+            dismiss()
         }
     }
 
     override fun onDestroyView() {
-        if (this::mRealm.isInitialized && !mRealm.isClosed) {
-            mRealm.close()
-        }
         _binding = null
         super.onDestroyView()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeam.kt
@@ -8,8 +8,8 @@ import android.widget.ListView
 import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import io.realm.Realm
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.databinding.ItemTeamGridBinding
 import org.ole.planet.myplanet.databinding.LayoutUserListBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
@@ -19,7 +19,7 @@ import org.ole.planet.myplanet.utilities.DiffUtils
 class AdapterTeam(
     private val context: Context,
     teams: List<RealmMyTeam>,
-    private val mRealm: Realm
+    private val databaseService: DatabaseService,
 ) : ListAdapter<RealmMyTeam, AdapterTeam.ViewHolderTeam>(
     DiffUtils.itemCallback(
         areItemsTheSame = { oldItem, newItem -> oldItem._id == newItem._id },
@@ -57,13 +57,17 @@ class AdapterTeam(
 
     private fun showUserList(realmMyTeam: RealmMyTeam) {
         val layoutUserListBinding = LayoutUserListBinding.inflate(LayoutInflater.from(context))
-        users = RealmMyTeam.getUsers(realmMyTeam._id, mRealm, "")
-        setListAdapter(layoutUserListBinding.listUser, users)
+        databaseService.withRealm { realm ->
+            users = realm.copyFromRealm(RealmMyTeam.getUsers(realmMyTeam._id, realm, ""))
+            setListAdapter(layoutUserListBinding.listUser, users)
+        }
         layoutUserListBinding.etSearch.addTextChangedListener(object : android.text.TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-                users = RealmMyTeam.filterUsers(realmMyTeam._id, "$s", mRealm)
-                setListAdapter(layoutUserListBinding.listUser, users)
+                databaseService.withRealm { realm ->
+                    users = realm.copyFromRealm(RealmMyTeam.filterUsers(realmMyTeam._id, "$s", realm))
+                    setListAdapter(layoutUserListBinding.listUser, users)
+                }
             }
             override fun afterTextChanged(s: android.text.Editable) {}
         })

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeam.kt
@@ -9,9 +9,9 @@ import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.databinding.ItemTeamGridBinding
 import org.ole.planet.myplanet.databinding.LayoutUserListBinding
+import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.utilities.DiffUtils


### PR DESCRIPTION
## Summary
- drop mRealm field from AddLinkFragment
- use DatabaseService.withRealm for team queries and save
- let AdapterTeam query users via DatabaseService instead of holding Realm

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c2999578832ba1b2068ea06aaa31