### PR TITLE
all: smoother `FileUtils.kt` context handling (fixes #7298)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3053
-        versionName = "0.30.53"
+        versionCode = 3060
+        versionName = "0.30.60"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
@@ -84,7 +84,7 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
     fun getUrlsAndStartDownload(lib: List<RealmMyLibrary?>, urls: ArrayList<String>) {
         for (library in lib) {
             val url = UrlUtils.getUrl(library)
-            if (!FileUtils.checkFileExist(url) && !TextUtils.isEmpty(url)) {
+            if (!FileUtils.checkFileExist(requireContext(), url) && !TextUtils.isEmpty(url)) {
                 urls.add(url)
             }
         }
@@ -105,7 +105,7 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
             val library = pendingAutoOpenLibrary!!
             shouldAutoOpenAfterDownload = false
             pendingAutoOpenLibrary = null
-            if (library.isResourceOffline() || FileUtils.checkFileExist(UrlUtils.getUrl(library))) {
+            if (library.isResourceOffline() || FileUtils.checkFileExist(requireContext(), UrlUtils.getUrl(library))) {
                 ResourceOpener.openFileType(requireActivity(), library, "offline", profileDbHandler)
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
@@ -30,7 +30,6 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.news.AdapterNews
 import org.ole.planet.myplanet.ui.news.AdapterNews.OnNewsItemClickListener
 import org.ole.planet.myplanet.ui.news.ReplyActivity
-import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.FileUtils.getFileNameFromUrl
 import org.ole.planet.myplanet.utilities.FileUtils.getRealPathFromURI
 import org.ole.planet.myplanet.utilities.FileUtils

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
@@ -33,7 +33,7 @@ import org.ole.planet.myplanet.ui.news.ReplyActivity
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.FileUtils.getFileNameFromUrl
 import org.ole.planet.myplanet.utilities.FileUtils.getRealPathFromURI
-import org.ole.planet.myplanet.utilities.FileUtils.openOleFolder
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
 
 @RequiresApi(api = Build.VERSION_CODES.O)
@@ -131,7 +131,7 @@ abstract class BaseNewsFragment : BaseContainerFragment(), OnNewsItemClickListen
 
     override fun addImage(llImage: LinearLayout?) {
         this.llImage = llImage
-        val openFolderIntent = openOleFolder()
+        val openFolderIntent = FileUtils.openOleFolder(requireContext())
         openFolderLauncher.launch(openFolderIntent)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DownloadWorker.kt
@@ -20,7 +20,7 @@ import org.ole.planet.myplanet.di.ApiInterfaceEntryPoint
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.utilities.DownloadUtils
 import org.ole.planet.myplanet.utilities.FileUtils.getFileNameFromUrl
-import org.ole.planet.myplanet.utilities.FileUtils.getSDPathFromUrl
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.UrlUtils
 
 class DownloadWorker(val context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
@@ -93,7 +93,7 @@ class DownloadWorker(val context: Context, workerParams: WorkerParameters) : Cor
 
     private suspend fun downloadFileBody(body: ResponseBody, url: String, index: Int, total: Int) {
         val fileSize = body.contentLength()
-        val outputFile: File = getSDPathFromUrl(url)
+        val outputFile: File = FileUtils.getSDPathFromUrl(context, url)
         var totalBytes: Long = 0
 
         outputFile.sink().buffer().use { sink ->

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
@@ -33,7 +33,7 @@ import org.ole.planet.myplanet.utilities.DownloadUtils
 import org.ole.planet.myplanet.utilities.FileUtils.availableExternalMemorySize
 import org.ole.planet.myplanet.utilities.FileUtils.externalMemoryAvailable
 import org.ole.planet.myplanet.utilities.FileUtils.getFileNameFromUrl
-import org.ole.planet.myplanet.utilities.FileUtils.getSDPathFromUrl
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.UrlUtils.header
 
 class MyDownloadService : Service() {
@@ -213,7 +213,7 @@ class MyDownloadService : Service() {
     @Throws(IOException::class)
     private fun downloadFile(body: ResponseBody, url: String) {
         val fileSize = body.contentLength()
-        outputFile = getSDPathFromUrl(url)
+        outputFile = FileUtils.getSDPathFromUrl(this@MyDownloadService, url)
         var total: Long = 0
         val startTime = System.currentTimeMillis()
         var timeCount = 1

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -123,7 +123,7 @@ class Service @Inject constructor(
                     try {
                         val checksum = response.body()?.string()
                         if (TextUtils.isEmpty(checksum)) {
-                            val f = FileUtils.getSDPathFromUrl(path)
+                            val f = FileUtils.getSDPathFromUrl(context, path)
                             if (f.exists()) {
                                 val sha256 = Sha256Utils().getCheckSumFromFile(f)
                                 if (checksum?.contains(sha256) == true) {

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
@@ -299,7 +299,7 @@ open class RealmMyLibrary : RealmObject() {
                         if (key.indexOf("/") < 0) {
                             resourceRemoteAddress = "${settings.getString("couchdbURL", "http://")}/resources/$resourceId/$key"
                             resourceLocalAddress = key
-                            resourceOffline = FileUtils.checkFileExist(resourceRemoteAddress)
+                            resourceOffline = FileUtils.checkFileExist(context, resourceRemoteAddress)
                         }
                     }
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
@@ -45,7 +45,6 @@ import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.DownloadUtils.downloadAllFiles
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utilities.FileUtils
-import org.ole.planet.myplanet.utilities.FileUtils.availableOverTotalMemoryFormattedString
 import org.ole.planet.myplanet.utilities.LocaleHelper
 import org.ole.planet.myplanet.utilities.ThemeManager
 import org.ole.planet.myplanet.utilities.Utilities
@@ -133,7 +132,7 @@ class SettingActivity : AppCompatActivity() {
             // Show Available space under the "Freeup Space" preference.
             val spacePreference = findPreference<Preference>("freeup_space")
             if (spacePreference != null) {
-                spacePreference.summary = "${getString(R.string.available_space_colon)} $availableOverTotalMemoryFormattedString"
+                spacePreference.summary = "${getString(R.string.available_space_colon)} ${FileUtils.availableOverTotalMemoryFormattedString(requireContext())}"
             }
 
             val autoDownload = findPreference<SwitchPreference>("beta_auto_download")
@@ -191,7 +190,7 @@ class SettingActivity : AppCompatActivity() {
                                         library.resourceOffline = false
                                     }
                                 }, {
-                                    val f = File(FileUtils.SD_PATH)
+                                    val f = File(FileUtils.getOlePath(requireContext()))
                                     deleteRecursive(f)
                                     Utilities.toast(requireActivity(), R.string.data_cleared.toString())
                                 }) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -132,7 +132,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     override fun downloadDictionary() {
         val list = ArrayList<String>()
         list.add(Constants.DICTIONARY_URL)
-        if (!FileUtils.checkFileExist(Constants.DICTIONARY_URL)) {
+        if (!FileUtils.checkFileExist(requireContext(), Constants.DICTIONARY_URL)) {
             Utilities.toast(activity, getString(R.string.downloading_started_please_check_notification))
             DownloadUtils.openDownloadService(activity, list, false)
         } else {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -89,7 +89,7 @@ import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 import org.ole.planet.myplanet.utilities.DialogUtils.guestDialog
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils
-import org.ole.planet.myplanet.utilities.FileUtils.totalAvailableMemoryRatio
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utilities.LocaleHelper
 import org.ole.planet.myplanet.utilities.NotificationUtils
@@ -798,7 +798,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     }
 
     private fun createStorageDatabaseNotifications(realm: Realm, userId: String?) {
-        val storageRatio = totalAvailableMemoryRatio
+        val storageRatio = FileUtils.totalAvailableMemoryRatio(this)
         if (storageRatio > 85) {
             dashboardViewModel.createNotificationIfNotExists(realm, "storage", "$storageRatio%", "storage", userId)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
@@ -33,7 +33,7 @@ class DictionaryActivity : BaseActivity() {
         mRealm = databaseService.realmInstance
         list = mRealm.where(RealmDictionary::class.java)?.findAll()
         fragmentDictionaryBinding.tvResult.text = getString(R.string.list_size, list?.size)
-        if (FileUtils.checkFileExist(Constants.DICTIONARY_URL)) {
+        if (FileUtils.checkFileExist(this, Constants.DICTIONARY_URL)) {
             insertDictionary()
         } else {
             val list = ArrayList<String>()
@@ -46,7 +46,7 @@ class DictionaryActivity : BaseActivity() {
     private fun insertDictionary() {
         if (list.isNullOrEmpty()) {
             try {
-                val data = FileUtils.getStringFromFile(FileUtils.getSDPathFromUrl(Constants.DICTIONARY_URL))
+                val data = FileUtils.getStringFromFile(FileUtils.getSDPathFromUrl(this, Constants.DICTIONARY_URL))
                 val json = Gson().fromJson(data, JsonArray::class.java)
                 mRealm.executeTransactionAsync {
                     json?.forEach { js ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsDetailActivity.kt
@@ -84,7 +84,7 @@ class NewsDetailActivity : BaseActivity() {
                 }
                 msg = msg?.replace(
                     markDown,
-                    "<img style=\"float: right; padding: 10px 10px 10px 10px;\"  width=\"200px\" src=\"file://" + FileUtils.SD_PATH + "/" + library?.id + "/" + library?.resourceLocalAddress + "\"/>",
+                    "<img style=\"float: right; padding: 10px 10px 10px 10px;\"  width=\"200px\" src=\"file://" + FileUtils.getOlePath(this) + library?.id + "/" + library?.resourceLocalAddress + "\"/>",
                     false
                 )
             }
@@ -135,7 +135,7 @@ class NewsDetailActivity : BaseActivity() {
             }
             if (library != null) {
                 Glide.with(this)
-                    .load(File(FileUtils.SD_PATH, library.id + "/" + library.resourceLocalAddress))
+                    .load(File(FileUtils.getOlePath(this), library.id + "/" + library.resourceLocalAddress))
                     .into(binding.img)
                 binding.img.visibility = View.VISIBLE
                 return

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
@@ -32,7 +32,7 @@ import org.ole.planet.myplanet.ui.chat.ChatDetailFragment
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
-import org.ole.planet.myplanet.utilities.FileUtils.openOleFolder
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
 import org.ole.planet.myplanet.utilities.KeyboardUtils.setupUI
 
@@ -157,7 +157,7 @@ class NewsFragment : BaseNewsFragment() {
 
         binding.addNewsImage.setOnClickListener {
             llImage = binding.llImages
-            val openFolderIntent = openOleFolder()
+            val openFolderIntent = FileUtils.openOleFolder(requireContext())
             openFolderLauncher.launch(openFolderIntent)
         }
         binding.addNewsImage.visibility = if (showBetaFeature(Constants.KEY_NEWSADDIMAGE, requireActivity())) View.VISIBLE else View.GONE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -44,7 +44,7 @@ import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
 import org.ole.planet.myplanet.ui.userprofile.TeamListAdapter
 import org.ole.planet.myplanet.utilities.AuthHelper
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils
-import org.ole.planet.myplanet.utilities.FileUtils.availableOverTotalMemoryFormattedString
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.LocaleHelper
 import org.ole.planet.myplanet.utilities.NetworkUtils
 import org.ole.planet.myplanet.utilities.ThemeManager
@@ -83,7 +83,7 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
         binding.tvAvailableSpace.text = buildString {
             append(getString(R.string.available_space_colon))
             append(" ")
-            append(availableOverTotalMemoryFormattedString)
+            append(FileUtils.availableOverTotalMemoryFormattedString(this@LoginActivity))
         }
         changeLogoColor()
         declareElements()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -86,7 +86,6 @@ import org.ole.planet.myplanet.utilities.DialogUtils.showWifiSettingDialog
 import org.ole.planet.myplanet.utilities.DownloadUtils.downloadAllFiles
 import org.ole.planet.myplanet.utilities.DownloadUtils.openDownloadService
 import org.ole.planet.myplanet.utilities.FileUtils
-import org.ole.planet.myplanet.utilities.FileUtils.availableOverTotalMemoryFormattedString
 import org.ole.planet.myplanet.utilities.LocaleHelper
 import org.ole.planet.myplanet.utilities.NetworkUtils.extractProtocol
 import org.ole.planet.myplanet.utilities.NetworkUtils.getCustomDeviceName
@@ -235,7 +234,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
     }
 
     private fun clearInternalStorage() {
-        val myDir = File(FileUtils.SD_PATH)
+        val myDir = File(FileUtils.getOlePath(this))
         if (myDir.isDirectory) {
             val children = myDir.list()
             if (children != null) {
@@ -561,7 +560,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
             tvAvailableSpace.text = buildString {
                 append(getString(R.string.available_space_colon))
                 append(" ")
-                append(availableOverTotalMemoryFormattedString)
+                append(FileUtils.availableOverTotalMemoryFormattedString(this@SyncActivity))
             }
 
             inputName.hint = getString(R.string.hint_name)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamDiscussion/DiscussionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamDiscussion/DiscussionListFragment.kt
@@ -35,7 +35,7 @@ import org.ole.planet.myplanet.ui.news.AdapterNews
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
-import org.ole.planet.myplanet.utilities.FileUtils.openOleFolder
+import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -200,7 +200,7 @@ class DiscussionListFragment : BaseTeamFragment() {
         val layout = inputBinding.tlInput
         inputBinding.addNewsImage.setOnClickListener {
             llImage = inputBinding.llImage
-            val openFolderIntent = openOleFolder()
+            val openFolderIntent = FileUtils.openOleFolder(requireContext())
             openFolderLauncher.launch(openFolderIntent)
         }
         inputBinding.llImage.visibility = if (showBetaFeature(Constants.KEY_NEWSADDIMAGE, requireContext())) View.VISIBLE else View.GONE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/VideoPlayerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/VideoPlayerActivity.kt
@@ -90,7 +90,7 @@ class VideoPlayerActivity : AppCompatActivity(), AuthSessionUpdater.AuthCallback
         auth = headerAuth[0]
         runOnUiThread {
             streamVideoFromUrl(videoURL, auth)
-            if (videoType == "online" && !FileUtils.checkFileExist(videoURL)) {
+            if (videoType == "online" && !FileUtils.checkFileExist(this, videoURL)) {
                 try {
                     DownloadUtils.openDownloadService(this, arrayListOf(videoURL), false)
                 } catch (e: Exception) {
@@ -116,7 +116,7 @@ class VideoPlayerActivity : AppCompatActivity(), AuthSessionUpdater.AuthCallback
             when {
                 videoURL.startsWith("http") -> {
                     streamVideoFromUrl(videoURL, auth)
-                    if (videoType == "online" && !FileUtils.checkFileExist(videoURL)) {
+                    if (videoType == "online" && !FileUtils.checkFileExist(this, videoURL)) {
                         try {
                             DownloadUtils.openDownloadService(this, arrayListOf(videoURL), false)
                         } catch (e: Exception) {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
@@ -87,7 +87,7 @@ object CameraUtils {
 
     @JvmStatic
     private fun savePicture(data: ByteArray, callback: ImageCaptureCallback) {
-        val pictureFileDir = File("${FileUtils.SD_PATH}/userimages")
+        val pictureFileDir = File("${FileUtils.getOlePath(context)}/userimages")
         if (!pictureFileDir.exists() && !pictureFileDir.mkdirs()) {
             pictureFileDir.mkdirs()
         }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/FileUtils.kt
@@ -20,18 +20,17 @@ import java.io.InputStream
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.util.UUID
-import org.ole.planet.myplanet.MainApplication.Companion.context
-
 object FileUtils {
-    val SD_PATH: String by lazy {
-        context.getExternalFilesDir(null)?.let { "${it}/ole/" } ?: ""
+    @JvmStatic
+    fun getOlePath(context: Context): String {
+        return context.getExternalFilesDir(null)?.let { "${it}/ole/" } ?: ""
     }
 
     @JvmStatic
     @Throws(IOException::class)
     fun fullyReadFileToBytes(f: File): ByteArray = f.readBytes()
 
-    private fun createFilePath(folder: String, filename: String): File {
+    private fun createFilePath(context: Context, folder: String, filename: String): File {
         val baseDirectory = File(context.getExternalFilesDir(null), folder)
 
         if (filename.contains("/")) {
@@ -63,14 +62,14 @@ object FileUtils {
     }
 
     @JvmStatic
-    fun getSDPathFromUrl(url: String?): File {
-        return createFilePath("/ole/${getIdFromUrl(url)}", getFileNameFromUrl(url))
+    fun getSDPathFromUrl(context: Context, url: String?): File {
+        return createFilePath(context, "/ole/${getIdFromUrl(url)}", getFileNameFromUrl(url))
     }
 
     @JvmStatic
-    fun checkFileExist(url: String?): Boolean {
+    fun checkFileExist(context: Context, url: String?): Boolean {
         if (url.isNullOrEmpty()) return false
-        val f = getSDPathFromUrl(url)
+        val f = getSDPathFromUrl(context, url)
         return f.exists()
     }
 
@@ -202,9 +201,9 @@ object FileUtils {
     }
 
     @JvmStatic
-    fun openOleFolder(): Intent {
+    fun openOleFolder(context: Context): Intent {
         val intent = Intent(Intent.ACTION_GET_CONTENT)
-        val uri = SD_PATH.toUri()
+        val uri = getOlePath(context).toUri()
         intent.setDataAndType(uri, "*/*")
         return Intent.createChooser(intent, "Open folder")
     }
@@ -272,33 +271,29 @@ object FileUtils {
      * @return A string with size followed by an appropriate suffix
      */
     @JvmStatic
-    fun formatSize(size: Long): String {
+    fun formatSize(context: Context, size: Long): String {
         return Formatter.formatFileSize(context, size)
     }
 
     @JvmStatic
-    val totalMemoryCapacity: Long
-        get() = getStorageStats(context).first
+    fun totalMemoryCapacity(context: Context): Long = getStorageStats(context).first
 
     @JvmStatic
-    val totalAvailableMemory: Long
-        get() = getStorageStats(context).second
+    fun totalAvailableMemory(context: Context): Long = getStorageStats(context).second
 
     @JvmStatic
-    val totalAvailableMemoryRatio: Long
-        get() {
-            val total = totalMemoryCapacity
-            val available = totalAvailableMemory
-            return Math.round(available.toDouble() / total.toDouble() * 100)
-        }
+    fun totalAvailableMemoryRatio(context: Context): Long {
+        val total = totalMemoryCapacity(context)
+        val available = totalAvailableMemory(context)
+        return Math.round(available.toDouble() / total.toDouble() * 100)
+    }
 
     @JvmStatic
-    val availableOverTotalMemoryFormattedString: String
-        get() {
-            val available = totalAvailableMemory
-            val total = totalMemoryCapacity
-            return formatSize(available) + "/" + formatSize(total)
-        }
+    fun availableOverTotalMemoryFormattedString(context: Context): String {
+        val available = totalAvailableMemory(context)
+        val total = totalMemoryCapacity(context)
+        return formatSize(context, available) + "/" + formatSize(context, total)
+    }
 
     private fun getStorageStats(context: Context): Pair<Long, Long> {
         val storageStatsManager =

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/ResourceOpener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/ResourceOpener.kt
@@ -81,7 +81,7 @@ object ResourceOpener {
             } else {
                 bundle.putString(
                     "videoURL",
-                    Uri.fromFile(FileUtils.getSDPathFromUrl(items.resourceRemoteAddress)).toString()
+                    Uri.fromFile(FileUtils.getSDPathFromUrl(activity, items.resourceRemoteAddress)).toString()
                 )
             }
             bundle.putString("Auth", "")


### PR DESCRIPTION
## Summary
- Remove static MainApplication context from FileUtils
- Require explicit Context for file path helpers and memory stats
- Update call sites to supply Context when accessing FileUtils

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b801c53248832b94eae554baa4fc3e