### PR TITLE
all: less challenge actions is more (fixes #8079)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3353
-        versionName = "0.33.53"
+        versionCode = 3358
+        versionName = "0.33.58"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmUserChallengeActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmUserChallengeActions.kt
@@ -14,18 +14,6 @@ open class RealmUserChallengeActions : RealmObject() {
     var time: Long = 0
 
     companion object {
-        fun createAction(realm: Realm, userId: String, resourceId: String?, actionType: String) {
-            realm.executeTransaction { transactionRealm ->
-                val action = transactionRealm.createObject(
-                    RealmUserChallengeActions::class.java, UUID.randomUUID().toString()
-                )
-                action.userId = userId
-                action.actionType = actionType
-                action.resourceId = resourceId
-                action.time = System.currentTimeMillis()
-            }
-        }
-
         fun createActionAsync(
             realm: Realm,
             userId: String,


### PR DESCRIPTION
## Summary
- remove the unused synchronous helper from `RealmUserChallengeActions`

## Testing
- `CI=true ./gradlew test --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68dd218b4988832b90b0ce0b1cf7fb14