### PR TITLE
Inject Gson into RatingRepositoryImpl

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingRepositoryImpl.kt
@@ -9,10 +9,9 @@ import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmUserModel
 
 class RatingRepositoryImpl @Inject constructor(
-    databaseService: DatabaseService
+    databaseService: DatabaseService,
+    private val gson: Gson,
 ) : RealmRepository(databaseService), RatingRepository {
-
-    private val gson = Gson()
 
     override suspend fun getRatings(type: String, userId: String?): Map<String, Int> {
         val ratings = queryList(RealmRating::class.java) {


### PR DESCRIPTION
## Summary
- inject Gson into `RatingRepositoryImpl` via constructor so Hilt can provide the dependency
- continue using the injected Gson when persisting rating data

## Testing
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d428b5303c832b9f2aa5cd9c6a67d5