### PR TITLE
teams: smoother task repository status completion updating (fixes #8083)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3353
-        versionName = "0.33.53"
+        versionCode = 3364
+        versionName = "0.33.64"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -28,6 +28,7 @@ interface TeamRepository {
     suspend fun deleteTask(taskId: String)
     suspend fun upsertTask(task: RealmTeamTask)
     suspend fun assignTask(taskId: String, assigneeId: String?)
+    suspend fun setTaskCompletion(taskId: String, completed: Boolean)
     suspend fun createTeam(
         category: String?,
         name: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -217,6 +217,14 @@ class TeamRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun setTaskCompletion(taskId: String, completed: Boolean) {
+        update(RealmTeamTask::class.java, "id", taskId) { task ->
+            task.completed = completed
+            task.completedTime = if (completed) Date().time else 0
+            task.isUpdated = true
+        }
+    }
+
     override suspend fun createTeam(
         category: String?,
         name: String,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
@@ -257,13 +257,17 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
         }
     }
 
-    override fun onCheckChange(realmTeamTask: RealmTeamTask?, b: Boolean) {
-        if (!mRealm.isInTransaction) mRealm.beginTransaction()
-        realmTeamTask?.completed = b
-        realmTeamTask?.isUpdated = true
-        realmTeamTask?.completedTime = Date().time
-        mRealm.commitTransaction()
-        setAdapter()
+    override fun onCheckChange(realmTeamTask: RealmTeamTask?, completed: Boolean) {
+        val taskId = realmTeamTask?.id ?: return
+        viewLifecycleOwner.lifecycleScope.launch {
+            teamRepository.setTaskCompletion(taskId, completed)
+
+            if (!mRealm.isClosed) {
+                mRealm.refresh()
+            }
+
+            setAdapter()
+        }
     }
 
     override fun onEdit(task: RealmTeamTask?) {


### PR DESCRIPTION
## Summary
- add a repository API for toggling team task completion that updates timestamp and sync flag
- use the new repository API from TeamTaskFragment to handle completion toggles via coroutines

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd26c56c00832b93ca27c42bfabb39