### PR TITLE
Revert "all: smoother notification repository (fixes #7593) (#7556)" fixes #7769

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -1,7 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import org.ole.planet.myplanet.model.RealmNotification
-
 data class JoinRequestNotificationMetadata(
     val requesterName: String?,
     val teamName: String?,
@@ -14,9 +12,6 @@ data class TaskNotificationMetadata(
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
     suspend fun updateResourceNotification(userId: String?)
-    suspend fun getNotifications(userId: String, filter: String): List<RealmNotification>
-    suspend fun markAsRead(notificationId: String)
-    suspend fun markAllAsRead(userId: String)
     suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata?
     suspend fun getTaskNotificationMetadata(taskTitle: String): TaskNotificationMetadata?
     suspend fun ensureNotification(type: String, message: String, relatedId: String?, userId: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import io.realm.Sort
 import java.util.Date
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
@@ -96,31 +95,6 @@ class NotificationRepositoryImpl @Inject constructor(
         }
 
         save(notification)
-    }
-
-    override suspend fun getNotifications(userId: String, filter: String): List<RealmNotification> {
-        return queryList(RealmNotification::class.java) {
-            equalTo("userId", userId)
-            when (filter) {
-                "read" -> equalTo("isRead", true)
-                "unread" -> equalTo("isRead", false)
-            }
-            sort("createdAt", Sort.DESCENDING)
-        }.filter { it.message.isNotEmpty() && it.message != "INVALID" }
-    }
-
-    override suspend fun markAsRead(notificationId: String) {
-        update(RealmNotification::class.java, "id", notificationId) { it.isRead = true }
-    }
-
-    override suspend fun markAllAsRead(userId: String) {
-        executeTransaction { realm ->
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("isRead", false)
-                .findAll()
-                .forEach { it.isRead = true }
-        }
     }
 
     override suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata? {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/NotificationUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/NotificationUtils.kt
@@ -22,7 +22,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.repository.NotificationRepository
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 
 object NotificationUtils {
@@ -487,7 +488,7 @@ object NotificationUtils {
 @AndroidEntryPoint
 class NotificationActionReceiver : BroadcastReceiver() {
     @Inject
-    lateinit var notificationRepository: NotificationRepository
+    lateinit var databaseService: DatabaseService
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.action
         val notificationId = intent.getStringExtra(NotificationUtils.EXTRA_NOTIFICATION_ID)
@@ -539,7 +540,14 @@ class NotificationActionReceiver : BroadcastReceiver() {
 
         MainApplication.applicationScope.launch(Dispatchers.IO) {
             try {
-                notificationRepository.markAsRead(notificationId)
+                databaseService.executeTransactionAsync { realm ->
+                    realm.where(RealmNotification::class.java)
+                        .equalTo("id", notificationId)
+                        .findFirst()
+                        ?.let { notification ->
+                            notification.isRead = true
+                        }
+                }
 
                 withContext(Dispatchers.Main) {
                     delay(200)


### PR DESCRIPTION
## Summary
- remove the notification repository APIs that handled listing and marking notifications as read
- switch the notifications fragment to load and update Realm data directly when filtering or marking notifications
- update the notification action receiver to write to Realm without using the repository abstraction

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df06db6a4c832bb39cdbf67e7027fc