### PR TITLE
teams: smoother team repository (fixes #7615)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3156
-        versionName = "0.31.56"
+        versionCode = 3168
+        versionName = "0.31.68"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -1,12 +1,20 @@
 package org.ole.planet.myplanet.repository
 
+import android.content.Context
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.service.UploadManager
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
     suspend fun isMember(userId: String?, teamId: String): Boolean
+    suspend fun getTeamLeaderId(teamId: String): String?
+    suspend fun isTeamLeader(teamId: String, userId: String?): Boolean
+    suspend fun hasPendingRequest(teamId: String, userId: String?): Boolean
+    suspend fun requestToJoin(teamId: String, user: RealmUserModel?, teamType: String?)
+    suspend fun leaveTeam(teamId: String, userId: String?)
     suspend fun deleteTask(taskId: String)
     suspend fun upsertTask(task: RealmTeamTask)
+    suspend fun syncTeamActivities(context: Context, uploadManager: UploadManager)
 }
-

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -1,13 +1,18 @@
 package org.ole.planet.myplanet.repository
 
+import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import java.util.Date
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.utilities.AndroidDecrypter
 
 class TeamRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
@@ -34,6 +39,65 @@ class TeamRepositoryImpl @Inject constructor(
         }.isNotEmpty()
     }
 
+    override suspend fun getTeamLeaderId(teamId: String): String? {
+        if (teamId.isBlank()) return null
+        return withRealm { realm ->
+            realm.where(RealmMyTeam::class.java)
+                .equalTo("teamId", teamId)
+                .equalTo("isLeader", true)
+                .findFirst()?.userId
+        }
+    }
+
+    override suspend fun isTeamLeader(teamId: String, userId: String?): Boolean {
+        if (teamId.isBlank() || userId.isNullOrBlank()) return false
+        return count(RealmMyTeam::class.java) {
+            equalTo("teamId", teamId)
+            equalTo("docType", "membership")
+            equalTo("userId", userId)
+            equalTo("isLeader", true)
+        } > 0
+    }
+
+    override suspend fun hasPendingRequest(teamId: String, userId: String?): Boolean {
+        if (teamId.isBlank() || userId.isNullOrBlank()) return false
+        return count(RealmMyTeam::class.java) {
+            equalTo("docType", "request")
+            equalTo("teamId", teamId)
+            equalTo("userId", userId)
+        } > 0
+    }
+
+    override suspend fun requestToJoin(teamId: String, user: RealmUserModel?, teamType: String?) {
+        val userId = user?.id ?: return
+        if (teamId.isBlank()) return
+        executeTransaction { realm ->
+            val request = realm.createObject(RealmMyTeam::class.java, AndroidDecrypter.generateIv())
+            request.docType = "request"
+            request.createdDate = Date().time
+            request.teamType = teamType
+            request.userId = userId
+            request.teamId = teamId
+            request.updated = true
+            request.teamPlanetCode = user.planetCode
+            request.userPlanetCode = user.planetCode
+        }
+    }
+
+    override suspend fun leaveTeam(teamId: String, userId: String?) {
+        if (teamId.isBlank() || userId.isNullOrBlank()) return
+        executeTransaction { realm ->
+            val memberships = realm.where(RealmMyTeam::class.java)
+                .equalTo("userId", userId)
+                .equalTo("teamId", teamId)
+                .equalTo("docType", "membership")
+                .findAll()
+            memberships.forEach { member ->
+                member?.deleteFromRealm()
+            }
+        }
+    }
+
     override suspend fun deleteTask(taskId: String) {
         delete(RealmTeamTask::class.java, "id", taskId)
     }
@@ -51,6 +115,10 @@ class TeamRepositoryImpl @Inject constructor(
             task.sync = Gson().toJson(syncObj)
         }
         save(task)
