### PR TITLE
Refactor team action button state handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/AdapterTeamList.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.ui.team
 
 import android.content.Context
 import android.content.DialogInterface
-import android.graphics.PorterDuff
 import android.graphics.Typeface
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -140,56 +139,22 @@ class AdapterTeamList(
         team: RealmMyTeam,
         user: RealmUserModel?,
     ) {
-        if (isMyTeam) {
-            name.setTypeface(null, Typeface.BOLD)
-        } else {
-            name.setTypeface(null, Typeface.NORMAL)
+        val viewContext = root.context
+        name.setTypeface(null, if (isMyTeam) Typeface.BOLD else Typeface.NORMAL)
+
+        val state = when {
+            user?.isGuest() == true -> TeamActionButtonState.Hidden
+            isTeamLeader -> TeamActionButtonState.Edit("${viewContext.getString(R.string.edit)} ${team.name}")
+            isMyTeam && !isTeamLeader -> TeamActionButtonState.Leave("${viewContext.getString(R.string.leave)} ${team.name}")
+            !isMyTeam && hasPendingRequest -> TeamActionButtonState.Requested(
+                "${viewContext.getString(R.string.requested)} ${team.name}",
+                "#9fa0a4".toColorInt(),
+            )
+            !isMyTeam -> TeamActionButtonState.Join("${viewContext.getString(R.string.request_to_join)} ${team.name}")
+            else -> TeamActionButtonState.Hidden
         }
-        when {
-            user?.isGuest() == true -> joinLeave.visibility = View.GONE
 
-            isTeamLeader -> {
-                joinLeave.apply {
-                    isEnabled = true
-                    contentDescription = "${context.getString(R.string.edit)} ${team.name}"
-                    visibility = View.VISIBLE
-                    setImageResource(R.drawable.ic_edit)
-                    clearColorFilter()
-                }
-            }
-
-            isMyTeam && !isTeamLeader -> {
-                joinLeave.apply {
-                    isEnabled = true
-                    contentDescription = "${context.getString(R.string.leave)} ${team.name}"
-                    visibility = View.VISIBLE
-                    setImageResource(R.drawable.logout)
-                    clearColorFilter()
-                }
-            }
-
-            !isMyTeam && hasPendingRequest -> {
-                joinLeave.apply {
-                    isEnabled = false
-                    contentDescription = "${context.getString(R.string.requested)} ${team.name}"
-                    visibility = View.VISIBLE
-                    setImageResource(R.drawable.baseline_hourglass_top_24)
-                    setColorFilter("#9fa0a4".toColorInt(), PorterDuff.Mode.SRC_IN)
-                }
-            }
-
-            !isMyTeam -> {
-                joinLeave.apply {
-                    isEnabled = true
-                    contentDescription = "${context.getString(R.string.request_to_join)} ${team.name}"
-                    visibility = View.VISIBLE
-                    setImageResource(R.drawable.ic_join_request)
-                    clearColorFilter()
-                }
-            }
-
-            else -> joinLeave.visibility = View.GONE
-        }
+        applyActionButtonState(state)
     }
 
     private fun handleJoinLeaveClick(team: RealmMyTeam, user: RealmUserModel?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamActionButtonState.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamActionButtonState.kt
@@ -1,0 +1,56 @@
+package org.ole.planet.myplanet.ui.team
+
+import android.graphics.PorterDuff
+import android.view.View
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.databinding.ItemTeamListBinding
+
+sealed class TeamActionButtonState(
+    val iconRes: Int?,
+    val isEnabled: Boolean,
+    val contentDescription: String?,
+    val visibility: Int = View.VISIBLE,
+    val colorFilter: Int? = null,
+    val colorFilterMode: PorterDuff.Mode = PorterDuff.Mode.SRC_IN,
+) {
+    object Hidden : TeamActionButtonState(iconRes = null, isEnabled = false, contentDescription = null, visibility = View.GONE)
+
+    class Join(contentDescription: String) : TeamActionButtonState(
+        iconRes = R.drawable.ic_join_request,
+        isEnabled = true,
+        contentDescription = contentDescription,
+    )
+
+    class Requested(contentDescription: String, colorFilter: Int) : TeamActionButtonState(
+        iconRes = R.drawable.baseline_hourglass_top_24,
+        isEnabled = false,
+        contentDescription = contentDescription,
+        colorFilter = colorFilter,
+    )
+
+    class Leave(contentDescription: String) : TeamActionButtonState(
+        iconRes = R.drawable.logout,
+        isEnabled = true,
+        contentDescription = contentDescription,
+    )
+
+    class Edit(contentDescription: String) : TeamActionButtonState(
+        iconRes = R.drawable.ic_edit,
+        isEnabled = true,
+        contentDescription = contentDescription,
+    )
+}
+
+fun ItemTeamListBinding.applyActionButtonState(state: TeamActionButtonState) {
+    joinLeave.visibility = state.visibility
+    joinLeave.isEnabled = state.isEnabled
+    joinLeave.contentDescription = state.contentDescription
+
+    state.iconRes?.let { joinLeave.setImageResource(it) }
+
+    if (state.colorFilter != null) {
+        joinLeave.setColorFilter(state.colorFilter, state.colorFilterMode)
+    } else {
+        joinLeave.clearColorFilter()
+    }
+}


### PR DESCRIPTION
## Summary
- add a sealed `TeamActionButtonState` and binding extension to describe the join/leave button modes
- refactor `AdapterTeamList.showActionButton` to select a state and apply it while keeping the typeface handling simple

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e54ea4b67c832b9503970a3b9de325