### PR TITLE
Add repository backed visit counts to team list

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -14,6 +14,7 @@ interface TeamRepository {
     suspend fun isMember(userId: String?, teamId: String): Boolean
     suspend fun isTeamLeader(teamId: String, userId: String?): Boolean
     suspend fun hasPendingRequest(teamId: String, userId: String?): Boolean
+    suspend fun getRecentVisitCounts(teamIds: Collection<String>): Map<String, Long>
     suspend fun requestToJoin(teamId: String, user: RealmUserModel?, teamType: String?)
     suspend fun leaveTeam(teamId: String, userId: String?)
     suspend fun addResourceLinks(teamId: String, resources: List<RealmMyLibrary>, user: RealmUserModel?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.core.net.toUri
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import java.util.Calendar
 import java.util.Date
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
@@ -16,6 +17,7 @@ import org.ole.planet.myplanet.datamanager.ApiInterface
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UploadManager
@@ -85,6 +87,29 @@ class TeamRepositoryImpl @Inject constructor(
             equalTo("teamId", teamId)
             equalTo("userId", userId)
         } > 0
+    }
+
+    override suspend fun getRecentVisitCounts(teamIds: Collection<String>): Map<String, Long> {
+        if (teamIds.isEmpty()) return emptyMap()
+
+        val validIds = teamIds.filter { it.isNotBlank() }.distinct()
+        if (validIds.isEmpty()) return emptyMap()
+
+        val cutoff = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, -30) }.timeInMillis
+
+        return withRealmAsync { realm ->
+            val counts = mutableMapOf<String, Long>()
+            realm.where(RealmTeamLog::class.java)
+                .equalTo("type", "teamVisit")
+                .greaterThan("time", cutoff)
+                .`in`("teamId", validIds.toTypedArray())
+                .findAll()
+                .forEach { log ->
+                    val teamId = log.teamId ?: return@forEach
+                    counts[teamId] = (counts[teamId] ?: 0L) + 1L
+                }
+            counts
+        }
     }
 
     override suspend fun requestToJoin(teamId: String, user: RealmUserModel?, teamType: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -13,18 +13,17 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.graphics.toColorInt
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.RecyclerView
-import io.realm.Realm
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemTeamListBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.TeamRepository
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
@@ -35,7 +34,6 @@ import org.ole.planet.myplanet.utilities.TimeUtils
 class AdapterTeamList(
     private val context: Context,
     private val list: List<RealmMyTeam>,
-    private val mRealm: Realm,
     private val fragmentManager: FragmentManager,
     private val teamRepository: TeamRepository,
     private val currentUser: RealmUserModel?,
@@ -48,6 +46,7 @@ class AdapterTeamList(
     private lateinit var prefData: SharedPrefManager
     private val scope = MainScope()
     private val teamStatusCache = mutableMapOf<String, TeamStatus>()
+    private var visitCounts: Map<String, Long> = emptyMap()
 
     data class TeamStatus(
         val isMember: Boolean,
@@ -90,9 +89,10 @@ class AdapterTeamList(
             type.text = team.teamType
             type.visibility = if (team.teamType == null) View.GONE else View.VISIBLE
             name.text = team.name
-            noOfVisits.text = context.getString(R.string.number_placeholder, RealmTeamLog.getVisitByTeam(mRealm, team._id))
+            val visitCount = visitCounts[team._id.orEmpty()] ?: 0L
+            noOfVisits.text = context.getString(R.string.number_placeholder, visitCount)
 
-            val teamId = team._id
+            val teamId = team._id.orEmpty()
             val userId = user?.id
             val cacheKey = "${teamId}_${userId}"
             val teamStatus = teamStatusCache[cacheKey] ?: TeamStatus(
@@ -193,7 +193,7 @@ class AdapterTeamList(
     }
 
     private fun handleJoinLeaveClick(team: RealmMyTeam, user: RealmUserModel?) {
-        val teamId = team._id
+        val teamId = team._id.orEmpty()
         val userId = user?.id
         val cacheKey = "${teamId}_${userId}"
         val teamStatus = teamStatusCache[cacheKey] ?: TeamStatus(
@@ -225,12 +225,25 @@ class AdapterTeamList(
 
         scope.launch {
             val validTeams = list.filter { it.status?.isNotEmpty() == true }
-            val teamData = validTeams.map { team ->
-                Triple(team, team._id ?: "", RealmTeamLog.getVisitByTeam(mRealm, team._id))
+            if (validTeams.isEmpty()) {
+                withContext(Dispatchers.Main) {
+                    visitCounts = emptyMap()
+                    filteredList = emptyList()
+                    notifyDataSetChanged()
+                    updateCompleteListener?.onUpdateComplete(filteredList.size)
+                }
+                return@launch
             }
 
-            val teamStatusJobs = teamData.map { (team, teamId, visitCount) ->
+            val teamIds = validTeams.mapNotNull { it._id?.takeIf { id -> id.isNotBlank() } }
+
+            val visitCountsDeferred = async(Dispatchers.IO) {
+                teamRepository.getRecentVisitCounts(teamIds)
+            }
+
+            val teamStatusJobs = validTeams.map { team ->
                 async(Dispatchers.IO) {
+                    val teamId = team._id.orEmpty()
                     val cacheKey = "${teamId}_${userId}"
                     if (!teamStatusCache.containsKey(cacheKey)) {
                         val isMember = teamRepository.isMember(userId, teamId)
@@ -239,23 +252,27 @@ class AdapterTeamList(
                         val status = TeamStatus(isMember, isLeader, hasPendingRequest)
                         teamStatusCache[cacheKey] = status
                     }
-                    Triple(team, teamStatusCache[cacheKey]!!, visitCount)
+                    team to teamStatusCache[cacheKey]!!
                 }
             }
 
-            val teamWithStatuses = teamStatusJobs.map { it.await() }
+            val teamWithStatuses = teamStatusJobs.awaitAll()
+            val visitCounts = visitCountsDeferred.await()
 
-            val sortedTeams = teamWithStatuses.sortedWith(compareByDescending<Triple<RealmMyTeam, TeamStatus, Long>> { (_, status, _) ->
-                when {
-                    status.isLeader -> 3
-                    status.isMember -> 2
-                    else -> 1
+            val sortedTeams = teamWithStatuses.sortedWith(
+                compareByDescending<Pair<RealmMyTeam, TeamStatus>> { (_, status) ->
+                    when {
+                        status.isLeader -> 3
+                        status.isMember -> 2
+                        else -> 1
+                    }
+                }.thenByDescending { (team, _) ->
+                    visitCounts[team._id.orEmpty()] ?: 0L
                 }
-            }.thenByDescending { (_, _, visitCount) ->
-                visitCount
-            }).map { it.first }
+            ).map { it.first }
 
             withContext(Dispatchers.Main) {
+                this@AdapterTeamList.visitCounts = visitCounts
                 filteredList = sortedTeams
                 notifyDataSetChanged()
                 updateCompleteListener?.onUpdateComplete(filteredList.size)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamFragment.kt
@@ -258,7 +258,6 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem, AdapterTeamLis
                     val adapterTeamList = AdapterTeamList(
                         activity as Context,
                         sortedList,
-                        mRealm,
                         childFragmentManager,
                         teamRepository,
                         user,
@@ -295,7 +294,7 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem, AdapterTeamLis
         }
 
         adapterTeamList = activity?.let {
-            AdapterTeamList(it, list, mRealm, childFragmentManager, teamRepository, user)
+            AdapterTeamList(it, list, childFragmentManager, teamRepository, user)
         } ?: return
         adapterTeamList.setType(type)
         adapterTeamList.setTeamListener(this@TeamFragment)
@@ -367,7 +366,6 @@ class TeamFragment : Fragment(), AdapterTeamList.OnClickTeamItem, AdapterTeamLis
             val adapterTeamList = AdapterTeamList(
                 activity as Context,
                 sortedList,
-                mRealm,
                 childFragmentManager,
                 teamRepository,
                 user,


### PR DESCRIPTION
## Summary
- add a TeamRepository API that returns recent visit counts using RealmTeamLog
- refactor AdapterTeamList to consume repository visit counts and drop direct Realm usage
- update TeamFragment call sites for the adapter changes

## Testing
- ./gradlew :app:compileDefaultDebugKotlin --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dbf023d480832bbb0129d503d4dee1