+    }
+
+    override suspend fun syncTeamActivities(context: Context, uploadManager: UploadManager) {
+        RealmMyTeam.syncTeamActivities(context, uploadManager)
     }
 
     private suspend fun getResourceIds(teamId: String): List<String> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -70,6 +70,7 @@ class TeamRepositoryImpl @Inject constructor(
 
     override suspend fun requestToJoin(teamId: String, user: RealmUserModel?, teamType: String?) {
         val userId = user?.id ?: return
+        val userPlanetCode = user?.planetCode
         if (teamId.isBlank()) return
         executeTransaction { realm ->
             val request = realm.createObject(RealmMyTeam::class.java, AndroidDecrypter.generateIv())
@@ -79,8 +80,8 @@ class TeamRepositoryImpl @Inject constructor(
             request.userId = userId
             request.teamId = teamId
             request.updated = true
-            request.teamPlanetCode = user.planetCode
-            request.userPlanetCode = user.planetCode
+            request.teamPlanetCode = userPlanetCode
+            request.userPlanetCode = userPlanetCode
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -20,11 +20,11 @@ import org.ole.planet.myplanet.databinding.ItemTeamListBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
-import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -14,20 +14,28 @@ import androidx.core.graphics.toColorInt
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.RecyclerView
 import io.realm.Realm
+import kotlinx.coroutines.runBlocking
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemTeamListBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
 
-class AdapterTeamList(private val context: Context, private val list: List<RealmMyTeam>, private val mRealm: Realm, private val fragmentManager: FragmentManager, private val uploadManager: UploadManager) : RecyclerView.Adapter<AdapterTeamList.ViewHolderTeam>() {
+class AdapterTeamList(
+    private val context: Context,
+    private val list: List<RealmMyTeam>,
+    private val mRealm: Realm,
+    private val fragmentManager: FragmentManager,
+    private val uploadManager: UploadManager,
+    private val teamRepository: TeamRepository,
+) : RecyclerView.Adapter<AdapterTeamList.ViewHolderTeam>() {
     private lateinit var itemTeamListBinding: ItemTeamListBinding
     private var type: String? = ""
     private var teamListener: OnClickTeamItem? = null
@@ -63,8 +71,12 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
             name.text = team.name
             noOfVisits.text = context.getString(R.string.number_placeholder, RealmTeamLog.getVisitByTeam(mRealm, team._id))
 
-            val isMyTeam = team.isMyTeam(user?.id, mRealm)
-            showActionButton(isMyTeam, team, user)
+            val teamId = team._id
+            val userId = user?.id
+            val isMyTeam = isMemberOfTeam(teamId, userId)
+            val isTeamLeader = isUserTeamLeader(teamId, userId)
+            val hasPendingRequest = hasPendingRequest(teamId, userId)
+            showActionButton(isMyTeam, isTeamLeader, hasPendingRequest, team, user)
 
             root.setOnClickListener {
                 val activity = context as? AppCompatActivity ?: return@setOnClickListener
@@ -91,12 +103,18 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
             }
 
             joinLeave.setOnClickListener {
-                handleJoinLeaveClick(isMyTeam, team, user)
+                handleJoinLeaveClick(team, user)
             }
         }
     }
 
-    private fun ItemTeamListBinding.showActionButton(isMyTeam: Boolean, team: RealmMyTeam, user: RealmUserModel?) {
+    private fun ItemTeamListBinding.showActionButton(
+        isMyTeam: Boolean,
+        isTeamLeader: Boolean,
+        hasPendingRequest: Boolean,
+        team: RealmMyTeam,
+        user: RealmUserModel?,
+    ) {
         if (isMyTeam) {
             name.setTypeface(null, Typeface.BOLD)
         } else {
@@ -105,8 +123,9 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
         when {
             user?.isGuest() == true -> joinLeave.visibility = View.GONE
 
-            isMyTeam && RealmMyTeam.getTeamLeader(team._id, mRealm) != user?.id -> {
+            isMyTeam && !isTeamLeader -> {
                 joinLeave.apply {
+                    isEnabled = true
                     contentDescription = "${context.getString(R.string.leave)} ${team.name}"
                     visibility = View.VISIBLE
                     setImageResource(R.drawable.logout)
@@ -114,7 +133,7 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
                 }
             }
 
-            !isMyTeam && team.requested(user?.id, mRealm) -> {
+            !isMyTeam && hasPendingRequest -> {
                 joinLeave.apply {
                     isEnabled = false
                     contentDescription = "${context.getString(R.string.requested)} ${team.name}"
@@ -134,8 +153,9 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
                 }
             }
 
-            RealmMyTeam.getTeamLeader(team._id, mRealm) == user?.id -> {
+            isTeamLeader -> {
                 joinLeave.apply {
+                    isEnabled = true
                     contentDescription = "${context.getString(R.string.edit)} ${team.name}"
                     visibility = View.VISIBLE
                     setImageResource(R.drawable.ic_edit)
@@ -147,22 +167,25 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
         }
     }
 
-    private fun handleJoinLeaveClick(isMyTeam: Boolean, team: RealmMyTeam, user: RealmUserModel?) {
+    private fun handleJoinLeaveClick(team: RealmMyTeam, user: RealmUserModel?) {
+        val teamId = team._id
+        val userId = user?.id
+        val isMyTeam = isMemberOfTeam(teamId, userId)
         if (isMyTeam) {
-            if (RealmMyTeam.isTeamLeader(team._id, user?.id, mRealm)) {
+            if (isUserTeamLeader(teamId, userId)) {
                 teamListener?.onEditTeam(team)
             } else {
                 AlertDialog.Builder(context, R.style.CustomAlertDialog).setMessage(R.string.confirm_exit)
                     .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
-                        team.leave(user, mRealm)
+                        leaveTeam(team, userId)
                         updateList()
                     }.setNegativeButton(R.string.no, null).show()
             }
         } else {
-            RealmMyTeam.requestToJoin(team._id, user, mRealm, team.teamType)
+            requestToJoin(team, user)
             updateList()
         }
-        syncTeamActivities(context, uploadManager)
+        syncTeamActivities()
     }
 
     private fun updateList() {
@@ -172,14 +195,43 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
         val validTeams = list.filter { it.status?.isNotEmpty() == true }
         filteredList = validTeams.sortedWith(compareByDescending<RealmMyTeam> { team ->
             when {
-                userId != null && RealmMyTeam.isTeamLeader(team._id, userId, mRealm) -> 3
-                team.isMyTeam(userId, mRealm) -> 2
+                isUserTeamLeader(team._id, userId) -> 3
+                isMemberOfTeam(team._id, userId) -> 2
                 else -> 1
             }
         }.thenByDescending { team ->
             RealmTeamLog.getVisitByTeam(mRealm, team._id)
         })
         notifyDataSetChanged()
+    }
+
+    private fun isMemberOfTeam(teamId: String?, userId: String?): Boolean {
+        if (teamId.isNullOrBlank()) return false
+        return runBlocking { teamRepository.isMember(userId, teamId) }
+    }
+
+    private fun isUserTeamLeader(teamId: String?, userId: String?): Boolean {
+        if (teamId.isNullOrBlank()) return false
+        return runBlocking { teamRepository.isTeamLeader(teamId, userId) }
+    }
+
+    private fun hasPendingRequest(teamId: String?, userId: String?): Boolean {
+        if (teamId.isNullOrBlank()) return false
+        return runBlocking { teamRepository.hasPendingRequest(teamId, userId) }
+    }
+
+    private fun requestToJoin(team: RealmMyTeam, user: RealmUserModel?) {
+        val teamId = team._id ?: return
+        runBlocking { teamRepository.requestToJoin(teamId, user, team.teamType) }
+    }
+
+    private fun leaveTeam(team: RealmMyTeam, userId: String?) {
+        val teamId = team._id ?: return
+        runBlocking { teamRepository.leaveTeam(teamId, userId) }
+    }
+
+    private fun syncTeamActivities() {
+        runBlocking { teamRepository.syncTeamActivities(context, uploadManager) }
     }
 
     private fun getBundle(team: RealmMyTeam): Bundle {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -27,6 +27,7 @@ import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getMyTeamsByUserId
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
@@ -41,6 +42,8 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private lateinit var mRealm: Realm
     @Inject
     lateinit var databaseService: DatabaseService
+    @Inject
+    lateinit var teamRepository: TeamRepository
     var type: String? = null
     private var fromDashboard: Boolean = false
     var user: RealmUserModel? = null
@@ -252,7 +255,12 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                     }.thenBy { it.name })
 
                     val adapterTeamList = AdapterTeamList(
-                        activity as Context, sortedList, mRealm, childFragmentManager, uploadManager
+                        activity as Context,
+                        sortedList,
+                        mRealm,
+                        childFragmentManager,
+                        uploadManager,
+                        teamRepository,
                     )
                     adapterTeamList.setTeamListener(this@TeamFragment)
                     binding.rvTeamList.adapter = adapterTeamList
@@ -280,7 +288,9 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
 
     private fun setTeamList() {
         val list = teamList ?: return
-        adapterTeamList = activity?.let { AdapterTeamList(it, list, mRealm, childFragmentManager, uploadManager) } ?: return
+        adapterTeamList = activity?.let {
+            AdapterTeamList(it, list, mRealm, childFragmentManager, uploadManager, teamRepository)
+        } ?: return
         adapterTeamList.setType(type)
         adapterTeamList.setTeamListener(this@TeamFragment)
         requireView().findViewById<View>(R.id.type).visibility =
@@ -319,7 +329,14 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
         viewLifecycleOwner.lifecycleScope.launch {
             val list = teamList ?: return@launch
             val sortedList = sortTeams(list)
-            val adapterTeamList = AdapterTeamList(activity as Context, sortedList, mRealm, childFragmentManager, uploadManager).apply {
+            val adapterTeamList = AdapterTeamList(
+                activity as Context,
+                sortedList,
+                mRealm,
+                childFragmentManager,
+                uploadManager,
+                teamRepository,
+            ).apply {
                 setType(type)
                 setTeamListener(this@TeamFragment)
             }


### PR DESCRIPTION
## Summary
- extend the team repository contract with leader, membership, request, and sync helpers
- implement the new helpers in the Realm-backed repository to manage team membership actions
- inject the repository into the team list UI and use it instead of static RealmMyTeam calls

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68c8489761f4832bb10a4c90da4959cf