### PR TITLE
Optimize resource notification count

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -26,9 +26,19 @@ class NotificationRepositoryImpl @Inject constructor(
     override suspend fun updateResourceNotification(userId: String?) {
         userId ?: return
 
-        val resourceCount = queryList(RealmMyLibrary::class.java) {
-            equalTo("isPrivate", false)
-        }.count { it.needToUpdate() && it.userId?.contains(userId) == true }
+        val resourceCount = withRealm { realm ->
+            val resources = realm.where(RealmMyLibrary::class.java)
+                .equalTo("isPrivate", false)
+                .findAll()
+
+            var count = 0
+            resources.forEach { resource ->
+                if (resource.userId?.contains(userId) == true && resource.needToUpdate()) {
+                    count++
+                }
+            }
+            count
+        }
 
         val existingNotification = findByField(RealmNotification::class.java, "userId", userId)
             ?.takeIf { it.type == "resource" }


### PR DESCRIPTION
## Summary
- compute the resource notification count within a managed Realm context to avoid creating large intermediate lists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d11f8ddde4832b889c1c6a0a9d176e