### PR TITLE
mylife: smoother achievement context (fixes #7567)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3138
-        versionName = "0.31.38"
+        versionCode = 3150
+        versionName = "0.31.50"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
@@ -20,7 +20,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
@@ -76,7 +75,7 @@ class AchievementFragment : BaseContainerFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentAchievementBinding.inflate(inflater, container, false)
         aRealm = databaseService.realmInstance
-        user = UserProfileDbHandler(MainApplication.context).userModel
+        user = UserProfileDbHandler(requireContext()).userModel
         binding.btnEdit.setOnClickListener {
             if (listener != null) listener?.openCallFragment(EditAchievementFragment())
         }
@@ -238,7 +237,7 @@ class AchievementFragment : BaseContainerFragment() {
     }
 
     private fun createAchievementView(ob: JsonObject): View {
-        val binding = RowAchievementBinding.inflate(LayoutInflater.from(MainApplication.context))
+        val binding = RowAchievementBinding.inflate(LayoutInflater.from(requireContext()))
         val desc = getString("description", ob)
         binding.tvDescription.text = desc
         binding.tvDate.text = getString("date", ob)
@@ -266,7 +265,7 @@ class AchievementFragment : BaseContainerFragment() {
     }
 
     private fun createResourceButton(lib: RealmMyLibrary): View {
-        val btnBinding = LayoutButtonPrimaryBinding.inflate(LayoutInflater.from(MainApplication.context))
+        val btnBinding = LayoutButtonPrimaryBinding.inflate(LayoutInflater.from(requireContext()))
         btnBinding.root.text = lib.title
         btnBinding.root.setCompoundDrawablesWithIntrinsicBounds(
             0,
@@ -285,9 +284,9 @@ class AchievementFragment : BaseContainerFragment() {
     }
 
     private fun setupReferences() {
-        binding.rvOtherInfo.layoutManager = LinearLayoutManager(MainApplication.context)
+        binding.rvOtherInfo.layoutManager = LinearLayoutManager(requireContext())
         binding.rvOtherInfo.adapter =
-            AdapterOtherInfo(MainApplication.context, achievement?.references ?: RealmList())
+            AdapterOtherInfo(requireContext(), achievement?.references ?: RealmList())
     }
 
     private fun getLibraries(array: JsonArray): List<RealmMyLibrary> {


### PR DESCRIPTION
## Summary
- replace MainApplication.context with requireContext() in AchievementFragment
- use fragment context for inflaters and helpers

## Testing
- `./gradlew assembleDebug` *(fails: Unable to strip libraries, build incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_68c465895400832baf5bf9f9cb618b97