### PR TITLE
fix: copy realm objects before diff (fixes #7319)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -87,7 +87,8 @@ internal class AdapterCourses(
     }
 
     fun setCourseList(courseList: List<RealmMyCourse?>) {
-        submitList(courseList)
+        val safeList = mRealm?.copyFromRealm(courseList.filterNotNull()) ?: courseList.filterNotNull()
+        submitList(safeList)
     }
 
     private fun sortCourseListByTitle(list: List<RealmMyCourse?>): List<RealmMyCourse?> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -86,9 +86,21 @@ internal class AdapterCourses(
         return currentList
     }
 
-    fun setCourseList(courseList: List<RealmMyCourse?>) {
-        val safeList = mRealm?.copyFromRealm(courseList.filterNotNull()) ?: courseList.filterNotNull()
-        submitList(safeList)
+    override fun submitList(list: List<RealmMyCourse?>?) {
+        submitList(list, null)
+    }
+
+    override fun submitList(list: List<RealmMyCourse?>?, commitCallback: Runnable?) {
+        val safeList = list?.let { courses ->
+            if (mRealm != null) {
+                mRealm!!.copyFromRealm(courses.filterNotNull())
+            } else {
+                Realm.getDefaultInstance().use { realm ->
+                    realm.copyFromRealm(courses.filterNotNull())
+                }
+            }
+        }
+        super.submitList(safeList, commitCallback)
     }
 
     private fun sortCourseListByTitle(list: List<RealmMyCourse?>): List<RealmMyCourse?> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -92,13 +92,18 @@ internal class AdapterCourses(
 
     override fun submitList(list: List<RealmMyCourse?>?, commitCallback: Runnable?) {
         val safeList = list?.let { courses ->
-            if (mRealm != null) {
-                mRealm!!.copyFromRealm(courses.filterNotNull())
-            } else {
-                Realm.getDefaultInstance().use { realm ->
-                    realm.copyFromRealm(courses.filterNotNull())
+            val realm = mRealm ?: Realm.getDefaultInstance()
+            val copied = courses.map { course ->
+                if (course != null && course.isManaged) {
+                    realm.copyFromRealm(course)
+                } else {
+                    course
                 }
             }
+            if (realm !== mRealm) {
+                realm.close()
+            }
+            copied
         }
         super.submitList(safeList, commitCallback)
     }


### PR DESCRIPTION
## Summary
- copy Realm objects in course list before diffing to avoid cross-thread Realm access

## Testing
- `./gradlew lint` *(fails: Gradle build timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68b9da76c7b8832bb9ee2a2744b67c80