### PR TITLE
Delegate team visit logging to TeamRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -25,6 +25,13 @@ interface TeamRepository {
     suspend fun upsertTask(task: RealmTeamTask)
     suspend fun assignTask(taskId: String, assigneeId: String?)
     suspend fun setTaskCompletion(taskId: String, completed: Boolean)
+    suspend fun logTeamVisit(
+        teamId: String,
+        userName: String?,
+        userPlanetCode: String?,
+        userParentCode: String?,
+        teamType: String?,
+    )
     suspend fun createTeam(
         category: String?,
         name: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -271,6 +271,26 @@ class TeamRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun logTeamVisit(
+        teamId: String,
+        userName: String?,
+        userPlanetCode: String?,
+        userParentCode: String?,
+        teamType: String?,
+    ) {
+        if (teamId.isBlank() || userName.isNullOrBlank()) return
+        executeTransaction { realm ->
+            val log = realm.createObject(RealmTeamLog::class.java, UUID.randomUUID().toString())
+            log.teamId = teamId
+            log.user = userName
+            log.createdOn = userPlanetCode
+            log.type = "teamVisit"
+            log.teamType = teamType
+            log.parentCode = userParentCode
+            log.time = Date().time
+        }
+    }
+
     override suspend fun createTeam(
         category: String?,
         name: String,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamDetailFragment.kt
@@ -11,8 +11,6 @@ import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.Date
-import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -30,7 +28,6 @@ import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMemberCount
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
@@ -476,16 +473,13 @@ class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener, TeamUpdateL
         val teamType = getEffectiveTeamType()
 
         viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-            databaseService.executeTransactionAsync { r ->
-                val log = r.createObject(RealmTeamLog::class.java, "${UUID.randomUUID()}")
-                log.teamId = getEffectiveTeamId()
-                log.user = userName
-                log.createdOn = userPlanetCode
-                log.type = "teamVisit"
-                log.teamType = teamType
-                log.parentCode = userParentCode
-                log.time = Date().time
-            }
+            teamRepository.logTeamVisit(
+                teamId = getEffectiveTeamId(),
+                userName = userName,
+                userPlanetCode = userPlanetCode,
+                userParentCode = userParentCode,
+                teamType = teamType,
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- add a logTeamVisit suspend API to TeamRepository and implement it with executeTransaction
- route TeamDetailFragment visit logging through the repository instead of touching DatabaseService directly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e650474438832b91b75e7bf1898444