### PR TITLE
all: less submission repository methods is more (fixes #7663)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3183
-        versionName = "0.31.83"
+        versionCode = 3187
+        versionName = "0.31.87"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -9,11 +9,9 @@ interface SubmissionRepository {
     suspend fun getSurveyTitlesFromSubmissions(submissions: List<RealmSubmission>): List<String>
     suspend fun getSubmissionById(id: String): RealmSubmission?
     suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission>
-    suspend fun getSubmissionsByType(type: String): List<RealmSubmission>
     suspend fun getExamMapForSubmissions(submissions: List<RealmSubmission>): Map<String?, RealmStepExam>
     suspend fun getExamQuestionCount(stepId: String): Int
     suspend fun createSurveySubmission(examId: String, userId: String?)
     suspend fun saveSubmission(submission: RealmSubmission)
     suspend fun updateSubmission(id: String, updater: (RealmSubmission) -> Unit)
-    suspend fun deleteSubmission(id: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -88,12 +88,6 @@ class SubmissionRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getSubmissionsByType(type: String): List<RealmSubmission> {
-        return queryList(RealmSubmission::class.java) {
-            equalTo("type", type)
-        }
-    }
-
     override suspend fun createSurveySubmission(examId: String, userId: String?) {
         withRealm { realm ->
             val exam = realm.where(RealmStepExam::class.java).equalTo("id", examId).findFirst()
@@ -133,7 +127,4 @@ class SubmissionRepositoryImpl @Inject constructor(
         update(RealmSubmission::class.java, "id", id, updater)
     }
 
-    override suspend fun deleteSubmission(id: String) {
-        delete(RealmSubmission::class.java, "id", id)
-    }
 }


### PR DESCRIPTION
## Summary
- remove unused submission-related APIs from `SubmissionRepository`
- drop corresponding overrides from `SubmissionRepositoryImpl`

## Testing
- ./gradlew :app:testDefaultDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ca87e26338832bab9f03a80ea04373