### PR TITLE
Remove unused companion object from RealmSearchActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
@@ -37,18 +37,4 @@ open class RealmSearchActivity(
         obj.add("filter", Gson().fromJson(filter, JsonObject::class.java))
         return obj
     }
-
-    companion object {
-        @JvmStatic
-        fun insert(log: RealmNewsLog): JsonObject {
-            val ob = JsonObject()
-            ob.addProperty("user", log.userId)
-            ob.addProperty("type", log.type)
-            ob.addProperty("time", log.time)
-            ob.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            ob.addProperty("deviceName", NetworkUtils.getDeviceName())
-            ob.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(MainApplication.context))
-            return ob
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- remove the unused companion object and insert helper from RealmSearchActivity to simplify the model class

## Testing
- ./gradlew :app:lintDefaultDebug --no-daemon --console=plain *(fails: missing Android SDK Platform 36 android.jar in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68fa167f3430832b91ae2c9ab9e7f333