### PR TITLE
Refactor rating summary query to use Realm aggregates

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingRepositoryImpl.kt
@@ -19,25 +19,26 @@ class RatingRepositoryImpl @Inject constructor(
         itemId: String,
         userId: String,
     ): RatingSummary {
-        val ratings = queryList(RealmRating::class.java) {
-            equalTo("type", type)
-            equalTo("item", itemId)
-        }
-        val existingRating = ratings.firstOrNull { it.userId == userId }
+        return withRealmAsync { realm ->
+            val ratings =
+                realm.where(RealmRating::class.java)
+                    .equalTo("type", type)
+                    .equalTo("item", itemId)
+                    .findAll()
 
-        val totalRatings = ratings.size
-        val averageRating = if (totalRatings > 0) {
-            ratings.sumOf { it.rate }.toFloat() / totalRatings
-        } else {
-            0f
-        }
+            val totalRatings = ratings.size
+            val averageRating = ratings.averageDouble("rate")?.toFloat() ?: 0f
+            val existingRating = ratings.where()
+                .equalTo("userId", userId)
+                .findFirst()
 
-        return RatingSummary(
-            existingRating = existingRating?.toRatingEntry(),
-            averageRating = averageRating,
-            totalRatings = totalRatings,
-            userRating = existingRating?.rate,
-        )
+            RatingSummary(
+                existingRating = existingRating?.toRatingEntry(),
+                averageRating = averageRating,
+                totalRatings = totalRatings,
+                userRating = existingRating?.rate,
+            )
+        }
     }
 
     override suspend fun submitRating(


### PR DESCRIPTION
## Summary
- fetch rating summary data inside `withRealmAsync` to ensure Realm access happens on the managed thread
- use a single RealmResults query to derive total count, average rating, and the current user's rating without copying the full list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904f909ec8c832bb57d1d13fac7c01d