### PR TITLE
teams: less submission count repository is more (fixes #8212)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3407
-        versionName = "0.34.7"
+        versionCode = 3411
+        versionName = "0.34.11"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -6,7 +6,6 @@ import org.ole.planet.myplanet.model.RealmSubmission
 interface SubmissionRepository {
     suspend fun getPendingSurveys(userId: String?): List<RealmSubmission>
     suspend fun getUniquePendingSurveys(userId: String?): List<RealmSubmission>
-    suspend fun getSubmissionCountByUser(userId: String?): Int
     suspend fun getSurveyTitlesFromSubmissions(submissions: List<RealmSubmission>): List<String>
     suspend fun getSubmissionById(id: String): RealmSubmission?
     suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -54,16 +54,6 @@ class SubmissionRepositoryImpl @Inject constructor(
         return uniqueSurveys.values.toList()
     }
 
-    override suspend fun getSubmissionCountByUser(userId: String?): Int {
-        if (userId == null) return 0
-
-        return count(RealmSubmission::class.java) {
-            equalTo("userId", userId)
-            equalTo("type", "survey")
-            equalTo("status", "pending")
-        }.toInt()
-    }
-
     override suspend fun getSurveyTitlesFromSubmissions(
         submissions: List<RealmSubmission>
     ): List<String> {


### PR DESCRIPTION
## Summary
- remove the `getSubmissionCountByUser` declaration from `SubmissionRepository`
- drop the unused override from `SubmissionRepositoryImpl`

## Testing
- ./gradlew lint --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68e3c9fbc284832b8b218eec76f987f7