### PR TITLE
Refactor meetup member query to reuse repository helpers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/MeetupRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/MeetupRepositoryImpl.kt
@@ -26,22 +26,18 @@ class MeetupRepositoryImpl @Inject constructor(
         if (meetupId.isBlank()) {
             return emptyList()
         }
-        return withRealmAsync { realm ->
-            val meetupMembers = realm.where(RealmMeetup::class.java)
-                .equalTo("meetupId", meetupId)
-                .isNotEmpty("userId")
-                .findAll()
-            val memberIds = meetupMembers.mapNotNull { member ->
-                member.userId?.takeUnless { it.isBlank() }
-            }.distinct()
-            if (memberIds.isEmpty()) {
-                emptyList()
-            } else {
-                val users = realm.where(RealmUserModel::class.java)
-                    .`in`("id", memberIds.toTypedArray())
-                    .findAll()
-                realm.copyFromRealm(users)
-            }
+        val meetupMembers = queryList(RealmMeetup::class.java) {
+            equalTo("meetupId", meetupId)
+            isNotEmpty("userId")
+        }
+        val memberIds = meetupMembers.mapNotNull { member ->
+            member.userId?.takeUnless { it.isBlank() }
+        }.distinct()
+        if (memberIds.isEmpty()) {
+            return emptyList()
+        }
+        return queryList(RealmUserModel::class.java) {
+            `in`("id", memberIds.toTypedArray())
         }
     }
 


### PR DESCRIPTION
## Summary
- refactor `getJoinedMembers` to use repository `queryList` helpers instead of raw Realm access
- build member ID list from meetup attendee records and fetch users via a filtered query

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fb3d13a5d8832b9596d6e86c246a48