### PR TITLE
Refactor chat detail to use chat repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
@@ -1,9 +1,13 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmNews
 
 interface ChatRepository {
     suspend fun getChatHistoryForUser(userName: String?): List<RealmChatHistory>
     suspend fun getPlanetNewsMessages(planetCode: String?): List<RealmNews>
+    suspend fun getLatestRevision(chatId: String): String?
+    suspend fun saveChatHistory(payload: JsonObject)
+    suspend fun appendConversation(chatId: String, query: String, response: String, newRev: String?)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonObject
 import io.realm.Case
 import io.realm.Sort
 import javax.inject.Inject
@@ -28,6 +29,46 @@ class ChatRepositoryImpl @Inject constructor(
         return queryList(RealmNews::class.java) {
             equalTo("docType", "message", Case.INSENSITIVE)
             equalTo("createdOn", planetCode, Case.INSENSITIVE)
+        }
+    }
+
+    override suspend fun getLatestRevision(chatId: String): String? {
+        if (chatId.isBlank()) {
+            return null
+        }
+        return withRealmAsync { realm ->
+            realm.refresh()
+            val results = realm.where(RealmChatHistory::class.java)
+                .equalTo("_id", chatId)
+                .findAll()
+            results.maxByOrNull { history ->
+                history._rev?.substringBefore("-")?.toIntOrNull() ?: 0
+            }?._rev
+        }
+    }
+
+    override suspend fun saveChatHistory(payload: JsonObject) {
+        executeTransaction { realm ->
+            RealmChatHistory.insert(realm, payload)
+        }
+    }
+
+    override suspend fun appendConversation(chatId: String, query: String, response: String, newRev: String?) {
+        if (chatId.isBlank()) {
+            return
+        }
+        withRealmAsync { realm ->
+            try {
+                RealmChatHistory.addConversationToChatHistory(realm, chatId, query, response, newRev)
+                if (realm.isInTransaction) {
+                    realm.commitTransaction()
+                }
+            } catch (exception: Exception) {
+                if (realm.isInTransaction) {
+                    realm.cancelTransaction()
+                }
+                exception.printStackTrace()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add chat history persistence methods to the `ChatRepository` contract
- implement revision lookup, history save, and conversation append helpers in `ChatRepositoryImpl`
- refactor `ChatDetailFragment` to use the repository instead of direct `DatabaseService` access

## Testing
- not run (Android tooling setup is lengthy in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68eff132f3a4832bbb279394fb3ca0aa