### PR TITLE
Annotate rating viewmodel for hilt and use viewModels in fragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
@@ -9,11 +9,11 @@ import android.view.ViewGroup
 import android.widget.RatingBar
 import android.widget.RatingBar.OnRatingBarChangeListener
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
@@ -26,8 +26,7 @@ import org.ole.planet.myplanet.utilities.Utilities
 class RatingFragment : DialogFragment() {
     private var _binding: FragmentRatingBinding? = null
     private val binding get() = _binding!!
-    @Inject
-    lateinit var viewModel: RatingViewModel
+    private val viewModel: RatingViewModel by viewModels()
     private var currentUser: RealmUserModel? = null
     var id: String? = ""
     var type: String? = ""

--- a/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingViewModel.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.ui.rating
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,6 +14,7 @@ import org.ole.planet.myplanet.repository.RatingRepository
 import org.ole.planet.myplanet.repository.RatingSummary
 import org.ole.planet.myplanet.repository.UserRepository
 
+@HiltViewModel
 class RatingViewModel @Inject constructor(
     private val ratingRepository: RatingRepository,
     private val userRepository: UserRepository


### PR DESCRIPTION
## Summary
- annotate RatingViewModel with HiltViewModel to enable injection via Hilt
- update RatingFragment to obtain the RatingViewModel instance using the viewModels delegate instead of field injection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d426eb1c28832babdda5c4ab95ed35