### PR TITLE
mylife: less my personals is more (fixes #8213)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3407
-        versionName = "0.34.7"
+        versionCode = 3412
+        versionName = "0.3412"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/MyPersonalsFragment.kt
@@ -60,7 +60,6 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
             val b = Bundle()
             b.putInt("type", 1)
             addResourceFragment?.arguments = b
-            addResourceFragment?.setMyPersonalsFragment(this)
             addResourceFragment?.show(childFragmentManager, getString(R.string.add_resource))
         }
         return binding.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -44,7 +44,6 @@ import org.ole.planet.myplanet.repository.MyPersonalRepository
 import org.ole.planet.myplanet.service.AudioRecorderService
 import org.ole.planet.myplanet.service.AudioRecorderService.AudioRecordListener
 import org.ole.planet.myplanet.service.UserProfileDbHandler
-import org.ole.planet.myplanet.ui.myPersonals.MyPersonalsFragment
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
@@ -55,7 +54,6 @@ class AddResourceFragment : BottomSheetDialogFragment() {
     var tvTime: TextView? = null
     var floatingActionButton: FloatingActionButton? = null
     private var audioRecorderService: AudioRecorderService? = null
-    private var myPersonalsFragment: MyPersonalsFragment? = null
     private var photoURI: Uri? = null
     private var videoUri: Uri? = null
     private lateinit var captureImageLauncher: ActivityResultLauncher<Uri>
@@ -265,16 +263,11 @@ class AddResourceFragment : BottomSheetDialogFragment() {
         }
     }
 
-    fun setMyPersonalsFragment(myPersonalsFragment: MyPersonalsFragment) {
-        this.myPersonalsFragment = myPersonalsFragment
-    }
-
     companion object {
         const val REQUEST_VIDEO_CAPTURE = 1
         const val REQUEST_CAPTURE_PICTURE = 2
         const val REQUEST_FILE_SELECTION = 3
         var type = 0
-        private val myPersonalsFragment: MyPersonalsFragment? = null
         fun showAlert(context: Context, path: String?, repository: MyPersonalRepository) {
             val v = LayoutInflater.from(context).inflate(R.layout.alert_my_personal, null)
             val etTitle = v.findViewById<EditText>(R.id.et_title)
@@ -300,9 +293,6 @@ class AddResourceFragment : BottomSheetDialogFragment() {
                                 context.getString(R.string.resource_saved_to_my_personal)
                             )
                         }
-                    }
-                    if (type == 1) {
-                        myPersonalsFragment?.refreshFragment()
                     }
                 }.setNegativeButton(R.string.dismiss, null).show()
         }


### PR DESCRIPTION
## Summary
- remove the stored MyPersonalsFragment reference from AddResourceFragment and stop invoking it during the save flow
- update MyPersonalsFragment to no longer call the removed setter when launching the add-resource sheet

## Testing
- ./gradlew --console=plain -Dorg.gradle.wrapper.disableDistributionProgress=true :app:testDefaultDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_e_68e3ca41d78c832bbaba07f98b5de33c