### PR TITLE
Revert notification repository changes

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -1,7 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import org.ole.planet.myplanet.model.RealmNotification
-
 data class JoinRequestNotificationMetadata(
     val requesterName: String?,
     val teamName: String?,
@@ -14,9 +12,6 @@ data class TaskNotificationMetadata(
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
     suspend fun updateResourceNotification(userId: String?)
-    suspend fun getNotifications(userId: String, filter: String): List<RealmNotification>
-    suspend fun markAsRead(notificationId: String)
-    suspend fun markAllAsRead(userId: String)
     suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata?
     suspend fun getTaskNotificationMetadata(taskTitle: String): TaskNotificationMetadata?
     suspend fun ensureNotification(type: String, message: String, relatedId: String?, userId: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import io.realm.Sort
 import java.util.Date
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
@@ -11,8 +10,8 @@ import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 
 class NotificationRepositoryImpl @Inject constructor(
-    databaseService: DatabaseService,
-) : RealmRepository(databaseService), NotificationRepository {
+        databaseService: DatabaseService,
+    ) : RealmRepository(databaseService), NotificationRepository {
 
     override suspend fun getUnreadCount(userId: String?): Int {
         if (userId == null) return 0
@@ -59,7 +58,6 @@ class NotificationRepositoryImpl @Inject constructor(
             existingNotification?.let { delete(RealmNotification::class.java, "id", it.id) }
         }
     }
-
     override suspend fun ensureNotification(
         type: String,
         message: String,
@@ -97,32 +95,6 @@ class NotificationRepositoryImpl @Inject constructor(
 
         save(notification)
     }
-
-    override suspend fun getNotifications(userId: String, filter: String): List<RealmNotification> {
-        return queryList(RealmNotification::class.java) {
-            equalTo("userId", userId)
-            when (filter) {
-                "read" -> equalTo("isRead", true)
-                "unread" -> equalTo("isRead", false)
-            }
-            sort("createdAt", Sort.DESCENDING)
-        }.filter { it.message.isNotEmpty() && it.message != "INVALID" }
-    }
-
-    override suspend fun markAsRead(notificationId: String) {
-        update(RealmNotification::class.java, "id", notificationId) { it.isRead = true }
-    }
-
-    override suspend fun markAllAsRead(userId: String) {
-        executeTransaction { realm ->
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("isRead", false)
-                .findAll()
-                .forEach { it.isRead = true }
-        }
-    }
-
     override suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata? {
         val rawId = joinRequestId?.takeUnless { it.isBlank() } ?: return null
         val sanitizedId = rawId.removePrefix("join_request_")


### PR DESCRIPTION
## Summary
- revert "all: smoother notification repository (fixes #7593) (#7556)" to remove the repository APIs for listing and marking notifications
- restore dashboard notification screens to query Realm directly for loading and marking notifications while keeping later metadata helpers intact
- keep notification repository metadata helpers and ensure notification utilities continue to operate with the restored logic

## Testing
- ./gradlew --console=plain :app:assembleDebug *(fails: Android SDK Platform 36 install error during SDK download)*

------
https://chatgpt.com/codex/tasks/task_e_68df0d21a530832b990e760db9c2735f