### PR TITLE
team add document button (fixes #7325)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -82,6 +82,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
     private var pageConfigs: List<TeamPageConfig> = emptyList()
+    private var pendingAddDocument = false
 
     private fun pageIndexById(pageId: String?): Int? {
         pageId ?: return null
@@ -255,6 +256,10 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
                     team?._id?.let { teamId ->
                         pageConfigs.getOrNull(position)?.id?.let { pageId ->
                             teamLastPage[teamId] = pageId
+                            if (pendingAddDocument && pageId == DocumentsPage.id) {
+                                pendingAddDocument = false
+                                MainApplication.listener?.onAddDocument()
+                            }
                         }
                     }
                 }
@@ -312,9 +317,9 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
 
         binding.btnAddDoc.setOnClickListener {
             MainApplication.showDownload = true
+            pendingAddDocument = true
             selectPage(DocumentsPage.id)
             MainApplication.showDownload = false
-            MainApplication.listener?.onAddDocument()
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure Add Documents button opens document addition flow after navigating to the Documents page
- defer listener call until page creation to trigger picker

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68beaae1dc58832bb456cfa0858e9416