### PR TITLE
Ensure Realm instances are scoped in UploadManager

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
@@ -86,15 +86,20 @@ class UploadManager @Inject constructor(
 
     private fun uploadNewsActivities() {
         val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
-        realm.executeTransactionAsync { realm: Realm ->
-            val newsLog: List<RealmNewsLog> = realm.where(RealmNewsLog::class.java)
-                .isNull("_id").or().isEmpty("_id")
-                .findAll()
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val newsLog: List<RealmNewsLog> = transactionRealm.where(RealmNewsLog::class.java)
+                    .isNull("_id").or().isEmpty("_id")
+                    .findAll()
 
-            newsLog.processInBatches { news ->
+                newsLog.processInBatches { news ->
                     try {
-                        val `object` = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/myplanet_activities", RealmNewsLog.serialize(news))?.execute()?.body()
+                        val `object` = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/myplanet_activities",
+                            RealmNewsLog.serialize(news)
+                        )?.execute()?.body()
 
                         if (`object` != null) {
                             news._id = getString("id", `object`)
@@ -103,6 +108,7 @@ class UploadManager @Inject constructor(
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
+                }
             }
         }
 
@@ -170,27 +176,27 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadExamResult(listener: SuccessListener) {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync({ transactionRealm ->
+                val submissions: List<RealmSubmission> = transactionRealm.where(RealmSubmission::class.java).findAll()
 
-        realm.executeTransactionAsync({ realm: Realm ->
-            val submissions: List<RealmSubmission> = realm.where(RealmSubmission::class.java).findAll()
-
-            submissions.processInBatches { sub ->
+                submissions.processInBatches { sub ->
                     try {
                         if ((sub.answers?.size ?: 0) > 0) {
-                            RealmSubmission.continueResultUpload(sub, apiInterface, realm, context)
+                            RealmSubmission.continueResultUpload(sub, apiInterface, transactionRealm, context)
                         }
                     } catch (e: Exception) {
                         e.printStackTrace()
                     }
+                }
+            }, {
+                uploadCourseProgress()
+                listener.onSuccess("Result sync completed successfully")
+            }) { e: Throwable ->
+                e.printStackTrace()
+                listener.onSuccess("Error during result sync: ${e.message}")
             }
-        }, {
-            uploadCourseProgress()
-            listener.onSuccess("Result sync completed successfully")
-        }) { e: Throwable ->
-            e.printStackTrace()
-            listener.onSuccess("Error during result sync: ${e.message}")
         }
     }
 
@@ -213,16 +219,17 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadAchievement() {
-        val realm = getRealm()
-        realm.executeTransactionAsync { realm: Realm ->
-            val list: List<RealmAchievement> = realm.where(RealmAchievement::class.java).findAll()
-            list.processInBatches { sub ->
-                try {
-                    if (sub._id?.startsWith("guest") == true) {
-                        return@processInBatches
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val list: List<RealmAchievement> = transactionRealm.where(RealmAchievement::class.java).findAll()
+                list.processInBatches { sub ->
+                    try {
+                        if (sub._id?.startsWith("guest") == true) {
+                            return@processInBatches
+                        }
+                    } catch (e: IOException) {
+                        e.printStackTrace()
                     }
-                } catch (e: IOException) {
-                    e.printStackTrace()
                 }
             }
         }
@@ -231,21 +238,26 @@ class UploadManager @Inject constructor(
 
     private fun uploadCourseProgress() {
         val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
-        realm.executeTransactionAsync { realm: Realm ->
-            val data: List<RealmCourseProgress> = realm.where(RealmCourseProgress::class.java).isNull("_id").findAll()
-            var successCount = 0
-            var skipCount = 0
-            var errorCount = 0
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val data: List<RealmCourseProgress> = transactionRealm.where(RealmCourseProgress::class.java).isNull("_id").findAll()
+                var successCount = 0
+                var skipCount = 0
+                var errorCount = 0
 
-            data.processInBatches { sub ->
+                data.processInBatches { sub ->
                     try {
                         if (sub.userId?.startsWith("guest") == true) {
                             skipCount++
                             return@processInBatches
                         }
 
-                        val `object` = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/courses_progress", RealmCourseProgress.serializeProgress(sub))?.execute()?.body()
+                        val `object` = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/courses_progress",
+                            RealmCourseProgress.serializeProgress(sub)
+                        )?.execute()?.body()
                         if (`object` != null) {
                             sub._id = getString("id", `object`)
                             sub._rev = getString("rev", `object`)
@@ -257,63 +269,76 @@ class UploadManager @Inject constructor(
                         errorCount++
                         e.printStackTrace()
                     }
+                }
             }
-
         }
     }
 
     fun uploadFeedback(listener: SuccessListener) {
         val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
-        realm.executeTransactionAsync(Realm.Transaction { realm: Realm ->
-            val feedbacks: List<RealmFeedback> = realm.where(RealmFeedback::class.java).findAll()
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync(
+                Realm.Transaction { transactionRealm ->
+                    val feedbacks: List<RealmFeedback> = transactionRealm.where(RealmFeedback::class.java).findAll()
 
-            if (feedbacks.isEmpty()) {
-                return@Transaction
-            }
-
-            var successCount = 0
-            var errorCount = 0
-
-            feedbacks.processInBatches { feedback ->
-                try {
-                    val res: Response<JsonObject>? = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/feedback", RealmFeedback.serializeFeedback(feedback))?.execute()
-
-                    val r = res?.body()
-                    if (r != null) {
-                        val revElement = r["rev"]
-                        val idElement = r["id"]
-                        if (revElement != null && idElement != null) {
-                            feedback._rev = revElement.asString
-                            feedback._id = idElement.asString
-                            successCount++
-                        } else {
-                            errorCount++
-                        }
-                    } else {
-                        errorCount++
+                    if (feedbacks.isEmpty()) {
+                        return@Transaction
                     }
-                } catch (e: IOException) {
-                    errorCount++
-                    e.printStackTrace()
+
+                    var successCount = 0
+                    var errorCount = 0
+
+                    feedbacks.processInBatches { feedback ->
+                        try {
+                            val res: Response<JsonObject>? = apiInterface?.postDoc(
+                                UrlUtils.header,
+                                "application/json",
+                                "${UrlUtils.getUrl()}/feedback",
+                                RealmFeedback.serializeFeedback(feedback)
+                            )?.execute()
+
+                            val r = res?.body()
+                            if (r != null) {
+                                val revElement = r["rev"]
+                                val idElement = r["id"]
+                                if (revElement != null && idElement != null) {
+                                    feedback._rev = revElement.asString
+                                    feedback._id = idElement.asString
+                                    successCount++
+                                } else {
+                                    errorCount++
+                                }
+                            } else {
+                                errorCount++
+                            }
+                        } catch (e: IOException) {
+                            errorCount++
+                            e.printStackTrace()
+                        }
+                    }
+                }, {
+                    listener.onSuccess("Feedback sync completed successfully")
+                }, { error ->
+                    listener.onSuccess("Feedback sync failed: ${error.message}")
+                    error.printStackTrace()
                 }
-            }
-        }, {
-            listener.onSuccess("Feedback sync completed successfully")
-        }, { error ->
-            listener.onSuccess("Feedback sync failed: ${error.message}")
-            error.printStackTrace()
-        })
+            )
+        }
     }
 
     fun uploadSubmitPhotos(listener: SuccessListener?) {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
-        realm.executeTransactionAsync { realm: Realm ->
-            val data: List<RealmSubmitPhotos> = realm.where(RealmSubmitPhotos::class.java).equalTo("uploaded", false).findAll()
-            data.processInBatches { sub ->
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val data: List<RealmSubmitPhotos> = transactionRealm.where(RealmSubmitPhotos::class.java).equalTo("uploaded", false).findAll()
+                data.processInBatches { sub ->
                     try {
-                        val `object` = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/submissions", RealmSubmitPhotos.serializeRealmSubmitPhotos(sub))?.execute()?.body()
+                        val `object` = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/submissions",
+                            RealmSubmitPhotos.serializeRealmSubmitPhotos(sub)
+                        )?.execute()?.body()
                         if (`object` != null) {
                             val rev = getString("rev", `object`)
                             val id = getString("id", `object`)
@@ -325,83 +350,90 @@ class UploadManager @Inject constructor(
                     } catch (e: Exception) {
                         e.printStackTrace()
                     }
-            }
-            if (data.isEmpty()) {
-                listener?.onSuccess("No photos to upload")
+                }
+                if (data.isEmpty()) {
+                    listener?.onSuccess("No photos to upload")
+                }
             }
         }
     }
 
     fun uploadResource(listener: SuccessListener?) {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync({ transactionRealm ->
+                val user = transactionRealm.where(RealmUserModel::class.java)
+                    .equalTo("id", pref.getString("userId", ""))
+                    .findFirst()
 
-        realm.executeTransactionAsync({ realm: Realm ->
-            val user = realm.where(RealmUserModel::class.java)
-                .equalTo("id", pref.getString("userId", ""))
-                .findFirst()
+                val data: List<RealmMyLibrary> = transactionRealm.where(RealmMyLibrary::class.java)
+                    .isNull("_rev")
+                    .findAll()
 
-            val data: List<RealmMyLibrary> = realm.where(RealmMyLibrary::class.java)
-                .isNull("_rev")
-                .findAll()
-
-            if (data.isEmpty()) {
-                return@executeTransactionAsync
-            }
-
-            data.processInBatches { sub ->
-                try {
-                    val `object` = apiInterface?.postDoc(
-                        UrlUtils.header,
-                        "application/json",
-                        "${UrlUtils.getUrl()}/resources",
-                        RealmMyLibrary.serialize(sub, user)
-                    )?.execute()?.body()
-
-                    if (`object` != null) {
-                        val rev = getString("rev", `object`)
-                        val id = getString("id", `object`)
-                        sub._rev = rev
-                        sub._id = id
-                        listener?.let { uploadAttachment(id, rev, sub, it) }
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
+                if (data.isEmpty()) {
+                    return@executeTransactionAsync
                 }
+
+                data.processInBatches { sub ->
+                    try {
+                        val `object` = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/resources",
+                            RealmMyLibrary.serialize(sub, user)
+                        )?.execute()?.body()
+
+                        if (`object` != null) {
+                            val rev = getString("rev", `object`)
+                            val id = getString("id", `object`)
+                            sub._rev = rev
+                            sub._id = id
+                            listener?.let { uploadAttachment(id, rev, sub, it) }
+                        }
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
+                }
+            }, {
+                listener?.onSuccess("No resources to upload")
+            }) { error ->
+                listener?.onSuccess("Resource upload failed: ${error.message}")
             }
-        }, {
-            listener?.onSuccess("No resources to upload")
-        }) { error ->
-            listener?.onSuccess("Resource upload failed: ${error.message}")
         }
     }
 
     fun uploadMyPersonal(personal: RealmMyPersonal, listener: SuccessListener) {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
 
         if (!personal.isUploaded) {
-            apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/resources", RealmMyPersonal.serialize(personal, context))?.enqueue(object : Callback<JsonObject?> {
+            apiInterface?.postDoc(
+                UrlUtils.header,
+                "application/json",
+                "${UrlUtils.getUrl()}/resources",
+                RealmMyPersonal.serialize(personal, context)
+            )?.enqueue(object : Callback<JsonObject?> {
                 override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
                     val `object` = response.body()
                     if (`object` != null) {
-                        try {
-                            if (!realm.isInTransaction) {
-                                realm.beginTransaction()
-                            }
-                            val rev = getString("rev", `object`)
-                            val id = getString("id", `object`)
-                            personal.isUploaded = true
-                            personal._rev = rev
-                            personal._id = id
-                            realm.commitTransaction()
+                        databaseService.withRealm { realm ->
+                            try {
+                                if (!realm.isInTransaction) {
+                                    realm.beginTransaction()
+                                }
+                                val rev = getString("rev", `object`)
+                                val id = getString("id", `object`)
+                                personal.isUploaded = true
+                                personal._rev = rev
+                                personal._id = id
+                                realm.commitTransaction()
 
-                            uploadAttachment(id, rev, personal, listener)
-                        } catch (e: Exception) {
-                            if (realm.isInTransaction) {
-                                realm.cancelTransaction()
+                                uploadAttachment(id, rev, personal, listener)
+                            } catch (e: Exception) {
+                                if (realm.isInTransaction) {
+                                    realm.cancelTransaction()
+                                }
+                                listener.onSuccess("Error updating personal resource: ${e.message}")
                             }
-                            listener.onSuccess("Error updating personal resource: ${e.message}")
                         }
                     } else {
                         listener.onSuccess("Failed to upload personal resource: No response")
@@ -418,17 +450,22 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadTeamTask() {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
-        realm.executeTransactionAsync { realm: Realm ->
-            val list: List<RealmTeamTask> = realm.where(RealmTeamTask::class.java).findAll()
-            val tasksToUpload = list.filter { task ->
-                TextUtils.isEmpty(task._id) || task.isUpdated
-            }
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val list: List<RealmTeamTask> = transactionRealm.where(RealmTeamTask::class.java).findAll()
+                val tasksToUpload = list.filter { task ->
+                    TextUtils.isEmpty(task._id) || task.isUpdated
+                }
 
-            tasksToUpload.processInBatches { task ->
+                tasksToUpload.processInBatches { task ->
                     try {
-                        val `object` = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/tasks", RealmTeamTask.serialize(realm, task))?.execute()?.body()
+                        val `object` = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/tasks",
+                            RealmTeamTask.serialize(transactionRealm, task)
+                        )?.execute()?.body()
 
                         if (`object` != null) {
                             val rev = getString("rev", `object`)
@@ -439,22 +476,27 @@ class UploadManager @Inject constructor(
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
+                }
             }
         }
     }
 
     fun uploadSubmissions() {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val list: List<RealmSubmission> = transactionRealm.where(RealmSubmission::class.java)
+                    .equalTo("isUpdated", true).or().isEmpty("_id").findAll()
 
-        realm.executeTransactionAsync { realm: Realm ->
-            val list: List<RealmSubmission> = realm.where(RealmSubmission::class.java)
-                .equalTo("isUpdated", true).or().isEmpty("_id").findAll()
-
-            list.processInBatches { submission ->
+                list.processInBatches { submission ->
                     try {
-                        val requestJson = RealmSubmission.serialize(realm, submission)
-                        val response = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/submissions", requestJson)?.execute()
+                        val requestJson = RealmSubmission.serialize(transactionRealm, submission)
+                        val response = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/submissions",
+                            requestJson
+                        )?.execute()
 
                         val jsonObject = response?.body()
                         if (jsonObject != null) {
@@ -467,19 +509,24 @@ class UploadManager @Inject constructor(
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
+                }
             }
         }
     }
 
     fun uploadTeams() {
         val apiInterface = client?.create(ApiInterface::class.java)
-        val realm = getRealm()
-
-        realm.executeTransactionAsync { realm: Realm ->
-            val teams: List<RealmMyTeam> = realm.where(RealmMyTeam::class.java).equalTo("updated", true).findAll()
-            teams.processInBatches { team ->
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val teams: List<RealmMyTeam> = transactionRealm.where(RealmMyTeam::class.java).equalTo("updated", true).findAll()
+                teams.processInBatches { team ->
                     try {
-                        val `object` = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/teams", RealmMyTeam.serialize(team))?.execute()?.body()
+                        val `object` = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/teams",
+                            RealmMyTeam.serialize(team)
+                        )?.execute()?.body()
                         if (`object` != null) {
                             team._rev = getString("rev", `object`)
                             team.updated = false
@@ -487,6 +534,7 @@ class UploadManager @Inject constructor(
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
+                }
             }
         }
     }
@@ -503,30 +551,34 @@ class UploadManager @Inject constructor(
             return
         }
 
-        val realm = getRealm()
-        realm.executeTransactionAsync({ transactionRealm: Realm ->
-            val activities = transactionRealm.where(RealmOfflineActivity::class.java).isNull("_rev").equalTo("type", "login").findAll()
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync({ transactionRealm: Realm ->
+                val activities = transactionRealm.where(RealmOfflineActivity::class.java).isNull("_rev").equalTo("type", "login").findAll()
 
-            activities.processInBatches { act ->
-                try {
-                    if (act.userId?.startsWith("guest") == true) {
-                        return@processInBatches
+                activities.processInBatches { act ->
+                    try {
+                        if (act.userId?.startsWith("guest") == true) {
+                            return@processInBatches
+                        }
+
+                        val `object` = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/login_activities",
+                            RealmOfflineActivity.serializeLoginActivities(act, context)
+                        )?.execute()?.body()
+                        act.changeRev(`object`)
+                    } catch (e: IOException) {
+                        e.printStackTrace()
                     }
-
-                    val `object` = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/login_activities", RealmOfflineActivity.serializeLoginActivities(act, context))?.execute()?.body()
-                    act.changeRev(`object`)
-                } catch (e: IOException) {
-                    e.printStackTrace()
                 }
+                uploadTeamActivities(transactionRealm, apiInterface)
+            }, {
+                listener.onSuccess("User activities sync completed successfully")
+            }) { e: Throwable ->
+                e.printStackTrace()
+                listener.onSuccess(e.message)
             }
-            uploadTeamActivities(transactionRealm, apiInterface)
-        }, {
-            realm.close()
-            listener.onSuccess("User activities sync completed successfully")
-        }) { e: Throwable ->
-            realm.close()
-            e.printStackTrace()
-            listener.onSuccess(e.message)
         }
     }
 
@@ -546,12 +598,11 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadRating() {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
-
-        realm.executeTransactionAsync { realm: Realm ->
-            val activities = realm.where(RealmRating::class.java).equalTo("isUpdated", true).findAll()
-            activities.processInBatches { act ->
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val activities = transactionRealm.where(RealmRating::class.java).equalTo("isUpdated", true).findAll()
+                activities.processInBatches { act ->
                     try {
                         if (act.userId?.startsWith("guest") == true) {
                             return@processInBatches
@@ -571,17 +622,17 @@ class UploadManager @Inject constructor(
                     } catch (e: Exception) {
                         e.printStackTrace()
                     }
+                }
             }
         }
     }
 
     fun uploadNews() {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
-
-        realm.executeTransactionAsync { realm: Realm ->
-            val activities = realm.where(RealmNews::class.java).findAll()
-            activities.processInBatches { act ->
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val activities = transactionRealm.where(RealmNews::class.java).findAll()
+                activities.processInBatches { act ->
                     try {
                         if (act.userId?.startsWith("guest") == true) {
                             return@processInBatches
@@ -589,7 +640,7 @@ class UploadManager @Inject constructor(
 
                         val `object` = RealmNews.serializeNews(act)
                         val image = act.imagesArray
-                        val user = realm.where(RealmUserModel::class.java).equalTo("id", pref.getString("userId", "")).findFirst()
+                        val user = transactionRealm.where(RealmUserModel::class.java).equalTo("id", pref.getString("userId", "")).findFirst()
 
                         if (act.imageUrls != null && act.imageUrls?.isNotEmpty() == true) {
                             act.imageUrls?.chunked(5)?.forEach { imageChunk ->
@@ -648,27 +699,28 @@ class UploadManager @Inject constructor(
                     }
                 }
             }
+        }
         uploadNewsActivities()
     }
 
     fun uploadCrashLog() {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
+        databaseService.withRealm { realm ->
+            try {
+                val hasLooper = Looper.myLooper() != null
 
-        try {
-            val hasLooper = Looper.myLooper() != null
-
-            if (hasLooper) {
-                realm.executeTransactionAsync { realm: Realm ->
-                    uploadCrashLogData(realm, apiInterface)
+                if (hasLooper) {
+                    realm.executeTransactionAsync { transactionRealm ->
+                        uploadCrashLogData(transactionRealm, apiInterface)
+                    }
+                } else {
+                    realm.executeTransaction { transactionRealm ->
+                        uploadCrashLogData(transactionRealm, apiInterface)
+                    }
                 }
-            } else {
-                realm.executeTransaction { realm: Realm ->
-                    uploadCrashLogData(realm, apiInterface)
-                }
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
-        } catch (e: Exception) {
-            e.printStackTrace()
         }
     }
 
@@ -689,26 +741,31 @@ class UploadManager @Inject constructor(
     }
 
     fun uploadSearchActivity() {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
-        realm.executeTransactionAsync { realm: Realm ->
-            val logs: RealmResults<RealmSearchActivity> = realm.where(RealmSearchActivity::class.java).isEmpty("_rev").findAll()
-            logs.processInBatches { act ->
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val logs: RealmResults<RealmSearchActivity> = transactionRealm.where(RealmSearchActivity::class.java).isEmpty("_rev").findAll()
+                logs.processInBatches { act ->
                     try {
-                        val o = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/search_activities", act.serialize())?.execute()?.body()
+                        val o = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/search_activities",
+                            act.serialize()
+                        )?.execute()?.body()
                         if (o != null) {
                             act._rev = getString("rev", o)
                         }
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
+                }
             }
         }
 
     }
 
     fun uploadResourceActivities(type: String) {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
 
         val db = if (type == "sync") {
@@ -717,16 +774,22 @@ class UploadManager @Inject constructor(
             "resource_activities"
         }
 
-        realm.executeTransactionAsync { realm: Realm ->
-            val activities: RealmResults<RealmResourceActivity> =
-                if (type == "sync") {
-                    realm.where(RealmResourceActivity::class.java).isNull("_rev").equalTo("type", "sync").findAll()
-                } else {
-                    realm.where(RealmResourceActivity::class.java).isNull("_rev").notEqualTo("type", "sync").findAll()
-                }
-            activities.processInBatches { act ->
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val activities: RealmResults<RealmResourceActivity> =
+                    if (type == "sync") {
+                        transactionRealm.where(RealmResourceActivity::class.java).isNull("_rev").equalTo("type", "sync").findAll()
+                    } else {
+                        transactionRealm.where(RealmResourceActivity::class.java).isNull("_rev").notEqualTo("type", "sync").findAll()
+                    }
+                activities.processInBatches { act ->
                     try {
-                        val `object` = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/" + db, RealmResourceActivity.serializeResourceActivities(act))?.execute()?.body()
+                        val `object` = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/" + db,
+                            RealmResourceActivity.serializeResourceActivities(act)
+                        )?.execute()?.body()
 
                         if (`object` != null) {
                             act._rev = getString("rev", `object`)
@@ -735,19 +798,24 @@ class UploadManager @Inject constructor(
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
+                }
             }
         }
     }
 
     fun uploadCourseActivities() {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
-
-        realm.executeTransactionAsync { realm: Realm ->
-            val activities: RealmResults<RealmCourseActivity> = realm.where(RealmCourseActivity::class.java).isNull("_rev").notEqualTo("type", "sync").findAll()
-            activities.processInBatches { act ->
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val activities: RealmResults<RealmCourseActivity> = transactionRealm.where(RealmCourseActivity::class.java).isNull("_rev").notEqualTo("type", "sync").findAll()
+                activities.processInBatches { act ->
                     try {
-                        val `object` = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/course_activities", RealmCourseActivity.serializeSerialize(act))?.execute()?.body()
+                        val `object` = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/course_activities",
+                            RealmCourseActivity.serializeSerialize(act)
+                        )?.execute()?.body()
 
                         if (`object` != null) {
                             act._rev = getString("rev", `object`)
@@ -756,19 +824,25 @@ class UploadManager @Inject constructor(
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
+                }
             }
         }
     }
 
     fun uploadMeetups() {
-        val realm = getRealm()
         val apiInterface = client?.create(ApiInterface::class.java)
-        realm.executeTransactionAsync { realm: Realm ->
-            val meetups: List<RealmMeetup> = realm.where(RealmMeetup::class.java).findAll()
-            meetups.processInBatches { meetup ->
+        databaseService.withRealm { realm ->
+            realm.executeTransactionAsync { transactionRealm ->
+                val meetups: List<RealmMeetup> = transactionRealm.where(RealmMeetup::class.java).findAll()
+                meetups.processInBatches { meetup ->
                     try {
                         val meetupJson = RealmMeetup.serialize(meetup)
-                        val `object` = apiInterface?.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/meetups", meetupJson)?.execute()?.body()
+                        val `object` = apiInterface?.postDoc(
+                            UrlUtils.header,
+                            "application/json",
+                            "${UrlUtils.getUrl()}/meetups",
+                            meetupJson
+                        )?.execute()?.body()
 
                         if (`object` != null) {
                             meetup.meetupId = getString("id", `object`)
@@ -777,6 +851,7 @@ class UploadManager @Inject constructor(
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- wrap Realm usage in UploadManager with `databaseService.withRealm` to close instances automatically
- move `executeTransactionAsync` calls inside managed Realm scopes
- open and close Realm within callbacks such as `uploadMyPersonal`

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b96be40ec0832b8e2e3cc171c98e71