### PR TITLE
resources: smoother pdf reader realm handling (fixes #7297)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3053
-        versionName = "0.30.53"
+        versionCode = 3059
+        versionName = "0.30.59"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- remove manual Realm instance from `PDFReaderActivity`
- wrap library lookup and translation update with `databaseService.withRealm`
- simplify cleanup since `withRealm` handles Realm lifecycle

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b806e965f8832bbd8731115079a146