### PR TITLE
Use repository to check team membership

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -4,5 +4,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
+
+    suspend fun isMember(userId: String?, teamId: String): Boolean
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -20,6 +20,15 @@ class TeamRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun isMember(userId: String?, teamId: String): Boolean {
+        userId ?: return false
+        return queryList(RealmMyTeam::class.java) {
+            equalTo("userId", userId)
+            equalTo("teamId", teamId)
+            equalTo("docType", "membership")
+        }.isNotEmpty()
+    }
+
     private suspend fun getResourceIds(teamId: String): List<String> {
         return queryList(RealmMyTeam::class.java) {
             equalTo("teamId", teamId)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
@@ -3,10 +3,13 @@ package org.ole.planet.myplanet.ui.team
 import android.os.Bundle
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Realm
+import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
 import org.ole.planet.myplanet.base.BaseNewsFragment
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.TeamRepository
 
 private val Realm.isOpen: Boolean
     get() = !isClosed
@@ -16,6 +19,8 @@ abstract class BaseTeamFragment : BaseNewsFragment() {
     var user: RealmUserModel? = null
     lateinit var teamId: String
     var team: RealmMyTeam? = null
+    @Inject
+    lateinit var teamRepository: TeamRepository
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,12 +50,8 @@ abstract class BaseTeamFragment : BaseNewsFragment() {
 
     override fun setData(list: List<RealmNews?>?) {}
 
-    fun isMember(): Boolean {
-        return mRealm.where(RealmMyTeam::class.java)
-            .equalTo("userId", user?.id)
-            .equalTo("teamId", teamId)
-            .equalTo("docType", "membership")
-            .count() > 0
+    fun isMember(): Boolean = runBlocking {
+        teamRepository.isMember(user?.id, teamId)
     }
 
     private fun shouldQueryTeamFromRealm(): Boolean {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamResource/TeamResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamResource/TeamResourceFragment.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.UUID
-import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.TeamPageListener
@@ -23,7 +22,6 @@ import org.ole.planet.myplanet.databinding.MyLibraryAlertdialogBinding
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
 import org.ole.planet.myplanet.utilities.CheckboxListView
 
@@ -32,9 +30,6 @@ class TeamResourceFragment : BaseTeamFragment(), TeamPageListener, ResourceUpdat
     private var _binding: FragmentTeamResourceBinding? = null
     private val binding get() = _binding!!
     private lateinit var adapterLibrary: AdapterTeamResource
-
-    @Inject
-    lateinit var teamRepository: TeamRepository
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentTeamResourceBinding.inflate(inflater, container, false)


### PR DESCRIPTION
## Summary
- extend `TeamRepository` with suspend `isMember` and implement in `TeamRepositoryImpl`
- inject `TeamRepository` into `BaseTeamFragment` and replace direct Realm lookup with repository call
- drop redundant repository field from `TeamResourceFragment`

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68c19c36c120832bbbd914fb228714ed