### PR TITLE
Add updateAll helper for course flag updates

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -39,11 +39,8 @@ class CourseRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateMyCourseFlag(courseIds: List<String>, isMyCourse: Boolean) {
-        executeTransaction { realm ->
-            realm.where(RealmMyCourse::class.java)
-                .`in`("courseId", courseIds.toTypedArray())
-                .findAll()
-                .forEach { it.isMyCourse = isMyCourse }
-        }
+        updateAll(RealmMyCourse::class.java, {
+            `in`("courseId", courseIds.toTypedArray())
+        }) { it.isMyCourse = isMyCourse }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -82,6 +82,19 @@ open class RealmRepository(private val databaseService: DatabaseService) {
         }
     }
 
+    protected suspend fun <T : RealmObject> updateAll(
+        clazz: Class<T>,
+        builder: RealmQuery<T>.() -> Unit,
+        updater: (T) -> Unit,
+    ) {
+        executeTransaction { realm ->
+            realm.where(clazz)
+                .apply(builder)
+                .findAll()
+                .forEach { updater(it) }
+        }
+    }
+
     protected suspend fun <T : RealmObject, V : Any> delete(
         clazz: Class<T>,
         fieldName: String,


### PR DESCRIPTION
## Summary
- add a reusable `updateAll` helper to `RealmRepository` for batch updates
- refactor `CourseRepositoryImpl.updateMyCourseFlag` to use the shared helper

## Testing
- ./gradlew test --console=plain --info *(aborted after extended dependency processing)*

------
https://chatgpt.com/codex/tasks/task_e_68c932ca82b0832b9eaa75c05242a133