### PR TITLE
Refactor team action button state handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -115,55 +115,47 @@ class AdapterTeamList(
         team: RealmMyTeam,
         user: RealmUserModel?,
     ) {
-        if (isMyTeam) {
-            name.setTypeface(null, Typeface.BOLD)
-        } else {
-            name.setTypeface(null, Typeface.NORMAL)
+        val typefaceStyle = if (isMyTeam) Typeface.BOLD else Typeface.NORMAL
+        name.setTypeface(null, typefaceStyle)
+
+        val state = when {
+            user?.isGuest() == true -> TeamActionButtonState.Hidden
+            isMyTeam && !isTeamLeader -> TeamActionButtonState.Leave(
+                "${context.getString(R.string.leave)} ${team.name}",
+            )
+            !isMyTeam && hasPendingRequest -> TeamActionButtonState.Requested(
+                "${context.getString(R.string.requested)} ${team.name}",
+                "#9fa0a4".toColorInt(),
+            )
+            !isMyTeam -> TeamActionButtonState.Join(
+                "${context.getString(R.string.request_to_join)} ${team.name}",
+            )
+            isTeamLeader -> TeamActionButtonState.Edit(
+                "${context.getString(R.string.edit)} ${team.name}",
+            )
+            else -> TeamActionButtonState.Hidden
         }
-        when {
-            user?.isGuest() == true -> joinLeave.visibility = View.GONE
 
-            isMyTeam && !isTeamLeader -> {
-                joinLeave.apply {
-                    isEnabled = true
-                    contentDescription = "${context.getString(R.string.leave)} ${team.name}"
-                    visibility = View.VISIBLE
-                    setImageResource(R.drawable.logout)
-                    clearColorFilter()
-                }
+        applyActionButtonState(state)
+    }
+
+    private fun ItemTeamListBinding.applyActionButtonState(state: TeamActionButtonState) {
+        if (state is TeamActionButtonState.Hidden) {
+            joinLeave.visibility = View.GONE
+            return
+        }
+
+        joinLeave.apply {
+            visibility = View.VISIBLE
+            isEnabled = state.isEnabled
+            contentDescription = state.contentDescription
+            state.iconRes?.let { iconRes -> setImageResource(iconRes) }
+            val tintColor = state.tintColor
+            if (tintColor != null) {
+                setColorFilter(tintColor, PorterDuff.Mode.SRC_IN)
+            } else {
+                clearColorFilter()
             }
-
-            !isMyTeam && hasPendingRequest -> {
-                joinLeave.apply {
-                    isEnabled = false
-                    contentDescription = "${context.getString(R.string.requested)} ${team.name}"
-                    visibility = View.VISIBLE
-                    setImageResource(R.drawable.baseline_hourglass_top_24)
-                    setColorFilter("#9fa0a4".toColorInt(), PorterDuff.Mode.SRC_IN)
-                }
-            }
-
-            !isMyTeam -> {
-                joinLeave.apply {
-                    isEnabled = true
-                    contentDescription = "${context.getString(R.string.request_to_join)} ${team.name}"
-                    visibility = View.VISIBLE
-                    setImageResource(R.drawable.ic_join_request)
-                    clearColorFilter()
-                }
-            }
-
-            isTeamLeader -> {
-                joinLeave.apply {
-                    isEnabled = true
-                    contentDescription = "${context.getString(R.string.edit)} ${team.name}"
-                    visibility = View.VISIBLE
-                    setImageResource(R.drawable.ic_edit)
-                    clearColorFilter()
-                }
-            }
-
-            else -> joinLeave.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamActionButtonState.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamActionButtonState.kt
@@ -1,0 +1,57 @@
+package org.ole.planet.myplanet.ui.team
+
+import androidx.annotation.ColorInt
+import androidx.annotation.DrawableRes
+import org.ole.planet.myplanet.R
+
+sealed class TeamActionButtonState {
+    abstract val isEnabled: Boolean
+    abstract val contentDescription: String?
+    open val iconRes: Int? = null
+    @ColorInt
+    open val tintColor: Int? = null
+
+    object Hidden : TeamActionButtonState() {
+        override val isEnabled: Boolean = false
+        override val contentDescription: String? = null
+    }
+
+    data class Join(
+        private val description: String,
+    ) : TeamActionButtonState() {
+        override val isEnabled: Boolean = true
+        override val contentDescription: String = description
+        @DrawableRes
+        override val iconRes: Int = R.drawable.ic_join_request
+    }
+
+    data class Requested(
+        private val description: String,
+        private val tint: Int,
+    ) : TeamActionButtonState() {
+        override val isEnabled: Boolean = false
+        override val contentDescription: String = description
+        @DrawableRes
+        override val iconRes: Int = R.drawable.baseline_hourglass_top_24
+        @ColorInt
+        override val tintColor: Int = tint
+    }
+
+    data class Leave(
+        private val description: String,
+    ) : TeamActionButtonState() {
+        override val isEnabled: Boolean = true
+        override val contentDescription: String = description
+        @DrawableRes
+        override val iconRes: Int = R.drawable.logout
+    }
+
+    data class Edit(
+        private val description: String,
+    ) : TeamActionButtonState() {
+        override val isEnabled: Boolean = true
+        override val contentDescription: String = description
+        @DrawableRes
+        override val iconRes: Int = R.drawable.ic_edit
+    }
+}


### PR DESCRIPTION
## Summary
- add a sealed `TeamActionButtonState` model to describe the possible join/leave button modes
- refactor the team list binding to compute the state once and apply it through a shared extension
- simplify the name typeface decision while centralizing icon, enabled, and tint updates

## Testing
- ./gradlew --console=plain :app:compileDefaultDebugKotlin

------
https://chatgpt.com/codex/tasks/task_e_68d184e55d74832ba3149f3ac5504245