### PR TITLE
sync: less shutdown paths is more (fixes #7998)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3322
-        versionName = "0.33.22"
+        versionCode = 3325
+        versionName = "0.33.25"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/ImprovedSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/ImprovedSyncManager.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
@@ -230,11 +229,6 @@ class ImprovedSyncManager @Inject constructor(
             org.ole.planet.myplanet.MainApplication.syncFailedCount++
             listener?.onSyncFailed(message)
         }
-    }
-    
-    suspend fun shutdown() {
-        syncScope.cancel()
-        poolManager.shutdown()
     }
     
     // Compatibility methods for existing code

--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/RealmConnectionPool.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/RealmConnectionPool.kt
@@ -40,8 +40,6 @@ class RealmConnectionPool(
     private val poolMutex = Mutex()
     
     private var lastValidationTime = 0L
-    private var isShuttingDown = false
-    
     suspend fun <T> useRealm(operation: suspend (Realm) -> T): T {
         // Check if current thread already has a realm instance
         val existingRealm = threadLocalConnections.get()
@@ -77,10 +75,6 @@ class RealmConnectionPool(
     }
     
     private suspend fun acquireConnection(): PooledRealm = poolMutex.withLock {
-        if (isShuttingDown) {
-            throw IllegalStateException("Connection pool is shutting down")
-        }
-        
         validateConnectionsIfNeeded()
         
         // Try to get an available connection
@@ -113,7 +107,7 @@ class RealmConnectionPool(
     }
     
     private suspend fun releaseConnection(pooledRealm: PooledRealm) = poolMutex.withLock {
-        if (!isShuttingDown && isConnectionValid(pooledRealm)) {
+        if (isConnectionValid(pooledRealm)) {
             val updatedConnection = pooledRealm.copy(
                 lastUsedAt = System.currentTimeMillis(),
                 isInUse = false
@@ -181,16 +175,6 @@ class RealmConnectionPool(
         }
     }
     
-    suspend fun shutdown() = poolMutex.withLock {
-        isShuttingDown = true
-        
-        // Close all connections
-        allConnections.values.forEach { closeConnection(it) }
-        availableConnections.clear()
-        allConnections.clear()
-        activeConnections.set(0)
-    }
-    
     fun getPoolStats(): PoolStats {
         return PoolStats(
             totalConnections = allConnections.size,
@@ -242,13 +226,8 @@ class RealmPoolManager private constructor() {
         val pool = connectionPool ?: throw IllegalStateException("Pool not initialized")
         return pool.useRealmTransaction(operation)
     }
-    
+
     fun getPoolStats(): PoolStats? {
         return connectionPool?.getPoolStats()
-    }
-    
-    suspend fun shutdown() = mutex.withLock {
-        connectionPool?.shutdown()
-        connectionPool = null
     }
 }


### PR DESCRIPTION
## Summary
- remove the unused shutdown entry point from `ImprovedSyncManager`
- delete the now-unreachable shutdown helpers in the Realm pool implementation

## Testing
- ./gradlew lint --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68daad343240832b9171764649ce4123