### PR TITLE
Fetch team courses via repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
@@ -6,6 +6,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 
 interface CourseRepository {
     suspend fun getCourseByCourseId(courseId: String?): RealmMyCourse?
+    suspend fun getCoursesByIds(ids: Collection<String>): List<RealmMyCourse>
     suspend fun getCourseOnlineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseOfflineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseExamCount(courseId: String?): Int

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -18,6 +18,16 @@ class CourseRepositoryImpl @Inject constructor(
         return findByField(RealmMyCourse::class.java, "courseId", courseId)
     }
 
+    override suspend fun getCoursesByIds(ids: Collection<String>): List<RealmMyCourse> {
+        val filteredIds = ids.filter { it.isNotBlank() }
+        if (filteredIds.isEmpty()) {
+            return emptyList()
+        }
+        return queryList(RealmMyCourse::class.java) {
+            `in`("id", filteredIds.toTypedArray())
+        }
+    }
+
     override suspend fun getCourseOnlineResources(courseId: String?): List<RealmMyLibrary> {
         return getCourseResources(courseId, isOffline = false)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
@@ -4,16 +4,23 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
-import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.repository.CourseRepository
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class TeamCourseFragment : BaseTeamFragment() {
     private var _binding: FragmentTeamCourseBinding? = null
     private val binding get() = _binding!!
     private var adapterTeamCourse: AdapterTeamCourse? = null
+    @Inject
+    lateinit var courseRepository: CourseRepository
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentTeamCourseBinding.inflate(inflater, container, false)
@@ -26,12 +33,19 @@ class TeamCourseFragment : BaseTeamFragment() {
     }
     
     private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { AdapterTeamCourse(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
         binding.rvCourse.layoutManager = LinearLayoutManager(activity)
-        binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+        val courseIds = team?.courses?.filterNotNull()?.filter { it.isNotBlank() } ?: emptyList()
+        viewLifecycleOwner.lifecycleScope.launch {
+            val courses = withContext(Dispatchers.IO) {
+                courseRepository.getCoursesByIds(courseIds)
+            }
+            adapterTeamCourse = settings?.let {
+                AdapterTeamCourse(requireActivity(), courses.toMutableList(), mRealm, teamId, it)
+            }
+            binding.rvCourse.adapter = adapterTeamCourse
+            adapterTeamCourse?.let {
+                showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+            }
         }
     }
     override fun onNewsItemClick(news: RealmNews?) {}


### PR DESCRIPTION
## Summary
- add a repository API for loading multiple courses by ID
- use the repository from TeamCourseFragment so the adapter is fed from a coroutine lookup

## Testing
- ./gradlew --console=plain :app:compileLiteDebugKotlin

------
https://chatgpt.com/codex/tasks/task_e_68f7b62baec4832baf02eed3d1788c72