### PR TITLE
Refactor MyLife data access into repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -45,6 +45,7 @@ import org.ole.planet.myplanet.model.RealmSubmission.Companion.getExamMap
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.LibraryRepository
+import org.ole.planet.myplanet.repository.MyLifeRepository
 import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.service.UserProfileDbHandler
@@ -75,6 +76,8 @@ abstract class BaseResourceFragment : Fragment() {
     lateinit var libraryRepository: LibraryRepository
     @Inject
     lateinit var submissionRepository: SubmissionRepository
+    @Inject
+    lateinit var myLifeRepository: MyLifeRepository
     @Inject
     lateinit var databaseService: DatabaseService
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -13,6 +13,8 @@ import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.repository.FeedbackRepositoryImpl
 import org.ole.planet.myplanet.repository.LibraryRepository
 import org.ole.planet.myplanet.repository.LibraryRepositoryImpl
+import org.ole.planet.myplanet.repository.MyLifeRepository
+import org.ole.planet.myplanet.repository.MyLifeRepositoryImpl
 import org.ole.planet.myplanet.repository.MyPersonalRepository
 import org.ole.planet.myplanet.repository.MyPersonalRepositoryImpl
 import org.ole.planet.myplanet.repository.NewsRepository
@@ -51,6 +53,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindLibraryRepository(impl: LibraryRepositoryImpl): LibraryRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindMyLifeRepository(impl: MyLifeRepositoryImpl): MyLifeRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/org/ole/planet/myplanet/repository/MyLifeRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MyLifeRepository.kt
@@ -1,0 +1,9 @@
+package org.ole.planet.myplanet.repository
+
+import org.ole.planet.myplanet.model.RealmMyLife
+
+interface MyLifeRepository {
+    suspend fun getMyLifeByUserId(userId: String?): List<RealmMyLife>
+    suspend fun updateWeight(weight: Int, id: String?, userId: String?)
+    suspend fun updateVisibility(isVisible: Boolean, id: String?)
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/MyLifeRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MyLifeRepositoryImpl.kt
@@ -1,0 +1,51 @@
+package org.ole.planet.myplanet.repository
+
+import javax.inject.Inject
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyLife
+
+class MyLifeRepositoryImpl @Inject constructor(
+    databaseService: DatabaseService,
+) : RealmRepository(databaseService), MyLifeRepository {
+
+    override suspend fun getMyLifeByUserId(userId: String?): List<RealmMyLife> {
+        if (userId == null) return emptyList()
+
+        return withRealm { realm ->
+            realm.where(RealmMyLife::class.java)
+                .equalTo("userId", userId)
+                .findAll()
+                .sort("weight")
+                .let { realm.copyFromRealm(it) }
+        }
+    }
+
+    override suspend fun updateWeight(weight: Int, id: String?, userId: String?) {
+        if (id.isNullOrEmpty() || userId == null) return
+
+        executeTransaction { realm ->
+            val targetItem = realm.where(RealmMyLife::class.java)
+                .equalTo("_id", id)
+                .findFirst()
+
+            targetItem?.let { item ->
+                val currentWeight = item.weight
+                item.weight = weight
+
+                val otherItem = realm.where(RealmMyLife::class.java)
+                    .equalTo("userId", userId)
+                    .equalTo("weight", weight)
+                    .notEqualTo("_id", id)
+                    .findFirst()
+
+                otherItem?.weight = currentWeight
+            }
+        }
+    }
+
+    override suspend fun updateVisibility(isVisible: Boolean, id: String?) {
+        if (id.isNullOrEmpty()) return
+
+        update(RealmMyLife::class.java, "_id", id) { it.isVisible = isVisible }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -26,6 +26,7 @@ import io.realm.Sort
 import java.util.Calendar
 import java.util.UUID
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.NotificationCallback
 import org.ole.planet.myplanet.callback.SyncListener
@@ -246,17 +247,17 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     private fun myLifeListInit(flexboxLayout: FlexboxLayout) {
-        val dbMylife: MutableList<RealmMyLife> = ArrayList()
-        val rawMylife: List<RealmMyLife> = RealmMyLife.getMyLifeByUserId(mRealm, settings)
-        for (item in rawMylife) if (item.isVisible) dbMylife.add(item)
-        for ((itemCnt, items) in dbMylife.withIndex()) {
+        val userId = settings.getString("userId", "--")
+        val visibleMyLife = runBlocking { myLifeRepository.getMyLifeByUserId(userId) }
+            .filter { it.isVisible }
+        for ((itemCnt, items) in visibleMyLife.withIndex()) {
             flexboxLayout.addView(getLayout(itemCnt, items), params)
         }
     }
 
     private fun setUpMyLife(userId: String?) {
         val realm = databaseService.realmInstance
-        val realmObjects = RealmMyLife.getMyLifeByUserId(mRealm, settings)
+        val realmObjects = runBlocking { myLifeRepository.getMyLifeByUserId(userId) }
         if (realmObjects.isEmpty()) {
             if (!realm.isInTransaction) {
                 realm.beginTransaction()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mylife/AdapterMyLife.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mylife/AdapterMyLife.kt
@@ -154,8 +154,11 @@ class AdapterMyLife(
         override fun onItemClear(viewHolder: RecyclerView.ViewHolder?) {
             itemView.setBackgroundColor(ContextCompat.getColor(context, R.color.daynight_grey))
             if (viewHolder != null) {
-                if (!myLifeList[viewHolder.bindingAdapterPosition].isVisible) {
-                    (viewHolder as ViewHolderMyLife?)?.rvItemContainer?.alpha = hide
+                val adapterPosition = viewHolder.bindingAdapterPosition
+                if (adapterPosition != RecyclerView.NO_POSITION && adapterPosition in myLifeList.indices) {
+                    if (!myLifeList[adapterPosition].isVisible) {
+                        (viewHolder as ViewHolderMyLife?)?.rvItemContainer?.alpha = hide
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mylife/AdapterMyLife.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mylife/AdapterMyLife.kt
@@ -124,19 +124,8 @@ class AdapterMyLife(
 
         MainApplication.applicationScope.launch(Dispatchers.IO) {
             myLifeRepository.updateWeight(toPosition + 1, movedItem._id, userId)
-            reloadData()
         }
         return true
-    }
-
-    private suspend fun reloadData() {
-        val currentUserId = userId ?: return
-        val updatedList = myLifeRepository.getMyLifeByUserId(currentUserId)
-        withContext(Dispatchers.Main) {
-            myLifeList.clear()
-            myLifeList.addAll(updatedList)
-            notifyDataSetChanged()
-        }
     }
 
     internal inner class ViewHolderMyLife(itemView: View) : RecyclerView.ViewHolder(itemView),

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mylife/LifeFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mylife/LifeFragment.kt
@@ -10,8 +10,8 @@ import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.databinding.FragmentLifeBinding
+import kotlinx.coroutines.runBlocking
 import org.ole.planet.myplanet.model.RealmMyLife
-import org.ole.planet.myplanet.model.RealmMyLife.Companion.getMyLifeByUserId
 import org.ole.planet.myplanet.ui.mylife.helper.OnStartDragListener
 import org.ole.planet.myplanet.ui.mylife.helper.SimpleItemTouchHelperCallback
 import org.ole.planet.myplanet.utilities.KeyboardUtils.setupUI
@@ -36,8 +36,15 @@ class LifeFragment : BaseRecyclerFragment<RealmMyLife?>(), OnStartDragListener {
     }
 
     override fun getAdapter(): RecyclerView.Adapter<*> {
-        val myLifeList = getMyLifeByUserId(mRealm, model?.id)
-        adapterMyLife = AdapterMyLife(requireContext(), myLifeList, mRealm, this)
+        val userId = model?.id
+        val myLifeList = runBlocking { myLifeRepository.getMyLifeByUserId(userId) }
+        adapterMyLife = AdapterMyLife(
+            requireContext(),
+            myLifeList.toMutableList(),
+            userId,
+            myLifeRepository,
+            this,
+        )
         return adapterMyLife
     }
 


### PR DESCRIPTION
## Summary
- add a dedicated MyLifeRepository to encapsulate RealmMyLife queries and updates
- inject the repository through the existing DI module and use it from the dashboard and life UI
- remove the static helper methods from RealmMyLife now that repository calls replace them

## Testing
- ./gradlew --no-daemon :app:lintDefaultDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68c933db113c832b81b580804312c6c3