### PR TITLE
Fetch survey exams via repository in notifications

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepository.kt
@@ -12,6 +12,7 @@ interface SubmissionRepository {
     suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission>
     suspend fun getExamMapForSubmissions(submissions: List<RealmSubmission>): Map<String?, RealmStepExam>
     suspend fun getExamQuestionCount(stepId: String): Int
+    suspend fun findStepExamByName(name: String): RealmStepExam?
     suspend fun hasSubmission(
         stepExamId: String?,
         courseId: String?,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionRepositoryImpl.kt
@@ -97,6 +97,10 @@ class SubmissionRepositoryImpl @Inject constructor(
         return findByField(RealmStepExam::class.java, "stepId", stepId)?.noOfQuestions ?: 0
     }
 
+    override suspend fun findStepExamByName(name: String): RealmStepExam? {
+        return findByField(RealmStepExam::class.java, "name", name)
+    }
+
     override suspend fun getSubmissionById(id: String): RealmSubmission? {
         return findByField(RealmSubmission::class.java, "id", id)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/notification/NotificationsFragment.kt
@@ -29,9 +29,9 @@ import org.ole.planet.myplanet.databinding.FragmentNotificationsBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNotification
-import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.repository.NotificationRepository
+import org.ole.planet.myplanet.repository.SubmissionRepository
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.resources.ResourcesFragment
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
@@ -48,6 +48,8 @@ class NotificationsFragment : Fragment() {
     lateinit var databaseService: DatabaseService
     @Inject
     lateinit var notificationRepository: NotificationRepository
+    @Inject
+    lateinit var submissionRepository: SubmissionRepository
     private lateinit var adapter: AdapterNotification
     private lateinit var userId: String
     private var notificationUpdateListener: NotificationListener? = null
@@ -122,18 +124,19 @@ class NotificationsFragment : Fragment() {
                 startActivity(intent)
             }
             "survey" -> {
-                databaseService.withRealm { realm ->
-                    val currentStepExam = realm.where(RealmStepExam::class.java)
-                        .equalTo("name", notification.relatedId)
-                        .findFirst()
-                    if (currentStepExam != null && activity is OnHomeItemClickListener) {
-                        AdapterMySubmission.openSurvey(
-                            activity as OnHomeItemClickListener,
-                            currentStepExam.id,
-                            false,
-                            false,
-                            "",
-                        )
+                val surveyName = notification.relatedId
+                if (!surveyName.isNullOrEmpty()) {
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        val currentStepExam = submissionRepository.findStepExamByName(surveyName)
+                        if (currentStepExam?.id != null && activity is OnHomeItemClickListener) {
+                            AdapterMySubmission.openSurvey(
+                                activity as OnHomeItemClickListener,
+                                currentStepExam.id,
+                                false,
+                                false,
+                                "",
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add a repository API to locate step exams by name
- use the new repository method to load survey exams inside `NotificationsFragment`
- trigger survey navigation from a coroutine instead of a Realm query block

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffa4bef14c832b9406d35bd5bfff4d