### PR TITLE
teams: smoother calendar event details binding (fixes #7361)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3073
-        versionName = "0.30.73"
+        versionCode = 3081
+        versionName = "0.30.81"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mymeetup/MyMeetupDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mymeetup/MyMeetupDetailFragment.kt
@@ -24,7 +24,8 @@ import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 
 @AndroidEntryPoint
 class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
-    private lateinit var fragmentMyMeetupDetailBinding: FragmentMyMeetupDetailBinding
+    private var _binding: FragmentMyMeetupDetailBinding? = null
+    private val binding get() = _binding!!
     private var meetups: RealmMeetup? = null
     @Inject
     lateinit var databaseService: DatabaseService
@@ -43,17 +44,17 @@ class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentMyMeetupDetailBinding = FragmentMyMeetupDetailBinding.inflate(inflater, container, false)
-        listDesc = fragmentMyMeetupDetailBinding.root.findViewById(R.id.list_desc)
-        listUsers = fragmentMyMeetupDetailBinding.root.findViewById(R.id.list_users)
-        tvJoined = fragmentMyMeetupDetailBinding.root.findViewById(R.id.tv_joined)
-        fragmentMyMeetupDetailBinding.btnInvite.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
-        fragmentMyMeetupDetailBinding.btnLeave.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
-        fragmentMyMeetupDetailBinding.btnLeave.setOnClickListener(this)
+        _binding = FragmentMyMeetupDetailBinding.inflate(inflater, container, false)
+        listDesc = binding.root.findViewById(R.id.list_desc)
+        listUsers = binding.root.findViewById(R.id.list_users)
+        tvJoined = binding.root.findViewById(R.id.tv_joined)
+        binding.btnInvite.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
+        binding.btnLeave.visibility = if (showBetaFeature(Constants.KEY_MEETUPS, requireContext())) View.VISIBLE else View.GONE
+        binding.btnLeave.setOnClickListener(this)
         mRealm = databaseService.realmInstance
         profileDbHandler = UserProfileDbHandler(requireContext())
         user = profileDbHandler?.userModel?.let { mRealm.copyFromRealm(it) }
-        return fragmentMyMeetupDetailBinding.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -71,7 +72,7 @@ class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
     }
 
     private fun setUpData() {
-        fragmentMyMeetupDetailBinding.meetupTitle.text = meetups?.title
+        binding.meetupTitle.text = meetups?.title
         val map: HashMap<String, String>? = meetups?.let { getHashMap(it) }
         val keys = ArrayList(map?.keys ?: emptyList())
         listDesc?.adapter = object : ArrayAdapter<String?>(requireActivity(), R.layout.row_description, keys) {
@@ -97,12 +98,17 @@ class MyMeetupDetailFragment : Fragment(), View.OnClickListener {
         mRealm.executeTransaction {
             if (meetups?.userId?.isEmpty() == true) {
                 meetups?.userId = user?.id
-                fragmentMyMeetupDetailBinding.btnLeave.setText(R.string.leave)
+                binding.btnLeave.setText(R.string.leave)
             } else {
                 meetups?.userId = ""
-                fragmentMyMeetupDetailBinding.btnLeave.setText(R.string.join)
+                binding.btnLeave.setText(R.string.join)
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## Summary
- use view binding backing property in MyMeetupDetailFragment
- clear binding in onDestroyView

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68bada25fb4c832ba43310829d45a728