### PR TITLE
Add chat repository helpers for history persistence

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmNews
 
@@ -14,4 +15,6 @@ interface ChatRepository {
     )
 
     suspend fun getLatestRevisionId(chatHistoryId: String): String?
+
+    suspend fun saveChatHistory(chatHistory: JsonObject)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -1,11 +1,13 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonObject
 import io.realm.Case
 import io.realm.Sort
 import javax.inject.Inject
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmChatHistory.Companion.addConversationToChatHistory
+import org.ole.planet.myplanet.model.RealmChatHistory.Companion.insert
 import org.ole.planet.myplanet.model.RealmNews
 
 class ChatRepositoryImpl @Inject constructor(
@@ -38,6 +40,7 @@ class ChatRepositoryImpl @Inject constructor(
         response: String?,
         newRev: String?,
     ) {
+        if (chatHistoryId.isNullOrBlank()) return
         executeTransaction { realm ->
             addConversationToChatHistory(realm, chatHistoryId, query, response, newRev)
         }
@@ -59,5 +62,11 @@ class ChatRepositoryImpl @Inject constructor(
 
     private fun parseRevisionNumber(revision: String?): Int {
         return revision?.substringBefore('-')?.toIntOrNull() ?: 0
+    }
+
+    override suspend fun saveChatHistory(chatHistory: JsonObject) {
+        executeTransaction { realm ->
+            insert(realm, chatHistory)
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -39,7 +39,6 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentChatDetailBinding
-import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.model.AiProvider
 import org.ole.planet.myplanet.model.ChatModel
@@ -48,7 +47,6 @@ import org.ole.planet.myplanet.model.ContentData
 import org.ole.planet.myplanet.model.ContinueChatModel
 import org.ole.planet.myplanet.model.Conversation
 import org.ole.planet.myplanet.model.Data
-import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.ChatRepository
 import org.ole.planet.myplanet.repository.UserRepository
@@ -84,8 +82,6 @@ class ChatDetailFragment : Fragment() {
     lateinit var userRepository: UserRepository
     @Inject
     lateinit var chatRepository: ChatRepository
-    @Inject
-    lateinit var databaseService: DatabaseService
     private val gson = Gson()
     private val serverUrlMapper = ServerUrlMapper()
     private val jsonMediaType = "application/json".toMediaTypeOrNull()
@@ -505,9 +501,7 @@ class ChatDetailFragment : Fragment() {
         val jsonObject = buildChatHistoryObject(query, chatResponse, responseBody)
         viewLifecycleOwner.lifecycleScope.launch {
             try {
-                databaseService.executeTransactionAsync { realm ->
-                    RealmChatHistory.insert(realm, jsonObject)
-                }
+                chatRepository.saveChatHistory(jsonObject)
                 if (isAdded && activity is DashboardActivity) {
                     (activity as DashboardActivity).refreshChatHistoryList()
                 }


### PR DESCRIPTION
## Summary
- add repository APIs to append chat history entries and fetch the latest revision id
- update ChatDetailFragment to use the repository for revision lookup and history persistence while keeping dashboard refreshes intact

## Testing
- ./gradlew :app:compileDefaultDebugKotlin --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68fb3c4c7d9c832b93cb70e71706a4ff