### PR TITLE
mylife: smoother dictionary realm closing (fixes #7295)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3053
-        versionName = "0.30.53"
+        versionCode = 3057
+        versionName = "0.30.57"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
@@ -91,7 +91,7 @@ class DictionaryActivity : BaseActivity() {
     }
 
     override fun onDestroy() {
-        if (this::mRealm.isInitialized && !mRealm.isClosed) {
+        if (!mRealm.isClosed) {
             mRealm.close()
         }
         super.onDestroy()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
@@ -89,4 +89,11 @@ class DictionaryActivity : BaseActivity() {
             }
         }
     }
+
+    override fun onDestroy() {
+        if (this::mRealm.isInitialized && !mRealm.isClosed) {
+            mRealm.close()
+        }
+        super.onDestroy()
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `DictionaryActivity` closes Realm instance in `onDestroy`

## Testing
- `./gradlew assembleDebug -x test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8072ea314832ba5b4812efade5c09