### PR TITLE
Use repository for course progress updates

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -44,6 +44,7 @@ import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmSubmission.Companion.getExamMap
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.CourseProgressRepository
 import org.ole.planet.myplanet.repository.LibraryRepository
 import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.repository.UserRepository
@@ -75,6 +76,8 @@ abstract class BaseResourceFragment : Fragment() {
     lateinit var libraryRepository: LibraryRepository
     @Inject
     lateinit var submissionRepository: SubmissionRepository
+    @Inject
+    lateinit var courseProgressRepository: CourseProgressRepository
     @Inject
     lateinit var databaseService: DatabaseService
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseProgressRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseProgressRepository.kt
@@ -4,4 +4,5 @@ import org.ole.planet.myplanet.model.RealmCourseProgress
 
 interface CourseProgressRepository {
     suspend fun getCourseProgress(userId: String?): Map<String, RealmCourseProgress>
+    suspend fun saveProgress(courseId: String, userId: String?, stepNum: Int, passed: Boolean)
 }


### PR DESCRIPTION
## Summary
- extend the course progress repository with a suspend saveProgress API and a Realm-backed implementation
- inject the repository into shared fragments so progress writes go through the repository layer
- refactor CourseStepFragment and BaseExamFragment to launch coroutines that persist step progress via the repository

## Testing
- ./gradlew :app:lintLiteDebug --console=plain *(fails: Gradle daemon disappeared unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68c931c48acc832b9a43b97f9403ed71