### PR TITLE
courses: smoother submission repository exams (fixes #7367)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3073
-        versionName = "0.30.73"
+        versionCode = 3086
+        versionName = "0.30.86"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.repository
 
+import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 
 interface SubmissionRepository {
@@ -9,6 +10,7 @@ interface SubmissionRepository {
     suspend fun getSubmissionById(id: String): RealmSubmission?
     suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission>
     suspend fun getSubmissionsByType(type: String): List<RealmSubmission>
+    suspend fun getExamMapForSubmissions(submissions: List<RealmSubmission>): Map<String?, RealmStepExam>
     suspend fun saveSubmission(submission: RealmSubmission)
     suspend fun updateSubmission(id: String, updater: (RealmSubmission) -> Unit)
     suspend fun deleteSubmission(id: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -42,6 +42,27 @@ class SubmissionRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getExamMapForSubmissions(
+        submissions: List<RealmSubmission>
+    ): Map<String?, RealmStepExam> {
+        return withRealm { realm ->
+            val exams = HashMap<String?, RealmStepExam>()
+            submissions.forEach { sub ->
+                var id = sub.parentId
+                if (id?.contains("@") == true) {
+                    id = id.split("@").firstOrNull()
+                }
+                val survey = realm.where(RealmStepExam::class.java)
+                    .equalTo("id", id)
+                    .findFirst()
+                if (survey != null) {
+                    exams[sub.parentId] = realm.copyFromRealm(survey)
+                }
+            }
+            exams
+        }
+    }
+
     override suspend fun getSubmissionById(id: String): RealmSubmission? {
         return findByField(RealmSubmission::class.java, "id", id)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submission/MySubmissionFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submission/MySubmissionFragment.kt
@@ -12,15 +12,12 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
-import io.realm.Realm
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.databinding.FragmentMySubmissionBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
-import org.ole.planet.myplanet.model.RealmSubmission.Companion.getExamMap
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.service.UserProfileDbHandler
@@ -29,9 +26,6 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 class MySubmissionFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
     private var _binding: FragmentMySubmissionBinding? = null
     private val binding get() = _binding!!
-    lateinit var mRealm: Realm
-    @Inject
-    lateinit var databaseService: DatabaseService
     @Inject
     lateinit var submissionRepository: SubmissionRepository
     var type: String? = ""
@@ -53,14 +47,14 @@ class MySubmissionFragment : Fragment(), CompoundButton.OnCheckedChangeListener 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        mRealm = databaseService.realmInstance
         binding.rvMysurvey.layoutManager = LinearLayoutManager(activity)
         binding.rvMysurvey.addItemDecoration(
             DividerItemDecoration(activity, DividerItemDecoration.VERTICAL)
         )
         viewLifecycleOwner.lifecycleScope.launch {
-            submissions = submissionRepository.getSubmissionsByUserId(user?.id ?: "")
-            exams = getExamMap(mRealm, submissions)
+            val subs = submissionRepository.getSubmissionsByUserId(user?.id ?: "")
+            submissions = subs
+            exams = HashMap(submissionRepository.getExamMapForSubmissions(subs))
             setData("")
         }
         binding.etSearch.addTextChangedListener(object : TextWatcher {
@@ -146,15 +140,11 @@ class MySubmissionFragment : Fragment(), CompoundButton.OnCheckedChangeListener 
             }
         }
 
-        adapter.setmRealm(mRealm)
         adapter.setType(type)
         binding.rvMysurvey.adapter = adapter
     }
 
     override fun onDestroyView() {
-        if (::mRealm.isInitialized && !mRealm.isClosed) {
-            mRealm.close()
-        }
         _binding = null
         super.onDestroyView()
     }


### PR DESCRIPTION
## Summary
- expose exam map lookup on SubmissionRepository
- implement new exam lookup using RealmRepository
- streamline MySubmissionFragment to use repository and drop Realm instance

## Testing
- `./gradlew assembleDebug` *(fails: process interrupted at 25%)*

------
https://chatgpt.com/codex/tasks/task_e_68bad91d34f4832b8cd8c7ace666e4a6