### PR TITLE
resources: smoother creation binding (fixes #7359)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3073
-        versionName = "0.30.73"
+        versionCode = 3078
+        versionName = "0.30.78"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -50,7 +50,8 @@ import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
 class AddResourceFragment : BottomSheetDialogFragment() {
-    private lateinit var fragmentAddResourceBinding: FragmentAddResourceBinding
+    private var _binding: FragmentAddResourceBinding? = null
+    private val binding get() = _binding!!
     var tvTime: TextView? = null
     var floatingActionButton: FloatingActionButton? = null
     private var audioRecorderService: AudioRecorderService? = null
@@ -131,12 +132,17 @@ class AddResourceFragment : BottomSheetDialogFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentAddResourceBinding = FragmentAddResourceBinding.inflate(inflater, container, false)
-        fragmentAddResourceBinding.llRecordVideo.setOnClickListener { dispatchTakeVideoIntent() }
-        fragmentAddResourceBinding.llRecordAudio.setOnClickListener { showAudioRecordAlert() }
-        fragmentAddResourceBinding.llCaptureImage.setOnClickListener { takePhoto() }
-        fragmentAddResourceBinding.llDraft.setOnClickListener { openFolderLauncher.launch("*/*") }
-        return fragmentAddResourceBinding.root
+        _binding = FragmentAddResourceBinding.inflate(inflater, container, false)
+        binding.llRecordVideo.setOnClickListener { dispatchTakeVideoIntent() }
+        binding.llRecordAudio.setOnClickListener { showAudioRecordAlert() }
+        binding.llCaptureImage.setOnClickListener { takePhoto() }
+        binding.llDraft.setOnClickListener { openFolderLauncher.launch("*/*") }
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun showAudioRecordAlert() {


### PR DESCRIPTION
## Summary
- use nullable backing property with getter for AddResourceFragment binding
- clear binding in onDestroyView to prevent leaks

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68bada48533c832b81bde0f711bd0f77