### PR TITLE
Inject profile handler via Hilt in resource fragments

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseNewsFragment.kt
@@ -28,7 +28,6 @@ import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.ImageThumbBinding
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.ui.news.AdapterNews
 import org.ole.planet.myplanet.ui.news.AdapterNews.OnNewsItemClickListener
@@ -52,7 +51,6 @@ abstract class BaseNewsFragment : BaseContainerFragment(), OnNewsItemClickListen
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         imageList = RealmList()
-        profileDbHandler = UserProfileDbHandler(requireContext())
         openFolderLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
             if (result.resultCode == Activity.RESULT_OK) {
                 val data = result.data
@@ -102,12 +100,6 @@ abstract class BaseNewsFragment : BaseContainerFragment(), OnNewsItemClickListen
         if (context is OnHomeItemClickListener) homeItemClickListener = context
     }
 
-    override fun onDestroy() {
-        profileDbHandler?.onDestroy()
-        profileDbHandler = null
-        super.onDestroy()
-    }
-
     override fun showReply(news: RealmNews?, fromLogin: Boolean, nonTeamMember: Boolean) {
         if (news != null) {
             val intent = Intent(activity, ReplyActivity::class.java).putExtra("id", news.id)
@@ -119,7 +111,7 @@ abstract class BaseNewsFragment : BaseContainerFragment(), OnNewsItemClickListen
 
     override fun onMemberSelected(userModel: RealmUserModel?) {
         if (!isAdded) return
-        val handler = profileDbHandler ?: return
+        val handler = profileDbHandler
         val fragment = NewsActions.showMemberDetails(userModel, handler) ?: return
         NavigationHelper.replaceFragment(
             requireActivity().supportFragmentManager,

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -34,7 +34,6 @@ import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.onAdd
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmTag
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.utilities.Utilities.toast
 
 abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), OnRatingChangeListener {
@@ -86,8 +85,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         selectedItems = mutableListOf()
         list = mutableListOf()
         mRealm = databaseService.realmInstance
-        profileDbHandler = UserProfileDbHandler(requireActivity())
-        model = profileDbHandler?.userModel
+        model = profileDbHandler.userModel
         val adapter = getAdapter()
         recyclerView.adapter = adapter
         if (isMyCourseLib && adapter.itemCount != 0 && courseLib == "courses") {
@@ -125,13 +123,13 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
                     val myObject = mRealm.where(RealmMyLibrary::class.java)
                         .equalTo("resourceId", `object`.resourceId).findFirst()
                     createFromResource(myObject, mRealm, model?.id)
-                    val userId = profileDbHandler?.userModel?.id
+                    val userId = profileDbHandler.userModel?.id
                     onAdd(mRealm, "resources", userId, myObject?.resourceId)
                     toast(activity, getString(R.string.added_to_my_library))
                 } else {
                     val myObject = getMyCourse(mRealm, (`object` as RealmMyCourse).courseId)
                     createMyCourse(myObject, mRealm, model?.id)
-                    val userId = profileDbHandler?.userModel?.id
+                    val userId = profileDbHandler.userModel?.id
                     onAdd(mRealm, "courses", userId, myObject?.courseId)
                     toast(activity, getString(R.string.added_to_my_courses))
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -22,7 +22,6 @@ import org.ole.planet.myplanet.model.RealmMyCourse.Companion.isMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.exam.TakeExamFragment
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
 import org.ole.planet.myplanet.utilities.CameraUtils.ImageCaptureCallback
@@ -50,7 +49,7 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentCourseStepBinding = FragmentCourseStepBinding.inflate(inflater, container, false)
-        user = UserProfileDbHandler(requireContext()).userModel
+        user = profileDbHandler.userModel
         fragmentCourseStepBinding.btnTakeTest.visibility = View.VISIBLE
         fragmentCourseStepBinding.btnTakeSurvey.visibility = View.VISIBLE
         return fragmentCourseStepBinding.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -40,7 +40,6 @@ import org.ole.planet.myplanet.model.RealmTeamNotification
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.TransactionSyncManager
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.service.UserProfileDbHandler.Companion.KEY_LOGIN
 import org.ole.planet.myplanet.ui.exam.UserInformationFragment
 import org.ole.planet.myplanet.ui.myhealth.UserListArrayAdapter
@@ -68,11 +67,10 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
     private lateinit var offlineActivitiesResults: RealmResults<RealmOfflineActivity>
     fun onLoaded(v: View) {
-        profileDbHandler = UserProfileDbHandler(requireContext())
-        model = profileDbHandler?.userModel
-        fullName = profileDbHandler?.userModel?.getFullName()
+        model = profileDbHandler.userModel
+        fullName = profileDbHandler.userModel?.getFullName()
         if (fullName?.trim().isNullOrBlank()) {
-            fullName = profileDbHandler?.userModel?.name
+            fullName = profileDbHandler.userModel?.name
             v.findViewById<LinearLayout>(R.id.ll_prompt).visibility = View.VISIBLE
             v.findViewById<LinearLayout>(R.id.ll_prompt).setOnClickListener {
                 if (!childFragmentManager.isStateSaved) {
@@ -101,12 +99,12 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
         }
 
         offlineActivitiesResults = mRealm.where(RealmOfflineActivity::class.java)
-            .equalTo("userName", profileDbHandler?.userModel?.name)
+            .equalTo("userName", profileDbHandler.userModel?.name)
             .equalTo("type", KEY_LOGIN)
             .findAllAsync()
         v.findViewById<TextView>(R.id.txtRole).text = getString(R.string.user_role, model?.getRoleAsString())
-        val offlineVisits = profileDbHandler?.offlineVisits ?: 0
-        v.findViewById<TextView>(R.id.txtFullName).text =getString(R.string.user_name, fullName, offlineVisits)
+        val offlineVisits = profileDbHandler.offlineVisits
+        v.findViewById<TextView>(R.id.txtFullName).text = getString(R.string.user_name, fullName, offlineVisits)
     }
 
     override fun forceDownloadNewsImages() {
@@ -209,7 +207,7 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
 
     private fun myTeamInit(flexboxLayout: FlexboxLayout): Int {
         val dbMyTeam = RealmMyTeam.getMyTeamsByUserId(mRealm, settings)
-        val userId = UserProfileDbHandler(requireContext()).userModel?.id
+        val userId = profileDbHandler.userModel?.id
         for ((count, ob) in dbMyTeam.withIndex()) {
             val v = LayoutInflater.from(activity).inflate(R.layout.item_home_my_team, flexboxLayout, false)
             val name = v.findViewById<TextView>(R.id.tv_name)
@@ -284,8 +282,6 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     override fun onDestroy() {
-        profileDbHandler?.onDestroy()
-        profileDbHandler = null
         if (::myCoursesResults.isInitialized) {
             myCoursesResults.removeChangeListener(myCoursesChangeListener)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragmentPlugin.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragmentPlugin.kt
@@ -17,7 +17,6 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmSubmission
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.calendar.CalendarFragment
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
 import org.ole.planet.myplanet.ui.myPersonals.MyPersonalsFragment
@@ -116,10 +115,7 @@ open class BaseDashboardFragmentPlugin : BaseContainerFragment() {
         setBackgroundColor(v, itemCnt)
 
         val title = (obj as RealmMyLife).title
-        val handler = profileDbHandler ?: UserProfileDbHandler(requireContext()).also {
-            profileDbHandler = it
-        }
-        val user = handler.userModel
+        val user = profileDbHandler.userModel
         itemMyLifeBinding.img.setImageResource(resources.getIdentifier(obj.imageId, "drawable", requireActivity().packageName))
         itemMyLifeBinding.tvName.text = title
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -23,7 +23,6 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyLibrary.Companion.listToString
 import org.ole.planet.myplanet.model.RealmRating.Companion.getRatingsById
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.utilities.FileUtils.getFileExtension
 import org.ole.planet.myplanet.utilities.Utilities
@@ -56,7 +55,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
         }
         fragmentScope.launch {
             val userId = withContext(Dispatchers.Main) {
-                profileDbHandler?.userModel?.id
+                profileDbHandler.userModel?.id
             }
             withContext(Dispatchers.IO) {
                 try {
@@ -72,7 +71,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             }
             withContext(Dispatchers.Main) {
                 binding.btnDownload.setImageResource(R.drawable.ic_play)
-                val currentUserId = profileDbHandler?.userModel?.id
+                val currentUserId = profileDbHandler.userModel?.id
                 if (currentUserId != null && library.userId?.contains(currentUserId) != true) {
                     Utilities.toast(activity, getString(R.string.added_to_my_library))
                     binding.btnRemove.setImageResource(R.drawable.close_x)
@@ -84,7 +83,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         super.onCreateView(inflater, container, savedInstanceState)
         _binding = FragmentLibraryDetailBinding.inflate(inflater, container, false)
-        userModel = UserProfileDbHandler(requireContext()).userModel!!
+        userModel = profileDbHandler.userModel
         setLoadingState(true)
         return binding.root
     }
@@ -143,7 +142,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
         fragmentScope.launch {
             withContext(Dispatchers.Main) {
                 try {
-                    profileDbHandler?.setResourceOpenCount(library)
+                    profileDbHandler.setResourceOpenCount(library)
                 } catch (ex: Exception) {
                     ex.printStackTrace()
                 }
@@ -196,7 +195,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             }
             openResource(library)
         }
-        val userId = profileDbHandler?.userModel?.id
+        val userId = profileDbHandler.userModel?.id
         val isAdd = userId?.let { library.userId?.contains(it) } != true
         if (userModel?.isGuest() != true) {
             binding.btnRemove.setImageResource(
@@ -216,7 +215,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             binding.btnRemove.visibility = View.GONE
         }
         binding.btnRemove.setOnClickListener {
-            val userId = profileDbHandler?.userModel?.id
+            val userId = profileDbHandler.userModel?.id
             fragmentScope.launch {
                 withContext(Dispatchers.IO) {
                     try {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
@@ -27,7 +27,6 @@ import org.ole.planet.myplanet.databinding.FragmentSurveyBinding
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.repository.SurveyRepository
 import org.ole.planet.myplanet.service.SyncManager
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncHelper
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
 import org.ole.planet.myplanet.utilities.DialogUtils
@@ -72,8 +71,7 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), SurveyAdoptListen
         super.onCreate(savedInstanceState)
         isTeam = arguments?.getBoolean("isTeam", false) == true
         teamId = arguments?.getString("teamId", null)
-        profileDbHandler = UserProfileDbHandler(requireContext())
-        val userProfileModel = profileDbHandler?.userModel
+        val userProfileModel = profileDbHandler.userModel
         adapter = AdapterSurvey(requireActivity(), mRealm, userProfileModel?.id, isTeam, teamId, this, settings)
         prefManager = SharedPrefManager(requireContext())
         

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
@@ -34,7 +34,6 @@ import org.ole.planet.myplanet.model.RealmAchievement
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.service.SyncManager
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.service.sync.RealtimeSyncCoordinator
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.JsonUtils.getString
@@ -75,7 +74,7 @@ class AchievementFragment : BaseContainerFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentAchievementBinding.inflate(inflater, container, false)
         aRealm = databaseService.realmInstance
-        user = UserProfileDbHandler(requireContext()).userModel
+        user = profileDbHandler.userModel
         binding.btnEdit.setOnClickListener {
             if (listener != null) listener?.openCallFragment(EditAchievementFragment())
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/EditAchievementFragment.kt
@@ -39,7 +39,6 @@ import org.ole.planet.myplanet.model.RealmAchievement
 import org.ole.planet.myplanet.model.RealmAchievement.Companion.createReference
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.navigation.NavigationHelper
 import org.ole.planet.myplanet.utilities.CheckboxListView
 import org.ole.planet.myplanet.utilities.DialogUtils.getDialog
@@ -64,7 +63,7 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         fragmentEditAchievementBinding = FragmentEditAchievementBinding.inflate(inflater, container, false)
         aRealm = databaseService.realmInstance
-        user = UserProfileDbHandler(requireContext()).userModel
+        user = profileDbHandler.userModel
         achievementArray = JsonArray()
         achievement = aRealm.where(RealmAchievement::class.java).equalTo("_id", user?.id + "@" + user?.planetCode).findFirst()
         initializeData()


### PR DESCRIPTION
## Summary
- inject `UserProfileDbHandler` into `BaseResourceFragment` via Hilt and keep lifecycle cleanup
- remove manual database handler instantiation in base resource/container fragments and downstream screens
- update dashboard, resource, survey, and achievement flows to rely on the injected handler

## Testing
- ./gradlew :app:compileLiteDebugKotlin --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68e6501b3dc0832bbfeb7e284cf3e03d