### PR TITLE
Scope downloads to service lifecycle

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/MyDownloadService.kt
@@ -24,6 +24,8 @@ import java.io.IOException
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import okhttp3.ResponseBody
 import org.ole.planet.myplanet.MainApplication.Companion.createLog
@@ -49,6 +51,7 @@ class MyDownloadService : Service() {
 
     private var totalDownloadsCount = 0
     private var completedDownloadsCount = 0
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -75,7 +78,7 @@ class MyDownloadService : Service() {
 
         updateNotificationForBatchDownload()
 
-        CoroutineScope(Dispatchers.IO).launch {
+        serviceScope.launch {
             urls.forEachIndexed { index, url ->
                 currentIndex = index
                 initDownload(url, fromSync)
@@ -343,6 +346,7 @@ class MyDownloadService : Service() {
             stopForeground(true)
         } catch (_: Exception) {
         }
+        serviceScope.cancel()
         notificationManager?.cancel(ONGOING_NOTIFICATION_ID)
         super.onDestroy()
     }


### PR DESCRIPTION
## Summary
- add a SupervisorJob-backed IO coroutine scope to MyDownloadService
- launch downloads from the retained service scope instead of a transient CoroutineScope
- cancel the service scope when the service is destroyed so work stops cleanly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6903924a4330832baeac8b387ddfecfc