### PR TITLE
sync: less realm transaction is more (fixes #7966)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3303
-        versionName = "0.33.3"
+        versionCode = 3304
+        versionName = "0.33.4"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/RealmConnectionPool.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/RealmConnectionPool.kt
@@ -208,30 +208,6 @@ data class PoolStats(
     val maxConnections: Int
 )
 
-// Helper function to handle the blocking executeTransaction in a suspend context
-private suspend fun <T> Realm.executeTransactionSuspend(operation: suspend (Realm) -> T): T {
-    return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-        var result: T? = null
-        var exception: Exception? = null
-        
-        executeTransaction { realm ->
-            try {
-                // This is still problematic as executeTransaction doesn't support suspend
-                // In a real implementation, you'd need to restructure this
-                kotlinx.coroutines.runBlocking {
-                    result = operation(realm)
-                }
-            } catch (e: Exception) {
-                exception = e
-                throw e
-            }
-        }
-        
-        exception?.let { throw it }
-        result!!
-    }
-}
-
 class RealmPoolManager private constructor() {
     companion object {
         @Volatile


### PR DESCRIPTION
## Summary
- remove the unused executeTransactionSuspend helper from RealmConnectionPool

## Testing
- ./gradlew lint --console=plain *(fails: missing Android SDK Build-Tools 35 / Platform 36 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d68edcab18832b9ef4672cbb5b6499