### PR TITLE
Remove unused task list dialog callbacks

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/callback/NotificationCallback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/NotificationCallback.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.callback
 
 interface NotificationCallback {
     fun showPendingSurveyDialog()
-    fun showTaskListDialog()
     fun showUserResourceDialog()
     fun showResourceDownloadDialog()
     fun syncKeyId()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -7,12 +7,10 @@ import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.AdapterView
-import android.widget.ArrayAdapter
 import android.widget.DatePicker
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
@@ -39,7 +37,6 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmTeamNotification
-import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.TransactionSyncManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
@@ -419,19 +416,4 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
         di?.dismiss()
     }
 
-    override fun showTaskListDialog() {
-        val tasks = mRealm.where(RealmTeamTask::class.java).equalTo("assignee", model?.id)
-            .equalTo("completed", false)
-            .greaterThan("deadline", Calendar.getInstance().timeInMillis).findAll()
-        if (tasks.isEmpty()) {
-            Utilities.toast(requireContext(), getString(R.string.no_due_tasks))
-            return
-        }
-        val adapter = ArrayAdapter(requireContext(), android.R.layout.simple_expandable_list_item_1, tasks)
-        AlertDialog.Builder(requireContext()).setTitle(getString(R.string.due_tasks))
-            .setAdapter(adapter) { _, _ ->
-//                var task = adapter.getItem(p1);
-            }
-            .setNegativeButton(R.string.dismiss, null).show()
-    }
 }


### PR DESCRIPTION
## Summary
- remove the unused task list dialog callback from the notification interface
- delete the unused task list dialog implementation and related imports from the dashboard fragment
- confirm there are no remaining references to the removed callback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69f55148c832babc1bc59994e5e0b