### PR TITLE
Refactor fragments to use nullable view binding

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -45,7 +45,8 @@ import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
 class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnClickListener {
-    private lateinit var fragmentTakeCourseBinding: FragmentTakeCourseBinding
+    private var _binding: FragmentTakeCourseBinding? = null
+    private val binding get() = _binding!!
     @Inject
     lateinit var databaseService: DatabaseService
     lateinit var mRealm: Realm
@@ -65,63 +66,63 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentTakeCourseBinding = FragmentTakeCourseBinding.inflate(inflater, container, false)
+        _binding = FragmentTakeCourseBinding.inflate(inflater, container, false)
         mRealm = databaseService.realmInstance
         userModel = UserProfileDbHandler(requireContext()).userModel
         currentCourse = mRealm.where(RealmMyCourse::class.java).equalTo("courseId", courseId).findFirst()
-        return fragmentTakeCourseBinding.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        fragmentTakeCourseBinding.tvCourseTitle.text = currentCourse?.courseTitle
+        binding.tvCourseTitle.text = currentCourse?.courseTitle
         steps = getCourseSteps(mRealm, courseId)
         if (steps.isEmpty()) {
-            fragmentTakeCourseBinding.nextStep.visibility = View.GONE
-            fragmentTakeCourseBinding.previousStep.visibility = View.GONE
+            binding.nextStep.visibility = View.GONE
+            binding.previousStep.visibility = View.GONE
         }
 
         currentStep = getCourseProgress()
         position = if (currentStep > 0) currentStep  else 0
         setNavigationButtons()
-        fragmentTakeCourseBinding.viewPager2.adapter =
+        binding.viewPager2.adapter =
             CoursesPagerAdapter(
                 this@TakeCourseFragment,
                 courseId,
                 getCourseStepIds(mRealm, courseId)
             )
 
-        fragmentTakeCourseBinding.viewPager2.isUserInputEnabled = false
-        fragmentTakeCourseBinding.viewPager2.setCurrentItem(position, false)
+        binding.viewPager2.isUserInputEnabled = false
+        binding.viewPager2.setCurrentItem(position, false)
 
         updateStepDisplay(position)
 
         if (position == 0) {
-            fragmentTakeCourseBinding.previousStep.visibility = View.GONE
+            binding.previousStep.visibility = View.GONE
         }
         setCourseData()
         setListeners()
         checkSurveyCompletion()
-        fragmentTakeCourseBinding.backButton.setOnClickListener {
+        binding.backButton.setOnClickListener {
             NavigationHelper.popBackStack(requireActivity().supportFragmentManager)
         }
     }
 
     override fun onResume() {
         super.onResume()
-        updateStepDisplay(fragmentTakeCourseBinding.viewPager2.currentItem)
+        updateStepDisplay(binding.viewPager2.currentItem)
     }
 
     private fun setListeners() {
-        fragmentTakeCourseBinding.nextStep.setOnClickListener(this)
-        fragmentTakeCourseBinding.previousStep.setOnClickListener(this)
-        fragmentTakeCourseBinding.btnRemove.setOnClickListener(this)
-        fragmentTakeCourseBinding.finishStep.setOnClickListener(this)
-        fragmentTakeCourseBinding.courseProgress.setOnSeekBarChangeListener(object : OnSeekBarChangeListener {
+        binding.nextStep.setOnClickListener(this)
+        binding.previousStep.setOnClickListener(this)
+        binding.btnRemove.setOnClickListener(this)
+        binding.finishStep.setOnClickListener(this)
+        binding.courseProgress.setOnSeekBarChangeListener(object : OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, i: Int, b: Boolean) {
                 val currentProgress = getCurrentProgress(steps, mRealm, userModel?.id, courseId)
                 if (b && i <= currentProgress + 1) {
-                    fragmentTakeCourseBinding.viewPager2.currentItem = i
+                    binding.viewPager2.currentItem = i
                 }
             }
 
@@ -132,31 +133,31 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
 
     private fun updateStepDisplay(position: Int) {
         val currentPosition = position
-        fragmentTakeCourseBinding.tvStep.text = String.format(getString(R.string.step) + " %d/%d", currentPosition, steps.size)
+        binding.tvStep.text = String.format(getString(R.string.step) + " %d/%d", currentPosition, steps.size)
 
         val currentProgress = getCurrentProgress(steps, mRealm, userModel?.id, courseId)
         if (currentProgress < steps.size) {
-            fragmentTakeCourseBinding.courseProgress.secondaryProgress = currentProgress + 1
+            binding.courseProgress.secondaryProgress = currentProgress + 1
         }
-        fragmentTakeCourseBinding.courseProgress.progress = currentProgress
+        binding.courseProgress.progress = currentProgress
     }
 
     private fun setCourseData() {
         val isGuest = userModel?.isGuest() == true
         val containsUserId = currentCourse?.userId?.contains(userModel?.id) == true
         val stepsSize = steps.size
-        val currentItem = fragmentTakeCourseBinding.viewPager2.currentItem
+        val currentItem = binding.viewPager2.currentItem
 
         lifecycleScope.launch {
             withContext(Dispatchers.Main) {
                 if (!isGuest && !containsUserId) {
-                    fragmentTakeCourseBinding.btnRemove.visibility = View.VISIBLE
-                    fragmentTakeCourseBinding.btnRemove.text = getString(R.string.join)
+                    binding.btnRemove.visibility = View.VISIBLE
+                    binding.btnRemove.text = getString(R.string.join)
                     getAlertDialog(requireActivity(), getString(R.string.do_you_want_to_join_this_course), getString(R.string.join_this_course)) { _: DialogInterface?, _: Int ->
                         addRemoveCourse()
                     }
                 } else {
-                    fragmentTakeCourseBinding.btnRemove.visibility = View.GONE
+                    binding.btnRemove.visibility = View.GONE
                 }
             }
             
@@ -175,17 +176,17 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
             }
 
             withContext(Dispatchers.Main) {
-                fragmentTakeCourseBinding.courseProgress.max = stepsSize
+                binding.courseProgress.max = stepsSize
 
                 if (containsUserId) {
                     if(position != currentCourse?.courseSteps?.size){
-                        fragmentTakeCourseBinding.nextStep.visibility = View.VISIBLE
+                        binding.nextStep.visibility = View.VISIBLE
                     }
-                    fragmentTakeCourseBinding.courseProgress.visibility = View.VISIBLE
+                    binding.courseProgress.visibility = View.VISIBLE
                 } else {
-                    fragmentTakeCourseBinding.nextStep.visibility = View.GONE
-                    fragmentTakeCourseBinding.previousStep.visibility = View.GONE
-                    fragmentTakeCourseBinding.courseProgress.visibility = View.GONE
+                    binding.nextStep.visibility = View.GONE
+                    binding.previousStep.visibility = View.GONE
+                    binding.courseProgress.visibility = View.GONE
                 }
             }
         }
@@ -197,9 +198,9 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
         if (position > 0) {
             if (position - 1 < steps.size) changeNextButtonState(position)
         } else {
-            fragmentTakeCourseBinding.nextStep.visibility = View.VISIBLE
-            fragmentTakeCourseBinding.nextStep.isClickable = true
-            fragmentTakeCourseBinding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
+            binding.nextStep.visibility = View.VISIBLE
+            binding.nextStep.isClickable = true
+            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
         }
 
         updateStepDisplay(position)
@@ -207,40 +208,40 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
 
     private fun changeNextButtonState(position: Int) {
         if (isStepCompleted(mRealm, steps[position - 1]?.id, userModel?.id)) {
-            fragmentTakeCourseBinding.nextStep.isClickable = true
-            fragmentTakeCourseBinding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
+            binding.nextStep.isClickable = true
+            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
         } else {
-            fragmentTakeCourseBinding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_grey_500))
-            fragmentTakeCourseBinding.nextStep.isClickable = false
+            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_grey_500))
+            binding.nextStep.isClickable = false
         }
     }
 
     override fun onPageScrollStateChanged(state: Int) {}
 
     private fun onClickNext() {
-        fragmentTakeCourseBinding.tvStep.text = String.format(Locale.getDefault(), "${getString(R.string.step)} %d/%d", fragmentTakeCourseBinding.viewPager2.currentItem, currentCourse?.courseSteps?.size)
-        if (fragmentTakeCourseBinding.viewPager2.currentItem == currentCourse?.courseSteps?.size) {
-            fragmentTakeCourseBinding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_grey_500))
-            fragmentTakeCourseBinding.nextStep.visibility = View.GONE
-            fragmentTakeCourseBinding.finishStep.visibility = View.VISIBLE
+        binding.tvStep.text = String.format(Locale.getDefault(), "${getString(R.string.step)} %d/%d", binding.viewPager2.currentItem, currentCourse?.courseSteps?.size)
+        if (binding.viewPager2.currentItem == currentCourse?.courseSteps?.size) {
+            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_grey_500))
+            binding.nextStep.visibility = View.GONE
+            binding.finishStep.visibility = View.VISIBLE
         }else{
-            fragmentTakeCourseBinding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
-            fragmentTakeCourseBinding.nextStep.visibility = View.VISIBLE
-            fragmentTakeCourseBinding.finishStep.visibility = View.GONE
+            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
+            binding.nextStep.visibility = View.VISIBLE
+            binding.finishStep.visibility = View.GONE
 
         }
     }
 
     private fun onClickPrevious() {
-        fragmentTakeCourseBinding.tvStep.text = String.format(Locale.getDefault(), "${getString(R.string.step)} %d/%d", fragmentTakeCourseBinding.viewPager2.currentItem - 1, currentCourse?.courseSteps?.size)
-        if (fragmentTakeCourseBinding.viewPager2.currentItem - 1 == 0) {
-            fragmentTakeCourseBinding.previousStep.visibility = View.GONE
-            fragmentTakeCourseBinding.nextStep.visibility = View.VISIBLE
-            fragmentTakeCourseBinding.finishStep.visibility = View.GONE
+        binding.tvStep.text = String.format(Locale.getDefault(), "${getString(R.string.step)} %d/%d", binding.viewPager2.currentItem - 1, currentCourse?.courseSteps?.size)
+        if (binding.viewPager2.currentItem - 1 == 0) {
+            binding.previousStep.visibility = View.GONE
+            binding.nextStep.visibility = View.VISIBLE
+            binding.finishStep.visibility = View.GONE
         }else{
-            fragmentTakeCourseBinding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
-            fragmentTakeCourseBinding.nextStep.visibility = View.VISIBLE
-            fragmentTakeCourseBinding.finishStep.visibility = View.GONE
+            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
+            binding.nextStep.visibility = View.VISIBLE
+            binding.finishStep.visibility = View.GONE
         }
     }
 
@@ -248,8 +249,8 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
         when (view.id) {
             R.id.next_step -> {
                 if (isValidClickRight) {
-                    fragmentTakeCourseBinding.viewPager2.currentItem += 1
-                    fragmentTakeCourseBinding.previousStep.visibility = View.VISIBLE
+                    binding.viewPager2.currentItem += 1
+                    binding.previousStep.visibility = View.VISIBLE
                 }
                 onClickNext()
             }
@@ -257,7 +258,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
             R.id.previous_step -> {
                 onClickPrevious()
                 if (isValidClickLeft) {
-                    fragmentTakeCourseBinding.viewPager2.currentItem -= 1
+                    binding.viewPager2.currentItem -= 1
                 }
             }
 
@@ -301,12 +302,12 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
         }
 
         if (hasUnfinishedSurvey && courseId == "4e6b78800b6ad18b4e8b0e1e38a98cac") {
-            fragmentTakeCourseBinding.finishStep.setOnClickListener {
+            binding.finishStep.setOnClickListener {
                 Toast.makeText(context, getString(R.string.please_complete_survey), Toast.LENGTH_SHORT).show() }
         } else {
-            fragmentTakeCourseBinding.finishStep.isEnabled = true
-            fragmentTakeCourseBinding.finishStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
-            fragmentTakeCourseBinding.finishStep.setOnClickListener {
+            binding.finishStep.isEnabled = true
+            binding.finishStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
+            binding.finishStep.setOnClickListener {
                 NavigationHelper.popBackStack(requireActivity().supportFragmentManager)
             }
         }
@@ -314,26 +315,27 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
 
     private fun setNavigationButtons(){
         if(position == currentCourse?.courseSteps?.size){
-            fragmentTakeCourseBinding.nextStep.visibility = View.GONE
-            fragmentTakeCourseBinding.finishStep.visibility = View.VISIBLE
+            binding.nextStep.visibility = View.GONE
+            binding.finishStep.visibility = View.VISIBLE
         } else {
-            fragmentTakeCourseBinding.nextStep.visibility = View.VISIBLE
-            fragmentTakeCourseBinding.finishStep.visibility = View.GONE
+            binding.nextStep.visibility = View.VISIBLE
+            binding.finishStep.visibility = View.GONE
         }
 
     }
 
     override fun onDestroyView() {
-        fragmentTakeCourseBinding.courseProgress.setOnSeekBarChangeListener(null)
+        binding.courseProgress.setOnSeekBarChangeListener(null)
         lifecycleScope.coroutineContext.cancelChildren()
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        _binding = null
         super.onDestroyView()
     }
 
-    private val isValidClickRight: Boolean get() = fragmentTakeCourseBinding.viewPager2.adapter != null && fragmentTakeCourseBinding.viewPager2.currentItem < fragmentTakeCourseBinding.viewPager2.adapter?.itemCount!!
-    private val isValidClickLeft: Boolean get() = fragmentTakeCourseBinding.viewPager2.adapter != null && fragmentTakeCourseBinding.viewPager2.currentItem > 0
+    private val isValidClickRight: Boolean get() = binding.viewPager2.adapter != null && binding.viewPager2.currentItem < binding.viewPager2.adapter?.itemCount!!
+    private val isValidClickLeft: Boolean get() = binding.viewPager2.adapter != null && binding.viewPager2.currentItem > 0
 
     companion object {
         var courseId: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -50,7 +50,8 @@ import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.TimeUtils
 
 class BellDashboardFragment : BaseDashboardFragment() {
-    private lateinit var fragmentHomeBellBinding: FragmentHomeBellBinding
+    private var _binding: FragmentHomeBellBinding? = null
+    private val binding get() = _binding!!
     private var networkStatusJob: Job? = null
     private val viewModel: BellDashboardViewModel by viewModels()
     var user: RealmUserModel? = null
@@ -61,19 +62,19 @@ class BellDashboardFragment : BaseDashboardFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentHomeBellBinding = FragmentHomeBellBinding.inflate(inflater, container, false)
+        _binding = FragmentHomeBellBinding.inflate(inflater, container, false)
         user = UserProfileDbHandler(requireContext()).userModel
-        val view = fragmentHomeBellBinding.root
+        val view = binding.root
         initView(view)
         declareElements()
         onLoaded(view)
-        return fragmentHomeBellBinding.root
+        return view
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        fragmentHomeBellBinding.cardProfileBell.txtDate.text = TimeUtils.formatDate(Date().time, "")
-        fragmentHomeBellBinding.cardProfileBell.txtCommunityName.text = model?.planetCode
+        binding.cardProfileBell.txtDate.text = TimeUtils.formatDate(Date().time, "")
+        binding.cardProfileBell.txtCommunityName.text = model?.planetCode
         setupNetworkStatusMonitoring()
         (activity as DashboardActivity?)?.supportActionBar?.hide()
         showBadges()
@@ -99,7 +100,7 @@ class BellDashboardFragment : BaseDashboardFragment() {
     private fun setNetworkIndicatorColor(colorRes: Int) {
         if (isAdded && view?.isAttachedToWindow == true) {
             val color = ContextCompat.getColor(requireContext(), colorRes)
-            fragmentHomeBellBinding.cardProfileBell.imageView.borderColor = color
+            binding.cardProfileBell.imageView.borderColor = color
         }
     }
 
@@ -377,13 +378,13 @@ class BellDashboardFragment : BaseDashboardFragment() {
     }
 
     private fun showBadges() {
-        fragmentHomeBellBinding.cardProfileBell.llBadges.removeAllViews()
+        binding.cardProfileBell.llBadges.removeAllViews()
         val completedCourses = getCompletedCourses(mRealm, user?.id)
         completedCourses.forEachIndexed { index, course ->
             val rootView = requireActivity().findViewById<ViewGroup>(android.R.id.content)
             val star = LayoutInflater.from(activity).inflate(R.layout.image_start, rootView, false) as ImageView
             setColor(course.courseId, star)
-            fragmentHomeBellBinding.cardProfileBell.llBadges.addView(star)
+            binding.cardProfileBell.llBadges.addView(star)
             star.contentDescription = "${getString(R.string.completed_course)} ${course.courseTitle}"
             star.setOnClickListener {
                 openCourse(course, index)
@@ -423,7 +424,7 @@ class BellDashboardFragment : BaseDashboardFragment() {
     }
 
     private fun declareElements() {
-        fragmentHomeBellBinding.homeCardTeams.llHomeTeam.setOnClickListener {
+        binding.homeCardTeams.llHomeTeam.setOnClickListener {
             val fragment = TeamFragment().apply {
                 arguments = Bundle().apply {
                     putBoolean("fromDashboard", true)
@@ -431,23 +432,23 @@ class BellDashboardFragment : BaseDashboardFragment() {
             }
             homeItemClickListener?.openMyFragment(fragment)
         }
-        fragmentHomeBellBinding.homeCardLibrary.myLibraryImageButton.setOnClickListener {
+        binding.homeCardLibrary.myLibraryImageButton.setOnClickListener {
             if (user?.id?.startsWith("guest") == true) {
                 guestDialog(requireContext())
             } else {
                 homeItemClickListener?.openMyFragment(ResourcesFragment())
             }
         }
-        fragmentHomeBellBinding.homeCardCourses.myCoursesImageButton.setOnClickListener {
+        binding.homeCardCourses.myCoursesImageButton.setOnClickListener {
             if (user?.id?.startsWith("guest") == true) {
                 guestDialog(requireContext())
             } else {
                 homeItemClickListener?.openMyFragment(CoursesFragment())
             }
         }
-        fragmentHomeBellBinding.fabMyActivity.setOnClickListener { openHelperFragment(MyActivityFragment()) }
-        fragmentHomeBellBinding.cardProfileBell.fabFeedback.setOnClickListener { openHelperFragment(FeedbackListFragment()) }
-        fragmentHomeBellBinding.homeCardMyLife.myLifeImageButton.setOnClickListener { homeItemClickListener?.openCallFragment(LifeFragment()) }
+        binding.fabMyActivity.setOnClickListener { openHelperFragment(MyActivityFragment()) }
+        binding.cardProfileBell.fabFeedback.setOnClickListener { openHelperFragment(FeedbackListFragment()) }
+        binding.homeCardMyLife.myLifeImageButton.setOnClickListener { homeItemClickListener?.openCallFragment(LifeFragment()) }
     }
 
     private fun openHelperFragment(f: Fragment) {
@@ -460,6 +461,7 @@ class BellDashboardFragment : BaseDashboardFragment() {
     override fun onDestroyView() {
         networkStatusJob?.cancel()
         surveyReminderJob?.cancel()
+        _binding = null
         super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/TakeExamFragment.kt
@@ -41,23 +41,24 @@ import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 import org.ole.planet.myplanet.utilities.Utilities.toast
 
 class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButton.OnCheckedChangeListener, ImageCaptureCallback {
-    private lateinit var fragmentTakeExamBinding: FragmentTakeExamBinding
+    private var _binding: FragmentTakeExamBinding? = null
+    private val binding get() = _binding!!
     private var isCertified = false
     var container: NestedScrollView? = null
     private val gson = Gson()
     override fun onCreateView(inflater: LayoutInflater, parent: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentTakeExamBinding = FragmentTakeExamBinding.inflate(inflater, parent, false)
+        _binding = FragmentTakeExamBinding.inflate(inflater, parent, false)
         listAns = HashMap()
         val dbHandler = UserProfileDbHandler(requireActivity())
         user = dbHandler.userModel
-        return fragmentTakeExamBinding.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initExam()
         questions = mRealm.where(RealmExamQuestion::class.java).equalTo("examId", exam?.id).findAll()
-        fragmentTakeExamBinding.tvQuestionCount.text = getString(R.string.Q1, questions?.size)
+        binding.tvQuestionCount.text = getString(R.string.Q1, questions?.size)
         var q: RealmQuery<*> = mRealm.where(RealmSubmission::class.java)
             .equalTo("userId", user?.id)
             .equalTo("parentId", if (!TextUtils.isEmpty(exam?.courseId)) {
@@ -77,21 +78,21 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
             updateNavButtons()
         } else {
             container?.visibility = View.GONE
-            fragmentTakeExamBinding.btnSubmit.visibility = View.GONE
-            fragmentTakeExamBinding.tvQuestionCount.setText(R.string.no_questions)
-            Snackbar.make(fragmentTakeExamBinding.tvQuestionCount, R.string.no_questions_available, Snackbar.LENGTH_LONG).show()
+            binding.btnSubmit.visibility = View.GONE
+            binding.tvQuestionCount.setText(R.string.no_questions)
+            Snackbar.make(binding.tvQuestionCount, R.string.no_questions_available, Snackbar.LENGTH_LONG).show()
         }
 
-        fragmentTakeExamBinding.btnBack.setOnClickListener {
+        binding.btnBack.setOnClickListener {
             saveCurrentAnswer()
             goToPreviousQuestion()
         }
-        fragmentTakeExamBinding.btnNext.setOnClickListener {
+        binding.btnNext.setOnClickListener {
             saveCurrentAnswer()
             goToNextQuestion()
         }
 
-        fragmentTakeExamBinding.etAnswer.addTextChangedListener(object : TextWatcher {
+        binding.etAnswer.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable?) {
@@ -127,11 +128,11 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
     }
 
     private fun updateNavButtons() {
-        fragmentTakeExamBinding.btnBack.visibility = if (currentIndex == 0) View.GONE else View.VISIBLE
+        binding.btnBack.visibility = if (currentIndex == 0) View.GONE else View.VISIBLE
         val isLastQuestion = currentIndex == (questions?.size ?: 0) - 1
         val isCurrentQuestionAnswered = isQuestionAnswered()
 
-        fragmentTakeExamBinding.btnNext.visibility = if (isLastQuestion || !isCurrentQuestionAnswered) View.GONE else View.VISIBLE
+        binding.btnNext.visibility = if (isLastQuestion || !isCurrentQuestionAnswered) View.GONE else View.VISIBLE
 
         setButtonText()
     }
@@ -141,7 +142,7 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
         val singleOtherOptionSelected = ans == "other"
         val multipleOtherOptionSelected = listAns?.containsKey("Other")
         val otherOptionSelected = singleOtherOptionSelected || multipleOtherOptionSelected == true
-        val otherNotAnswered = fragmentTakeExamBinding.etAnswer.text.toString().isEmpty()
+        val otherNotAnswered = binding.etAnswer.text.toString().isEmpty()
         if(currentQuestion?.hasOtherOption == true && otherOptionSelected && otherNotAnswered){
             return false
         }
@@ -155,7 +156,7 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
             }
             currentQuestion?.type.equals("input", ignoreCase = true) ||
                     currentQuestion?.type.equals("textarea", ignoreCase = true) -> {
-                fragmentTakeExamBinding.etAnswer.text.toString().isNotEmpty()
+                binding.etAnswer.text.toString().isNotEmpty()
             }
             currentQuestion?.type.equals("ratingScale", ignoreCase = true) -> {
                 ans.isNotEmpty()
@@ -228,44 +229,44 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
     }
 
     override fun startExam(question: RealmExamQuestion?) {
-        fragmentTakeExamBinding.tvQuestionCount.text = getString(R.string.Q, currentIndex + 1, questions?.size)
+        binding.tvQuestionCount.text = getString(R.string.Q, currentIndex + 1, questions?.size)
         setButtonText()
-        fragmentTakeExamBinding.groupChoices.removeAllViews()
-        fragmentTakeExamBinding.llCheckbox.removeAllViews()
-        fragmentTakeExamBinding.etAnswer.visibility = View.GONE
-        fragmentTakeExamBinding.groupChoices.visibility = View.GONE
-        fragmentTakeExamBinding.llCheckbox.visibility = View.GONE
-        fragmentTakeExamBinding.llRatingScale.visibility = View.GONE
+        binding.groupChoices.removeAllViews()
+        binding.llCheckbox.removeAllViews()
+        binding.etAnswer.visibility = View.GONE
+        binding.groupChoices.visibility = View.GONE
+        binding.llCheckbox.visibility = View.GONE
+        binding.llRatingScale.visibility = View.GONE
         clearAnswer()
 
         loadSavedAnswer()
 
         when {
             question?.type.equals("select", ignoreCase = true) -> {
-                fragmentTakeExamBinding.groupChoices.visibility = View.VISIBLE
-                fragmentTakeExamBinding.etAnswer.visibility = View.GONE
+                binding.groupChoices.visibility = View.VISIBLE
+                binding.etAnswer.visibility = View.GONE
                 selectQuestion(question, ans)
             }
             question?.type.equals("input", ignoreCase = true) ||
                     question?.type.equals("textarea", ignoreCase = true) -> {
                 question?.type?.let {
-                    setMarkdownViewAndShowInput(fragmentTakeExamBinding.etAnswer, it, ans)
+                    setMarkdownViewAndShowInput(binding.etAnswer, it, ans)
                 }
             }
             question?.type.equals("selectMultiple", ignoreCase = true) -> {
-                fragmentTakeExamBinding.llCheckbox.visibility = View.VISIBLE
-                fragmentTakeExamBinding.etAnswer.visibility = View.GONE
+                binding.llCheckbox.visibility = View.VISIBLE
+                binding.etAnswer.visibility = View.GONE
                 showCheckBoxes(question, ans)
             }
             question?.type.equals("ratingScale", ignoreCase = true) -> {
-                fragmentTakeExamBinding.llRatingScale.visibility = View.VISIBLE
-                fragmentTakeExamBinding.etAnswer.visibility = View.GONE
+                binding.llRatingScale.visibility = View.VISIBLE
+                binding.etAnswer.visibility = View.GONE
                 setupRatingScale(ans)
             }
         }
-        fragmentTakeExamBinding.tvHeader.text = question?.header
-        question?.body?.let { setMarkdownText(fragmentTakeExamBinding.tvBody, it) }
-        fragmentTakeExamBinding.btnSubmit.setOnClickListener(this)
+        binding.tvHeader.text = question?.header
+        question?.body?.let { setMarkdownText(binding.tvBody, it) }
+        binding.btnSubmit.setOnClickListener(this)
 
         updateNavButtons()
     }
@@ -296,8 +297,8 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
                 val text = jsonObject.get("text").asString
 
                 if (id == "other") {
-                    fragmentTakeExamBinding.etAnswer.setText(text)
-                    fragmentTakeExamBinding.etAnswer.visibility = View.VISIBLE
+                    binding.etAnswer.setText(text)
+                    binding.etAnswer.visibility = View.VISIBLE
                 }
                 id
             } catch (e: Exception) {
@@ -330,14 +331,14 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
         }
 
         if (hasOtherOption) {
-            fragmentTakeExamBinding.etAnswer.setText(otherText)
-            fragmentTakeExamBinding.etAnswer.visibility = View.VISIBLE
+            binding.etAnswer.setText(otherText)
+            binding.etAnswer.visibility = View.VISIBLE
         }
     }
 
     private fun loadTextSavedAnswer(savedAnswer: RealmAnswer) {
         ans = savedAnswer.value ?: ""
-        fragmentTakeExamBinding.etAnswer.setText(ans)
+        binding.etAnswer.setText(ans)
     }
 
     private fun loadRatingScaleSavedAnswer(savedAnswer: RealmAnswer) {
@@ -351,15 +352,15 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
     
     private fun setupRatingScale(oldAnswer: String) {
         val ratingButtons = listOf(
-            fragmentTakeExamBinding.rbRating1,
-            fragmentTakeExamBinding.rbRating2,
-            fragmentTakeExamBinding.rbRating3,
-            fragmentTakeExamBinding.rbRating4,
-            fragmentTakeExamBinding.rbRating5,
-            fragmentTakeExamBinding.rbRating6,
-            fragmentTakeExamBinding.rbRating7,
-            fragmentTakeExamBinding.rbRating8,
-            fragmentTakeExamBinding.rbRating9
+            binding.rbRating1,
+            binding.rbRating2,
+            binding.rbRating3,
+            binding.rbRating4,
+            binding.rbRating5,
+            binding.rbRating6,
+            binding.rbRating7,
+            binding.rbRating8,
+            binding.rbRating9
         )
         
         ratingButtons.forEachIndexed { index, button ->
@@ -381,15 +382,15 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
     
     private fun selectRatingValue(value: Int) {
         val ratingButtons = listOf(
-            fragmentTakeExamBinding.rbRating1,
-            fragmentTakeExamBinding.rbRating2,
-            fragmentTakeExamBinding.rbRating3,
-            fragmentTakeExamBinding.rbRating4,
-            fragmentTakeExamBinding.rbRating5,
-            fragmentTakeExamBinding.rbRating6,
-            fragmentTakeExamBinding.rbRating7,
-            fragmentTakeExamBinding.rbRating8,
-            fragmentTakeExamBinding.rbRating9
+            binding.rbRating1,
+            binding.rbRating2,
+            binding.rbRating3,
+            binding.rbRating4,
+            binding.rbRating5,
+            binding.rbRating6,
+            binding.rbRating7,
+            binding.rbRating8,
+            binding.rbRating9
         )
 
         selectedRatingButton?.isSelected = false
@@ -403,7 +404,7 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
 
     private fun clearAnswer() {
         ans = ""
-        fragmentTakeExamBinding.etAnswer.setText(R.string.empty_text)
+        binding.etAnswer.setText(R.string.empty_text)
         listAns?.clear()
         selectedRatingButton?.isSelected = false
         selectedRatingButton = null
@@ -411,9 +412,9 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
 
     private fun setButtonText() {
         if (currentIndex == (questions?.size?.minus(1) ?: 0)) {
-            fragmentTakeExamBinding.btnSubmit.setText(R.string.finish)
+            binding.btnSubmit.setText(R.string.finish)
         } else {
-            fragmentTakeExamBinding.btnSubmit.setText(R.string.submit)
+            binding.btnSubmit.setText(R.string.submit)
         }
     }
 
@@ -456,15 +457,15 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
 
     private fun addRadioButton(choice: String, oldAnswer: String) {
         val inflater = LayoutInflater.from(activity)
-        val rdBtn = inflater.inflate(R.layout.item_radio_btn, fragmentTakeExamBinding.groupChoices, false) as RadioButton
+        val rdBtn = inflater.inflate(R.layout.item_radio_btn, binding.groupChoices, false) as RadioButton
         rdBtn.text = choice
         rdBtn.isChecked = choice == oldAnswer
         rdBtn.setOnCheckedChangeListener(this)
-        fragmentTakeExamBinding.groupChoices.addView(rdBtn)
+        binding.groupChoices.addView(rdBtn)
 
         if (choice.equals("Other", ignoreCase = true) && choice == oldAnswer) {
-            fragmentTakeExamBinding.etAnswer.visibility = View.VISIBLE
-            fragmentTakeExamBinding.etAnswer.setText(oldAnswer)
+            binding.etAnswer.visibility = View.VISIBLE
+            binding.etAnswer.setText(oldAnswer)
         }
     }
 
@@ -473,7 +474,7 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
             LayoutInflater.from(activity)
                 .inflate(
                     R.layout.item_radio_btn,
-                    fragmentTakeExamBinding.groupChoices, false
+                    binding.groupChoices, false
                 ) as RadioButton
         } else {
             LayoutInflater.from(activity)
@@ -496,15 +497,15 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
         rdBtn.setOnCheckedChangeListener(this)
         if (isRadio) {
             rdBtn.id = View.generateViewId()
-            fragmentTakeExamBinding.groupChoices.addView(rdBtn)
+            binding.groupChoices.addView(rdBtn)
         } else {
             rdBtn.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
             rdBtn.buttonTintList = ContextCompat.getColorStateList(requireContext(), R.color.daynight_textColor)
-            fragmentTakeExamBinding.llCheckbox.addView(rdBtn)
+            binding.llCheckbox.addView(rdBtn)
         }
 
         if (choiceText.equals("Other", ignoreCase = true) && rdBtn.isChecked) {
-            fragmentTakeExamBinding.etAnswer.visibility = View.VISIBLE
+            binding.etAnswer.visibility = View.VISIBLE
         }
     }
 
@@ -521,7 +522,7 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
                 val cont = updateAnsDb()
 
                 if (this.type == "exam" && !cont) {
-                    Snackbar.make(fragmentTakeExamBinding.root, getString(R.string.incorrect_ans), Snackbar.LENGTH_LONG).show()
+                    Snackbar.make(binding.root, getString(R.string.incorrect_ans), Snackbar.LENGTH_LONG).show()
                     return
                 }
 
@@ -544,15 +545,15 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
 
     private fun showTextInput(type: String?) {
         if (type.equals("input", ignoreCase = true) || type.equals("textarea", ignoreCase = true) ||
-            (fragmentTakeExamBinding.etAnswer.isVisible)) {
-            ans = fragmentTakeExamBinding.etAnswer.text.toString()
+            (binding.etAnswer.isVisible)) {
+            ans = binding.etAnswer.text.toString()
         }
     }
 
     private fun updateAnsDb(): Boolean {
         val currentQuestion = questions?.get(currentIndex) ?: return true
-        val otherText = if (fragmentTakeExamBinding.etAnswer.isVisible) {
-            fragmentTakeExamBinding.etAnswer.text.toString()
+        val otherText = if (binding.etAnswer.isVisible) {
+            binding.etAnswer.text.toString()
         } else {
             null
         }
@@ -563,7 +564,7 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
             ans,
             listAns,
             otherText,
-            fragmentTakeExamBinding.etAnswer.isVisible,
+            binding.etAnswer.isVisible,
             type ?: "exam",
             currentIndex,
             questions?.size ?: 0
@@ -583,11 +584,11 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
         val selectedText = "${compoundButton.text}"
 
         if (selectedText.equals("Other", ignoreCase = true)) {
-            fragmentTakeExamBinding.etAnswer.visibility = View.VISIBLE
-            fragmentTakeExamBinding.etAnswer.requestFocus()
+            binding.etAnswer.visibility = View.VISIBLE
+            binding.etAnswer.requestFocus()
         } else if (!isOtherOptionSelected()) {
-            fragmentTakeExamBinding.etAnswer.visibility = View.GONE
-            fragmentTakeExamBinding.etAnswer.text.clear()
+            binding.etAnswer.visibility = View.GONE
+            binding.etAnswer.text.clear()
         }
 
         addAnswer(compoundButton)
@@ -598,8 +599,8 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
             val selectedText = "${compoundButton.text}"
 
             if (selectedText.equals("Other", ignoreCase = true)) {
-                fragmentTakeExamBinding.etAnswer.visibility = View.GONE
-                fragmentTakeExamBinding.etAnswer.text.clear()
+                binding.etAnswer.visibility = View.GONE
+                binding.etAnswer.text.clear()
             }
 
             listAns?.remove("${compoundButton.text}")
@@ -607,8 +608,8 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
     }
 
     private fun isOtherOptionSelected(): Boolean {
-        for (i in 0 until fragmentTakeExamBinding.llCheckbox.childCount) {
-            val child = fragmentTakeExamBinding.llCheckbox.getChildAt(i)
+        for (i in 0 until binding.llCheckbox.childCount) {
+            val child = binding.llCheckbox.getChildAt(i)
             if (child is CompoundButton &&
                 child.text.toString().equals("Other", ignoreCase = true) &&
                 child.isChecked) {
@@ -616,5 +617,10 @@ class TakeExamFragment : BaseExamFragment(), View.OnClickListener, CompoundButto
             }
         }
         return false
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
@@ -22,7 +22,8 @@ import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
 class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
-    private lateinit var fragmentMyPersonalsBinding: FragmentMyPersonalsBinding
+    private var _binding: FragmentMyPersonalsBinding? = null
+    private val binding get() = _binding!!
     lateinit var mRealm: Realm
     private lateinit var pg: DialogUtils.CustomProgressDialog
     private var addResourceFragment: AddResourceFragment? = null
@@ -42,11 +43,11 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentMyPersonalsBinding = FragmentMyPersonalsBinding.inflate(inflater, container, false)
+        _binding = FragmentMyPersonalsBinding.inflate(inflater, container, false)
         pg = DialogUtils.getCustomProgressDialog(requireContext())
         mRealm = databaseService.realmInstance
-        fragmentMyPersonalsBinding.rvMypersonal.layoutManager = LinearLayoutManager(activity)
-        fragmentMyPersonalsBinding.addMyPersonal.setOnClickListener {
+        binding.rvMypersonal.layoutManager = LinearLayoutManager(activity)
+        binding.addMyPersonal.setOnClickListener {
             addResourceFragment = AddResourceFragment()
             val b = Bundle()
             b.putInt("type", 1)
@@ -54,7 +55,7 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
             addResourceFragment?.setMyPersonalsFragment(this)
             addResourceFragment?.show(childFragmentManager, getString(R.string.add_resource))
         }
-        return fragmentMyPersonalsBinding.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -69,7 +70,7 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
         personalAdapter = AdapterMyPersonal(requireActivity(), realmMyPersonals.toMutableList())
         personalAdapter?.setListener(this)
         personalAdapter?.setRealm(mRealm)
-        fragmentMyPersonalsBinding.rvMypersonal.adapter = personalAdapter
+        binding.rvMypersonal.adapter = personalAdapter
         showNodata()
         mRealm.addChangeListener {
             updatePersonalList()
@@ -85,12 +86,17 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
     }
 
     private fun showNodata() {
-        if (fragmentMyPersonalsBinding.rvMypersonal.adapter?.itemCount == 0) {
-            fragmentMyPersonalsBinding.tvNodata.visibility = View.VISIBLE
-            fragmentMyPersonalsBinding.tvNodata.setText(R.string.no_data_available_please_click_button_to_add_new_resource_in_mypersonal)
+        if (binding.rvMypersonal.adapter?.itemCount == 0) {
+            binding.tvNodata.visibility = View.VISIBLE
+            binding.tvNodata.setText(R.string.no_data_available_please_click_button_to_add_new_resource_in_mypersonal)
         } else {
-            fragmentMyPersonalsBinding.tvNodata.visibility = View.GONE
+            binding.tvNodata.visibility = View.GONE
         }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## Summary
- refactor MyPersonalsFragment, BellDashboardFragment, TakeExamFragment, and TakeCourseFragment to use a nullable backing property for view binding
- clear view binding references in onDestroyView to prevent leaks

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68c17ac60774832b9f6f6275c5defec8