### PR TITLE
Refactor Realm inserts to use repository helper

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SearchRepositoryImpl.kt
@@ -24,25 +24,26 @@ class SearchRepositoryImpl @Inject constructor(
         gradeLevel: String,
         subjectLevel: String
     ) {
-        executeTransaction { realm ->
-            val activity = realm.createObject(RealmSearchActivity::class.java, UUID.randomUUID().toString())
-            activity.user = userId ?: ""
-            activity.time = Calendar.getInstance().timeInMillis
-            activity.createdOn = userPlanetCode ?: ""
-            activity.parentCode = userParentCode ?: ""
-            activity.text = searchText
-            activity.type = "courses"
-
-            val filter = JsonObject()
+        val filter = JsonObject().apply {
             val tagsArray = JsonArray()
             tags.forEach { tag ->
                 tagsArray.add(tag.name)
             }
-            filter.add("tags", tagsArray)
-            filter.addProperty("doc.gradeLevel", gradeLevel)
-            filter.addProperty("doc.subjectLevel", subjectLevel)
-
-            activity.filter = gson.toJson(filter)
+            add("tags", tagsArray)
+            addProperty("doc.gradeLevel", gradeLevel)
+            addProperty("doc.subjectLevel", subjectLevel)
         }
+
+        val activity = RealmSearchActivity(UUID.randomUUID().toString()).apply {
+            user = userId ?: ""
+            time = Calendar.getInstance().timeInMillis
+            createdOn = userPlanetCode ?: ""
+            parentCode = userParentCode ?: ""
+            text = searchText
+            type = "courses"
+            this.filter = gson.toJson(filter)
+        }
+
+        save(activity)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -72,17 +72,18 @@ class TeamRepositoryImpl @Inject constructor(
         val userId = user?.id ?: return
         val userPlanetCode = user?.planetCode
         if (teamId.isBlank()) return
-        executeTransaction { realm ->
-            val request = realm.createObject(RealmMyTeam::class.java, AndroidDecrypter.generateIv())
-            request.docType = "request"
-            request.createdDate = Date().time
-            request.teamType = teamType
-            request.userId = userId
-            request.teamId = teamId
-            request.updated = true
-            request.teamPlanetCode = userPlanetCode
-            request.userPlanetCode = userPlanetCode
+        val request = RealmMyTeam().apply {
+            _id = AndroidDecrypter.generateIv()
+            docType = "request"
+            createdDate = Date().time
+            teamType = teamType
+            this.userId = userId
+            this.teamId = teamId
+            updated = true
+            teamPlanetCode = userPlanetCode
+            userPlanetCode = userPlanetCode
         }
+        save(request)
     }
 
     override suspend fun leaveTeam(teamId: String, userId: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -76,12 +76,12 @@ class TeamRepositoryImpl @Inject constructor(
             _id = AndroidDecrypter.generateIv()
             docType = "request"
             createdDate = Date().time
-            teamType = teamType
+            this.teamType = teamType
             this.userId = userId
             this.teamId = teamId
             updated = true
-            teamPlanetCode = userPlanetCode
-            userPlanetCode = userPlanetCode
+            this.teamPlanetCode = userPlanetCode
+            this.userPlanetCode = userPlanetCode
         }
         save(request)
     }


### PR DESCRIPTION
## Summary
- instantiate RealmSearchActivity outside manual transactions and persist using the repository helper
- apply the same helper-based save flow to RealmMyTeam join requests
- drop redundant manual executeTransaction blocks now that save(...) handles persistence

## Testing
- ./gradlew test --console=plain *(fails: missing Android SDK Build-Tools 35 and Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8a6086d8832ba01acd136b53174e