### PR TITLE
notifications shows 0 on launch (fixes #8429)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -862,8 +862,13 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         val menuItem = binding.appBarBell.bellToolbar.menu.findItem(R.id.action_notifications)
         val actionView = MenuItemCompat.getActionView(menuItem)
         val smsCountTxt = actionView.findViewById<TextView>(R.id.notification_badge)
-        smsCountTxt.text = "$count"
-        smsCountTxt.visibility = if (count > 0) View.VISIBLE else View.GONE
+        if (count > 0) {
+            smsCountTxt.text = "$count"
+            smsCountTxt.visibility = View.VISIBLE
+        } else {
+            smsCountTxt.text = ""
+            smsCountTxt.visibility = View.GONE
+        }
         actionView.setOnClickListener(onClickListener)
     }
 

--- a/app/src/main/res/layout/custom_notification_badge.xml
+++ b/app/src/main/res/layout/custom_notification_badge.xml
@@ -21,7 +21,7 @@
         android:background="@drawable/badge_background"
         android:gravity="center"
         android:padding="3dp"
-        android:text="0"
+        android:visibility="gone"
         android:textColor="@android:color/white"
         android:textSize="10sp" />
 </FrameLayout>


### PR DESCRIPTION
fixes #8429

## Summary
- hide the notification badge by default in the custom action layout so it is not shown with a zero value
- update the dashboard badge updater to only show the badge when the unread count is greater than zero and clear the text otherwise

## Testing
- not run (per instruction)

------
https://chatgpt.com/codex/tasks/task_e_68efa9d3d388832bb5d89d5851395743