### PR TITLE
Revert "all: smoother notification repository (fixes #7593) (#7556)"

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -1,7 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import org.ole.planet.myplanet.model.RealmNotification
-
 data class JoinRequestNotificationMetadata(
     val requesterName: String?,
     val teamName: String?,
@@ -14,9 +12,6 @@ data class TaskNotificationMetadata(
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
     suspend fun updateResourceNotification(userId: String?)
-    suspend fun getNotifications(userId: String, filter: String): List<RealmNotification>
-    suspend fun markAsRead(notificationId: String)
-    suspend fun markAllAsRead(userId: String)
     suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata?
     suspend fun getTaskNotificationMetadata(taskTitle: String): TaskNotificationMetadata?
     suspend fun ensureNotification(type: String, message: String, relatedId: String?, userId: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import io.realm.Sort
 import java.util.Date
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
@@ -96,31 +95,6 @@ class NotificationRepositoryImpl @Inject constructor(
         }
 
         save(notification)
-    }
-
-    override suspend fun getNotifications(userId: String, filter: String): List<RealmNotification> {
-        return queryList(RealmNotification::class.java) {
-            equalTo("userId", userId)
-            when (filter) {
-                "read" -> equalTo("isRead", true)
-                "unread" -> equalTo("isRead", false)
-            }
-            sort("createdAt", Sort.DESCENDING)
-        }.filter { it.message.isNotEmpty() && it.message != "INVALID" }
-    }
-
-    override suspend fun markAsRead(notificationId: String) {
-        update(RealmNotification::class.java, "id", notificationId) { it.isRead = true }
-    }
-
-    override suspend fun markAllAsRead(userId: String) {
-        executeTransaction { realm ->
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("isRead", false)
-                .findAll()
-                .forEach { it.isRead = true }
-        }
     }
 
     override suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata? {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
+import io.realm.Sort
 import java.util.ArrayList
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
@@ -202,14 +203,38 @@ class NotificationsFragment : Fragment() {
 
     private suspend fun fetchNotificationsAndUnreadCount(filter: String): Pair<List<RealmNotification>, Int> =
         withContext(Dispatchers.IO) {
-            val notifications = notificationRepository.getNotifications(userId, filter)
-            val unreadCount = notificationRepository.getUnreadCount(userId)
-            notifications to unreadCount
+            databaseService.withRealm { realm ->
+                val query = realm.where(RealmNotification::class.java)
+                    .equalTo("userId", userId)
+
+                when (filter) {
+                    "read" -> query.equalTo("isRead", true)
+                    "unread" -> query.equalTo("isRead", false)
+                }
+
+                val results = query.sort("createdAt", Sort.DESCENDING).findAll()
+                val notifications = realm.copyFromRealm(results).filter {
+                    it.message.isNotEmpty() && it.message != "INVALID"
+                }
+
+                val unreadCount = realm.where(RealmNotification::class.java)
+                    .equalTo("userId", userId)
+                    .equalTo("isRead", false)
+                    .count()
+                    .toInt()
+
+                notifications to unreadCount
+            }
         }
 
     private fun markAsReadById(notificationId: String) {
         markNotificationsAsRead(setOf(notificationId), isMarkAll = false) {
-            notificationRepository.markAsRead(notificationId)
+            databaseService.executeTransactionAsync { realm ->
+                realm.where(RealmNotification::class.java)
+                    .equalTo("id", notificationId)
+                    .findFirst()
+                    ?.isRead = true
+            }
             setOf(notificationId)
         }
     }
@@ -217,8 +242,21 @@ class NotificationsFragment : Fragment() {
     private fun markAllAsRead() {
         val notificationIds = adapter.currentList.map { it.id }.toSet()
         markNotificationsAsRead(notificationIds, isMarkAll = true) {
-            notificationRepository.markAllAsRead(userId)
-            notificationRepository.getNotifications(userId, "all").map { it.id }.toSet()
+            val idsToClear = databaseService.withRealm { realm ->
+                realm.where(RealmNotification::class.java)
+                    .equalTo("userId", userId)
+                    .findAll()
+                    .map { it.id }
+                    .toSet()
+            }
+            databaseService.executeTransactionAsync { realm ->
+                realm.where(RealmNotification::class.java)
+                    .equalTo("userId", userId)
+                    .equalTo("isRead", false)
+                    .findAll()
+                    .forEach { it.isRead = true }
+            }
+            idsToClear
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the notification list and mark helpers from `NotificationRepository`
- drop the repository implementations that wrapped notification queries and updates
- return `NotificationsFragment` to querying Realm directly through `DatabaseService`

## Testing
- ./gradlew --console=plain :app:compileDebugKotlin *(fails: task name is ambiguous)*

------
https://chatgpt.com/codex/tasks/task_e_68df0abcaee0832b95099a7af7b0df55