### PR TITLE
sync: less realm pool stats is more (fixes #7997)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3322
-        versionName = "0.33.22"
+        versionCode = 3324
+        versionName = "0.33.24"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/RealmConnectionPool.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/RealmConnectionPool.kt
@@ -191,22 +191,7 @@ class RealmConnectionPool(
         activeConnections.set(0)
     }
     
-    fun getPoolStats(): PoolStats {
-        return PoolStats(
-            totalConnections = allConnections.size,
-            activeConnections = allConnections.values.count { it.isInUse },
-            availableConnections = availableConnections.size,
-            maxConnections = config.maxConnections
-        )
-    }
 }
-
-data class PoolStats(
-    val totalConnections: Int,
-    val activeConnections: Int,
-    val availableConnections: Int,
-    val maxConnections: Int
-)
 
 class RealmPoolManager private constructor() {
     companion object {
@@ -241,10 +226,6 @@ class RealmPoolManager private constructor() {
     suspend fun <T> useRealmTransaction(operation: suspend (Realm) -> T): T {
         val pool = connectionPool ?: throw IllegalStateException("Pool not initialized")
         return pool.useRealmTransaction(operation)
-    }
-    
-    fun getPoolStats(): PoolStats? {
-        return connectionPool?.getPoolStats()
     }
     
     suspend fun shutdown() = mutex.withLock {


### PR DESCRIPTION
## Summary
- remove the unused connection pool statistics data class and accessor
- drop the corresponding RealmPoolManager wrapper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daacfdfa64832b9e7b2bf1f652d57c