### PR TITLE
all: smoother feedback repository constructor (fixes #7412)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3089
-        versionName = "0.30.89"
+        versionCode = 3100
+        versionName = "0.31.0"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -11,8 +11,8 @@ import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmUserModel
 
 class FeedbackRepositoryImpl @Inject constructor(
-    private val databaseService: DatabaseService,
-    private val gson: Gson,
+    databaseService: DatabaseService,
+    private val gson: Gson
 ) : RealmRepository(databaseService), FeedbackRepository {
 
     override fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>> =


### PR DESCRIPTION
## Summary
- stop storing DatabaseService in FeedbackRepositoryImpl and delegate to RealmRepository directly

## Testing
- `./gradlew :app:compileDefaultDebugKotlin`


------
https://chatgpt.com/codex/tasks/task_e_68beadf53fd8832ba3ec126220492290