### PR TITLE
Refactor team activity sync into repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -1,8 +1,11 @@
 package org.ole.planet.myplanet.repository
 
+import android.content.Context
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.service.UploadManager
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
+    fun syncTeamActivities(context: Context, uploadManager: UploadManager)
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -1,13 +1,25 @@
 package org.ole.planet.myplanet.repository
 
+import android.content.Context
+import androidx.core.net.toUri
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.ole.planet.myplanet.MainApplication
+import org.ole.planet.myplanet.datamanager.ApiClient.client
+import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.datamanager.queryList
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
+import org.ole.planet.myplanet.utilities.ServerUrlMapper
 
 class TeamRepositoryImpl @Inject constructor(
-    databaseService: DatabaseService,
+    private val databaseService: DatabaseService,
 ) : RealmRepository(databaseService), TeamRepository {
 
     override suspend fun getTeamResources(teamId: String): List<RealmMyLibrary> {
@@ -17,6 +29,51 @@ class TeamRepositoryImpl @Inject constructor(
                 realm.queryList(RealmMyLibrary::class.java) {
                     `in`("id", resourceIds.toTypedArray())
                 }
+        }
+    }
+
+    override fun syncTeamActivities(context: Context, uploadManager: UploadManager) {
+        val settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val updateUrl = "${settings.getString("serverURL", "")}"
+        val serverUrlMapper = ServerUrlMapper()
+        val mapping = serverUrlMapper.processUrl(updateUrl)
+
+        CoroutineScope(Dispatchers.IO).launch {
+            val primaryAvailable = MainApplication.isServerReachable(mapping.primaryUrl)
+            val alternativeAvailable =
+                mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
+
+            if (!primaryAvailable && alternativeAvailable) {
+                mapping.alternativeUrl?.let { alternativeUrl ->
+                    val uri = updateUrl.toUri()
+                    val editor = settings.edit()
+                    serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, settings)
+                }
+            }
+
+            withContext(Dispatchers.Main) {
+                uploadTeamActivities(context, uploadManager)
+            }
+        }
+    }
+
+    private fun uploadTeamActivities(context: Context, uploadManager: UploadManager) {
+        MainApplication.applicationScope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    uploadManager.uploadTeams()
+                }
+                withContext(Dispatchers.IO) {
+                    val apiInterface = client?.create(ApiInterface::class.java)
+                    databaseService.withRealm { realm ->
+                        realm.executeTransaction { transactionRealm ->
+                            uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -20,6 +20,7 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
@@ -27,7 +28,14 @@ import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
 
-class AdapterTeamList(private val context: Context, private val list: List<RealmMyTeam>, private val mRealm: Realm, private val fragmentManager: FragmentManager, private val uploadManager: UploadManager) : RecyclerView.Adapter<AdapterTeamList.ViewHolderTeam>() {
+class AdapterTeamList(
+    private val context: Context,
+    private val list: List<RealmMyTeam>,
+    private val mRealm: Realm,
+    private val fragmentManager: FragmentManager,
+    private val uploadManager: UploadManager,
+    private val teamRepository: TeamRepository,
+) : RecyclerView.Adapter<AdapterTeamList.ViewHolderTeam>() {
     private lateinit var itemTeamListBinding: ItemTeamListBinding
     private var type: String? = ""
     private var teamListener: OnClickTeamItem? = null
@@ -162,7 +170,7 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
             RealmMyTeam.requestToJoin(team._id, user, mRealm, team.teamType)
             updateList()
         }
-        syncTeamActivities(context, uploadManager)
+        syncTeamActivities(context, uploadManager, teamRepository)
     }
 
     private fun updateList() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -31,6 +31,7 @@ import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.service.SyncManager
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
@@ -66,6 +67,8 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
 
     @Inject
     lateinit var uploadManager: UploadManager
+    @Inject
+    lateinit var teamRepository: TeamRepository
     
     private val syncCoordinator = RealtimeSyncCoordinator.getInstance()
     private lateinit var realtimeSyncListener: BaseRealtimeSyncListener
@@ -285,7 +288,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
                     RealmMyTeam.requestToJoin(currentTeam._id!!, user, mRealm, team?.teamType)
                     binding.btnLeave.text = getString(R.string.requested)
                     binding.btnLeave.isEnabled = false
-                    syncTeamActivities(requireContext(), uploadManager)
+                    syncTeamActivities(requireContext(), uploadManager, teamRepository)
                 }
             }
         } else {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -25,6 +25,7 @@ import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getMyTeamsByUserId
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
@@ -49,6 +50,8 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private var conditionApplied: Boolean = false
     @Inject
     lateinit var uploadManager: UploadManager
+    @Inject
+    lateinit var teamRepository: TeamRepository
     private val settings by lazy {
         requireActivity().getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE)
     }
