### PR TITLE
chat history not saving new chats (fixes #8712)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmChatHistory.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmChatHistory.kt
@@ -16,6 +16,7 @@ open class RealmChatHistory : RealmObject() {
     var _id: String? = null
     var _rev: String? = null
     var user: String? = null
+    var ownerId: String? = null
     var aiProvider: String? = null
     var title: String? = null
     var createdDate: String? = null
@@ -35,6 +36,8 @@ open class RealmChatHistory : RealmObject() {
             chatHistory.createdDate = JsonUtils.getString("createdDate", act)
             chatHistory.updatedDate = JsonUtils.getString("updatedDate", act)
             chatHistory.user = JsonUtils.getString("user", act)
+            val ownerIdValue = JsonUtils.getString("ownerId", act)
+            chatHistory.ownerId = ownerIdValue?.takeIf { it.isNotBlank() }
             chatHistory.aiProvider = JsonUtils.getString("aiProvider", act)
             chatHistory.conversations = parseConversations(mRealm, JsonUtils.getJsonArray("conversations", act))
             chatHistory.lastUsed = Date().time
@@ -50,7 +53,14 @@ open class RealmChatHistory : RealmObject() {
             return conversations
         }
 
-        fun addConversationToChatHistory(mRealm: Realm, chatHistoryId: String?, query: String?, response: String?, newRev: String?) {
+        fun addConversationToChatHistory(
+            mRealm: Realm,
+            chatHistoryId: String?,
+            query: String?,
+            response: String?,
+            newRev: String?,
+            ownerId: String?,
+        ) {
             val chatHistory = mRealm.where(RealmChatHistory::class.java).equalTo("_id", chatHistoryId).findFirst()
             if (chatHistory != null) {
                 if (chatHistory.conversations == null) {
@@ -61,6 +71,9 @@ open class RealmChatHistory : RealmObject() {
                 conversation.response = response
                 chatHistory.conversations?.add(conversation)
                 chatHistory.lastUsed = Date().time
+                if (chatHistory.ownerId.isNullOrEmpty()) {
+                    chatHistory.ownerId = ownerId ?: chatHistory.user
+                }
                 if (!newRev.isNullOrEmpty()) {
                     chatHistory._rev = newRev
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
@@ -4,6 +4,6 @@ import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmNews
 
 interface ChatRepository {
-    suspend fun getChatHistoryForUser(userName: String?): List<RealmChatHistory>
+    suspend fun getChatHistoryForUser(ownerId: String?, userName: String?): List<RealmChatHistory>
     suspend fun getPlanetNewsMessages(planetCode: String?): List<RealmNews>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -11,12 +11,25 @@ class ChatRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
 ) : RealmRepository(databaseService), ChatRepository {
 
-    override suspend fun getChatHistoryForUser(userName: String?): List<RealmChatHistory> {
-        if (userName.isNullOrEmpty()) {
+    override suspend fun getChatHistoryForUser(ownerId: String?, userName: String?): List<RealmChatHistory> {
+        if (ownerId.isNullOrEmpty() && userName.isNullOrEmpty()) {
             return emptyList()
         }
         return queryList(RealmChatHistory::class.java) {
-            equalTo("user", userName)
+            when {
+                !ownerId.isNullOrEmpty() -> {
+                    beginGroup()
+                    equalTo("ownerId", ownerId)
+                    if (!userName.isNullOrEmpty()) {
+                        or()
+                        equalTo("user", userName)
+                    }
+                    endGroup()
+                }
+                !userName.isNullOrEmpty() -> {
+                    equalTo("user", userName)
+                }
+            }
             sort("id", Sort.DESCENDING)
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryListFragment.kt
@@ -248,7 +248,8 @@ class ChatHistoryListFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             val currentUser = loadCurrentUser()
             sharedNewsMessages = chatRepository.getPlanetNewsMessages(currentUser?.planetCode)
-            val list = chatRepository.getChatHistoryForUser(currentUser?.name)
+            val ownerId = currentUser?.id ?: currentUser?._id ?: settings.getString("userId", "")
+            val list = chatRepository.getChatHistoryForUser(ownerId, currentUser?.name)
             shareTargets = loadShareTargets()
 
             val adapter = binding.recyclerView.adapter as? ChatHistoryListAdapter


### PR DESCRIPTION
fixes #8712

## Summary
- wait for the active user to load before saving or updating chat conversations and stamp chat history payloads with a stable owner id
- add an ownerId field to RealmChatHistory and populate it on insert/update without disturbing legacy rows
- fetch chat histories by ownerId with a fallback to the legacy user field and request both identifiers when building the chat list

------
https://chatgpt.com/codex/tasks/task_e_690257fc3e80832ba3b017ba5eee5b02