### PR TITLE
Use Hilt entry point in DialogUtils guest dialog

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -10,13 +10,14 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
+import dagger.hilt.android.EntryPointAccessors
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.DialogProgressBinding
 import org.ole.planet.myplanet.datamanager.MyDownloadService
 import org.ole.planet.myplanet.datamanager.Service
+import org.ole.planet.myplanet.di.WorkerDependenciesEntryPoint
 import org.ole.planet.myplanet.model.MyPlanet
-import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.sync.SyncActivity
 import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
 
@@ -34,7 +35,12 @@ object DialogUtils {
     }
 
     fun guestDialog(context: Context) {
-        val profileDbHandler = UserProfileDbHandler(context)
+        val profileDbHandler = EntryPointAccessors
+            .fromApplication(
+                context.applicationContext,
+                WorkerDependenciesEntryPoint::class.java,
+            )
+            .userProfileDbHandler()
         val builder = android.app.AlertDialog.Builder(context, R.style.CustomAlertDialog)
         builder.setTitle(context.getString(R.string.become_a_member))
         builder.setMessage(context.getString(R.string.to_access_this_feature_become_a_member))


### PR DESCRIPTION
## Summary
- add the Hilt entry point accessor to DialogUtils
- resolve the UserProfileDbHandler via WorkerDependenciesEntryPoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f895c0e988832ba82c526841d0f5c6