### PR TITLE
Refactor MyPersonal adapter to use repository callbacks

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepository.kt
@@ -13,4 +13,8 @@ interface MyPersonalRepository {
     )
 
     fun getPersonalResources(userId: String?): Flow<List<RealmMyPersonal>>
+
+    suspend fun deletePersonalResource(id: String)
+
+    suspend fun updatePersonalResource(id: String, title: String, description: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepositoryImpl.kt
@@ -33,4 +33,15 @@ class MyPersonalRepositoryImpl @Inject constructor(
         queryListFlow(RealmMyPersonal::class.java) {
             equalTo("userId", userId)
         }
+
+    override suspend fun deletePersonalResource(id: String) {
+        delete(RealmMyPersonal::class.java, "id", id)
+    }
+
+    override suspend fun updatePersonalResource(id: String, title: String, description: String) {
+        update(RealmMyPersonal::class.java, "id", id) { personal ->
+            personal.title = title
+            personal.description = description
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- remove direct Realm usage from AdapterMyPersonal
- handle delete and edit via repository callbacks in MyPersonalsFragment
- add delete and update operations to MyPersonalRepository

## Testing
- `./gradlew -q assembleDebug --no-daemon --console=plain` *(fails: terminated due to time)*
- `./gradlew -q help`


------
https://chatgpt.com/codex/tasks/task_e_68c46538f320832bafb722fbf761aa9e