### PR TITLE
Use shared profile handler in dashboard plugin

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragmentPlugin.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragmentPlugin.kt
@@ -116,7 +116,10 @@ open class BaseDashboardFragmentPlugin : BaseContainerFragment() {
         setBackgroundColor(v, itemCnt)
 
         val title = (obj as RealmMyLife).title
-        val user = UserProfileDbHandler(requireContext()).userModel
+        val handler = profileDbHandler ?: UserProfileDbHandler(requireContext()).also {
+            profileDbHandler = it
+        }
+        val user = handler.userModel
         itemMyLifeBinding.img.setImageResource(resources.getIdentifier(obj.imageId, "drawable", requireActivity().packageName))
         itemMyLifeBinding.tvName.text = title
 


### PR DESCRIPTION
## Summary
- reuse the shared profileDbHandler when building dashboard layout items
- lazily initialize the handler if it is unexpectedly null before use

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d947f298832b84f1505589426c2e