### PR TITLE
Remove unused RealmMeetup joined user helper

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMeetup.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMeetup.kt
@@ -109,16 +109,6 @@ open class RealmMeetup : RealmObject() {
             return map
         }
 
-        @JvmStatic
-        fun getJoinedUserIds(mRealm: Realm): Array<String?> {
-            val list: List<RealmMeetup> = mRealm.where(RealmMeetup::class.java).isNotEmpty("userId").findAll()
-            val myIds = arrayOfNulls<String>(list.size)
-            for (i in list.indices) {
-                myIds[i] = list[i].userId
-            }
-            return myIds
-        }
-
         private fun checkNull(s: String?): String {
             return if (TextUtils.isEmpty(s)) "" else s!!
         }


### PR DESCRIPTION
## Summary
- remove the unused getJoinedUserIds helper from RealmMeetup

## Testing
- ./gradlew lint --console=plain *(fails: missing build properties for Android SDK Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_68f8954fdefc832bb6e9be34fe87b730