### PR TITLE
dashboard: smoother profile (fixes #7299)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3053
-        versionName = "0.30.53"
+        versionCode = 3061
+        versionName = "0.30.61"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- inject `UserRepository` into `UserDetailFragment`
- fetch user with `userRepository.getUserById` and drop direct `DatabaseService`
- clean up fragment imports of realm-specific service

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68b80178bdec832bbe012d5f4d0268ef