### PR TITLE
Close UserProfileDbHandler in DialogUtils

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -35,6 +35,8 @@ object DialogUtils {
 
     fun guestDialog(context: Context) {
         val profileDbHandler = UserProfileDbHandler(context)
+        val username = profileDbHandler.userModel?.name
+        profileDbHandler.onDestroy()
         val builder = android.app.AlertDialog.Builder(context, R.style.CustomAlertDialog)
         builder.setTitle(context.getString(R.string.become_a_member))
         builder.setMessage(context.getString(R.string.to_access_this_feature_become_a_member))
@@ -53,7 +55,7 @@ object DialogUtils {
         becomeMember.setOnClickListener {
             val guest = true
             val intent = Intent(context, BecomeMemberActivity::class.java)
-            intent.putExtra("username", profileDbHandler.userModel?.name)
+            intent.putExtra("username", username)
             intent.putExtra("guest", guest)
             context.startActivity(intent)
         }


### PR DESCRIPTION
## Summary
- Ensure UserProfileDbHandler is properly closed in guest dialog

## Testing
- `./gradlew lint` *(fails: Task :app:kaptDefaultDebugKotlin FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e34fc780832b94c4d2609b0d33b7