### PR TITLE
Add localized loading profile translations

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -95,6 +95,7 @@
     <string name="type">النوع:</string>
     <string name="resource_colon">المصدر:</string>
     <string name="your_rating">تقييمك</string>
+    <string name="loading_user_profile">جارٍ تجهيز ملفك الشخصي…</string>
     <string name="your_comment">اترك تعليقك</string>
     <string name="show_top_nav">عرض شريط التنقل العلوي في لوحة التحكم</string>
     <string name="sync_now">مزامنة الآن</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -95,6 +95,7 @@
     <string name="type">Tipo:</string>
     <string name="resource_colon">Recurso:</string>
     <string name="your_rating">Tu calificación</string>
+    <string name="loading_user_profile">Preparando tu perfil…</string>
     <string name="your_comment">Deja tu comentario</string>
     <string name="show_top_nav">Mostrar la barra de navegación superior en el panel de control</string>
     <string name="sync_now">sincronizar ahora</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -95,6 +95,7 @@
     <string name="type">Type:</string>
     <string name="resource_colon">Ressource:</string>
     <string name="your_rating">Votre évaluation</string>
+    <string name="loading_user_profile">Préparation de votre profil…</string>
     <string name="your_comment">Laissez votre commentaire</string>
     <string name="show_top_nav">Afficher la barre de navigation supérieure dans le tableau de bord</string>
     <string name="sync_now">synchroniser maintenant</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -95,6 +95,7 @@
     <string name="type">प्रकार:</string>
     <string name="resource_colon">स्रोत:</string>
     <string name="your_rating">तपाईंको मत *</string>
+    <string name="loading_user_profile">तपाईंको प्रोफाइल तयार गर्दै…</string>
     <string name="your_comment">तपाईंको टिप्पणी छोड्नुहोस्</string>
     <string name="show_top_nav">ड्यासबोर्डमा शीर्ष नेभिगेशन पट्ट देखाउनुहोस्</string>
     <string name="sync_now">अहिले सिङ्क गर्नुहोस्</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -95,6 +95,7 @@
     <string name="type">Nooca:</string>
     <string name="resource_colon">Ilaha:</string>
     <string name="your_rating">qiimayntaada</string>
+    <string name="loading_user_profile">Diyaarinayaa astaantaada…</string>
     <string name="your_comment">ka tag faallooyinkaaga</string>
     <string name="show_top_nav">Show sare navigation Bar gudaha Dashboard</string>
     <string name="sync_now">isku-dar hadda</string>


### PR DESCRIPTION
## Summary
- add translations for the `loading_user_profile` string in Arabic, Spanish, French, Nepali, and Somali resource files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902ca8aef2c832baf9d144b49f057f9