### PR TITLE
Refine team resource removal flow

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -17,6 +17,7 @@ interface TeamRepository {
     suspend fun requestToJoin(teamId: String, user: RealmUserModel?, teamType: String?)
     suspend fun leaveTeam(teamId: String, userId: String?)
     suspend fun addResourceLinks(teamId: String, resources: List<RealmMyLibrary>, user: RealmUserModel?)
+    suspend fun removeResourceLink(teamId: String, resourceId: String)
     suspend fun deleteTask(taskId: String)
     suspend fun upsertTask(task: RealmTeamTask)
     suspend fun assignTask(taskId: String, assigneeId: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -139,6 +139,21 @@ class TeamRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun removeResourceLink(teamId: String, resourceId: String) {
+        if (teamId.isBlank() || resourceId.isBlank()) return
+        executeTransaction { realm ->
+            realm.where(RealmMyTeam::class.java)
+                .equalTo("teamId", teamId)
+                .equalTo("resourceId", resourceId)
+                .equalTo("docType", "resourceLink")
+                .findFirst()
+                ?.let { teamResource ->
+                    teamResource.resourceId = ""
+                    teamResource.updated = true
+                }
+        }
+    }
+
     override suspend fun deleteTask(taskId: String) {
         delete(RealmTeamTask::class.java, "id", taskId)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamResource/ResourceUpdateListner.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamResource/ResourceUpdateListner.kt
@@ -2,4 +2,5 @@ package org.ole.planet.myplanet.ui.team.teamResource
 
 interface  ResourceUpdateListner {
     fun onResourceListUpdated()
+    fun onResourceUpdateFailed(messageResId: Int)
 }


### PR DESCRIPTION
## Summary
- add a suspend removeResourceLink API to TeamRepository and implement it with Realm helpers
- refactor the team resource adapter to drop direct Realm access and expose a removal callback
- handle resource removal in TeamResourceFragment, updating the list and surfacing failures via ResourceUpdateListner

## Testing
- ./gradlew :app:lint --console=plain --no-daemon *(fails: Android SDK Platform 36 is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11a48a8c4832ba4de0b22f28e7653