### PR TITLE
userprofile Image not showing (fixes #7696)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmUserModel.kt
@@ -166,10 +166,12 @@ open class RealmUserModel : RealmObject() {
             val obj = element.asJsonObject
             val entries = obj.entrySet()
             for ((key1) in entries) {
-                userImage = UrlUtils.getUserImageUrl(id, key1)
+                val remoteImageUrl = UrlUtils.getUserImageUrl(id, key1)
+                userImage = UrlUtils.sanitizeUserImageUrl(remoteImageUrl)
                 break
             }
         }
+        userImage = UrlUtils.sanitizeUserImageUrl(userImage)
     }
 
     fun isManager(): Boolean {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -53,6 +53,7 @@ import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.DownloadUtils
 import org.ole.planet.myplanet.utilities.FileUtils
+import org.ole.planet.myplanet.utilities.UrlUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCallback,
@@ -88,9 +89,10 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
             v.findViewById<LinearLayout>(R.id.ll_prompt).visibility = View.GONE
         }
         val imageView = v.findViewById<ImageView>(R.id.imageView)
-        if (!TextUtils.isEmpty(model?.userImage)) {
+        val userImageUrl = UrlUtils.sanitizeUserImageUrl(model?.userImage)
+        if (!TextUtils.isEmpty(userImageUrl)) {
             Glide.with(requireActivity())
-                .load(model?.userImage)
+                .load(userImageUrl)
                 .placeholder(R.drawable.profile)
                 .error(R.drawable.profile)
                 .into(imageView)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/UserListArrayAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/UserListArrayAdapter.kt
@@ -12,6 +12,7 @@ import com.bumptech.glide.Glide
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.utilities.TimeUtils
+import org.ole.planet.myplanet.utilities.UrlUtils
 
 class UserListArrayAdapter(activity: Activity, val view: Int, var list: List<RealmUserModel>) : ArrayAdapter<RealmUserModel>(activity, view, list) {
     private class ViewHolder {
@@ -41,10 +42,11 @@ class UserListArrayAdapter(activity: Activity, val view: Int, var list: List<Rea
             holder.joined?.text = context.getString(R.string.joined_colon, TimeUtils.formatDate(um.joinDate))
         }
 
-        if (!TextUtils.isEmpty(um?.userImage)) {
+        val sanitizedUserImage = UrlUtils.sanitizeUserImageUrl(um?.userImage)
+        if (!TextUtils.isEmpty(sanitizedUserImage)) {
             holder.image?.let {
                 Glide.with(it.context)
-                    .load(um?.userImage)
+                    .load(sanitizedUserImage)
                     .placeholder(R.drawable.profile)
                     .error(R.drawable.profile)
                     .into(it)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.kt
@@ -16,6 +16,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowJoinedUserBinding
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
+import org.ole.planet.myplanet.utilities.UrlUtils
 
 data class JoinedMemberData(
     val user: RealmUserModel,
@@ -58,8 +59,9 @@ class AdapterJoinedMember(
             R.string.last_visit,
             memberData.lastVisitDate
         )
+        val sanitizedUserImage = UrlUtils.sanitizeUserImageUrl(member.userImage)
         Glide.with(binding.memberImage.context)
-            .load(member.userImage)
+            .load(sanitizedUserImage)
             .placeholder(R.drawable.profile)
             .error(R.drawable.profile)
             .into(binding.memberImage)
@@ -88,7 +90,7 @@ class AdapterJoinedMember(
                 memberData.profileLastVisit,
                 "${member.firstName} ${member.lastName}",
                 member.level.toString(),
-                member.userImage
+                sanitizedUserImage
             )
             NavigationHelper.replaceFragment(
                 activity.supportFragmentManager,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/UserProfileFragment.kt
@@ -62,6 +62,7 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.TimeUtils
+import org.ole.planet.myplanet.utilities.UrlUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -179,7 +180,7 @@ class UserProfileFragment : Fragment() {
 
     private fun loadProfileImage() {
         val binding = _binding ?: return
-        val profileImageUrl = model?.userImage
+        val profileImageUrl = UrlUtils.sanitizeUserImageUrl(model?.userImage)
 
         if (profileImageUrl.isNullOrBlank()) {
             binding.image.setImageResource(R.drawable.profile)

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/ImageUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/ImageUtils.kt
@@ -6,9 +6,10 @@ import org.ole.planet.myplanet.R
 
 object ImageUtils {
     fun loadImage(userImage: String?, imageView: ImageView) {
-        if (!userImage.isNullOrEmpty()) {
+        val sanitizedUrl = UrlUtils.sanitizeUserImageUrl(userImage)
+        if (!sanitizedUrl.isNullOrEmpty()) {
             Glide.with(imageView.context)
-                .load(userImage)
+                .load(sanitizedUrl)
                 .placeholder(R.drawable.profile)
                 .error(R.drawable.profile)
                 .into(imageView)

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/UrlUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/UrlUtils.kt
@@ -74,7 +74,17 @@ object UrlUtils {
     }
 
     fun getUserImageUrl(userId: String?, imageName: String): String {
-        return "${getUrl()}/_users/$userId/$imageName"
+        val settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val base = baseUrl(settings).trimEnd('/')
+        return "$base/_users/$userId/$imageName"
+    }
+
+    fun sanitizeUserImageUrl(url: String?): String? {
+        if (url.isNullOrEmpty()) {
+            return url
+        }
+        val sanitized = url.replace("/db/_users/", "/_users/")
+        return sanitized.replace("//_users/", "/_users/")
     }
 
     fun getUrl(): String {


### PR DESCRIPTION
fixes #7696

- Build user image URLs from the base server path so profile photos load from the _users database directly.
- Sanitize previously cached profile image URLs at usage sites to strip legacy /db segments and avoid stale caching issues.

------
https://chatgpt.com/codex/tasks/task_e_68d16a738dc8832b8ea804ce7e2b04b2