### PR TITLE
Migrate sync dialogs to Material Dialogs 3.x

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -199,7 +199,7 @@ dependencies {
     implementation 'com.github.jeancsanchez:jcplayer:2.7.2'
     implementation 'com.github.clans:fab:1.6.4'
     implementation 'com.applandeo:material-calendar-view:1.9.2'
-    implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
+    implementation 'com.afollestad.material-dialogs:core:3.3.0'
     implementation 'com.borax12.materialdaterangepicker:library:2.0'
     implementation 'com.nex3z:toggle-button-group:1.2.3'
     implementation 'com.caverock:androidsvg-aar:1.4'

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/DashboardElementActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/DashboardElementActivity.kt
@@ -21,6 +21,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.customview.customView
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -171,10 +172,9 @@ abstract class DashboardElementActivity : SyncActivity(), FragmentManager.OnBack
         val dialogServerUrlBinding = DialogServerUrlBinding.inflate(LayoutInflater.from(this))
         val contextWrapper = ContextThemeWrapper(this, R.style.AlertDialogTheme)
 
-        val builder = MaterialDialog.Builder(contextWrapper)
-            .customView(dialogServerUrlBinding.root, true)
-
-        val dialog = builder.build()
+        val dialog = MaterialDialog(contextWrapper).apply {
+            customView(view = dialogServerUrlBinding.root, scrollable = true)
+        }
         currentDialog = dialog
         service.getMinApk(this, url, serverPin, this, "DashboardActivity")
         createActionAsync(mRealm, "${profileDbHandler.userModel?.id}", null, "sync")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -26,6 +26,7 @@ import androidx.core.content.edit
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.customview.customView
 import com.bumptech.glide.Glide
 import java.util.Locale
 import kotlinx.coroutines.delay
@@ -244,8 +245,9 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
 
                     val dialogServerUrlBinding = DialogServerUrlBinding.inflate(LayoutInflater.from(this))
                     val contextWrapper = ContextThemeWrapper(this, R.style.AlertDialogTheme)
-                    val builder = MaterialDialog.Builder(contextWrapper).customView(dialogServerUrlBinding.root, true)
-                    val dialog = builder.build()
+                    val dialog = MaterialDialog(contextWrapper).apply {
+                        customView(view = dialogServerUrlBinding.root, scrollable = true)
+                    }
                     currentDialog = dialog
                     service.getMinApk(this, url, serverPin, this, "LoginActivity")
                 } else {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
@@ -7,8 +7,9 @@ import android.widget.ArrayAdapter
 import android.widget.CompoundButton
 import android.widget.RadioGroup
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.WhichButton
+import com.afollestad.materialdialogs.actions.getActionButton
 import io.realm.Sort
 import org.ole.planet.myplanet.BuildConfig
 import org.ole.planet.myplanet.R
@@ -24,7 +25,7 @@ fun SyncActivity.showConfigurationUIElements(
     serverAddresses.visibility = if (manualSelected) View.GONE else View.VISIBLE
     syncToServerText.visibility = if (manualSelected) View.GONE else View.VISIBLE
     positiveAction.visibility = if (manualSelected) View.VISIBLE else View.GONE
-    dialog.getActionButton(DialogAction.NEUTRAL).text =
+    dialog.getActionButton(WhichButton.NEUTRAL).text =
         if (manualSelected) {
             getString(R.string.btn_sync_save)
         } else {
@@ -208,7 +209,7 @@ fun SyncActivity.onNeutralButtonClick(dialog: MaterialDialog) {
     if (!prefData.getManualConfig()) {
         showAdditionalServers = !showAdditionalServers
         refreshServerList()
-        dialog.getActionButton(DialogAction.NEUTRAL).text =
+        dialog.getActionButton(WhichButton.NEUTRAL).text =
             if (showAdditionalServers) getString(R.string.show_less) else getString(R.string.show_more)
     } else {
         serverConfigAction = "save"


### PR DESCRIPTION
## Summary
- replace the deprecated Material Dialogs Commons dependency with the AndroidX-compatible 3.x core module
- update sync-related activities to use the Material Dialogs 3.x builder API and button helpers

## Testing
- `./gradlew :app:assembleDebug` *(fails: missing Android SDK Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f40aba38832b8877e0526189815f