### PR TITLE
teams: smoother leaders binding (fixes #7273)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3039
-        versionName = "0.30.39"
+        versionCode = 3047
+        versionName = "0.30.47"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/LeadersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/LeadersFragment.kt
@@ -16,24 +16,31 @@ import org.ole.planet.myplanet.model.RealmUserModel
 
 @AndroidEntryPoint
 class LeadersFragment : Fragment() {
-    private lateinit var fragmentMembersBinding: FragmentMembersBinding
+    private var binding: FragmentMembersBinding? = null
     @Inject
     @AppPreferences
     lateinit var settings: SharedPreferences
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentMembersBinding = FragmentMembersBinding.inflate(inflater, container, false)
-        return fragmentMembersBinding.root
+        binding = FragmentMembersBinding.inflate(inflater, container, false)
+        return binding!!.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val leaders = settings.getString("communityLeaders", "")
         if (leaders.isNullOrEmpty()) {
-            fragmentMembersBinding.tvNodata.text = getString(R.string.no_data_available)
+            binding?.tvNodata?.let { it.text = getString(R.string.no_data_available) }
         } else {
             val leadersList = RealmUserModel.parseLeadersJson(leaders)
-            fragmentMembersBinding.rvMember.layoutManager = GridLayoutManager(activity, 2)
-            fragmentMembersBinding.rvMember.adapter = AdapterLeader(requireActivity(), leadersList)
+            binding?.rvMember?.apply {
+                layoutManager = GridLayoutManager(activity, 2)
+                adapter = AdapterLeader(requireActivity(), leadersList)
+            }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
     }
 }


### PR DESCRIPTION
## Summary
- make FragmentMembersBinding nullable and clear it in onDestroyView
- update references to use binding with null safety

## Testing
- `./gradlew assembleDebug` *(fails: command did not complete within environment limits)*
- `./gradlew -q help`


------
https://chatgpt.com/codex/tasks/task_e_68b6c2fad57c832ba5a9bda5f520ea42