### PR TITLE
Use base profile handler for bell dashboard

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -34,7 +34,6 @@ import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.courses.CoursesFragment
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
 import org.ole.planet.myplanet.ui.feedback.FeedbackListFragment
@@ -62,11 +61,11 @@ class BellDashboardFragment : BaseDashboardFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentHomeBellBinding.inflate(inflater, container, false)
-        user = UserProfileDbHandler(requireContext()).userModel
         val view = binding.root
         initView(view)
         declareElements()
         onLoaded(view)
+        user = profileDbHandler?.userModel
         return binding.root
     }
 


### PR DESCRIPTION
## Summary
- rely on the BaseDashboardFragment profile database handler when initializing the BellDashboardFragment user reference

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3d80d2b00832bb9da7f4069cbcf30