### PR TITLE
teams: smoother member joining realm handling (fixes #7595)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3118
-        versionName = "0.31.18"
+        versionCode = 3163
+        versionName = "0.31.63"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/JoinedMemberFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/JoinedMemberFragment.kt
@@ -1,45 +1,95 @@
 package org.ole.planet.myplanet.ui.team.teamMember
 
 import android.content.res.Configuration
+import android.widget.Toast
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import io.realm.Realm
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseMemberFragment
 import org.ole.planet.myplanet.callback.MemberChangeListener
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMember
-import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.model.RealmNews
 
 class JoinedMemberFragment : BaseMemberFragment() {
     private var memberChangeListener: MemberChangeListener = object : MemberChangeListener {
         override fun onMemberChanged() {
-            //fallback listener to prevent crash
+            // fallback listener to prevent crash
         }
     }
+
+    private var adapterJoined: AdapterJoinedMember? = null
 
     fun setMemberChangeListener(listener: MemberChangeListener) {
         this.memberChangeListener = listener
     }
-    override val list: List<RealmUserModel>
-        get() {
-            val members = getJoinedMember(teamId, mRealm).toMutableList()
-            val leader = members.find { it.id == getTeamLeaderId() }
+
+    private val joinedMembers: List<JoinedMemberData>
+        get() = databaseService.withRealm { realm ->
+            val members = getJoinedMember(teamId, realm).map { realm.copyFromRealm(it) }.toMutableList()
+            val leaderId = realm.where(RealmMyTeam::class.java)
+                .equalTo("teamId", teamId)
+                .equalTo("isLeader", true)
+                .findFirst()?.userId
+            val leader = members.find { it.id == leaderId }
             if (leader != null) {
                 members.remove(leader)
                 members.add(0, leader)
             }
-            return members
+            members.map { member ->
+                val lastVisitTimestamp = RealmTeamLog.getLastVisit(realm, member.name, teamId)
+                val lastVisitDate = if (lastVisitTimestamp != null) {
+                    val sdf = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
+                    sdf.format(Date(lastVisitTimestamp))
+                } else {
+                    getString(R.string.no_visit)
+                }
+                val visitCount = RealmTeamLog.getVisitCount(realm, member.name, teamId)
+                val offlineVisits = profileDbHandler.getOfflineVisits(member).toString()
+                val profileLastVisit = profileDbHandler.getLastVisit(member)
+                JoinedMemberData(
+                    member,
+                    visitCount,
+                    lastVisitDate,
+                    offlineVisits,
+                    profileLastVisit,
+                    member.id == leaderId
+                )
+            }
         }
 
-    private fun getTeamLeaderId(): String? {
-        val team = mRealm.where(RealmMyTeam::class.java)
-            .equalTo("teamId", teamId)
-            .equalTo("isLeader", true)
-            .findFirst()
-        return team?.userId
-    }
+    override val list: List<RealmUserModel>
+        get() = joinedMembers.map { it.user }
+
     override val adapter: RecyclerView.Adapter<*>
-        get() = AdapterJoinedMember(requireActivity(), list.toMutableList(), mRealm, teamId, memberChangeListener)
+        get() {
+            if (adapterJoined == null) {
+                val members = joinedMembers
+                val currentUserId = user?.id
+                val isLeader = members.any { it.user.id == currentUserId && it.isLeader }
+                adapterJoined = AdapterJoinedMember(
+                    requireActivity(),
+                    members.toMutableList(),
+                    isLeader,
+                    object : AdapterJoinedMember.MemberActionListener {
+                        override fun onRemoveMember(member: JoinedMemberData, position: Int) {
+                            handleRemoveMember(member)
+                        }
+
+                        override fun onMakeLeader(member: JoinedMemberData) {
+                            member.user.id?.let { handleMakeLeader(it) }
+                        }
+                    }
+                )
+            }
+            return adapterJoined as AdapterJoinedMember
+        }
 
     override val layoutManager: RecyclerView.LayoutManager
         get() {
@@ -52,9 +102,104 @@ class JoinedMemberFragment : BaseMemberFragment() {
             return GridLayoutManager(activity, columns)
         }
 
+    private fun handleRemoveMember(member: JoinedMemberData) {
+        databaseService.withRealm { realm ->
+            val currentUserId = user?.id
+            if (currentUserId != member.user.id) {
+                member.user.id?.let { removeMember(realm, it) }
+                memberChangeListener.onMemberChanged()
+            } else {
+                val nextOfKin = getNextOfKin(realm)
+                if (nextOfKin != null && nextOfKin.id != null) {
+                    makeLeader(realm, nextOfKin.id!!)
+                    member.user.id?.let { removeMember(realm, it) }
+                    memberChangeListener.onMemberChanged()
+                } else {
+                    Toast.makeText(requireContext(), R.string.cannot_remove_user, Toast.LENGTH_SHORT).show()
+                    return@withRealm
+                }
+            }
+        }
+        refreshMembers()
+    }
+
+    private fun handleMakeLeader(userId: String) {
+        databaseService.withRealm { realm ->
+            makeLeader(realm, userId)
+        }
+        Toast.makeText(requireContext(), getString(R.string.leader_selected), Toast.LENGTH_SHORT).show()
+        memberChangeListener.onMemberChanged()
+        refreshMembers()
+    }
+
+    private fun refreshMembers() {
+        val members = joinedMembers
+        val currentUserId = user?.id
+        val isLeader = members.any { it.user.id == currentUserId && it.isLeader }
+        adapterJoined?.updateData(members.toMutableList(), isLeader)
+        showNoData(binding.tvNodata, members.size, "members")
+    }
+
+    private fun makeLeader(realm: Realm, userId: String) {
+        realm.executeTransaction { r ->
+            val currentLeader = r.where(RealmMyTeam::class.java)
+                .equalTo("teamId", teamId)
+                .equalTo("isLeader", true)
+                .findFirst()
+            val newLeader = r.where(RealmMyTeam::class.java)
+                .equalTo("teamId", teamId)
+                .equalTo("userId", userId)
+                .findFirst()
+            currentLeader?.isLeader = false
+            newLeader?.isLeader = true
+        }
+    }
+
+    private fun removeMember(realm: Realm, userId: String) {
+        realm.executeTransaction { r ->
+            val team = r.where(RealmMyTeam::class.java)
+                .equalTo("teamId", teamId)
+                .equalTo("userId", userId)
+                .findFirst()
+            team?.deleteFromRealm()
+        }
+    }
+
+    private fun getNextOfKin(realm: Realm): RealmUserModel? {
+        val members: List<RealmMyTeam> = realm.where(RealmMyTeam::class.java)
+            .equalTo("teamId", teamId)
+            .equalTo("isLeader", false)
+            .notEqualTo("status", "archived")
+            .findAll()
+
+        if (members.isEmpty()) {
+            return null
+        }
+
+        var successorTeamMember: RealmMyTeam? = null
+        var maxVisitCount: Long = -1
+
+        for (member in members) {
+            val user = realm.where(RealmUserModel::class.java).equalTo("id", member.userId).findFirst()
+            if (user != null) {
+                val visitCount = RealmTeamLog.getVisitCount(realm, user.name, teamId)
+                if (visitCount > maxVisitCount) {
+                    maxVisitCount = visitCount
+                    successorTeamMember = member
+                }
+            }
+        }
+
+        return successorTeamMember?.userId?.let { id ->
+            realm.where(RealmUserModel::class.java).equalTo("id", id).findFirst()?.let { realm.copyFromRealm(it) }
+        }
+    }
+
     override fun onNewsItemClick(news: RealmNews?) {}
+
     override fun clearImages() {
         imageList.clear()
         llImage?.removeAllViews()
     }
 }
+


### PR DESCRIPTION
## Summary
- Move team member queries and role changes into JoinedMemberFragment using DatabaseService
- Simplify AdapterJoinedMember to accept plain data objects and callbacks instead of a Realm instance

## Testing
- `./gradlew lint`

------
https://chatgpt.com/codex/tasks/task_e_68c17a10ce7c832bb4f1085006aa0fca