### PR TITLE
Inject UserProfileDbHandler in FeedbackListFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
@@ -53,6 +53,11 @@ class UserProfileDbHandler @Inject constructor(
             .findFirst()
     }
 
+    fun getDetachedUserModel(): RealmUserModel? {
+        val managedUser = userModel ?: return null
+        return mRealm.copyFromRealm(managedUser)
+    }
+
     fun onLogin() {
         onLoginAsync()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -48,9 +48,11 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     @Inject
     lateinit var feedbackRepository: FeedbackRepository
     private val serverUrlMapper = ServerUrlMapper()
-    
+
     @Inject
     lateinit var syncManager: SyncManager
+    @Inject
+    lateinit var userProfileDbHandler: UserProfileDbHandler
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
     
@@ -67,7 +69,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentFeedbackListBinding.inflate(inflater, container, false)
-        userModel = UserProfileDbHandler(requireContext()).userModel
+        userModel = userProfileDbHandler.userModel
 
         binding.fab.setOnClickListener {
             val feedbackFragment = FeedbackFragment()
@@ -176,6 +178,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
         if (::realtimeSyncListener.isInitialized) {
             syncCoordinator.removeListener(realtimeSyncListener)
         }
+        userModel = null
         _binding = null
         super.onDestroyView()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -69,7 +69,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentFeedbackListBinding.inflate(inflater, container, false)
-        userModel = userProfileDbHandler.userModel
+        userModel = userProfileDbHandler.getDetachedUserModel()
 
         binding.fab.setOnClickListener {
             val feedbackFragment = FeedbackFragment()


### PR DESCRIPTION
## Summary
- inject `UserProfileDbHandler` into `FeedbackListFragment`
- reference the injected handler when retrieving the `userModel`
- clear the cached user model when the view is destroyed

## Testing
- `./gradlew :app:lintDebug` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d5283496f8832ba21855bc614da4f7