### PR TITLE
Fix password hint color contrast on login screen

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -165,6 +165,7 @@
                                     android:layout_centerVertical="true"
                                     android:autofillHints=""
                                     android:hint="@string/password"
+                                    android:textColorHint="@color/hint_color"
                                     android:backgroundTint="@color/daynight_textColor"
                                     android:drawablePadding="12dp"
                                     android:inputType="textPassword"


### PR DESCRIPTION
## Summary
- Ensure password field hint color matches username placeholder in light theme

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68bde227b8cc832b9bd0a217bca40ce4