### PR TITLE
teams: smoother voices refreshing (fixes #8081)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3353
-        versionName = "0.33.53"
+        versionCode = 3362
+        versionName = "0.33.62"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
@@ -88,13 +88,13 @@ abstract class BaseNewsFragment : BaseContainerFragment(), OnNewsItemClickListen
             if (result.resultCode == Activity.RESULT_OK) {
                 val newsId = result.data?.getStringExtra("newsId")
                 newsId.let { adapterNews?.updateReplyBadge(it) }
-                adapterNews?.notifyDataSetChanged()
+                adapterNews?.refreshCurrentItems()
             }
         }
     }
 
     override fun onDataChanged() {
-        adapterNews?.notifyDataSetChanged()
+        adapterNews?.refreshCurrentItems()
     }
 
     override fun onAttach(context: Context) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/AdapterNews.kt
@@ -390,6 +390,10 @@ class AdapterNews(var context: Context, private var currentUser: RealmUserModel?
         submitListSafely(newList)
     }
 
+    fun refreshCurrentItems() {
+        submitListSafely(currentList.toList())
+    }
+
     private fun submitListSafely(list: List<RealmNews?>, commitCallback: Runnable? = null) {
         userCache.clear()
         val detachedList = list.map { news ->


### PR DESCRIPTION
## Summary
- add a helper on AdapterNews to resubmit the current snapshot through ListAdapter diffing
- replace BaseNewsFragment's notifyDataSetChanged calls with the new helper to limit UI refresh scope

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd24e72ddc832b94dc152c5f46d5af