### PR TITLE
Refactor team adapter to reuse user profile handler

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -255,6 +255,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                         mRealm,
                         childFragmentManager,
                         teamRepository,
+                        user,
                     )
                     adapterTeamList.setTeamListener(this@TeamFragment)
                     binding.rvTeamList.adapter = adapterTeamList
@@ -283,7 +284,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
     private fun setTeamList() {
         val list = teamList ?: return
         adapterTeamList = activity?.let {
-            AdapterTeamList(it, list, mRealm, childFragmentManager, teamRepository)
+            AdapterTeamList(it, list, mRealm, childFragmentManager, teamRepository, user)
         } ?: return
         adapterTeamList.setType(type)
         adapterTeamList.setTeamListener(this@TeamFragment)
@@ -354,6 +355,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
                 mRealm,
                 childFragmentManager,
                 teamRepository,
+                user,
             ).apply {
                 setType(type)
                 setTeamListener(this@TeamFragment)
@@ -402,6 +404,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem {
         if (this::mRealm.isInitialized && !mRealm.isClosed) {
             mRealm.close()
         }
+        userProfileDbHandler.onDestroy()
         _binding = null
         super.onDestroyView()
     }


### PR DESCRIPTION
## Summary
- reuse a shared Realm user model in AdapterTeamList instead of instantiating a UserProfileDbHandler for every bind
- provide the cached user from TeamFragment to the adapter and close the injected handler during teardown

## Testing
- ./gradlew :app:lint *(fails: Failed to find target with hash string 'android-36')*

------
https://chatgpt.com/codex/tasks/task_e_68d528d0f7c8832b8fc63b0fdfa2ddec