### PR TITLE
Refactor UploadManager to use managed Realm helpers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -40,6 +40,23 @@ class DatabaseService(context: Context) {
         }
     }
 
+    fun executeTransactionAsync(
+        transaction: (Realm) -> Unit,
+        onSuccess: (() -> Unit)? = null,
+        onError: ((Throwable) -> Unit)? = null,
+    ) {
+        val realm = Realm.getDefaultInstance()
+        realm.executeTransactionAsync({ backgroundRealm ->
+            transaction(backgroundRealm)
+        }, {
+            realm.close()
+            onSuccess?.invoke()
+        }, { error ->
+            realm.close()
+            onError?.invoke(error)
+        })
+    }
+
     suspend fun executeTransactionAsync(transaction: (Realm) -> Unit) {
         withContext(Dispatchers.IO) {
             withRealmInstance { realm ->


### PR DESCRIPTION
## Summary
- add a DatabaseService.executeTransactionAsync helper that closes Realm instances after callbacks
- refactor UploadManager to use withRealm/executeTransactionAsync wrappers instead of storing Realm handles manually
- update upload flows to rely on the new helpers so Realm instances are managed consistently

## Testing
- ./gradlew test *(fails: missing Android SDK Platform 36 on CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d120132e28832bac5abc63410ead7f