### PR TITLE
courses: smoother filter refreshing (fixes #7489)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3127
-        versionName = "0.31.27"
+        versionCode = 3152
+        versionName = "0.31.52"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -186,6 +186,13 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         }
     }
 
+    private fun getFullCourseList(): List<RealmMyCourse?> {
+        val courseList: List<RealmMyCourse?> = getList(RealmMyCourse::class.java)
+            .filterIsInstance<RealmMyCourse?>()
+            .filter { !it?.courseTitle.isNullOrBlank() }
+        return courseList.sortedWith(compareBy({ it?.isMyCourse }, { it?.courseTitle }))
+    }
+
     private fun refreshCoursesData() {
         if (!isAdded || requireActivity().isFinishing) return
 
@@ -283,11 +290,10 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                 if (!etSearch.isFocused) return
                 val query = s.toString().trim()
                 if (query.isEmpty()) {
-                    val courseList = filterCourseByTag(query, searchTags)
-                    val sortedCourseList = courseList.sortedWith(compareBy({ it.isMyCourse }, { it.courseTitle }))
-                    adapterCourses.setOriginalCourseList(sortedCourseList)
-                }
-                else {
+                    adapterCourses.setCourseList(getFullCourseList())
+                    scrollToTop()
+                    showNoData(tvMessage, adapterCourses.itemCount, "courses")
+                } else {
                     adapterCourses.setCourseList(filterCourseByTag(etSearch.text.toString(), searchTags))
                     scrollToTop()
                     showNoData(tvMessage, adapterCourses.itemCount, "courses")
@@ -482,7 +488,11 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             }
             gradeLevel = if (spnGrade.selectedItem.toString() == "All") "" else spnGrade.selectedItem.toString()
             subjectLevel = if (spnSubject.selectedItem.toString() == "All") "" else spnSubject.selectedItem.toString()
-            adapterCourses.setCourseList(filterCourseByTag(etSearch.text.toString(), searchTags))
+            if (etSearch.text.toString().isEmpty() && searchTags.isEmpty() && gradeLevel.isEmpty() && subjectLevel.isEmpty()) {
+                adapterCourses.setCourseList(getFullCourseList())
+            } else {
+                adapterCourses.setCourseList(filterCourseByTag(etSearch.text.toString(), searchTags))
+            }
             scrollToTop()
             showNoFilter(tvMessage, adapterCourses.itemCount)
         }
@@ -495,7 +505,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             searchTags.clear()
             etSearch.setText(R.string.empty_text)
             tvSelected.text = context?.getString(R.string.empty_text)
-            adapterCourses.setCourseList(filterCourseByTag("", searchTags))
+            adapterCourses.setCourseList(getFullCourseList())
             scrollToTop()
             showNoData(tvMessage, adapterCourses.itemCount, "courses")
             spnGrade.setSelection(0)
@@ -597,7 +607,11 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     override fun onOkClicked(list: List<RealmTag>?) {
         if (list?.isEmpty() == true) {
             searchTags.clear()
-            adapterCourses.setCourseList(filterCourseByTag(etSearch.text.toString(), searchTags))
+            if (etSearch.text.toString().isEmpty() && gradeLevel.isEmpty() && subjectLevel.isEmpty()) {
+                adapterCourses.setCourseList(getFullCourseList())
+            } else {
+                adapterCourses.setCourseList(filterCourseByTag(etSearch.text.toString(), searchTags))
+            }
             scrollToTop()
             showNoData(tvMessage, adapterCourses.itemCount, "courses")
         } else {


### PR DESCRIPTION
## Summary
- fixes #7489
- ensure clearing course filters reloads entire course list without blank entries

## Testing
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2d85ae92c832b93470502e8a379b5