### PR TITLE
Remove beta course preference handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/SettingActivity.kt
@@ -211,20 +211,12 @@ class SettingActivity : AppCompatActivity() {
 
         private fun setBetaToggleOn() {
             val beta = findPreference<SwitchPreference>("beta_function")
-            val course = findPreference<SwitchPreference>("beta_course")
 //            val rating = findPreference<SwitchPreference>("beta_rating")
 //            val myHealth = findPreference<SwitchPreference>("beta_myHealth")
 //            val healthWorker = findPreference<SwitchPreference>("beta_healthWorker")
 
-            if (beta != null) {
-                beta.onPreferenceChangeListener = OnPreferenceChangeListener { _: Preference?, _: Any? ->
-                    if (beta.isChecked) {
-                        if (course != null) {
-                            course.isChecked = true
-                        }
-                    }
-                    true
-                }
+            beta?.onPreferenceChangeListener = OnPreferenceChangeListener { _: Preference?, _: Any? ->
+                true
             }
         }
 


### PR DESCRIPTION
## Summary
- remove the beta course preference lookup and coupling from the settings screen
- keep the beta toggle listener without redundant checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e628678fe0832b9123476b846d9af2