### PR TITLE
Refine feedback submission workflow

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
@@ -6,17 +6,16 @@ import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmUserModel
 
 interface FeedbackRepository {
-    fun createFeedback(
+    suspend fun submitFeedback(
         user: String?,
         urgent: String,
         type: String,
         message: String,
         item: String? = null,
         state: String? = null,
-    ): RealmFeedback
+    )
     fun getFeedback(userModel: RealmUserModel?): Flow<List<RealmFeedback>>
     suspend fun getFeedbackById(id: String?): RealmFeedback?
     suspend fun closeFeedback(id: String?)
     suspend fun addReply(id: String?, obj: JsonObject)
-    suspend fun saveFeedback(feedback: RealmFeedback)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -84,9 +84,8 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
         val type = rbType.text.toString()
         val item = arguments?.getString("item")
         val state = arguments?.getString("state")
-        val feedback = feedbackRepository.createFeedback(user, urgent, type, message, item, state)
         viewLifecycleOwner.lifecycleScope.launch {
-            feedbackRepository.saveFeedback(feedback)
+            feedbackRepository.submitFeedback(user, urgent, type, message, item, state)
             Utilities.toast(activity, R.string.feedback_saved.toString())
         }
         Toast.makeText(activity, R.string.thank_you_your_feedback_has_been_submitted, Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
## Summary
- replace the `createFeedback`/`saveFeedback` pair with a single `submitFeedback` entry point in the repository API
- move Realm entity construction and persistence into `FeedbackRepositoryImpl.submitFeedback`
- update `FeedbackFragment` to call the new repository method directly

## Testing
- ./gradlew :app:compileLiteDebugKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d2b3892518832b90af0c8c6bd25b42