### PR TITLE
feat(profile): Move TeamListAdapter diffing to background thread

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -421,7 +421,7 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
         updateTeamDropdown()
 
         if (mAdapter == null) {
-            mAdapter = TeamListAdapter(prefData.getSavedUsers().toMutableList(), this)
+            mAdapter = TeamListAdapter(prefData.getSavedUsers().toMutableList(), this, lifecycleScope)
             binding.recyclerView.layoutManager = LinearLayoutManager(this)
             binding.recyclerView.adapter = mAdapter
         } else {


### PR DESCRIPTION
Moves the `DiffUtil.calculateDiff` operation in `TeamListAdapter` to a background coroutine to prevent blocking the main thread.

- Modified `TeamListAdapter` to accept a `CoroutineScope` in its constructor.
- Updated `updateList` to launch a coroutine on the provided scope.
- `DiffUtil.calculateDiff` is now executed on `Dispatchers.IO`.
- The `membersList` and `RecyclerView` are updated on `Dispatchers.Main`.
- Updated `LoginActivity` to pass its `lifecycleScope` to the adapter.

---
https://jules.google.com/session/9605718022012992077