### PR TITLE
Refactor course step loading via repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
@@ -3,6 +3,13 @@ package org.ole.planet.myplanet.repository
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmStepExam
+
+data class CourseStepData(
+    val step: RealmCourseStep,
+    val courseExams: List<RealmStepExam>,
+    val surveyExams: List<RealmStepExam>,
+)
 
 interface CourseRepository {
     suspend fun getAllCourses(): List<RealmMyCourse>
@@ -11,4 +18,5 @@ interface CourseRepository {
     suspend fun getCourseOfflineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseExamCount(courseId: String?): Int
     suspend fun getCourseSteps(courseId: String?): List<RealmCourseStep>
+    suspend fun getCourseStepData(stepId: String): CourseStepData?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -2,9 +2,11 @@ package org.ole.planet.myplanet.repository
 
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.datamanager.queryList
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.getNoOfExam
 
 class CourseRepositoryImpl @Inject constructor(
@@ -47,6 +49,24 @@ class CourseRepositoryImpl @Inject constructor(
             } else {
                 realm.copyFromRealm(steps)
             }
+        }
+    }
+
+    override suspend fun getCourseStepData(stepId: String): CourseStepData? {
+        if (stepId.isBlank()) {
+            return null
+        }
+        val step = findByField(RealmCourseStep::class.java, "id", stepId) ?: return null
+        return withRealmAsync { realm ->
+            val courseExams = realm.queryList(RealmStepExam::class.java) {
+                equalTo("stepId", stepId)
+                equalTo("type", "courses")
+            }
+            val surveyExams = realm.queryList(RealmStepExam::class.java) {
+                equalTo("stepId", stepId)
+                equalTo("type", "surveys")
+            }
+            CourseStepData(step, courseExams, surveyExams)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -8,8 +8,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import java.util.Date
 import java.util.UUID
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
@@ -22,6 +27,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.CourseRepository
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.exam.TakeExamFragment
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
@@ -35,11 +41,13 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     private lateinit var fragmentCourseStepBinding: FragmentCourseStepBinding
     var stepId: String? = null
     private lateinit var step: RealmCourseStep
-    private lateinit var resources: List<RealmMyLibrary>
-    private lateinit var stepExams: List<RealmStepExam>
-    private lateinit var stepSurvey: List<RealmStepExam>
+    private var resources: List<RealmMyLibrary> = emptyList()
+    private var stepExams: List<RealmStepExam> = emptyList()
+    private var stepSurvey: List<RealmStepExam> = emptyList()
     var user: RealmUserModel? = null
     private var stepNumber = 0
+    @Inject
+    lateinit var courseRepository: CourseRepository
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
@@ -82,58 +90,67 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        databaseService.withRealm { realm ->
-            step = realm.where(RealmCourseStep::class.java)
-                .equalTo("id", stepId)
-                .findFirst()
-                ?.let { realm.copyFromRealm(it) }!!
-            resources = realm.where(RealmMyLibrary::class.java)
-                .equalTo("stepId", stepId)
-                .findAll()
-                .let { realm.copyFromRealm(it) }
-            stepExams = realm.where(RealmStepExam::class.java)
-                .equalTo("stepId", stepId)
-                .equalTo("type", "courses")
-                .findAll()
-                .let { realm.copyFromRealm(it) }
-            stepSurvey = realm.where(RealmStepExam::class.java)
-                .equalTo("stepId", stepId)
-                .equalTo("type", "surveys")
-                .findAll()
-                .let { realm.copyFromRealm(it) }
-        }
-        fragmentCourseStepBinding.btnResources.text = getString(R.string.resources_size, resources.size)
-        hideTestIfNoQuestion()
-        fragmentCourseStepBinding.tvTitle.text = step.stepTitle
-        val markdownContentWithLocalPaths = prependBaseUrlToImages(
-            step.description,
-            "file://${MainApplication.context.getExternalFilesDir(null)}/ole/",
-            600,
-            350
-        )
-        setMarkdownText(fragmentCourseStepBinding.description, markdownContentWithLocalPaths)
-        fragmentCourseStepBinding.description.movementMethod = LinkMovementMethod.getInstance()
-        val userHasCourse = databaseService.withRealm { realm ->
-            isMyCourse(user?.id, step.courseId, realm)
-        }
-        if (!userHasCourse) {
-            fragmentCourseStepBinding.btnTakeTest.visibility = View.GONE
-            fragmentCourseStepBinding.btnTakeSurvey.visibility = View.GONE
-        }
-        setListeners()
-        val textWithSpans = fragmentCourseStepBinding.description.text
-        if (textWithSpans is Spannable) {
-            val urlSpans = textWithSpans.getSpans(0, textWithSpans.length, URLSpan::class.java)
-            for (urlSpan in urlSpans) {
-                val start = textWithSpans.getSpanStart(urlSpan)
-                val end = textWithSpans.getSpanEnd(urlSpan)
-                val dynamicTitle = textWithSpans.subSequence(start, end).toString()
-                textWithSpans.setSpan(CustomClickableSpan(urlSpan.url, dynamicTitle, requireActivity()), start, end, textWithSpans.getSpanFlags(urlSpan))
-                textWithSpans.removeSpan(urlSpan)
+        viewLifecycleOwner.lifecycleScope.launch {
+            val currentStepId = stepId
+            if (currentStepId.isNullOrEmpty()) {
+                resources = emptyList()
+                stepExams = emptyList()
+                stepSurvey = emptyList()
+                return@launch
             }
-        }
-        if (isVisible && userHasCourse) {
-            saveCourseProgress()
+            val stepData = courseRepository.getCourseStepData(currentStepId) ?: run {
+                resources = emptyList()
+                stepExams = emptyList()
+                stepSurvey = emptyList()
+                return@launch
+            }
+            val resourceList = withContext(Dispatchers.IO) {
+                databaseService.withRealm { realm ->
+                    realm.where(RealmMyLibrary::class.java)
+                        .equalTo("stepId", currentStepId)
+                        .findAll()
+                        .let { realm.copyFromRealm(it) }
+                }
+            }
+            step = stepData.step
+            stepExams = stepData.courseExams
+            stepSurvey = stepData.surveyExams
+            resources = resourceList
+            fragmentCourseStepBinding.btnResources.text = getString(R.string.resources_size, resources.size)
+            hideTestIfNoQuestion()
+            fragmentCourseStepBinding.tvTitle.text = step.stepTitle
+            val markdownContentWithLocalPaths = prependBaseUrlToImages(
+                step.description,
+                "file://${MainApplication.context.getExternalFilesDir(null)}/ole/",
+                600,
+                350
+            )
+            setMarkdownText(fragmentCourseStepBinding.description, markdownContentWithLocalPaths)
+            fragmentCourseStepBinding.description.movementMethod = LinkMovementMethod.getInstance()
+            val userHasCourse = withContext(Dispatchers.IO) {
+                databaseService.withRealm { realm ->
+                    isMyCourse(user?.id, step.courseId, realm)
+                }
+            }
+            if (!userHasCourse) {
+                fragmentCourseStepBinding.btnTakeTest.visibility = View.GONE
+                fragmentCourseStepBinding.btnTakeSurvey.visibility = View.GONE
+            }
+            setListeners()
+            val textWithSpans = fragmentCourseStepBinding.description.text
+            if (textWithSpans is Spannable) {
+                val urlSpans = textWithSpans.getSpans(0, textWithSpans.length, URLSpan::class.java)
+                for (urlSpan in urlSpans) {
+                    val start = textWithSpans.getSpanStart(urlSpan)
+                    val end = textWithSpans.getSpanEnd(urlSpan)
+                    val dynamicTitle = textWithSpans.subSequence(start, end).toString()
+                    textWithSpans.setSpan(CustomClickableSpan(urlSpan.url, dynamicTitle, requireActivity()), start, end, textWithSpans.getSpanFlags(urlSpan))
+                    textWithSpans.removeSpan(urlSpan)
+                }
+            }
+            if (isVisible && userHasCourse) {
+                saveCourseProgress()
+            }
         }
     }
 
@@ -178,7 +195,7 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     override fun setMenuVisibility(visible: Boolean) {
         super.setMenuVisibility(visible)
         try {
-            if (visible) {
+            if (visible && ::step.isInitialized) {
                 val userHasCourse = databaseService.withRealm { realm ->
                     isMyCourse(user?.id, step.courseId, realm)
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -7,7 +7,6 @@ import android.text.style.URLSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import java.util.Date
 import java.util.UUID
@@ -15,6 +14,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
@@ -37,6 +37,7 @@ import org.ole.planet.myplanet.utilities.CustomClickableSpan
 import org.ole.planet.myplanet.utilities.Markdown.prependBaseUrlToImages
 import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 
+@AndroidEntryPoint
 class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     private lateinit var fragmentCourseStepBinding: FragmentCourseStepBinding
     var stepId: String? = null
@@ -220,11 +221,12 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
         setResourceButton(notDownloadedResources, fragmentCourseStepBinding.btnResources)
         fragmentCourseStepBinding.btnTakeTest.setOnClickListener {
             if (stepExams.isNotEmpty()) {
-                val takeExam: Fragment = TakeExamFragment()
-                val b = Bundle()
-                b.putString("stepId", stepId)
-                b.putInt("stepNum", stepNumber)
-                takeExam.arguments = b
+                val takeExam = TakeExamFragment().apply {
+                    arguments = Bundle().apply {
+                        putString("stepId", stepId)
+                        putInt("stepNum", stepNumber)
+                    }
+                }
                 homeItemClickListener?.openCallFragment(takeExam)
                 capturePhoto(this)
             }


### PR DESCRIPTION
## Summary
- add a CourseStepData model and repository API to load step, course exams, and survey exams together
- implement the repository method with Realm helpers to return detached copies of step and exam data
- inject the repository into CourseStepFragment and load step data asynchronously before updating the UI

## Testing
- ./gradlew :app:compileDefaultDebugKotlin --console=plain > /tmp/gradle.log && tail -n 20 /tmp/gradle.log

------
https://chatgpt.com/codex/tasks/task_e_68dd26f70398832b8e46b6c040078e65