### PR TITLE
Refactor meetup member lookup

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/MeetupRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MeetupRepositoryImpl.kt
@@ -26,22 +26,19 @@ class MeetupRepositoryImpl @Inject constructor(
         if (meetupId.isBlank()) {
             return emptyList()
         }
-        return withRealmAsync { realm ->
-            val meetupMembers = realm.where(RealmMeetup::class.java)
-                .equalTo("meetupId", meetupId)
-                .isNotEmpty("userId")
-                .findAll()
-            val memberIds = meetupMembers.mapNotNull { member ->
-                member.userId?.takeUnless { it.isBlank() }
-            }.distinct()
-            if (memberIds.isEmpty()) {
-                emptyList()
-            } else {
-                val users = realm.where(RealmUserModel::class.java)
-                    .`in`("id", memberIds.toTypedArray())
-                    .findAll()
-                realm.copyFromRealm(users)
-            }
+        val memberIds = queryList(RealmMeetup::class.java) {
+            equalTo("meetupId", meetupId)
+            isNotEmpty("userId")
+        }.mapNotNull { meetup ->
+            meetup.userId?.takeUnless { it.isBlank() }
+        }.distinct()
+
+        if (memberIds.isEmpty()) {
+            return emptyList()
+        }
+
+        return queryList(RealmUserModel::class.java) {
+            `in`("id", memberIds.toTypedArray())
         }
     }
 


### PR DESCRIPTION
## Summary
- refactor meetup member retrieval to reuse RealmRepository queryList helpers
- maintain guard clauses for blank meetup IDs and empty member lists

## Testing
- ./gradlew test *(fails: Android SDK Platform 36 not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa1dc81dd0832b87652e83143a180f