### PR TITLE
Refactor notification metadata lookups

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -117,51 +117,36 @@ class NotificationRepositoryImpl @Inject constructor(
         val rawId = joinRequestId?.takeUnless { it.isBlank() } ?: return null
         val sanitizedId = rawId.removePrefix("join_request_")
 
-        return withRealm { realm ->
-            val joinRequest = realm.where(RealmMyTeam::class.java)
-                .equalTo("_id", sanitizedId)
-                .equalTo("docType", "request")
-                .findFirst()
+        val joinRequest =
+            findFirst(RealmMyTeam::class.java) {
+                equalTo("_id", sanitizedId)
+                equalTo("docType", "request")
+            } ?: return null
 
-            joinRequest?.let {
-                val teamName = it.teamId?.let { teamId ->
-                    realm.where(RealmMyTeam::class.java)
-                        .equalTo("_id", teamId)
-                        .findFirst()
-                        ?.name
-                }
-
-                val requesterName = it.userId?.let { userId ->
-                    realm.where(RealmUserModel::class.java)
-                        .equalTo("id", userId)
-                        .findFirst()
-                        ?.name
-                }
-
-                JoinRequestNotificationMetadata(requesterName, teamName)
-            }
+        val teamName = joinRequest.teamId?.let { teamId ->
+            findByField(RealmMyTeam::class.java, "_id", teamId)?.name
         }
+
+        val requesterName = joinRequest.userId?.let { userId ->
+            findByField(RealmUserModel::class.java, "id", userId)?.name
+        }
+
+        return JoinRequestNotificationMetadata(requesterName, teamName)
     }
 
     override suspend fun getTaskNotificationMetadata(taskTitle: String): TaskNotificationMetadata? {
         if (taskTitle.isBlank()) return null
 
-        return withRealm { realm ->
-            val task = realm.where(RealmTeamTask::class.java)
-                .equalTo("title", taskTitle)
-                .findFirst()
+        val task =
+            findFirst(RealmTeamTask::class.java) {
+                equalTo("title", taskTitle)
+            } ?: return null
 
-            task?.let {
-                val teamName = it.teamId?.let { teamId ->
-                    realm.where(RealmMyTeam::class.java)
-                        .equalTo("_id", teamId)
-                        .findFirst()
-                        ?.name
-                }
-
-                TaskNotificationMetadata(teamName)
-            }
+        val teamName = task.teamId?.let { teamId ->
+            findByField(RealmMyTeam::class.java, "_id", teamId)?.name
         }
+
+        return TaskNotificationMetadata(teamName)
     }
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -56,9 +56,13 @@ open class RealmRepository(private val databaseService: DatabaseService) {
             realm.findCopyByField(clazz, fieldName, value)
         }
 
-    protected suspend fun <T : RealmObject> findFirst(clazz: Class<T>): T? =
+    protected suspend fun <T : RealmObject> findFirst(
+        clazz: Class<T>,
+        builder: RealmQuery<T>.() -> Unit = {},
+    ): T? =
         withRealm { realm ->
             realm.where(clazz)
+                .apply(builder)
                 .findFirst()
                 ?.let { realm.copyFromRealm(it) }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -60,7 +60,7 @@ open class RealmRepository(private val databaseService: DatabaseService) {
         clazz: Class<T>,
         builder: RealmQuery<T>.() -> Unit = {},
     ): T? =
-        withRealm { realm ->
+        databaseService.withRealmAsync { realm ->
             realm.where(clazz)
                 .apply(builder)
                 .findFirst()


### PR DESCRIPTION
## Summary
- extend RealmRepository with a configurable findFirst helper
- refactor notification metadata queries to use repository helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd5c0d4520832bad92bbe2d1b0bbbf