### PR TITLE
Refactor team course loading to use repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepository.kt
@@ -6,6 +6,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 
 interface CourseRepository {
     suspend fun getCourseByCourseId(courseId: String?): RealmMyCourse?
+    suspend fun getCoursesByIds(courseIds: Collection<String>): List<RealmMyCourse>
     suspend fun getCourseOnlineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseOfflineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseExamCount(courseId: String?): Int

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CourseRepositoryImpl.kt
@@ -18,6 +18,15 @@ class CourseRepositoryImpl @Inject constructor(
         return findByField(RealmMyCourse::class.java, "courseId", courseId)
     }
 
+    override suspend fun getCoursesByIds(courseIds: Collection<String>): List<RealmMyCourse> {
+        if (courseIds.isEmpty()) {
+            return emptyList()
+        }
+        return queryList(RealmMyCourse::class.java) {
+            `in`("id", courseIds.toTypedArray())
+        }
+    }
+
     override suspend fun getCourseOnlineResources(courseId: String?): List<RealmMyLibrary> {
         return getCourseResources(courseId, isOffline = false)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
@@ -4,16 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import javax.inject.Inject
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
-import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.repository.CourseRepository
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
 
 class TeamCourseFragment : BaseTeamFragment() {
     private var _binding: FragmentTeamCourseBinding? = null
     private val binding get() = _binding!!
     private var adapterTeamCourse: AdapterTeamCourse? = null
+    @Inject
+    lateinit var courseRepository: CourseRepository
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentTeamCourseBinding.inflate(inflater, container, false)
@@ -26,12 +31,16 @@ class TeamCourseFragment : BaseTeamFragment() {
     }
     
     private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { AdapterTeamCourse(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
-        binding.rvCourse.layoutManager = LinearLayoutManager(activity)
-        binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+        viewLifecycleOwner.lifecycleScope.launch {
+            val courses = courseRepository.getCoursesByIds(team?.courses.orEmpty())
+            adapterTeamCourse = settings?.let {
+                AdapterTeamCourse(requireActivity(), courses.toMutableList(), mRealm, teamId, it)
+            }
+            binding.rvCourse.layoutManager = LinearLayoutManager(activity)
+            binding.rvCourse.adapter = adapterTeamCourse
+            adapterTeamCourse?.let {
+                showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+            }
         }
     }
     override fun onNewsItemClick(news: RealmNews?) {}


### PR DESCRIPTION
## Summary
- add a repository contract to load multiple courses by their identifiers
- implement the multi-course lookup with RealmRepository utilities and early empty handling
- inject CourseRepository into TeamCourseFragment and load courses asynchronously via lifecycleScope

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900ad5d6fa8832bb010683b5960c72a