### PR TITLE
Remove unused COLOR_MAP in constants

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/Constants.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/Constants.kt
@@ -10,7 +10,6 @@ import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyHealthPojo
-import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmOfflineActivity
@@ -33,7 +32,6 @@ object Constants {
     const val DISCLAIMER = R.string.disclaimer
     const val ABOUT = R.string.about
     const val PREFS_NAME = "OLE_PLANET"
-    private val COLOR_MAP = mutableMapOf<Class<*>, Int>()
     var classList = mutableMapOf<String, Class<*>>()
     var LABELS = mutableMapOf<String, String>()
     const val KEY_NOTIFICATION_SHOWN = "notification_shown"
@@ -46,14 +44,6 @@ object Constants {
             ShelfData("meetupIds", "meetups", "meetupId"),
             ShelfData("courseIds", "courses", "courseId"),
             ShelfData("myTeamIds", "teams", "teamId")
-        )
-        COLOR_MAP.putAll(
-            mapOf(
-                RealmMyLibrary::class.java to R.color.md_red_200,
-                RealmMyCourse::class.java to R.color.md_amber_200,
-                RealmMyTeam::class.java to R.color.md_green_200,
-                RealmMeetup::class.java to R.color.md_purple_200
-            )
         )
         LABELS = mutableMapOf(
             "Help Wanted" to "help",


### PR DESCRIPTION
## Summary
- remove the unused COLOR_MAP field from Constants
- clean up the related import

## Testing
- TERM=dumb ./gradlew lint --no-daemon --console=plain *(fails: missing /usr/lib/android-sdk/platforms/android-36/android.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d103570748832baf5c0cde461c0e47