### PR TITLE
resources: resolve crash (fixes #8265)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
@@ -202,9 +202,11 @@ class AdapterResource(
                     tagRepository.getTagsForResource(resourceId)
                 }
                 tagCache[resourceId] = tags
-                val adapterPosition = holder.bindingAdapterPosition
-                if (adapterPosition != RecyclerView.NO_POSITION) {
-                    notifyItemChanged(adapterPosition, TAGS_PAYLOAD)
+                holder.itemView.post {
+                    val adapterPosition = holder.bindingAdapterPosition
+                    if (adapterPosition != RecyclerView.NO_POSITION) {
+                        notifyItemChanged(adapterPosition, TAGS_PAYLOAD)
+                    }
                 }
             } finally {
                 tagRequestsInProgress.remove(resourceId)


### PR DESCRIPTION
fixes #8265
The notifyItemChanged call is now wrapped in holder.itemView.post {} to ensure it executes after the RecyclerView layout pass completes, preventing the crash.