### PR TITLE
Refactor notification read handling into repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -3,4 +3,6 @@ package org.ole.planet.myplanet.repository
 interface NotificationRepository {
     suspend fun getUnreadCount(userId: String?): Int
     suspend fun updateResourceNotification(userId: String?)
+    suspend fun markNotificationsAsRead(notificationIds: Set<String>): Set<String>
+    suspend fun markAllUnreadAsRead(userId: String?): Set<String>
 }


### PR DESCRIPTION
## Summary
- add repository APIs for marking notifications read individually and in bulk
- implement realm-backed update logic that returns affected notification ids
- switch the notifications fragment to use the repository for marking notifications read and clearing OS notifications

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e537b3e044832bb1a16744cd91cb0e