### PR TITLE
teams: less leader is more (fixes #8078)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3353
-        versionName = "0.33.53"
+        versionCode = 3357
+        versionName = "0.33.57"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -224,15 +224,6 @@ open class RealmMyTeam : RealmObject() {
         }
 
         @JvmStatic
-        fun getTeamLeader(teamId: String?, realm: Realm): String {
-            val team = realm.where(RealmMyTeam::class.java)
-                .equalTo("teamId", teamId)
-                .equalTo("isLeader", true)
-                .findFirst()
-            return team?.userId ?: ""
-        }
-
-        @JvmStatic
         fun insert(mRealm: Realm, doc: JsonObject) {
             insertMyTeams(doc, mRealm)
         }


### PR DESCRIPTION
## Summary
- remove the unused `getTeamLeader` helper from `RealmMyTeam`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2175cc90832bae89a9994e41963c