### PR TITLE
Add repository API for combined team status lookup

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -6,6 +6,12 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 
+data class TeamStatusResult(
+    val isMember: Boolean,
+    val isLeader: Boolean,
+    val hasPendingRequest: Boolean,
+)
+
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
     suspend fun getTeamByDocumentIdOrTeamId(id: String): RealmMyTeam?
@@ -14,6 +20,7 @@ interface TeamRepository {
     suspend fun isMember(userId: String?, teamId: String): Boolean
     suspend fun isTeamLeader(teamId: String, userId: String?): Boolean
     suspend fun hasPendingRequest(teamId: String, userId: String?): Boolean
+    suspend fun getTeamStatus(teamId: String, userId: String?): TeamStatusResult
     suspend fun requestToJoin(teamId: String, user: RealmUserModel?, teamType: String?)
     suspend fun leaveTeam(teamId: String, userId: String?)
     suspend fun addResourceLinks(teamId: String, resources: List<RealmMyLibrary>, user: RealmUserModel?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -87,6 +87,42 @@ class TeamRepositoryImpl @Inject constructor(
         } > 0
     }
 
+    override suspend fun getTeamStatus(teamId: String, userId: String?): TeamStatusResult {
+        if (teamId.isBlank() || userId.isNullOrBlank()) {
+            return TeamStatusResult(isMember = false, isLeader = false, hasPendingRequest = false)
+        }
+
+        return withRealmAsync { realm ->
+            val results = realm.where(RealmMyTeam::class.java)
+                .equalTo("teamId", teamId)
+                .equalTo("userId", userId)
+                .`in`("docType", arrayOf("membership", "request"))
+                .findAll()
+
+            var isMember = false
+            var isLeader = false
+            var hasPendingRequest = false
+
+            results.forEach { entry ->
+                when (entry?.docType) {
+                    "membership" -> {
+                        isMember = true
+                        if (entry.isLeader) {
+                            isLeader = true
+                        }
+                    }
+                    "request" -> hasPendingRequest = true
+                }
+            }
+
+            TeamStatusResult(
+                isMember = isMember,
+                isLeader = isLeader,
+                hasPendingRequest = hasPendingRequest,
+            )
+        }
+    }
+
     override suspend fun requestToJoin(teamId: String, user: RealmUserModel?, teamType: String?) {
         val userId = user?.id ?: return
         val userPlanetCode = user?.planetCode

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -233,10 +233,12 @@ class AdapterTeamList(
                 async(Dispatchers.IO) {
                     val cacheKey = "${teamId}_${userId}"
                     if (!teamStatusCache.containsKey(cacheKey)) {
-                        val isMember = teamRepository.isMember(userId, teamId)
-                        val isLeader = teamRepository.isTeamLeader(teamId, userId)
-                        val hasPendingRequest = teamRepository.hasPendingRequest(teamId, userId)
-                        val status = TeamStatus(isMember, isLeader, hasPendingRequest)
+                        val statusResult = teamRepository.getTeamStatus(teamId, userId)
+                        val status = TeamStatus(
+                            isMember = statusResult.isMember,
+                            isLeader = statusResult.isLeader,
+                            hasPendingRequest = statusResult.hasPendingRequest,
+                        )
                         teamStatusCache[cacheKey] = status
                     }
                     Triple(team, teamStatusCache[cacheKey]!!, visitCount)


### PR DESCRIPTION
## Summary
- add a TeamStatusResult data class and repository API to fetch membership, leader, and pending request flags together
- implement the combined team status lookup in TeamRepositoryImpl using a single Realm query
- update AdapterTeamList to consume the combined status result when populating the cache

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbedb5a68c832b98a2c3667c307fce