### PR TITLE
resources: smoother rating view model realm closing (fixes #7365)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3073
-        versionName = "0.30.73"
+        versionCode = 3084
+        versionName = "0.30.84"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- use `realmInstance.use{}` in `submitRating` to guarantee Realm is closed after execution

## Testing
- `./gradlew app:assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68badaa73488832ba49a820af5911ef4