### PR TITLE
Refactor meetup member query

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/MeetupRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MeetupRepositoryImpl.kt
@@ -26,22 +26,18 @@ class MeetupRepositoryImpl @Inject constructor(
         if (meetupId.isBlank()) {
             return emptyList()
         }
-        return withRealmAsync { realm ->
-            val meetupMembers = realm.where(RealmMeetup::class.java)
-                .equalTo("meetupId", meetupId)
-                .isNotEmpty("userId")
-                .findAll()
-            val memberIds = meetupMembers.mapNotNull { member ->
-                member.userId?.takeUnless { it.isBlank() }
-            }.distinct()
-            if (memberIds.isEmpty()) {
-                emptyList()
-            } else {
-                val users = realm.where(RealmUserModel::class.java)
-                    .`in`("id", memberIds.toTypedArray())
-                    .findAll()
-                realm.copyFromRealm(users)
-            }
+        val meetupMembers = queryList(RealmMeetup::class.java) {
+            equalTo("meetupId", meetupId)
+            isNotEmpty("userId")
+        }
+        val memberIds = meetupMembers
+            .mapNotNull { member -> member.userId?.takeUnless { it.isBlank() } }
+            .distinct()
+        if (memberIds.isEmpty()) {
+            return emptyList()
+        }
+        return queryList(RealmUserModel::class.java) {
+            `in`("id", memberIds.toTypedArray())
         }
     }
 


### PR DESCRIPTION
## Summary
- refactor `getJoinedMembers` to reuse the shared `queryList` helper for meetup and user lookups
- keep blank-id guards while using Kotlin collection helpers for cleaned member IDs

## Testing
- :app:assembleDebug *(fails: build tooling download stalled in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f897f39680832b96233b030598ff74