### PR TITLE
refactor: centralize news list scroll (fixes #7499)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/NewsFragment.kt
@@ -88,6 +88,7 @@ class NewsFragment : BaseNewsFragment() {
             labelFilteredList = applyLabelFilter(filteredNewsList)
             searchFilteredList = applySearchFilter(labelFilteredList)
             setData(searchFilteredList)
+            scrollToTop()
         }
         
         etSearch = binding.root.findViewById(R.id.et_search)
@@ -130,6 +131,7 @@ class NewsFragment : BaseNewsFragment() {
         labelFilteredList = applyLabelFilter(filteredNewsList)
         searchFilteredList = applySearchFilter(labelFilteredList)
         setData(searchFilteredList)
+        scrollToTop()
         binding.btnSubmit.setOnClickListener {
             val message = binding.etMessage.text.toString().trim { it <= ' ' }
             if (message.isEmpty()) {
@@ -152,9 +154,7 @@ class NewsFragment : BaseNewsFragment() {
             labelFilteredList = applyLabelFilter(filteredNewsList)
             searchFilteredList = applySearchFilter(labelFilteredList)
             setData(searchFilteredList)
-            binding.rvNews.post {
-                binding.rvNews.smoothScrollToPosition(0)
-            }
+            scrollToTop()
         }
 
         binding.addNewsImage.setOnClickListener {
@@ -295,13 +295,20 @@ class NewsFragment : BaseNewsFragment() {
         }
         return news.time
     }
-    
+
+    private fun scrollToTop() {
+        binding.rvNews.post {
+            binding.rvNews.scrollToPosition(0)
+        }
+    }
+
     private fun setupSearchTextListener() {
         etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 searchFilteredList = applySearchFilter(labelFilteredList)
                 setData(searchFilteredList)
+                scrollToTop()
             }
             override fun afterTextChanged(s: Editable) {}
         })
@@ -332,6 +339,7 @@ class NewsFragment : BaseNewsFragment() {
                 labelFilteredList = applyLabelFilter(filteredNewsList)
                 searchFilteredList = applySearchFilter(labelFilteredList)
                 setData(searchFilteredList)
+                scrollToTop()
             }
             override fun onNothingSelected(parent: AdapterView<*>?) {}
         }


### PR DESCRIPTION
fixes #7499

## Summary
- centralize RecyclerView scroll logic in NewsFragment with scrollToTop helper
- trigger scrollToTop after data changes like filtering and new posts

## Testing
- ⚠️ `./gradlew lint` (partial run; terminated due to time constraints)


------
https://chatgpt.com/codex/tasks/task_e_68c322478aa8832b8791619ddf909ac8