### PR TITLE
Refactor exam id parsing in submission repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -14,6 +14,10 @@ class SubmissionRepositoryImpl @Inject constructor(
     databaseService: DatabaseService
 ) : RealmRepository(databaseService), SubmissionRepository {
 
+    private fun RealmSubmission.examIdFromParentId(): String? {
+        return parentId?.substringBefore("@")
+    }
+
     override suspend fun getPendingSurveys(userId: String?): List<RealmSubmission> {
         if (userId == null) return emptyList()
 
@@ -30,9 +34,7 @@ class SubmissionRepositoryImpl @Inject constructor(
         val pendingSurveys = getPendingSurveys(userId)
         if (pendingSurveys.isEmpty()) return emptyList()
 
-        val examIds = pendingSurveys.mapNotNull { submission ->
-            submission.parentId?.split("@")?.firstOrNull()
-        }.distinct()
+        val examIds = pendingSurveys.mapNotNull { it.examIdFromParentId() }.distinct()
 
         if (examIds.isEmpty()) return emptyList()
 
@@ -43,7 +45,7 @@ class SubmissionRepositoryImpl @Inject constructor(
 
         val uniqueSurveys = linkedMapOf<String, RealmSubmission>()
         pendingSurveys.forEach { submission ->
-            val examId = submission.parentId?.split("@")?.firstOrNull()
+            val examId = submission.examIdFromParentId()
             if (examId != null && validExamIds.contains(examId) && !uniqueSurveys.containsKey(examId)) {
                 uniqueSurveys[examId] = submission
             }
@@ -65,7 +67,7 @@ class SubmissionRepositoryImpl @Inject constructor(
     override suspend fun getSurveyTitlesFromSubmissions(
         submissions: List<RealmSubmission>
     ): List<String> {
-        val examIds = submissions.mapNotNull { it.parentId?.split("@")?.firstOrNull() }
+        val examIds = submissions.mapNotNull { it.examIdFromParentId() }
         if (examIds.isEmpty()) {
             return emptyList()
         }
@@ -76,7 +78,7 @@ class SubmissionRepositoryImpl @Inject constructor(
         val examMap = exams.associate { it.id to (it.name ?: "") }
 
         return submissions.map { submission ->
-            val examId = submission.parentId?.split("@")?.firstOrNull()
+            val examId = submission.examIdFromParentId()
             examMap[examId] ?: ""
         }
     }
@@ -84,9 +86,7 @@ class SubmissionRepositoryImpl @Inject constructor(
     override suspend fun getExamMapForSubmissions(
         submissions: List<RealmSubmission>
     ): Map<String?, RealmStepExam> {
-        val examIds = submissions.mapNotNull { sub ->
-            sub.parentId?.split("@")?.firstOrNull()
-        }.distinct()
+        val examIds = submissions.mapNotNull { it.examIdFromParentId() }.distinct()
 
         if (examIds.isEmpty()) {
             return emptyMap()
@@ -98,7 +98,7 @@ class SubmissionRepositoryImpl @Inject constructor(
 
         return submissions.mapNotNull { sub ->
             val parentId = sub.parentId
-            val examId = parentId?.split("@")?.firstOrNull()
+            val examId = sub.examIdFromParentId()
             examMap[examId]?.let { parentId to it }
         }.toMap()
     }


### PR DESCRIPTION
## Summary
- add a private helper on `RealmSubmission` to derive the exam id from `parentId`
- replace duplicated split logic in survey and exam lookup helpers with the new helper

## Testing
- ./gradlew --no-daemon --console=plain :app:compileDefaultDebugKotlin

------
https://chatgpt.com/codex/tasks/task_e_68dfdaa251b0832bbef496bf141a4a46