### PR TITLE
Refactor updateUserLibrary to leverage shared Realm update helper

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LibraryRepositoryImpl.kt
@@ -73,16 +73,16 @@ class LibraryRepositoryImpl @Inject constructor(
         userId: String,
         isAdd: Boolean,
     ): RealmMyLibrary? {
-        executeTransaction { realm ->
-            realm.where(RealmMyLibrary::class.java)
-                .equalTo("resourceId", resourceId)
-                .findFirst()?.let { library ->
-                    if (isAdd) {
-                        library.setUserId(userId)
-                    } else {
-                        library.removeUserId(userId)
-                    }
-                }
+        update(
+            RealmMyLibrary::class.java,
+            "resourceId",
+            resourceId,
+        ) { library ->
+            if (isAdd) {
+                library.setUserId(userId)
+            } else {
+                library.removeUserId(userId)
+            }
         }
         withRealmAsync { realm ->
             if (isAdd) {


### PR DESCRIPTION
## Summary
- replace the manual Realm transaction in `updateUserLibrary` with the shared `update` helper
- move the user ID add/remove logic into the updater lambda while keeping the add/remove logging intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffa4aec6a4832ba0aa17e7d63c7d0c