### PR TITLE
Remove unused RealmAnswer value choice mutation

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmAnswer.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmAnswer.kt
@@ -31,20 +31,6 @@ open class RealmAnswer : RealmObject() {
             return array
         }
 
-    fun setValueChoices(map: HashMap<String, String>?, isLastAnsValid: Boolean) {
-        if (!isLastAnsValid) {
-            valueChoices?.clear()
-        }
-        if (map != null) {
-            for (key in map.keys) {
-                val ob = JsonObject()
-                ob.addProperty("id", map[key])
-                ob.addProperty("text", key)
-                valueChoices?.add(Gson().toJson(ob))
-            }
-        }
-    }
-
     companion object {
         @JvmStatic
         fun serializeRealmAnswer(answers: RealmList<RealmAnswer>): JsonArray {


### PR DESCRIPTION
## Summary
- remove the unused value choice mutation helper from RealmAnswer

## Testing
- ./gradlew lint --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e6277e98d0832bb9013bb4e5316e91