### PR TITLE
remove unused addlinkfragment code (fixes #7405)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/AddLinkFragment.kt
@@ -1,15 +1,11 @@
 package org.ole.planet.myplanet.ui.community
 
-import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
-import android.widget.FrameLayout
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
@@ -56,19 +52,6 @@ class AddLinkFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedL
             })
             binding.rvList.adapter = adapter
         }
-    }
-
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val bottomSheetDialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
-        bottomSheetDialog.setOnShowListener { d ->
-            val dialog = d as BottomSheetDialog
-            val bottomSheet =
-                dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
-            BottomSheetBehavior.from(bottomSheet!!).state = BottomSheetBehavior.STATE_EXPANDED
-            BottomSheetBehavior.from(bottomSheet).skipCollapsed = true
-            BottomSheetBehavior.from(bottomSheet).setHideable(true)
-        }
-        return bottomSheetDialog
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {


### PR DESCRIPTION
## Summary
- remove unused BottomSheetDialog code from AddLinkFragment

## Testing
- `./gradlew assembleDebug` *(fails: Build-tool 35.0.0 has corrupt source.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68c0041fdaec832bba94d54f23e30033