### PR TITLE
Remove legacy UserProfileDbHandler constructor usage

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/TransactionSyncManager.kt
@@ -7,12 +7,14 @@ import android.util.Base64
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import dagger.hilt.android.EntryPointAccessors
 import io.realm.Realm
 import java.io.IOException
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.callback.SyncListener
 import org.ole.planet.myplanet.datamanager.ApiClient.client
 import org.ole.planet.myplanet.datamanager.ApiInterface
+import org.ole.planet.myplanet.di.WorkerDependenciesEntryPoint
 import org.ole.planet.myplanet.model.DocumentResponse
 import org.ole.planet.myplanet.model.RealmChatHistory.Companion.insert
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.saveConcatenatedLinksToPrefs
@@ -81,7 +83,11 @@ object TransactionSyncManager {
 
     fun syncKeyIv(mRealm: Realm, settings: SharedPreferences, listener: SyncListener) {
         listener.onSyncStarted()
-        val model = UserProfileDbHandler(MainApplication.context).userModel
+        val entryPoint = EntryPointAccessors.fromApplication(
+            MainApplication.context,
+            WorkerDependenciesEntryPoint::class.java
+        )
+        val model = entryPoint.userProfileDbHandler().userModel
         val userName = SecurePrefs.getUserName(MainApplication.context, settings) ?: ""
         val password = SecurePrefs.getPassword(MainApplication.context, settings) ?: ""
 //        val table = "userdb-" + model?.planetCode?.let { Utilities.toHex(it) } + "-" + model?.name?.let { Utilities.toHex(it) }

--- a/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UserProfileDbHandler.kt
@@ -15,7 +15,6 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.Utilities
 
 class UserProfileDbHandler @Inject constructor(
@@ -25,13 +24,6 @@ class UserProfileDbHandler @Inject constructor(
 ) {
     var mRealm: Realm
     private val fullName: String
-
-    // Backward compatibility constructor
-    constructor(context: Context) : this(
-        context,
-        DatabaseService(context),
-        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    )
 
     init {
         try {

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -10,13 +10,14 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
+import dagger.hilt.android.EntryPointAccessors
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.DialogProgressBinding
 import org.ole.planet.myplanet.datamanager.MyDownloadService
 import org.ole.planet.myplanet.datamanager.Service
+import org.ole.planet.myplanet.di.WorkerDependenciesEntryPoint
 import org.ole.planet.myplanet.model.MyPlanet
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.sync.SyncActivity
 import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
 
@@ -34,7 +35,11 @@ object DialogUtils {
     }
 
     fun guestDialog(context: Context) {
-        val profileDbHandler = UserProfileDbHandler(context)
+        val entryPoint = EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            WorkerDependenciesEntryPoint::class.java
+        )
+        val profileDbHandler = entryPoint.userProfileDbHandler()
         val builder = android.app.AlertDialog.Builder(context, R.style.CustomAlertDialog)
         builder.setTitle(context.getString(R.string.become_a_member))
         builder.setMessage(context.getString(R.string.to_access_this_feature_become_a_member))


### PR DESCRIPTION
## Summary
- delete the legacy UserProfileDbHandler overload that manually built a DatabaseService
- update DialogUtils and TransactionSyncManager to resolve the handler through the Hilt entry point

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f895d531f0832bb9c6ba249e7b54ce