### PR TITLE
teams: smoother submission repository survey titles (fixes #7368)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3073
-        versionName = "0.30.73"
+        versionCode = 3087
+        versionName = "0.30.87"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- fetch all RealmStepExam objects in a single query when gathering survey titles

## Testing
- `./gradlew lint` *(fails: interrupted due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68bad85eddf0832b8810619ce2c7955b