### PR TITLE
Optimize search normalization in BaseRecyclerFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -203,6 +203,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         val queryParts = s.split(" ").filterNot { it.isEmpty() }
         val data: RealmResults<LI> = mRealm.where(c).findAll()
         val normalizedQuery = normalizeText(s)
+        val normalizedParts = queryParts.map { normalizeText(it) }
         val startsWithQuery = mutableListOf<LI>()
         val containsQuery = mutableListOf<LI>()
 
@@ -211,7 +212,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
 
             if (title.startsWith(normalizedQuery, ignoreCase = true)) {
                 startsWithQuery.add(item)
-            } else if (queryParts.all { title.contains(normalizeText(it), ignoreCase = true) }) {
+            } else if (normalizedParts.all { title.contains(it, ignoreCase = true) }) {
                 containsQuery.add(item)
             }
         }


### PR DESCRIPTION
## Summary
- pre-compute normalized search parts once before iterating Realm results
- reuse the cached normalized parts when evaluating the per-item filter clause

## Testing
- ⚠️ `./gradlew test --no-daemon --console=plain` *(fails: command was interrupted after hanging without producing results)*

------
https://chatgpt.com/codex/tasks/task_e_68ee837c8934832b84e339a43bc91eba