### PR TITLE
Fix Realm flow helper and cleanup registration (fixes #7774)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/AdapterMyPersonal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/AdapterMyPersonal.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.RecyclerView
 import io.realm.Realm
+import io.realm.RealmObject
 import java.io.File
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnSelectedMyPersonal
@@ -35,7 +36,12 @@ class AdapterMyPersonal(private val context: Context, private var list: MutableL
     }
 
     fun updateList(newList: List<RealmMyPersonal>) {
-        val safeNewList = realm?.copyFromRealm(newList) ?: newList
+        val safeNewList =
+            if (realm != null && newList.any { RealmObject.isManaged(it) }) {
+                realm!!.copyFromRealm(newList)
+            } else {
+                newList
+            }
         val diffResult = DiffUtils.calculateDiff(
             list,
             safeNewList,


### PR DESCRIPTION
 fixes #7774

## Summary
- run Realm flow producers directly inside the callbackFlow builder and manage Realm lifecycle with an awaitClose hook
- update queryListFlow to send the initial snapshot, register its change listener, and hand back a cleanup block that removes it

## Testing
- ./gradlew testDefaultDebugUnitTest testLiteDebugUnitTest --console=plain --no-daemon


------
https://chatgpt.com/codex/tasks/task_e_68d2f8c79784832ba6deca9325ea6372