### PR TITLE
Remove unused realtime sync clear methods

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/RealtimeSyncCoordinator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/RealtimeSyncCoordinator.kt
@@ -131,11 +131,4 @@ class RealtimeSyncCoordinator {
         return tableProgress.toMap()
     }
     
-    fun clearProgress() {
-        tableProgress.clear()
-    }
-    
-    fun clearTableProgress(table: String) {
-        tableProgress.remove(table)
-    }
 }


### PR DESCRIPTION
## Summary
- remove the unused clearProgress and clearTableProgress helpers from RealtimeSyncCoordinator

## Testing
- ./gradlew --console=plain lint test

------
https://chatgpt.com/codex/tasks/task_e_68cbfeb69d68832bbe88dfbff7ee154a