### PR TITLE
test: add repository tests with in-memory realm

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/repository/CourseRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CourseRepositoryImplTest.kt
@@ -1,0 +1,60 @@
+package org.ole.planet.myplanet.repository
+
+import android.app.Application
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyCourse
+
+class CourseRepositoryImplTest {
+
+    private lateinit var databaseService: DatabaseService
+    private lateinit var repository: CourseRepositoryImpl
+
+    @Before
+    fun setup() {
+        val context = Application()
+        databaseService = DatabaseService(context)
+        val config = RealmConfiguration.Builder()
+            .inMemory()
+            .name("test-realm")
+            .schemaVersion(4)
+            .allowWritesOnUiThread(true)
+            .build()
+        Realm.setDefaultConfiguration(config)
+        repository = CourseRepositoryImpl(databaseService)
+    }
+
+    @After
+    fun tearDown() {
+        Realm.getDefaultInstance().use { it.executeTransaction { realm -> realm.deleteAll() } }
+    }
+
+    @Test
+    fun getAllCourses_returnsAllInsertedCourses() = runBlocking {
+        databaseService.executeTransactionAsync { realm ->
+            val course1 = RealmMyCourse().apply {
+                id = "1"
+                courseId = "c1"
+                courseTitle = "Course 1"
+            }
+            val course2 = RealmMyCourse().apply {
+                id = "2"
+                courseId = "c2"
+                courseTitle = "Course 2"
+            }
+            realm.copyToRealmOrUpdate(course1)
+            realm.copyToRealmOrUpdate(course2)
+        }
+
+        val courses = repository.getAllCourses()
+        assertEquals(2, courses.size)
+        assertEquals(setOf("c1", "c2"), courses.map { it.courseId }.toSet())
+    }
+}
+

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamRepositoryImplTest.kt
@@ -1,0 +1,57 @@
+package org.ole.planet.myplanet.repository
+
+import android.app.Application
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmMyTeam
+
+class TeamRepositoryImplTest {
+
+    private lateinit var databaseService: DatabaseService
+    private lateinit var repository: TeamRepositoryImpl
+
+    @Before
+    fun setup() {
+        val context = Application()
+        databaseService = DatabaseService(context)
+        val config = RealmConfiguration.Builder()
+            .inMemory()
+            .name("team-test-realm")
+            .schemaVersion(4)
+            .allowWritesOnUiThread(true)
+            .build()
+        Realm.setDefaultConfiguration(config)
+        repository = TeamRepositoryImpl(databaseService)
+    }
+
+    @After
+    fun tearDown() {
+        Realm.getDefaultInstance().use { it.executeTransaction { realm -> realm.deleteAll() } }
+    }
+
+    @Test
+    fun getTeamResources_returnsAssociatedLibraries() = runBlocking {
+        databaseService.executeTransactionAsync { realm ->
+            val lib1 = RealmMyLibrary().apply { id = "lib1"; title = "Library 1" }
+            val lib2 = RealmMyLibrary().apply { id = "lib2"; title = "Library 2" }
+            realm.copyToRealmOrUpdate(lib1)
+            realm.copyToRealmOrUpdate(lib2)
+            val team1 = RealmMyTeam().apply { _id = "1"; teamId = "team1"; resourceId = "lib1" }
+            val team2 = RealmMyTeam().apply { _id = "2"; teamId = "team1"; resourceId = "lib2" }
+            realm.copyToRealmOrUpdate(team1)
+            realm.copyToRealmOrUpdate(team2)
+        }
+
+        val resources = repository.getTeamResources("team1")
+        assertEquals(2, resources.size)
+        assertEquals(setOf("lib1", "lib2"), resources.map { it.id }.toSet())
+    }
+}
+


### PR DESCRIPTION
## Summary
- add CourseRepositoryImpl test for fetching all courses using in-memory Realm
- add TeamRepositoryImpl test validating team resource lookups

## Testing
- `./gradlew :app:compileDefaultDebugUnitTestKotlin`


------
https://chatgpt.com/codex/tasks/task_e_68b80300106c832bb406dd28ec858956