### PR TITLE
Add deleteTask to TeamRepository and use repository in TeamTaskFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -4,5 +4,6 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
+    suspend fun deleteTask(taskId: String)
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -4,6 +4,7 @@ import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.model.RealmTeamTask
 
 class TeamRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
@@ -24,6 +25,10 @@ class TeamRepositoryImpl @Inject constructor(
         return queryList(RealmMyTeam::class.java) {
             equalTo("teamId", teamId)
         }.mapNotNull { it.resourceId?.takeIf { id -> id.isNotBlank() } }
+    }
+
+    override suspend fun deleteTask(taskId: String) {
+        delete(RealmTeamTask::class.java, "id", taskId)
     }
 }
 


### PR DESCRIPTION
## Summary
- add suspend `deleteTask` to `TeamRepository`
- implement `deleteTask` in `TeamRepositoryImpl` using Realm delete
- inject `TeamRepository` into `TeamTaskFragment` and invoke `deleteTask` on deletion

## Testing
- `./gradlew :app:assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68c19c7b4f28832b91a26d9a0fb6f4b8