### PR TITLE
Revert "sync: smoother user repository secrets storing (fixes #8653) (#8629)"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3599
-        versionName = "0.35.99"
+        versionCode = 3598
+        versionName = "0.35.98"
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -10,13 +10,4 @@ interface UserRepository {
         startMillis: Long,
         endMillis: Long,
     ): Map<Int, Int>
-    suspend fun updateSecurityData(
-        name: String,
-        userId: String?,
-        rev: String?,
-        derivedKey: String?,
-        salt: String?,
-        passwordScheme: String?,
-        iterations: String?,
-    )
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -45,24 +45,4 @@ class UserRepositoryImpl @Inject constructor(
             .eachCount()
             .toSortedMap()
     }
-
-    override suspend fun updateSecurityData(
-        name: String,
-        userId: String?,
-        rev: String?,
-        derivedKey: String?,
-        salt: String?,
-        passwordScheme: String?,
-        iterations: String?,
-    ) {
-        update(RealmUserModel::class.java, "name", name) { user ->
-            user._id = userId
-            user._rev = rev
-            user.derived_key = derivedKey
-            user.salt = salt
-            user.password_scheme = passwordScheme
-            user.iterations = iterations
-            user.isUpdated = false
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -47,7 +47,6 @@ import org.ole.planet.myplanet.utilities.DialogUtils.showAlert
 import org.ole.planet.myplanet.utilities.DialogUtils.showError
 import org.ole.planet.myplanet.utilities.FileUtils.installApk
 import org.ole.planet.myplanet.utilities.UrlUtils
-import org.ole.planet.myplanet.repository.UserRepository
 
 @AndroidEntryPoint
 abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
@@ -64,9 +63,6 @@ abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
 
     @Inject
     lateinit var uploadToShelfService: UploadToShelfService
-
-    @Inject
-    lateinit var userRepository: UserRepository
     
     lateinit var settings: SharedPreferences
     val customProgressDialog: DialogUtils.CustomProgressDialog by lazy {
@@ -336,7 +332,9 @@ abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
                     val iterations = userDoc?.get("iterations")?.asString
                     val userId = userDoc?.get("_id")?.asString
                     val rev = userDoc?.get("_rev")?.asString
-                    updateRealmUserSecurityData(name, userId, rev, derivedKey, salt, passwordScheme, iterations, securityCallback)
+                    withContext(Dispatchers.Main) {
+                        updateRealmUserSecurityData(name, userId, rev, derivedKey, salt, passwordScheme, iterations, securityCallback)
+                    }
 
                 } else {
                     withContext(Dispatchers.Main) {
@@ -353,26 +351,33 @@ abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
         }
     }
 
-    private suspend fun updateRealmUserSecurityData(
-        name: String,
-        userId: String?,
-        rev: String?,
-        derivedKey: String?,
-        salt: String?,
-        passwordScheme: String?,
-        iterations: String?,
-        securityCallback: SecurityDataCallback? = null,
-    ) {
+    private fun updateRealmUserSecurityData(name: String, userId: String?, rev: String?, derivedKey: String?, salt: String?, passwordScheme: String?, iterations: String?, securityCallback: SecurityDataCallback? = null) {
         try {
-            userRepository.updateSecurityData(name, userId, rev, derivedKey, salt, passwordScheme, iterations)
-            withContext(Dispatchers.Main) {
-                securityCallback?.onSecurityDataUpdated()
+            databaseService.withRealm { realm ->
+                realm.executeTransactionAsync({ transactionRealm ->
+                    val user = transactionRealm.where(RealmUserModel::class.java)
+                        .equalTo("name", name)
+                        .findFirst()
+
+                    if (user != null) {
+                        user._id = userId
+                        user._rev = rev
+                        user.derived_key = derivedKey
+                        user.salt = salt
+                        user.password_scheme = passwordScheme
+                        user.iterations = iterations
+                        user.isUpdated = false
+                    }
+                }, {
+                    securityCallback?.onSecurityDataUpdated()
+                }) { error ->
+                    error.printStackTrace()
+                    securityCallback?.onSecurityDataUpdated()
+                }
             }
         } catch (e: Exception) {
-            withContext(Dispatchers.Main) {
-                e.printStackTrace()
-                securityCallback?.onSecurityDataUpdated()
-            }
+            e.printStackTrace()
+            securityCallback?.onSecurityDataUpdated()
         }
     }
 }


### PR DESCRIPTION
## Summary
- revert the user security data helper added to the repository layer
- restore ProcessUserDataActivity to perform Realm transactions directly
- adjust the app version metadata to 0.35.98/3598

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb6b606108832b83098e3f2fe33689