### PR TITLE
Use LibraryRepository for course step resource buttons

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepository.kt
@@ -8,6 +8,7 @@ interface LibraryRepository {
     suspend fun getLibraryItemByResourceId(resourceId: String): RealmMyLibrary?
     suspend fun getLibraryItemsByLocalAddress(localAddress: String): List<RealmMyLibrary>
     suspend fun getLibraryListForUser(userId: String?): List<RealmMyLibrary>
+    suspend fun getStepResources(stepId: String?, offline: Boolean): List<RealmMyLibrary>
     suspend fun saveLibraryItem(item: RealmMyLibrary)
     suspend fun markResourceAdded(userId: String?, resourceId: String)
     suspend fun updateUserLibrary(resourceId: String, userId: String, isAdd: Boolean): RealmMyLibrary?

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -39,6 +39,14 @@ class LibraryRepositoryImpl @Inject constructor(
             .filter { it.userId?.contains(userId) == true }
     }
 
+    override suspend fun getStepResources(stepId: String?, offline: Boolean): List<RealmMyLibrary> {
+        return queryList(RealmMyLibrary::class.java) {
+            equalTo("stepId", stepId)
+            equalTo("resourceOffline", offline)
+            isNotNull("resourceLocalAddress")
+        }
+    }
+
     override suspend fun saveLibraryItem(item: RealmMyLibrary) {
         save(item)
     }


### PR DESCRIPTION
## Summary
- add a repository API to fetch course step resources with offline filtering
- update the course step fragment to load resource lists through the repository in coroutines

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd273105f8832b9ccfea9b935fc758