### PR TITLE
Move resource notification update logic to repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -2,4 +2,5 @@ package org.ole.planet.myplanet.repository
 
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
+    suspend fun updateResourceNotification(userId: String?)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -1,8 +1,12 @@
 package org.ole.planet.myplanet.repository
 
 import javax.inject.Inject
+import org.ole.planet.myplanet.base.BaseResourceFragment
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmNotification
+import io.realm.Realm
+import java.util.Date
+import java.util.UUID
 
 class NotificationRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
@@ -15,6 +19,64 @@ class NotificationRepositoryImpl @Inject constructor(
                 .equalTo("isRead", false)
                 .count()
                 .toInt()
+        }
+    }
+
+    override suspend fun updateResourceNotification(userId: String?) {
+        try {
+            executeTransaction { realm ->
+                val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
+                if (resourceCount > 0) {
+                    val existingNotification = realm.where(RealmNotification::class.java)
+                        .equalTo("userId", userId)
+                        .equalTo("type", "resource")
+                        .findFirst()
+
+                    if (existingNotification != null) {
+                        existingNotification.message = "$resourceCount"
+                        existingNotification.relatedId = "$resourceCount"
+                    } else {
+                        createNotificationIfNotExists(
+                            realm,
+                            "resource",
+                            "$resourceCount",
+                            "$resourceCount",
+                            userId
+                        )
+                    }
+                } else {
+                    realm.where(RealmNotification::class.java)
+                        .equalTo("userId", userId)
+                        .equalTo("type", "resource")
+                        .findFirst()?.deleteFromRealm()
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun createNotificationIfNotExists(
+        realm: Realm,
+        type: String,
+        message: String,
+        relatedId: String?,
+        userId: String?
+    ) {
+        val existingNotification = realm.where(RealmNotification::class.java)
+            .equalTo("userId", userId)
+            .equalTo("type", type)
+            .equalTo("relatedId", relatedId)
+            .findFirst()
+
+        if (existingNotification == null) {
+            realm.createObject(RealmNotification::class.java, "${UUID.randomUUID()}").apply {
+                this.userId = userId ?: ""
+                this.type = type
+                this.message = message
+                this.relatedId = relatedId
+                this.createdAt = Date()
+            }
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -4,17 +4,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.Realm
-import java.util.Date
-import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.base.BaseResourceFragment
-import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.model.RealmNotification
+import java.util.Date
+import java.util.UUID
 import org.ole.planet.myplanet.model.RealmSubmission
+import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.repository.CourseRepository
 import org.ole.planet.myplanet.repository.LibraryRepository
 import org.ole.planet.myplanet.repository.NotificationRepository
@@ -23,7 +21,6 @@ import org.ole.planet.myplanet.repository.UserRepository
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
-    private val databaseService: DatabaseService,
     private val userRepository: UserRepository,
     private val libraryRepository: LibraryRepository,
     private val courseRepository: CourseRepository,
@@ -68,34 +65,16 @@ class DashboardViewModel @Inject constructor(
     }
 
     suspend fun updateResourceNotification(userId: String?) {
-        try {
-            databaseService.executeTransactionAsync { realm ->
-                val resourceCount = BaseResourceFragment.getLibraryList(realm, userId).size
-                if (resourceCount > 0) {
-                    val existingNotification = realm.where(RealmNotification::class.java)
-                        .equalTo("userId", userId)
-                        .equalTo("type", "resource")
-                        .findFirst()
-
-                    if (existingNotification != null) {
-                        existingNotification.message = "$resourceCount"
-                        existingNotification.relatedId = "$resourceCount"
-                    } else {
-                        createNotificationIfNotExists(realm, "resource", "$resourceCount", "$resourceCount", userId)
-                    }
-                } else {
-                    realm.where(RealmNotification::class.java)
-                        .equalTo("userId", userId)
-                        .equalTo("type", "resource")
-                        .findFirst()?.deleteFromRealm()
-                }
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+        notificationRepository.updateResourceNotification(userId)
     }
 
-    fun createNotificationIfNotExists(realm: Realm, type: String, message: String, relatedId: String?, userId: String?) {
+    fun createNotificationIfNotExists(
+        realm: Realm,
+        type: String,
+        message: String,
+        relatedId: String?,
+        userId: String?
+    ) {
         val existingNotification = realm.where(RealmNotification::class.java)
             .equalTo("userId", userId)
             .equalTo("type", type)


### PR DESCRIPTION
## Summary
- add `updateResourceNotification` to `NotificationRepository`
- move resource notification update transaction logic from `DashboardViewModel` into repository
- delegate `DashboardViewModel.updateResourceNotification` to repository

## Testing
- `./gradlew :app:assembleDebug --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68b6c1bcc918832b8f95fac4e3af5eb6