@@ -252,7 +255,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                     }.thenBy { it.name })
 
                     val adapterTeamList = AdapterTeamList(
-                        activity as Context, sortedList, mRealm, childFragmentManager, uploadManager
+                        activity as Context, sortedList, mRealm, childFragmentManager, uploadManager, teamRepository
                     )
                     adapterTeamList.setTeamListener(this@TeamFragment)
                     binding.rvTeamList.adapter = adapterTeamList
@@ -280,7 +283,9 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
 
     private fun setTeamList() {
         val list = teamList!!
-        adapterTeamList = activity?.let { AdapterTeamList(it, list, mRealm, childFragmentManager, uploadManager) } ?: return
+        adapterTeamList = activity?.let {
+            AdapterTeamList(it, list, mRealm, childFragmentManager, uploadManager, teamRepository)
+        } ?: return
         adapterTeamList.setType(type)
         adapterTeamList.setTeamListener(this@TeamFragment)
         requireView().findViewById<View>(R.id.type).visibility =
@@ -318,7 +323,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private fun updatedTeamList() {
         viewLifecycleOwner.lifecycleScope.launch {
             val sortedList = sortTeams(teamList!!)
-            val adapterTeamList = AdapterTeamList(activity as Context, sortedList, mRealm, childFragmentManager, uploadManager).apply {
+            val adapterTeamList = AdapterTeamList(activity as Context, sortedList, mRealm, childFragmentManager, uploadManager, teamRepository).apply {
                 setType(type)
                 setTeamListener(this@TeamFragment)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterMemberRequest.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterMemberRequest.kt
@@ -12,10 +12,19 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMember
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.utilities.Utilities
 
-class AdapterMemberRequest(private val context: Context, private val list: MutableList<RealmUserModel>, private val mRealm: Realm, private val currentUser: RealmUserModel, private val listener: MemberChangeListener, private val uploadManager: UploadManager) : RecyclerView.Adapter<AdapterMemberRequest.ViewHolderUser>() {
+class AdapterMemberRequest(
+    private val context: Context,
+    private val list: MutableList<RealmUserModel>,
+    private val mRealm: Realm,
+    private val currentUser: RealmUserModel,
+    private val listener: MemberChangeListener,
+    private val uploadManager: UploadManager,
+    private val teamRepository: TeamRepository,
+) : RecyclerView.Adapter<AdapterMemberRequest.ViewHolderUser>() {
     private lateinit var rowMemberRequestBinding: RowMemberRequestBinding
     private var teamId: String? = null
     private lateinit var team: RealmMyTeam
@@ -96,7 +105,7 @@ class AdapterMemberRequest(private val context: Context, private val list: Mutab
                 }
             }
         }, {
-            syncTeamActivities(context, uploadManager)
+            syncTeamActivities(context, uploadManager, teamRepository)
             listener.onMemberChanged()
         }, { error ->
             list.add(position, userModel)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MembersFragment.kt
@@ -12,6 +12,7 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getRequestedMember
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 
@@ -23,6 +24,8 @@ class MembersFragment : BaseMemberFragment() {
 
     @Inject
     lateinit var uploadManager: UploadManager
+    @Inject
+    lateinit var teamRepository: TeamRepository
 
     fun setMemberChangeListener(listener: MemberChangeListener) {
         this.memberChangeListener = listener
@@ -44,7 +47,7 @@ class MembersFragment : BaseMemberFragment() {
 
     override val adapter: RecyclerView.Adapter<*>
         get() = AdapterMemberRequest(requireActivity(), list.toMutableList(),
-            mRealm, currentUser, memberChangeListener, uploadManager).apply { setTeamId(teamId) }
+            mRealm, currentUser, memberChangeListener, uploadManager, teamRepository).apply { setTeamId(teamId) }
 
     override val layoutManager: RecyclerView.LayoutManager
         get() {


### PR DESCRIPTION
## Summary
- add `syncTeamActivities` to `TeamRepository` and implement repository-driven upload using injected `DatabaseService`
- delegate `RealmMyTeam.syncTeamActivities` to repository and pass through new dependency
- update team fragments and adapters to inject `TeamRepository` instead of relying on `MainApplication.context`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b96dc1c1a4832b8cc35dff40849cac