### PR TITLE
Refactor task assignment handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -16,5 +16,6 @@ interface TeamRepository {
     suspend fun leaveTeam(teamId: String, userId: String?)
     suspend fun deleteTask(taskId: String)
     suspend fun upsertTask(task: RealmTeamTask)
+    suspend fun assignTask(taskId: String, assigneeId: String?)
     suspend fun syncTeamActivities(context: Context, uploadManager: UploadManager)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -118,6 +118,13 @@ class TeamRepositoryImpl @Inject constructor(
         save(task)
     }
 
+    override suspend fun assignTask(taskId: String, assigneeId: String?) {
+        update(RealmTeamTask::class.java, "id", taskId) { task ->
+            task.assignee = assigneeId
+            task.isUpdated = true
+        }
+    }
+
     override suspend fun syncTeamActivities(context: Context, uploadManager: UploadManager) {
         RealmMyTeam.syncTeamActivities(context, uploadManager)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
@@ -282,15 +282,17 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
                     return@setPositiveButton
                 }
                 val user = selectedItem as RealmUserModel
-                val userId = user.id
-                if (!mRealm.isInTransaction) {
-                    mRealm.beginTransaction()
+                val taskId = realmTeamTask?.id
+                if (taskId.isNullOrBlank()) {
+                    Toast.makeText(context, R.string.no_tasks, Toast.LENGTH_SHORT).show()
+                    return@setPositiveButton
                 }
-                realmTeamTask?.assignee = userId
-                Utilities.toast(activity, getString(R.string.assign_task_to) + " " + user.name)
-                mRealm.commitTransaction()
-                adapter.notifyDataSetChanged()
-                setAdapter()
+                viewLifecycleOwner.lifecycleScope.launch {
+                    teamRepository.assignTask(taskId, user.id)
+                    Utilities.toast(activity, getString(R.string.assign_task_to) + " " + user.name)
+                    adapter.notifyDataSetChanged()
+                    setAdapter()
+                }
             }.show()
     }
 


### PR DESCRIPTION
## Summary
- add an assignTask API to the team repository and implement it with Realm updates
- refactor TeamTaskFragment task assignment flow to call the repository from a coroutine

## Testing
- ./gradlew testDefaultDebugUnitTest --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68ca89b65620832bb54fa5625c68869a