### PR TITLE
Handle unmanaged Realm user model in BaseTeamFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/BaseTeamFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Realm
+import io.realm.RealmObject
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,7 +45,13 @@ abstract class BaseTeamFragment : BaseNewsFragment() {
         val sParentCode = settings.getString("parentCode", "")
         val communityName = settings.getString("communityName", "")
         mRealm = databaseService.realmInstance
-        user = profileDbHandler?.userModel?.let { mRealm.copyFromRealm(it) }
+        user = profileDbHandler?.userModel?.let { userModel ->
+            if (RealmObject.isManaged(userModel)) {
+                mRealm.copyFromRealm(userModel)
+            } else {
+                userModel
+            }
+        }
         teamId = requireArguments().getString("id", "") ?: "$communityName@$sParentCode"
 
         loadTeamData()


### PR DESCRIPTION
## Summary
- avoid copying unmanaged Realm user models when initializing BaseTeamFragment
- only invoke copyFromRealm when the user model is a managed Realm object

## Testing
- `./gradlew assembleDebug --stacktrace --no-configuration-cache --console=plain` *(fails: Cannot query the value of this provider because it has no value available.)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e59da7c84832b91f48cd3624457f1)