### PR TITLE
Remove course flag update operations

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
@@ -6,10 +6,6 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 
 interface CourseRepository {
     suspend fun getAllCourses(): List<RealmMyCourse>
-    suspend fun updateMyCourseFlag(courseId: String, isMyCourse: Boolean)
-    suspend fun updateMyCourseFlag(courseIds: List<String>, isMyCourse: Boolean) {
-        courseIds.forEach { updateMyCourseFlag(it, isMyCourse) }
-    }
     suspend fun getCourseByCourseId(courseId: String?): RealmMyCourse?
     suspend fun getCourseOnlineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseOfflineResources(courseId: String?): List<RealmMyLibrary>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -15,19 +15,6 @@ class CourseRepositoryImpl @Inject constructor(
         return queryList(RealmMyCourse::class.java)
     }
 
-    override suspend fun updateMyCourseFlag(courseId: String, isMyCourse: Boolean) {
-        update(RealmMyCourse::class.java, "courseId", courseId) { it.isMyCourse = isMyCourse }
-    }
-
-    override suspend fun updateMyCourseFlag(courseIds: List<String>, isMyCourse: Boolean) {
-        executeTransaction { realm ->
-            realm.where(RealmMyCourse::class.java)
-                .`in`("courseId", courseIds.toTypedArray())
-                .findAll()
-                .forEach { it.isMyCourse = isMyCourse }
-        }
-    }
-
     override suspend fun getCourseByCourseId(courseId: String?): RealmMyCourse? {
         return courseId?.let { findByField(RealmMyCourse::class.java, "courseId", it) }
     }


### PR DESCRIPTION
## Summary
- remove the updateMyCourseFlag overloads from CourseRepository and its implementation now that they are unused

## Testing
- ./gradlew compileDebugKotlin *(fails: Task 'compileDebugKotlin' is ambiguous in root project 'myplanet')*


------
https://chatgpt.com/codex/tasks/task_e_68d4240f7d10832bb8bcf7e2b448dad4