### PR TITLE
all: smoother feedback repository realm flowing (fixes #7335)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3063
-        versionName = "0.30.63"
+        versionCode = 3070
+        versionName = "0.30.70"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -3,13 +3,9 @@ package org.ole.planet.myplanet.repository
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import io.realm.RealmChangeListener
-import io.realm.RealmResults
 import io.realm.Sort
 import javax.inject.Inject
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmUserModel
@@ -20,29 +16,12 @@ class FeedbackRepositoryImpl @Inject constructor(
 ) : RealmRepository(databaseService), FeedbackRepository {
 
     override fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>> =
-        callbackFlow {
-            val realm = databaseService.realmInstance
-            val feedbackList: RealmResults<RealmFeedback> =
-                if (userModel?.isManager() == true) {
-                    realm.where(RealmFeedback::class.java)
-                        .sort("openTime", Sort.DESCENDING)
-                        .findAllAsync()
-                } else {
-                    realm.where(RealmFeedback::class.java)
-                        .equalTo("owner", userModel?.name)
-                        .sort("openTime", Sort.DESCENDING)
-                        .findAllAsync()
-                }
-
-            val listener = RealmChangeListener<RealmResults<RealmFeedback>> { results ->
-                trySend(realm.copyFromRealm(results))
-            }
-
-            feedbackList.addChangeListener(listener)
-
-            awaitClose {
-                feedbackList.removeChangeListener(listener)
-                realm.close()
+        queryListFlow(RealmFeedback::class.java) {
+            if (userModel?.isManager() == true) {
+                sort("openTime", Sort.DESCENDING)
+            } else {
+                equalTo("owner", userModel?.name)
+                sort("openTime", Sort.DESCENDING)
             }
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -1,8 +1,13 @@
 package org.ole.planet.myplanet.repository
 
 import io.realm.Realm
+import io.realm.RealmChangeListener
 import io.realm.RealmObject
 import io.realm.RealmQuery
+import io.realm.RealmResults
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.datamanager.applyEqualTo
 import org.ole.planet.myplanet.datamanager.findCopyByField
@@ -12,9 +17,24 @@ open class RealmRepository(private val databaseService: DatabaseService) {
 
     protected suspend fun <T : RealmObject> queryList(
         clazz: Class<T>,
-        builder: RealmQuery<T>.() -> Unit = {}
+        builder: RealmQuery<T>.() -> Unit = {},
     ): List<T> = databaseService.withRealmAsync { realm ->
         realm.queryList(clazz, builder)
+    }
+
+    protected fun <T : RealmObject> queryListFlow(
+        clazz: Class<T>,
+        builder: RealmQuery<T>.() -> Unit = {},
+    ): Flow<List<T>> = callbackFlow {
+        withRealm { realm ->
+            val results = realm.where(clazz).apply(builder).findAllAsync()
+            val listener = RealmChangeListener<RealmResults<T>> {
+                trySend(realm.queryList(clazz, builder))
+            }
+            results.addChangeListener(listener)
+            trySend(realm.queryList(clazz, builder))
+            awaitClose { results.removeChangeListener(listener) }
+        }
     }
 
     protected suspend fun <T : RealmObject, V : Any> findByField(


### PR DESCRIPTION
## Summary
- Add `queryListFlow` helper in `RealmRepository` to stream query results and manage realm lifecycle
- Refactor `FeedbackRepositoryImpl.getFeedback` to leverage `queryListFlow` and `withRealm`

## Testing
- `./gradlew -q help` *(fails: process did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b97affbf08832b8229f90c816473f7