### PR TITLE
Remove unused filterUsers helper from RealmMyTeam

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -296,21 +296,6 @@ open class RealmMyTeam : RealmObject() {
         }
 
         @JvmStatic
-        fun filterUsers(teamId: String?, user: String, mRealm: Realm): MutableList<RealmUserModel> {
-            val myTeam = mRealm.where(RealmMyTeam::class.java).equalTo("teamId", teamId).findAll()
-            val list = mutableListOf<RealmUserModel>()
-            for (team in myTeam) {
-                val model = mRealm.where(RealmUserModel::class.java)
-                    .equalTo("id", team.userId)
-                    .findFirst()
-                if (model != null && model.name?.contains(user) == true) {
-                    list.add(model)
-                }
-            }
-            return list
-        }
-
-        @JvmStatic
         fun serialize(team: RealmMyTeam): JsonObject {
             val gson = Gson()
             val `object` = JsonObject()


### PR DESCRIPTION
## Summary
- remove the unused `filterUsers` helper from `RealmMyTeam`

## Testing
- not run (no relevant Realm/team unit tests available)


------
https://chatgpt.com/codex/tasks/task_e_68dd211e1eec832bad72b44c2700b429