### PR TITLE
library sort options fail (fixes #6952)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
@@ -178,11 +178,13 @@ class AdapterResource(
     fun toggleTitleSortOrder() {
         isTitleAscending = !isTitleAscending
         updateList(sortLibraryListByTitle())
+        notifyDataSetChanged()
     }
 
     fun toggleSortOrder() {
         isAscending = !isAscending
         updateList(sortLibraryList())
+        notifyDataSetChanged()
     }
 
     private fun sortLibraryListByTitle(): List<RealmMyLibrary?> {


### PR DESCRIPTION
#6952

## Summary
- enable library list sorting by title or date as chosen by the user

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68c02a4ed754832b8f413c55826ca3b4