### PR TITLE
teams: less delete report is more (fixes #8076)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3353
-        versionName = "0.33.53"
+        versionCode = 3355
+        versionName = "0.33.55"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -173,14 +173,6 @@ open class RealmMyTeam : RealmObject() {
         }
 
         @JvmStatic
-        fun deleteReport(reportId: String, realm: Realm) {
-            realm.executeTransactionAsync { transactionRealm ->
-                val report = transactionRealm.where(RealmMyTeam::class.java).equalTo("_id", reportId).findFirst()
-                report?.deleteFromRealm()
-            }
-        }
-
-        @JvmStatic
         fun getResourceIds(teamId: String?, realm: Realm): MutableList<String> {
             val teams = realm.where(RealmMyTeam::class.java).equalTo("teamId", teamId).findAll()
             val ids = mutableListOf<String>()


### PR DESCRIPTION
## Summary
- remove the unused `deleteReport` helper from `RealmMyTeam`

## Testing
- `./gradlew :app:testDefaultDebugUnitTest --no-daemon --console=plain --no-configuration-cache --stacktrace` *(fails: Could not determine the dependencies of task ':app:compileDefaultDebugJavaWithJavac'. Cannot query the value of this provider because it has no value available.)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2115166c832bb6152183af8652d5