### PR TITLE
Add repository helper to mark notifications read

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -2,4 +2,5 @@ package org.ole.planet.myplanet.repository
 
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
+    suspend fun markAsRead(id: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -17,4 +17,10 @@ class NotificationRepositoryImpl @Inject constructor(
                 .toInt()
         }
     }
+
+    override suspend fun markAsRead(id: String) {
+        update(RealmNotification::class.java, "id", id) { notification ->
+            notification.isRead = true
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/NotificationUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/NotificationUtils.kt
@@ -21,8 +21,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.repository.NotificationRepository
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 
 object NotificationUtils {
@@ -487,7 +486,7 @@ object NotificationUtils {
 @AndroidEntryPoint
 class NotificationActionReceiver : BroadcastReceiver() {
     @Inject
-    lateinit var databaseService: DatabaseService
+    lateinit var notificationRepository: NotificationRepository
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.action
         val notificationId = intent.getStringExtra(NotificationUtils.EXTRA_NOTIFICATION_ID)
@@ -536,21 +535,9 @@ class NotificationActionReceiver : BroadcastReceiver() {
             return
         }
 
-
-        try {
-            databaseService.withRealm { realm ->
-                realm.executeTransaction { r ->
-                    val notification = r.where(RealmNotification::class.java)
-                        .equalTo("id", notificationId)
-                        .findFirst()
-
-                    if (notification != null) {
-                        notification.isRead = true
-                    }
-                }
-            }
-
-            MainApplication.applicationScope.launch(Dispatchers.Main) {
+        MainApplication.applicationScope.launch(Dispatchers.Main) {
+            try {
+                notificationRepository.markAsRead(notificationId)
                 delay(200)
                 val broadcastIntent = Intent("org.ole.planet.myplanet.NOTIFICATION_READ_FROM_SYSTEM")
                 broadcastIntent.setPackage(context.packageName)
@@ -575,10 +562,9 @@ class NotificationActionReceiver : BroadcastReceiver() {
                 } catch (e: Exception) {
                     e.printStackTrace()
                 }
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
-            
-        } catch (e: Exception) {
-            e.printStackTrace()
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `markAsRead` to `NotificationRepository` and its implementation
- use repository in `NotificationActionReceiver` instead of direct Realm access

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68b6c3691524832b8a2a865f693a995f