### PR TITLE
Refactor notification repository queries

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -2,8 +2,6 @@ package org.ole.planet.myplanet.repository
 
 import javax.inject.Inject
 import java.util.Date
-import java.util.UUID
-import io.realm.Realm
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNotification
@@ -23,62 +21,30 @@ class NotificationRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateResourceNotification(userId: String?) {
-        try {
-            executeTransaction { realm ->
-                val resourceCount = realm.where(RealmMyLibrary::class.java)
-                    .equalTo("isPrivate", false)
-                    .findAll()
-                    .filter { it.needToUpdate() && it.userId?.contains(userId) == true }
-                    .size
+        userId ?: return
 
-                val existingNotification = realm.where(RealmNotification::class.java)
-                    .equalTo("userId", userId)
-                    .equalTo("type", "resource")
-                    .findFirst()
+        val resourceCount = queryList(RealmMyLibrary::class.java) {
+            equalTo("isPrivate", false)
+        }.count { it.needToUpdate() && it.userId?.contains(userId) == true }
 
-                if (resourceCount > 0) {
-                    if (existingNotification != null) {
-                        existingNotification.message = "$resourceCount"
-                        existingNotification.relatedId = "$resourceCount"
-                    } else {
-                        createNotificationIfNotExists(
-                            realm,
-                            "resource",
-                            "$resourceCount",
-                            "$resourceCount",
-                            userId
-                        )
-                    }
-                } else {
-                    existingNotification?.deleteFromRealm()
-                }
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
+        val existingNotification = findByField(RealmNotification::class.java, "userId", userId)
+            ?.takeIf { it.type == "resource" }
 
-    private fun createNotificationIfNotExists(
-        realm: Realm,
-        type: String,
-        message: String,
-        relatedId: String?,
-        userId: String?
-    ) {
-        val existingNotification = realm.where(RealmNotification::class.java)
-            .equalTo("userId", userId)
-            .equalTo("type", type)
-            .equalTo("relatedId", relatedId)
-            .findFirst()
-
-        if (existingNotification == null) {
-            realm.createObject(RealmNotification::class.java, UUID.randomUUID().toString()).apply {
-                this.userId = userId ?: ""
-                this.type = type
-                this.message = message
-                this.relatedId = relatedId
+        if (resourceCount > 0) {
+            val notification = existingNotification?.apply {
+                message = "$resourceCount"
+                relatedId = "$resourceCount"
+            } ?: RealmNotification().apply {
+                this.userId = userId
+                this.type = "resource"
+                this.message = "$resourceCount"
+                this.relatedId = "$resourceCount"
                 this.createdAt = Date()
             }
+            save(notification)
+        } else {
+            existingNotification?.let { delete(RealmNotification::class.java, "id", it.id) }
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- streamline resource notification updates
- build notifications directly and persist with save

## Testing
- `./gradlew assembleDebug -x test`


------
https://chatgpt.com/codex/tasks/task_e_68c19b63a5cc832b92d22c609fc3df4f