### PR TITLE
Use withRealmAsync for login sync database access

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -678,13 +678,8 @@ abstract class SyncActivity : ProcessUserDataActivity(), SyncListener, CheckVers
                             withContext(Dispatchers.Main) {
                                 startUpload("login")
                             }
-                            withContext(Dispatchers.Default) {
-                                val backgroundRealm = databaseService.realmInstance
-                                try {
-                                    TransactionSyncManager.syncDb(backgroundRealm, "login_activities")
-                                } finally {
-                                    backgroundRealm.close()
-                                }
+                            databaseService.withRealmAsync { realm ->
+                                TransactionSyncManager.syncDb(realm, "login_activities")
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- replace manual Realm instance management in SyncActivity with `withRealmAsync`
- rely on DatabaseService to handle realm lifecycle when syncing login activities

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f896147a1c832b9cf4f8127d55ec83