### PR TITLE
Add suspend Realm helper for background notifications

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -44,6 +44,19 @@ class DatabaseService(context: Context) {
         }
     }
 
+    suspend fun <T> withRealmSuspend(operation: suspend (Realm) -> T): T {
+        return withContext(Dispatchers.IO) {
+            val realm = realmInstance
+            try {
+                operation(realm)
+            } finally {
+                if (!realm.isClosed) {
+                    realm.close()
+                }
+            }
+        }
+    }
+
     suspend fun executeTransactionAsync(transaction: (Realm) -> Unit) {
         withContext(Dispatchers.IO) {
             withRealmInstance { realm ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -585,13 +585,10 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
             try {
                 dashboardViewModel.updateResourceNotification(userId)
-                val backgroundRealm = databaseService.realmInstance
-                try {
-                    val createdNotifications = createNotifications(backgroundRealm, userId)
-                    newNotifications.addAll(createdNotifications)
-                } finally {
-                    backgroundRealm.close()
+                val createdNotifications = databaseService.withRealmSuspend { realm ->
+                    createNotifications(realm, userId)
                 }
+                newNotifications.addAll(createdNotifications)
 
                 unreadCount = dashboardViewModel.getUnreadNotificationsSize(userId)
             } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- add a suspend-aware Realm helper in `DatabaseService` to manage lifecycle automatically
- refactor dashboard notification creation to run inside the managed helper scope

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd25bb7cf0832babd085f7b676f818