### PR TITLE
Use withRealm for rating data loading

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingViewModel.kt
@@ -47,35 +47,34 @@ class RatingViewModel @Inject constructor(
             try {
                 _ratingState.value = RatingUiState.Loading
                 
-                val realm = databaseService.realmInstance
-                val existingRating = realm.where(RealmRating::class.java)
-                    .equalTo("type", type)
-                    .equalTo("userId", userId)
-                    .equalTo("item", itemId)
-                    .findFirst()
+                databaseService.withRealm { realm ->
+                    val existingRating = realm.where(RealmRating::class.java)
+                        .equalTo("type", type)
+                        .equalTo("userId", userId)
+                        .equalTo("item", itemId)
+                        .findFirst()
 
-                val allRatings = realm.where(RealmRating::class.java)
-                    .equalTo("type", type)
-                    .equalTo("item", itemId)
-                    .findAll()
-                
-                val totalRatings = allRatings.size
-                val averageRating = if (totalRatings > 0) {
-                    allRatings.sumOf { it.rate }.toFloat() / totalRatings
-                } else {
-                    0f
+                    val allRatings = realm.where(RealmRating::class.java)
+                        .equalTo("type", type)
+                        .equalTo("item", itemId)
+                        .findAll()
+
+                    val totalRatings = allRatings.size
+                    val averageRating = if (totalRatings > 0) {
+                        allRatings.sumOf { it.rate }.toFloat() / totalRatings
+                    } else {
+                        0f
+                    }
+
+                    val userRating = existingRating?.rate
+
+                    _ratingState.value = RatingUiState.Success(
+                        existingRating = existingRating,
+                        averageRating = averageRating,
+                        totalRatings = totalRatings,
+                        userRating = userRating
+                    )
                 }
-                
-                val userRating = existingRating?.rate
-                
-                _ratingState.value = RatingUiState.Success(
-                    existingRating = existingRating,
-                    averageRating = averageRating,
-                    totalRatings = totalRatings,
-                    userRating = userRating
-                )
-                
-                realm.close()
             } catch (e: Exception) {
                 _ratingState.value = RatingUiState.Error(e.message ?: "Failed to load rating data")
             }


### PR DESCRIPTION
## Summary
- simplify rating load by using `DatabaseService.withRealm`
- remove manual realm closure in RatingViewModel

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68beac2c3818832b9c43468d87759702