### PR TITLE
Financial report header wrapping (fixes #7210)

### DIFF
--- a/app/src/main/res/layout/report_list_item.xml
+++ b/app/src/main/res/layout/report_list_item.xml
@@ -13,6 +13,10 @@
         android:textColor="@color/daynight_textColor"
         android:textSize="16sp"
         android:textStyle="bold"
+        android:ellipsize="end"
+        android:breakStrategy="balanced"
+        android:hyphenationFrequency="none"
+        android:maxLines="2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
fixes #7210
## Summary
- prevent financial report header from breaking words by adding ellipsize and balanced line breaking

## Testing
- `./gradlew assembleDebug` *(fails: process exceeded allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68be4651fc04832bae7b6c12c62aef55