### PR TITLE
Resource Management (fixes #6882)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -151,15 +151,18 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
                 val connection = withContext(Dispatchers.IO) {
                     url.openConnection()
                 } as HttpURLConnection
-                connection.requestMethod = "GET"
-                connection.connectTimeout = 5000
-                connection.readTimeout = 5000
-                withContext(Dispatchers.IO) {
-                    connection.connect()
+                try {
+                    connection.requestMethod = "GET"
+                    connection.connectTimeout = 5000
+                    connection.readTimeout = 5000
+                    withContext(Dispatchers.IO) {
+                        connection.connect()
+                    }
+                    val responseCode = connection.responseCode
+                    responseCode in 200..299
+                } finally {
+                    connection.disconnect()
                 }
-                val responseCode = connection.responseCode
-                connection.disconnect()
-                responseCode in 200..299
 
             } catch (e: Exception) {
                 e.printStackTrace()

--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/FileUploadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/FileUploadService.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.datamanager
 import com.google.gson.JsonObject
 import java.io.File
 import java.io.IOException
+import java.net.URLConnection
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.callback.SuccessListener
@@ -44,8 +45,7 @@ open class FileUploadService {
     private fun uploadDoc(id: String, rev: String, format: String, f: File, name: String, listener: SuccessListener) {
         val apiInterface = ApiClient.client?.create(ApiInterface::class.java)
         try {
-            val connection = f.toURI().toURL().openConnection()
-            val mimeType = connection.contentType
+            val mimeType = URLConnection.guessContentTypeFromName(f.name) ?: "application/octet-stream"
             val body = FileUtils.fullyReadFileToBytes(f)
                 .toRequestBody("application/octet-stream".toMediaTypeOrNull())
             val url = String.format(format, UrlUtils.getUrl(), id, name)

--- a/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UploadManager.kt
@@ -12,6 +12,7 @@ import io.realm.RealmResults
 import java.io.File
 import java.io.IOException
 import java.util.Date
+import java.net.URLConnection
 import javax.inject.Inject
 import javax.inject.Singleton
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -603,8 +604,7 @@ class UploadManager @Inject constructor(
                                     val f = File(getString("imageUrl", imgObject))
                                     val name = FileUtils.getFileNameFromUrl(getString("imageUrl", imgObject))
                                     val format = "%s/resources/%s/%s"
-                                    val connection = f.toURI().toURL().openConnection()
-                                    val mimeType = connection.contentType
+                                    val mimeType = URLConnection.guessContentTypeFromName(f.name) ?: "application/octet-stream"
                                     val body = FileUtils.fullyReadFileToBytes(f)
                                         .toRequestBody("application/octet-stream".toMediaTypeOrNull())
                                     val url = String.format(format, UrlUtils.getUrl(), id, name)


### PR DESCRIPTION
fixes #6882

## Summary
- wrap AuthSessionUpdater's network post in try/finally and use
- disconnect HttpURLConnection in MainApplication safely
- avoid leaking file URL connections when uploading resources

------
https://chatgpt.com/codex/tasks/task_e_68c06c7fc078832b9d7e09628863bdc9