### PR TITLE
resources: smoother opening (fixes #7402)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3138
-        versionName = "0.31.38"
+        versionCode = 3142
+        versionName = "0.31.42"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
@@ -151,13 +151,22 @@ class UserProfileDbHandler @Inject constructor(
             return
         }
 
-        if (!mRealm.isInTransaction) mRealm.beginTransaction()
-        val offlineActivities = mRealm.copyToRealm(createResourceUser(model))
-        offlineActivities.type = type
-        offlineActivities.title = item.title
-        offlineActivities.resourceId = item.resourceId
-        offlineActivities.time = Date().time
-        mRealm.commitTransaction()
+        val userName = model?.name
+        val parentCode = model?.parentCode
+        val planetCode = model?.planetCode
+        val itemTitle = item.title
+        val itemResourceId = item.resourceId
+
+        mRealm.executeTransactionAsync { realm ->
+            val offlineActivities = realm.createObject(RealmResourceActivity::class.java, "${UUID.randomUUID()}")
+            offlineActivities.user = userName
+            offlineActivities.parentCode = parentCode
+            offlineActivities.createdOn = planetCode
+            offlineActivities.type = type
+            offlineActivities.title = itemTitle
+            offlineActivities.resourceId = itemResourceId
+            offlineActivities.time = Date().time
+        }
     }
 
     private fun createResourceUser(model: RealmUserModel?): RealmResourceActivity {


### PR DESCRIPTION
fixes #7402
 1. Moved database operation off main thread: Replaced synchronous beginTransaction()/commitTransaction() with executeTransactionAsync() to prevent the 2.5-second UI freeze.
  2. Fixed thread access violations: Extracted data from RealmObjects (model and item) on the main thread before the async block, since Realm objects can't be accessed across
  threads.