### PR TITLE
Refactor personal and rating fragments to use withRealm

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
-import io.realm.Realm
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
@@ -32,7 +31,6 @@ class RatingFragment : DialogFragment() {
     lateinit var databaseService: DatabaseService
     @Inject
     lateinit var viewModel: RatingViewModel
-    lateinit var mRealm: Realm
     var model: RealmUserModel? = null
     var id: String? = ""
     var type: String? = ""
@@ -55,16 +53,19 @@ class RatingFragment : DialogFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentRatingBinding.inflate(inflater, container, false)
-        mRealm = databaseService.realmInstance
         settings = requireActivity().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        model = mRealm.where(RealmUserModel::class.java)
-            .equalTo("id", settings.getString("userId", "")).findFirst()
-        
+        model = databaseService.withRealm { realm ->
+            realm.where(RealmUserModel::class.java)
+                .equalTo("id", settings.getString("userId", ""))
+                .findFirst()
+                ?.let { realm.copyFromRealm(it) }
+        }
+
         setupUI()
         observeViewModel()
         loadRatingData()
@@ -142,9 +143,6 @@ class RatingFragment : DialogFragment() {
     }
 
     override fun onDestroyView() {
-        if (::mRealm.isInitialized && !mRealm.isClosed) {
-            mRealm.close()
-        }
         _binding = null
         super.onDestroyView()
     }


### PR DESCRIPTION
## Summary
- replace direct Realm access in MyPersonalsFragment and AdapterMyPersonal with DatabaseService.withRealm so that the fragment no longer manages an open Realm instance
- load the current user in RatingFragment via DatabaseService.withRealm and drop the stored Realm reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c847e2f248832b8928baaa697c2394