### PR TITLE
Inject UserProfileDbHandler in MyPersonalsFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
@@ -39,6 +39,8 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
     lateinit var databaseService: DatabaseService
     @Inject
     lateinit var myPersonalRepository: MyPersonalRepository
+    @Inject
+    lateinit var userProfileDbHandler: UserProfileDbHandler
     fun refreshFragment() {
         if (isAdded) {
             setAdapter()
@@ -70,7 +72,7 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
     }
 
     private fun setAdapter() {
-        val model = UserProfileDbHandler(requireContext()).userModel
+        val model = userProfileDbHandler.userModel
         personalAdapter = AdapterMyPersonal(requireActivity(), mutableListOf())
         personalAdapter?.setListener(this)
         personalAdapter?.setRealm(mRealm)


### PR DESCRIPTION
## Summary
- inject `UserProfileDbHandler` into `MyPersonalsFragment` via Hilt
- reuse the injected handler when loading the user model instead of creating a new instance

## Testing
- Attempted `./gradlew --console=plain :app:lintVitalRelease` (terminated due to prolonged dependency resolution)


------
https://chatgpt.com/codex/tasks/task_e_68d5283c03f0832b8ef6a67bb37e1e3f