### PR TITLE
notifications shows 0 on launch (fixes #8429)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -592,7 +592,17 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                     val createdNotifications = createNotifications(backgroundRealm, userId)
                     newNotifications.addAll(createdNotifications)
 
-                    unreadCount = dashboardViewModel.getUnreadNotificationsSize(userId)
+                    backgroundRealm.refresh()
+                    val unreadQuery = backgroundRealm.where(RealmNotification::class.java)
+                        .equalTo("isRead", false)
+
+                    val filteredQuery = if (userId != null) {
+                        unreadQuery.equalTo("userId", userId)
+                    } else {
+                        unreadQuery.isNull("userId")
+                    }
+
+                    unreadCount = filteredQuery.count().toInt()
                 }
             } catch (e: Exception) {
                 e.printStackTrace()


### PR DESCRIPTION
fixes #8429

## Summary
- refresh the background Realm after creating notifications so newly created items are visible immediately
- compute the unread notification count directly from the refreshed Realm and continue updating the badge on the main thread

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7e3acf144832b83425d82751cc23c