### PR TITLE
Use submission repository for survey notifications

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -11,6 +11,7 @@ interface SubmissionRepository {
     suspend fun getSubmissionById(id: String): RealmSubmission?
     suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission>
     suspend fun getExamMapForSubmissions(submissions: List<RealmSubmission>): Map<String?, RealmStepExam>
+    suspend fun getExamByName(name: String): RealmStepExam?
     suspend fun getExamQuestionCount(stepId: String): Int
     suspend fun createSurveySubmission(examId: String, userId: String?)
     suspend fun saveSubmission(submission: RealmSubmission)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -116,6 +116,10 @@ class SubmissionRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getExamByName(name: String): RealmStepExam? {
+        return findByField(RealmStepExam::class.java, "name", name)
+    }
+
     override suspend fun createSurveySubmission(examId: String, userId: String?) {
         withRealmAsync { realm ->
             val courseId = realm.where(RealmStepExam::class.java).equalTo("id", examId).findFirst()?.courseId

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -27,9 +27,9 @@ import org.ole.planet.myplanet.databinding.FragmentNotificationsBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNotification
-import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.repository.NotificationRepository
+import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.resources.ResourcesFragment
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
@@ -45,6 +45,8 @@ class NotificationsFragment : Fragment() {
     lateinit var databaseService: DatabaseService
     @Inject
     lateinit var notificationRepository: NotificationRepository
+    @Inject
+    lateinit var submissionRepository: SubmissionRepository
     private lateinit var adapter: AdapterNotification
     private lateinit var userId: String
     private var notificationUpdateListener: NotificationListener? = null
@@ -110,18 +112,19 @@ class NotificationsFragment : Fragment() {
                 startActivity(intent)
             }
             "survey" -> {
-                databaseService.withRealm { realm ->
-                    val currentStepExam = realm.where(RealmStepExam::class.java)
-                        .equalTo("name", notification.relatedId)
-                        .findFirst()
-                    if (currentStepExam != null && activity is OnHomeItemClickListener) {
-                        AdapterMySubmission.openSurvey(
-                            activity as OnHomeItemClickListener,
-                            currentStepExam.id,
-                            false,
-                            false,
-                            "",
-                        )
+                val relatedName = notification.relatedId
+                if (relatedName != null) {
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        val currentStepExam = submissionRepository.getExamByName(relatedName)
+                        if (currentStepExam != null && activity is OnHomeItemClickListener) {
+                            AdapterMySubmission.openSurvey(
+                                activity as OnHomeItemClickListener,
+                                currentStepExam.id,
+                                false,
+                                false,
+                                "",
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add a submission repository method to fetch exams by name
- update the notifications fragment to resolve survey clicks through the repository
- remove the direct Realm usage from the fragment imports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6db751a8c832b898e2779402bdad3