### PR TITLE
resource download dialog in myCourses (fixes #7323)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -6,6 +6,7 @@ import android.content.DialogInterface
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
@@ -61,6 +62,8 @@ import org.ole.planet.myplanet.utilities.SharedPrefManager
 class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSelected, TagClickListener, RealtimeSyncMixin {
 
     companion object {
+        private const val TAG = "CoursesFragment"
+
         fun newInstance(isMyCourseLib: Boolean): CoursesFragment {
             val fragment = CoursesFragment()
             val args = Bundle()
@@ -707,5 +710,9 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             realtimeSyncHelper.cleanup()
         }
         super.onDestroyView()
+    }
+
+    override fun logDownloadDialog(message: String) {
+        Log.d(TAG, message)
     }
 }

--- a/app/src/main/res/layout/my_library_alertdialog.xml
+++ b/app/src/main/res/layout/my_library_alertdialog.xml
@@ -8,13 +8,14 @@
     android:padding="10dp">
 
     <ScrollView
+        android:id="@+id/downloadListScroll"
         android:layout_width="match_parent"
         android:layout_height="300dp"
         android:fillViewport="true"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
+        app:layout_constraintBottom_toTopOf="@id/snoozeLabel">
 
         <org.ole.planet.myplanet.utilities.CheckboxListView
             android:id="@+id/alertDialog_listView"
@@ -23,4 +24,28 @@
             android:minHeight="100dp"
             android:scrollbars="vertical"/>
     </ScrollView>
+
+    <TextView
+        android:id="@+id/snoozeLabel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingTop="12dp"
+        android:text="@string/download_dialog_snooze_label"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/downloadListScroll"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/snoozeSpinner"/>
+
+    <Spinner
+        android:id="@+id/snoozeSpinner"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/snoozeLabel"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="my_courses_download_snooze_labels">
+        <item>@string/download_dialog_snooze_option_one_hour</item>
+        <item>@string/download_dialog_snooze_option_six_hours</item>
+        <item>@string/download_dialog_snooze_option_one_day</item>
+        <item>@string/download_dialog_snooze_option_three_days</item>
+    </string-array>
+    <integer-array name="my_courses_download_snooze_durations">
+        <item>3600000</item>
+        <item>21600000</item>
+        <item>86400000</item>
+        <item>259200000</item>
+    </integer-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,12 @@
     <string name="download_selected">Download Selected</string>
     <string name="txt_cancel">Cancel</string>
     <string name="download_all">Download All</string>
+    <string name="remind_me_later">Remind me later</string>
+    <string name="download_dialog_snooze_label">Remind me again in:</string>
+    <string name="download_dialog_snooze_option_one_hour">1 hour</string>
+    <string name="download_dialog_snooze_option_six_hours">6 hours</string>
+    <string name="download_dialog_snooze_option_one_day">1 day</string>
+    <string name="download_dialog_snooze_option_three_days">3 days</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="add_to_mycourse">Add to my courses</string>
     <string name="join_selected">Join Selected</string>


### PR DESCRIPTION
fixes #7323 Add a snooze-backed guard so the myCourses download dialog shows at a controlled cadence.

------
https://chatgpt.com/codex/tasks/task_e_68cb00724c18832eb3464df28ec73453