### PR TITLE
financial report header word-break fix (fixes #7210)

### DIFF
--- a/app/src/main/res/layout/report_list_item.xml
+++ b/app/src/main/res/layout/report_list_item.xml
@@ -13,6 +13,8 @@
         android:textColor="@color/daynight_textColor"
         android:textSize="16sp"
         android:textStyle="bold"
+        android:singleLine="true"
+        android:ellipsize="end"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
## Summary
- prevent word-break in financial report header by constraining the title to a single line with ellipsis

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68c017a9344c832bbe25c5e35a0107dd