### PR TITLE
teams: experienced a crash while accepting a join request (fixes #7694)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -388,10 +388,15 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener {
     }
 
     override fun onMemberChanged() {
-        if(getJoinedMemberCount("${team?._id}", mRealm) <= 1){
-            binding.btnLeave.visibility = View.GONE
-        } else{
-            binding.btnLeave.visibility = View.VISIBLE
+        _binding ?: return
+        _binding?.let { binding ->
+            val teamId = team?._id ?: return@let
+            val joinedCount = getJoinedMemberCount(teamId, mRealm)
+            binding.btnLeave.visibility = if (joinedCount <= 1) {
+                View.GONE
+            } else {
+                View.VISIBLE
+            }
         }
     }
 


### PR DESCRIPTION
fixes #7694
- guard the member change UI updates behind a binding check so late callbacks after `onDestroyView` no longer crash

------
https://chatgpt.com/codex/tasks/task_e_68d16a267e64832baae09c4575d1f8f6