### PR TITLE
Add helper for single Realm lookups

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -40,10 +40,10 @@ class NotificationRepositoryImpl @Inject constructor(
             count
         }
 
-        val existingNotification = queryList(RealmNotification::class.java) {
+        val existingNotification = findFirst(RealmNotification::class.java) {
             equalTo("userId", userId)
             equalTo("type", "resource")
-        }.firstOrNull()
+        }
 
         if (resourceCount > 0) {
             val notification = existingNotification?.apply {
@@ -129,10 +129,11 @@ class NotificationRepositoryImpl @Inject constructor(
         val rawId = joinRequestId?.takeUnless { it.isBlank() } ?: return null
         val sanitizedId = rawId.removePrefix("join_request_")
 
-        val joinRequest = queryList(RealmMyTeam::class.java) {
-            equalTo("_id", sanitizedId)
-            equalTo("docType", "request")
-        }.firstOrNull() ?: return null
+        val joinRequest =
+            findFirst(RealmMyTeam::class.java) {
+                equalTo("_id", sanitizedId)
+                equalTo("docType", "request")
+            } ?: return null
 
         val teamName = joinRequest.teamId?.let { teamId ->
             findByField(RealmMyTeam::class.java, "_id", teamId)?.name

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingRepositoryImpl.kt
@@ -58,11 +58,11 @@ class RatingRepositoryImpl @Inject constructor(
         val userId = user.id ?: user._id
         require(!userId.isNullOrBlank()) { "User ID is required to submit a rating" }
 
-        val existingRating = queryList(RealmRating::class.java) {
+        val existingRating = findFirst(RealmRating::class.java) {
             equalTo("type", type)
             equalTo("userId", userId)
             equalTo("item", itemId)
-        }.firstOrNull()
+        }
 
         if (existingRating == null || existingRating.id.isNullOrBlank()) {
             val newRating = RealmRating().apply {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -24,6 +24,17 @@ open class RealmRepository(private val databaseService: DatabaseService) {
             realm.queryList(clazz, builder)
         }
 
+    protected suspend fun <T : RealmObject> findFirst(
+        clazz: Class<T>,
+        builder: RealmQuery<T>.() -> Unit = {},
+    ): T? =
+        databaseService.withRealmAsync { realm ->
+            realm.where(clazz)
+                .apply(builder)
+                .findFirst()
+                ?.let { realm.copyFromRealm(it) }
+        }
+
     protected suspend fun <T : RealmObject> count(
         clazz: Class<T>,
         builder: RealmQuery<T>.() -> Unit = {},


### PR DESCRIPTION
## Summary
- add a reusable `findFirst` helper in `RealmRepository` for efficient single-object queries
- update notification and rating repositories to use the new helper for one-off lookups

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d52b5f3044832bac7c0813863901c4