### PR TITLE
Refactor team resource link creation

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -17,6 +17,7 @@ interface TeamRepository {
     suspend fun hasPendingRequest(teamId: String, userId: String?): Boolean
     suspend fun requestToJoin(teamId: String, user: RealmUserModel?, teamType: String?)
     suspend fun leaveTeam(teamId: String, userId: String?)
+    suspend fun addResourceLinks(teamId: String, resources: List<RealmMyLibrary>, user: RealmUserModel?)
     suspend fun deleteTask(taskId: String)
     suspend fun upsertTask(task: RealmTeamTask)
     suspend fun assignTask(taskId: String, assigneeId: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -21,6 +21,7 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.ServerUrlMapper
+import java.util.UUID
 
 class TeamRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
@@ -134,6 +135,28 @@ class TeamRepositoryImpl @Inject constructor(
                 .findAll()
             memberships.forEach { member ->
                 member?.deleteFromRealm()
+            }
+        }
+    }
+
+    override suspend fun addResourceLinks(
+        teamId: String,
+        resources: List<RealmMyLibrary>,
+        user: RealmUserModel?,
+    ) {
+        if (teamId.isBlank() || resources.isEmpty() || user == null) return
+        executeTransaction { realm ->
+            resources.forEach { resource ->
+                val teamResource = realm.createObject(RealmMyTeam::class.java, UUID.randomUUID().toString())
+                teamResource.teamId = teamId
+                teamResource.title = resource.title
+                teamResource.status = user.parentCode
+                teamResource.resourceId = resource._id
+                teamResource.docType = "resourceLink"
+                teamResource.updated = true
+                teamResource.teamType = "local"
+                teamResource.teamPlanetCode = user.planetCode
+                teamResource.userPlanetCode = user.planetCode
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamResource/TeamResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamResource/TeamResourceFragment.kt
@@ -13,14 +13,12 @@ import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.UUID
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.TeamPageListener
 import org.ole.planet.myplanet.databinding.FragmentTeamResourceBinding
 import org.ole.planet.myplanet.databinding.MyLibraryAlertdialogBinding
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
 import org.ole.planet.myplanet.utilities.CheckboxListView
@@ -90,23 +88,12 @@ class TeamResourceFragment : BaseTeamFragment(), TeamPageListener, ResourceUpdat
 
             alertDialogBuilder.setView(myLibraryAlertdialogBinding.root)
                 .setPositiveButton(R.string.add) { _: DialogInterface?, _: Int ->
-
-                    if (!mRealm.isInTransaction) {
-                        mRealm.beginTransaction()
+                    val selectedResources = myLibraryAlertdialogBinding.alertDialogListView.selectedItemsList
+                        .map { index -> availableLibraries[index] }
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        teamRepository.addResourceLinks(teamId, selectedResources, user)
+                        showLibraryList()
                     }
-                    for (se in myLibraryAlertdialogBinding.alertDialogListView.selectedItemsList) {
-                        val team = mRealm.createObject(RealmMyTeam::class.java, UUID.randomUUID().toString())
-                        team.teamId = teamId
-                        team.title = availableLibraries[se].title
-                        team.status = user!!.parentCode
-                        team.resourceId = availableLibraries[se]._id
-                        team.docType = "resourceLink"
-                        team.updated = true
-                        team.teamType = "local"
-                        team.teamPlanetCode = user!!.planetCode
-                    }
-                    mRealm.commitTransaction()
-                    showLibraryList()
                 }.setNegativeButton(R.string.cancel, null)
 
             val alertDialog = alertDialogBuilder.create()


### PR DESCRIPTION
## Summary
- add a TeamRepository API to create resource links with Realm transactions
- update the team resource fragment to use the repository instead of local Realm writes
- ensure new links capture the current user's context while keeping the fragment focused on UI concerns

## Testing
- ./gradlew lint *(fails: Android SDK Platform 36 download archive error)*

------
https://chatgpt.com/codex/tasks/task_e_68cc22ba8244832b85e32b46ff4bb612