### PR TITLE
Refactor feedback repository to use scoped realm

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -34,7 +34,7 @@ class DatabaseService(context: Context) {
         return withRealmInstance(operation)
     }
 
-    suspend fun <T> withRealm(operation: suspend (Realm) -> T): T {
+    suspend fun <T> withRealmSuspend(operation: suspend (Realm) -> T): T {
         val realm = realmInstance
         return try {
             operation(realm)

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -34,7 +34,7 @@ class DatabaseService(context: Context) {
         return withRealmInstance(operation)
     }
 
-    suspend fun <T> withRealmSuspend(operation: suspend (Realm) -> T): T {
+    suspend fun <T> withRealm(operation: suspend (Realm) -> T): T {
         val realm = realmInstance
         return try {
             operation(realm)

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -34,6 +34,15 @@ class DatabaseService(context: Context) {
         return withRealmInstance(operation)
     }
 
+    suspend fun <T> withRealm(operation: suspend (Realm) -> T): T {
+        val realm = realmInstance
+        return try {
+            operation(realm)
+        } finally {
+            realm.close()
+        }
+    }
+
     suspend fun <T> withRealmAsync(operation: (Realm) -> T): T {
         return withContext(Dispatchers.IO) {
             withRealmInstance(operation)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -41,7 +41,7 @@ class FeedbackRepositoryImpl @Inject constructor(
 
                 feedbackList.addChangeListener(listener)
 
-                runBlocking {
+                runBlocking(this@callbackFlow.coroutineContext) {
                     awaitClose {
                         feedbackList.removeChangeListener(listener)
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -10,7 +10,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.runBlocking
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmUserModel
@@ -41,10 +40,8 @@ class FeedbackRepositoryImpl @Inject constructor(
 
                 feedbackList.addChangeListener(listener)
 
-                runBlocking(this@callbackFlow.coroutineContext) {
-                    awaitClose {
-                        feedbackList.removeChangeListener(listener)
-                    }
+                awaitClose {
+                    feedbackList.removeChangeListener(listener)
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -21,7 +21,7 @@ class FeedbackRepositoryImpl @Inject constructor(
 
     override fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>> =
         callbackFlow {
-            databaseService.withRealm { realm ->
+            databaseService.withRealmSuspend { realm ->
                 val feedbackList: RealmResults<RealmFeedback> =
                     if (userModel?.isManager() == true) {
                         realm.where(RealmFeedback::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -21,7 +21,7 @@ class FeedbackRepositoryImpl @Inject constructor(
 
     override fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>> =
         callbackFlow {
-            databaseService.withRealmSuspend { realm ->
+            databaseService.withRealm { realm ->
                 val feedbackList: RealmResults<RealmFeedback> =
                     if (userModel?.isManager() == true) {
                         realm.where(RealmFeedback::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -10,6 +10,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.runBlocking
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmUserModel
@@ -40,8 +41,10 @@ class FeedbackRepositoryImpl @Inject constructor(
 
                 feedbackList.addChangeListener(listener)
 
-                awaitClose {
-                    feedbackList.removeChangeListener(listener)
+                runBlocking {
+                    awaitClose {
+                        feedbackList.removeChangeListener(listener)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- use DatabaseService.withRealm in feedback flow
- manage Realm change listener without manual close

## Testing
- `./gradlew --no-daemon --console=plain :app:compileDebugKotlin -q` (fails: Cannot locate tasks that match ':app:compileDebugKotlin')
- `./gradlew --no-daemon --console=plain -q help`


------
https://chatgpt.com/codex/tasks/task_e_68b80251ad6c832bbd39f1a395df9154