### PR TITLE
mylife: smoother dictionary realm handling (fixes #7331)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3063
-        versionName = "0.30.63"
+        versionCode = 3066
+        versionName = "0.30.66"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
@@ -6,7 +6,6 @@ import com.google.gson.Gson
 import com.google.gson.JsonArray
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Case
-import io.realm.RealmResults
 import java.util.UUID
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseActivity
@@ -22,7 +21,6 @@ import org.ole.planet.myplanet.utilities.Utilities
 @AndroidEntryPoint
 class DictionaryActivity : BaseActivity() {
     private lateinit var fragmentDictionaryBinding: FragmentDictionaryBinding
-    var list: RealmResults<RealmDictionary>? = null
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         fragmentDictionaryBinding = FragmentDictionaryBinding.inflate(layoutInflater)
@@ -30,9 +28,13 @@ class DictionaryActivity : BaseActivity() {
         EdgeToEdgeUtils.setupEdgeToEdge(this, fragmentDictionaryBinding.root)
         initActionBar()
         title = getString(R.string.dictionary)
-        mRealm = databaseService.realmInstance
-        list = mRealm.where(RealmDictionary::class.java)?.findAll()
-        fragmentDictionaryBinding.tvResult.text = getString(R.string.list_size, list?.size)
+
+        databaseService.withRealm { realm ->
+            val list = realm.where(RealmDictionary::class.java).findAll()
+            fragmentDictionaryBinding.tvResult.text =
+                getString(R.string.list_size, list.size)
+        }
+
         if (FileUtils.checkFileExist(this, Constants.DICTIONARY_URL)) {
             insertDictionary()
         } else {
@@ -44,56 +46,69 @@ class DictionaryActivity : BaseActivity() {
     }
 
     private fun insertDictionary() {
-        if (list.isNullOrEmpty()) {
-            try {
-                val data = FileUtils.getStringFromFile(FileUtils.getSDPathFromUrl(this, Constants.DICTIONARY_URL))
-                val json = Gson().fromJson(data, JsonArray::class.java)
-                mRealm.executeTransactionAsync {
-                    json?.forEach { js ->
-                        val doc = js.asJsonObject
-                        var dict = it.where(RealmDictionary::class.java)
-                            ?.equalTo("id", UUID.randomUUID().toString())?.findFirst()
-                        if (dict == null) {
-                            dict = it.createObject(
-                                RealmDictionary::class.java, UUID.randomUUID().toString()
-                            )
+        databaseService.withRealm { realm ->
+            val list = realm.where(RealmDictionary::class.java).findAll()
+            if (list.isEmpty()) {
+                try {
+                    val data = FileUtils.getStringFromFile(
+                        FileUtils.getSDPathFromUrl(this, Constants.DICTIONARY_URL)
+                    )
+                    val json = Gson().fromJson(data, JsonArray::class.java)
+                    realm.executeTransactionAsync {
+                        json?.forEach { js ->
+                            val doc = js.asJsonObject
+                            var dict = it.where(RealmDictionary::class.java)
+                                .equalTo("id", UUID.randomUUID().toString())
+                                .findFirst()
+                            if (dict == null) {
+                                dict = it.createObject(
+                                    RealmDictionary::class.java, UUID.randomUUID().toString()
+                                )
+                            }
+                            dict?.code = JsonUtils.getString("code", doc)
+                            dict?.language = JsonUtils.getString("language", doc)
+                            dict?.advanceCode = JsonUtils.getString("advance_code", doc)
+                            dict?.word = JsonUtils.getString("word", doc)
+                            dict?.meaning = JsonUtils.getString("meaning", doc)
+                            dict?.definition = JsonUtils.getString("definition", doc)
+                            dict?.synonym = JsonUtils.getString("synonym", doc)
+                            dict?.antonym = JsonUtils.getString("antonoym", doc)
                         }
-                        dict?.code = JsonUtils.getString("code", doc)
-                        dict?.language = JsonUtils.getString("language", doc)
-                        dict?.advanceCode = JsonUtils.getString("advance_code", doc)
-                        dict?.word = JsonUtils.getString("word", doc)
-                        dict?.meaning = JsonUtils.getString("meaning", doc)
-                        dict?.definition = JsonUtils.getString("definition", doc)
-                        dict?.synonym = JsonUtils.getString("synonym", doc)
-                        dict?.antonym = JsonUtils.getString("antonoym", doc)
                     }
+                } catch (e: Exception) {
+                    e.printStackTrace()
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
+            } else {
+                setClickListener()
             }
-        } else {
-            setClickListener()
         }
     }
 
     private fun setClickListener() {
         fragmentDictionaryBinding.btnSearch.setOnClickListener {
-            val dict = mRealm.where(RealmDictionary::class.java)?.equalTo("word", fragmentDictionaryBinding.etSearch.text.toString(), Case.INSENSITIVE)?.findFirst()
-            if (dict != null) {
-                fragmentDictionaryBinding.tvResult.text = HtmlCompat.fromHtml(
-                    "Definition of '<b>" + dict.word + "</b>'<br/><br/>\n " + "<b>" + dict.definition + "\n</b><br/><br/><br/>" + "<b>Synonym : </b>" + dict.synonym + "\n<br/><br/>" + "<b>Antonoym : </b>" + dict.antonym + "\n<br/>",
-                    HtmlCompat.FROM_HTML_MODE_LEGACY
-                )
-            } else {
-                Utilities.toast(this, getString(R.string.word_not_available_in_our_database))
+            databaseService.withRealm { realm ->
+                val dict = realm.where(RealmDictionary::class.java)
+                    .equalTo(
+                        "word",
+                        fragmentDictionaryBinding.etSearch.text.toString(),
+                        Case.INSENSITIVE
+                    )
+                    .findFirst()
+                if (dict != null) {
+                    fragmentDictionaryBinding.tvResult.text = HtmlCompat.fromHtml(
+                        "Definition of '<b>" + dict.word + "</b>'<br/><br/>\n " +
+                            "<b>" + dict.definition + "\n</b><br/><br/><br/>" +
+                            "<b>Synonym : </b>" + dict.synonym + "\n<br/><br/>" +
+                            "<b>Antonoym : </b>" + dict.antonym + "\n<br/>",
+                        HtmlCompat.FROM_HTML_MODE_LEGACY
+                    )
+                } else {
+                    Utilities.toast(
+                        this,
+                        getString(R.string.word_not_available_in_our_database)
+                    )
+                }
             }
         }
-    }
-
-    override fun onDestroy() {
-        if (!mRealm.isClosed) {
-            mRealm.close()
-        }
-        super.onDestroy()
     }
 }


### PR DESCRIPTION
## Summary
- remove persistent Realm usage in `DictionaryActivity`
- handle Realm reads/writes via `databaseService.withRealm`

## Testing
- `./gradlew tasks`

------
https://chatgpt.com/codex/tasks/task_e_68b9692e6404832bb42f66a8387144f9