### PR TITLE
Refactor notifications Realm lookups into repositories

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -11,6 +11,7 @@ interface SubmissionRepository {
     suspend fun getSubmissionById(id: String): RealmSubmission?
     suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission>
     suspend fun getExamMapForSubmissions(submissions: List<RealmSubmission>): Map<String?, RealmStepExam>
+    suspend fun getStepExamByName(name: String?): RealmStepExam?
     suspend fun getExamQuestionCount(stepId: String): Int
     suspend fun createSurveySubmission(examId: String, userId: String?)
     suspend fun saveSubmission(submission: RealmSubmission)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -102,6 +102,13 @@ class SubmissionRepositoryImpl @Inject constructor(
         }.toMap()
     }
 
+    override suspend fun getStepExamByName(name: String?): RealmStepExam? {
+        if (name.isNullOrBlank()) {
+            return null
+        }
+        return findByField(RealmStepExam::class.java, "name", name)
+    }
+
     override suspend fun getExamQuestionCount(stepId: String): Int {
         return findByField(RealmStepExam::class.java, "stepId", stepId)?.noOfQuestions ?: 0
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -21,4 +21,6 @@ interface TeamRepository {
     suspend fun upsertTask(task: RealmTeamTask)
     suspend fun assignTask(taskId: String, assigneeId: String?)
     suspend fun syncTeamActivities(context: Context)
+    suspend fun getTaskById(taskId: String?): RealmTeamTask?
+    suspend fun getJoinRequestById(joinRequestId: String?): RealmMyTeam?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -165,6 +165,26 @@ class TeamRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getTaskById(taskId: String?): RealmTeamTask? {
+        if (taskId.isNullOrBlank()) {
+            return null
+        }
+        return findByField(RealmTeamTask::class.java, "id", taskId)
+    }
+
+    override suspend fun getJoinRequestById(joinRequestId: String?): RealmMyTeam? {
+        if (joinRequestId.isNullOrBlank()) {
+            return null
+        }
+        return withRealm { realm ->
+            realm.where(RealmMyTeam::class.java)
+                .equalTo("_id", joinRequestId)
+                .equalTo("docType", "request")
+                .findFirst()
+                ?.let { realm.copyFromRealm(it) }
+        }
+    }
+
     override suspend fun syncTeamActivities(context: Context) {
         val applicationContext = context.applicationContext
         val settings = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -56,6 +56,7 @@ class TeamRepositoryImpl @Inject constructor(
     override suspend fun getTeamById(teamId: String): RealmMyTeam? {
         if (teamId.isBlank()) return null
         return findByField(RealmMyTeam::class.java, "_id", teamId)
+            ?: findByField(RealmMyTeam::class.java, "teamId", teamId)
     }
 
     override suspend fun isMember(userId: String?, teamId: String): Boolean {
@@ -170,6 +171,7 @@ class TeamRepositoryImpl @Inject constructor(
             return null
         }
         return findByField(RealmTeamTask::class.java, "id", taskId)
+            ?: findByField(RealmTeamTask::class.java, "_id", taskId)
     }
 
     override suspend fun getJoinRequestById(joinRequestId: String?): RealmMyTeam? {


### PR DESCRIPTION
## Summary
- add repository APIs to fetch step exams, team tasks, and join requests
- inject submission and team repositories into NotificationsFragment and replace direct Realm access
- clean up notification handling to use repository calls while keeping existing behaviour

## Testing
- ./gradlew :app:compileLiteDebugKotlin --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d11ac0bd60832b8b7817450a217860