### PR TITLE
feat: Inject SharedPrefManager in MyHealthFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
@@ -87,7 +87,7 @@ class MyHealthFragment : Fragment() {
     lateinit var adapter: UserListArrayAdapter
     var dialog: AlertDialog? = null
     private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
-    lateinit var prefManager: SharedPrefManager
+    @Inject lateinit var prefManager: SharedPrefManager
     lateinit var settings: SharedPreferences
     private val serverUrlMapper = ServerUrlMapper()
     private val serverUrl: String
@@ -95,7 +95,6 @@ class MyHealthFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        prefManager = SharedPrefManager(requireContext())
         settings = requireContext().getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         startHealthSync()
     }


### PR DESCRIPTION
Refactors MyHealthFragment to use Hilt for SharedPrefManager dependency injection instead of manual instantiation.
---
https://jules.google.com/session/3357255560519415177