### PR TITLE
Use repository to mark downloaded resources offline

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
@@ -13,4 +13,5 @@ interface LibraryRepository {
     suspend fun markResourceAdded(userId: String?, resourceId: String)
     suspend fun updateUserLibrary(resourceId: String, userId: String, isAdd: Boolean): RealmMyLibrary?
     suspend fun updateLibraryItem(id: String, updater: (RealmMyLibrary) -> Unit)
+    suspend fun markResourceOfflineByLocalAddress(localAddress: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -89,6 +89,18 @@ class LibraryRepositoryImpl @Inject constructor(
         update(RealmMyLibrary::class.java, "id", id, updater)
     }
 
+    override suspend fun markResourceOfflineByLocalAddress(localAddress: String) {
+        executeTransaction { realm ->
+            realm.where(RealmMyLibrary::class.java)
+                .equalTo("resourceLocalAddress", localAddress)
+                .findAll()
+                ?.forEach { library ->
+                    library.resourceOffline = true
+                    library.downloadedRev = library._rev
+                }
+        }
+    }
+
     private fun filterLibrariesNeedingUpdate(results: Collection<RealmMyLibrary>): List<RealmMyLibrary> {
         return results.filter { it.needToUpdate() }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DownloadUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DownloadUtils.kt
@@ -13,12 +13,19 @@ import androidx.core.content.edit
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.util.regex.Pattern
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.datamanager.DownloadWorker
 import org.ole.planet.myplanet.datamanager.MyDownloadService
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.repository.LibraryRepository
 
 object DownloadUtils {
     private const val DOWNLOAD_CHANNEL = "DownloadChannel"
@@ -238,19 +245,30 @@ object DownloadUtils {
     @JvmStatic
     fun updateResourceOfflineStatus(url: String) {
         val currentFileName = FileUtils.getFileNameFromUrl(url)
-        try {
-            MainApplication.service.withRealm { realm ->
-                realm.executeTransaction {
-                    realm.where(RealmMyLibrary::class.java)
-                        .equalTo("resourceLocalAddress", currentFileName)
-                        .findAll()?.forEach {
-                            it.resourceOffline = true
-                            it.downloadedRev = it._rev
-                        }
-                }
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
+        if (currentFileName.isBlank()) {
+            return
         }
+
+        MainApplication.applicationScope.launch(Dispatchers.IO) {
+            try {
+                libraryRepository.markResourceOfflineByLocalAddress(currentFileName)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private val libraryRepository: LibraryRepository by lazy {
+        val entryPoint = EntryPointAccessors.fromApplication(
+            MainApplication.context,
+            DownloadUtilsEntryPoint::class.java
+        )
+        entryPoint.libraryRepository()
+    }
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface DownloadUtilsEntryPoint {
+        fun libraryRepository(): LibraryRepository
     }
 }


### PR DESCRIPTION
## Summary
- extend LibraryRepository with an API for marking local resources offline and wire it up in the Realm implementation
- switch DownloadUtils to resolve LibraryRepository via a Hilt entry point and update matches on MainApplication.applicationScope
- skip work when the decoded file name is blank and remove the direct Realm usage from DownloadUtils

## Testing
- ./gradlew :app:lint *(fails: requires Android SDK Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_68cd60930cec832bb93a50dad2d9b441