### PR TITLE
Refactor chat detail fragment to use repositories

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
@@ -1,7 +1,16 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.RealmChatHistory
 
 interface ChatRepository {
     suspend fun getChatHistoryForUser(userName: String?): List<RealmChatHistory>
+    suspend fun getLatestRevision(chatId: String): String?
+    suspend fun insertChatHistory(chatHistory: JsonObject?)
+    suspend fun appendConversationToHistory(
+        chatId: String,
+        query: String?,
+        response: String?,
+        newRev: String?,
+    )
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -1,9 +1,11 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonObject
 import io.realm.Sort
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmChatHistory
+import org.ole.planet.myplanet.model.RealmChatHistory.Companion.addConversationToChatHistory
 
 class ChatRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
@@ -16,6 +18,40 @@ class ChatRepositoryImpl @Inject constructor(
         return queryList(RealmChatHistory::class.java) {
             equalTo("user", userName)
             sort("id", Sort.DESCENDING)
+        }
+    }
+
+    override suspend fun getLatestRevision(chatId: String): String? {
+        if (chatId.isEmpty()) {
+            return null
+        }
+        return queryList(RealmChatHistory::class.java) {
+            equalTo("_id", chatId)
+        }.maxByOrNull { rev ->
+            rev._rev?.substringBefore("-")?.toIntOrNull() ?: 0
+        }?._rev
+    }
+
+    override suspend fun insertChatHistory(chatHistory: JsonObject?) {
+        if (chatHistory == null) {
+            return
+        }
+        executeTransaction { realm ->
+            RealmChatHistory.insert(realm, chatHistory)
+        }
+    }
+
+    override suspend fun appendConversationToHistory(
+        chatId: String,
+        query: String?,
+        response: String?,
+        newRev: String?,
+    ) {
+        if (chatId.isEmpty()) {
+            return
+        }
+        executeTransaction { realm ->
+            addConversationToChatHistory(realm, chatId, query, response, newRev)
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the chat repository with helpers to look up revisions, insert chat history, and append conversation entries
- inject chat and user repositories into ChatDetailFragment and migrate Realm operations onto the new APIs
- update chat detail workflows to use coroutine-based repository calls and clean up unused Realm dependencies

## Testing
- ./gradlew :app:compileDefaultDebugKotlin --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d6e6453be4832ba13b19619773799e