### PR TITLE
Optimize survey title query

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -29,16 +29,16 @@ class SubmissionRepositoryImpl @Inject constructor(
     override suspend fun getSurveyTitlesFromSubmissions(
         submissions: List<RealmSubmission>
     ): List<String> {
+        val examIds = submissions
+            .mapNotNull { it.parentId?.split("@")?.firstOrNull() }
+            .toTypedArray()
+        if (examIds.isEmpty()) return emptyList()
+
         return withRealm { realm ->
-            val titles = mutableListOf<String>()
-            submissions.forEach { submission ->
-                val examId = submission.parentId?.split("@")?.firstOrNull() ?: ""
-                val exam = realm.where(RealmStepExam::class.java)
-                    .equalTo("id", examId)
-                    .findFirst()
-                exam?.name?.let { titles.add(it) }
-            }
-            titles
+            realm.where(RealmStepExam::class.java)
+                .`in`("id", examIds)
+                .findAll()
+                .mapNotNull { it.name }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -31,14 +31,14 @@ class SubmissionRepositoryImpl @Inject constructor(
     ): List<String> {
         val examIds = submissions
             .mapNotNull { it.parentId?.split("@")?.firstOrNull() }
-            .toTypedArray()
         if (examIds.isEmpty()) return emptyList()
 
         return withRealm { realm ->
-            realm.where(RealmStepExam::class.java)
-                .`in`("id", examIds)
+            val exams = realm.where(RealmStepExam::class.java)
+                .`in`("id", examIds.distinct().toTypedArray())
                 .findAll()
-                .mapNotNull { it.name }
+            val examMap = exams.associate { it.id to it.name }
+            examIds.mapNotNull { examMap[it] }
         }
     }
 


### PR DESCRIPTION
## Summary
- Gather submission exam IDs and query them in a single Realm call
- Map fetched exams directly to titles

## Testing
- `./gradlew :app:compileLiteDebugKotlin`


------
https://chatgpt.com/codex/tasks/task_e_68b97b1b6588832b8deeeec1606af2e9