### PR TITLE
sync: less performance monitor metrics is more (fixes #8211)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3407
-        versionName = "0.34.7"
+        versionCode = 3410
+        versionName = "0.34.10"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary
- remove unused performance comparison helpers from `SyncPerformanceMonitor`
- retain only metrics recording needed by `SyncTracker`

## Testing
- ./gradlew lint *(fails: missing Android SDK Build-Tools 35 and Platform 36 in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c99cad30832ba4705abe5e370ba7