### PR TITLE
Refactor team activity sync into repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -1,8 +1,6 @@
 package org.ole.planet.myplanet.model
 
-import android.content.Context
 import android.content.SharedPreferences
-import androidx.core.net.toUri
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
@@ -12,22 +10,12 @@ import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.annotations.PrimaryKey
 import java.util.Date
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.context
-import org.ole.planet.myplanet.datamanager.ApiClient.client
-import org.ole.planet.myplanet.datamanager.ApiInterface
-import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DownloadUtils.extractLinks
 import org.ole.planet.myplanet.utilities.DownloadUtils.openDownloadService
 import org.ole.planet.myplanet.utilities.JsonUtils
-import org.ole.planet.myplanet.utilities.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.UrlUtils.getUrl
 
 open class RealmMyTeam : RealmObject() {
@@ -258,52 +246,6 @@ open class RealmMyTeam : RealmObject() {
             team.teamPlanetCode = userModel?.planetCode
             team.userPlanetCode = userModel?.planetCode
             mRealm.commitTransaction()
-        }
-
-        @JvmStatic
-        fun syncTeamActivities(context: Context, uploadManager: UploadManager) {
-            val settings = MainApplication.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            val updateUrl = "${settings.getString("serverURL", "")}"
-            val serverUrlMapper = ServerUrlMapper()
-            val mapping = serverUrlMapper.processUrl(updateUrl)
-
-            CoroutineScope(Dispatchers.IO).launch {
-                val primaryAvailable = MainApplication.isServerReachable(mapping.primaryUrl)
-                val alternativeAvailable =
-                    mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
-
-                if (!primaryAvailable && alternativeAvailable) {
-                    mapping.alternativeUrl.let { alternativeUrl ->
-                        val uri = updateUrl.toUri()
-                        val editor = settings.edit()
-                        serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, settings)
-                    }
-                }
-
-                withContext(Dispatchers.Main) {
-                    uploadTeamActivities(context, uploadManager)
-                }
-            }
-        }
-
-        private fun uploadTeamActivities(context: Context, uploadManager: UploadManager) {
-            MainApplication.applicationScope.launch {
-                try {
-                    withContext(Dispatchers.IO) {
-                        uploadManager.uploadTeams()
-                    }
-                    withContext(Dispatchers.IO) {
-                        val apiInterface = client?.create(ApiInterface::class.java)
-                        DatabaseService(context).withRealm { realm ->
-                            realm.executeTransaction { transactionRealm ->
-                                uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
-                            }
-                        }
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
@@ -16,5 +15,5 @@ interface TeamRepository {
     suspend fun leaveTeam(teamId: String, userId: String?)
     suspend fun deleteTask(taskId: String)
     suspend fun upsertTask(task: RealmTeamTask)
-    suspend fun syncTeamActivities(context: Context, uploadManager: UploadManager)
+    suspend fun syncTeamActivities(context: Context)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -1,10 +1,16 @@
 package org.ole.planet.myplanet.repository
 
 import android.content.Context
+import androidx.core.net.toUri
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import java.util.Date
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.ole.planet.myplanet.MainApplication
+import org.ole.planet.myplanet.datamanager.ApiClient.client
+import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
@@ -13,10 +19,13 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
+import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
+import org.ole.planet.myplanet.utilities.ServerUrlMapper
 
 class TeamRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
     private val userProfileDbHandler: UserProfileDbHandler,
+    private val uploadManager: UploadManager,
 ) : RealmRepository(databaseService), TeamRepository {
 
     override suspend fun getTeamResources(teamId: String): List<RealmMyLibrary> {
@@ -118,8 +127,44 @@ class TeamRepositoryImpl @Inject constructor(
         save(task)
     }
 
-    override suspend fun syncTeamActivities(context: Context, uploadManager: UploadManager) {
-        RealmMyTeam.syncTeamActivities(context, uploadManager)
+    override suspend fun syncTeamActivities(context: Context) {
+        val applicationContext = context.applicationContext
+        val settings = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val updateUrl = settings.getString("serverURL", "") ?: ""
+        val serverUrlMapper = ServerUrlMapper()
+        val mapping = serverUrlMapper.processUrl(updateUrl)
+
+        val primaryAvailable = MainApplication.isServerReachable(mapping.primaryUrl)
+        val alternativeAvailable =
+            mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
+
+        if (!primaryAvailable && alternativeAvailable) {
+            mapping.alternativeUrl?.let { alternativeUrl ->
+                val uri = updateUrl.toUri()
+                val editor = settings.edit()
+                serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, settings)
+            }
+        }
+
+        uploadTeamActivities()
+    }
+
+    private suspend fun uploadTeamActivities() {
+        try {
+            withContext(Dispatchers.IO) {
+                uploadManager.uploadTeams()
+            }
+            val apiInterface = client?.create(ApiInterface::class.java)
+            withContext(Dispatchers.IO) {
+                withRealm { realm ->
+                    realm.executeTransaction { transactionRealm ->
+                        uploadManager.uploadTeamActivities(transactionRealm, apiInterface)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     private suspend fun getResourceIds(teamId: String): List<String> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -14,14 +14,15 @@ import androidx.core.graphics.toColorInt
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.RecyclerView
 import io.realm.Realm
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemTeamListBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.repository.TeamRepository
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
@@ -33,7 +34,6 @@ class AdapterTeamList(
     private val list: List<RealmMyTeam>,
     private val mRealm: Realm,
     private val fragmentManager: FragmentManager,
-    private val uploadManager: UploadManager,
     private val teamRepository: TeamRepository,
 ) : RecyclerView.Adapter<AdapterTeamList.ViewHolderTeam>() {
     private lateinit var itemTeamListBinding: ItemTeamListBinding
@@ -231,7 +231,9 @@ class AdapterTeamList(
     }
 
     private fun syncTeamActivities() {
-        runBlocking { teamRepository.syncTeamActivities(context, uploadManager) }
+        MainApplication.applicationScope.launch {
+            teamRepository.syncTeamActivities(context)
+        }
     }
 
     private fun getBundle(team: RealmMyTeam): Bundle {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -27,12 +27,10 @@ import org.ole.planet.myplanet.callback.TableDataUpdate
 import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMemberCount
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.service.sync.RealtimeSyncCoordinator
 import org.ole.planet.myplanet.ui.team.TeamPageConfig.ApplicantsPage
@@ -64,9 +62,6 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     @Inject
     lateinit var syncManager: SyncManager
 
-    @Inject
-    lateinit var uploadManager: UploadManager
-    
     private val syncCoordinator = RealtimeSyncCoordinator.getInstance()
     private lateinit var realtimeSyncListener: BaseRealtimeSyncListener
 
@@ -291,7 +286,9 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
                 RealmMyTeam.requestToJoin(teamId, user, mRealm, team?.teamType)
                 binding.btnLeave.text = getString(R.string.requested)
                 binding.btnLeave.isEnabled = false
-                syncTeamActivities(requireContext(), uploadManager)
+                viewLifecycleOwner.lifecycleScope.launch {
+                    teamRepository.syncTeamActivities(requireContext())
+                }
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -28,7 +28,6 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getMyTeamsByUserId
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.TeamRepository
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.Constants
@@ -50,8 +49,6 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private var teamList: RealmResults<RealmMyTeam>? = null
     private lateinit var adapterTeamList: AdapterTeamList
     private var conditionApplied: Boolean = false
-    @Inject
-    lateinit var uploadManager: UploadManager
     private val settings by lazy {
         requireActivity().getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE)
     }
@@ -259,7 +256,6 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                         sortedList,
                         mRealm,
                         childFragmentManager,
-                        uploadManager,
                         teamRepository,
                     )
                     adapterTeamList.setTeamListener(this@TeamFragment)
@@ -289,7 +285,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private fun setTeamList() {
         val list = teamList ?: return
         adapterTeamList = activity?.let {
-            AdapterTeamList(it, list, mRealm, childFragmentManager, uploadManager, teamRepository)
+            AdapterTeamList(it, list, mRealm, childFragmentManager, teamRepository)
         } ?: return
         adapterTeamList.setType(type)
         adapterTeamList.setTeamListener(this@TeamFragment)
@@ -334,7 +330,6 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                 sortedList,
                 mRealm,
                 childFragmentManager,
-                uploadManager,
                 teamRepository,
             ).apply {
                 setType(type)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterMemberRequest.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterMemberRequest.kt
@@ -10,12 +10,20 @@ import org.ole.planet.myplanet.callback.MemberChangeListener
 import org.ole.planet.myplanet.databinding.RowMemberRequestBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMember
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.syncTeamActivities
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
+import org.ole.planet.myplanet.MainApplication
+import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.utilities.Utilities
+import kotlinx.coroutines.launch
 
-class AdapterMemberRequest(private val context: Context, private val list: MutableList<RealmUserModel>, private val mRealm: Realm, private val currentUser: RealmUserModel, private val listener: MemberChangeListener, private val uploadManager: UploadManager) : RecyclerView.Adapter<AdapterMemberRequest.ViewHolderUser>() {
+class AdapterMemberRequest(
+    private val context: Context,
+    private val list: MutableList<RealmUserModel>,
+    private val mRealm: Realm,
+    private val currentUser: RealmUserModel,
+    private val listener: MemberChangeListener,
+    private val teamRepository: TeamRepository,
+) : RecyclerView.Adapter<AdapterMemberRequest.ViewHolderUser>() {
     private lateinit var rowMemberRequestBinding: RowMemberRequestBinding
     private var teamId: String? = null
     private lateinit var team: RealmMyTeam
@@ -106,7 +114,9 @@ class AdapterMemberRequest(private val context: Context, private val list: Mutab
                 }
             }
         }, {
-            syncTeamActivities(context, uploadManager)
+            MainApplication.applicationScope.launch {
+                teamRepository.syncTeamActivities(context)
+            }
             listener.onMemberChanged()
         }, { error ->
             list.add(position, userModel)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MembersFragment.kt
@@ -12,7 +12,6 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getRequestedMember
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 
 @AndroidEntryPoint
@@ -20,9 +19,6 @@ class MembersFragment : BaseMemberFragment() {
 
     private lateinit var currentUser: RealmUserModel
     private lateinit var memberChangeListener: MemberChangeListener
-
-    @Inject
-    lateinit var uploadManager: UploadManager
 
     fun setMemberChangeListener(listener: MemberChangeListener) {
         this.memberChangeListener = listener
@@ -43,8 +39,14 @@ class MembersFragment : BaseMemberFragment() {
         get() = getRequestedMember(teamId, mRealm)
 
     override val adapter: RecyclerView.Adapter<*>
-        get() = AdapterMemberRequest(requireActivity(), list.toMutableList(),
-            mRealm, currentUser, memberChangeListener, uploadManager).apply { setTeamId(teamId) }
+        get() = AdapterMemberRequest(
+            requireActivity(),
+            list.toMutableList(),
+            mRealm,
+            currentUser,
+            memberChangeListener,
+            teamRepository,
+        ).apply { setTeamId(teamId) }
 
     override val layoutManager: RecyclerView.LayoutManager
         get() {


### PR DESCRIPTION
## Summary
- move team activity upload orchestration into `TeamRepositoryImpl` using the injected `UploadManager` and `DatabaseService`
- remove the legacy companion sync entry point from `RealmMyTeam`
- update team UI flows to call the repository method and launch the work asynchronously

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68c9cc773a28832ba3e19a304308f3e8