### PR TITLE
Remove unused user profile persistence from repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -3,8 +3,6 @@ package org.ole.planet.myplanet.repository
 import org.ole.planet.myplanet.model.RealmUserModel
 
 interface UserRepository {
-    suspend fun getUserProfile(): String?
-    suspend fun saveUserData(data: String)
     suspend fun getCurrentUser(): RealmUserModel?
     suspend fun getUserById(userId: String): RealmUserModel?
     suspend fun getUserByName(username: String): RealmUserModel?

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -1,24 +1,12 @@
 package org.ole.planet.myplanet.repository
 
-import android.content.SharedPreferences
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.model.RealmUserModel
 
 class UserRepositoryImpl @Inject constructor(
-    databaseService: DatabaseService,
-    @AppPreferences private val preferences: SharedPreferences
+    databaseService: DatabaseService
 ) : RealmRepository(databaseService), UserRepository {
-
-    override suspend fun getUserProfile(): String? {
-        return preferences.getString("user_profile", null)
-    }
-
-    override suspend fun saveUserData(data: String) {
-        preferences.edit().putString("user_profile", data).apply()
-    }
-
     override suspend fun getCurrentUser(): RealmUserModel? {
         return findFirst(RealmUserModel::class.java)
     }


### PR DESCRIPTION
## Summary
- remove the user profile accessors from the `UserRepository` contract
- drop the unused shared preferences dependency from `UserRepositoryImpl`

## Testing
- ./gradlew lintDefaultDebug --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cbff208504832b9282f87eb02933ce