### PR TITLE
Remove unused enhanced Retrofit client

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiClient.kt
@@ -10,12 +10,6 @@ import retrofit2.Retrofit
 
 object ApiClient {
     lateinit var client: Retrofit
-    lateinit var enhancedRetrofit: Retrofit
-
-    fun getEnhancedClient(): ApiInterface {
-        return enhancedRetrofit.create(ApiInterface::class.java)
-    }
-
     fun <T> executeWithRetry(operation: () -> Response<T>?): Response<T>? = runBlocking {
         RetryUtils.retry(
             maxAttempts = 3,

--- a/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
@@ -105,10 +105,8 @@ object NetworkModule {
     @Singleton
     fun provideApiClient(
         @StandardRetrofit retrofit: Retrofit,
-        @EnhancedRetrofit enhancedRetrofit: Retrofit,
     ): ApiClient {
         ApiClient.client = retrofit
-        ApiClient.enhancedRetrofit = enhancedRetrofit
         return ApiClient
     }
 }


### PR DESCRIPTION
## Summary
- drop the unused enhanced Retrofit instance from ApiClient
- simplify the NetworkModule provider to only configure the standard Retrofit client

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d103b96da8832bb0cdd281b922407c