### PR TITLE
Refactor course step fragment to use repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.repository
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmStepExam
 
 interface CourseRepository {
     suspend fun getAllCourses(): List<RealmMyCourse>
@@ -11,4 +12,7 @@ interface CourseRepository {
     suspend fun getCourseOfflineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseExamCount(courseId: String?): Int
     suspend fun getCourseSteps(courseId: String?): List<RealmCourseStep>
+    suspend fun getCourseStep(stepId: String?): RealmCourseStep?
+    suspend fun getStepResources(stepId: String?, offlineOnly: Boolean? = null): List<RealmMyLibrary>
+    suspend fun getStepExams(stepId: String?, type: String?): List<RealmStepExam>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -45,6 +45,36 @@ class CourseRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getCourseStep(stepId: String?): RealmCourseStep? {
+        if (stepId.isNullOrEmpty()) {
+            return null
+        }
+        return findByField(RealmCourseStep::class.java, "id", stepId)
+    }
+
+    override suspend fun getStepResources(stepId: String?, offlineOnly: Boolean?): List<RealmMyLibrary> {
+        if (stepId.isNullOrEmpty()) {
+            return emptyList()
+        }
+        return queryList(RealmMyLibrary::class.java) {
+            equalTo("stepId", stepId)
+            offlineOnly?.let {
+                equalTo("resourceOffline", it)
+                isNotNull("resourceLocalAddress")
+            }
+        }
+    }
+
+    override suspend fun getStepExams(stepId: String?, type: String?): List<RealmStepExam> {
+        if (stepId.isNullOrEmpty()) {
+            return emptyList()
+        }
+        return queryList(RealmStepExam::class.java) {
+            equalTo("stepId", stepId)
+            type?.let { equalTo("type", it) }
+        }
+    }
+
     private suspend fun getCourseResources(courseId: String?, isOffline: Boolean): List<RealmMyLibrary> {
         if (courseId.isNullOrEmpty()) {
             return emptyList()


### PR DESCRIPTION
## Summary
- inject the shared CourseRepository into CourseStepFragment and load step data via coroutines
- extend CourseRepository with helpers for step details, resources, and exams backed by Realm queries
- refactor CourseStepFragment listeners to rely on the repository helpers instead of direct Realm access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee8709a18c832bb404f5b1c9cc5495