### PR TITLE
courses: less completion counter is more (fixes #7967)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3303
-        versionName = "0.33.3"
+        versionCode = 3305
+        versionName = "0.33.5"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/MyProgressFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/MyProgressFragment.kt
@@ -120,26 +120,6 @@ class MyProgressFragment : Fragment() {
             return null
         }
 
-        fun countUsersWhoCompletedCourse(realm: Realm, courseId: String): Int {
-            var completedCount = 0
-            val allUsers = realm.where(RealmUserModel::class.java).findAll()
-
-            allUsers.forEach { user ->
-                val userId = user.id
-                val courses = RealmMyCourse.getMyCourseByUserId(userId, realm.where(RealmMyCourse::class.java).findAll())
-
-                val course = courses.find { it.courseId == courseId }
-                if (course != null) {
-                    val steps = RealmMyCourse.getCourseSteps(realm, courseId)
-                    val currentProgress = RealmCourseProgress.getCurrentProgress(steps, realm, userId, courseId)
-
-                    if (currentProgress == steps.size) {
-                        completedCount++
-                    }
-                }
-            }
-            return completedCount
-        }
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
## Summary
- remove the unused `countUsersWhoCompletedCourse` helper from `MyProgressFragment`

## Testing
- ./gradlew lintDefaultDebug --no-configuration-cache --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d69eee7d2c832bbaa92f60f9a323cc