### PR TITLE
Remove unused course library lookup

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
@@ -8,7 +8,6 @@ interface LibraryRepository {
     suspend fun getLibraryItemByResourceId(resourceId: String): RealmMyLibrary?
     suspend fun getLibraryItemsByLocalAddress(localAddress: String): List<RealmMyLibrary>
     suspend fun getLibraryListForUser(userId: String?): List<RealmMyLibrary>
-    suspend fun getCourseLibraryItems(courseIds: List<String>): List<RealmMyLibrary>
     suspend fun saveLibraryItem(item: RealmMyLibrary)
     suspend fun markResourceAdded(userId: String?, resourceId: String)
     suspend fun updateUserLibrary(resourceId: String, userId: String, isAdd: Boolean): RealmMyLibrary?

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -39,14 +39,6 @@ class LibraryRepositoryImpl @Inject constructor(
             .filter { it.userId?.contains(userId) == true }
     }
 
-    override suspend fun getCourseLibraryItems(courseIds: List<String>): List<RealmMyLibrary> {
-        return queryList(RealmMyLibrary::class.java) {
-            `in`("courseId", courseIds.toTypedArray())
-            equalTo("resourceOffline", false)
-            isNotNull("resourceLocalAddress")
-        }
-    }
-
     override suspend fun saveLibraryItem(item: RealmMyLibrary) {
         save(item)
     }


### PR DESCRIPTION
## Summary
- remove the unused course resource helper from the library repository interface and implementation
- rely on CourseRepository for fetching course resources

## Testing
- ./gradlew test --console=plain *(fails: missing Android SDK Build-Tools 35 / Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_68d69e378194832badc03b48fa7757f1