### PR TITLE
test: add unit tests for ChatRepositoryImpl

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
@@ -1,0 +1,34 @@
+package org.ole.planet.myplanet.repository
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatRepositoryImplTest {
+    private fun createRepository(): ChatRepositoryImpl {
+        val unsafeClass = Class.forName("sun.misc.Unsafe")
+        val field = unsafeClass.getDeclaredField("theUnsafe")
+        try {
+            field.isAccessible = true
+        } catch (exception: Exception) {
+            throw IllegalStateException("Unable to access Unsafe", exception)
+        }
+        val unsafe = field.get(null)
+        val allocateInstance = unsafeClass.getMethod("allocateInstance", Class::class.java)
+        return allocateInstance.invoke(unsafe, ChatRepositoryImpl::class.java) as ChatRepositoryImpl
+    }
+
+    @Test
+    fun getChatHistoryForUserReturnsEmptyWhenUserNameIsNull() = runBlocking {
+        val repository = createRepository()
+        val result = repository.getChatHistoryForUser(null)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun getPlanetNewsMessagesReturnsEmptyWhenPlanetCodeIsNull() = runBlocking {
+        val repository = createRepository()
+        val result = repository.getPlanetNewsMessages(null)
+        assertTrue(result.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- add ChatRepositoryImplTest verifying empty results when chat history and news are requested with null identifiers
- instantiate ChatRepositoryImpl via reflective Unsafe allocation to avoid real DatabaseService dependency

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68efd7d92a648329ad9a3e64e56fe65d