### PR TITLE
Update team join request cache handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -213,6 +213,15 @@ class AdapterTeamList(
                     }.setNegativeButton(R.string.no, null).show()
             }
         } else {
+            teamStatusCache[cacheKey] = TeamStatus(
+                isMember = false,
+                isLeader = false,
+                hasPendingRequest = true,
+            )
+            val position = filteredList.indexOf(team)
+            if (position != -1) {
+                notifyItemChanged(position)
+            }
             requestToJoin(team, user)
             updateList()
         }
@@ -269,7 +278,17 @@ class AdapterTeamList(
         scope.launch(Dispatchers.IO) {
             teamRepository.requestToJoin(teamId, user, team.teamType)
             val cacheKey = "${teamId}_${user?.id}"
-            teamStatusCache.remove(cacheKey)
+            withContext(Dispatchers.Main) {
+                teamStatusCache[cacheKey] = TeamStatus(
+                    isMember = false,
+                    isLeader = false,
+                    hasPendingRequest = true,
+                )
+                val position = filteredList.indexOfFirst { it._id == teamId }
+                if (position != -1) {
+                    notifyItemChanged(position)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- update the team status cache immediately when requesting to join so the UI shows a pending state
- refresh the affected row and confirm the cached status after the join request completes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc1313c24c832ba78067b11667a3bb