### PR TITLE
Remove unused user creation helpers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
@@ -114,16 +114,6 @@ class UserProfileDbHandler @Inject constructor(
         }
     }
 
-    private fun createUser(realm: Realm = mRealm): RealmOfflineActivity {
-        val offlineActivities = realm.createObject(RealmOfflineActivity::class.java, UUID.randomUUID().toString())
-        val model = userModel
-        offlineActivities.userId = model?.id
-        offlineActivities.userName = model?.name
-        offlineActivities.parentCode = model?.parentCode
-        offlineActivities.createdOn = model?.planetCode
-        return offlineActivities
-    }
-
     val lastVisit: Long? get() = mRealm.where(RealmOfflineActivity::class.java).max("loginTime") as Long?
     val offlineVisits: Int get() = getOfflineVisits(userModel)
 
@@ -175,14 +165,6 @@ class UserProfileDbHandler @Inject constructor(
             offlineActivities.resourceId = itemResourceId
             offlineActivities.time = Date().time
         }
-    }
-
-    private fun createResourceUser(model: RealmUserModel?): RealmResourceActivity {
-        val offlineActivities = mRealm.createObject(RealmResourceActivity::class.java, "${UUID.randomUUID()}")
-        offlineActivities.user = model?.name
-        offlineActivities.parentCode = model?.parentCode
-        offlineActivities.createdOn = model?.planetCode
-        return offlineActivities
     }
 
     val numberOfResourceOpen: String get() {


### PR DESCRIPTION
## Summary
- remove the unused createUser and createResourceUser helpers from UserProfileDbHandler

## Testing
- `./gradlew assembleDebug --console=plain` *(fails: missing Android SDK platform 36 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d424a54af4832b81f36ca8ce09320c