### PR TITLE
Fix chat history user resolution

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -20,6 +20,10 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getCurrentUser(): RealmUserModel? {
+        val userId = preferences.getString("userId", null)
+        if (!userId.isNullOrBlank()) {
+            getUserById(userId)?.let { return it }
+        }
         return findFirst(RealmUserModel::class.java)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -409,15 +409,25 @@ class ChatDetailFragment : Fragment() {
         json.toRequestBody(jsonMediaType)
 
     private fun createContinueChatRequest(message: String, aiProvider: AiProvider, id: String, rev: String): RequestBody {
-        val continueChatData = ContinueChatModel(data = Data("${user?.name}", message, aiProvider, id, rev), save = true)
+        val continueChatData =
+            ContinueChatModel(data = Data(resolveCurrentUserName(), message, aiProvider, id, rev), save = true)
         val jsonContent = gson.toJson(continueChatData)
         return jsonRequestBody(jsonContent)
     }
 
     private fun createChatRequest(message: String, aiProvider: AiProvider): RequestBody {
-        val chatData = ChatRequestModel(data = ContentData("${user?.name}", message, aiProvider), save = true)
+        val chatData = ChatRequestModel(
+            data = ContentData(resolveCurrentUserName(), message, aiProvider),
+            save = true
+        )
         val jsonContent = gson.toJson(chatData)
         return jsonRequestBody(jsonContent)
+    }
+
+    private fun resolveCurrentUserName(): String {
+        return user?.name?.takeIf { it.isNotBlank() }
+            ?: settings.getString("name", "")?.takeIf { it.isNotBlank() }
+            ?: ""
     }
 
     private fun getLatestRev(id: String): String? {
@@ -516,7 +526,7 @@ class ChatDetailFragment : Fragment() {
             addProperty("_rev", responseBody.couchDBResponse?.rev ?: "")
             addProperty("_id", responseBody.couchDBResponse?.id ?: "")
             addProperty("aiProvider", aiName)
-            addProperty("user", user?.name)
+            addProperty("user", resolveCurrentUserName())
             addProperty("title", query)
             addProperty("createdTime", Date().time)
             addProperty("updatedDate", "")


### PR DESCRIPTION
## Summary
- ensure the repository resolves the current user using the stored user id before falling back to the first Realm record
- provide a safe helper in the chat detail flow so chat requests and saved history always include the current user's name

## Testing
- ./gradlew lint *(fails: missing Android SDK Platform 36 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c96550c8dc832eab815b15658c91fb