### PR TITLE
Add ChatRepositoryImpl null parameter tests

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
@@ -1,0 +1,42 @@
+package org.ole.planet.myplanet.repository
+
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import sun.misc.Unsafe
+
+class ChatRepositoryImplTest {
+    @Test
+    fun getChatHistoryForUser_nullUsername_returnsEmptyList() = runTest {
+        val repository = createUninitializedChatRepository()
+
+        val result = repository.getChatHistoryForUser(null)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun getChatHistoryForUser_emptyUsername_returnsEmptyList() = runTest {
+        val repository = createUninitializedChatRepository()
+
+        val result = repository.getChatHistoryForUser("")
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun getPlanetNewsMessages_nullPlanetCode_returnsEmptyList() = runTest {
+        val repository = createUninitializedChatRepository()
+
+        val result = repository.getPlanetNewsMessages(null)
+
+        assertTrue(result.isEmpty())
+    }
+
+    private fun createUninitializedChatRepository(): ChatRepositoryImpl {
+        val field = Unsafe::class.java.getDeclaredField("theUnsafe")
+        field.isAccessible = true
+        val unsafe = field.get(null) as Unsafe
+        return unsafe.allocateInstance(ChatRepositoryImpl::class.java) as ChatRepositoryImpl
+    }
+}


### PR DESCRIPTION
## Summary
- add a unit test suite for `ChatRepositoryImpl`
- verify that null and empty inputs return empty lists without touching Realm

## Testing
- not run (Gradle download stalled in CI environment)

------
https://chatgpt.com/codex/tasks/task_e_68efd7d92a648329ad9a3e64e56fe65d