### PR TITLE
Refactor notification click paths to use repository helpers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -11,6 +11,21 @@ data class TaskNotificationMetadata(
     val teamName: String?,
 )
 
+data class SurveyNotificationDestination(
+    val examId: String,
+)
+
+data class TaskNotificationDestination(
+    val teamId: String,
+    val teamName: String?,
+    val teamType: String?,
+)
+
+data class JoinRequestNotificationDestination(
+    val teamId: String,
+    val teamName: String?,
+)
+
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
     suspend fun updateResourceNotification(userId: String?)
@@ -19,4 +34,7 @@ interface NotificationRepository {
     suspend fun markAllAsRead(userId: String)
     suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata?
     suspend fun getTaskNotificationMetadata(taskTitle: String): TaskNotificationMetadata?
+    suspend fun getSurveyNotificationDestination(examTitle: String?): SurveyNotificationDestination?
+    suspend fun getTaskNotificationDestination(taskId: String?): TaskNotificationDestination?
+    suspend fun getJoinRequestDestination(joinRequestId: String?): JoinRequestNotificationDestination?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -60,7 +60,9 @@ class NotificationRepositoryImpl @Inject constructor(
                 "unread" -> equalTo("isRead", false)
             }
             sort("createdAt", Sort.DESCENDING)
-        }.filter { it.message.isNotEmpty() && it.message != "INVALID" }
+        }
+            .filter { it.message.isNotEmpty() && it.message != "INVALID" }
+            .distinctBy { it.id }
     }
 
     override suspend fun markAsRead(notificationId: String) {


### PR DESCRIPTION
## Summary
- add notification repository DTOs for survey, task, and join request navigation
- implement repository helpers that resolve IDs and team metadata for notification clicks
- refactor the notifications fragment to fetch navigation data from the repository instead of raw Realm access

## Testing
- ./gradlew :app:lint *(fails: Installed Build Tools revision 35.0.0 is corrupted in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1f809b04832ba2f0af6a779aeb9b