### PR TITLE
Remove sync progress data class and overrides

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/StandardSyncStrategy.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/StandardSyncStrategy.kt
@@ -43,24 +43,7 @@ class StandardSyncStrategy : SyncStrategy {
         }
     }
     
-    override suspend fun syncTableWithProgress(
-        table: String,
-        realm: Realm,
-        config: SyncConfig
-    ): Flow<SyncProgress> = flow {
-        // Standard sync doesn't provide detailed progress
-        emit(
-            SyncProgress(
-                table = table,
-                processedItems = 0,
-                totalItems = -1,
-                currentBatch = 1,
-                totalBatches = 1
-            )
-        )
-    }
-    
     override fun getStrategyName(): String = "standard"
-    
+
     override fun isSupported(table: String): Boolean = true
 }

--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/SyncStrategy.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/SyncStrategy.kt
@@ -21,27 +21,13 @@ data class SyncResult(
     val strategy: String
 )
 
-data class SyncProgress(
-    val table: String,
-    val processedItems: Int,
-    val totalItems: Int,
-    val currentBatch: Int,
-    val totalBatches: Int
-)
-
 interface SyncStrategy {
     suspend fun syncTable(
-        table: String, 
-        realm: Realm, 
+        table: String,
+        realm: Realm,
         config: SyncConfig
     ): Flow<SyncResult>
-    
-    suspend fun syncTableWithProgress(
-        table: String, 
-        realm: Realm, 
-        config: SyncConfig
-    ): Flow<SyncProgress>
-    
+
     fun getStrategyName(): String
     fun isSupported(table: String): Boolean
 }


### PR DESCRIPTION
## Summary
- remove the unused SyncProgress data class from SyncStrategy
- drop syncTableWithProgress overrides from Standard and Optimized strategies
- prune helper logic that only supported progress reporting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d525cd4028832ba9cd86151799d3ce