### PR TITLE
Refine user library lookup query

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -72,9 +72,17 @@ class LibraryRepositoryImpl @Inject constructor(
                 onRemove(realm, "resources", userId, resourceId)
             }
         }
-        return findByField(RealmMyLibrary::class.java, "resourceId", resourceId)
-            ?: getLibraryItemById(resourceId)
-            ?: getLibraryItemByResourceId(resourceId)
+        val matches = queryList(RealmMyLibrary::class.java) {
+            beginGroup()
+                .equalTo("resourceId", resourceId)
+                .or().equalTo("id", resourceId)
+                .or().equalTo("_id", resourceId)
+            endGroup()
+        }
+
+        return matches.firstOrNull { it.resourceId == resourceId }
+            ?: matches.firstOrNull { it.id == resourceId }
+            ?: matches.firstOrNull { it._id == resourceId }
     }
 
     override suspend fun updateLibraryItem(id: String, updater: (RealmMyLibrary) -> Unit) {


### PR DESCRIPTION
## Summary
- replace the chained user-library lookups with a single Realm query covering resourceId, id, and _id
- keep the return ordering by preferring the resourceId match before id and _id fallbacks

## Testing
- ./gradlew :app:testDefaultDebugUnitTest --console=plain
- ./gradlew :app:testLiteDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dfda7cc944832baea1ee7e484eacd2