### PR TITLE
Remove jcplayer dependency and refresh audio player UI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -196,7 +196,6 @@ dependencies {
 
     implementation "com.github.VaibhavLakhera:Circular-Progress-View:0.1.2"
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
-    implementation 'com.github.jeancsanchez:jcplayer:2.7.2'
     implementation 'com.github.clans:fab:1.6.4'
     implementation 'com.applandeo:material-calendar-view:1.9.2'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/AudioPlayerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/AudioPlayerActivity.kt
@@ -4,15 +4,12 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
-import android.widget.FrameLayout
 import android.widget.ImageButton
-import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
-import com.bumptech.glide.Glide
 import java.io.File
 import java.util.regex.Pattern
 import org.ole.planet.myplanet.R
@@ -52,31 +49,14 @@ class AudioPlayerActivity : AppCompatActivity() {
         playButton = binding.playerView.findViewById(R.id.exo_play)
         pauseButton = binding.playerView.findViewById(R.id.exo_pause)
 
-        val overlay = binding.playerView.findViewById<FrameLayout>(R.id.exo_overlay)
-
-
-        val blurredImageView = ImageView(this).apply {
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.MATCH_PARENT
-            )
-            scaleType = ImageView.ScaleType.CENTER_CROP
-        }
-
-        Glide.with(this)
-            .load(getThemeBackground()) // or from URL or filePath
-            .into(blurredImageView)
-
-        overlay.addView(blurredImageView, 0)
+        binding.backgroundImage.setImageResource(getThemeBackground())
         val controller = binding.playerView.findViewById<View>(R.id.exo_controller)
         controller?.setBackgroundColor(android.graphics.Color.TRANSPARENT)
 
-
         initializeExoPlayer()
-
         setupPlayPauseButtons()
 
-        binding.playerView.setOnTouchListener { _,_ -> true}
+        binding.playerView.setOnTouchListener { _, _ -> true }
     }
 
     private fun initializeExoPlayer() {
@@ -126,7 +106,11 @@ class AudioPlayerActivity : AppCompatActivity() {
     private fun getThemeBackground(): Int {
         val isDarkMode = resources.configuration.uiMode and
                 Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
-        return if (isDarkMode) R.drawable.bg_player_dark else R.drawable.bg_player_white
+        return if (isDarkMode) {
+            R.drawable.audio_player_background_dark
+        } else {
+            R.drawable.audio_player_background_light
+        }
     }
 
     private fun setupPlayPauseButtons() {

--- a/app/src/main/res/drawable/audio_player_background_dark.xml
+++ b/app/src/main/res/drawable/audio_player_background_dark.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="90"
+        android:endColor="@color/colorPrimaryDark"
+        android:startColor="@color/colorPrimary" />
+    <corners android:radius="24dp" />
+</shape>

--- a/app/src/main/res/drawable/audio_player_background_light.xml
+++ b/app/src/main/res/drawable/audio_player_background_light.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="90"
+        android:endColor="@color/card_bg"
+        android:startColor="@color/mainColorLight" />
+    <corners android:radius="24dp" />
+</shape>

--- a/app/src/main/res/drawable/ic_play.xml
+++ b/app/src/main/res/drawable/ic_play.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/daynight_textColor"
+        android:pathData="M8,5v14l11,-7z" />
+</vector>

--- a/app/src/main/res/layout/fragment_library_detail.xml
+++ b/app/src/main/res/layout/fragment_library_detail.xml
@@ -63,7 +63,7 @@
                         android:contentDescription="@string/download"
                         android:text="@string/download"
                         app:srcCompat="@drawable/ic_download"
-                        app:tint="@color/md_black_1000" />
+                        app:tint="@color/daynight_textColor" />
                     <ImageButton
                         android:id="@+id/btn_remove"
                         style="@style/YellowButtons"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1049,7 +1049,6 @@
     <string name="confirm_removal">تأكيد الحذف</string>
     <string name="returning_user">مستخدم عائد</string>
     <string name="send_to_nation">اسمح بمشاركة إنجازاتك مع الوطن</string>
-    <string name="jcplayer_description">مشغل الصوت</string>
     <string name="image_resource">مصدر الصورة</string>
     <string name="play_audio">تشغيل الصوت</string>
     <string name="video_player">مشغل الفيديو</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1049,7 +1049,6 @@
     <string name="confirm_removal">Confirmar eliminación</string>
     <string name="returning_user">Usuario recurrente</string>
     <string name="send_to_nation">Permite que tus logros se compartan con la nación</string>
-    <string name="jcplayer_description">reproductor de audio</string>
     <string name="image_resource">recurso de imagen</string>
     <string name="play_audio">reproducir audio</string>
     <string name="video_player">reproductor de video</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1049,7 +1049,6 @@
     <string name="confirm_removal">Confirmer la suppression</string>
     <string name="returning_user">Utilisateur régulier</string>
     <string name="send_to_nation">Autorisez la partage de vos réalisations avec la nation</string>
-    <string name="jcplayer_description">lecteur audio</string>
     <string name="image_resource">ressource d\'image</string>
     <string name="play_audio">lire l\'audio</string>
     <string name="video_player">lecteur vidéo</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -1049,7 +1049,6 @@
     <string name="confirm_removal">हटाउनु हेरदैछ</string>
     <string name="returning_user">पुनराबृत्ति गर्ने प्रयोगकर्ता</string>
     <string name="send_to_nation">तपाइको उपलब्धिहरूलाई देशसँग साझा गर्न अनुमति दिनुहोस्</string>
-    <string name="jcplayer_description">आडियो प्लेयर</string>
     <string name="image_resource">तस्वीर स्रोत</string>
     <string name="play_audio">आडियो प्ले गर्नुहोस्</string>
     <string name="video_player">भिडियो प्लेयर</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -1049,7 +1049,6 @@
     <string name="confirm_removal">Xaqiiji tirtirka</string>
     <string name="returning_user">Isticmaale sare leh</string>
     <string name="send_to_nation">Geli codbixiyeyaashaaga qaranka</string>
-    <string name="jcplayer_description">qalabka codka</string>
     <string name="image_resource">deriska sawirka</string>
     <string name="play_audio">bixi codka</string>
     <string name="video_player">qalabka fiidyowga</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1049,7 +1049,6 @@
     <string name="confirm_removal">Confirm removal</string>
     <string name="returning_user">Returning user</string>
     <string name="send_to_nation">Allow your achievements to be shared with the nation</string>
-    <string name="jcplayer_description">audio player</string>
     <string name="image_resource">image resource</string>
     <string name="play_audio">play audio</string>
     <string name="video_player">video player</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -246,21 +246,6 @@
         <item name="android:textColor">@color/daynight_textColor</item>
     </style>
 
-    <style name="jcplayerstyle">
-        <item name="text_audio_current_duration_color">@color/daynight_textColor</item>
-        <item name="next_icon_color">@color/daynight_textColor</item>
-        <item name="pause_icon_color">@color/daynight_textColor</item>
-        <item name="play_icon_color">@color/daynight_textColor</item>
-        <item name="previous_icon_color">@color/daynight_textColor</item>
-        <item name="progress_color">@color/daynight_textColor</item>
-        <item name="random_icon_color">@color/daynight_textColor</item>
-        <item name="repeat_one_icon_color">@color/daynight_textColor</item>
-        <item name="text_audio_duration_color">@color/daynight_textColor</item>
-        <item name="repeat_one_icon">@color/daynight_textColor</item>
-        <item name="seek_bar_color">@color/daynight_textColor</item>
-        <item name="text_audio_title_color">@color/daynight_textColor</item>
-    </style>
-
     <style name="NumberPickerTheme" parent="Theme.AppCompat.Light">
         <item name="colorControlNormal">@color/accent</item>
         <item name="android:textColorPrimary">@color/daynight_textColor</item>


### PR DESCRIPTION
## Summary
- remove the legacy jcplayer dependency and its unused theme/strings
- add day/night aware assets for the Media3 audio player and tint the library download action to match
- simplify AudioPlayerActivity to use the new resources while keeping Media3 as the sole playback implementation

## Testing
- ./gradlew :app:assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e4f3714ccc832b95c99357601b077c