### PR TITLE
Use async realm when logging resource additions

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -44,7 +44,7 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markResourceAdded(userId: String?, resourceId: String) {
-        executeTransaction { realm ->
+        withRealmAsync { realm ->
             RealmRemovedLog.onAdd(realm, "resources", userId, resourceId)
         }
     }


### PR DESCRIPTION
## Summary
- replace the extra transaction in `markResourceAdded` with a `withRealmAsync` call so resource logs reuse the async realm session

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbed5b0d60832b860a27dc15114b58