### PR TITLE
team join delay (fixes #8698)

### DIFF
--- a/app/src/main/res/layout/item_team_list.xml
+++ b/app/src/main/res/layout/item_team_list.xml
@@ -52,9 +52,20 @@
         android:background="?attr/selectableItemBackground"
         android:padding="8dp"
         android:src="@drawable/ic_join_request"
-        app:layout_constraintEnd_toStartOf="@id/btn_feedback"
+        app:layout_constraintEnd_toStartOf="@id/join_progress"
         app:layout_constraintTop_toTopOf="parent"
         app:tint="@color/daynight_textColor" />
+
+    <ProgressBar
+        android:id="@+id/join_progress"
+        style="?android:attr/progressBarStyleSmall"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginEnd="8dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/join_leave"
+        app:layout_constraintEnd_toStartOf="@id/btn_feedback"
+        app:layout_constraintTop_toTopOf="@id/join_leave" />
     <ImageView
         android:id="@+id/btn_feedback"
         android:layout_width="40dp"


### PR DESCRIPTION
fixes #8698 Immediately mark join requests as pending, show a lightweight progress indicator, and debounce the list refresh so the UI stays responsive.

------
https://chatgpt.com/codex/tasks/task_e_6902584c0ff0832b885fa9c49dfca87f