### PR TITLE
Fix team tab switching showing wrong page (fixes #7494)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamPagerAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamPagerAdapter.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.ui.team
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.callback.MemberChangeListener
@@ -18,21 +17,21 @@ import org.ole.planet.myplanet.ui.team.teamMember.MembersFragment
 import org.ole.planet.myplanet.ui.team.teamResource.TeamResourceFragment
 
 class TeamPagerAdapter(
-    private val fm: FragmentActivity,
+    private val host: Fragment,
     private val pages: List<TeamPageConfig>,
     private val teamId: String?,
     private val memberChangeListener: MemberChangeListener
-) : FragmentStateAdapter(fm) {
+) : FragmentStateAdapter(host) {
 
     override fun getItemCount(): Int = pages.size
 
     fun getPageTitle(position: Int): CharSequence =
-        fm.getString(pages[position].titleRes)
+        host.getString(pages[position].titleRes)
 
-    override fun getItemId(position: Int): Long = position.toLong()
+    override fun getItemId(position: Int): Long = pages[position].id.hashCode().toLong()
 
     override fun containsItem(itemId: Long): Boolean =
-        itemId in 0 until pages.size
+        pages.any { it.id.hashCode().toLong() == itemId }
 
     override fun createFragment(position: Int): Fragment {
         val page = pages[position]


### PR DESCRIPTION
fixes #7494
## Summary
- reset the team detail ViewPager setup when rebuilding so the selected tab and page stay in sync
- host the pager adapter from the fragment with stable page ids to prevent fragment reuse mismatches

## Testing
- ./gradlew --console=plain lint *(fails: Build Tools 35.0.0 is corrupted in the runner)*

------
https://chatgpt.com/codex/tasks/task_e_68c95c9ab408832ea844d70b0c4162af

[Screen_recording_20250916_164134.webm](https://github.com/user-attachments/assets/b4648dd1-5a87-45f5-b878-e8136048e2e1)
