### PR TITLE
Refactor personal resources to repository operations

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnSelectedMyPersonal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnSelectedMyPersonal.kt
@@ -5,4 +5,6 @@ import org.ole.planet.myplanet.model.RealmMyPersonal
 interface OnSelectedMyPersonal {
     fun onUpload(personal: RealmMyPersonal?)
     fun onAddedResource()
+    fun onDeletePersonal(personal: RealmMyPersonal)
+    fun onEditPersonal(personal: RealmMyPersonal, title: String, description: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepository.kt
@@ -12,5 +12,13 @@ interface MyPersonalRepository {
         description: String?
     )
 
+    suspend fun updatePersonalResource(
+        personalId: String,
+        title: String?,
+        description: String?,
+    )
+
+    suspend fun deletePersonalResource(personalId: String)
+
     fun getPersonalResources(userId: String?): Flow<List<RealmMyPersonal>>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MyPersonalRepositoryImpl.kt
@@ -32,6 +32,37 @@ class MyPersonalRepositoryImpl @Inject constructor(
         save(personal)
     }
 
+    override suspend fun updatePersonalResource(
+        personalId: String,
+        title: String?,
+        description: String?,
+    ) {
+        if (personalId.isBlank()) {
+            return
+        }
+
+        update(
+            RealmMyPersonal::class.java,
+            "_id",
+            personalId,
+        ) { personal ->
+            personal.title = title
+            personal.description = description
+        }
+    }
+
+    override suspend fun deletePersonalResource(personalId: String) {
+        if (personalId.isBlank()) {
+            return
+        }
+
+        delete(
+            RealmMyPersonal::class.java,
+            "_id",
+            personalId,
+        )
+    }
+
     override fun getPersonalResources(userId: String?): Flow<List<RealmMyPersonal>> {
         if (userId.isNullOrBlank()) {
             return flowOf(emptyList())

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mypersonals/AdapterMyPersonal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mypersonals/AdapterMyPersonal.kt
@@ -35,7 +35,12 @@ class AdapterMyPersonal(private val context: Context, private var list: MutableL
     }
 
     fun updateList(newList: List<RealmMyPersonal>) {
-        val safeNewList = realm?.copyFromRealm(newList) ?: newList
+        val shouldDetach = newList.firstOrNull()?.isManaged == true
+        val safeNewList = if (shouldDetach) {
+            realm?.copyFromRealm(newList) ?: newList
+        } else {
+            newList
+        }
         val diffResult = DiffUtils.calculateDiff(
             list,
             safeNewList,
@@ -55,7 +60,10 @@ class AdapterMyPersonal(private val context: Context, private var list: MutableL
     fun getList(): List<RealmMyPersonal> = list
     fun setRealm(realm: Realm?) {
         this.realm = realm
-        list = realm?.copyFromRealm(list)?.toMutableList() ?: list
+        val shouldDetach = list.firstOrNull()?.isManaged == true
+        if (shouldDetach) {
+            list = realm?.copyFromRealm(list)?.toMutableList() ?: list
+        }
     }
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderMyPersonal {
         rowMyPersonalBinding = RowMyPersonalBinding.inflate(LayoutInflater.from(context), parent, false)
@@ -69,14 +77,10 @@ class AdapterMyPersonal(private val context: Context, private var list: MutableL
             AlertDialog.Builder(context, R.style.AlertDialogTheme)
                 .setMessage(R.string.delete_record)
                 .setPositiveButton(R.string.ok) { _: DialogInterface?, _: Int ->
-                    if (realm?.isInTransaction != true) realm?.beginTransaction()
-                    val personal = realm?.where(RealmMyPersonal::class.java)
-                        ?.equalTo("_id", list[position]._id)?.findFirst()
-                    personal?.deleteFromRealm()
-                    realm?.commitTransaction()
-                    updateList(realm?.where(RealmMyPersonal::class.java)?.findAll()?.toList() ?: emptyList())
-                    listener?.onAddedResource()
-                }.setNegativeButton(R.string.cancel, null).show()
+                    listener?.onDeletePersonal(list[position])
+                }
+                .setNegativeButton(R.string.cancel, null)
+                .show()
         }
         rowMyPersonalBinding.imgEdit.setOnClickListener {
             editPersonal(list[position])
@@ -129,12 +133,7 @@ class AdapterMyPersonal(private val context: Context, private var list: MutableL
                     Utilities.toast(context, context.getString(R.string.please_enter_title))
                     return@setPositiveButton
                 }
-                if (!realm?.isInTransaction!!) realm?.beginTransaction()
-                personal.description = desc
-                personal.title = title
-                realm?.commitTransaction()
-                updateList(realm?.where(RealmMyPersonal::class.java)?.findAll()?.toList() ?: emptyList())
-                listener?.onAddedResource()
+                listener?.onEditPersonal(personal, title, desc)
             }
             .setNegativeButton(R.string.cancel, null)
             .show()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mypersonals/MyPersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mypersonals/MyPersonalsFragment.kt
@@ -113,4 +113,18 @@ class MyPersonalsFragment : Fragment(), OnSelectedMyPersonal {
     override fun onAddedResource() {
         // List updates are handled via repository flow
     }
+
+    override fun onDeletePersonal(personal: RealmMyPersonal) {
+        val personalId = personal._id ?: personal.id ?: return
+        viewLifecycleOwner.lifecycleScope.launch {
+            myPersonalRepository.deletePersonalResource(personalId)
+        }
+    }
+
+    override fun onEditPersonal(personal: RealmMyPersonal, title: String, description: String) {
+        val personalId = personal._id ?: personal.id ?: return
+        viewLifecycleOwner.lifecycleScope.launch {
+            myPersonalRepository.updatePersonalResource(personalId, title, description)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add suspend update and delete APIs to `MyPersonalRepository`
- refactor `AdapterMyPersonal` to delegate edit and delete actions to host callbacks
- launch repository updates from `MyPersonalsFragment` so list changes flow through existing observers
- guard `AdapterMyPersonal` from copying already-detached Realm objects before diffing

## Testing
- ./gradlew :app:compileLiteDebugKotlin --console=plain --no-daemon | tail -n 200


------
https://chatgpt.com/codex/tasks/task_e_68f1ffdd6020832b9a25451b538a5c80