### PR TITLE
Async team loading in TeamDetailFragment

### DIFF
--- a/app/src/main/res/layout/fragment_team_detail.xml
+++ b/app/src/main/res/layout/fragment_team_detail.xml
@@ -8,6 +8,7 @@
     tools:context=".ui.team.TeamDetailFragment">
 
     <LinearLayout
+        android:id="@+id/contentContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
@@ -93,4 +94,23 @@
                 android:background="@color/secondary_bg" />
         </LinearLayout>
     </LinearLayout>
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="@style/Widget.AppCompat.ProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/emptyStateText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:padding="16dp"
+        android:text="@string/no_team_available"
+        android:textColor="@color/daynight_textColor"
+        android:visibility="gone" />
+
 </FrameLayout>


### PR DESCRIPTION
## Summary
- fetch the current user via the injected `UserProfileDbHandler`
- move team lookup work onto a lifecycle-aware coroutine and update the UI on the main thread
- add loading and empty states to keep the team detail screen responsive while data loads

## Testing
- `./gradlew lint --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d28abe3288832b9ebdb21675085847