### PR TITLE
Refactor notifications loading to use repository coroutines

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationFilter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationFilter.kt
@@ -1,0 +1,17 @@
+package org.ole.planet.myplanet.repository
+
+enum class NotificationFilter {
+    ALL,
+    READ,
+    UNREAD;
+
+    companion object {
+        fun fromSelection(selection: String): NotificationFilter {
+            return when (selection.lowercase()) {
+                "read" -> READ
+                "unread" -> UNREAD
+                else -> ALL
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationRepository.kt
@@ -1,6 +1,9 @@
 package org.ole.planet.myplanet.repository
 
+import org.ole.planet.myplanet.model.RealmNotification
+
 interface NotificationRepository {
+    suspend fun getNotificationsForUser(userId: String, filter: NotificationFilter): List<RealmNotification>
     suspend fun getUnreadCount(userId: String?): Int
     suspend fun updateResourceNotification(userId: String?)
     suspend fun markNotificationsAsRead(notificationIds: Set<String>): Set<String>


### PR DESCRIPTION
## Summary
- add a NotificationFilter type and repository API to fetch notifications off the main thread
- update NotificationsFragment to load, filter, and refresh unread counts through lifecycleScope coroutines
- ensure mark-as-read flows rely on repository writes and refresh the UI from coroutine results

## Testing
- ./gradlew test --console=plain *(fails: Android SDK Platform 36 not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68e7f70c1424832bb04ccccfcc801592