### PR TITLE
Refactor team course loading to use repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
@@ -7,6 +7,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 interface CourseRepository {
     suspend fun getAllCourses(): List<RealmMyCourse>
     suspend fun getCourseByCourseId(courseId: String?): RealmMyCourse?
+    suspend fun getCoursesByIds(ids: Collection<String>): List<RealmMyCourse>
     suspend fun getCourseOnlineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseOfflineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseExamCount(courseId: String?): Int

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -19,6 +19,15 @@ class CourseRepositoryImpl @Inject constructor(
         return courseId?.let { findByField(RealmMyCourse::class.java, "courseId", it) }
     }
 
+    override suspend fun getCoursesByIds(ids: Collection<String>): List<RealmMyCourse> {
+        if (ids.isEmpty()) {
+            return emptyList()
+        }
+        return queryList(RealmMyCourse::class.java) {
+            `in`("id", ids.toTypedArray())
+        }
+    }
+
     override suspend fun getCourseOnlineResources(courseId: String?): List<RealmMyLibrary> {
         return getCourseResources(courseId, isOffline = false)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/AdapterTeamCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/AdapterTeamCourse.kt
@@ -7,28 +7,31 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import io.realm.Realm
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.RowTeamResourceBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getTeamCreator
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
 import org.ole.planet.myplanet.ui.team.teamCourse.AdapterTeamCourse.ViewHolderTeamCourse
 import org.ole.planet.myplanet.utilities.DiffUtils
 
-class AdapterTeamCourse(private val context: Context, private var list: MutableList<RealmMyCourse>, mRealm: Realm?, teamId: String?, settings: SharedPreferences) : RecyclerView.Adapter<ViewHolderTeamCourse>() {
+class AdapterTeamCourse(
+    private val context: Context,
+    private var list: MutableList<RealmMyCourse>,
+    private val teamCreator: String,
+    settings: SharedPreferences,
+) : RecyclerView.Adapter<ViewHolderTeamCourse>() {
     private lateinit var rowTeamResourceBinding: RowTeamResourceBinding
     private var listener: OnHomeItemClickListener? = null
     private val settings: SharedPreferences
-    private val teamCreator: String
+    private val teamCreatorId: String
 
     init {
         if (context is OnHomeItemClickListener) {
             listener = context
         }
         this.settings = settings
-        teamCreator = getTeamCreator(teamId, mRealm)
+        teamCreatorId = teamCreator
     }
     
     fun updateList(newList: List<RealmMyCourse>) {
@@ -64,7 +67,7 @@ class AdapterTeamCourse(private val context: Context, private var list: MutableL
                 listener?.openCallFragment(TakeCourseFragment.newInstance(b))
             }
         }
-        if (!settings.getString("userId", "--").equals(teamCreator, ignoreCase = true)) {
+        if (!settings.getString("userId", "--").equals(teamCreatorId, ignoreCase = true)) {
             holder.itemView.findViewById<View>(R.id.iv_remove).visibility = View.GONE
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
@@ -4,16 +4,22 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import javax.inject.Inject
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
-import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
+import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getTeamCreator
+import org.ole.planet.myplanet.repository.CourseRepository
 
 class TeamCourseFragment : BaseTeamFragment() {
     private var _binding: FragmentTeamCourseBinding? = null
     private val binding get() = _binding!!
     private var adapterTeamCourse: AdapterTeamCourse? = null
+    @Inject
+    lateinit var courseRepository: CourseRepository
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentTeamCourseBinding.inflate(inflater, container, false)
@@ -26,12 +32,18 @@ class TeamCourseFragment : BaseTeamFragment() {
     }
     
     private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { AdapterTeamCourse(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
+        val teamCreator = team?.userId ?: if (isRealmInitialized()) getTeamCreator(teamId, mRealm) else ""
+        adapterTeamCourse = AdapterTeamCourse(requireActivity(), mutableListOf(), teamCreator, settings)
         binding.rvCourse.layoutManager = LinearLayoutManager(activity)
         binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+
+        val courseIds = team?.courses?.filterNotNull() ?: emptyList()
+        viewLifecycleOwner.lifecycleScope.launch {
+            val courses = courseRepository.getCoursesByIds(courseIds)
+            adapterTeamCourse?.updateList(courses)
+            adapterTeamCourse?.let {
+                showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+            }
         }
     }
     override fun onNewsItemClick(news: RealmNews?) {}


### PR DESCRIPTION
## Summary
- add a repository method to fetch courses by id collections
- load team course data through the repository from TeamCourseFragment
- update AdapterTeamCourse to operate on plain lists without a Realm dependency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6529994d0832bb1e9d7383d02aa65