### PR TITLE
Revert "all: smoother notification repository (fixes #7593) (#7556)"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3382
-        versionName = "0.33.82"
+        versionCode = 3381
+        versionName = "0.33.81"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -1,7 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import org.ole.planet.myplanet.model.RealmNotification
-
 data class JoinRequestNotificationMetadata(
     val requesterName: String?,
     val teamName: String?,
@@ -14,9 +12,6 @@ data class TaskNotificationMetadata(
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
     suspend fun updateResourceNotification(userId: String?)
-    suspend fun getNotifications(userId: String, filter: String): List<RealmNotification>
-    suspend fun markAsRead(notificationId: String)
-    suspend fun markAllAsRead(userId: String)
     suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata?
     suspend fun getTaskNotificationMetadata(taskTitle: String): TaskNotificationMetadata?
     suspend fun ensureNotification(type: String, message: String, relatedId: String?, userId: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import io.realm.Sort
 import java.util.Date
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
@@ -96,31 +95,6 @@ class NotificationRepositoryImpl @Inject constructor(
         }
 
         save(notification)
-    }
-
-    override suspend fun getNotifications(userId: String, filter: String): List<RealmNotification> {
-        return queryList(RealmNotification::class.java) {
-            equalTo("userId", userId)
-            when (filter) {
-                "read" -> equalTo("isRead", true)
-                "unread" -> equalTo("isRead", false)
-            }
-            sort("createdAt", Sort.DESCENDING)
-        }.filter { it.message.isNotEmpty() && it.message != "INVALID" }
-    }
-
-    override suspend fun markAsRead(notificationId: String) {
-        update(RealmNotification::class.java, "id", notificationId) { it.isRead = true }
-    }
-
-    override suspend fun markAllAsRead(userId: String) {
-        executeTransaction { realm ->
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("isRead", false)
-                .findAll()
-                .forEach { it.isRead = true }
-        }
     }
 
     override suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata? {


### PR DESCRIPTION
## Summary
- restore the pre-#7556 versionCode/versionName in app/build.gradle
- drop the additional notification repository APIs for listing and marking notifications so realm access happens directly again
- update the notifications fragment and action receiver to query Realm via DatabaseService when loading or marking notifications read

## Testing
- ./gradlew :app:compileDefaultDebugKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68df0abcaee0832b95099a7af7b0df55