### PR TITLE
sync: less circuit breaker utilities is more (fixes #8000)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3322
-        versionName = "0.33.22"
+        versionCode = 3327
+        versionName = "0.33.27"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/CircuitBreaker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/CircuitBreaker.kt
@@ -159,11 +159,4 @@ class SyncErrorRecovery {
         return retryHandler.executeWithRetry(circuitBreaker, operation)
     }
     
-    fun getCircuitBreakerStatus(): Map<String, CircuitState> {
-        return circuitBreakers.mapValues { it.value.getState() }
-    }
-    
-    fun resetAllCircuitBreakers() {
-        circuitBreakers.clear()
-    }
 }


### PR DESCRIPTION
## Summary
- remove the unused circuit breaker status and reset helpers
- leave SyncErrorRecovery focused on execution only

## Testing
- ./gradlew lint --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68daacee9224832bb08e7312096e389c