### PR TITLE
CameraAccessException (fixes #7444)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
@@ -39,16 +39,21 @@ object CameraUtils {
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
             return
         }
-        openCamera(context)
-        imageReader = ImageReader.newInstance(IMAGE_WIDTH, IMAGE_HEIGHT, ImageFormat.JPEG, 1)
-        imageReader?.setOnImageAvailableListener({ reader ->
-            val image = reader.acquireLatestImage()
-            val buffer = image.planes[0].buffer
-            val bytes = ByteArray(buffer.capacity())
-            buffer.get(bytes)
-            savePicture(bytes, callback)
-            image.close()
-        }, backgroundHandler)
+        try {
+            openCamera(context)
+            imageReader = ImageReader.newInstance(IMAGE_WIDTH, IMAGE_HEIGHT, ImageFormat.JPEG, 1)
+            imageReader?.setOnImageAvailableListener({ reader ->
+                val image = reader.acquireLatestImage()
+                val buffer = image.planes[0].buffer
+                val bytes = ByteArray(buffer.capacity())
+                buffer.get(bytes)
+                savePicture(bytes, callback)
+                image.close()
+            }, backgroundHandler)
+        } catch (e: CameraAccessException) {
+            e.printStackTrace()
+            return
+        }
 
         try {
             val captureBuilder = cameraDevice?.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE)
@@ -71,7 +76,11 @@ object CameraUtils {
 
     private fun reopenCamera(context: Context) {
         closeCamera()
-        openCamera(context)
+        try {
+            openCamera(context)
+        } catch (e: CameraAccessException) {
+            e.printStackTrace()
+        }
     }
 
     private fun closeCamera() {
@@ -117,7 +126,6 @@ object CameraUtils {
                 }
 
                 override fun onDisconnected(camera: CameraDevice) {
-                    closeCamera()
                     reopenCamera(context)
                 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/CameraUtils.kt
@@ -90,8 +90,6 @@ object CameraUtils {
         cameraDevice = null
         imageReader?.close()
         imageReader = null
-        sessionExecutor?.shutdown()
-        sessionExecutor = null
     }
 
     @JvmStatic
@@ -161,6 +159,15 @@ object CameraUtils {
                     }
 
                     override fun onConfigureFailed(session: CameraCaptureSession) {}
+
+                    override fun onClosed(session: CameraCaptureSession) {
+                        if (!executor.isShutdown) {
+                            executor.shutdown()
+                        }
+                        if (sessionExecutor == executor) {
+                            sessionExecutor = null
+                        }
+                    }
                 }
 
                 val sessionConfiguration = SessionConfiguration(SessionConfiguration.SESSION_REGULAR, outputConfigurations, executor, stateCallback)


### PR DESCRIPTION
fixes #7444

## Summary
- Wrap camera startup in try/catch to catch CameraAccessException
- Reinitialize camera on disconnect to recover session

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68c472b3b230832ba6ebf5d429f36a48