### PR TITLE
Refactor team creation into repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -1,8 +1,18 @@
 package org.ole.planet.myplanet.repository
 
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmUserModel
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
+
+    suspend fun createTeam(
+        name: String?,
+        teamType: String?,
+        map: Map<String, String>,
+        isPublic: Boolean,
+        isEnterprise: Boolean,
+        user: RealmUserModel
+    )
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -1,9 +1,12 @@
 package org.ole.planet.myplanet.repository
 
 import javax.inject.Inject
+import java.util.Date
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.utilities.AndroidDecrypter
 
 class TeamRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
@@ -24,6 +27,50 @@ class TeamRepositoryImpl @Inject constructor(
         return queryList(RealmMyTeam::class.java) {
             equalTo("teamId", teamId)
         }.mapNotNull { it.resourceId?.takeIf { id -> id.isNotBlank() } }
+    }
+
+    override suspend fun createTeam(
+        name: String?,
+        teamType: String?,
+        map: Map<String, String>,
+        isPublic: Boolean,
+        isEnterprise: Boolean,
+        user: RealmUserModel
+    ) {
+        executeTransaction { realm ->
+            val teamId = AndroidDecrypter.generateIv()
+            val team = realm.createObject(RealmMyTeam::class.java, teamId)
+            team.status = "active"
+            team.createdDate = Date().time
+            if (isEnterprise) {
+                team.type = "enterprise"
+                team.services = map["services"]
+                team.rules = map["rules"]
+            } else {
+                team.type = "team"
+                team.teamType = teamType
+            }
+            team.name = name
+            team.description = map["desc"]
+            team.createdBy = user._id
+            team.teamId = ""
+            team.isPublic = isPublic
+            team.userId = user.id
+            team.parentCode = user.parentCode
+            team.teamPlanetCode = user.planetCode
+            team.updated = true
+
+            val teamMemberObj =
+                realm.createObject(RealmMyTeam::class.java, AndroidDecrypter.generateIv())
+            teamMemberObj.userId = user._id
+            teamMemberObj.teamId = teamId
+            teamMemberObj.teamPlanetCode = user.planetCode
+            teamMemberObj.userPlanetCode = user.planetCode
+            teamMemberObj.docType = "membership"
+            teamMemberObj.isLeader = true
+            teamMemberObj.teamType = teamType
+            teamMemberObj.updated = true
+        }
     }
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -37,6 +37,11 @@ class TeamRepositoryImpl @Inject constructor(
         isEnterprise: Boolean,
         user: RealmUserModel
     ) {
+        val createdBy = user._id
+        val userId = user.id
+        val parentCode = user.parentCode
+        val planetCode = user.planetCode
+
         executeTransaction { realm ->
             val teamId = AndroidDecrypter.generateIv()
             val team = realm.createObject(RealmMyTeam::class.java, teamId)
@@ -52,20 +57,20 @@ class TeamRepositoryImpl @Inject constructor(
             }
             team.name = name
             team.description = map["desc"]
-            team.createdBy = user._id
+            team.createdBy = createdBy
             team.teamId = ""
             team.isPublic = isPublic
-            team.userId = user.id
-            team.parentCode = user.parentCode
-            team.teamPlanetCode = user.planetCode
+            team.userId = userId
+            team.parentCode = parentCode
+            team.teamPlanetCode = planetCode
             team.updated = true
 
             val teamMemberObj =
                 realm.createObject(RealmMyTeam::class.java, AndroidDecrypter.generateIv())
-            teamMemberObj.userId = user._id
+            teamMemberObj.userId = createdBy
             teamMemberObj.teamId = teamId
-            teamMemberObj.teamPlanetCode = user.planetCode
-            teamMemberObj.userPlanetCode = user.planetCode
+            teamMemberObj.teamPlanetCode = planetCode
+            teamMemberObj.userPlanetCode = planetCode
             teamMemberObj.docType = "membership"
             teamMemberObj.isLeader = true
             teamMemberObj.teamType = teamType


### PR DESCRIPTION
## Summary
- add createTeam to TeamRepository and TeamRepositoryImpl
- use TeamRepository in TeamFragment to save new teams
- remove direct Realm transaction from fragment

## Testing
- `./gradlew :app:compileDefaultDebugKotlin --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68c18b05bfe8832b877d795b3560b636