### PR TITLE
Refactor search activity persistence

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SearchRepositoryImpl.kt
@@ -24,25 +24,25 @@ class SearchRepositoryImpl @Inject constructor(
         gradeLevel: String,
         subjectLevel: String
     ) {
-        executeTransaction { realm ->
-            val activity = realm.createObject(RealmSearchActivity::class.java, UUID.randomUUID().toString())
-            activity.user = userId ?: ""
-            activity.time = Calendar.getInstance().timeInMillis
-            activity.createdOn = userPlanetCode ?: ""
-            activity.parentCode = userParentCode ?: ""
-            activity.text = searchText
-            activity.type = "courses"
+        val activity = RealmSearchActivity(id = UUID.randomUUID().toString())
+        activity.user = userId ?: ""
+        activity.time = Calendar.getInstance().timeInMillis
+        activity.createdOn = userPlanetCode ?: ""
+        activity.parentCode = userParentCode ?: ""
+        activity.text = searchText
+        activity.type = "courses"
 
-            val filter = JsonObject()
-            val tagsArray = JsonArray()
-            tags.forEach { tag ->
-                tagsArray.add(tag.name)
-            }
-            filter.add("tags", tagsArray)
-            filter.addProperty("doc.gradeLevel", gradeLevel)
-            filter.addProperty("doc.subjectLevel", subjectLevel)
-
-            activity.filter = gson.toJson(filter)
+        val filter = JsonObject()
+        val tagsArray = JsonArray()
+        tags.forEach { tag ->
+            tagsArray.add(tag.name)
         }
+        filter.add("tags", tagsArray)
+        filter.addProperty("doc.gradeLevel", gradeLevel)
+        filter.addProperty("doc.subjectLevel", subjectLevel)
+
+        activity.filter = gson.toJson(filter)
+
+        save(activity)
     }
 }


### PR DESCRIPTION
## Summary
- create the RealmSearchActivity instance with a generated id, populate its fields, and persist it through RealmRepository.save
- keep the Gson-based filter serialization while removing the direct Realm transaction usage

## Testing
- ./gradlew compileDefaultDebugKotlin --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68cc225d520c832bae4a5ab9e3ad9926