### PR TITLE
Refactor team resource lookup to avoid realm exposure

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.repository
 
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.datamanager.queryList
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 
@@ -11,13 +10,20 @@ class TeamRepositoryImpl @Inject constructor(
 ) : RealmRepository(databaseService), TeamRepository {
 
     override suspend fun getTeamResources(teamId: String): List<RealmMyLibrary> {
-        return withRealm { realm ->
-            val resourceIds = RealmMyTeam.getResourceIds(teamId, realm)
-            if (resourceIds.isEmpty()) emptyList() else
-                realm.queryList(RealmMyLibrary::class.java) {
-                    `in`("id", resourceIds.toTypedArray())
-                }
+        val resourceIds = getResourceIds(teamId)
+        return if (resourceIds.isEmpty()) {
+            emptyList()
+        } else {
+            queryList(RealmMyLibrary::class.java) {
+                `in`("id", resourceIds.toTypedArray())
+            }
         }
+    }
+
+    private suspend fun getResourceIds(teamId: String): List<String> {
+        return queryList(RealmMyTeam::class.java) {
+            equalTo("teamId", teamId)
+        }.mapNotNull { it.resourceId?.takeIf { id -> id.isNotBlank() } }
     }
 }
 


### PR DESCRIPTION
## Summary
- Retrieve team resource IDs via helper avoiding Realm exposure
- Query library resources with `queryList` instead of explicit `withRealm`
- Remove unused `queryList` import

## Testing
- ⚠️ `./gradlew :app:compileLiteDebugKotlin -x test` *(timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b97a6e8148832bb7a1d2110375ecda