### PR TITLE
all: less team repository syncing is more (fixes #7663)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3183
-        versionName = "0.31.83"
+        versionCode = 3187
+        versionName = "0.31.87"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -1,10 +1,8 @@
 package org.ole.planet.myplanet.repository
 
-import android.content.Context
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
@@ -16,5 +14,4 @@ interface TeamRepository {
     suspend fun leaveTeam(teamId: String, userId: String?)
     suspend fun deleteTask(taskId: String)
     suspend fun upsertTask(task: RealmTeamTask)
-    suspend fun syncTeamActivities(context: Context, uploadManager: UploadManager)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import java.util.Date
@@ -10,7 +9,6 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UploadManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 
@@ -116,10 +114,6 @@ class TeamRepositoryImpl @Inject constructor(
             task.sync = Gson().toJson(syncObj)
         }
         save(task)
-    }
-
-    override suspend fun syncTeamActivities(context: Context, uploadManager: UploadManager) {
-        RealmMyTeam.syncTeamActivities(context, uploadManager)
     }
 
     private suspend fun getResourceIds(teamId: String): List<String> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -231,7 +231,7 @@ class AdapterTeamList(
     }
 
     private fun syncTeamActivities() {
-        runBlocking { teamRepository.syncTeamActivities(context, uploadManager) }
+        RealmMyTeam.syncTeamActivities(context, uploadManager)
     }
 
     private fun getBundle(team: RealmMyTeam): Bundle {


### PR DESCRIPTION
## Summary
- drop the syncTeamActivities contract from TeamRepository and its Realm implementation
- update the team list adapter to call RealmMyTeam.syncTeamActivities directly so it no longer relies on the repository

## Testing
- `./gradlew testDefaultDebugUnitTest testLiteDebugUnitTest --console=plain` *(fails: Gradle daemon disappeared during execution)*
- `./gradlew connectedDefaultDebugAndroidTest connectedLiteDebugAndroidTest --console=plain` *(fails: No connected devices available)*

------
https://chatgpt.com/codex/tasks/task_e_68ca87a41d2c832bb5978f722fe19ca3