### PR TITLE
Remove deprecated myMessages item from myLife dashboard

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragmentPlugin.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragmentPlugin.kt
@@ -139,7 +139,6 @@ open class BaseDashboardFragmentPlugin : BaseContainerFragment() {
     fun getMyLifeListBase(userId: String?): List<RealmMyLife> {
         val myLifeList: MutableList<RealmMyLife> = ArrayList()
         myLifeList.add(RealmMyLife("ic_myhealth", userId, getString(R.string.myhealth)))
-        myLifeList.add(RealmMyLife("ic_messages", userId, getString(R.string.messeges)))
         myLifeList.add(RealmMyLife("my_achievement", userId, getString(R.string.achievements)))
         myLifeList.add(RealmMyLife("ic_submissions", userId, getString(R.string.submission)))
         myLifeList.add(RealmMyLife("ic_my_survey", userId, getString(R.string.my_survey)))

--- a/app/src/main/res/layout/row_life.xml
+++ b/app/src/main/res/layout/row_life.xml
@@ -17,7 +17,7 @@
             android:layout_width="100dp"
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
-            app:srcCompat="@drawable/ic_messages"
+            app:srcCompat="@drawable/ic_myhealth"
             app:tint="@color/daynight_textColor" />
         <TextView
             android:id="@+id/titleTextView"
@@ -26,7 +26,7 @@
             android:layout_marginLeft="15dp"
             android:layout_marginTop="@dimen/_20dp"
             android:layout_toRightOf="@id/itemImageView"
-            android:hint="@string/messeges"
+            android:hint="@string/myhealth"
             android:textStyle="bold"
             android:textColor="@color/daynight_textColor" />
         <ImageButton

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -142,7 +142,6 @@
     <string name="languages">اللغات</string>
     <string name="txt_myLife">حياتي</string>
     <string name="achievements">إنجازاتي</string>
-    <string name="messeges">رسائلي</string>
     <string name="contacts">جهات الاتصال</string>
     <string name="news">أخبار</string>
     <string name="references">المراجع</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -142,7 +142,6 @@
     <string name="languages">Idiomas</string>
     <string name="txt_myLife">miVida</string>
     <string name="achievements">misLogros</string>
-    <string name="messeges">misMensajes</string>
     <string name="contacts">Contactos</string>
     <string name="news">Noticias</string>
     <string name="references">Referencias</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -142,7 +142,6 @@
     <string name="languages">Langues</string>
     <string name="txt_myLife">maVie</string>
     <string name="achievements">mesRéalisations</string>
-    <string name="messeges">mesMessages</string>
     <string name="contacts">Contacts</string>
     <string name="news">Nouvelles</string>
     <string name="references">Références</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -142,7 +142,6 @@
     <string name="languages">भाषाहरू</string>
     <string name="txt_myLife">मेरो जीवन</string>
     <string name="achievements">मेरो साधारणता</string>
-    <string name="messeges">मेरा सन्देशहरू</string>
     <string name="contacts">सम्पर्कहरू</string>
     <string name="news">समाचार</string>
     <string name="references">सन्दर्भहरू</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -142,7 +142,6 @@
     <string name="languages">Luqadaha</string>
     <string name="txt_myLife">Nolosheyda</string>
     <string name="achievements">Dhamaanada</string>
-    <string name="messeges">Farriimahayga</string>
     <string name="contacts">Xiriirrada</string>
     <string name="news">Wararka</string>
     <string name="references">Tixraacyo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,6 @@
     <string name="languages">Languages</string>
     <string name="txt_myLife">myLife</string>
     <string name="achievements">myAchievements</string>
-    <string name="messeges">myMessages</string>
     <string name="contacts">Contacts</string>
     <string name="news">News</string>
     <string name="references">References</string>


### PR DESCRIPTION
## Summary
- remove the myMessages entry from the dashboard myLife list
- update the myLife row layout defaults and delete the obsolete `messeges` string resources across locales

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd23001a08832ba35e0388a65ee331