### PR TITLE
all: smoother feedback timestamp handling (fixes #8082)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3353
-        versionName = "0.33.53"
+        versionCode = 3363
+        versionName = "0.33.63"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -36,7 +36,8 @@ class FeedbackRepositoryImpl @Inject constructor(
             feedback.title = "Question regarding /"
             feedback.url = "/"
         }
-        feedback.openTime = Date().time
+        val timestamp = Date().time
+        feedback.openTime = timestamp
         feedback.owner = user
         feedback.source = user
         feedback.status = "Open"
@@ -45,8 +46,8 @@ class FeedbackRepositoryImpl @Inject constructor(
         feedback.parentCode = "dev"
         val obj = JsonObject().apply {
             addProperty("message", message)
-            addProperty("time", Date().time.toString() + "")
-            addProperty("user", user + "")
+            addProperty("time", timestamp.toString())
+            addProperty("user", user.orEmpty())
         }
         val msgArray = JsonArray().apply { add(obj) }
         feedback.setMessages(msgArray)


### PR DESCRIPTION
## Summary
- capture a single timestamp when creating feedback and reuse it for both openTime and the initial message entry
- replace string concatenations with safer conversions and confirm no remaining dependencies on the prior "null" sentinel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd266ce4c8832b96756ab941345963