### PR TITLE
refactor: use DiffUtils for team course updates

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/AdapterTeamCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/AdapterTeamCourse.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import io.realm.Realm
 import org.ole.planet.myplanet.R
@@ -16,6 +15,7 @@ import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getTeamCreator
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
 import org.ole.planet.myplanet.ui.team.teamCourse.AdapterTeamCourse.ViewHolderTeamCourse
+import org.ole.planet.myplanet.utilities.DiffUtils
 
 class AdapterTeamCourse(private val context: Context, private var list: MutableList<RealmMyCourse>, mRealm: Realm?, teamId: String?, settings: SharedPreferences) : RecyclerView.Adapter<ViewHolderTeamCourse>() {
     private lateinit var rowTeamResourceBinding: RowTeamResourceBinding
@@ -32,8 +32,16 @@ class AdapterTeamCourse(private val context: Context, private var list: MutableL
     }
     
     fun updateList(newList: List<RealmMyCourse>) {
-        val diffCallback = TeamCourseDiffCallback(list, newList)
-        val diffResult = DiffUtil.calculateDiff(diffCallback)
+        val diffResult = DiffUtils.calculateDiff(
+            list,
+            newList,
+            areItemsTheSame = { old, new -> old.courseId == new.courseId },
+            areContentsTheSame = { old, new ->
+                old.courseTitle == new.courseTitle &&
+                    old.description == new.description &&
+                    old.createdDate == new.createdDate
+            }
+        )
         list.clear()
         list.addAll(newList)
         diffResult.dispatchUpdatesTo(this)
@@ -67,34 +75,4 @@ class AdapterTeamCourse(private val context: Context, private var list: MutableL
 
     class ViewHolderTeamCourse(rowTeamResourceBinding: RowTeamResourceBinding) :
         RecyclerView.ViewHolder(rowTeamResourceBinding.root)
-    
-    private class TeamCourseDiffCallback(
-        private val oldList: List<RealmMyCourse>,
-        private val newList: List<RealmMyCourse>
-    ) : DiffUtil.Callback() {
-        
-        override fun getOldListSize(): Int = oldList.size
-        
-        override fun getNewListSize(): Int = newList.size
-        
-        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            return try {
-                oldList[oldItemPosition].courseId == newList[newItemPosition].courseId
-            } catch (e: Exception) {
-                false
-            }
-        }
-        
-        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            return try {
-                val oldItem = oldList[oldItemPosition]
-                val newItem = newList[newItemPosition]
-                oldItem.courseTitle == newItem.courseTitle &&
-                    oldItem.description == newItem.description &&
-                    oldItem.createdDate == newItem.createdDate
-            } catch (e: Exception) {
-                false
-            }
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- simplify team course updates by using shared `DiffUtils.calculateDiff`
- remove custom `TeamCourseDiffCallback` implementation

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68c03d2690b0832b9833cc9a3e48749b