### PR TITLE
Add helper to fetch detached team by id

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -2,12 +2,14 @@ package org.ole.planet.myplanet.repository
 
 import android.content.Context
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UploadManager
 
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
+    suspend fun getTeamByDocumentIdOrTeamId(id: String): RealmMyTeam?
     suspend fun isMember(userId: String?, teamId: String): Boolean
     suspend fun getTeamLeaderId(teamId: String): String?
     suspend fun isTeamLeader(teamId: String, userId: String?): Boolean

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -30,6 +30,24 @@ class TeamRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getTeamByDocumentIdOrTeamId(id: String): RealmMyTeam? {
+        if (id.isBlank()) return null
+        return withRealm { realm ->
+            val teamByDocumentId = realm.where(RealmMyTeam::class.java)
+                .equalTo("_id", id)
+                .findFirst()
+
+            if (teamByDocumentId != null) {
+                realm.copyFromRealm(teamByDocumentId)
+            } else {
+                realm.where(RealmMyTeam::class.java)
+                    .equalTo("teamId", id)
+                    .findFirst()
+                    ?.let { realm.copyFromRealm(it) }
+            }
+        }
+    }
+
     override suspend fun isMember(userId: String?, teamId: String): Boolean {
         userId ?: return false
         return queryList(RealmMyTeam::class.java) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
@@ -33,17 +33,12 @@ abstract class BaseTeamFragment : BaseNewsFragment() {
 
         if (shouldQueryTeamFromRealm()) {
             team = try {
-                mRealm.where(RealmMyTeam::class.java).equalTo("_id", teamId).findFirst()
-                    ?: throw IllegalArgumentException("Team not found for ID: $teamId")
+                runBlocking {
+                    teamRepository.getTeamByDocumentIdOrTeamId(teamId)
+                } ?: throw IllegalArgumentException("Team not found for ID: $teamId")
             } catch (e: IllegalArgumentException) {
                 e.printStackTrace()
-                try {
-                    mRealm.where(RealmMyTeam::class.java).equalTo("teamId", teamId).findFirst()
-                        ?: throw IllegalArgumentException("Team not found for ID: $teamId")
-                } catch (e: IllegalArgumentException) {
-                    e.printStackTrace()
-                    return
-                }
+                return
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a repository helper to fetch a team by document id or team id and return a detached RealmMyTeam
- implement the helper in TeamRepositoryImpl to try document id first, then team id, using copyFromRealm for detachment
- use the repository helper from BaseTeamFragment via runBlocking to remove direct Realm lookups while preserving error handling

## Testing
- ./gradlew --console=plain :app:lintVitalDefaultRelease

------
https://chatgpt.com/codex/tasks/task_e_68ca897ec14c832b975f88d6061f3945