### PR TITLE
Refactor team list adapter user handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -298,6 +298,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                         mRealm,
                         childFragmentManager,
                         teamRepository,
+                        userProfileDbHandler,
                     )
                     adapterTeamList.setTeamListener(this@TeamFragment)
                     binding.rvTeamList.adapter = adapterTeamList
@@ -326,8 +327,9 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private fun setTeamList() {
         val list = teamList ?: return
         adapterTeamList = activity?.let {
-            AdapterTeamList(it, list, mRealm, childFragmentManager, teamRepository)
+            AdapterTeamList(it, list, mRealm, childFragmentManager, teamRepository, userProfileDbHandler)
         } ?: return
+        adapterTeamList.refreshCurrentUser()
         adapterTeamList.setType(type)
         adapterTeamList.setTeamListener(this@TeamFragment)
         requireView().findViewById<View>(R.id.type).visibility =
@@ -397,7 +399,9 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                 mRealm,
                 childFragmentManager,
                 teamRepository,
+                userProfileDbHandler,
             ).apply {
+                refreshCurrentUser()
                 setType(type)
                 setTeamListener(this@TeamFragment)
             }


### PR DESCRIPTION
## Summary
- pass the shared UserProfileDbHandler into AdapterTeamList so user info is reused instead of creating a handler per bind
- cache the current user in the adapter and expose refreshCurrentUser to keep state up to date
- update TeamFragment to supply the handler and refresh the adapter’s cached user when rebuilding lists

## Testing
- ./gradlew :app:lint --console=plain (terminated after extended runtime)


------
https://chatgpt.com/codex/tasks/task_e_68d4277defa8832bbf240f8746948888