### PR TITLE
all: smoother `DialogUtils.kt` (fixes #7569)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3127
-        versionName = "0.31.27"
+        versionCode = 3154
+        versionName = "0.31."54
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 3154
-        versionName = "0.31."54
+        versionName = "0.31.54"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -40,7 +41,7 @@ import org.ole.planet.myplanet.model.RealmSubmission.Companion.isStepCompleted
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
-import org.ole.planet.myplanet.utilities.DialogUtils.getAlertDialog
+import org.ole.planet.myplanet.utilities.DialogUtils.getDialog
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -54,6 +55,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     lateinit var steps: List<RealmCourseStep?>
     var position = 0
     private var currentStep = 0
+    private var joinDialog: AlertDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -153,9 +155,14 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
                 if (!isGuest && !containsUserId) {
                     binding.btnRemove.visibility = View.VISIBLE
                     binding.btnRemove.text = getString(R.string.join)
-                    getAlertDialog(requireActivity(), getString(R.string.do_you_want_to_join_this_course), getString(R.string.join_this_course)) { _: DialogInterface?, _: Int ->
+                    joinDialog = getDialog(
+                        requireActivity(),
+                        getString(R.string.do_you_want_to_join_this_course),
+                        getString(R.string.join_this_course)
+                    ) { _: DialogInterface?, _: Int ->
                         addRemoveCourse()
                     }
+                    joinDialog?.show()
                 } else {
                     binding.btnRemove.visibility = View.GONE
                 }
@@ -330,6 +337,8 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        joinDialog?.dismiss()
+        joinDialog = null
         _binding = null
         super.onDestroyView()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
@@ -42,7 +42,7 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.utilities.CheckboxListView
-import org.ole.planet.myplanet.utilities.DialogUtils.getAlertDialog
+import org.ole.planet.myplanet.utilities.DialogUtils.getDialog
 import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
 import org.ole.planet.myplanet.utilities.Utilities
 
@@ -59,6 +59,7 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
     private var referenceArray: JsonArray? = null
     private var achievementArray: JsonArray? = null
     private var resourceArray: JsonArray? = null
+    private var referenceDialog: AlertDialog? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentEditAchievementBinding = FragmentEditAchievementBinding.inflate(inflater, container, false)
@@ -153,8 +154,9 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
         )
         setPrevReference(ar, `object`)
         val alertReferenceView: View = alertReferenceBinding.root
-        val d = getAlertDialog(requireActivity(), getString(R.string.add_reference), alertReferenceView)
-        d.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+        referenceDialog = getDialog(requireActivity(), getString(R.string.add_reference), alertReferenceView)
+        referenceDialog?.show()
+        referenceDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.setOnClickListener {
             val name = alertReferenceBinding.etName.text.toString().trim { it <= ' ' }
             if (name.isEmpty()) {
                 alertReferenceBinding.tlName.error = getString(R.string.name_is_required)
@@ -164,7 +166,7 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
             if (referenceArray == null) referenceArray = JsonArray()
             referenceArray?.add(createReference(name, alertReferenceBinding.etRelationship, alertReferenceBinding.etPhone, alertReferenceBinding.etEmail))
             showReference()
-            d.dismiss()
+            referenceDialog?.dismiss()
         }
     }
 
@@ -320,6 +322,12 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
         achievement?.setAchievements(achievementArray!!)
         achievement?.setReferences(referenceArray)
         achievement?.sendToNation = fragmentEditAchievementBinding.cbSendToNation.isChecked.toString() + ""
+    }
+
+    override fun onDestroyView() {
+        referenceDialog?.dismiss()
+        referenceDialog = null
+        super.onDestroyView()
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -123,13 +123,18 @@ object DialogUtils {
     }
 
     @JvmStatic
-    fun getAlertDialog(context: Context, message: String, pos: String, listener: DialogInterface.OnClickListener?): AlertDialog {
+    fun getDialog(
+        context: Context,
+        message: String,
+        pos: String,
+        listener: DialogInterface.OnClickListener?
+    ): AlertDialog {
         return AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialog))
             .setMessage(message)
             .setIcon(R.drawable.courses)
             .setPositiveButton(pos, listener)
             .setNegativeButton(R.string.button_cancel, null)
-            .show()
+            .create()
     }
 
     @JvmStatic
@@ -142,14 +147,14 @@ object DialogUtils {
     }
 
     @JvmStatic
-    fun getAlertDialog(context: Context, title: String, v: View): AlertDialog {
+    fun getDialog(context: Context, title: String, v: View): AlertDialog {
         return AlertDialog.Builder(ContextThemeWrapper(context, R.style.CustomAlertDialog))
             .setTitle(title)
             .setIcon(R.drawable.ic_edit)
             .setView(v)
             .setPositiveButton(R.string.submit, null)
             .setNegativeButton(R.string.cancel, null)
-            .show()
+            .create()
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary
- Return new `AlertDialog` instances from `DialogUtils.getDialog` without showing them
- Use `DialogUtils.getDialog` in `TakeCourseFragment` and dismiss dialog in `onDestroyView`
- Manage reference dialog lifecycle in `EditAchievementFragment`

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68c2e5aa7cd4832b902e1bdaf748eb5e