### PR TITLE
sync: less realtime metrics flow is more (fixes #8001)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3322
-        versionName = "0.33.22"
+        versionCode = 3328
+        versionName = "0.33.28"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/SyncPerformanceMonitor.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/SyncPerformanceMonitor.kt
@@ -5,9 +5,6 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.roundToInt
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 
 data class SyncMetrics(
@@ -84,9 +81,6 @@ class SyncPerformanceMonitor(private val context: Context) {
     private val currentMetrics = ConcurrentHashMap<String, SyncMetrics>()
     private val historicalMetrics = mutableListOf<SyncMetrics>()
     
-    private val _realTimeMetrics = MutableStateFlow<Map<String, SyncMetrics>>(emptyMap())
-    val realTimeMetrics: StateFlow<Map<String, SyncMetrics>> = _realTimeMetrics.asStateFlow()
-    
     private val maxHistoricalRecords = 100
     
     init {
@@ -106,7 +100,6 @@ class SyncPerformanceMonitor(private val context: Context) {
             historicalMetrics.removeAt(0)
         }
         
-        _realTimeMetrics.value = currentMetrics.toMap()
         saveMetricsToPrefs(metrics)
     }
     


### PR DESCRIPTION
## Summary
- remove the real-time metrics state flow from `SyncPerformanceMonitor`
- drop the unused coroutine flow imports

## Testing
- ./gradlew :app:testDefaultDebugUnitTest --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68daad17d624832b83d47ed1056683f7