### PR TITLE
resources: less library repository methods is more (fixes #7662)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3183
-        versionName = "0.31.83"
+        versionCode = 3186
+        versionName = "0.31.86"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
@@ -6,7 +6,6 @@ interface LibraryRepository {
     suspend fun getAllLibraryItems(): List<RealmMyLibrary>
     suspend fun getLibraryItemById(id: String): RealmMyLibrary?
     suspend fun getLibraryItemByResourceId(resourceId: String): RealmMyLibrary?
-    suspend fun getLibraryByResourceId(resourceId: String): RealmMyLibrary?
     suspend fun getLibraryItemsByLocalAddress(localAddress: String): List<RealmMyLibrary>
     suspend fun getLibraryListForUser(userId: String?): List<RealmMyLibrary>
     suspend fun getAllLibraryList(): List<RealmMyLibrary>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -23,10 +23,6 @@ class LibraryRepositoryImpl @Inject constructor(
         return findByField(RealmMyLibrary::class.java, "_id", resourceId)
     }
 
-    override suspend fun getLibraryByResourceId(resourceId: String): RealmMyLibrary? {
-        return findByField(RealmMyLibrary::class.java, "resourceId", resourceId)
-    }
-
     override suspend fun getLibraryItemsByLocalAddress(localAddress: String): List<RealmMyLibrary> {
         return queryList(RealmMyLibrary::class.java) {
             equalTo("resourceLocalAddress", localAddress)
@@ -91,7 +87,9 @@ class LibraryRepositoryImpl @Inject constructor(
                 onRemove(realm, "resources", userId, resourceId)
             }
         }
-        return getLibraryByResourceId(resourceId)
+        return findByField(RealmMyLibrary::class.java, "resourceId", resourceId)
+            ?: getLibraryItemById(resourceId)
+            ?: getLibraryItemByResourceId(resourceId)
     }
 
     override suspend fun deleteLibraryItem(id: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -36,6 +36,12 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     private lateinit var library: RealmMyLibrary
     var userModel: RealmUserModel? = null
     private val fragmentScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+    private suspend fun fetchLibrary(libraryId: String): RealmMyLibrary? {
+        return libraryRepository.getLibraryItemById(libraryId)
+            ?: libraryRepository.getLibraryItemByResourceId(libraryId)
+            ?: libraryRepository.getAllLibraryItems().firstOrNull { it.resourceId == libraryId }
+    }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
@@ -51,7 +57,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             }
             withContext(Dispatchers.IO) {
                 try {
-                    val backgroundLibrary = libraryRepository.getLibraryByResourceId(libraryId!!)
+                    val backgroundLibrary = fetchLibrary(libraryId!!)
                     if (backgroundLibrary != null && backgroundLibrary.userId?.contains(userId) != true && userId != null) {
                         library = libraryRepository.updateUserLibrary(libraryId!!, userId, true)!!
                     } else if (backgroundLibrary != null) {
@@ -76,7 +82,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
         _binding = FragmentLibraryDetailBinding.inflate(inflater, container, false)
         userModel = UserProfileDbHandler(requireContext()).userModel!!
         library = runBlocking {
-            libraryRepository.getLibraryByResourceId(libraryId!!)
+            fetchLibrary(libraryId!!)
         }!!
         return binding.root
     }


### PR DESCRIPTION
## Summary
- remove the library repository method that queried by `resourceId`
- inline the resourceId lookup in the repository implementation and fall back to other identifiers
- update resource detail fragment to resolve library items without the removed repository API

## Testing
- ./gradlew lintDefaultDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ca8774b4e8832b95aa0ba7671fd9cf