### PR TITLE
Inject UserProfileDbHandler into MembersFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/MembersFragment.kt
@@ -5,6 +5,7 @@ import android.content.res.Configuration
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import org.ole.planet.myplanet.base.BaseMemberFragment
 import org.ole.planet.myplanet.callback.MemberChangeListener
 import org.ole.planet.myplanet.model.RealmMyTeam
@@ -16,6 +17,9 @@ import org.ole.planet.myplanet.service.UserProfileDbHandler
 @AndroidEntryPoint
 class MembersFragment : BaseMemberFragment() {
 
+    @Inject
+    lateinit var userProfileDbHandler: UserProfileDbHandler
+
     private lateinit var currentUser: RealmUserModel
     private lateinit var memberChangeListener: MemberChangeListener
 
@@ -25,7 +29,7 @@ class MembersFragment : BaseMemberFragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        currentUser = UserProfileDbHandler(context).userModel!!
+        currentUser = userProfileDbHandler.userModel ?: RealmUserModel()
     }
 
     override fun onNewsItemClick(news: RealmNews?) {}


### PR DESCRIPTION
## Summary
- inject UserProfileDbHandler into MembersFragment and use it to obtain the current user
- fall back to an empty RealmUserModel when the stored user profile is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deadd07e78832bb6cb7f59d192dbaa