### PR TITLE
Refactor team loading to repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -1,8 +1,11 @@
 package org.ole.planet.myplanet.repository
 
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmMyTeam
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
+    suspend fun getTeams(type: String?, search: String?): List<RealmMyTeam>
+    suspend fun sortTeams(list: List<RealmMyTeam>): List<RealmMyTeam>
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -1,12 +1,16 @@
 package org.ole.planet.myplanet.repository
 
+import android.content.SharedPreferences
+import io.realm.Case
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.di.AppPreferences
 
 class TeamRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
+    @AppPreferences private val settings: SharedPreferences,
 ) : RealmRepository(databaseService), TeamRepository {
 
     override suspend fun getTeamResources(teamId: String): List<RealmMyLibrary> {
@@ -24,6 +28,52 @@ class TeamRepositoryImpl @Inject constructor(
         return queryList(RealmMyTeam::class.java) {
             equalTo("teamId", teamId)
         }.mapNotNull { it.resourceId?.takeIf { id -> id.isNotBlank() } }
+    }
+
+    override suspend fun getTeams(type: String?, search: String?): List<RealmMyTeam> {
+        val userId = settings.getString("userId", "--") ?: "--"
+        return withRealm { realm ->
+            if (type == "my") {
+                val membershipIds = realm.where(RealmMyTeam::class.java)
+                    .equalTo("userId", userId)
+                    .equalTo("docType", "membership")
+                    .findAll()
+                    .mapNotNull { it.teamId }
+                    .toTypedArray()
+                var query = realm.where(RealmMyTeam::class.java)
+                    .`in`("_id", membershipIds)
+                if (!search.isNullOrBlank()) {
+                    query = query.contains("name", search, Case.INSENSITIVE)
+                }
+                realm.copyFromRealm(query.findAll())
+            } else {
+                var query = realm.where(RealmMyTeam::class.java)
+                    .isEmpty("teamId")
+                    .notEqualTo("status", "archived")
+                if (!search.isNullOrBlank()) {
+                    query = query.contains("name", search, Case.INSENSITIVE)
+                }
+                query = if (type.isNullOrEmpty() || type == "team") {
+                    query.notEqualTo("type", "enterprise")
+                } else {
+                    query.equalTo("type", "enterprise")
+                }
+                realm.copyFromRealm(query.findAll())
+            }
+        }
+    }
+
+    override suspend fun sortTeams(list: List<RealmMyTeam>): List<RealmMyTeam> {
+        val userId = settings.getString("userId", null)
+        return withRealm { realm ->
+            list.sortedWith(compareByDescending<RealmMyTeam> { team ->
+                when {
+                    RealmMyTeam.isTeamLeader(team.teamId, userId, realm) -> 3
+                    team.isMyTeam(userId, realm) -> 2
+                    else -> 1
+                }
+            })
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add team query & sorting APIs in repository
- use repository in TeamFragment via Hilt injection
- replace direct Realm queries with repository calls

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68c18af27790832bb8771e93221a85e7