### PR TITLE
Remove unused answer helper from exam base fragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/BaseExamFragment.kt
@@ -184,18 +184,6 @@ abstract class BaseExamFragment : Fragment(), ImageCaptureCallback {
             )
         }
     }
-
-    fun addAnswer(compoundButton: CompoundButton) {
-        val btnText = compoundButton.text.toString()
-        val btnId = compoundButton.tag?.toString() ?: ""
-
-        if (compoundButton is RadioButton) {
-            ans = btnId
-        } else if (compoundButton is CheckBox) {
-            listAns?.put(btnText, btnId)
-        }
-    }
-
     abstract fun startExam(question: RealmExamQuestion?)
     private fun insertIntoSubmitPhotos(submitId: String?) {
         mRealm.beginTransaction()


### PR DESCRIPTION
## Summary
- remove the unused `addAnswer` helper from `BaseExamFragment` so subclasses rely on the active answer storage logic

## Testing
- ./gradlew --console=plain :app:compileDefaultDebugKotlin

------
https://chatgpt.com/codex/tasks/task_e_68d69ef8afec832b8e43a4563b1bca03