### PR TITLE
course mismatch (fixes #7157)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
@@ -187,7 +187,7 @@ open class RealmMyCourse : RealmObject() {
         fun getMyByUserId(mRealm: Realm, settings: SharedPreferences?): RealmResults<RealmMyCourse> {
             val userId = settings?.getString("userId", "--")
             return mRealm.where(RealmMyCourse::class.java)
-                .equalTo("userId", userId)
+                .contains("userId", userId)
                 .findAll()
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -18,7 +18,7 @@ class CourseRepositoryImpl @Inject constructor(
 
     override suspend fun getCoursesByUserId(userId: String): List<RealmMyCourse> {
         return queryList(RealmMyCourse::class.java) {
-            equalTo("userId", userId)
+            contains("userId", userId)
         }
     }
 


### PR DESCRIPTION
fixes #7157
## Summary
- ensure course lookups use list containment for user IDs
- keep dashboard and My Library in sync by using consistent query

## Testing
- `./gradlew assembleDebug` *(fails: process did not complete in allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68beab2c7d80832b83c65083ba6893ec