### PR TITLE
Cache chat data for chat history adapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NewsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NewsRepository.kt
@@ -1,7 +1,11 @@
 package org.ole.planet.myplanet.repository
 
+import java.util.HashMap
 import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.model.RealmUserModel
 
 interface NewsRepository {
     suspend fun getNewsWithReplies(newsId: String): Pair<RealmNews?, List<RealmNews>>
+    suspend fun getMessagesForPlanet(planetCode: String?): List<RealmNews>
+    suspend fun createChatNews(map: HashMap<String?, String>, user: RealmUserModel?): RealmNews?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NewsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NewsRepositoryImpl.kt
@@ -4,7 +4,10 @@ import io.realm.Case
 import io.realm.Sort
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import java.util.HashMap
 import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.model.RealmNews.Companion.createNews
+import org.ole.planet.myplanet.model.RealmUserModel
 
 class NewsRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
@@ -17,5 +20,26 @@ class NewsRepositoryImpl @Inject constructor(
             sort("time", Sort.DESCENDING)
         }
         return news to replies
+    }
+
+    override suspend fun getMessagesForPlanet(planetCode: String?): List<RealmNews> {
+        if (planetCode.isNullOrBlank()) {
+            return emptyList()
+        }
+        return queryList(RealmNews::class.java) {
+            equalTo("docType", "message", Case.INSENSITIVE)
+            equalTo("createdOn", planetCode, Case.INSENSITIVE)
+        }
+    }
+
+    override suspend fun createChatNews(
+        map: HashMap<String?, String>,
+        user: RealmUserModel?,
+    ): RealmNews? {
+        user ?: return null
+        return withRealmAsync { realm ->
+            val news = createNews(map, realm, user, null)
+            realm.copyFromRealm(news)
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -11,6 +11,7 @@ interface TeamRepository {
     suspend fun getTeamByDocumentIdOrTeamId(id: String): RealmMyTeam?
     suspend fun getTeamLinks(): List<RealmMyTeam>
     suspend fun getTeamById(teamId: String): RealmMyTeam?
+    suspend fun getRootTeamsByType(type: String): List<RealmMyTeam>
     suspend fun isMember(userId: String?, teamId: String): Boolean
     suspend fun isTeamLeader(teamId: String, userId: String?): Boolean
     suspend fun hasPendingRequest(teamId: String, userId: String?): Boolean

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -59,6 +59,15 @@ class TeamRepositoryImpl @Inject constructor(
         return findByField(RealmMyTeam::class.java, "_id", teamId)
     }
 
+    override suspend fun getRootTeamsByType(type: String): List<RealmMyTeam> {
+        if (type.isBlank()) return emptyList()
+        return queryList(RealmMyTeam::class.java) {
+            isEmpty("teamId")
+            notEqualTo("status", "archived")
+            equalTo("type", type)
+        }
+    }
+
     override suspend fun isMember(userId: String?, teamId: String): Boolean {
         userId ?: return false
         return queryList(RealmMyTeam::class.java) {


### PR DESCRIPTION
## Summary
- load the current user once, fetch related chat news and team data, and pass them to the chat history adapter
- update ChatHistoryListAdapter to consume cached user/news data and remove direct DatabaseService usage
- extend the news and team repositories with helpers for chat sharing operations

## Testing
- ./gradlew lint *(fails: Installed Build Tools revision 35.0.0 is corrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d528c2ffb8832ba26d1249de756e27