### PR TITLE
test: add unit tests for CourseRepositoryImpl

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,6 +176,8 @@ repositories {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'io.mockk:mockk:1.13.13'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
     implementation fileTree(include: ['*.jar', '*.aar'], dir: 'libs')
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CourseRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CourseRepositoryImplTest.kt
@@ -1,0 +1,63 @@
+package org.ole.planet.myplanet.repository
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.clearAllMocks
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmCourseStep
+import org.ole.planet.myplanet.model.RealmMyCourse
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CourseRepositoryImplTest {
+
+    private lateinit var databaseService: DatabaseService
+    private lateinit var repository: CourseRepositoryImpl
+
+    @Before
+    fun setUp() {
+        databaseService = mockk(relaxed = true)
+        repository = CourseRepositoryImpl(databaseService)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun getCourseByCourseId_returnsCourseWhenIdProvided() = runTest {
+        val expected = RealmMyCourse().apply { courseId = "course-1" }
+        coEvery { databaseService.withRealmAsync<RealmMyCourse?>(any()) } returns expected
+
+        val result = repository.getCourseByCourseId("course-1")
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) { databaseService.withRealmAsync<RealmMyCourse?>(any()) }
+    }
+
+    @Test
+    fun getCourseExamCount_returnsExamTotal() = runTest {
+        coEvery { databaseService.withRealmAsync<Long>(any()) } returns 4L
+
+        val result = repository.getCourseExamCount("course-1")
+
+        assertEquals(4, result)
+        coVerify(exactly = 1) { databaseService.withRealmAsync<Long>(any()) }
+    }
+
+    @Test
+    fun getCourseSteps_returnsEmptyListWhenCourseIdMissing() = runTest {
+        val result = repository.getCourseSteps(null)
+
+        assertTrue(result.isEmpty())
+        coVerify(exactly = 0) { databaseService.withRealmAsync<List<RealmCourseStep>>(any()) }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering CourseRepositoryImpl happy and null-input scenarios
- add MockK and coroutine testing dependencies for the unit tests

## Testing
- ./gradlew testDefaultDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68efe8782ff883298d033f5f5d82b86c