### PR TITLE
teams: smoother team repository realm model

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -1,8 +1,6 @@
 package org.ole.planet.myplanet.model
 
-import android.content.Context
 import android.content.SharedPreferences
-import androidx.core.net.toUri
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
@@ -12,22 +10,11 @@ import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.annotations.PrimaryKey
 import java.util.Date
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.context
-import org.ole.planet.myplanet.datamanager.ApiClient.client
-import org.ole.planet.myplanet.datamanager.ApiInterface
-import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
-import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DownloadUtils.extractLinks
 import org.ole.planet.myplanet.utilities.DownloadUtils.openDownloadService
 import org.ole.planet.myplanet.utilities.JsonUtils
-import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.UrlUtils.getUrl
 
 open class RealmMyTeam : RealmObject() {
@@ -258,52 +245,6 @@ open class RealmMyTeam : RealmObject() {
             team.teamPlanetCode = userModel?.planetCode
             team.userPlanetCode = userModel?.planetCode
             mRealm.commitTransaction()
-        }
-
-        @JvmStatic
-        fun syncTeamActivities(context: Context, uploadManager: UploadManager) {
-            val settings = MainApplication.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            val updateUrl = "${settings.getString("serverURL", "")}"
-            val serverUrlMapper = ServerUrlMapper()
-            val mapping = serverUrlMapper.processUrl(updateUrl)
-
-            CoroutineScope(Dispatchers.IO).launch {
-                val primaryAvailable = MainApplication.isServerReachable(mapping.primaryUrl)
-                val alternativeAvailable =
-                    mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
-
-                if (!primaryAvailable && alternativeAvailable) {
-                    mapping.alternativeUrl.let { alternativeUrl ->
-                        val uri = updateUrl.toUri()
-                        val editor = settings.edit()
-                        serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, settings)
-                    }
-                }
-
-                withContext(Dispatchers.Main) {
-                    uploadTeamActivities(context, uploadManager)
-                }
-            }
-        }
-
-        private fun uploadTeamActivities(context: Context, uploadManager: UploadManager) {
-            MainApplication.applicationScope.launch {
-                try {
-                    withContext(Dispatchers.IO) {
-                        uploadManager.uploadTeams()
-                    }
-                    withContext(Dispatchers.IO) {
-                        val apiInterface = client?.create(ApiInterface::class.java)
-                        DatabaseService(context).withRealm { realm ->
-                            realm.executeTransaction { transactionRealm ->
-                                uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
-                            }
-                        }
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -8,5 +8,6 @@ interface TeamRepository {
     suspend fun isMember(userId: String?, teamId: String): Boolean
     suspend fun deleteTask(taskId: String)
     suspend fun upsertTask(task: RealmTeamTask)
+    fun syncTeamActivities()
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -17,17 +17,22 @@ import io.realm.Realm
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemTeamListBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.utilities.TimeUtils
 
-class AdapterTeamList(private val context: Context, private val list: List<RealmMyTeam>, private val mRealm: Realm, private val fragmentManager: FragmentManager, private val uploadManager: UploadManager) : RecyclerView.Adapter<AdapterTeamList.ViewHolderTeam>() {
+class AdapterTeamList(
+    private val context: Context,
+    private val list: List<RealmMyTeam>,
+    private val mRealm: Realm,
+    private val fragmentManager: FragmentManager,
+    private val teamRepository: TeamRepository,
+) : RecyclerView.Adapter<AdapterTeamList.ViewHolderTeam>() {
     private lateinit var itemTeamListBinding: ItemTeamListBinding
     private var type: String? = ""
     private var teamListener: OnClickTeamItem? = null
@@ -162,7 +167,7 @@ class AdapterTeamList(private val context: Context, private val list: List<Realm
             RealmMyTeam.requestToJoin(team._id, user, mRealm, team.teamType)
             updateList()
         }
-        syncTeamActivities(context, uploadManager)
+        teamRepository.syncTeamActivities()
     }
 
     private fun updateList() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -27,12 +27,10 @@ import org.ole.planet.myplanet.callback.TableDataUpdate
 import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMemberCount
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.service.sync.RealtimeSyncCoordinator
 import org.ole.planet.myplanet.ui.team.TeamPageConfig.ApplicantsPage
@@ -64,9 +62,6 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     @Inject
     lateinit var syncManager: SyncManager
 
-    @Inject
-    lateinit var uploadManager: UploadManager
-    
     private val syncCoordinator = RealtimeSyncCoordinator.getInstance()
     private lateinit var realtimeSyncListener: BaseRealtimeSyncListener
 
@@ -291,7 +286,7 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
                 RealmMyTeam.requestToJoin(teamId, user, mRealm, team?.teamType)
                 binding.btnLeave.text = getString(R.string.requested)
                 binding.btnLeave.isEnabled = false
-                syncTeamActivities(requireContext(), uploadManager)
+                teamRepository.syncTeamActivities()
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -27,7 +27,7 @@ import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getMyTeamsByUserId
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.Constants
@@ -48,7 +48,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private lateinit var adapterTeamList: AdapterTeamList
     private var conditionApplied: Boolean = false
     @Inject
-    lateinit var uploadManager: UploadManager
+    lateinit var teamRepository: TeamRepository
     private val settings by lazy {
         requireActivity().getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE)
     }
@@ -252,7 +252,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                     }.thenBy { it.name })
 
                     val adapterTeamList = AdapterTeamList(
-                        activity as Context, sortedList, mRealm, childFragmentManager, uploadManager
+                        activity as Context, sortedList, mRealm, childFragmentManager, teamRepository
                     )
                     adapterTeamList.setTeamListener(this@TeamFragment)
                     binding.rvTeamList.adapter = adapterTeamList
@@ -280,7 +280,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
 
     private fun setTeamList() {
         val list = teamList ?: return
-        adapterTeamList = activity?.let { AdapterTeamList(it, list, mRealm, childFragmentManager, uploadManager) } ?: return
+        adapterTeamList = activity?.let { AdapterTeamList(it, list, mRealm, childFragmentManager, teamRepository) } ?: return
         adapterTeamList.setType(type)
         adapterTeamList.setTeamListener(this@TeamFragment)
         requireView().findViewById<View>(R.id.type).visibility =
@@ -319,7 +319,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
         viewLifecycleOwner.lifecycleScope.launch {
             val list = teamList ?: return@launch
             val sortedList = sortTeams(list)
-            val adapterTeamList = AdapterTeamList(activity as Context, sortedList, mRealm, childFragmentManager, uploadManager).apply {
+            val adapterTeamList = AdapterTeamList(activity as Context, sortedList, mRealm, childFragmentManager, teamRepository).apply {
                 setType(type)
                 setTeamListener(this@TeamFragment)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterMemberRequest.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterMemberRequest.kt
@@ -10,12 +10,18 @@ import org.ole.planet.myplanet.callback.MemberChangeListener
 import org.ole.planet.myplanet.databinding.RowMemberRequestBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMember
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.utilities.Utilities
 
-class AdapterMemberRequest(private val context: Context, private val list: MutableList<RealmUserModel>, private val mRealm: Realm, private val currentUser: RealmUserModel, private val listener: MemberChangeListener, private val uploadManager: UploadManager) : RecyclerView.Adapter<AdapterMemberRequest.ViewHolderUser>() {
+class AdapterMemberRequest(
+    private val context: Context,
+    private val list: MutableList<RealmUserModel>,
+    private val mRealm: Realm,
+    private val currentUser: RealmUserModel,
+    private val listener: MemberChangeListener,
+    private val teamRepository: TeamRepository,
+) : RecyclerView.Adapter<AdapterMemberRequest.ViewHolderUser>() {
     private lateinit var rowMemberRequestBinding: RowMemberRequestBinding
     private var teamId: String? = null
     private lateinit var team: RealmMyTeam
@@ -96,7 +102,7 @@ class AdapterMemberRequest(private val context: Context, private val list: Mutab
                 }
             }
         }, {
-            syncTeamActivities(context, uploadManager)
+            teamRepository.syncTeamActivities()
             listener.onMemberChanged()
         }, { error ->
             list.add(position, userModel)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MembersFragment.kt
@@ -5,14 +5,12 @@ import android.content.res.Configuration
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import org.ole.planet.myplanet.base.BaseMemberFragment
 import org.ole.planet.myplanet.callback.MemberChangeListener
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getRequestedMember
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 
 @AndroidEntryPoint
@@ -20,9 +18,6 @@ class MembersFragment : BaseMemberFragment() {
 
     private lateinit var currentUser: RealmUserModel
     private lateinit var memberChangeListener: MemberChangeListener
-
-    @Inject
-    lateinit var uploadManager: UploadManager
 
     fun setMemberChangeListener(listener: MemberChangeListener) {
         this.memberChangeListener = listener
@@ -44,7 +39,7 @@ class MembersFragment : BaseMemberFragment() {
 
     override val adapter: RecyclerView.Adapter<*>
         get() = AdapterMemberRequest(requireActivity(), list.toMutableList(),
-            mRealm, currentUser, memberChangeListener, uploadManager).apply { setTeamId(teamId) }
+            mRealm, currentUser, memberChangeListener, teamRepository).apply { setTeamId(teamId) }
 
     override val layoutManager: RecyclerView.LayoutManager
         get() {


### PR DESCRIPTION
## Summary
- move team activity upload logic from RealmMyTeam into TeamRepositoryImpl so it can use injected dependencies
- expose syncTeamActivities on TeamRepository and update adapters/fragments to call the repository instead of the Realm model
- simplify RealmMyTeam by removing companion object networking logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c84ad47f84832b8cda943cb4d7d370