### PR TITLE
Filter library queries by user in Realm

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -110,7 +110,7 @@ class LibraryRepositoryImpl @Inject constructor(
     private suspend fun queryLibrariesNeedingUpdateForUser(userId: String): List<RealmMyLibrary> {
         val results = queryList(RealmMyLibrary::class.java) {
             equalTo("isPrivate", false)
-            contains("userId", userId)
+            equalTo("userId", userId)
         }
         return filterLibrariesNeedingUpdate(results)
     }


### PR DESCRIPTION
## Summary
- add the userId filter directly to the Realm query for non-private library items
- share the filtered Realm results between counting and listing to avoid duplicate contains checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb3cdfed34832ba8d127cff1ecdb7e