### PR TITLE
Refactor notification metadata lookups

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -79,51 +79,32 @@ class NotificationRepositoryImpl @Inject constructor(
         val rawId = joinRequestId?.takeUnless { it.isBlank() } ?: return null
         val sanitizedId = rawId.removePrefix("join_request_")
 
-        return withRealm { realm ->
-            val joinRequest = realm.where(RealmMyTeam::class.java)
-                .equalTo("_id", sanitizedId)
-                .equalTo("docType", "request")
-                .findFirst()
+        val joinRequest = queryList(RealmMyTeam::class.java) {
+            equalTo("_id", sanitizedId)
+            equalTo("docType", "request")
+        }.firstOrNull() ?: return null
 
-            joinRequest?.let {
-                val teamName = it.teamId?.let { teamId ->
-                    realm.where(RealmMyTeam::class.java)
-                        .equalTo("_id", teamId)
-                        .findFirst()
-                        ?.name
-                }
-
-                val requesterName = it.userId?.let { userId ->
-                    realm.where(RealmUserModel::class.java)
-                        .equalTo("id", userId)
-                        .findFirst()
-                        ?.name
-                }
-
-                JoinRequestNotificationMetadata(requesterName, teamName)
-            }
+        val teamName = joinRequest.teamId?.let { teamId ->
+            findByField(RealmMyTeam::class.java, "_id", teamId)?.name
         }
+
+        val requesterName = joinRequest.userId?.let { userId ->
+            findByField(RealmUserModel::class.java, "id", userId)?.name
+        }
+
+        return JoinRequestNotificationMetadata(requesterName, teamName)
     }
 
     override suspend fun getTaskNotificationMetadata(taskTitle: String): TaskNotificationMetadata? {
         if (taskTitle.isBlank()) return null
 
-        return withRealm { realm ->
-            val task = realm.where(RealmTeamTask::class.java)
-                .equalTo("title", taskTitle)
-                .findFirst()
+        val task = findByField(RealmTeamTask::class.java, "title", taskTitle) ?: return null
 
-            task?.let {
-                val teamName = it.teamId?.let { teamId ->
-                    realm.where(RealmMyTeam::class.java)
-                        .equalTo("_id", teamId)
-                        .findFirst()
-                        ?.name
-                }
-
-                TaskNotificationMetadata(teamName)
-            }
+        val teamName = task.teamId?.let { teamId ->
+            findByField(RealmMyTeam::class.java, "_id", teamId)?.name
         }
+
+        return TaskNotificationMetadata(teamName)
     }
 }
 


### PR DESCRIPTION
## Summary
- refactor join request metadata retrieval to use repository helper queries
- simplify task notification metadata lookup and remove direct Realm access

## Testing
- ./gradlew --console=plain compileDefaultDebugKotlin compileLiteDebugKotlin

------
https://chatgpt.com/codex/tasks/task_e_68cc223d6624832bb22f48d102ae0e5f