### PR TITLE
dashboard: less loading is more (fixes #8124)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3366
-        versionName = "0.33.66"
+        versionCode = 3367
+        versionName = "0.33.67"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -1,13 +1,11 @@
 package org.ole.planet.myplanet.ui.dashboard
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.repository.CourseRepository
 import org.ole.planet.myplanet.repository.LibraryRepository
@@ -40,24 +38,6 @@ class DashboardViewModel @Inject constructor(
         val earnedDollarsSurvey = if (!hasUnfinishedSurvey) 1 else 0
         val total = earnedDollarsVoice + earnedDollarsSurvey
         return total.coerceAtMost(11)
-    }
-
-    fun loadDashboardData(userId: String?) {
-        loadSurveyWarning(userId)
-        loadUnreadNotifications(userId)
-    }
-
-    private fun loadSurveyWarning(userId: String?) {
-        viewModelScope.launch {
-            val count = submissionRepository.getSubmissionCountByUser(userId)
-            _surveyWarning.value = count == 0
-        }
-    }
-
-    private fun loadUnreadNotifications(userId: String?) {
-        viewModelScope.launch {
-            _unreadNotifications.value = notificationRepository.getUnreadCount(userId)
-        }
     }
 
     suspend fun updateResourceNotification(userId: String?) {


### PR DESCRIPTION
## Summary
- remove unused dashboard data loading helpers from `DashboardViewModel`

## Testing
- ./gradlew testDefaultDebugUnitTest --console=plain > /tmp/gradle-testDefaultDebugUnitTest.log 2>&1
- ./gradlew testLiteDebugUnitTest --console=plain > /tmp/gradle-testLiteDebugUnitTest.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68de9f662cc8832b85746f23834fe47a