### PR TITLE
sync: less adaptive batch processor retrying is more (fixes #7999)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3322
-        versionName = "0.33.22"
+        versionCode = 3326
+        versionName = "0.33.26"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/AdaptiveBatchProcessor.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/AdaptiveBatchProcessor.kt
@@ -160,17 +160,4 @@ class AdaptiveBatchProcessor(private val context: Context) {
     fun createSemaphore(config: SyncConfig): Semaphore {
         return Semaphore(config.concurrencyLevel)
     }
-    
-    fun adjustConfigForRetry(config: SyncConfig, attemptNumber: Int): SyncConfig {
-        val backoffFactor = 1.5
-        val adjustedBatchSize = max(10, (config.batchSize / (backoffFactor * attemptNumber)).toInt())
-        val adjustedConcurrency = max(1, config.concurrencyLevel - attemptNumber + 1)
-        val adjustedTimeout = (config.timeoutMs * (1 + attemptNumber * 0.5)).toLong()
-        
-        return config.copy(
-            batchSize = adjustedBatchSize,
-            concurrencyLevel = adjustedConcurrency,
-            timeoutMs = adjustedTimeout
-        )
-    }
 }


### PR DESCRIPTION
## Summary
- remove the unused retry adjustment helper from AdaptiveBatchProcessor
- clean up the class now that the retry adjustment logic is gone

## Testing
- ./gradlew lint *(fails: missing Android SDK Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_68daad2a0ff4832b819f589ce1f6f87e