### PR TITLE
Use withRealmAsync for dashboard notification creation

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -588,14 +588,15 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
             try {
                 dashboardViewModel.updateResourceNotification(userId)
-                databaseService.realmInstance.use { backgroundRealm ->
-                    val createdNotifications = createNotifications(backgroundRealm, userId)
-                    newNotifications.addAll(createdNotifications)
-
-                    unreadCount = dashboardViewModel.getUnreadNotificationsSize(userId)
+                val createdNotifications = databaseService.withRealmAsync { backgroundRealm ->
+                    createNotifications(backgroundRealm, userId)
                 }
+
+                newNotifications.addAll(createdNotifications)
+                unreadCount = dashboardViewModel.getUnreadNotificationsSize(userId)
             } catch (e: Exception) {
                 e.printStackTrace()
+                throw e
             }
 
             withContext(Dispatchers.Main) {


### PR DESCRIPTION
## Summary
- wrap dashboard notification creation with `databaseService.withRealmAsync`
- collect the created notifications outside the realm scope and continue computing the unread count
- rethrow exceptions so coroutine failures are surfaced instead of being swallowed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f895fece64832b890061129e8d58bc