### PR TITLE
Refactor finance transactions to use TeamRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -1,6 +1,8 @@
 package org.ole.planet.myplanet.repository
 
 import android.content.Context
+import io.realm.RealmResults
+import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamTask
@@ -52,4 +54,19 @@ interface TeamRepository {
         createdBy: String,
     ): Boolean
     suspend fun syncTeamActivities(context: Context)
+    fun getTeamTransactions(
+        teamId: String,
+        startDate: Long? = null,
+        endDate: Long? = null,
+        sortAscending: Boolean = false,
+    ): Flow<RealmResults<RealmMyTeam>>
+    suspend fun createTransaction(
+        teamId: String,
+        type: String,
+        note: String,
+        amount: Int,
+        date: Long,
+        parentCode: String?,
+        planetCode: String?,
+    ): Result<Unit>
 }


### PR DESCRIPTION
## Summary
- add transaction APIs to TeamRepository for fetching and creating finance records via Realm helpers
- implement transaction retrieval flow and creation logic in TeamRepositoryImpl with shared filters and Realm helpers
- update FinanceFragment to rely on TeamRepository for loading, filtering, and creating transactions without direct Realm access

## Testing
- ./gradlew --console=plain :app:compileLiteDebugKotlin

------
https://chatgpt.com/codex/tasks/task_e_68dfdb5045d4832bb6f594259a6e62b2