### PR TITLE
sync: less realtime progress tracking is more (fixes #8209)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3407
-        versionName = "0.34.7"
+        versionCode = 3408
+        versionName = "0.34.8"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/RealtimeSyncCoordinator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/RealtimeSyncCoordinator.kt
@@ -1,12 +1,10 @@
 package org.ole.planet.myplanet.service.sync
 
 import android.util.Log
-import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import org.ole.planet.myplanet.callback.RealtimeSyncListener
-import org.ole.planet.myplanet.callback.SyncProgressUpdate
 import org.ole.planet.myplanet.callback.TableDataUpdate
 
 class RealtimeSyncCoordinator {
@@ -23,11 +21,6 @@ class RealtimeSyncCoordinator {
     }
     
     private val listeners = mutableSetOf<RealtimeSyncListener>()
-    private val tableProgress = ConcurrentHashMap<String, SyncProgressUpdate>()
-    
-    private val _syncProgressFlow = MutableSharedFlow<SyncProgressUpdate>()
-    val syncProgressFlow: SharedFlow<SyncProgressUpdate> = _syncProgressFlow.asSharedFlow()
-    
     private val _dataUpdateFlow = MutableSharedFlow<TableDataUpdate>()
     val dataUpdateFlow: SharedFlow<TableDataUpdate> = _dataUpdateFlow.asSharedFlow()
     
@@ -43,46 +36,11 @@ class RealtimeSyncCoordinator {
         }
     }
     
-    fun notifyTableSyncStarted(table: String, totalItems: Int) {
-        val update = SyncProgressUpdate(
-            table = table,
-            itemsProcessed = 0,
-            totalItems = totalItems,
-            percentage = 0f,
-            message = "Starting sync for $table",
-            isComplete = false
-        )
-        tableProgress[table] = update
-        
-        synchronized(listeners) {
-            listeners.forEach { it.onTableSyncStarted(table, totalItems) }
-        }
-        _syncProgressFlow.tryEmit(update)
-    }
-    
-    fun notifyTableSyncProgress(table: String, itemsProcessed: Int, totalItems: Int, message: String? = null) {
-        val percentage = if (totalItems > 0) (itemsProcessed.toFloat() / totalItems.toFloat()) * 100f else 0f
-        val update = SyncProgressUpdate(
-            table = table,
-            itemsProcessed = itemsProcessed,
-            totalItems = totalItems,
-            percentage = percentage,
-            message = message ?: "Syncing $table: $itemsProcessed/$totalItems",
-            isComplete = false
-        )
-        tableProgress[table] = update
-        
-        synchronized(listeners) {
-            listeners.forEach { it.onTableSyncProgress(update) }
-        }
-        _syncProgressFlow.tryEmit(update)
-    }
-    
     fun notifyTableDataUpdated(table: String, newItemsCount: Int, updatedItemsCount: Int) {
         Log.d("RealtimeSyncCoordinator", "=== notifyTableDataUpdated ===")
         Log.d("RealtimeSyncCoordinator", "Table: $table, newItems: $newItemsCount, updatedItems: $updatedItemsCount")
         Log.d("RealtimeSyncCoordinator", "Active listeners count: ${listeners.size}")
-        
+
         val update = TableDataUpdate(
             table = table,
             newItemsCount = newItemsCount,
@@ -99,30 +57,5 @@ class RealtimeSyncCoordinator {
         _dataUpdateFlow.tryEmit(update)
         Log.d("RealtimeSyncCoordinator", "=== notifyTableDataUpdated END ===")
     }
-    
-    fun notifyTableSyncCompleted(table: String, itemsProcessed: Int, success: Boolean) {
-        val update = SyncProgressUpdate(
-            table = table,
-            itemsProcessed = itemsProcessed,
-            totalItems = tableProgress[table]?.totalItems ?: itemsProcessed,
-            percentage = 100f,
-            message = if (success) "Completed $table sync" else "Failed $table sync",
-            isComplete = true
-        )
-        tableProgress[table] = update
-        
-        synchronized(listeners) {
-            listeners.forEach { it.onTableSyncCompleted(table, itemsProcessed, success) }
-        }
-        _syncProgressFlow.tryEmit(update)
-    }
-    
-    fun getCurrentProgress(table: String): SyncProgressUpdate? {
-        return tableProgress[table]
-    }
-    
-    fun getAllProgress(): Map<String, SyncProgressUpdate> {
-        return tableProgress.toMap()
-    }
-    
+
 }


### PR DESCRIPTION
## Summary
- remove progress tracking fields, flows, and helper methods from `RealtimeSyncCoordinator`
- drop unused imports that supported the removed progress APIs

## Testing
- ./gradlew --console=plain lint > lint.log 2>&1 *(fails: missing Android SDK Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c9444afc832ba36b51aa905023cb