### PR TITLE
Remove unused getUserByName repository method

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -5,6 +5,5 @@ import org.ole.planet.myplanet.model.RealmUserModel
 interface UserRepository {
     suspend fun getCurrentUser(): RealmUserModel?
     suspend fun getUserById(userId: String): RealmUserModel?
-    suspend fun getUserByName(username: String): RealmUserModel?
     suspend fun getAllUsers(): List<RealmUserModel>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -15,10 +15,6 @@ class UserRepositoryImpl @Inject constructor(
         return findByField(RealmUserModel::class.java, "id", userId)
     }
 
-    override suspend fun getUserByName(username: String): RealmUserModel? {
-        return findByField(RealmUserModel::class.java, "name", username)
-    }
-
     override suspend fun getAllUsers(): List<RealmUserModel> {
         return queryList(RealmUserModel::class.java)
     }


### PR DESCRIPTION
## Summary
- remove the unused `getUserByName` declaration from `UserRepository`
- drop the corresponding override from `UserRepositoryImpl`

## Testing
- ./gradlew lint --console=plain *(fails: missing Android SDK Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_68d1040d5c40832b90d33bce7b967e2f