### PR TITLE
Remove redundant RealmApkLog error helpers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmApkLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmApkLog.kt
@@ -20,30 +20,6 @@ open class RealmApkLog : RealmObject() {
     var createdOn: String? = null
     var time: String? = null
 
-    fun setError(e: Throwable) {
-        error += "--------- Stack trace ---------\n\n"
-        appendReport(e)
-        error += "--------- Cause ---------\n\n"
-        val cause = e.cause
-        appendReport(cause)
-    }
-
-    private fun appendReport(cause: Throwable?) {
-        if (cause != null) {
-            error += """
-                $cause
-                
-                
-                """.trimIndent()
-            val arr = cause.stackTrace
-            for (i in arr.indices) {
-                error += """    ${arr[i]}
-"""
-            }
-        }
-        error += "-------------------------------\n\n"
-    }
-
     companion object {
         @Ignore
         const val ERROR_TYPE_CRASH = "crash"


### PR DESCRIPTION
## Summary
- remove the unused RealmApkLog.setError and appendReport helpers so only MainApplication.createLog writes the error field

## Testing
- ./gradlew lint *(fails: corrupted Android SDK package.xml in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e62797e8b4832b92d83c6253d82519