### PR TITLE
fix(database): move executeTransactionAsync to IO dispatcher

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/DatabaseService.kt
@@ -45,7 +45,7 @@ class DatabaseService(context: Context) {
     }
 
     suspend fun executeTransactionAsync(transaction: (Realm) -> Unit) {
-        return withContext(Dispatchers.Main) {
+        return withContext(Dispatchers.IO) {
             kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
                 val realm = Realm.getDefaultInstance()
                 realm.executeTransactionAsync(


### PR DESCRIPTION
Moves the `executeTransactionAsync` function in `DatabaseService.kt` to the `Dispatchers.IO` context. This prevents database transactions from blocking the main thread, improving UI responsiveness.