### PR TITLE
csv open error (fixes #7317)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
@@ -10,7 +10,9 @@ import androidx.core.content.ContextCompat
 import com.opencsv.CSVParserBuilder
 import com.opencsv.CSVReaderBuilder
 import java.io.File
-import java.io.FileReader
+import java.io.FileInputStream
+import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ActivityCsvviewerBinding
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils
@@ -44,7 +46,9 @@ class CSVViewerActivity : AppCompatActivity() {
                 val basePath = getExternalFilesDir(null)
                 File(basePath, "ole/$fileName")
             }
-            val reader = CSVReaderBuilder(FileReader(csvFile))
+            val reader = CSVReaderBuilder(
+                InputStreamReader(FileInputStream(csvFile), StandardCharsets.UTF_8)
+            )
                 .withCSVParser(CSVParserBuilder().withSeparator(',').withQuoteChar('"').build())
                 .build()
 

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
@@ -64,6 +64,10 @@ object Utilities {
 
     fun getMimeType(url: String?): String? {
         val extension = FileUtils.getFileExtension(url)
-        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+        return if (extension.equals("csv", ignoreCase = true)) {
+            "text/csv"
+        } else {
+            MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure `csv` MIME type resolves to `text/csv`
- read CSV files with UTF-8 encoding in viewer

## Testing
- `jshell --class-path opencsv.jar:commons-lang3.jar` and parsed sample CSV files

------
https://chatgpt.com/codex/tasks/task_e_68beaaee726c832bbc01e83aa319db93