### PR TITLE
Clean up profile database handler lifecycle

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
@@ -108,7 +108,9 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
                 shouldAutoOpenAfterDownload = false
                 pendingAutoOpenLibrary = null
                 if (library.isResourceOffline() || FileUtils.checkFileExist(requireContext(), UrlUtils.getUrl(library))) {
-                    ResourceOpener.openFileType(requireActivity(), library, "offline", profileDbHandler)
+                    profileDbHandler?.let {
+                        ResourceOpener.openFileType(requireActivity(), library, "offline", it)
+                    }
                 }
             }
         }
@@ -124,7 +126,7 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
                 }
                 true
             }
-            val userModel = UserProfileDbHandler(context).userModel
+            val userModel = profileDbHandler?.userModel
             if (userModel?.isGuest() == false) {
                 setOnClickListener {
                     homeItemClickListener?.showRatingDialog(type, id, title, listener)
@@ -203,17 +205,23 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
 
             val offlineItem = matchingItems.firstOrNull { it.isResourceOffline() }
             if (offlineItem != null) {
-                ResourceOpener.openFileType(requireActivity(), offlineItem, "offline", profileDbHandler)
+                profileDbHandler?.let {
+                    ResourceOpener.openFileType(requireActivity(), offlineItem, "offline", it)
+                }
                 return@launch
             }
 
             when {
-                items.isResourceOffline() -> ResourceOpener.openFileType(requireActivity(), items, "offline", profileDbHandler)
-                FileUtils.getFileExtension(items.resourceLocalAddress) == "mp4" -> ResourceOpener.openFileType(requireActivity(), items, "online", profileDbHandler)
+                items.isResourceOffline() -> profileDbHandler?.let {
+                    ResourceOpener.openFileType(requireActivity(), items, "offline", it)
+                }
+                FileUtils.getFileExtension(items.resourceLocalAddress) == "mp4" -> profileDbHandler?.let {
+                    ResourceOpener.openFileType(requireActivity(), items, "online", it)
+                }
                 else -> {
                     val arrayList = arrayListOf(UrlUtils.getUrl(items))
                     startDownloadWithAutoOpen(arrayList, items)
-                    profileDbHandler.setResourceOpenCount(items, KEY_RESOURCE_DOWNLOAD)
+                    profileDbHandler?.setResourceOpenCount(items, KEY_RESOURCE_DOWNLOAD)
                 }
             }
         }
@@ -300,7 +308,9 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
 
     private fun openFileType(items: RealmMyLibrary, videoType: String) {
         dismissProgressDialog()
-        ResourceOpener.openFileType(requireActivity(), items, videoType, profileDbHandler)
+        profileDbHandler?.let {
+            ResourceOpener.openFileType(requireActivity(), items, videoType, it)
+        }
     }
 
     private fun showResourceList(downloadedResources: List<RealmMyLibrary>) {
@@ -372,6 +382,8 @@ abstract class BaseContainerFragment : BaseResourceFragment() {
 
     override fun onDestroy() {
         dismissProgressDialog()
+        profileDbHandler?.onDestroy()
+        profileDbHandler = null
         super.onDestroy()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
@@ -99,7 +99,8 @@ abstract class BaseNewsFragment : BaseContainerFragment(), OnNewsItemClickListen
     }
 
     override fun onDestroy() {
-        profileDbHandler.onDestroy()
+        profileDbHandler?.onDestroy()
+        profileDbHandler = null
         super.onDestroy()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -87,7 +87,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         list = mutableListOf()
         mRealm = databaseService.realmInstance
         profileDbHandler = UserProfileDbHandler(requireActivity())
-        model = profileDbHandler.userModel
+        model = profileDbHandler?.userModel
         val adapter = getAdapter()
         recyclerView.adapter = adapter
         if (isMyCourseLib && adapter.itemCount != 0 && courseLib == "courses") {
@@ -125,12 +125,14 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
                     val myObject = mRealm.where(RealmMyLibrary::class.java)
                         .equalTo("resourceId", `object`.resourceId).findFirst()
                     createFromResource(myObject, mRealm, model?.id)
-                    onAdd(mRealm, "resources", profileDbHandler.userModel?.id, myObject?.resourceId)
+                    val userId = profileDbHandler?.userModel?.id
+                    onAdd(mRealm, "resources", userId, myObject?.resourceId)
                     toast(activity, getString(R.string.added_to_my_library))
                 } else {
                     val myObject = getMyCourse(mRealm, (`object` as RealmMyCourse).courseId)
                     createMyCourse(myObject, mRealm, model?.id)
-                    onAdd(mRealm, "courses", profileDbHandler.userModel?.id, myObject?.courseId)
+                    val userId = profileDbHandler?.userModel?.id
+                    onAdd(mRealm, "courses", userId, myObject?.courseId)
                     toast(activity, getString(R.string.added_to_my_courses))
                 }
                 

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -64,7 +64,7 @@ abstract class BaseResourceFragment : Fragment() {
     var homeItemClickListener: OnHomeItemClickListener? = null
     var model: RealmUserModel? = null
     protected lateinit var mRealm: Realm
-    lateinit var profileDbHandler: UserProfileDbHandler
+    var profileDbHandler: UserProfileDbHandler? = null
     var editor: SharedPreferences.Editor? = null
     var lv: CheckboxListView? = null
     var convertView: View? = null
@@ -387,16 +387,18 @@ abstract class BaseResourceFragment : Fragment() {
     fun addToLibrary(libraryItems: List<RealmMyLibrary?>, selectedItems: ArrayList<Int>) {
         if (!isRealmInitialized()) return
         
+        val userId = profileDbHandler?.userModel?.id ?: return
+
         try {
             if (!mRealm.isInTransaction) {
                 mRealm.beginTransaction()
             }
-            
+
             selectedItems.forEach { index ->
                 val item = libraryItems[index]
-                if (item?.userId?.contains(profileDbHandler.userModel?.id) == false) {
-                    item.setUserId(profileDbHandler.userModel?.id)
-                    RealmRemovedLog.onAdd(mRealm, "resources", profileDbHandler.userModel?.id, item.resourceId)
+                if (item?.userId?.contains(userId) == false) {
+                    item.setUserId(userId)
+                    RealmRemovedLog.onAdd(mRealm, "resources", userId, item.resourceId)
                 }
             }
             
@@ -415,15 +417,17 @@ abstract class BaseResourceFragment : Fragment() {
     fun addAllToLibrary(libraryItems: List<RealmMyLibrary?>) {
         if (!isRealmInitialized()) return
         
+        val userId = profileDbHandler?.userModel?.id ?: return
+
         try {
             if (!mRealm.isInTransaction) {
                 mRealm.beginTransaction()
             }
-            
+
             libraryItems.forEach { libraryItem ->
-                if (libraryItem?.userId?.contains(profileDbHandler.userModel?.id) == false) {
-                    libraryItem.setUserId(profileDbHandler.userModel?.id, mRealm)
-                    RealmRemovedLog.onAdd(mRealm, "resources", profileDbHandler.userModel?.id, libraryItem.resourceId)
+                if (libraryItem?.userId?.contains(userId) == false) {
+                    libraryItem.setUserId(userId, mRealm)
+                    RealmRemovedLog.onAdd(mRealm, "resources", userId, libraryItem.resourceId)
                 }
             }
             
@@ -440,6 +444,8 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     override fun onDestroy() {
+        profileDbHandler?.onDestroy()
+        profileDbHandler = null
         cleanupRealm()
         super.onDestroy()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -71,10 +71,10 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     private lateinit var offlineActivitiesResults: RealmResults<RealmOfflineActivity>
     fun onLoaded(v: View) {
         profileDbHandler = UserProfileDbHandler(requireContext())
-        model = profileDbHandler.userModel
-        fullName = profileDbHandler.userModel?.getFullName()
+        model = profileDbHandler?.userModel
+        fullName = profileDbHandler?.userModel?.getFullName()
         if (fullName?.trim().isNullOrBlank()) {
-            fullName = profileDbHandler.userModel?.name
+            fullName = profileDbHandler?.userModel?.name
             v.findViewById<LinearLayout>(R.id.ll_prompt).visibility = View.VISIBLE
             v.findViewById<LinearLayout>(R.id.ll_prompt).setOnClickListener {
                 if (!childFragmentManager.isStateSaved) {
@@ -103,11 +103,12 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
         }
 
         offlineActivitiesResults = mRealm.where(RealmOfflineActivity::class.java)
-            .equalTo("userName", profileDbHandler.userModel?.name)
+            .equalTo("userName", profileDbHandler?.userModel?.name)
             .equalTo("type", KEY_LOGIN)
             .findAllAsync()
         v.findViewById<TextView>(R.id.txtRole).text = getString(R.string.user_role, model?.getRoleAsString())
-        v.findViewById<TextView>(R.id.txtFullName).text =getString(R.string.user_name, fullName, profileDbHandler.offlineVisits)
+        val offlineVisits = profileDbHandler?.offlineVisits ?: 0
+        v.findViewById<TextView>(R.id.txtFullName).text =getString(R.string.user_name, fullName, offlineVisits)
     }
 
     override fun forceDownloadNewsImages() {
@@ -286,7 +287,8 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     override fun onDestroy() {
-        profileDbHandler.onDestroy()
+        profileDbHandler?.onDestroy()
+        profileDbHandler = null
         if (::myCoursesResults.isInitialized) {
             myCoursesResults.removeChangeListener(myCoursesChangeListener)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -53,7 +53,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
         super.onDownloadComplete()
         fragmentScope.launch {
             val userId = withContext(Dispatchers.Main) {
-                profileDbHandler.userModel?.id
+                profileDbHandler?.userModel?.id
             }
             withContext(Dispatchers.IO) {
                 try {
@@ -69,7 +69,8 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             }
             withContext(Dispatchers.Main) {
                 binding.btnDownload.setImageResource(R.drawable.ic_play)
-                if (!library.userId?.contains(profileDbHandler.userModel?.id)!!) {
+                val currentUserId = profileDbHandler?.userModel?.id
+                if (currentUserId != null && library.userId?.contains(currentUserId) != true) {
                     Utilities.toast(activity, getString(R.string.added_to_my_library))
                     binding.btnRemove.setImageResource(R.drawable.close_x)
                 }
@@ -109,7 +110,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
         fragmentScope.launch {
             withContext(Dispatchers.Main) {
                 try {
-                    profileDbHandler.setResourceOpenCount(library)
+                    profileDbHandler?.setResourceOpenCount(library)
                 } catch (ex: Exception) {
                     ex.printStackTrace()
                 }
@@ -162,7 +163,8 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             }
             openResource(library)
         }
-        val isAdd = !library.userId?.contains(profileDbHandler.userModel?.id)!!
+        val userId = profileDbHandler?.userModel?.id
+        val isAdd = userId?.let { library.userId?.contains(it) } != true
         if (userModel?.isGuest() != true) {
             binding.btnRemove.setImageResource(
                 if (isAdd) {
@@ -181,7 +183,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             binding.btnRemove.visibility = View.GONE
         }
         binding.btnRemove.setOnClickListener {
-            val userId = profileDbHandler.userModel?.id
+            val userId = profileDbHandler?.userModel?.id
             fragmentScope.launch {
                 withContext(Dispatchers.IO) {
                     try {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -214,7 +214,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         isMyCourseLib = arguments?.getBoolean("isMyCourseLib", false) ?: false
-        userModel = profileDbHandler.userModel
+        userModel = profileDbHandler?.userModel
         searchTags = ArrayList()
         config = Utilities.getCloudConfig().showClose(R.color.black_overlay)
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
@@ -69,7 +69,7 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), SurveyAdoptListen
         isTeam = arguments?.getBoolean("isTeam", false) == true
         teamId = arguments?.getString("teamId", null)
         profileDbHandler = UserProfileDbHandler(requireContext())
-        val userProfileModel = profileDbHandler.userModel
+        val userProfileModel = profileDbHandler?.userModel
         adapter = AdapterSurvey(requireActivity(), mRealm, userProfileModel?.id, isTeam, teamId, this, settings)
         prefManager = SharedPrefManager(requireContext())
         

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
@@ -29,7 +29,7 @@ abstract class BaseTeamFragment : BaseNewsFragment() {
         val communityName = settings.getString("communityName", "")
         teamId = requireArguments().getString("id", "") ?: "$communityName@$sParentCode"
         mRealm = databaseService.realmInstance
-        user = profileDbHandler.userModel?.let { mRealm.copyFromRealm(it) }
+        user = profileDbHandler?.userModel?.let { mRealm.copyFromRealm(it) }
 
         if (shouldQueryTeamFromRealm()) {
             team = try {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/JoinedMemberFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/JoinedMemberFragment.kt
@@ -53,8 +53,8 @@ class JoinedMemberFragment : BaseMemberFragment() {
                     getString(R.string.no_visit)
                 }
                 val visitCount = RealmTeamLog.getVisitCount(realm, member.name, teamId)
-                val offlineVisits = profileDbHandler.getOfflineVisits(member).toString()
-                val profileLastVisit = profileDbHandler.getLastVisit(member)
+                val offlineVisits = profileDbHandler?.getOfflineVisits(member)?.toString() ?: "0"
+                val profileLastVisit = profileDbHandler?.getLastVisit(member) ?: ""
                 JoinedMemberData(
                     member,
                     visitCount,


### PR DESCRIPTION
## Summary
- release `profileDbHandler` during fragment destruction to avoid leaking the handler
- reuse the shared profile database handler for rating interactions instead of creating new instances
- update dependent fragments to work with the nullable handler safely

## Testing
- ./gradlew lint --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cd59539138832b90f86137451e0251