### PR TITLE
dashboard: smoother profile image binding (fixes #7488)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3156
-        versionName = "0.31.56"
+        versionCode = 3167
+        versionName = "0.31.67"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
@@ -195,13 +195,14 @@ class UserProfileFragment : Fragment() {
                 override fun onLoadFailed(
                     e: GlideException?,
                     model: Any?,
-                    target: Target<Drawable>?,
+                    target: Target<Drawable>,
                     isFirstResource: Boolean
                 ): Boolean {
-                    if (!isAdded || _binding == null) {
+                    if (!isAdded) {
                         return true
                     }
-                    _binding?.image?.apply {
+                    val currentBinding = _binding ?: return true
+                    currentBinding.image.apply {
                         visibility = View.VISIBLE
                         setImageResource(R.drawable.profile)
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
@@ -178,23 +178,47 @@ class UserProfileFragment : Fragment() {
     }
 
     private fun loadProfileImage() {
-        model?.userImage.let {
-            Glide.with(requireContext())
-                .load(it)
-                .apply(RequestOptions().placeholder(R.drawable.profile).error(R.drawable.profile))
-                .listener(object : RequestListener<Drawable> {
-                    override fun onLoadFailed(e: GlideException?, model: Any?, target: Target<Drawable>, isFirstResource: Boolean): Boolean {
-                        binding.image.setImageResource(R.drawable.profile)
-                        return false
-                    }
+        val binding = _binding ?: return
+        val profileImageUrl = model?.userImage
 
-                    override fun onResourceReady(resource: Drawable, model: Any, target: Target<Drawable>?, dataSource: DataSource, isFirstResource: Boolean): Boolean {
-                        return false
-                    }
-
-                })
-                .into(binding.image)
+        if (profileImageUrl.isNullOrBlank()) {
+            binding.image.setImageResource(R.drawable.profile)
+            return
         }
+
+        if (!isAdded) return
+
+        Glide.with(this)
+            .load(profileImageUrl)
+            .apply(RequestOptions().placeholder(R.drawable.profile).error(R.drawable.profile))
+            .listener(object : RequestListener<Drawable> {
+                override fun onLoadFailed(
+                    e: GlideException?,
+                    model: Any?,
+                    target: Target<Drawable>?,
+                    isFirstResource: Boolean
+                ): Boolean {
+                    if (!isAdded || _binding == null) {
+                        return true
+                    }
+                    _binding?.image?.apply {
+                        visibility = View.VISIBLE
+                        setImageResource(R.drawable.profile)
+                    }
+                    return true
+                }
+
+                override fun onResourceReady(
+                    resource: Drawable,
+                    model: Any,
+                    target: Target<Drawable>?,
+                    dataSource: DataSource,
+                    isFirstResource: Boolean
+                ): Boolean {
+                    return false
+                }
+            })
+            .into(binding.image)
     }
 
     private fun openEditProfileDialog() {


### PR DESCRIPTION
fixes #7488

- guard profile image loading against null binding so Glide callbacks no longer touch a destroyed view
- fall back to the default avatar when the profile picture fails to load

------
https://chatgpt.com/codex/tasks/task_e_68c84b091e18832b85d554aa1395b2b5