### PR TITLE
Use repository for team courses list

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
@@ -10,6 +10,7 @@ interface CourseRepository {
     suspend fun updateMyCourseFlag(courseIds: List<String>, isMyCourse: Boolean) {
         courseIds.forEach { updateMyCourseFlag(it, isMyCourse) }
     }
+    suspend fun getCoursesByIds(courseIds: Collection<String>): List<RealmMyCourse>
     suspend fun getCourseByCourseId(courseId: String?): RealmMyCourse?
     suspend fun getCourseOnlineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseOfflineResources(courseId: String?): List<RealmMyLibrary>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -28,6 +28,15 @@ class CourseRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getCoursesByIds(courseIds: Collection<String>): List<RealmMyCourse> {
+        if (courseIds.isEmpty()) {
+            return emptyList()
+        }
+        return queryList(RealmMyCourse::class.java) {
+            `in`("id", courseIds.toTypedArray())
+        }
+    }
+
     override suspend fun getCourseByCourseId(courseId: String?): RealmMyCourse? {
         return courseId?.let { findByField(RealmMyCourse::class.java, "courseId", it) }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
@@ -4,16 +4,24 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
+import org.ole.planet.myplanet.repository.CourseRepository
 
+@AndroidEntryPoint
 class TeamCourseFragment : BaseTeamFragment() {
     private var _binding: FragmentTeamCourseBinding? = null
     private val binding get() = _binding!!
     private var adapterTeamCourse: AdapterTeamCourse? = null
+    @Inject
+    lateinit var courseRepository: CourseRepository
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentTeamCourseBinding.inflate(inflater, container, false)
@@ -22,25 +30,16 @@ class TeamCourseFragment : BaseTeamFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.rvCourse.layoutManager = LinearLayoutManager(activity)
         setupCoursesList()
     }
-    
+
     private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { AdapterTeamCourse(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
-        binding.rvCourse.layoutManager = LinearLayoutManager(activity)
-        binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
-        }
+        loadAndSubmitCourses()
     }
-    
+
     fun updateCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse?.updateList(courses)
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
-        }
+        loadAndSubmitCourses()
     }
 
     override fun onNewsItemClick(news: RealmNews?) {}
@@ -52,5 +51,33 @@ class TeamCourseFragment : BaseTeamFragment() {
     override fun onDestroyView() {
         _binding = null
         super.onDestroyView()
+    }
+
+    private fun loadAndSubmitCourses() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val courses = loadTeamCourses()
+            submitCourses(courses)
+        }
+    }
+
+    private suspend fun loadTeamCourses(): List<RealmMyCourse> {
+        val courseIds = team?.courses?.mapNotNull { it } ?: emptyList()
+        if (courseIds.isEmpty()) {
+            return emptyList()
+        }
+        return courseRepository.getCoursesByIds(courseIds)
+    }
+
+    private fun submitCourses(courses: List<RealmMyCourse>) {
+        if (adapterTeamCourse == null) {
+            adapterTeamCourse = settings?.let {
+                AdapterTeamCourse(requireActivity(), courses.toMutableList(), mRealm, teamId, it)
+            }
+            binding.rvCourse.adapter = adapterTeamCourse
+        } else {
+            adapterTeamCourse?.updateList(courses)
+        }
+        val itemCount = adapterTeamCourse?.itemCount ?: 0
+        showNoData(binding.tvNodata, itemCount, "teamCourses")
     }
 }


### PR DESCRIPTION
## Summary
- add a repository API for loading courses by id collections
- implement the new API with a Realm `queryList` query
- inject and use the repository in `TeamCourseFragment` to load courses asynchronously

## Testing
- ./gradlew --console=plain :app:lint *(fails: Installed Build Tools revision 35.0.0 is corrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b27a34c8832b92623fa2d4820d1e