### PR TITLE
Remove realtime sync progress callback hooks

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/callback/RealtimeSyncListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/RealtimeSyncListener.kt
@@ -1,14 +1,5 @@
 package org.ole.planet.myplanet.callback
 
-data class SyncProgressUpdate(
-    val table: String,
-    val itemsProcessed: Int,
-    val totalItems: Int,
-    val percentage: Float,
-    val message: String,
-    val isComplete: Boolean = false
-)
-
 data class TableDataUpdate(
     val table: String,
     val newItemsCount: Int,
@@ -17,13 +8,11 @@ data class TableDataUpdate(
 )
 
 interface RealtimeSyncListener : SyncListener {
-    
+
     fun onTableSyncStarted(table: String, totalItems: Int)
-    
-    fun onTableSyncProgress(update: SyncProgressUpdate)
-    
+
     fun onTableDataUpdated(update: TableDataUpdate)
-    
+
     fun onTableSyncCompleted(table: String, itemsProcessed: Int, success: Boolean)
 }
 
@@ -44,11 +33,7 @@ abstract class BaseRealtimeSyncListener : RealtimeSyncListener {
     override fun onTableSyncStarted(table: String, totalItems: Int) {
         // Default implementation - can be overridden
     }
-    
-    override fun onTableSyncProgress(update: SyncProgressUpdate) {
-        // Default implementation - can be overridden
-    }
-    
+
     override fun onTableDataUpdated(update: TableDataUpdate) {
         // Default implementation - can be overridden
     }


### PR DESCRIPTION
## Summary
- remove the unused `SyncProgressUpdate` data class from `RealtimeSyncListener`
- drop the realtime sync progress callback from the listener interface and base implementation

## Testing
- ./gradlew :app:lint --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e4b2025d2c832b8dffe324ad0957ad