### PR TITLE
Restore synchronous notification data handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -1,23 +1,6 @@
 package org.ole.planet.myplanet.repository
 
-import org.ole.planet.myplanet.model.RealmNotification
-
-data class JoinRequestNotificationMetadata(
-    val requesterName: String?,
-    val teamName: String?,
-)
-
-data class TaskNotificationMetadata(
-    val teamName: String?,
-)
-
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
     suspend fun updateResourceNotification(userId: String?)
-    suspend fun getNotifications(userId: String, filter: String): List<RealmNotification>
-    suspend fun markAsRead(notificationId: String)
-    suspend fun markAllAsRead(userId: String)
-    suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata?
-    suspend fun getTaskNotificationMetadata(taskTitle: String): TaskNotificationMetadata?
-    suspend fun ensureNotification(type: String, message: String, relatedId: String?, userId: String?)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepositoryImpl.kt
@@ -1,18 +1,14 @@
 package org.ole.planet.myplanet.repository
 
-import io.realm.Sort
 import java.util.Date
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNotification
-import org.ole.planet.myplanet.model.RealmTeamTask
-import org.ole.planet.myplanet.model.RealmUserModel
 
 class NotificationRepositoryImpl @Inject constructor(
-    databaseService: DatabaseService,
-) : RealmRepository(databaseService), NotificationRepository {
+        databaseService: DatabaseService,
+    ) : RealmRepository(databaseService), NotificationRepository {
 
     override suspend fun getUnreadCount(userId: String?): Int {
         if (userId == null) return 0
@@ -28,26 +24,16 @@ class NotificationRepositoryImpl @Inject constructor(
 
         val resourceCount = queryList(RealmMyLibrary::class.java) {
             equalTo("isPrivate", false)
-        }.count { resource ->
-            resource.userId?.contains(userId) == true && resource.needToUpdate()
-        }
+        }.count { it.needToUpdate() && it.userId?.contains(userId) == true }
 
-        val notificationId = "$userId:resource:count"
-        val existingNotification = findByField(RealmNotification::class.java, "id", notificationId)
+        val existingNotification = findByField(RealmNotification::class.java, "userId", userId)
+            ?.takeIf { it.type == "resource" }
 
         if (resourceCount > 0) {
-            val previousCount = existingNotification?.message?.toIntOrNull() ?: 0
-            val countChanged = previousCount != resourceCount
-
             val notification = existingNotification?.apply {
                 message = "$resourceCount"
                 relatedId = "$resourceCount"
-                if (countChanged) {
-                    this.isRead = false
-                    this.createdAt = Date()
-                }
             } ?: RealmNotification().apply {
-                this.id = notificationId
                 this.userId = userId
                 this.type = "resource"
                 this.message = "$resourceCount"
@@ -59,110 +45,5 @@ class NotificationRepositoryImpl @Inject constructor(
             existingNotification?.let { delete(RealmNotification::class.java, "id", it.id) }
         }
     }
-
-    override suspend fun ensureNotification(
-        type: String,
-        message: String,
-        relatedId: String?,
-        userId: String?,
-    ) {
-        val ownerId = userId ?: ""
-        val trimmedMessage = message.trim()
-        val notificationId = buildNotificationId(type, relatedId, ownerId, trimmedMessage)
-
-        if (trimmedMessage.isEmpty()) {
-            delete(RealmNotification::class.java, "id", notificationId)
-            return
-        }
-
-        val existingNotification = findByField(RealmNotification::class.java, "id", notificationId)
-        val now = Date()
-
-        val notification = existingNotification?.apply {
-            if (this.message != trimmedMessage) {
-                this.message = trimmedMessage
-                this.createdAt = now
-            }
-            this.type = type
-            this.relatedId = relatedId
-            this.userId = ownerId
-        } ?: RealmNotification().apply {
-            id = notificationId
-            this.userId = ownerId
-            this.type = type
-            this.message = trimmedMessage
-            this.relatedId = relatedId
-            this.createdAt = now
-        }
-
-        save(notification)
-    }
-
-    override suspend fun getNotifications(userId: String, filter: String): List<RealmNotification> {
-        return queryList(RealmNotification::class.java) {
-            equalTo("userId", userId)
-            when (filter) {
-                "read" -> equalTo("isRead", true)
-                "unread" -> equalTo("isRead", false)
-            }
-            sort("createdAt", Sort.DESCENDING)
-        }.filter { it.message.isNotEmpty() && it.message != "INVALID" }
-    }
-
-    override suspend fun markAsRead(notificationId: String) {
-        update(RealmNotification::class.java, "id", notificationId) { it.isRead = true }
-    }
-
-    override suspend fun markAllAsRead(userId: String) {
-        executeTransaction { realm ->
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", userId)
-                .equalTo("isRead", false)
-                .findAll()
-                .forEach { it.isRead = true }
-        }
-    }
-
-    override suspend fun getJoinRequestMetadata(joinRequestId: String?): JoinRequestNotificationMetadata? {
-        val rawId = joinRequestId?.takeUnless { it.isBlank() } ?: return null
-        val sanitizedId = rawId.removePrefix("join_request_")
-
-        val joinRequest = queryList(RealmMyTeam::class.java) {
-            equalTo("_id", sanitizedId)
-            equalTo("docType", "request")
-        }.firstOrNull() ?: return null
-
-        val teamName = joinRequest.teamId?.let { teamId ->
-            findByField(RealmMyTeam::class.java, "_id", teamId)?.name
-        }
-
-        val requesterName = joinRequest.userId?.let { userId ->
-            findByField(RealmUserModel::class.java, "id", userId)?.name
-        }
-
-        return JoinRequestNotificationMetadata(requesterName, teamName)
-    }
-
-    override suspend fun getTaskNotificationMetadata(taskTitle: String): TaskNotificationMetadata? {
-        if (taskTitle.isBlank()) return null
-
-        val task = findByField(RealmTeamTask::class.java, "title", taskTitle) ?: return null
-
-        val teamName = task.teamId?.let { teamId ->
-            findByField(RealmMyTeam::class.java, "_id", teamId)?.name
-        }
-
-        return TaskNotificationMetadata(teamName)
-    }
-}
-
-private fun buildNotificationId(
-    type: String,
-    relatedId: String?,
-    userId: String,
-    message: String,
-): String {
-    val relatedKey = relatedId?.takeUnless { it.isBlank() } ?: message
-    return listOf(userId, type, relatedKey).joinToString(":")
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -585,15 +585,14 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
             try {
                 dashboardViewModel.updateResourceNotification(userId)
-                val backgroundRealm = databaseService.realmInstance
-                try {
-                    val createdNotifications = createNotifications(backgroundRealm, userId)
-                    newNotifications.addAll(createdNotifications)
-                } finally {
-                    backgroundRealm.close()
-                }
+                databaseService.realmInstance.use { backgroundRealm ->
+                    backgroundRealm.executeTransaction { realm ->
+                        val createdNotifications = createNotifications(realm, userId)
+                        newNotifications.addAll(createdNotifications)
+                    }
 
-                unreadCount = dashboardViewModel.getUnreadNotificationsSize(userId)
+                    unreadCount = dashboardViewModel.getUnreadNotificationsSize(userId)
+                }
             } catch (e: Exception) {
                 e.printStackTrace()
             }
@@ -706,14 +705,12 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-    private suspend fun createNotifications(realm: Realm, userId: String?): List<NotificationUtils.NotificationConfig> {
+    private fun createNotifications(realm: Realm, userId: String?): List<NotificationUtils.NotificationConfig> {
         val newNotifications = mutableListOf<NotificationUtils.NotificationConfig>()
         createSurveyDatabaseNotifications(realm, userId)
         createTaskDatabaseNotifications(realm, userId)
         createStorageDatabaseNotifications(realm, userId)
         createJoinRequestDatabaseNotifications(realm, userId)
-
-        realm.refresh()
 
         val unreadNotifications = realm.where(RealmNotification::class.java)
             .equalTo("userId", userId)
@@ -764,7 +761,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-    private suspend fun createSurveyDatabaseNotifications(realm: Realm, userId: String?) {
+    private fun createSurveyDatabaseNotifications(realm: Realm, userId: String?) {
         val pendingSurveys = realm.where(RealmSubmission::class.java)
             .equalTo("userId", userId)
             .equalTo("status", "pending")
@@ -778,11 +775,11 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                 .findFirst()
                 ?.name
         }.forEach { title ->
-            dashboardViewModel.createNotificationIfNotExists("survey", title, title, userId)
+            dashboardViewModel.createNotificationIfNotExists(realm, "survey", title, title, userId)
         }
     }
 
-    private suspend fun createTaskDatabaseNotifications(realm: Realm, userId: String?) {
+    private fun createTaskDatabaseNotifications(realm: Realm, userId: String?) {
         val tasks = realm.where(RealmTeamTask::class.java)
             .notEqualTo("status", "archived")
             .equalTo("completed", false)
@@ -791,6 +788,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
         tasks.forEach { task ->
             dashboardViewModel.createNotificationIfNotExists(
+                realm,
                 "task",
                 "${task.title} ${formatDate(task.deadline)}",
                 task.id,
@@ -799,16 +797,16 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
 
-    private suspend fun createStorageDatabaseNotifications(realm: Realm, userId: String?) {
+    private fun createStorageDatabaseNotifications(realm: Realm, userId: String?) {
         val storageRatio = FileUtils.totalAvailableMemoryRatio(this)
         if (storageRatio > 85) {
-            dashboardViewModel.createNotificationIfNotExists("storage", "$storageRatio%", "storage", userId)
+            dashboardViewModel.createNotificationIfNotExists(realm, "storage", "$storageRatio%", "storage", userId)
         }
 
-        dashboardViewModel.createNotificationIfNotExists("storage", "90%", "storage_test", userId)
+        dashboardViewModel.createNotificationIfNotExists(realm, "storage", "90%", "storage_test", userId)
     }
 
-    private suspend fun createJoinRequestDatabaseNotifications(realm: Realm, userId: String?) {
+    private fun createJoinRequestDatabaseNotifications(realm: Realm, userId: String?) {
         val teamLeaderMemberships = realm.where(RealmMyTeam::class.java)
             .equalTo("userId", userId)
             .equalTo("docType", "membership")
@@ -835,7 +833,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                 val message = getString(R.string.user_requested_to_join_team, requesterName, teamName)
 
                 dashboardViewModel.createNotificationIfNotExists(
-                    "join_request", message, joinRequest._id, userId
+                    realm, "join_request", message, joinRequest._id, userId
                 )
             }
         }
@@ -1046,6 +1044,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         when (selectedMenuId) {
             R.string.menu_myplanet -> openCallFragment(BellDashboardFragment())
             R.string.menu_library -> openCallFragment(ResourcesFragment())
+            R.string.menu_meetups -> {}
             R.string.menu_surveys -> openCallFragment(SurveyFragment())
             R.string.menu_courses -> openCallFragment(CoursesFragment())
             R.string.menu_community -> openCallFragment(CommunityTabFragment())

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -1,11 +1,17 @@
 package org.ole.planet.myplanet.ui.dashboard
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.realm.Realm
+import java.util.Date
+import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.repository.CourseRepository
 import org.ole.planet.myplanet.repository.LibraryRepository
@@ -40,12 +46,44 @@ class DashboardViewModel @Inject constructor(
         return total.coerceAtMost(11)
     }
 
+    fun loadDashboardData(userId: String?) {
+        loadSurveyWarning(userId)
+        loadUnreadNotifications(userId)
+    }
+
+    private fun loadSurveyWarning(userId: String?) {
+        viewModelScope.launch {
+            val count = submissionRepository.getSubmissionCountByUser(userId)
+            _surveyWarning.value = count == 0
+        }
+    }
+
+    private fun loadUnreadNotifications(userId: String?) {
+        viewModelScope.launch {
+            _unreadNotifications.value = notificationRepository.getUnreadCount(userId)
+        }
+    }
+
     suspend fun updateResourceNotification(userId: String?) {
         notificationRepository.updateResourceNotification(userId)
     }
 
-    suspend fun createNotificationIfNotExists(type: String, message: String, relatedId: String?, userId: String?) {
-        notificationRepository.ensureNotification(type, message, relatedId, userId)
+    fun createNotificationIfNotExists(realm: Realm, type: String, message: String, relatedId: String?, userId: String?) {
+        val existingNotification = realm.where(RealmNotification::class.java)
+            .equalTo("userId", userId)
+            .equalTo("type", type)
+            .equalTo("relatedId", relatedId)
+            .findFirst()
+
+        if (existingNotification == null) {
+            realm.createObject(RealmNotification::class.java, "${UUID.randomUUID()}").apply {
+                this.userId = userId ?: ""
+                this.type = type
+                this.message = message
+                this.relatedId = relatedId
+                this.createdAt = Date()
+            }
+        }
     }
 
     suspend fun getPendingSurveys(userId: String?): List<RealmSubmission> {


### PR DESCRIPTION
## Summary
- restore the synchronous notification repository API and drop the asynchronous metadata helpers
- revert dashboard activity/view-model and notification UI to the Realm-backed notification creation/mark-as-read workflow
- update the notification action receiver to mark notifications read via DatabaseService again

## Testing
- `./gradlew lintDebug assembleDebug` *(fails: task name is ambiguous for current variants)*
- `./gradlew app:lintDefaultDebug` *(cancelled due to very long compile time in the CI sandbox)*


------
https://chatgpt.com/codex/tasks/task_e_68dfce431f38832b866999407392af92