### PR TITLE
Use ListAdapter for news grandchild lists

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListAdapter.kt
@@ -279,12 +279,13 @@ class ChatHistoryListAdapter(
             context.getString(R.string.enterprises)
         }
 
-        val grandChildAdapter = GrandChildAdapter(items, section) { selectedItem ->
+        val grandChildAdapter = GrandChildAdapter(section) { selectedItem ->
             showEditTextAndShareButton(selectedItem, section, realmChatHistory)
             dialog?.dismiss()
         }
         grandChildDialogBinding.recyclerView.layoutManager = LinearLayoutManager(context)
         grandChildDialogBinding.recyclerView.adapter = grandChildAdapter
+        grandChildAdapter.submitList(items)
 
         val builder = AlertDialog.Builder(context, R.style.CustomAlertDialog)
         builder.setView(grandChildDialogBinding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/GrandChildAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/GrandChildAdapter.kt
@@ -5,11 +5,24 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.RealmMyTeam
 
-class GrandChildAdapter(private val items: List<RealmMyTeam>, private val section: String, private val onClick: (RealmMyTeam) -> Unit) : RecyclerView.Adapter<GrandChildAdapter.GrandChildViewHolder>() {
+class GrandChildAdapter(private val section: String, private val onClick: (RealmMyTeam) -> Unit) :
+    ListAdapter<RealmMyTeam, GrandChildAdapter.GrandChildViewHolder>(
+        object : DiffUtil.ItemCallback<RealmMyTeam>() {
+            override fun areItemsTheSame(oldItem: RealmMyTeam, newItem: RealmMyTeam): Boolean {
+                return oldItem._id == newItem._id
+            }
+
+            override fun areContentsTheSame(oldItem: RealmMyTeam, newItem: RealmMyTeam): Boolean {
+                return oldItem.name == newItem.name
+            }
+        }
+    ) {
     inner class GrandChildViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val textView: TextView = itemView.findViewById(R.id.textView)
         private val teamIcon: ImageView = itemView.findViewById(R.id.teamIcon)
@@ -26,13 +39,12 @@ class GrandChildAdapter(private val items: List<RealmMyTeam>, private val sectio
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GrandChildViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.expandable_list_grand_child_item, parent, false)
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.expandable_list_grand_child_item, parent, false)
         return GrandChildViewHolder(view)
     }
 
     override fun onBindViewHolder(holder: GrandChildViewHolder, position: Int) {
-        holder.bind(items[position])
+        holder.bind(getItem(position))
     }
-
-    override fun getItemCount() = items.size
 }


### PR DESCRIPTION
## Summary
- migrate `GrandChildAdapter` to `ListAdapter` with DiffUtil for id/name comparison
- update `ChatHistoryListAdapter` to submit lists and remove manual item count

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68b97a2ae324832b81e44c6068f9da6b