### PR TITLE
Use DiffUtil when updating team list

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -8,6 +8,12 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 
+data class TeamMembershipStatus(
+    val isMember: Boolean,
+    val isLeader: Boolean,
+    val hasPendingRequest: Boolean,
+)
+
 interface TeamRepository {
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
     suspend fun getTeamByDocumentIdOrTeamId(id: String): RealmMyTeam?
@@ -16,6 +22,10 @@ interface TeamRepository {
     suspend fun isMember(userId: String?, teamId: String): Boolean
     suspend fun isTeamLeader(teamId: String, userId: String?): Boolean
     suspend fun hasPendingRequest(teamId: String, userId: String?): Boolean
+    suspend fun getTeamMembershipStatuses(
+        userId: String?,
+        teamIds: Collection<String>,
+    ): Map<String, TeamMembershipStatus>
     suspend fun getRecentVisitCounts(teamIds: Collection<String>): Map<String, Long>
     suspend fun requestToJoin(teamId: String, userId: String?, userPlanetCode: String?, teamType: String?)
     suspend fun leaveTeam(teamId: String, userId: String?)


### PR DESCRIPTION
## Summary
- compute differences between the previous and new team lists using the shared DiffUtils helper
- dispatch granular adapter updates instead of always invalidating the entire list
- track visit counts and status snapshots so diff comparisons stay accurate

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f1ff49de38832b811005caba143169