### PR TITLE
voices to scroll to top (fixes #7499)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
@@ -302,6 +302,7 @@ class NewsFragment : BaseNewsFragment() {
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 searchFilteredList = applySearchFilter(labelFilteredList)
                 setData(searchFilteredList)
+                binding.rvNews.scrollToPosition(0)
             }
             override fun afterTextChanged(s: Editable) {}
         })
@@ -332,6 +333,7 @@ class NewsFragment : BaseNewsFragment() {
                 labelFilteredList = applyLabelFilter(filteredNewsList)
                 searchFilteredList = applySearchFilter(labelFilteredList)
                 setData(searchFilteredList)
+                binding.rvNews.scrollToPosition(0)
             }
             override fun onNothingSelected(parent: AdapterView<*>?) {}
         }


### PR DESCRIPTION
fixes #7499

## Summary
- ensure voices list resets to top whenever search or label filters change

## Testing
- `./gradlew lint`

------
https://chatgpt.com/codex/tasks/task_e_68c2d835276c832b90ad502d6dd71876