### PR TITLE
library filter dismissal (fixes #6953)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFilterFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFilterFragment.kt
@@ -45,7 +45,6 @@ class ResourcesFilterFragment : DialogFragment(), AdapterView.OnItemClickListene
         binding.listLang.onItemClickListener = this
         binding.listLevel.onItemClickListener = this
         binding.listSub.onItemClickListener = this
-        binding.ivClose.setOnClickListener { dismiss() }
         binding.subjectsLayout.setOnClickListener {
             toggleSection(
                 binding.expandableLayoutSubjects,
@@ -88,11 +87,14 @@ class ResourcesFilterFragment : DialogFragment(), AdapterView.OnItemClickListene
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.ivClose.setOnClickListener { dismiss() }
+        dialog?.setCanceledOnTouchOutside(true)
         initList()
     }
 
     override fun onStart() {
         super.onStart()
+        dialog?.setCanceledOnTouchOutside(true)
         dialog?.window?.let { window ->
             val params = window.attributes
             params.width = (resources.displayMetrics.widthPixels * 0.9).toInt()


### PR DESCRIPTION
## Summary
- allow closing the Library filter dialog with the X button or background tap

## Testing
- `./gradlew assembleDebug` *(fails: build did not complete within available time)*

------
https://chatgpt.com/codex/tasks/task_e_68beaad0277c832bb3b49292b42e1346