### PR TITLE
Adjust sync flows to emit Unit

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/StandardSyncStrategy.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/StandardSyncStrategy.kt
@@ -11,36 +11,9 @@ class StandardSyncStrategy : SyncStrategy {
         table: String,
         realm: Realm,
         config: SyncConfig
-    ): Flow<SyncResult> = flow {
-        val startTime = System.currentTimeMillis()
-        
-        try {
-            // Use the existing TransactionSyncManager for standard sync
-            TransactionSyncManager.syncDb(realm, table)
-            
-            val endTime = System.currentTimeMillis()
-            emit(
-                SyncResult(
-                    table = table,
-                    processedItems = -1, // TransactionSyncManager doesn't return count
-                    success = true,
-                    duration = endTime - startTime,
-                    strategy = getStrategyName()
-                )
-            )
-        } catch (e: Exception) {
-            val endTime = System.currentTimeMillis()
-            emit(
-                SyncResult(
-                    table = table,
-                    processedItems = 0,
-                    success = false,
-                    errorMessage = e.message,
-                    duration = endTime - startTime,
-                    strategy = getStrategyName()
-                )
-            )
-        }
+    ): Flow<Unit> = flow {
+        TransactionSyncManager.syncDb(realm, table)
+        emit(Unit)
     }
     
     override fun getStrategyName(): String = "standard"

--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/SyncStrategy.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/SyncStrategy.kt
@@ -12,21 +12,12 @@ data class SyncConfig(
     val fallbackToStandard: Boolean = true
 )
 
-data class SyncResult(
-    val table: String,
-    val processedItems: Int,
-    val success: Boolean,
-    val errorMessage: String? = null,
-    val duration: Long,
-    val strategy: String
-)
-
 interface SyncStrategy {
     suspend fun syncTable(
         table: String,
         realm: Realm,
         config: SyncConfig
-    ): Flow<SyncResult>
+    ): Flow<Unit>
 
     fun getStrategyName(): String
     fun isSupported(table: String): Boolean


### PR DESCRIPTION
## Summary
- remove the unused `SyncResult` data class and change `SyncStrategy.syncTable` to return `Flow<Unit>`
- update `StandardSyncStrategy` to emit `Unit` while delegating to `TransactionSyncManager`

## Testing
- ./gradlew :app:compileLiteDebugKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ff44131570832b9e32266d94268fb5