### PR TITLE
Refactor notification navigation through repository helpers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -11,6 +11,20 @@ data class TaskNotificationMetadata(
     val teamName: String?,
 )
 
+data class SurveyNotificationTarget(
+    val stepId: String,
+)
+
+data class TaskNavigationTarget(
+    val teamId: String,
+    val teamName: String?,
+    val teamType: String?,
+)
+
+data class JoinRequestNavigationTarget(
+    val teamId: String,
+)
+
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
     suspend fun updateResourceNotification(userId: String?)
@@ -20,4 +34,7 @@ interface NotificationRepository {
     suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata?
     suspend fun getTaskNotificationMetadata(taskTitle: String): TaskNotificationMetadata?
     suspend fun ensureNotification(type: String, message: String, relatedId: String?, userId: String?)
+    suspend fun resolveSurveyStepId(stepName: String?): SurveyNotificationTarget?
+    suspend fun resolveTaskNavigation(taskId: String?): TaskNavigationTarget?
+    suspend fun resolveJoinRequestTeam(joinRequestId: String?): JoinRequestNavigationTarget?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -19,16 +19,11 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.json.JSONObject
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.R.array.status_options
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentNotificationsBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
-import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNotification
-import org.ole.planet.myplanet.model.RealmStepExam
-import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.repository.NotificationRepository
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.resources.ResourcesFragment
@@ -41,8 +36,6 @@ import org.ole.planet.myplanet.utilities.NotificationUtils
 @AndroidEntryPoint
 class NotificationsFragment : Fragment() {
     private var _binding: FragmentNotificationsBinding? = null
-    @Inject
-    lateinit var databaseService: DatabaseService
     @Inject
     lateinit var notificationRepository: NotificationRepository
     private lateinit var adapter: AdapterNotification
@@ -104,86 +97,66 @@ class NotificationsFragment : Fragment() {
     }
 
     private fun handleNotificationClick(notification: RealmNotification) {
-        when (notification.type) {
-            "storage" -> {
-                val intent = Intent(ACTION_INTERNAL_STORAGE_SETTINGS)
-                startActivity(intent)
-            }
-            "survey" -> {
-                databaseService.withRealm { realm ->
-                    val currentStepExam = realm.where(RealmStepExam::class.java)
-                        .equalTo("name", notification.relatedId)
-                        .findFirst()
-                    if (currentStepExam != null && activity is OnHomeItemClickListener) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            when (notification.type) {
+                "storage" -> {
+                    val intent = Intent(ACTION_INTERNAL_STORAGE_SETTINGS)
+                    startActivity(intent)
+                }
+                "survey" -> {
+                    val surveyTarget = withContext(Dispatchers.IO) {
+                        notificationRepository.resolveSurveyStepId(notification.relatedId)
+                    }
+                    val onHomeListener = activity as? OnHomeItemClickListener
+                    if (surveyTarget != null && onHomeListener != null) {
                         AdapterMySubmission.openSurvey(
-                            activity as OnHomeItemClickListener,
-                            currentStepExam.id,
+                            onHomeListener,
+                            surveyTarget.stepId,
                             false,
                             false,
                             "",
                         )
                     }
                 }
-            }
-            "task" -> {
-                databaseService.withRealm { realm ->
-                    val taskId = notification.relatedId
-                    val task = realm.where(RealmTeamTask::class.java)
-                        .equalTo("id", taskId)
-                        .findFirst()
-
-                    val linkJson = JSONObject(task?.link ?: "{}")
-                    val teamId = linkJson.optString("teams")
-                    if (teamId.isNotEmpty() && activity is OnHomeItemClickListener) {
-                        val teamObject = realm.where(RealmMyTeam::class.java)
-                            .equalTo("_id", teamId)
-                            .findFirst()
-                        val f = TeamDetailFragment.newInstance(
-                            teamId = teamId,
-                            teamName = teamObject?.name ?: "",
-                            teamType = teamObject?.type ?: "",
+                "task" -> {
+                    val taskNavigation = withContext(Dispatchers.IO) {
+                        notificationRepository.resolveTaskNavigation(notification.relatedId)
+                    }
+                    val onHomeListener = activity as? OnHomeItemClickListener
+                    if (taskNavigation != null && onHomeListener != null) {
+                        val fragment = TeamDetailFragment.newInstance(
+                            teamId = taskNavigation.teamId,
+                            teamName = taskNavigation.teamName ?: "",
+                            teamType = taskNavigation.teamType ?: "",
                             isMyTeam = true,
                             navigateToPage = TasksPage,
                         )
-
-                        (activity as OnHomeItemClickListener).openCallFragment(f)
+                        onHomeListener.openCallFragment(fragment)
                     }
                 }
-            }
-            "join_request" -> {
-                val joinRequestId = notification.relatedId
-                if (joinRequestId?.isNotEmpty() == true && activity is OnHomeItemClickListener) {
-                    val actualJoinRequestId = if (joinRequestId.startsWith("join_request_")) {
-                        joinRequestId.removePrefix("join_request_")
-                    } else {
-                        joinRequestId
+                "join_request" -> {
+                    val joinRequestNavigation = withContext(Dispatchers.IO) {
+                        notificationRepository.resolveJoinRequestTeam(notification.relatedId)
                     }
-                    databaseService.withRealm { realm ->
-                        val joinRequest = realm.where(RealmMyTeam::class.java)
-                            .equalTo("_id", actualJoinRequestId)
-                            .equalTo("docType", "request")
-                            .findFirst()
-
-                        val teamId = joinRequest?.teamId
-                        if (teamId?.isNotEmpty() == true) {
-                            val f = TeamDetailFragment()
-                            val b = Bundle()
-                            b.putString("id", teamId)
-                            b.putBoolean("isMyTeam", true)
-                            b.putString("navigateToPage", JoinRequestsPage.id)
-                            f.arguments = b
-                            (activity as OnHomeItemClickListener).openCallFragment(f)
+                    val onHomeListener = activity as? OnHomeItemClickListener
+                    if (joinRequestNavigation != null && onHomeListener != null) {
+                        val fragment = TeamDetailFragment()
+                        fragment.arguments = Bundle().apply {
+                            putString("id", joinRequestNavigation.teamId)
+                            putBoolean("isMyTeam", true)
+                            putString("navigateToPage", JoinRequestsPage.id)
                         }
+                        onHomeListener.openCallFragment(fragment)
                     }
                 }
+                "resource" -> {
+                    dashboardActivity.openMyFragment(ResourcesFragment())
+                }
             }
-            "resource" -> {
-                dashboardActivity.openMyFragment(ResourcesFragment())
-            }
-        }
 
-        if (!notification.isRead) {
-            markAsReadById(notification.id)
+            if (!notification.isRead) {
+                markAsReadById(notification.id)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
* add DTOs and helper APIs to NotificationRepository for resolving survey, task, and join request targets
* implement the new helpers in NotificationRepositoryImpl so UI callers stay off Realm objects
* update NotificationsFragment to consume the repository helpers from coroutines and drop its DatabaseService dependency

## Testing
* ./gradlew --console=plain :app:testDefaultDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_e_68dd24769168832bb5519abff6f414d4