### PR TITLE
Use repository for team selection and link saving

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -1,8 +1,11 @@
 package org.ole.planet.myplanet.repository
 
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmMyTeam
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
+    suspend fun getSelectableTeams(type: String): List<RealmMyTeam>
+    suspend fun saveLinkItem(title: String, type: String, teamId: String)
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package org.ole.planet.myplanet.repository
 
+import java.util.Locale
+import java.util.UUID
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.datamanager.queryList
@@ -17,6 +19,26 @@ class TeamRepositoryImpl @Inject constructor(
                 realm.queryList(RealmMyLibrary::class.java) {
                     `in`("id", resourceIds.toTypedArray())
                 }
+        }
+    }
+
+    override suspend fun getSelectableTeams(type: String): List<RealmMyTeam> {
+        val teamType = if (type == "Enterprises") "enterprise" else ""
+        return queryList(RealmMyTeam::class.java) {
+            isEmpty("teamId")
+            isNotEmpty("name")
+            equalTo("type", teamType)
+            notEqualTo("status", "archived")
+        }
+    }
+
+    override suspend fun saveLinkItem(title: String, type: String, teamId: String) {
+        executeTransaction { realm ->
+            val team = realm.createObject(RealmMyTeam::class.java, UUID.randomUUID().toString())
+            team.docType = "link"
+            team.updated = true
+            team.title = title
+            team.route = "/${type.lowercase(Locale.ROOT)}/view/$teamId"
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
@@ -7,18 +7,19 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.FrameLayout
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.Locale
-import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentAddLinkBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.ui.team.AdapterTeam
 import org.ole.planet.myplanet.utilities.Utilities
 
@@ -31,21 +32,13 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
 
     @Inject
     lateinit var databaseService: DatabaseService
+    @Inject
+    lateinit var teamRepository: TeamRepository
     var selectedTeam: RealmMyTeam? = null
 
     override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
-        databaseService.withRealm { realm ->
-            val teams = realm.copyFromRealm(
-                realm.where(RealmMyTeam::class.java)
-                    .isEmpty("teamId")
-                    .isNotEmpty("name")
-                    .equalTo(
-                        "type",
-                        if (binding.spnLink.selectedItem.toString() == "Enterprises") "enterprise" else ""
-                    )
-                    .notEqualTo("status", "archived")
-                    .findAll()
-            )
+        viewLifecycleOwner.lifecycleScope.launch {
+            val teams = teamRepository.getSelectableTeams(binding.spnLink.selectedItem.toString())
             binding.rvList.layoutManager = LinearLayoutManager(requireActivity())
             val adapter = AdapterTeam(requireActivity(), teams, databaseService)
             adapter.setTeamSelectedListener(object : AdapterTeam.OnTeamSelectedListener {
@@ -91,16 +84,10 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
                 return@setOnClickListener
             }
 
-            databaseService.withRealm { realm ->
-                realm.executeTransaction { r ->
-                    val team = r.createObject(RealmMyTeam::class.java, UUID.randomUUID().toString())
-                    team.docType = "link"
-                    team.updated = true
-                    team.title = title
-                    team.route = """/${type.lowercase(Locale.ROOT)}/view/${selectedTeam!!._id}"""
-                }
+            viewLifecycleOwner.lifecycleScope.launch {
+                teamRepository.saveLinkItem(title, type, selectedTeam!!._id!!)
+                dismiss()
             }
-            dismiss()
         }
     }
 


### PR DESCRIPTION
## Summary
- extend TeamRepository with functions to fetch selectable teams and save link items
- integrate TeamRepository into AddLinkFragment instead of direct Realm calls

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68b96f471154832b8489222dc70543ad