### PR TITLE
chore: remove unused edge-to-edge padding helpers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/EdgeToEdgeUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/EdgeToEdgeUtils.kt
@@ -63,42 +63,6 @@ object EdgeToEdgeUtils {
     }
 
     /**
-     * Sets up edge-to-edge with only top padding (for activities with bottom navigation)
-     */
-    fun setupEdgeToEdgeWithTopPadding(
-        activity: Activity,
-        rootView: View,
-        lightStatusBar: Boolean = true,
-        lightNavigationBar: Boolean = true
-    ) {
-        configureEdgeToEdge(activity, rootView, lightStatusBar, lightNavigationBar)
-
-        ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, windowInsets ->
-            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.setPadding(insets.left, insets.top, insets.right, 0)
-            WindowInsetsCompat.CONSUMED
-        }
-    }
-
-    /**
-     * Sets up edge-to-edge with only bottom padding (for activities with toolbar)
-     */
-    fun setupEdgeToEdgeWithBottomPadding(
-        activity: Activity,
-        rootView: View,
-        lightStatusBar: Boolean = true,
-        lightNavigationBar: Boolean = true
-    ) {
-        configureEdgeToEdge(activity, rootView, lightStatusBar, lightNavigationBar)
-
-        ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, windowInsets ->
-            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.setPadding(insets.left, 0, insets.right, insets.bottom)
-            WindowInsetsCompat.CONSUMED
-        }
-    }
-
-    /**
      * Sets up edge-to-edge with keyboard handling
      */
     fun setupEdgeToEdgeWithKeyboard(


### PR DESCRIPTION
## Summary
- remove the unused `setupEdgeToEdgeWithTopPadding` and `setupEdgeToEdgeWithBottomPadding` helpers from `EdgeToEdgeUtils`
- rely on the remaining generic and keyboard-aware edge-to-edge utilities

## Testing
- ./gradlew lint --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cbfe019990832b812a2c925f34e7da