### PR TITLE
dashboard: smoother notification reading (fixes #7158)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3073
-        versionName = "0.30.73"
+        versionCode = 3080
+        versionName = "0.30.80"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/AdapterNotification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/AdapterNotification.kt
@@ -19,7 +19,7 @@ import org.ole.planet.myplanet.utilities.DiffUtils as DiffUtilExtensions
 class AdapterNotification(
     private val databaseService: DatabaseService,
     notifications: List<RealmNotification>,
-    private val onMarkAsReadClick: (Int) -> Unit,
+    private val onMarkAsReadClick: (String) -> Unit,
     private val onNotificationClick: (RealmNotification) -> Unit
 ) : ListAdapter<RealmNotification, AdapterNotification.ViewHolderNotifications>(
     DiffUtilExtensions.itemCallback(
@@ -39,7 +39,7 @@ class AdapterNotification(
 
     override fun onBindViewHolder(holder: ViewHolderNotifications, position: Int) {
         val notification = getItem(position)
-        holder.bind(notification, position)
+        holder.bind(notification)
     }
 
     fun updateNotifications(newNotifications: List<RealmNotification>) {
@@ -49,7 +49,7 @@ class AdapterNotification(
     inner class ViewHolderNotifications(private val rowNotificationsBinding: RowNotificationsBinding) :
         RecyclerView.ViewHolder(rowNotificationsBinding.root) {
 
-        fun bind(notification: RealmNotification, position: Int) {
+        fun bind(notification: RealmNotification) {
             val context = rowNotificationsBinding.root.context
             val currentNotification = formatNotificationMessage(notification, context)
             rowNotificationsBinding.title.text = Html.fromHtml(currentNotification, Html.FROM_HTML_MODE_LEGACY)
@@ -60,7 +60,7 @@ class AdapterNotification(
                 rowNotificationsBinding.btnMarkAsRead.visibility = View.VISIBLE
                 rowNotificationsBinding.root.alpha = 1.0f
                 rowNotificationsBinding.btnMarkAsRead.setOnClickListener {
-                    onMarkAsReadClick(position)
+                    onMarkAsReadClick(notification.id)
                 }
             }
 


### PR DESCRIPTION
fixes #7158

## Summary
- Pass notification ID to mark-as-read callback in `AdapterNotification`
- Handle mark-as-read via ID in `NotificationsFragment` and update list immediately
- Remove reliance on adapter positions and refresh unread counters/filters

------
https://chatgpt.com/codex/tasks/task_e_68bb222d9d00832bb341aa7110e97c9a