### PR TITLE
Remove unused resource not found strings

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -265,8 +265,8 @@ abstract class BaseResourceFragment : Fragment() {
             }
 
             resourceNotFoundDialog = AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
-                .setTitle(R.string.resource_not_found)
-                .setMessage(R.string.resource_not_found_message)
+                .setTitle(R.string.resources)
+                .setMessage(R.string.resource_not_downloaded)
                 .setNegativeButton(R.string.close) { dialog, _ ->
                     dialog.dismiss()
                 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="resource_not_found">لم يتم العثور على المورد</string>
-    <string name="resource_not_found_message">لا يمكن العثور على المورد المطلوب.</string>
     <string name="community_earnings">إجمالي أرباح المجتمع: **$%1$d** /$500</string>
     <string name="your_earnings">أرباحك الإجمالية: **$%1$d** /$11</string>
     <string name="congratulations">تهانينا! التحدي مكتمل</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="resource_not_found">Recurso no encontrado</string>
-    <string name="resource_not_found_message">No se pudo encontrar el recurso solicitado</string>
     <string name="community_earnings">Ingresos totales de la comunidad: **$%1$d** /$500</string>
     <string name="your_earnings">Tus ganancias totales: **$%1$d** /$11</string>
     <string name="congratulations">¡Felicidades! Reto completado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="resource_not_found">Ressource introuvable</string>
-    <string name="resource_not_found_message">La ressource demandée est introuvable</string>
     <string name="community_earnings">Revenus totaux de la communauté: **$%1$d** /$500</string>
     <string name="your_earnings">Vos gains totaux: **$%1$d** /$11</string>
     <string name="congratulations">Félicitations! Défi terminé</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="resource_not_found">स्रोत फेला परेन</string>
-    <string name="resource_not_found_message">अनुरोध गरिएको स्रोत फेला पार्न सकिएन</string>
     <string name="community_earnings">समुदायको कुल आम्दानी: **$%1$d** /$500</string>
     <string name="your_earnings">तपाईंको कुल आम्दानी: **$%1$d** /$11</string>
     <string name="congratulations">बधाई छ! चुनौती पूरा भयो</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="resource_not_found">Ilaha lama helin</string>
-    <string name="resource_not_found_message">Ilaha la codsaday waa la heli waayay</string>
     <string name="community_earnings">Dakhliga guud ee bulshada: **$%1$d** /$500</string>
     <string name="your_earnings">Dakhligaaga guud: **$%1$d** /$11</string>
     <string name="congratulations">Hambalyo! Tartanka waa la dhameeyay</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="resource_not_found">Resource not found</string>
-    <string name="resource_not_found_message">The requested resource could not be found</string>
     <string name="community_earnings">Community total earnings: **$%1$d** /$500</string>
     <string name="your_earnings">Your total earnings: **$%1$d** /$11</string>
     <string name="congratulations">Congratulations! Challenge Completed</string>


### PR DESCRIPTION
## Summary
- remove the obsolete `resource_not_found` strings from the default and translated resource files
- update the resource dialog to reuse the existing "resource not downloaded" copy

## Testing
- ./gradlew lint --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68f67535b600832b93a066aac9683da2