### PR TITLE
Refactor AddLinkFragment to use repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -1,8 +1,11 @@
 package org.ole.planet.myplanet.repository
 
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmMyTeam
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
+    suspend fun getSelectableTeams(isEnterprise: Boolean): List<RealmMyTeam>
+    suspend fun addLink(type: String, title: String, teamId: String)
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package org.ole.planet.myplanet.repository
 
 import javax.inject.Inject
+import java.util.Locale
+import java.util.UUID
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
@@ -17,6 +19,26 @@ class TeamRepositoryImpl @Inject constructor(
             queryList(RealmMyLibrary::class.java) {
                 `in`("resourceId", resourceIds.toTypedArray())
             }
+        }
+    }
+
+    override suspend fun getSelectableTeams(isEnterprise: Boolean): List<RealmMyTeam> {
+        val type = if (isEnterprise) "enterprise" else ""
+        return queryList(RealmMyTeam::class.java) {
+            isEmpty("teamId")
+            isNotEmpty("name")
+            equalTo("type", type)
+            notEqualTo("status", "archived")
+        }
+    }
+
+    override suspend fun addLink(type: String, title: String, teamId: String) {
+        executeTransaction { realm ->
+            val team = realm.createObject(RealmMyTeam::class.java, UUID.randomUUID().toString())
+            team.docType = "link"
+            team.updated = true
+            team.title = title
+            team.route = "/${type.lowercase(Locale.ROOT)}/view/$teamId"
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeam.kt
@@ -19,7 +19,7 @@ import org.ole.planet.myplanet.utilities.DiffUtils
 class AdapterTeam(
     private val context: Context,
     teams: List<RealmMyTeam>,
-    private val databaseService: DatabaseService,
+    private val databaseService: DatabaseService? = null,
 ) : ListAdapter<RealmMyTeam, AdapterTeam.ViewHolderTeam>(
     DiffUtils.itemCallback(
         areItemsTheSame = { oldItem, newItem -> oldItem._id == newItem._id },
@@ -56,15 +56,16 @@ class AdapterTeam(
     }
 
     private fun showUserList(realmMyTeam: RealmMyTeam) {
+        val ds = databaseService ?: return
         val layoutUserListBinding = LayoutUserListBinding.inflate(LayoutInflater.from(context))
-        databaseService.withRealm { realm ->
+        ds.withRealm { realm ->
             users = realm.copyFromRealm(RealmMyTeam.getUsers(realmMyTeam._id, realm, ""))
             setListAdapter(layoutUserListBinding.listUser, users)
         }
         layoutUserListBinding.etSearch.addTextChangedListener(object : android.text.TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-                databaseService.withRealm { realm ->
+                ds.withRealm { realm ->
                     users = realm.copyFromRealm(RealmMyTeam.filterUsers(realmMyTeam._id, "$s", realm))
                     setListAdapter(layoutUserListBinding.listUser, users)
                 }


### PR DESCRIPTION
## Summary
- extend `TeamRepository` to fetch selectable teams and create links
- inject `TeamRepository` into `AddLinkFragment` to load teams and save new links
- make `AdapterTeam`'s `DatabaseService` dependency optional

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68bee83c20c8832bbc7f2f55b2689653