### PR TITLE
login: smoother offline asyncing (fixes #7498)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3138
-        versionName = "0.31.38"
+        versionCode = 3144
+        versionName = "0.31.44"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -654,10 +654,20 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
 
     fun onLogin() {
         val handler = UserProfileDbHandler(this)
-        handler.onLogin()
+        handler.onLoginAsync(
+            callback = {
+                runOnUiThread {
+                    editor.putBoolean(Constants.KEY_LOGIN, true).commit()
+                    openDashboard()
+                }
+            },
+            onError = { error ->
+                runOnUiThread {
+                    Utilities.toast(this, "Login failed: ${error.message}")
+                }
+            }
+        )
         handler.onDestroy()
-        editor.putBoolean(Constants.KEY_LOGIN, true).commit()
-        openDashboard()
 
         isNetworkConnectedFlow.onEach { isConnected ->
             if (isConnected) {


### PR DESCRIPTION
fixes #7498
```
  - Moved userModel access to main thread before the async transaction
  - Eliminated the createUser(realm) call that was causing thread safety issues
  - Directly create and populate RealmOfflineActivity in the background transaction using extracted data
```