### PR TITLE
Replace course progress view with Material indicator

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -194,7 +194,6 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.13.1'
     implementation 'com.google.android.material:material:1.12.0'
 
-    implementation "com.github.VaibhavLakhera:Circular-Progress-View:0.1.2"
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
     implementation 'com.github.jeancsanchez:jcplayer:2.7.2'
     implementation 'com.github.clans:fab:1.6.4'

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
@@ -41,14 +41,19 @@ class CourseProgressActivity : BaseActivity() {
             val courseProgress = RealmCourseProgress.getCourseProgress(realm, user?.id)
             val progress = courseProgress[courseId]
             val course = realm.where(RealmMyCourse::class.java).equalTo("courseId", courseId).findFirst()
-            if (progress != null) {
+            binding.progressView.max = 100
+            val progressPercentage = if (progress != null) {
                 val maxProgress = progress["max"].asInt
                 if (maxProgress != 0) {
-                    binding.progressView.setProgress((progress["current"].asInt.toDouble() / maxProgress.toDouble() * 100).toInt(), true)
+                    (progress["current"].asInt.toDouble() / maxProgress.toDouble() * 100).toInt()
                 } else {
-                    binding.progressView.setProgress(0, true)
+                    0
                 }
+            } else {
+                0
             }
+            binding.progressView.setProgressCompat(progressPercentage, true)
+            binding.tvProgressPercentage.text = getString(R.string.percentage, progressPercentage.toString())
             binding.tvCourse.text = course?.courseTitle
             binding.tvProgress.text = getString(
                 R.string.course_progress,

--- a/app/src/main/res/drawable/bg_course_progress_indicator.xml
+++ b/app/src/main/res/drawable/bg_course_progress_indicator.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/mainColor" />
+</shape>

--- a/app/src/main/res/layout/activity_course_progress.xml
+++ b/app/src/main/res/layout/activity_course_progress.xml
@@ -13,27 +13,35 @@
         android:orientation="vertical"
         android:padding="@dimen/padding_normal">
 
-        <com.vaibhavlakhera.circularprogressview.CircularProgressView
-            android:id="@+id/progressView"
+        <FrameLayout
             android:layout_width="164dp"
             android:layout_height="164dp"
             android:layout_gravity="center"
-            app:animate="true"
-            app:animateDuration="600"
-            app:fillColor="@color/mainColor"
-            app:progressColor="#FFF"
-            app:progressInterpolator="@android:anim/accelerate_decelerate_interpolator"
-            app:progressRoundCap="true"
-            app:progressTextColor="#FFF"
-            app:progressTextEnabled="true"
-            app:progressTextSize="32sp"
-            app:progressTextType="progress"
-            app:progressValue="10"
-            app:progressWidth="12dp"
-            app:startAngle="270"
-            app:totalColor="@color/total_color"
-            app:totalValue="100"
-            app:totalWidth="20dp" />
+            android:background="@drawable/bg_course_progress_indicator"
+            android:padding="20dp">
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/progressView"
+                style="@style/Widget.MaterialComponents.CircularProgressIndicator"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:indeterminate="false"
+                app:indicatorColor="@android:color/white"
+                app:indicatorDirectionCircular="clockwise"
+                app:trackColor="@color/total_color"
+                app:trackThickness="12dp" />
+
+            <TextView
+                android:id="@+id/tv_progress_percentage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:textColor="@android:color/white"
+                android:textSize="32sp"
+                android:textStyle="bold"
+                tools:text="10%" />
+        </FrameLayout>
         <TextView
             android:id="@+id/tv_course"
             android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- swap the course progress screen to a Material circular progress indicator with an overlaid percentage label
- update CourseProgressActivity to drive the new indicator API and keep the percentage text in sync
- remove the legacy Circular-Progress-View dependency now that it is no longer needed

## Testing
- ./gradlew --console=plain :app:compileDefaultDebugSources

------
https://chatgpt.com/codex/tasks/task_e_68e4f397d18c832b89e27a007f08d236