### PR TITLE
Simplify realtime sync listener callbacks

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/callback/RealtimeSyncListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/RealtimeSyncListener.kt
@@ -1,14 +1,5 @@
 package org.ole.planet.myplanet.callback
 
-data class SyncProgressUpdate(
-    val table: String,
-    val itemsProcessed: Int,
-    val totalItems: Int,
-    val percentage: Float,
-    val message: String,
-    val isComplete: Boolean = false
-)
-
 data class TableDataUpdate(
     val table: String,
     val newItemsCount: Int,
@@ -17,14 +8,8 @@ data class TableDataUpdate(
 )
 
 interface RealtimeSyncListener : SyncListener {
-    
-    fun onTableSyncStarted(table: String, totalItems: Int)
-    
-    fun onTableSyncProgress(update: SyncProgressUpdate)
-    
+
     fun onTableDataUpdated(update: TableDataUpdate)
-    
-    fun onTableSyncCompleted(table: String, itemsProcessed: Int, success: Boolean)
 }
 
 abstract class BaseRealtimeSyncListener : RealtimeSyncListener {
@@ -36,24 +21,12 @@ abstract class BaseRealtimeSyncListener : RealtimeSyncListener {
     override fun onSyncComplete() {
         // Default implementation - can be overridden
     }
-    
+
     override fun onSyncFailed(msg: String?) {
         // Default implementation - can be overridden
     }
-    
-    override fun onTableSyncStarted(table: String, totalItems: Int) {
-        // Default implementation - can be overridden
-    }
-    
-    override fun onTableSyncProgress(update: SyncProgressUpdate) {
-        // Default implementation - can be overridden
-    }
-    
+
     override fun onTableDataUpdated(update: TableDataUpdate) {
-        // Default implementation - can be overridden
-    }
-    
-    override fun onTableSyncCompleted(table: String, itemsProcessed: Int, success: Boolean) {
         // Default implementation - can be overridden
     }
 }


### PR DESCRIPTION
## Summary
- remove the unused `SyncProgressUpdate` data class and related callback signatures from `RealtimeSyncListener`
- trim `BaseRealtimeSyncListener` to only provide default implementations for the callbacks that remain in use

## Testing
- ./gradlew :app:compileDefaultDebugKotlin --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68e4b23fc4d4832b95d452cd46a4b3af