### PR TITLE
all: smoother user repository findfirst (fixes #7414)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3089
-        versionName = "0.30.89"
+        versionCode = 3102
+        versionName = "0.31.2"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -44,6 +44,14 @@ open class RealmRepository(private val databaseService: DatabaseService) {
         realm.findCopyByField(clazz, fieldName, value)
     }
 
+    protected suspend fun <T : RealmObject> findFirst(
+        clazz: Class<T>,
+    ): T? = withRealm { realm ->
+        realm.where(clazz)
+            .findFirst()
+            ?.let { realm.copyFromRealm(it) }
+    }
+
     protected suspend fun <T : RealmObject> save(item: T) {
         executeTransaction { realm ->
             realm.copyToRealmOrUpdate(item)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -20,11 +20,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getCurrentUser(): RealmUserModel? {
-        return withRealm { realm ->
-            realm.where(RealmUserModel::class.java)
-                .findFirst()
-                ?.let { realm.copyFromRealm(it) }
-        }
+        return findFirst(RealmUserModel::class.java)
     }
 
     override suspend fun getUserById(userId: String): RealmUserModel? {


### PR DESCRIPTION
## Summary
- Add generic `findFirst` method in `RealmRepository` for retrieving a copy of the first object of a class
- Simplify `UserRepositoryImpl.getCurrentUser` using the new `findFirst` helper

## Testing
- ⚠️ `./gradlew assembleDebug -x lint` *(terminated early; see logs for partial output)*


------
https://chatgpt.com/codex/tasks/task_e_68beadc07f8c832b95b0d288cd4fcb28