### PR TITLE
resources: smoother base receivers (fixes #7597)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3156
-        versionName = "0.31.56"
+        versionCode = 3165
+        versionName = "0.31.65"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -326,6 +326,15 @@ abstract class BaseResourceFragment : Fragment() {
         bManager.registerReceiver(resourceNotFoundReceiver, resourceNotFoundFilter)
     }
 
+    private fun unregisterReceiver() {
+        val fragmentActivity = activity ?: return
+        val bManager = LocalBroadcastManager.getInstance(fragmentActivity)
+        bManager.unregisterReceiver(receiver)
+        bManager.unregisterReceiver(broadcastReceiver)
+        bManager.unregisterReceiver(stateReceiver)
+        bManager.unregisterReceiver(resourceNotFoundReceiver)
+    }
+
     suspend fun getLibraryList(mRealm: Realm): List<RealmMyLibrary> {
         return libraryRepository.getLibraryListForUser(
             settings.getString("userId", "--")
@@ -341,11 +350,12 @@ abstract class BaseResourceFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
-        val bManager = LocalBroadcastManager.getInstance(requireActivity())
-        bManager.unregisterReceiver(receiver)
-        bManager.unregisterReceiver(broadcastReceiver)
-        bManager.unregisterReceiver(stateReceiver)
-        bManager.unregisterReceiver(resourceNotFoundReceiver)
+        unregisterReceiver()
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        homeItemClickListener = null
     }
 
     fun removeFromShelf(`object`: RealmObject) {


### PR DESCRIPTION
## Summary
- add a dedicated helper to unregister all broadcast receivers
- use the helper from onPause and clear the home item listener on detach

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c846cb8a68832ba415c76efe255504