### PR TITLE
Move relative time helper to TimeUtils

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
@@ -47,6 +47,7 @@ import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.LocaleHelper
 import org.ole.planet.myplanet.utilities.ThemeManager
+import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -248,7 +249,7 @@ class SettingActivity : AppCompatActivity() {
             if (lastSynced == 0L) {
                 lastSyncDate?.setTitle(R.string.last_synced_never)
             } else if (lastSyncDate != null) {
-                lastSyncDate.title = getString(R.string.last_synced_colon) + Utilities.getRelativeTime(lastSynced)
+                lastSyncDate.title = getString(R.string.last_synced_colon) + TimeUtils.getRelativeTime(lastSynced)
             }
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -94,8 +94,8 @@ import org.ole.planet.myplanet.utilities.NotificationUtils.cancelAll
 import org.ole.planet.myplanet.utilities.ServerConfigUtils
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.UrlUtils
+import org.ole.planet.myplanet.utilities.TimeUtils.getRelativeTime
 import org.ole.planet.myplanet.utilities.Utilities
-import org.ole.planet.myplanet.utilities.Utilities.getRelativeTime
 
 @AndroidEntryPoint
 abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVersionCallback,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserDetailFragment.kt
@@ -18,6 +18,7 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDate
+import org.ole.planet.myplanet.utilities.TimeUtils.getRelativeTime
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -86,7 +87,7 @@ class UserDetailFragment : Fragment() {
         list.add(Detail("Language", user.language!!))
         list.add(Detail("Level", user.level!!))
         list.add(Detail("Number of Visits", db!!.offlineVisits.toString() + ""))
-        list.add(Detail("Last Login", Utilities.getRelativeTime(db.lastVisit!!)))
+        list.add(Detail("Last Login", getRelativeTime(db.lastVisit!!)))
         return list
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
@@ -379,7 +379,7 @@ class UserProfileFragment : Fragment() {
     private fun createStatsMap(): LinkedHashMap<String, String?> {
         return linkedMapOf(
             getString(R.string.community_name) to Utilities.checkNA(model?.planetCode),
-            getString(R.string.last_login) to handler.lastVisit?.let { Utilities.getRelativeTime(it) },
+            getString(R.string.last_login) to handler.lastVisit?.let { TimeUtils.getRelativeTime(it) },
             getString(R.string.total_visits_overall) to handler.offlineVisits.toString(),
             getString(R.string.most_opened_resource) to Utilities.checkNA(handler.maxOpenedResource),
             getString(R.string.number_of_resources_opened) to Utilities.checkNA(handler.numberOfResourceOpen)

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/TimeUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/TimeUtils.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.utilities
 
+import android.text.format.DateUtils
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -155,4 +156,11 @@ object TimeUtils {
             e.printStackTrace()
             null
         }
+
+    fun getRelativeTime(timestamp: Long): String {
+        val timeNow = System.currentTimeMillis()
+        return if (timestamp < timeNow) {
+            DateUtils.getRelativeTimeSpanString(timestamp, timeNow, 0).toString()
+        } else "Just now"
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Utilities.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.utilities
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.text.format.DateUtils
 import android.util.Log
 import android.util.Patterns
 import android.webkit.MimeTypeMap
@@ -45,13 +44,6 @@ object Utilities {
 
     fun checkNA(s: String?): String {
         return if (s.isNullOrEmpty()) "N/A" else s
-    }
-
-    fun getRelativeTime(timestamp: Long): String {
-        val timeNow = System.currentTimeMillis()
-        return if (timestamp < timeNow) {
-            DateUtils.getRelativeTimeSpanString(timestamp, timeNow, 0).toString()
-        } else "Just now"
     }
 
     fun getUserName(settings: SharedPreferences): String {


### PR DESCRIPTION
## Summary
- move the `getRelativeTime` helper from `Utilities` to `TimeUtils` so all time formatting lives together
- update sync, settings, and user profile screens to call `TimeUtils.getRelativeTime`

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68c84aa8c114832bb5dc9b998425f0a3