### PR TITLE
Refactor realtime sync listeners to flow

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/RealtimeSyncCoordinator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/RealtimeSyncCoordinator.kt
@@ -1,10 +1,8 @@
 package org.ole.planet.myplanet.service.sync
 
-import android.util.Log
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import org.ole.planet.myplanet.callback.RealtimeSyncListener
 import org.ole.planet.myplanet.callback.TableDataUpdate
 
 class RealtimeSyncCoordinator {
@@ -20,42 +18,7 @@ class RealtimeSyncCoordinator {
         }
     }
     
-    private val listeners = mutableSetOf<RealtimeSyncListener>()
     private val _dataUpdateFlow = MutableSharedFlow<TableDataUpdate>()
     val dataUpdateFlow: SharedFlow<TableDataUpdate> = _dataUpdateFlow.asSharedFlow()
-    
-    fun addListener(listener: RealtimeSyncListener) {
-        synchronized(listeners) {
-            listeners.add(listener)
-        }
-    }
-    
-    fun removeListener(listener: RealtimeSyncListener) {
-        synchronized(listeners) {
-            listeners.remove(listener)
-        }
-    }
-    
-    fun notifyTableDataUpdated(table: String, newItemsCount: Int, updatedItemsCount: Int) {
-        Log.d("RealtimeSyncCoordinator", "=== notifyTableDataUpdated ===")
-        Log.d("RealtimeSyncCoordinator", "Table: $table, newItems: $newItemsCount, updatedItems: $updatedItemsCount")
-        Log.d("RealtimeSyncCoordinator", "Active listeners count: ${listeners.size}")
-
-        val update = TableDataUpdate(
-            table = table,
-            newItemsCount = newItemsCount,
-            updatedItemsCount = updatedItemsCount,
-            shouldRefreshUI = true
-        )
-        
-        synchronized(listeners) {
-            listeners.forEach { 
-                Log.d("RealtimeSyncCoordinator", "Notifying listener: ${it.javaClass.simpleName}")
-                it.onTableDataUpdated(update) 
-            }
-        }
-        _dataUpdateFlow.tryEmit(update)
-        Log.d("RealtimeSyncCoordinator", "=== notifyTableDataUpdated END ===")
-    }
 
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
@@ -8,7 +8,6 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.callback.BaseRealtimeSyncListener
 import org.ole.planet.myplanet.callback.TableDataUpdate
 import org.ole.planet.myplanet.service.sync.RealtimeSyncCoordinator
 
@@ -26,24 +25,7 @@ class RealtimeSyncHelper(
     
     private val syncCoordinator = RealtimeSyncCoordinator.getInstance()
     
-    private val realtimeSyncListener = object : BaseRealtimeSyncListener() {
-        override fun onTableDataUpdated(update: TableDataUpdate) {
-            if (mixin.getWatchedTables().contains(update.table)) {
-                mixin.onDataUpdated(update.table, update)
-                if (mixin.shouldAutoRefresh(update.table)) {
-                    refreshRecyclerView()
-                }
-            }
-        }
-        
-        override fun onSyncStarted() {}
-        override fun onSyncComplete() {}
-        override fun onSyncFailed(msg: String?) {}
-    }
-    
     fun setupRealtimeSync() {
-        syncCoordinator.addListener(realtimeSyncListener)
-        
         // Listen to data update flow
         fragment.lifecycleScope.launch {
             fragment.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -63,14 +45,12 @@ class RealtimeSyncHelper(
             }
         }
     }
-    
+
     private fun refreshRecyclerView() {
         fragment.viewLifecycleOwner.lifecycleScope.launch {
             mixin.getSyncRecyclerView()?.adapter?.notifyDataSetChanged()
         }
     }
-    
-    fun cleanup() {
-        syncCoordinator.removeListener(realtimeSyncListener)
-    }
+
+    fun cleanup() {}
 }


### PR DESCRIPTION
## Summary
- remove manual realtime sync listener registration from the coordinator and dependents
- update fragments and mixin helpers to collect table updates from the shared flow instead of direct callbacks

## Testing
- ./gradlew --console=plain :app:compileDefaultDebugKotlin

------
https://chatgpt.com/codex/tasks/task_e_68e628110a74832b8021a5105d890954