### PR TITLE
Prevent multiple survey sync dialogs and clean up on destroy

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
@@ -99,9 +99,13 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), SurveyAdoptListen
             override fun onSyncStarted() {
                 viewLifecycleOwner.lifecycleScope.launch {
                     if (isAdded && !requireActivity().isFinishing) {
-                        customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-                        customProgressDialog?.setText("Syncing surveys...")
-                        customProgressDialog?.show()
+                        if (customProgressDialog == null) {
+                            customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
+                            customProgressDialog?.setText("Syncing surveys...")
+                        }
+                        if (customProgressDialog?.isShowing != true) {
+                            customProgressDialog?.show()
+                        }
                     }
                 }
             }
@@ -322,6 +326,8 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), SurveyAdoptListen
         if (::realtimeSyncHelper.isInitialized) {
             realtimeSyncHelper.cleanup()
         }
+        customProgressDialog?.dismiss()
+        customProgressDialog = null
         super.onDestroyView()
         _binding = null
     }


### PR DESCRIPTION
## Summary
- Guard against creating multiple sync progress dialogs in `SurveyFragment`
- Dismiss and null out progress dialog when the view is destroyed

## Testing
- `./gradlew help`
- `./gradlew :app:assembleDebug --console=plain --no-daemon` *(fails: timeout during build)*

------
https://chatgpt.com/codex/tasks/task_e_68c03b704b7c832bae527ba22457299d