### PR TITLE
Sort chat history by last used timestamp

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -17,7 +17,7 @@ class ChatRepositoryImpl @Inject constructor(
         }
         return queryList(RealmChatHistory::class.java) {
             equalTo("user", userName)
-            sort("id", Sort.DESCENDING)
+            sort("lastUsed", Sort.DESCENDING)
         }
     }
 


### PR DESCRIPTION
## Summary
- update the chat history query to order conversations by `lastUsed` so recent threads appear first

## Testing
- ./gradlew --no-daemon --console=plain assembleDebug

------
https://chatgpt.com/codex/tasks/task_e_68dfdad753e8832ba39d04db0c1a1078