### PR TITLE
courses: smoother submission repository steps checking (fixes #8084)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3353
-        versionName = "0.33.53"
+        versionCode = 3365
+        versionName = "0.33.65"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -12,6 +12,12 @@ interface SubmissionRepository {
     suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission>
     suspend fun getExamMapForSubmissions(submissions: List<RealmSubmission>): Map<String?, RealmStepExam>
     suspend fun getExamQuestionCount(stepId: String): Int
+    suspend fun hasSubmission(
+        stepExamId: String?,
+        courseId: String?,
+        userId: String?,
+        type: String,
+    ): Boolean
     suspend fun createSurveySubmission(examId: String, userId: String?)
     suspend fun saveSubmission(submission: RealmSubmission)
     suspend fun updateSubmission(id: String, updater: (RealmSubmission) -> Unit)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import java.util.Date
 import java.util.UUID
 import org.ole.planet.myplanet.MainApplication

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import java.util.Date
 import java.util.UUID
 import org.ole.planet.myplanet.MainApplication
@@ -16,11 +17,9 @@ import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.databinding.FragmentCourseStepBinding
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
-import org.ole.planet.myplanet.model.RealmExamQuestion
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.isMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmStepExam
-import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.exam.TakeExamFragment
@@ -140,37 +139,26 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     private fun hideTestIfNoQuestion() {
         fragmentCourseStepBinding.btnTakeTest.visibility = View.GONE
         fragmentCourseStepBinding.btnTakeSurvey.visibility = View.GONE
-        if (stepExams.isNotEmpty()) {
-            val firstStepId = stepExams[0].id
-            val isTestPersent = existsSubmission(firstStepId, "exam")
-            fragmentCourseStepBinding.btnTakeTest.text = if (isTestPersent) { getString(R.string.retake_test, stepExams.size) } else { getString(R.string.take_test, stepExams.size) }
-            fragmentCourseStepBinding.btnTakeTest.visibility = View.VISIBLE
-        }
-        if (stepSurvey.isNotEmpty()) {
-            val firstStepId = stepSurvey[0].id
-            val isSurveyPresent = existsSubmission(firstStepId, "survey")
-            fragmentCourseStepBinding.btnTakeSurvey.text = if (isSurveyPresent) { "redo survey" } else { "record survey" }
-            fragmentCourseStepBinding.btnTakeSurvey.visibility = View.VISIBLE
-        }
-    }
-
-    private fun existsSubmission(firstStepId: String?, submissionType: String): Boolean {
-        return databaseService.withRealm { realm ->
-            val questions = realm.where(RealmExamQuestion::class.java)
-                .equalTo("examId", firstStepId)
-                .findAll()
-            if (questions.isNotEmpty()) {
-                val examId = questions[0]?.examId
-                step.courseId?.let { courseId ->
-                    val parentId = "$examId@$courseId"
-                    realm.where(RealmSubmission::class.java)
-                        .equalTo("userId", user?.id)
-                        .equalTo("parentId", parentId)
-                        .equalTo("type", submissionType)
-                        .findFirst() != null
-                } ?: false
-            } else {
-                false
+        viewLifecycleOwner.lifecycleScope.launch {
+            if (stepExams.isNotEmpty()) {
+                val firstStepId = stepExams[0].id
+                val isTestPresent = submissionRepository.hasSubmission(firstStepId, step.courseId, user?.id, "exam")
+                fragmentCourseStepBinding.btnTakeTest.text = if (isTestPresent) {
+                    getString(R.string.retake_test, stepExams.size)
+                } else {
+                    getString(R.string.take_test, stepExams.size)
+                }
+                fragmentCourseStepBinding.btnTakeTest.visibility = View.VISIBLE
+            }
+            if (stepSurvey.isNotEmpty()) {
+                val firstStepId = stepSurvey[0].id
+                val isSurveyPresent = submissionRepository.hasSubmission(firstStepId, step.courseId, user?.id, "survey")
+                fragmentCourseStepBinding.btnTakeSurvey.text = if (isSurveyPresent) {
+                    "redo survey"
+                } else {
+                    "record survey"
+                }
+                fragmentCourseStepBinding.btnTakeSurvey.visibility = View.VISIBLE
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a reusable `hasSubmission` query to the submission repository
- refactor `CourseStepFragment` to use the repository for submission checks on a background thread

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd270a9a9c832ba54c8df66667b35e