### PR TITLE
Refactor my personal resources handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnSelectedMyPersonal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnSelectedMyPersonal.kt
@@ -4,5 +4,6 @@ import org.ole.planet.myplanet.model.RealmMyPersonal
 
 interface OnSelectedMyPersonal {
     fun onUpload(personal: RealmMyPersonal?)
-    fun onAddedResource()
+    fun onDeletePersonal(personal: RealmMyPersonal)
+    fun onEditPersonal(personal: RealmMyPersonal, title: String, description: String?)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepository.kt
@@ -13,4 +13,12 @@ interface MyPersonalRepository {
     )
 
     fun getPersonalResources(userId: String?): Flow<List<RealmMyPersonal>>
+
+    suspend fun updatePersonalResource(
+        personalId: String,
+        title: String,
+        description: String?,
+    )
+
+    suspend fun deletePersonalResource(personalId: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepositoryImpl.kt
@@ -41,4 +41,23 @@ class MyPersonalRepositoryImpl @Inject constructor(
             equalTo("userId", userId)
         }
     }
+
+    override suspend fun updatePersonalResource(
+        personalId: String,
+        title: String,
+        description: String?,
+    ) {
+        update(
+            RealmMyPersonal::class.java,
+            "_id",
+            personalId
+        ) { personal ->
+            personal.title = title
+            personal.description = description
+        }
+    }
+
+    override suspend fun deletePersonalResource(personalId: String) {
+        delete(RealmMyPersonal::class.java, "_id", personalId)
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/AdapterMyPersonal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myPersonals/AdapterMyPersonal.kt
@@ -111,14 +111,14 @@ class AdapterMyPersonal(private val context: Context) : RecyclerView.Adapter<Vie
             .setIcon(R.drawable.ic_edit)
             .setView(alertMyPersonalBinding.root)
             .setPositiveButton(R.string.button_submit) { _, _ ->
-                val title = alertMyPersonalBinding.etDescription.text.toString().trim { it <= ' ' }
-                val desc = alertMyPersonalBinding.etTitle.text.toString().trim { it <= ' ' }
+                val title = alertMyPersonalBinding.etTitle.text.toString().trim { it <= ' ' }
+                val desc = alertMyPersonalBinding.etDescription.text.toString().trim { it <= ' ' }
                 if (title.isEmpty()) {
                     Utilities.toast(context, context.getString(R.string.please_enter_title))
                     return@setPositiveButton
                 }
-                personal.description = desc
                 personal.title = title
+                personal.description = desc
                 val index = list.indexOfFirst { it._id == personal._id }
                 if (index != -1) {
                     notifyItemChanged(index)


### PR DESCRIPTION
## Summary
- add update and delete APIs to `MyPersonalRepository` for `RealmMyPersonal` records
- refactor `AdapterMyPersonal` to emit edit/delete callbacks and operate on unmanaged data copies
- update `MyPersonalsFragment` to invoke repository operations from lifecycle scope and drop direct Realm usage

## Testing
- ./gradlew :app:lintLiteDebug

------
https://chatgpt.com/codex/tasks/task_e_68e535a2ff08832b9383334f2d5e016f