### PR TITLE
Remove unused enrolled courses repository methods

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
@@ -4,7 +4,6 @@ import org.ole.planet.myplanet.model.RealmMyCourse
 
 interface CourseRepository {
     suspend fun getAllCourses(): List<RealmMyCourse>
-    suspend fun getEnrolledCourses(userId: String): List<RealmMyCourse>
     suspend fun updateMyCourseFlag(courseId: String, isMyCourse: Boolean)
     suspend fun updateMyCourseFlag(courseIds: List<String>, isMyCourse: Boolean) {
         courseIds.forEach { updateMyCourseFlag(it, isMyCourse) }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -12,12 +12,6 @@ class CourseRepositoryImpl @Inject constructor(
         return queryList(RealmMyCourse::class.java)
     }
 
-    override suspend fun getEnrolledCourses(userId: String): List<RealmMyCourse> {
-        return queryList(RealmMyCourse::class.java) {
-            equalTo("userId", userId)
-        }
-    }
-
     override suspend fun updateMyCourseFlag(courseId: String, isMyCourse: Boolean) {
         update(RealmMyCourse::class.java, "courseId", courseId) { it.isMyCourse = isMyCourse }
     }


### PR DESCRIPTION
## Summary
- remove the enrolled course query from CourseRepository
- delete the corresponding implementation from CourseRepositoryImpl

## Testing
- ./gradlew testDefaultDebugUnitTest --console=plain
- ./gradlew testLiteDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ca87689e48832b87f7f14f825bc55e