### PR TITLE
Remove unused extra setup and versions maps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,16 +3,6 @@ import org.gradle.api.tasks.Delete
 buildscript {
     val extra = project.extra
     extra["kotlin_version"] = "2.2.10"
-    extra["setup"] = mapOf(
-        "compileSdk" to 36,
-        "buildTools" to "36.0.0",
-        "minSdk" to 21,
-        "targetSdk" to 36
-    )
-    extra["versions"] = mapOf(
-        "supportLib" to "28.0.0"
-    )
-
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- remove unused `extra` setup and versions maps from the Gradle buildscript to tidy configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dea7ae1cb8832baf0ef19bc5c30605