### PR TITLE
Remove dead Android resources and dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,6 @@ android {
         ndkVersion = '26.3.11579264'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
-        multiDexEnabled = true
     }
     configurations.configureEach {
         resolutionStrategy.force 'com.google.android.material:material:1.12.0'
@@ -173,8 +172,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     implementation fileTree(include: ['*.jar', '*.aar'], dir: 'libs')
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.multidex:multidex:2.0.1'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.annotation:annotation:1.9.1'
@@ -202,7 +200,6 @@ dependencies {
     implementation 'de.hdodenhof:circleimageview:3.1.0'
     implementation 'de.rtner:PBKDF2:1.1.4'
     implementation 'org.osmdroid:osmdroid-android:6.1.20'
-    implementation 'org.jetbrains:annotations:26.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext['kotlin_version']}"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"

--- a/app/src/main/res/layout/add_meetup.xml
+++ b/app/src/main/res/layout/add_meetup.xml
@@ -16,7 +16,7 @@
         android:textStyle="bold"
         android:textColor="@color/md_white_1000"
         android:padding="10dp"/>
-    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_edit_achievement.xml
+++ b/app/src/main/res/layout/fragment_edit_achievement.xml
@@ -23,8 +23,6 @@
                 android:orientation="vertical">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
-                    xmlns:android="http://schemas.android.com/apk/res/android"
-                    xmlns:app="http://schemas.android.com/apk/res-auto"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:background="@color/colorPrimary"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -125,28 +125,22 @@
     <string name="clear_tags">مسح</string>
     <string name="add_an_achievement">إضافة إنجاز</string>
     <string name="add_a_reference">إضافة مرجع</string>
-    <string name="show_filter">عرض الفلتر</string>
     <string name="subjects">الموضوعات</string>
     <string name="mediums">وسائط</string>
     <string name="levels">المستويات*</string>
     <string name="languages">اللغات</string>
     <string name="txt_myLife">حياتي</string>
     <string name="achievements">إنجازاتي</string>
-    <string name="news">أخبار</string>
     <string name="references">المراجع</string>
     <string name="maps">الخرائط</string>
     <string name="btn_guest_login">تسجيل الدخول كضيف</string>
     <string name="enter_username">أدخل اسم المستخدم</string>
     <string name="login">تسجيل الدخول</string>
     <string name="courses">الدورات</string>
-    <string name="enter_message_here">أدخل الرسالة هنا</string>
     <string name="what_would">ما الذي ترغب في مشاركته؟</string>
     <string name="delete_record">هل أنت متأكد من رغبتك في حذف ما يلي؟</string>
     <string name="edit_post">تعديل المنشور</string>
-    <string name="search_user">البحث عن مستخدم</string>
     <string name="get_started">البدء</string>
-    <string name="enter_password">أدخل كلمة المرور</string>
-    <string name="managerial_login">تسجيل الدخول كمدير</string>
     <string name="year">السنة</string>
     <string name="publisher">الناشر</string>
     <string name="link_to_license">رابط الترخيص</string>
@@ -159,15 +153,12 @@
     <string name="status">الحالة</string>
     <string name="title_not_compulsary">العنوان (غير مطلوب)</string>
     <string name="add_message">إضافة رسالة</string>
-    <string name="enter_message">أدخل رسالتك هنا…</string>
     <string name="added_by">أُضيف بواسطة</string>
     <string name="record_audio">تسجيل الصوت</string>
     <string name="record_video">تسجيل الفيديو</string>
     <string name="select_gallery">اختيار من المعرض</string>
     <string name="add_resource">إضافة مصدر:</string>
     <string name="reply">الرد</string>
-    <string name="show_reply">إظهار الردود</string>
-    <string name="show_main_conversation">عرض المحادثة الرئيسية</string>
     <string name="https_protocol">https://</string>
     <string name="http_protocol">http://</string>
     <string name="showing_reply_of">عرض الرد على:</string>
@@ -199,17 +190,6 @@
     <string name="nepali">नेपाली</string>
     <string name="arabic">عربى</string>
     <string name="french">français</string>
-
-    <string-array name="info_type">
-        <item>اللغات</item>
-        <item>التعليم</item>
-        <item>سجل التوظيف</item>
-        <item>الشارات</item>
-        <item>الشهادات</item>
-        <item>التدريبات الصيفية</item>
-        <item>الجوائز</item>
-    </string-array>
-
     <string-array name="open_With">
         <item>HTML</item>
         <item>PDF.js</item>
@@ -272,32 +252,19 @@
         <item>مقروء</item>
         <item>غير مقروء</item>
     </string-array>
-
-    <string name="feature_not">الميزة غير متوفرة</string>
     <string name="myhealth">صحتي</string>
-    <string name="type_name_to_search">اكتب اسم للبحث</string>
     <string name="action">إجراء</string>
     <string name="created_on">تم الإنشاء في</string>
     <string name="name_normal">الاسم</string>
     <string name="mypersonals">معلوماتي الشخصية</string>
     <string name="capture_image">التقاط صورة</string>
-    <string name="team_name">أدخل اسم الفريق</string>
     <string name="resources">موارد</string>
     <string name="button_reject">رفض</string>
     <string name="button_accept">قبول</string>
     <string name="plan">خطة</string>
     <string name="body_temperature">درجة حرارة الجسم (°C)</string>
-    <string name="rectally">مستقيمياً</string>
-    <string name="axillary">تحت الإبط</string>
-    <string name="by_ear">عن طريق الأذن</string>
-    <string name="by_skin">عن طريق الجلد</string>
-    <string name="temperature_taken">تم قياس الحرارة:</string>
     <string name="pulse_rate">معدل النبض (نبضة في الدقيقة)</string>
-    <string name="respiration_rate">معدل التنفس</string>
-    <string name="systolic">الضغط الانقباضي</string>
-    <string name="diastolic">الضغط الانبساطي</string>
     <string name="blood_pressure">ضغط الدم (الضغط الانقباضي/الانبساطي)</string>
-    <string name="orally">عن طريق الفم</string>
     <string name="save">حفظ</string>
     <string name="task">المهمة (مطلوبة)</string>
     <string name="deadline_required">الموعد النهائي (مطلوب)</string>
@@ -306,14 +273,12 @@
     <string name="select_member">اختر عضو الفريق</string>
     <string name="assign_task_to">المهمة المخصصة لـ</string>
     <string name="leader_selected">القائد المختار</string>
-    <string name="user_removed_from_team">تمت إزالة المستخدم من الفريق</string>
     <string name="remove">إزالة</string>
     <string name="make_leader">جعله قائدًا</string>
     <string name="mission"><![CDATA[المهمة والخدمات]]></string>
     <string name="team">الفرق</string>
     <string name="applicants">المتقدمون</string>
     <string name="finances">المالية</string>
-    <string name="messages">رسائل</string>
     <string name="nodata">لا توجد بيانات متاحة</string>
     <string name="note">ملاحظة *</string>
     <string name="amount">المبلغ</string>
@@ -331,7 +296,6 @@
     <string name="daily">يوميًا</string>
     <string name="weekly">أسبوعيًا</string>
     <string name="recurring_frequency">تكرار التكرار</string>
-    <string name="filter_by_date">تصفية حسب التاريخ</string>
     <string name="date_reset">إعادة تعيين التاريخ</string>
     <string name="emergency_contact">جهة الاتصال في حالات الطوارئ</string>
     <string name="emergency_contact_details">الاسم: %1$s النوع: %2$s الاتصال: %3$s</string>
@@ -339,12 +303,8 @@
     <string name="special_needs">احتياجات خاصة</string>
     <string name="other_need">احتياجات أخرى</string>
     <string name="update_health_record">تحديث سجل الصحة</string>
-    <string name="vital_sign">علامات حيوية</string>
-    <string name="examination">فحص</string>
     <string name="add_examination">إضافة فحص</string>
-    <string name="new_patient">المريض التالي</string>
     <string name="height">الطول (سم)</string>
-    <string name="width">العرض</string>
     <string name="vision">الرؤية</string>
     <string name="hearing">السمع</string>
     <string name="vitals">مؤشرات الصحة</string>
@@ -360,17 +320,12 @@
     <string name="referrals">الإحالات</string>
     <string name="full_name">الاسم الكامل</string>
     <string name="weight">الوزن (كجم)</string>
-    <string name="no_records">لم يتم العثور على سجلات</string>
-    <string name="chats">المحادثات</string>
     <string name="select_health_member">اختر عضو الفريق</string>
-    <string name="notifications">الإشعارات</string>
     <string name="incorrect_ans">إجابة غير صحيحة، يرجى المحاولة مرة أخرى</string>
     <string name="diagnosis_note">ملاحظات التشخيص</string>
     <string name="menu_community">المجتمع</string>
     <string name="library">المكتبة</string>
     <string name="device_name">اسم الجهاز</string>
-    <string name="enter_title">أدخل العنوان</string>
-    <string name="add_link">إضافة رابط</string>
     <string name="chat">الدردشة</string>
     <string name="members">الأعضاء</string>
     <string name="tasks">المهام</string>
@@ -507,9 +462,6 @@
         <item>نقص فيتامين A</item>
         <item>زيكا</item>
     </string-array>
-
-    <string name="add_story">إضافة قصة</string>
-    <string name="txt_myprogress">تقدمي</string>
     <string name="more_action">تصفية</string>
     <string name="my_progress">تقدمي</string>
     <string name="my_activity">نشاطي</string>
@@ -523,7 +475,6 @@
     <string name="use_phone_number_as_password">استخدام رقم الهاتف ككلمة مرور</string>
     <string name="feedback">تغذية راجعة</string>
     <string name="add_member">إضافة عضو</string>
-    <string name="exit">"تأكيد الخروج"</string>
     <string name="confirm_exit">هل أنت متأكد أنك تريد مغادرة هذا الفريق؟</string>
     <string name="update_profile_alert">يرجى استكمال ملف التعريف الخاص بك للاستمتاع بجميع الميزات</string>
     <string name="other_notes">ملاحظات أخرى</string>
@@ -536,12 +487,9 @@
     <string name="our_courses">دوراتنا</string>
     <string name="file">%s :الملف</string>
     <string name="recording_audio">جارٍ تسجيل الصوت…</string>
-    <string name="show_replies">"عرض الردود "</string>
     <string name="selected">"المحدد: "</string>
     <string name="last_sync">%s :آخر مزامنة مع الخادم</string>
     <string name="last_syncs">آخر مزامنة</string>
-    <string name="login_user">اسم المستخدم لتسجيل الدخول</string>
-    <string name="login_password">كلمة مرور المستخدم لتسجيل الدخول</string>
     <string name="no_team_available">لا توجد فرق/مؤسسات متاحة</string>
     <string name="last_sync_date">%s :تاريخ آخر مزامنة</string>
     <string name="no_assignee">لا يوجد مُعيَّن</string>
@@ -571,20 +519,14 @@
     <string name="csv_filename">اسم ملف CSV</string>
     <string name="please_enter_reply">يرجى إدخال رد</string>
     <string name="image_filename">اسم ملف الصورة</string>
-    <string name="markdown_filename">اسم ملف التنسيق</string>
-    <string name="select_login_mode">حدد وضع تسجيل الدخول:</string>
-    <string name="normal_mode">الوضع العادي</string>
     <string name="select_date">حدد التاريخ</string>
     <string name="public_public">عام</string>
-    <string name="type_asterisk">اكتب*</string>
     <string name="joined_members_colon">الأعضاء المنضمون:</string>
     <string name="title">العنوان</string>
     <string name="source">المصدر</string>
     <string name="cloud_url">سحاب</string>
     <string name="interval">الفترة الزمنية</string>
     <string name="autosync">المزامنة التلقائية</string>
-    <string name="autosync_off">إيقاف المزامنة التلقائية!</string>
-    <string name="autosync_on">تشغيل المزامنة التلقائية</string>
     <string name="attached_resources">الموارد المرفقة:</string>
     <string name="edit">تحرير</string>
     <string name="my_achievements">إنجازاتي</string>
@@ -603,9 +545,6 @@
     <string name="download_resources">تحميل الموارد</string>
     <string name="take_test">إجراء الاختبار [%d]</string>
     <string name="search">بحث</string>
-    <string name="for_ambulance">للإسعاف</string>
-    <string name="for_police">للشرطة</string>
-    <string name="for_emergency">للطوارئ</string>
     <string name="submit_feedback">إرسال ملاحظات</string>
     <string name="media">وسائط:</string>
     <string name="filter">تصفية</string>
@@ -613,7 +552,6 @@
     <string name="subject_level">مستوى الموضوع</string>
     <string name="order_by_date">ترتيب حسب التاريخ</string>
     <string name="order_by_title">ترتيب حسب العنوان</string>
-    <string name="vital_signs_record">سجل علامات الحيوية</string>
     <string name="exams">الامتحانات</string>
     <string name="survey">الاستبيان</string>
     <string name="submitted_by">تم الإرسال بواسطة</string>
@@ -627,7 +565,6 @@
     <string name="all_task">جميع المهام</string>
     <string name="my_task">مهمتي</string>
     <string name="completed">تم الانتهاء</string>
-    <string name="add_profile_picture">إضافة صورة الملف الشخصي</string>
     <string name="two_dash">--</string>
     <string name="n_a">N/A</string>
     <string name="request_to_join">طلب الانضمام</string>
@@ -636,9 +573,6 @@
     <string name="mistakes">الأخطاء</string>
     <string name="take_survey">أداء الاستبيان</string>
     <string name="checkbox">خانة اختيار</string>
-    <string name="offer">عرض</string>
-    <string name="request_for_advice">طلب النصيحة</string>
-    <string name="no_images_to_download">لا توجد صور للتحميل.</string>
     <string name="this_file_type_is_currently_unsupported">نوع الملف غير مدعوم حاليًا</string>
     <string name="unable_to_open_resource">غير قادر على فتح المصدر</string>
     <string name="select_resource_to_open">"حدد المصدر للفتح: "</string>
@@ -654,10 +588,6 @@
     <string name="removed_from_mylibrary">تمت الإزالة من مكتبتي</string>
     <string name="removed_from_mycourse">تمت الإزالة من دوراتي</string>
     <string name="please_allow_usages_permission_to_myplanet_app">يرجى السماح بإذن الاستخدام لتطبيق MyPlanet.</string>
-    <string name="permissions_granted">الأذونات الممنوحة</string>
-    <string name="permissions_denied">الأذونات المرفوضة</string>
-    <string name="unable_to_upload_resource">غير قادر على رفع المصدر</string>
-    <string name="please_select_link_item_from_list">يرجى تحديد عنصر الرابط من القائمة</string>
     <string name="title_is_required">العنوان مطلوب</string>
     <string name="no_data_available">لا توجد بيانات متاحة</string>
     <string name="are_you_sure_you_want_to_leave_these_courses">هل أنت متأكد أنك تريد حذف هذه الدورات؟</string>
@@ -670,39 +600,20 @@
     <string name="retake_test">إعادة الاختبار [%d]</string>
     <string name="do_you_want_to_join_this_course">هل ترغب في الانضمام إلى هذه الدورة؟</string>
     <string name="join_this_course">انضم إلى هذه الدورة</string>
-    <string name="resource_not_downloaded">لم يتم تنزيل المصدر.</string>
-    <string name="bulk_resource_download">تنزيل مجمع للمصادر.</string>
-    <string name="pending_survey">استبيان معلق.</string>
-    <string name="download_news_images">تنزيل صور الأخبار.</string>
-    <string name="tasks_due">المهام المستحقة.</string>
-    <string name="storage_critically_low">"التخزين منخفض بشكل حرج: "</string>
-    <string name="available_please_free_up_space">متاح. يرجى تحرير المساحة.</string>
     <string name="storage_running_low">"التخزين قليل: "</string>
-    <string name="available">متاح.</string>
     <string name="storage_available">"التخزين المتاح: "</string>
-    <string name="health_record_not_available_click_to_sync">سجل الصحة غير متاح. انقر للمزامنة.</string>
-    <string name="visits">الزيارات</string>
     <string name="please_select_starting_date">"يرجى تحديد تاريخ البدء: "</string>
     <string name="read_offline_news_from">"قراءة الأخبار غير المتصلة من: "</string>
     <string name="downloading_started_please_check_notification">بدأ التنزيل، يرجى التحقق من الإشعار…</string>
     <string name="file_already_exists">الملف موجود بالفعل…</string>
-    <string name="syncing_health_please_wait">مزامنة الصحة، يرجى الانتظار…</string>
-    <string name="myhealth_synced_successfully">تمت مزامنة MyHealth بنجاح</string>
-    <string name="myhealth_synced_failed">فشلت عملية مزامنة MyHealth</string>
-    <string name="no_due_tasks">لا توجد مهام مستحقة</string>
-    <string name="due_tasks">المهام المستحقة</string>
-    <string name="feature_not_available_for_guest_user">الميزة غير متاحة للمستخدم الضيف</string>
     <string name="feature_not_available">الميزة غير متاحة</string>
-    <string name="health_record_not_available_sync_health_data">سجل الصحة غير متاح، هل ترغب في مزامنة بيانات الصحة؟</string>
     <string name="sync">مزامنة</string>
-    <string name="got_it">فهمت</string>
     <string name="session_expired">انتهت الجلسة.</string>
     <string name="downloading_started_please_check_notificati">بدأ التنزيل، يرجى التحقق من الإشعار…</string>
     <string name="dictionary">القاموس</string>
     <string name="list_size">%d حجم القائمة</string>
     <string name="word_not_available_in_our_database">الكلمة غير متوفرة في قاعدة بياناتنا.</string>
     <string name="description_is_required">الوصف مطلوب</string>
-    <string name="start_time_is_required">وقت البدء مطلوب</string>
     <string name="meetup_added">تمت إضافة اللقاء</string>
     <string name="meetup_not_added">ميكوشي ب نو ت د</string>
     <string name="add_transaction">إضافة المعاملة</string>
@@ -716,20 +627,14 @@
     <string name="complete">اكتمل</string>
     <string name="no_questions_available">لا تتوفر أسئلة</string>
     <string name="please_select_write_your_answer_to_continue">يرجى تحديد / كتابة إجابتك للمتابعة</string>
-    <string name="graded">تم التقييم</string>
-    <string name="pending">معلقة</string>
     <string name="user_profile_updated">تم تحديث ملف المستخدم</string>
     <string name="unable_to_update_user">غير قادر على تحديث المستخدم</string>
-    <string name="date_n_a">التاريخ: غ/م</string>
     <string name="please_enter_feedback">يرجى إدخال التعليقات.</string>
     <string name="feedback_priority_is_required">يجب تحديد أولوية التعليقات.</string>
     <string name="feedback_type_is_required">يجب تحديد نوع التعليقات.</string>
     <string name="thank_you_your_feedback_has_been_submitted">شكرًا لك، تم تقديم تعليقاتك بنجاح</string>
     <string name="feedback_saved">تم حفظ التعليقات..</string>
-    <string name="name_colon">"الاسم: "</string>
     <string name="email_colon">"البريد الإلكتروني: "</string>
-    <string name="phone_number_colon">"رقم الهاتف: "</string>
-    <string name="resource_saved_successfully">تم حفظ المصدر بنجاح</string>
     <string name="level_is_required">المستوى مطلوب</string>
     <string name="subject_is_required">الموضوع مطلوب</string>
     <string name="enter_resource_detail">أدخل تفاصيل المصدر</string>
@@ -766,12 +671,6 @@
     اختبارات مختبرية: %8$s\n
     الدراسات: %9$s\n
 </string>
-
-    <string name="diagnosis_colon">"التشخيص: "</string>
-    <string name="treatments_colon">"العلاجات: "</string>
-    <string name="medications_colon">"الأدوية: "</string>
-    <string name="immunizations_colon">"التطعيمات: "</string>
-    <string name="invalid_input">إدخال غير صالح</string>
     <string name="blood_pressure_should_be_numeric_systolic_diastolic">يجب أن يكون ضغط الدم عبارة عن أرقام نبضية/انبساطية</string>
     <string name="blood_pressure_should_be_systolic_diastolic">يجب أن يكون ضغط الدم عبارة عن نبضي/انبساطي</string>
     <string name="bp_must_be_between_60_40_and_300_200">يجب أن يكون ضغط الدم بين 60/40 و 300/200</string>
@@ -795,14 +694,11 @@
     <string name="no_data_available_please_click_button_to_add_new_resource_in_mypersonal">لا توجد بيانات متاحة، يرجى النقر على الزر + لإضافة مصدر جديد في "شخصي".</string>
     <string name="label_added">تمت إضافة التسمية.</string>
     <string name="please_enter_message">يرجى إدخال الرسالة</string>
-    <string name="new_not_available">غير متاح جديد</string>
-    <string name="hide_add_story">إخفاء إضافة قصة</string>
     <string name="no_items">لا توجد عناصر</string>
     <string name="record_survey">تسجيل الاستبيان</string>
     <string name="survey_sent_to_users">تم إرسال الاستبيان للمستخدمين</string>
     <string name="wifi_is_turned_off_saving_battery_power">تم تعطيل الواي فاي. يتم حفظ طاقة البطارية</string>
     <string name="turning_on_wifi_please_wait">جاري تشغيل الواي فاي. يرجى الانتظار…</string>
-    <string name="unable_to_connect_to_planet_wifi">غير قادر على الاتصال بشبكة بلانت اللاسلكية</string>
     <string name="you_are_now_connected">لقد تم الآن الاتصال</string>
     <string name="press_back_again_to_exit">اضغط BACK مرة أخرى للخروج</string>
     <string name="it_has_been_more_than">لقد مرت مدة تزيد عن </string>
@@ -811,7 +707,6 @@
     <string name="okay">موافق</string>
     <string name="connect_to_the_server_over_wifi_and_sync_your_device_to_continue">قم بالاتصال بالخادم عبر الواي فاي وقم بمزامنة جهازك للمتابعة</string>
     <string name="please_enter_server_url_first">يرجى إدخال عنوان URL الخادم أولاً.</string>
-    <string name="this_device_not_configured_properly_please_check_and_sync">لم يتم تكوين هذا الجهاز بشكل صحيح. يرجى التحقق والمزامنة.</string>
     <string name="username_cannot_be_empty">اسم المستخدم لا يمكن أن يكون فارغًا</string>
     <string name="unable_to_login">غير قادر على تسجيل الدخول</string>
     <string name="planet_server_not_reachable">غير قادر على الوصول إلى خادم بلانت</string>
@@ -820,14 +715,11 @@
     <string name="please_wait">يرجى الانتظار…</string>
     <string name="update_later">تحديث لاحقًا</string>
     <string name="checking_version">جاري التحقق من الإصدار…</string>
-    <string name="please_enter_your_password">يرجى إدخال كلمة المرور الخاصة بك</string>
     <string name="downloading">جارٍ التنزيل…</string>
     <string name="pin_is_required">مطلوب رمز التعريف الشخصي</string>
     <string name="invalid_url">عنوان URL غير صالح</string>
     <string name="please_enter_valid_url_to_continue">يرجى إدخال عنوان URL صالح للمتابعة</string>
     <string name="uploading_data_to_server_please_wait">جارٍ تحميل البيانات إلى الخادم، يرجى الانتظار…</string>
-    <string name="uploading_activities_to_server_please_wait">جارٍ تحميل الأنشطة إلى الخادم، يرجى الانتظار…</string>
-    <string name="connecting_to_server">جارٍ الاتصال بالخادم…</string>
     <string name="check_the_server_address_again_what_i_connected_to_wasn_t_the_planet_server">تحقق مرة أخرى من عنوان الخادم. ما قمت بالاتصال به ليس خادم بلانت</string>
     <string name="device_couldn_t_reach_local_server">لم يتمكن الجهاز من الوصول إلى الخادم. تحقق مما إذا كنت متصلاً بشبكة Wi-Fi الصحيحة للخادم المحلي (المجتمع).</string>
     <string name="device_couldn_t_reach_nation_server">لم يتمكن الجهاز من الوصول إلى الخادم. تحقق مما إذا كنت متصلاً بالإنترنت وحاول مرة أخرى.</string>
@@ -835,7 +727,6 @@
     <string name="syncing_data_please_wait">جارٍ مزامنة البيانات، يرجى الانتظار…</string>
     <string name="sync_failed">فشلت المزامنة</string>
     <string name="sync_completed">اكتملت المزامنة</string>
-    <string name="message_is_required">الرسالة مطلوبة</string>
     <string name="team_leader">قائد الفريق</string>
     <string name="select_resource">اختر المصدر:</string>
     <string name="add">إضافة</string>
@@ -850,7 +741,6 @@
     <string name="task_s_successfully">تمت المهمة %s بنجاح</string>
     <string name="task_deleted_successfully">تم حذف المهمة بنجاح</string>
     <string name="requested">طُلب</string>
-    <string name="resources_colon">الموارد:</string>
     <string name="left_team">غادر الفريق</string>
     <string name="enter_enterprise_s_name">أدخل اسم المؤسسة</string>
     <string name="what_is_your_team_s_plan">ما هو خطة فريقك؟</string>
@@ -861,7 +751,6 @@
     <string name="name_is_required">الاسم مطلوب</string>
     <string name="team_created">تم إنشاء الفريق</string>
     <string name="please_select_gender">يرجى تحديد الجنس</string>
-    <string name="please_enter_a_username">يرجى إدخال اسم المستخدم</string>
     <string name="invalid_username">اسم مستخدم غير صالح</string>
     <string name="please_enter_a_password">يرجى إدخال كلمة المرور</string>
     <string name="password_doesn_t_match">كلمة المرور غير متطابقة</string>
@@ -870,9 +759,7 @@
     <string name="add_reference">إضافة مرجع</string>
     <string name="add_achievement">إضافة إنجاز</string>
     <string name="select_resources">اختر الموارد:</string>
-    <string name="user_not_available_in_our_database">المستخدم غير متاح في قاعدة البيانات الخاصة بنا</string>
     <string name="date_of_birth">تاريخ الميلاد:</string>
-    <string name="unable_to_play_audio">غير قادر على تشغيل الصوت</string>
     <string name="unable_to_load">غير قادر على التحميل</string>
     <string name="recording_started">بدء التسجيل…</string>
     <string name="ole_is_recording_audio">أولي يقوم بتسجيل الصوت</string>
@@ -981,30 +868,22 @@
     <string name="auto_sync_device">جهاز مزامنة تلقائي</string>
     <string name="beta_functionality">وظائف بيتا</string>
     <string name="main_controls">التحكم الرئيسي</string>
-    <string name="select_user_to_login">اختر المستخدم لتسجيل الدخول</string>
     <string name="dismiss">رفض</string>
-    <string name="gps_is_settings">إعدادات نظام تحديد المواقع (GPS)</string>
-    <string name="gps_is_not_enabled_do_you_want_to_go_to_settings_menu">نظام تحديد المواقع (GPS) غير مفعل. هل ترغب في الانتقال إلى قائمة الإعدادات؟</string>
     <string name="available_space_colon">المساحة المتوفرة: </string>
     <string name="community_leaders">قادة المجتمع</string>
     <string name="services">الخدمات</string>
-    <string name="survey_taken">تم أخذ الاستبيان</string>
     <plurals name="survey_taken_count">
         <item quantity="one">تم أخذ الاستبيان %d مرة</item>
         <item quantity="other">تم أخذ الاستبيان %d مرات</item>
     </plurals>
-    <string name="times">مرات</string>
-    <string name="time">الوقت</string>
     <string name="ai_chat">AI Chat</string>
     <string name="kindly_give_a_rating">يرجى التقييم</string>
     <string name="must_start_with_letter_or_number">يجب أن تبدأ بحرف أو رقم</string>
     <string name="only_letters_numbers_and_are_allowed">فقط الأحرف من a إلى z والأرقام و "_" و "." و "-" مسموح بها</string>
-    <string name="config_not_available">التكوين غير متوفر.</string>
     <string name="unselect_all">إلغاء تحديد الكل</string>
     <string name="select_all">تحديد الكل</string>
     <string name="request_failed_please_retry">الطلب فشل، يرجى إعادة المحاولة</string>
     <string name="confirm_removal">تأكيد الحذف</string>
-    <string name="returning_user">مستخدم عائد</string>
     <string name="send_to_nation">اسمح بمشاركة إنجازاتك مع الوطن</string>
     <string name="image_resource">مصدر الصورة</string>
     <string name="play_audio">تشغيل الصوت</string>
@@ -1039,7 +918,6 @@
     <string name="trial_period_ended">انتهت الفترة التجريبية! يرجى استكمال التسجيل للمتابعة</string>
     <string name="drag">اسحب %1$s</string>
     <string name="visibility_of">تبديل ظهور %1$s</string>
-    <string name="actions_menu">قائمة الإجراءات</string>
     <string name="icon">أيقونة %1$s</string>
     <string name="select_res_course">حدد %1$s</string>
     <string name="kindly_enter_message">يرجى إدخال رسالة</string>
@@ -1047,7 +925,6 @@
     <string name="no_courses">لا تتوفر دورات</string>
     <string name="no_resources">لا تتوفر موارد</string>
     <string name="no_finance_record">لا يتوفر سجل مالي</string>
-    <string name="no_stories">لا تتوفر قصص</string>
     <string name="no_team_courses">لا تتوفر دورات الفريق</string>
     <string name="no_team_resources">لا تتوفر موارد الفريق</string>
     <string name="no_tasks">لا تتوفر مهام</string>
@@ -1056,7 +933,6 @@
     <string name="no_links_available">لا تتوفر روابط</string>
     <string name="user_requested_to_join_team">%1$s قد طلب الانضمام إلى %2$s</string>
     <string name="join_request_prefix">طلب الانضمام:</string>
-    <string name="new_request_to_join">طلب جديد للانضمام إلى %s</string>
     <string name="no_news">لا تتوفر أخبار</string>
     <string name="no_surveys">لا تتوفر استطلاعات</string>
     <string name="edit_image">تحرير صورة الملف الشخصي</string>
@@ -1072,21 +948,17 @@
     <string name="location_colon">&#160;الموقع:</string>
     <string name="recurring_colon">&#160;متكرر:</string>
     <string name="created_by_colon">&#160;تم إنشاؤه بواسطة:</string>
-    <string name="failed_to_get_configuration_id">فشل في الحصول على معرف التكوين. يرجى الاتصال بالمسؤول</string>
     <string name="you_want_to_connect_to_a_different_server">تريد الاتصال بخادم مختلف. امسح بيانات التطبيق للمتابعة</string>
     <string name="are_you_sure_you_want_to_clear_data">هل أنت متأكد أنك تريد مسح جميع البيانات؟</string>
     <string name="feedback_list">قائمة التغذية الراجعة</string>
     <string name="enterprise_list">قائمة الشركات</string>
     <string name="list_of_teams">قائمة الفرق</string>
-    <string name="sign_up_to_chat">يرجى التسجيل للوصول إلى الدردشة الذكية</string>
     <string name="share_chat">شارك الدردشة</string>
     <string name="shared_chat">دردشة مشتركة</string>
     <string name="check_apk_version">جارٍ فحص إصدار apk</string>
     <string name="checking_server">جارٍ فحص الخادم</string>
-    <string name="below_min_apk">إصدار Apk أقل من المسموح. يرجى تحديث التطبيق إلى أحدث إصدار.</string>
     <string name="add_note">إضافة ملاحظة (اختياري)</string>
     <string name="no_teams">الفرق غير متوفرة</string>
-    <string name="planet_name">كوكب %s</string>
     <string name="no_chats">لا توجد محادثات سابقة</string>
     <string name="no_feedback">لا توجد تعليقات متاحة</string>
     <string name="empty_text" />
@@ -1094,7 +966,6 @@
     <string name="reports">التقارير</string>
     <string name="number_placeholder">%d</string>
     <string name="float_placeholder">%.1f</string>
-    <string name="date_range">%1$s إلى %2$s</string>
     <string name="string_range">%1$s - %2$s</string>
     <string name="team_financial_report">%s تقرير مالي لـ</string>
     <string name="report_date_details">"تم إنشاء التقرير في: %1$s | تم تحديثه في: %2$s "</string>
@@ -1109,7 +980,6 @@
     <string name="resources_size">الموارد [%d]</string>
     <string name="user_role">- %s</string>
     <string name="user_name">%1$s (%2$s)</string>
-    <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>
     <string name="three_strings">%1$s %2$s %3$s</string>
     <string name="member_description"><![CDATA[(\u200E%2$d زيارة) \u200E%1$s]]></string>
@@ -1119,11 +989,6 @@
     <string name="dark_mode_off">إيقاف</string>
     <string name="dark_mode_on">تشغيل</string>
     <string name="dark_mode_follow_system">اتباع النظام</string>
-    <string-array name="dark_mode_options">
-        <item>@string/dark_mode_off</item>
-        <item>@string/dark_mode_on</item>
-        <item>@string/dark_mode_follow_system</item>
-    </string-array>
     <string name="are_you_sure_you_want_to_archive_these_courses">هل أنت متأكد أنك تريد أرشفة هذه الدورات؟</string>
     <string name="are_you_sure_you_want_to_archive_this_course">هل أنت متأكد أنك تريد أرشفة هذه الدورة؟</string>
     <string name="manual">يدوي</string>
@@ -1139,12 +1004,10 @@
     <string name="sync_ruiru">🇰🇪 planet ruiru</string>
     <string name="sync_embakasi">🇰🇪 planet embakasi</string>
     <string name="sync_cambridge">🇺🇸 planet cambridge</string>
-    <string name="sync_egdirbmac">🇺🇸 planet egdirbmac</string>
     <string name="surveys_to_complete">لديك %1$d %2$s لإكماله</string>
     <string name="show_less">عرض أقل</string>
     <string name="show_more">عرض المزيد</string>
     <string name="server_address_content_description">عنوان الخادم: %1$s</string>
-    <string name="member_only_allowed">انضم كعضو للوصول إلى هذه الميزة</string>
     <string name="select_theme_mode">اختر وضع السمة</string>
     <string name="beta_resources_auto_download">تنزيل الموارد التجريبيّة تلقائيًا</string>
     <string name="course_steps">خطوات الدورة</string>
@@ -1168,20 +1031,6 @@
     <string name="chat_enter_message">أدخل الرسالة</string>
     <string name="hour">ساعة</string>
     <string name="hours">ساعات</string>
-    <array name="material_calendar_months_array">
-        <item>يناير</item>
-        <item>فبراير</item>
-        <item>مارس</item>
-        <item>أبريل</item>
-        <item>مايو</item>
-        <item>يونيو</item>
-        <item>يوليو</item>
-        <item>أغسطس</item>
-        <item>سبتمبر</item>
-        <item>أكتوبر</item>
-        <item>نوفمبر</item>
-        <item>ديسمبر</item>
-    </array>
     <string name="switching_off_manual_configuration_to_clear_data">سيؤدي إيقاف التكوين اليدوي إلى مسح جميع البيانات، هل أنت متأكد أنك تريد المتابعة؟</string>
     <string name="switching_on_manual_configuration_to_clear_data">سيؤدي تشغيل التكوين اليدوي إلى مسح جميع البيانات، هل أنت متأكد أنك تريد المتابعة؟</string>
     <string name="chart_description">مخطط نشاط تسجيل الدخول</string>
@@ -1204,7 +1053,6 @@
     <string name="total_visits_overall">إجمالي الزيارات : </string>
     <string name="most_opened_resource">أكثر مورد تم فتحه : </string>
     <string name="number_of_resources_opened">عدد الموارد المفتوحة : </string>
-    <string name="number_of_visits">عدد الزيارات</string>
     <string name="kindly_enter_reply_message">يرجى إدخال رسالة الرد</string>
     <string name="start">ابدأ</string>
     <string name="continuation">استمر</string>
@@ -1229,15 +1077,12 @@
     <string name="user_verification_in_progress">جارٍ التحقق من المستخدم. يرجى الانتظار أثناء معالجة البيانات.</string>
     <string name="go_to_mylibrary">انتقل إلى مكتبتي</string>
     <string name="choose_an_option">اختر خيارًا</string>
-    <string name="welcome_back">مرحبًا بعودتك %1$s</string>
     <string name="welcome">%1$s بعودتك</string>
     <string name="edit_plan">تعديل الخطة</string>
     <string name="show_additional_fields">عرض الحقول الإضافية</string>
     <string name="hide_additional_fields">إخفاء الحقول الإضافية</string>
-    <string name="age">العمر</string>
     <string name="preparing_download">جارٍ تحضير التنزيل…</string>
     <string name="downloading_files">جارٍ تنزيل الملفات</string>
-    <string name="member_of_planet">عضو في planet</string>
     <string name="edit_mission_and_services">تعديل المهمة والخدمات</string>
     <string name="this_team_has_no_description_defined">هذا الفريق ليس لديه وصف محدد</string>
     <string name="contact_preference">contact preference</string>
@@ -1251,7 +1096,6 @@
     <string name="unable_to_save_user_please_sync">تعذّر حفظ المستخدم، يرجى المزامنة.</string>
     <string name="server_sync_successfully">تمت مزامنة الخادم بنجاح.</string>
     <string name="server_sync_has_failed">فشلت مزامنة الخادم.</string>
-    <string name="no_resources_to_download">لا توجد موارد للتحميل</string>
     <string name="response">استجابة</string>
     <string name="full_conversation_response">استجابة المحادثة الكاملة</string>
     <string name="add_new_event">+ حدث جديد</string>
@@ -1262,7 +1106,6 @@
     <string name="minutes">دقائق</string>
     <string name="days">أيام</string>
     <string name="set_reminder">تعيين تذكير</string>
-    <string name="reminder_set_for">تم تعيين التذكير بعد %1$s من الآن</string>
     <string name="reminder_surveys_to_complete">تذكير: لديك %1$d %2$s للإكمال</string>
 
     <plurals name="minutes">
@@ -1311,8 +1154,6 @@
     <string name="syncing_achievements">جارٍ مزامنة الإنجازات…</string>
     <string name="nation_leaders">قادة الأمة</string>
     <string name="filter_by_label">تصفية حسب التصنيف</string>
-    <string name="community_board">لوحة المجتمع</string>
-    <string name="nation_board">لوحة الوطن</string>
     <string name="is_available">%1$s متاح. انقر للمتابعة في التعلم</string>
     <string name="failed_to_add_please_retry">فشل في الإضافة. الرجاء المحاولة مرة أخرى</string>
     <string name="failed_to_mark_as_read">فشل في التعليم كمقروء. الرجاء المحاولة مرة أخرى</string>
@@ -1321,10 +1162,8 @@
     <string name="failed_to_save_chat">فشل في حفظ الدردشة. الرجاء المحاولة مرة أخرى.</string>
     <string name="failed_to_delete_report">فشل في حذف التقرير. الرجاء المحاولة مرة أخرى</string>
     <string name="delete_report">حذف التقرير</string>
-    <string name="checking_server_availability">فحص توفر الخادم…</string>
     <string name="loading_courses">جارٍ تحميل الدورات…</string>
     <string name="loading_teams">تحميل الفرق…</string>
-    <string name="loading_enterprises">تحميل المؤسسات…</string>
     <string name="year_of_birth">سنة الميلاد</string>
     <string name="year_of_birth_cannot_be_empty">لا يمكن أن تكون سنة الميلاد فارغة</string>
     <string name="please_enter_a_valid_year_of_birth">يرجى إدخال سنة ميلاد صالحة</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -125,28 +125,22 @@
     <string name="clear_tags">Limpiar</string>
     <string name="add_an_achievement">Agregar un logro</string>
     <string name="add_a_reference">Agregar una referencia</string>
-    <string name="show_filter">Mostrar filtro</string>
     <string name="subjects">Asignaturas</string>
     <string name="mediums">Medios</string>
     <string name="levels">Niveles*</string>
     <string name="languages">Idiomas</string>
     <string name="txt_myLife">miVida</string>
     <string name="achievements">misLogros</string>
-    <string name="news">Noticias</string>
     <string name="references">Referencias</string>
     <string name="maps">Mapas</string>
     <string name="btn_guest_login">Iniciar sesión como invitado</string>
     <string name="enter_username">Ingresa tu nombre de usuario</string>
     <string name="login">Iniciar sesión</string>
     <string name="courses">Cursos</string>
-    <string name="enter_message_here">Ingresa el mensaje aquí</string>
     <string name="what_would">¿Qué te gustaría compartir?</string>
     <string name="delete_record">¿Estás seguro de que quieres eliminar lo siguiente?</string>
     <string name="edit_post">Editar publicación</string>
-    <string name="search_user">Buscar usuario</string>
     <string name="get_started">EMPEZAR</string>
-    <string name="enter_password">Ingresar contraseña</string>
-    <string name="managerial_login">Iniciar sesión como administrador</string>
     <string name="year">Año</string>
     <string name="publisher">Editor</string>
     <string name="link_to_license">Enlace a la licencia</string>
@@ -159,15 +153,12 @@
     <string name="status">Estado</string>
     <string name="title_not_compulsary">Título</string>
     <string name="add_message">Agregar mensaje</string>
-    <string name="enter_message">Ingresa tu mensaje aquí…</string>
     <string name="added_by">Agregado por</string>
     <string name="record_audio">Grabar audio</string>
     <string name="record_video">Grabar video</string>
     <string name="select_gallery">Seleccionar de la galería</string>
     <string name="add_resource">Agregar recurso:</string>
     <string name="reply">Responder</string>
-    <string name="show_reply">Mostrar Respuestas</string>
-    <string name="show_main_conversation">Mostrar conversación principal</string>
     <string name="https_protocol">https://</string>
     <string name="http_protocol">http://</string>
     <string name="showing_reply_of">mostrando la respuesta de:</string>
@@ -199,17 +190,6 @@
     <string name="nepali">नेपाली</string>
     <string name="arabic">عربى</string>
     <string name="french">français</string>
-
-    <string-array name="info_type">
-        <item>Idiomas</item>
-        <item>Educación</item>
-        <item>Historial laboral</item>
-        <item>Insignias</item>
-        <item>Certificados</item>
-        <item>Prácticas</item>
-        <item>Premios</item>
-    </string-array>
-
     <string-array name="open_With">
         <item>HTML</item>
         <item>PDF.js</item>
@@ -272,32 +252,19 @@
         <item>leído</item>
         <item>no leído</item>
     </string-array>
-
-    <string name="feature_not">Función no disponible</string>
     <string name="myhealth">miSalud</string>
-    <string name="type_name_to_search">Escribe el nombre para buscar</string>
     <string name="action">Acción</string>
     <string name="created_on">Creado en</string>
     <string name="name_normal">Nombre</string>
     <string name="mypersonals">misPersonales</string>
     <string name="capture_image">Capturar imagen</string>
-    <string name="team_name">Ingresa nombre del equipo</string>
     <string name="resources">Recursos</string>
     <string name="button_reject">Rechazar</string>
     <string name="button_accept">Aceptar</string>
     <string name="plan">Plan</string>
     <string name="body_temperature">Temperatura corporal</string>
-    <string name="rectally">Rectamente</string>
-    <string name="axillary">Axilar</string>
-    <string name="by_ear">De oído</string>
-    <string name="by_skin">Por piel</string>
-    <string name="temperature_taken">Temperatura tomada:</string>
     <string name="pulse_rate">Frecuencia del pulso (lpm)</string>
-    <string name="respiration_rate">Ritmo respiratorio</string>
-    <string name="systolic">Sistólico</string>
-    <string name="diastolic">Diastólico</string>
     <string name="blood_pressure">Presión arterial</string>
-    <string name="orally">Oralmente</string>
     <string name="save">Guardar</string>
     <string name="task">Tarea</string>
     <string name="deadline_required">Fecha límite (obligatorio)</string>
@@ -306,14 +273,12 @@
     <string name="select_member">Seleccionar miembro del equipo</string>
     <string name="assign_task_to">Tarea asignada a</string>
     <string name="leader_selected">Líder seleccionado</string>
-    <string name="user_removed_from_team">Usuario eliminado del equipo</string>
     <string name="remove">Eliminar</string>
     <string name="make_leader">Asignar como líder</string>
     <string name="mission"><![CDATA[Misión y Servicios]]></string>
     <string name="team">Equipos</string>
     <string name="applicants">Solicitantes</string>
     <string name="finances">Finanzas</string>
-    <string name="messages">Mensajes</string>
     <string name="nodata">No hay datos disponibles</string>
     <string name="note">Nota *</string>
     <string name="amount">Cantidad</string>
@@ -331,7 +296,6 @@
     <string name="daily">Diario</string>
     <string name="weekly">Semanal</string>
     <string name="recurring_frequency">Frecuencia recurrente</string>
-    <string name="filter_by_date">Filtro fecha </string>
     <string name="date_reset">Restablecer Fecha</string>
     <string name="emergency_contact">Contacto de emergencia</string>
     <string name="emergency_contact_details">Nombre: %1$s Tipo: %2$s Contacto: %3$s</string>
@@ -339,12 +303,8 @@
     <string name="special_needs">Necesidades especiales</string>
     <string name="other_need">Otras necesidades</string>
     <string name="update_health_record">Actualizar registro de salud</string>
-    <string name="vital_sign">Signo vital</string>
-    <string name="examination">Examen</string>
     <string name="add_examination">Agregar examen</string>
-    <string name="new_patient">Nuevo miembro</string>
     <string name="height">Altura</string>
-    <string name="width">Ancho</string>
     <string name="vision">Visión</string>
     <string name="hearing">Audición</string>
     <string name="vitals">Vitales</string>
@@ -360,17 +320,12 @@
     <string name="referrals">Referencias</string>
     <string name="full_name">Nombre completo</string>
     <string name="weight">Peso</string>
-    <string name="no_records">No se encontraron registros</string>
-    <string name="chats">Chats</string>
     <string name="select_health_member">Seleccionar miembro</string>
-    <string name="notifications">Notificaciones</string>
     <string name="incorrect_ans">Respuesta incorrecta, por favor inténtalo de nuevo</string>
     <string name="diagnosis_note">Notas de diagnóstico</string>
     <string name="menu_community">Comunidad</string>
     <string name="library">Biblioteca</string>
     <string name="device_name">Nombre del dispositivo</string>
-    <string name="enter_title">Ingresar título</string>
-    <string name="add_link">Agregar enlace</string>
     <string name="chat">Chat</string>
     <string name="members">Miembros</string>
     <string name="tasks">Tareas</string>
@@ -507,9 +462,6 @@
         <item>Deficiencia de vitamina A</item>
         <item>Zika</item>
     </string-array>
-
-    <string name="add_story">Agregar historia</string>
-    <string name="txt_myprogress">miProgreso</string>
     <string name="more_action">Filtrar</string>
     <string name="my_progress">miProgreso</string>
     <string name="my_activity">miActividad</string>
@@ -523,7 +475,6 @@
     <string name="use_phone_number_as_password">Usar número de teléfono como contraseña</string>
     <string name="feedback">Comentarios</string>
     <string name="add_member">Agregar miembro</string>
-    <string name="exit">Confirmar salida</string>
     <string name="confirm_exit">¿Estás seguro/a de que quieres abandonar este equipo?</string>
     <string name="update_profile_alert">Por favor, completa tu perfil para disfrutar de todas las funciones</string>
     <string name="other_notes">Otras notas</string>
@@ -536,12 +487,9 @@
     <string name="our_courses">Nuestros cursos</string>
     <string name="file">Archivo: %s</string>
     <string name="recording_audio">Grabando audio…</string>
-    <string name="show_replies">"Mostrar respuestas "</string>
     <string name="selected">"Seleccionado: "</string>
     <string name="last_sync">Última sincronización con el servidor: %s</string>
     <string name="last_syncs">Última sincronización</string>
-    <string name="login_user">Nombre de usuario</string>
-    <string name="login_password">Usuario contraseña</string>
     <string name="no_team_available">No hay equipo/empresa disponible</string>
     <string name="last_sync_date">Fecha de última sincronización: %s</string>
     <string name="no_assignee">Sin asignado/a</string>
@@ -571,20 +519,14 @@
     <string name="csv_filename">Nombre del archivo CSV</string>
     <string name="please_enter_reply">Por favor, ingresa una respuesta</string>
     <string name="image_filename">Nombre del archivo de imagen</string>
-    <string name="markdown_filename">Nombre del archivo de Markdown</string>
-    <string name="select_login_mode">Selecciona el modo de inicio de sesión:</string>
-    <string name="normal_mode">Modo normal</string>
     <string name="select_date">Seleccionar fecha</string>
     <string name="public_public">Público</string>
-    <string name="type_asterisk">Tipo*</string>
     <string name="joined_members_colon">Miembros unidos:</string>
     <string name="title">Título</string>
     <string name="source">Fuente</string>
     <string name="cloud_url">nube</string>
     <string name="interval">Intervalo</string>
     <string name="autosync">Autosincronización</string>
-    <string name="autosync_off">¡Autosincronización desactivada!</string>
-    <string name="autosync_on">Autosincronización activada</string>
     <string name="attached_resources">Recursos adjuntos:</string>
     <string name="edit">Editar</string>
     <string name="my_achievements">misLogros</string>
@@ -603,9 +545,6 @@
     <string name="download_resources">Descargar recursos</string>
     <string name="take_test">Realizar examen [%d]</string>
     <string name="search">Buscar</string>
-    <string name="for_ambulance">Para ambulancia</string>
-    <string name="for_police">Para policía</string>
-    <string name="for_emergency">Para emergencia</string>
     <string name="submit_feedback">Enviar comentarios</string>
     <string name="media">Medios:</string>
     <string name="filter">Filtrar</string>
@@ -613,7 +552,6 @@
     <string name="subject_level">Nivel de asignatura</string>
     <string name="order_by_date">Ordenar por fecha</string>
     <string name="order_by_title">Ordenar por título</string>
-    <string name="vital_signs_record">Registro de signos vitales</string>
     <string name="exams">Exámenes</string>
     <string name="survey">Encuesta</string>
     <string name="submitted_by">Enviado por</string>
@@ -627,7 +565,6 @@
     <string name="all_task">Todas las tareas</string>
     <string name="my_task">Mi tarea</string>
     <string name="completed">Completadas</string>
-    <string name="add_profile_picture">Agregar foto de perfil</string>
     <string name="two_dash">--</string>
     <string name="n_a">N/A</string>
     <string name="request_to_join">Solicitar unirse</string>
@@ -636,9 +573,6 @@
     <string name="mistakes">Errores</string>
     <string name="take_survey">Realizar encuesta</string>
     <string name="checkbox">Casilla</string>
-    <string name="offer">Oferta</string>
-    <string name="request_for_advice">Solicitud de consejo</string>
-    <string name="no_images_to_download">No hay imágenes para descargar.</string>
     <string name="this_file_type_is_currently_unsupported">Este tipo de archivo no es compatible en este momento.</string>
     <string name="unable_to_open_resource">No se puede abrir el recurso.</string>
     <string name="select_resource_to_open">"Selecciona el recurso para abrir: "</string>
@@ -654,10 +588,6 @@
     <string name="removed_from_mylibrary">Eliminado de miBiblioteca.</string>
     <string name="removed_from_mycourse">Eliminado de misCursos.</string>
     <string name="please_allow_usages_permission_to_myplanet_app">Por favor, permite los permisos de uso a la aplicación myPlanet.</string>
-    <string name="permissions_granted">Permisos otorgados.</string>
-    <string name="permissions_denied">Permisos denegados.</string>
-    <string name="unable_to_upload_resource">No se puede subir el recurso.</string>
-    <string name="please_select_link_item_from_list">Por favor, selecciona un elemento de enlace de la lista.</string>
     <string name="title_is_required">Se requiere un título.</string>
     <string name="no_data_available">No hay datos disponibles.</string>
     <string name="are_you_sure_you_want_to_leave_these_courses">¿Estás seguro de que quieres eliminar estos cursos?</string>
@@ -670,39 +600,20 @@
     <string name="retake_test">Volver a tomar el test [%d]</string>
     <string name="do_you_want_to_join_this_course">¿Deseas unirte a este curso?</string>
     <string name="join_this_course">Unirse a este curso</string>
-    <string name="resource_not_downloaded">Recurso no descargado.</string>
-    <string name="bulk_resource_download">Descarga masiva de recursos.</string>
-    <string name="pending_survey">Encuesta pendiente.</string>
-    <string name="download_news_images">Descargar imágenes de noticias.</string>
-    <string name="tasks_due">tareas pendientes.</string>
-    <string name="storage_critically_low">"Almacenamiento críticamente bajo: "</string>
-    <string name="available_please_free_up_space">disponible. Por favor, libera espacio.</string>
     <string name="storage_running_low">"Almacenamiento bajo: "</string>
-    <string name="available">disponible.</string>
     <string name="storage_available">"Almacenamiento disponible: "</string>
-    <string name="health_record_not_available_click_to_sync">Registro de salud no disponible. Haz clic para sincronizar.</string>
-    <string name="visits">visitas</string>
     <string name="please_select_starting_date">"Por favor, selecciona la fecha de inicio: "</string>
     <string name="read_offline_news_from">"Leer noticias sin conexión desde: "</string>
     <string name="downloading_started_please_check_notification">Descarga iniciada, por favor revisa las notificaciones…</string>
     <string name="file_already_exists">El archivo ya existe…</string>
-    <string name="syncing_health_please_wait">Sincronizando salud, por favor espera…</string>
-    <string name="myhealth_synced_successfully">miSalud sincronizada correctamente</string>
-    <string name="myhealth_synced_failed">Error al sincronizar miSalud</string>
-    <string name="no_due_tasks">No hay tareas pendientes</string>
-    <string name="due_tasks">Tareas pendientes</string>
-    <string name="feature_not_available_for_guest_user">Función no disponible para usuarios invitados</string>
     <string name="feature_not_available">Función no disponible</string>
-    <string name="health_record_not_available_sync_health_data">Registro de salud no disponible. ¿Sincronizar datos de salud?</string>
     <string name="sync">Sincronizar</string>
-    <string name="got_it">ENTENDIDO</string>
     <string name="session_expired">Sesión expirada.</string>
     <string name="downloading_started_please_check_notificati">Descarga iniciada, por favor revisa las notificaciones…</string>
     <string name="dictionary">Diccionario</string>
     <string name="list_size">Tamaño de la lista %d</string>
     <string name="word_not_available_in_our_database">Palabra no disponible en nuestra base de datos.</string>
     <string name="description_is_required">Se requiere una descripción</string>
-    <string name="start_time_is_required">Se requiere la hora de inicio</string>
     <string name="meetup_added">Encuentro agregado</string>
     <string name="meetup_not_added">Encuentro no agregado</string>
     <string name="add_transaction">Agregar transacción</string>
@@ -716,20 +627,14 @@
     <string name="complete">completa</string>
     <string name="no_questions_available">No hay preguntas disponibles</string>
     <string name="please_select_write_your_answer_to_continue">Por favor, selecciona/escribe tu respuesta para continuar</string>
-    <string name="graded">calificado</string>
-    <string name="pending">pendiente</string>
     <string name="user_profile_updated">Perfil de usuario actualizado</string>
     <string name="unable_to_update_user">No se puede actualizar el usuario</string>
-    <string name="date_n_a">Fecha: N/A</string>
     <string name="please_enter_feedback">Por favor, ingresa tu comentario.</string>
     <string name="feedback_priority_is_required">Se requiere prioridad de comentario.</string>
     <string name="feedback_type_is_required">Se requiere tipo de comentario.</string>
     <string name="thank_you_your_feedback_has_been_submitted">Gracias, se ha enviado tu comentario</string>
     <string name="feedback_saved">Comentario guardado..</string>
-    <string name="name_colon">"Nombre: "</string>
     <string name="email_colon">"Correo electrónico: "</string>
-    <string name="phone_number_colon">"Número de teléfono: "</string>
-    <string name="resource_saved_successfully">Recurso guardado exitosamente</string>
     <string name="level_is_required">Se requiere nivel</string>
     <string name="subject_is_required">Se requiere asignatura</string>
     <string name="enter_resource_detail">Ingresa los detalles del recurso</string>
@@ -766,12 +671,6 @@
     Pruebas de laboratorio: %8$s\n
     Estudios: %9$s\n
 </string>
-
-    <string name="diagnosis_colon">"Diagnóstico: "</string>
-    <string name="treatments_colon">"Tratamientos: "</string>
-    <string name="medications_colon">"Medicamentos: "</string>
-    <string name="immunizations_colon">"Inmunizaciones: "</string>
-    <string name="invalid_input">Entrada inválida</string>
     <string name="blood_pressure_should_be_numeric_systolic_diastolic">La presión arterial debe ser numérica sistólica/diastólica</string>
     <string name="blood_pressure_should_be_systolic_diastolic">La presión arterial debe ser sistólica/diastólica</string>
     <string name="bp_must_be_between_60_40_and_300_200">La presión arterial debe estar entre 60/40 y 300/200</string>
@@ -795,14 +694,11 @@
     <string name="no_data_available_please_click_button_to_add_new_resource_in_mypersonal">No hay datos disponibles, por favor haz clic en el botón + para agregar un nuevo recurso en miPersonal.</string>
     <string name="label_added">Etiqueta agregada.</string>
     <string name="please_enter_message">Por favor ingresa un mensaje</string>
-    <string name="new_not_available">Nuevo no disponible</string>
-    <string name="hide_add_story">Ocultar agregar historia</string>
     <string name="no_items">No hay elementos</string>
     <string name="record_survey">Registrar encuesta</string>
     <string name="survey_sent_to_users">Encuesta enviada a los usuarios</string>
     <string name="wifi_is_turned_off_saving_battery_power">El wifi está desactivado. Ahorrando energía de la batería</string>
     <string name="turning_on_wifi_please_wait">Activando wifi. Por favor espera…</string>
-    <string name="unable_to_connect_to_planet_wifi">No se puede conectar al wifi de Planet.</string>
     <string name="you_are_now_connected">"Ahora estás conectado "</string>
     <string name="press_back_again_to_exit">Presiona ATRÁS de nuevo para salir</string>
     <string name="it_has_been_more_than">"Han pasado más de "</string>
@@ -811,7 +707,6 @@
     <string name="okay">De acuerdo</string>
     <string name="connect_to_the_server_over_wifi_and_sync_your_device_to_continue">Conéctate al servidor a través de wifi y sincroniza tu dispositivo para continuar</string>
     <string name="please_enter_server_url_first">Por favor ingresa la URL del servidor primero.</string>
-    <string name="this_device_not_configured_properly_please_check_and_sync">Este dispositivo no está configurado correctamente. Por favor verifica y sincroniza.</string>
     <string name="username_cannot_be_empty">El nombre de usuario no puede estar vacío</string>
     <string name="unable_to_login">No se puede iniciar sesión</string>
     <string name="planet_server_not_reachable">Servidor de Planet no accesible.</string>
@@ -820,14 +715,11 @@
     <string name="please_wait">Por favor espera....</string>
     <string name="update_later">Actualizar más tarde</string>
     <string name="checking_version">Verificando versión....</string>
-    <string name="please_enter_your_password">Por favor ingresa tu contraseña</string>
     <string name="downloading">"Descargando.... "</string>
     <string name="pin_is_required">Se requiere el PIN.</string>
     <string name="invalid_url">URL inválida</string>
     <string name="please_enter_valid_url_to_continue">Por favor ingresa una URL válida para continuar.</string>
     <string name="uploading_data_to_server_please_wait">Cargando datos al servidor, por favor espera.....</string>
-    <string name="uploading_activities_to_server_please_wait">Cargando actividades al servidor, por favor espera…</string>
-    <string name="connecting_to_server">Conectando al servidor....</string>
     <string name="check_the_server_address_again_what_i_connected_to_wasn_t_the_planet_server">Verifica de nuevo la dirección del servidor. A lo que me conecté no fue el servidor de Planet</string>
     <string name="device_couldn_t_reach_local_server">El dispositivo no pudo alcanzar el servidor. Verifique si está conectado a la red Wi-Fi correcta para el servidor local (comunidad).</string>
     <string name="device_couldn_t_reach_nation_server">El dispositivo no pudo alcanzar el servidor. Verifique si está conectado a Internet e inténtelo de nuevo.</string>
@@ -835,7 +727,6 @@
     <string name="syncing_data_please_wait">Sincronizando datos, por favor espera…</string>
     <string name="sync_failed">Sincronización fallida</string>
     <string name="sync_completed">Sincronización completada</string>
-    <string name="message_is_required">Se requiere un mensaje</string>
     <string name="team_leader">Líder de equipo</string>
     <string name="select_resource">"Seleccionar recurso: "</string>
     <string name="add">Agregar</string>
@@ -850,7 +741,6 @@
     <string name="task_s_successfully">Tarea %s exitosamente</string>
     <string name="task_deleted_successfully">Tarea eliminada exitosamente</string>
     <string name="requested">Solicitado</string>
-    <string name="resources_colon">"Recursos: "</string>
     <string name="left_team">Abandonó el equipo</string>
     <string name="enter_enterprise_s_name">Ingresa el nombre de la empresa</string>
     <string name="what_is_your_team_s_plan">¿Cuál es el plan de tu equipo?</string>
@@ -861,7 +751,6 @@
     <string name="name_is_required">Se requiere un nombre</string>
     <string name="team_created">Equipo creado</string>
     <string name="please_select_gender">Por favor selecciona el género</string>
-    <string name="please_enter_a_username">Por favor ingresa un nombre de usuario</string>
     <string name="invalid_username">Nombre de usuario inválido</string>
     <string name="please_enter_a_password">Por favor ingresa una contraseña</string>
     <string name="password_doesn_t_match">Las contraseñas no coinciden</string>
@@ -870,9 +759,7 @@
     <string name="add_reference">Agregar referencia</string>
     <string name="add_achievement">Agregar logro</string>
     <string name="select_resources">"Seleccionar recursos: "</string>
-    <string name="user_not_available_in_our_database">Usuario no disponible en nuestra base de datos</string>
     <string name="date_of_birth">"Fecha de nacimiento: "</string>
-    <string name="unable_to_play_audio">No se puede reproducir el audio.</string>
     <string name="unable_to_load">"No se puede cargar "</string>
     <string name="recording_started">Grabación iniciada....</string>
     <string name="ole_is_recording_audio">Ole está grabando audio</string>
@@ -981,30 +868,22 @@
     <string name="auto_sync_device">Sincronizar automáticamente el dispositivo</string>
     <string name="beta_functionality">Funcionalidad beta</string>
     <string name="main_controls">Controles principales</string>
-    <string name="select_user_to_login">Seleccionar usuario para iniciar sesión</string>
     <string name="dismiss">Descartar</string>
-    <string name="gps_is_settings">GPS está en configuraciones</string>
-    <string name="gps_is_not_enabled_do_you_want_to_go_to_settings_menu">GPS no está habilitado. ¿Deseas ir al menú de configuraciones?</string>
     <string name="available_space_colon">Espacio disponible: </string>
     <string name="community_leaders">Líderes comunitarios</string>
     <string name="services">Servicios</string>
-    <string name="survey_taken">Encuesta realizada</string>
     <plurals name="survey_taken_count">
         <item quantity="one">Encuesta realizada %d vez</item>
         <item quantity="other">Encuesta realizada %d veces</item>
     </plurals>
-    <string name="times">veces</string>
-    <string name="time">tiempo</string>
     <string name="ai_chat">Chat IA</string>
     <string name="kindly_give_a_rating">Por favor, dé una calificación</string>
     <string name="must_start_with_letter_or_number">Debe comenzar con una letra o número</string>
     <string name="only_letters_numbers_and_are_allowed">Solo se permiten letras (a–z), números y los caracteres "_", ".", "-"</string>
-    <string name="config_not_available">Configuración no disponible.</string>
     <string name="unselect_all">Deseleccionar todo</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="request_failed_please_retry">La solicitud ha fallado, por favor inténtelo de nuevo</string>
     <string name="confirm_removal">Confirmar eliminación</string>
-    <string name="returning_user">Usuario recurrente</string>
     <string name="send_to_nation">Permite que tus logros se compartan con la nación</string>
     <string name="image_resource">recurso de imagen</string>
     <string name="play_audio">reproducir audio</string>
@@ -1039,7 +918,6 @@
     <string name="trial_period_ended">¡El período de prueba ha terminado! Por favor, completa el registro para continuar</string>
     <string name="drag">arrastrar %1$s</string>
     <string name="visibility_of">alternar visibilidad de %1$s</string>
-    <string name="actions_menu">menú de acciones</string>
     <string name="icon">icono de %1$s</string>
     <string name="select_res_course">seleccionar %1$s</string>
     <string name="kindly_enter_message">Por favor, introduzca el mensaje</string>
@@ -1047,7 +925,6 @@
     <string name="no_courses">no hay cursos disponibles</string>
     <string name="no_resources">no hay recursos disponibles</string>
     <string name="no_finance_record">registro financiero no disponible</string>
-    <string name="no_stories">historias no disponibles</string>
     <string name="no_team_courses">cursos de equipo no disponibles</string>
     <string name="no_team_resources">recursos de equipo no disponibles</string>
     <string name="no_tasks">tareas no disponibles</string>
@@ -1056,7 +933,6 @@
     <string name="no_links_available">No hay enlaces disponibles</string>
     <string name="user_requested_to_join_team">%1$s ha solicitado unirse a %2$s</string>
     <string name="join_request_prefix">Solicitud de Unión:</string>
-    <string name="new_request_to_join">Nueva solicitud para unirse a %s</string>
     <string name="no_news">noticias no disponibles</string>
     <string name="no_surveys">encuestas no disponibles</string>
     <string name="edit_image">editar imagen de perfil</string>
@@ -1072,21 +948,17 @@
     <string name="location_colon">ubicación:&#160;</string>
     <string name="recurring_colon">recurrente:&#160;</string>
     <string name="created_by_colon">creado por:&#160;</string>
-    <string name="failed_to_get_configuration_id">No se pudo obtener el ID de configuración. Por favor, contacte al administrador</string>
     <string name="you_want_to_connect_to_a_different_server">¿Estás seguro de que deseas cambiar la configuración? Esta acción borrará los datos de la aplicación</string>
     <string name="are_you_sure_you_want_to_clear_data">¿Estás seguro de que deseas borrar todos los datos?</string>
     <string name="feedback_list">lista de comentarios</string>
     <string name="enterprise_list">lista de empresas</string>
     <string name="list_of_teams">lista de equipos</string>
-    <string name="sign_up_to_chat">Por favor regístrate para acceder al chat de IA</string>
     <string name="share_chat">compartir chat</string>
     <string name="shared_chat">chat compartido</string>
     <string name="check_apk_version">verificando versión de la aplicación</string>
     <string name="checking_server">verificando el servidor</string>
-    <string name="below_min_apk">La versión de la aplicación es inferior a la permitida. Por favor, actualiza la aplicación a la última versión.</string>
     <string name="add_note">Agregar una nota (opcional)</string>
     <string name="no_teams">equipos no disponibles</string>
-    <string name="planet_name">%s Planeta</string>
     <string name="no_chats">no hay chats anteriores</string>
     <string name="no_feedback">No hay comentarios aquí</string>
     <string name="empty_text" />
@@ -1094,7 +966,6 @@
     <string name="reports">informes</string>
     <string name="number_placeholder">%d</string>
     <string name="float_placeholder">%.1f</string>
-    <string name="date_range">%1$s a %2$s</string>
     <string name="string_range">%1$s - %2$s</string>
     <string name="team_financial_report">Informe financiero de %s</string>
     <string name="report_date_details">Informe creado el: %1$s | Actualizado el: %2$s</string>
@@ -1109,7 +980,6 @@
     <string name="resources_size">Recursos [%d]</string>
     <string name="user_role">- %s</string>
     <string name="user_name">%1$s (%2$s)</string>
-    <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>
     <string name="three_strings">%1$s %2$s %3$s</string>
     <string name="member_description">%1$s (%2$d visitas)</string>
@@ -1119,11 +989,6 @@
     <string name="dark_mode_off">Desactivado</string>
     <string name="dark_mode_on">Activado</string>
     <string name="dark_mode_follow_system">Seguir el sistema</string>
-    <string-array name="dark_mode_options">
-        <item>@string/dark_mode_off</item>
-        <item>@string/dark_mode_on</item>
-        <item>@string/dark_mode_follow_system</item>
-    </string-array>
     <string name="are_you_sure_you_want_to_archive_these_courses">¿Estás seguro de que deseas archivar estos cursos?</string>
     <string name="are_you_sure_you_want_to_archive_this_course">¿Estás seguro de que deseas archivar este curso?</string>
     <string name="manual">manual</string>
@@ -1139,12 +1004,10 @@
     <string name="sync_ruiru">🇰🇪 planet ruiru</string>
     <string name="sync_embakasi">🇰🇪 planet embakasi</string>
     <string name="sync_cambridge">🇺🇸 planet cambridge</string>
-    <string name="sync_egdirbmac">🇺🇸 planet egdirbmac</string>
     <string name="surveys_to_complete">Tienes %1$d %2$s para completar</string>
     <string name="show_less">mostrar menos</string>
     <string name="show_more">mostrar más</string>
     <string name="server_address_content_description">dirección del servidor: %1$s</string>
-    <string name="member_only_allowed">únete como miembro para acceder a esta función</string>
     <string name="select_theme_mode">seleccionar el modo de tema</string>
     <string name="beta_resources_auto_download">Descarga automática de recursos beta</string>
     <string name="course_steps">Pasos del curso</string>
@@ -1168,20 +1031,6 @@
     <string name="chat_enter_message">introduzca mensaje</string>
     <string name="hour">hora</string>
     <string name="hours">horas</string>
-    <array name="material_calendar_months_array">
-        <item>Enero</item>
-        <item>Febrero</item>
-        <item>Marzo</item>
-        <item>Abril</item>
-        <item>Mayo</item>
-        <item>Junio</item>
-        <item>Julio</item>
-        <item>Agosto</item>
-        <item>Septiembre</item>
-        <item>Octubre</item>
-        <item>Noviembre</item>
-        <item>Diciembre</item>
-    </array>
     <string name="switching_off_manual_configuration_to_clear_data">Desactivar la configuración manual borrará todos los datos, ¿Está seguro de que desea continuar?</string>
     <string name="switching_on_manual_configuration_to_clear_data">Activar la configuración manual borrará todos los datos, ¿Está seguro de que desea continuar?</string>
     <string name="chart_description">Gráfico de actividad de inicio de sesión</string>
@@ -1204,7 +1053,6 @@
     <string name="total_visits_overall">Total de visitas : </string>
     <string name="most_opened_resource">Recurso más abierto : </string>
     <string name="number_of_resources_opened">Número de recursos abiertos : </string>
-    <string name="number_of_visits">Número de visitas</string>
     <string name="kindly_enter_reply_message">Por favor, ingrese el mensaje de respuesta</string>
     <string name="start">iniciar</string>
     <string name="continuation">continuar</string>
@@ -1229,15 +1077,12 @@
     <string name="user_verification_in_progress">Verificación de usuario en progreso. Por favor, espere mientras procesamos los datos.</string>
     <string name="go_to_mylibrary">Ir a Mi Biblioteca</string>
     <string name="choose_an_option">Elige una opción</string>
-    <string name="welcome_back">Bienvenido de nuevo %1$s</string>
     <string name="welcome">Bienvenido %1$s</string>
     <string name="edit_plan">Editar plan</string>
     <string name="show_additional_fields">Mostrar campos adicionales</string>
     <string name="hide_additional_fields">Ocultar campos adicionales</string>
-    <string name="age">edad</string>
     <string name="preparing_download">Preparando la descarga…</string>
     <string name="downloading_files">Descargando archivos</string>
-    <string name="member_of_planet">miembro de planeta</string>
     <string name="edit_mission_and_services">editar misión y servicios</string>
     <string name="this_team_has_no_description_defined">Este equipo no tiene descripción definida</string>
     <string name="contact_preference">preferencia de contacto</string>
@@ -1251,7 +1096,6 @@
     <string name="unable_to_save_user_please_sync">No se pudo guardar el usuario, por favor sincronice.</string>
     <string name="server_sync_successfully">Sincronización del servidor con éxito.</string>
     <string name="server_sync_has_failed">La sincronización del servidor ha fallado.</string>
-    <string name="no_resources_to_download">No hay recursos para descargar</string>
     <string name="response">Respuesta</string>
     <string name="full_conversation_response">Respuesta completa de la conversación</string>
     <string name="add_new_event">+ nuevo evento</string>
@@ -1262,7 +1106,6 @@
     <string name="minutes">Minutos</string>
     <string name="days">Días</string>
     <string name="set_reminder">Establecer recordatorio</string>
-    <string name="reminder_set_for">Recordatorio establecido para %1$s a partir de ahora</string>
     <string name="reminder_surveys_to_complete">Recordatorio: Tienes %1$d %2$s por completar</string>
 
     <plurals name="minutes">
@@ -1311,8 +1154,6 @@
     <string name="syncing_achievements">Sincronizando logros…</string>
     <string name="nation_leaders">líderes nacionales</string>
     <string name="filter_by_label">filtrar por etiqueta</string>
-    <string name="community_board">tablero comunitario</string>
-    <string name="nation_board">tablero nacional</string>
     <string name="is_available">%1$s está disponible. Toca para continuar aprendiendo</string>
     <string name="failed_to_add_please_retry">Error al agregar. Por favor, inténtalo de nuevo</string>
     <string name="failed_to_mark_as_read">No se pudo marcar como leído. Por favor, inténtalo de nuevo</string>
@@ -1321,10 +1162,8 @@
     <string name="failed_to_save_chat">Error al guardar el chat. Por favor, inténtalo de nuevo.</string>
     <string name="failed_to_delete_report">Error al eliminar el informe. Por favor, inténtalo de nuevo</string>
     <string name="delete_report">Eliminar informe</string>
-    <string name="checking_server_availability">verificando disponibilidad del servidor…</string>
     <string name="loading_courses">Cargando cursos…</string>
     <string name="loading_teams">Cargando equipos…</string>
-    <string name="loading_enterprises">Cargando empresas…</string>
     <string name="year_of_birth">Año de nacimiento</string>
     <string name="year_of_birth_cannot_be_empty">el año de nacimiento no puede estar vacío</string>
     <string name="please_enter_a_valid_year_of_birth">por favor ingrese un año de nacimiento válido</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -125,28 +125,22 @@
     <string name="clear_tags">Effacer</string>
     <string name="add_an_achievement">Ajouter une réalisation</string>
     <string name="add_a_reference">Ajouter une référence</string>
-    <string name="show_filter">Afficher le filtre</string>
     <string name="subjects">Sujets</string>
     <string name="mediums">Moyens</string>
     <string name="levels">Niveaux*</string>
     <string name="languages">Langues</string>
     <string name="txt_myLife">maVie</string>
     <string name="achievements">mesRéalisations</string>
-    <string name="news">Nouvelles</string>
     <string name="references">Références</string>
     <string name="maps">Cartes</string>
     <string name="btn_guest_login">Connexion en tant qu\'invité</string>
     <string name="enter_username">Entrer le nom d\'utilisateur</string>
     <string name="login">Connexion</string>
     <string name="courses">Cours</string>
-    <string name="enter_message_here">Saisissez votre message ici</string>
     <string name="what_would">Que souhaitez-vous partager ?</string>
     <string name="delete_record">Êtes-vous sûr de vouloir supprimer les éléments suivants ?</string>
     <string name="edit_post">Modifier la publication</string>
-    <string name="search_user">Rechercher un utilisateur</string>
     <string name="get_started">COMMENCER</string>
-    <string name="enter_password">Entrer le mot de passe</string>
-    <string name="managerial_login">Connexion en tant que gestionnaire</string>
     <string name="year">Année</string>
     <string name="publisher">Éditeur</string>
     <string name="link_to_license">Lien vers la licence</string>
@@ -159,15 +153,12 @@
     <string name="status">Statut</string>
     <string name="title_not_compulsary">Titre</string>
     <string name="add_message">Ajouter un message</string>
-    <string name="enter_message">Entrez votre message ici…</string>
     <string name="added_by">Ajouté par</string>
     <string name="record_audio">Enregistrer un audio</string>
     <string name="record_video">Enregistrer une vidéo</string>
     <string name="select_gallery">Sélectionner depuis la galerie</string>
     <string name="add_resource">Ajouter une ressource :</string>
     <string name="reply">Répondre</string>
-    <string name="show_reply">Afficher les réponses</string>
-    <string name="show_main_conversation">Afficher la conversation principale</string>
     <string name="https_protocol">https://</string>
     <string name="http_protocol">http://</string>
     <string name="showing_reply_of">Affichage de la réponse de :</string>
@@ -199,17 +190,6 @@
     <string name="nepali">नेपाली</string>
     <string name="arabic">عربى</string>
     <string name="french">français</string>
-
-    <string-array name="info_type">
-        <item>Langues</item>
-        <item>Éducation</item>
-        <item>Histoire de l\'emploi</item>
-        <item>Insignes</item>
-        <item>Certificats</item>
-        <item>Stages</item>
-        <item>Distinctions</item>
-    </string-array>
-
     <string-array name="open_With">
         <item>HTML</item>
         <item>PDF.js</item>
@@ -272,32 +252,19 @@
         <item>lu</item>
         <item>non lu</item>
     </string-array>
-
-    <string name="feature_not">Fonctionnalité non disponible</string>
     <string name="myhealth">maSanté</string>
-    <string name="type_name_to_search">Saisissez le nom à rechercher</string>
     <string name="action">Action</string>
     <string name="created_on">Créé le</string>
     <string name="name_normal">Nom</string>
     <string name="mypersonals">mesPersonnels</string>
     <string name="capture_image">Capture d\'image</string>
-    <string name="team_name">Entrez le nom de l\'équipe</string>
     <string name="resources">Ressources</string>
     <string name="button_reject">Rejeter</string>
     <string name="button_accept">Accepter</string>
     <string name="plan">Plan</string>
     <string name="body_temperature">Température corporelle (°C)</string>
-    <string name="rectally">Rectal</string>
-    <string name="axillary">Axillaire</string>
-    <string name="by_ear">Par l\'oreille</string>
-    <string name="by_skin">Par la peau</string>
-    <string name="temperature_taken">Température prise :</string>
     <string name="pulse_rate">Fréquence cardiaque (bpm)</string>
-    <string name="respiration_rate">Fréquence respiratoire</string>
-    <string name="systolic">Systolique</string>
-    <string name="diastolic">Diastolique</string>
     <string name="blood_pressure">Pression artérielle (Systolique/Diastolique)</string>
-    <string name="orally">Par voie orale</string>
     <string name="save">Enregistrer</string>
     <string name="task">Tâche (obligatoire)</string>
     <string name="deadline_required">Date limite (obligatoire)</string>
@@ -306,14 +273,12 @@
     <string name="select_member">Sélectionnez un membre de l\'équipe</string>
     <string name="assign_task_to">Tâche attribuée à</string>
     <string name="leader_selected">Leader sélectionné</string>
-    <string name="user_removed_from_team">Utilisateur supprimé de l\'équipe</string>
     <string name="remove">Supprimer</string>
     <string name="make_leader">Faire de lui un leader</string>
     <string name="mission"><![CDATA[Mission et Services]]></string>
     <string name="team">Équipes</string>
     <string name="applicants">Candidats</string>
     <string name="finances">Finances</string>
-    <string name="messages">messages</string>
     <string name="nodata">Aucune donnée disponible</string>
     <string name="note">Note *</string>
     <string name="amount">Montant</string>
@@ -331,7 +296,6 @@
     <string name="daily">Quotidien</string>
     <string name="weekly">Hebdomadaire</string>
     <string name="recurring_frequency">Fréquence récurrente</string>
-    <string name="filter_by_date">Filtrer par date</string>
     <string name="date_reset">Réinitialisation de la date</string>
     <string name="emergency_contact">Contact d\'urgence</string>
     <string name="emergency_contact_details">Nom : %1$s Type : %2$s Contact : %3$s</string>
@@ -339,12 +303,8 @@
     <string name="special_needs">Besoins spéciaux</string>
     <string name="other_need">Autres besoins</string>
     <string name="update_health_record">Mettre à jour le dossier de santé</string>
-    <string name="vital_sign">Signe vital</string>
-    <string name="examination">Examen</string>
     <string name="add_examination">Ajouter un examen</string>
-    <string name="new_patient">Nouveau patient</string>
     <string name="height">Hauteur (cm)</string>
-    <string name="width">Largeur</string>
     <string name="vision">Vision</string>
     <string name="hearing">Audition</string>
     <string name="vitals">Signes vitaux</string>
@@ -360,17 +320,12 @@
     <string name="referrals">Références</string>
     <string name="full_name">Nom complet</string>
     <string name="weight">Poids (kg)</string>
-    <string name="no_records">Aucun enregistrement trouvé</string>
-    <string name="chats">Chats</string>
     <string name="select_health_member">Sélectionner un membre</string>
-    <string name="notifications">Notifications</string>
     <string name="incorrect_ans">Réponse incorrecte, veuillez réessayer</string>
     <string name="diagnosis_note">Notes de diagnostic</string>
     <string name="menu_community">Communauté</string>
     <string name="library">Bibliothèque</string>
     <string name="device_name">Nom de l\'appareil</string>
-    <string name="enter_title">Entrer un titre</string>
-    <string name="add_link">Ajouter un lien</string>
     <string name="chat">Discussion</string>
     <string name="members">Membres</string>
     <string name="tasks">Tâches</string>
@@ -507,9 +462,6 @@
         <item>Carence en vitamine A</item>
         <item>Zika</item>
     </string-array>
-
-    <string name="add_story">Ajouter une histoire</string>
-    <string name="txt_myprogress">myProgress</string>
     <string name="more_action">Filtrer</string>
     <string name="my_progress">Ma progression</string>
     <string name="my_activity">Mon activité</string>
@@ -523,7 +475,6 @@
     <string name="use_phone_number_as_password">Utiliser le numéro de téléphone comme mot de passe</string>
     <string name="feedback">Retour d\'information</string>
     <string name="add_member">Ajouter un membre</string>
-    <string name="exit">"Confirmer la sortie"</string>
     <string name="confirm_exit">Êtes-vous sûr de vouloir quitter cette équipe ?</string>
     <string name="update_profile_alert">Veuillez compléter votre profil pour profiter de toutes les fonctionnalités</string>
     <string name="other_notes">Autres notes</string>
@@ -536,12 +487,9 @@
     <string name="our_courses">Nos cours</string>
     <string name="file">Fichier : %s</string>
     <string name="recording_audio">Enregistrement audio en cours…</string>
-    <string name="show_replies">Afficher les réponses </string>
     <string name="selected">Sélectionné : </string>
     <string name="last_sync">Dernière synchronisation avec le serveur : %s</string>
     <string name="last_syncs">Dernière synchronisation</string>
-    <string name="login_user">Nom d\'utilisateur de connexion</string>
-    <string name="login_password">Mot de passe de l\'utilisateur de connexion</string>
     <string name="no_team_available">Aucune équipe/entreprise disponible</string>
     <string name="last_sync_date">Date de la dernière synchronisation : %s</string>
     <string name="no_assignee">Aucun assigné</string>
@@ -571,20 +519,14 @@
     <string name="csv_filename">Nom du fichier CSV</string>
     <string name="please_enter_reply">Veuillez saisir une réponse</string>
     <string name="image_filename">Nom du fichier image</string>
-    <string name="markdown_filename">Nom du fichier Markdown</string>
-    <string name="select_login_mode">Sélectionnez le mode de connexion :</string>
-    <string name="normal_mode">Mode normal</string>
     <string name="select_date">Sélectionner une date</string>
     <string name="public_public">Public</string>
-    <string name="type_asterisk">Type*</string>
     <string name="joined_members_colon">Membres inscrits :</string>
     <string name="title">Titre</string>
     <string name="source">Source</string>
     <string name="cloud_url">nuage</string>
     <string name="interval">Intervalle</string>
     <string name="autosync">Synchronisation automatique</string>
-    <string name="autosync_off">Désactivée</string>
-    <string name="autosync_on">Activée</string>
     <string name="attached_resources">Ressources attachées :</string>
     <string name="edit">Modifier</string>
     <string name="my_achievements">Mes réalisations</string>
@@ -603,9 +545,6 @@
     <string name="download_resources">Télécharger les ressources</string>
     <string name="take_test">Passer le test [%d]</string>
     <string name="search">Rechercher</string>
-    <string name="for_ambulance">Pour les ambulances</string>
-    <string name="for_police">Pour la police</string>
-    <string name="for_emergency">Pour les urgences</string>
     <string name="submit_feedback">Envoyer un commentaire</string>
     <string name="media">Média :</string>
     <string name="filter">Filtre</string>
@@ -613,7 +552,6 @@
     <string name="subject_level">Niveau du sujet</string>
     <string name="order_by_date">Trier par date</string>
     <string name="order_by_title">Trier par titre</string>
-    <string name="vital_signs_record">Dossier des signes vitaux</string>
     <string name="exams">Examens</string>
     <string name="survey">Enquête</string>
     <string name="submitted_by">Soumis par</string>
@@ -627,7 +565,6 @@
     <string name="all_task">Toutes les tâches</string>
     <string name="my_task">Mes tâches</string>
     <string name="completed">Terminé</string>
-    <string name="add_profile_picture">Ajouter une photo de profil</string>
     <string name="two_dash">--</string>
     <string name="n_a">N/A</string>
     <string name="request_to_join">Demander à rejoindre</string>
@@ -636,9 +573,6 @@
     <string name="mistakes">Erreurs</string>
     <string name="take_survey">Répondre à l\'enquête</string>
     <string name="checkbox">Case à cocher</string>
-    <string name="offer">Offre</string>
-    <string name="request_for_advice">Demande de conseil</string>
-    <string name="no_images_to_download">Aucune image à télécharger.</string>
     <string name="this_file_type_is_currently_unsupported">Ce type de fichier n\'est pas pris en charge actuellement.</string>
     <string name="unable_to_open_resource">Impossible d\'ouvrir la ressource.</string>
     <string name="select_resource_to_open">Sélectionnez la ressource à ouvrir: </string>
@@ -654,10 +588,6 @@
     <string name="removed_from_mylibrary">Supprimé de ma bibliothèque</string>
     <string name="removed_from_mycourse">Supprimé de mon cours</string>
     <string name="please_allow_usages_permission_to_myplanet_app">Veuillez autoriser les permissions d\'utilisation pour l\'application myPlanet.</string>
-    <string name="permissions_granted">Permissions accordées</string>
-    <string name="permissions_denied">Permissions refusées</string>
-    <string name="unable_to_upload_resource">Impossible de télécharger la ressource</string>
-    <string name="please_select_link_item_from_list">Veuillez sélectionner un élément de lien dans la liste</string>
     <string name="title_is_required">Le titre est requis</string>
     <string name="no_data_available">Aucune donnée disponible</string>
     <string name="are_you_sure_you_want_to_leave_these_courses">Êtes-vous sûr de vouloir quitter ces cours ?</string>
@@ -670,39 +600,20 @@
     <string name="retake_test">Repasser le test [%d]</string>
     <string name="do_you_want_to_join_this_course">Voulez-vous rejoindre ce cours ?</string>
     <string name="join_this_course">Rejoindre ce cours</string>
-    <string name="resource_not_downloaded">Ressource non téléchargée.</string>
-    <string name="bulk_resource_download">Téléchargement groupé de ressources.</string>
-    <string name="pending_survey">Enquête en attente.</string>
-    <string name="download_news_images">Télécharger les images d\'actualités.</string>
-    <string name="tasks_due">Tâches dues.</string>
-    <string name="storage_critically_low">Espace de stockage critique: </string>
-    <string name="available_please_free_up_space">disponible. Veuillez libérer de l\'espace.</string>
     <string name="storage_running_low">Espace de stockage presque plein: </string>
-    <string name="available">disponible.</string>
     <string name="storage_available">Espace de stockage disponible: </string>
-    <string name="health_record_not_available_click_to_sync">Dossier de santé non disponible. Cliquez pour synchroniser.</string>
-    <string name="visits">visites</string>
     <string name="please_select_starting_date">Veuillez sélectionner la date de début: </string>
     <string name="read_offline_news_from">Lire les actualités hors ligne depuis: </string>
     <string name="downloading_started_please_check_notification">Téléchargement commencé, veuillez vérifier les notifications…</string>
     <string name="file_already_exists">Le fichier existe déjà…</string>
-    <string name="syncing_health_please_wait">Synchronisation des données de santé en cours, veuillez patienter…</string>
-    <string name="myhealth_synced_successfully">Synchronisation réussie de myHealth</string>
-    <string name="myhealth_synced_failed">Échec de la synchronisation de myHealth</string>
-    <string name="no_due_tasks">Aucune tâche due</string>
-    <string name="due_tasks">Tâches dues</string>
-    <string name="feature_not_available_for_guest_user">Fonctionnalité non disponible pour l\'utilisateur invité</string>
     <string name="feature_not_available">Fonctionnalité non disponible</string>
-    <string name="health_record_not_available_sync_health_data">Dossier de santé non disponible, synchroniser les données de santé ?</string>
     <string name="sync">Synchroniser</string>
-    <string name="got_it">COMPRIS</string>
     <string name="session_expired">Session expirée.</string>
     <string name="downloading_started_please_check_notificati">Téléchargement commencé, veuillez vérifier les notifications…</string>
     <string name="dictionary">Dictionnaire</string>
     <string name="list_size">Taille de la liste %d</string>
     <string name="word_not_available_in_our_database">Le mot n\'est pas disponible dans notre base de données.</string>
     <string name="description_is_required">La description est requise</string>
-    <string name="start_time_is_required">L\'heure de début est requise</string>
     <string name="meetup_added">Rencontre ajoutée</string>
     <string name="meetup_not_added">Rencontre non ajoutée</string>
     <string name="add_transaction">Ajouter une transaction</string>
@@ -716,20 +627,14 @@
     <string name="complete">complète</string>
     <string name="no_questions_available">Aucune question disponible</string>
     <string name="please_select_write_your_answer_to_continue">Veuillez sélectionner/écrire votre réponse pour continuer</string>
-    <string name="graded">évaluée</string>
-    <string name="pending">en attente</string>
     <string name="user_profile_updated">Profil utilisateur mis à jour</string>
     <string name="unable_to_update_user">Impossible de mettre à jour l\'utilisateur</string>
-    <string name="date_n_a">Date: N/A</string>
     <string name="please_enter_feedback">Veuillez saisir un commentaire.</string>
     <string name="feedback_priority_is_required">La priorité du commentaire est requise.</string>
     <string name="feedback_type_is_required">Le type de commentaire est requis.</string>
     <string name="thank_you_your_feedback_has_been_submitted">Merci, votre commentaire a été soumis.</string>
     <string name="feedback_saved">Commentaire enregistré…</string>
-    <string name="name_colon">"Nom: "</string>
     <string name="email_colon">"E-mail: "</string>
-    <string name="phone_number_colon">"Numéro de téléphone: "</string>
-    <string name="resource_saved_successfully">Ressource enregistrée avec succès</string>
     <string name="level_is_required">Le niveau est requis</string>
     <string name="subject_is_required">Le sujet est requis</string>
     <string name="enter_resource_detail">Saisissez les détails de la ressource</string>
@@ -766,12 +671,6 @@
     Tests de laboratoire : %8$s\n
     Études : %9$s\n
 </string>
-
-    <string name="diagnosis_colon">"Diagnostic: "</string>
-    <string name="treatments_colon">"Traitements: "</string>
-    <string name="medications_colon">"Médicaments: "</string>
-    <string name="immunizations_colon">"Vaccinations: "</string>
-    <string name="invalid_input">Entrée invalide</string>
     <string name="blood_pressure_should_be_numeric_systolic_diastolic">La tension artérielle doit être numérique systolique/diastolique</string>
     <string name="blood_pressure_should_be_systolic_diastolic">La tension artérielle doit être systolique/diastolique</string>
     <string name="bp_must_be_between_60_40_and_300_200">La tension artérielle doit être entre 60/40 et 300/200</string>
@@ -795,14 +694,11 @@
     <string name="no_data_available_please_click_button_to_add_new_resource_in_mypersonal">Aucune donnée disponible, veuillez cliquer sur le bouton + pour ajouter une nouvelle ressource dans myPersonal.</string>
     <string name="label_added">Étiquette ajoutée.</string>
     <string name="please_enter_message">Veuillez saisir un message</string>
-    <string name="new_not_available">Nouveau non disponible</string>
-    <string name="hide_add_story">Masquer l\'ajout d\'une histoire</string>
     <string name="no_items">Aucun élément</string>
     <string name="record_survey">Enregistrer l\'enquête</string>
     <string name="survey_sent_to_users">Enquête envoyée aux utilisateurs</string>
     <string name="wifi_is_turned_off_saving_battery_power">Le wifi est désactivé. Économie de la batterie</string>
     <string name="turning_on_wifi_please_wait">Activation du wifi. Veuillez patienter…</string>
-    <string name="unable_to_connect_to_planet_wifi">Impossible de se connecter au wifi de Planet.</string>
     <string name="you_are_now_connected">"Vous êtes maintenant connecté "</string>
     <string name="press_back_again_to_exit">Appuyez à nouveau sur RETOUR pour quitter</string>
     <string name="it_has_been_more_than">"Cela fait plus de "</string>
@@ -811,7 +707,6 @@
     <string name="okay">D\'accord</string>
     <string name="connect_to_the_server_over_wifi_and_sync_your_device_to_continue">Connectez-vous au serveur via le wifi et synchronisez votre appareil pour continuer</string>
     <string name="please_enter_server_url_first">Veuillez d\'abord saisir l\'URL du serveur.</string>
-    <string name="this_device_not_configured_properly_please_check_and_sync">Cet appareil n\'est pas configuré correctement. Veuillez vérifier et synchroniser.</string>
     <string name="username_cannot_be_empty">Le nom d\'utilisateur ne peut pas être vide</string>
     <string name="unable_to_login">Impossible de se connecter</string>
     <string name="planet_server_not_reachable">Serveur Planet inaccessible.</string>
@@ -820,14 +715,11 @@
     <string name="please_wait">Veuillez patienter…</string>
     <string name="update_later">Mettre à jour plus tard</string>
     <string name="checking_version">Vérification de la version....</string>
-    <string name="please_enter_your_password">Veuillez saisir votre mot de passe</string>
     <string name="downloading">"Téléchargement.... "</string>
     <string name="pin_is_required">Le code PIN est requis.</string>
     <string name="invalid_url">URL invalide</string>
     <string name="please_enter_valid_url_to_continue">Veuillez entrer une URL valide pour continuer.</string>
     <string name="uploading_data_to_server_please_wait">Téléchargement des données vers le serveur, veuillez patienter.....</string>
-    <string name="uploading_activities_to_server_please_wait">Téléchargement des activités vers le serveur, veuillez patienter…</string>
-    <string name="connecting_to_server">Connexion au serveur....</string>
     <string name="check_the_server_address_again_what_i_connected_to_wasn_t_the_planet_server">Vérifiez à nouveau l\'adresse du serveur. Ce à quoi je me suis connecté n\'était pas le serveur Planet.</string>
     <string name="device_couldn_t_reach_local_server">l\'appareil n\'a pas pu atteindre le serveur. vérifiez si vous êtes connecté au réseau Wi-Fi correct pour le serveur local (communauté).</string>
     <string name="device_couldn_t_reach_nation_server">l\'appareil n\'a pas pu atteindre le serveur. vérifiez si vous êtes connecté à Internet et réessayez.</string>
@@ -835,7 +727,6 @@
     <string name="syncing_data_please_wait">Synchronisation des données, veuillez patienter…</string>
     <string name="sync_failed">Échec de la synchronisation</string>
     <string name="sync_completed">Synchronisation terminée</string>
-    <string name="message_is_required">Le message est requis</string>
     <string name="team_leader">Chef d\'équipe</string>
     <string name="select_resource">"Sélectionner la ressource: "</string>
     <string name="add">Ajouter</string>
@@ -850,7 +741,6 @@
     <string name="task_s_successfully">Tâche %s ajoutée avec succès</string>
     <string name="task_deleted_successfully">Tâche supprimée avec succès</string>
     <string name="requested">Demandé</string>
-    <string name="resources_colon">"Ressources: "</string>
     <string name="left_team">A quitté l\'équipe</string>
     <string name="enter_enterprise_s_name">Entrez le nom de l\'entreprise</string>
     <string name="what_is_your_team_s_plan">Quel est le plan de votre équipe ?</string>
@@ -861,7 +751,6 @@
     <string name="name_is_required">Le nom est requis</string>
     <string name="team_created">Équipe créée</string>
     <string name="please_select_gender">Veuillez sélectionner le genre</string>
-    <string name="please_enter_a_username">Veuillez entrer un nom d\'utilisateur</string>
     <string name="invalid_username">Nom d\'utilisateur invalide</string>
     <string name="please_enter_a_password">Veuillez entrer un mot de passe</string>
     <string name="password_doesn_t_match">Le mot de passe ne correspond pas</string>
@@ -870,9 +759,7 @@
     <string name="add_reference">Ajouter une référence</string>
     <string name="add_achievement">Ajouter un accomplissement</string>
     <string name="select_resources">"Sélectionner des ressources: "</string>
-    <string name="user_not_available_in_our_database">L\'utilisateur n\'est pas disponible dans notre base de données</string>
     <string name="date_of_birth">"Date de naissance: "</string>
-    <string name="unable_to_play_audio">Impossible de lire l\'audio.</string>
     <string name="unable_to_load">"Impossible de charger "</string>
     <string name="recording_started">Enregistrement démarré....</string>
     <string name="ole_is_recording_audio">Ole enregistre l\'audio</string>
@@ -981,30 +868,22 @@
     <string name="auto_sync_device">Appareil de synchronisation automatique</string>
     <string name="beta_functionality">Fonctionnalité bêta</string>
     <string name="main_controls">Commandes principales</string>
-    <string name="select_user_to_login">Sélectionner l\'utilisateur à connecter</string>
     <string name="dismiss">Ignorer</string>
-    <string name="gps_is_settings">Le GPS est un paramètre</string>
-    <string name="gps_is_not_enabled_do_you_want_to_go_to_settings_menu">Le GPS n\'est pas activé. Voulez-vous accéder au menu des paramètres ?</string>
     <string name="available_space_colon">Espace disponible : </string>
     <string name="community_leaders">Dirigeants de communauté</string>
     <string name="services">Services</string>
-    <string name="survey_taken">Enquête effectuée</string>
     <plurals name="survey_taken_count">
         <item quantity="one">Enquête effectuée %d fois</item>
         <item quantity="other">Enquête effectuée %d fois</item>
     </plurals>
-    <string name="times">fois</string>
-    <string name="time">temps</string>
     <string name="ai_chat">AI Chat</string>
     <string name="kindly_give_a_rating">Veuillez donner une note</string>
     <string name="must_start_with_letter_or_number">Doit commencer par une lettre ou un chiffre</string>
     <string name="only_letters_numbers_and_are_allowed">Seules les lettres de a à z, les chiffres, le "_", ".", et "-" sont autorisés</string>
-    <string name="config_not_available">Configuration non disponible.</string>
     <string name="unselect_all">Désélectionner tout</string>
     <string name="select_all">Sélectionner tout</string>
     <string name="request_failed_please_retry">La demande a échoué, veuillez réessayer</string>
     <string name="confirm_removal">Confirmer la suppression</string>
-    <string name="returning_user">Utilisateur régulier</string>
     <string name="send_to_nation">Autorisez la partage de vos réalisations avec la nation</string>
     <string name="image_resource">ressource d\'image</string>
     <string name="play_audio">lire l\'audio</string>
@@ -1039,7 +918,6 @@
     <string name="trial_period_ended">Période d\'essai terminée ! Veuillez terminer l\'inscription pour continuer</string>
     <string name="drag">glisser %1$s</string>
     <string name="visibility_of">basculer la visibilité de %1$s</string>
-    <string name="actions_menu">menu d\'actions</string>
     <string name="icon">icône %1$s</string>
     <string name="select_res_course">sélectionner %1$s</string>
     <string name="kindly_enter_message">Veuillez entrer le message</string>
@@ -1047,7 +925,6 @@
     <string name="no_courses">aucun cours disponible</string>
     <string name="no_resources">aucune ressource disponible</string>
     <string name="no_finance_record">aucun enregistrement financier disponible</string>
-    <string name="no_stories">aucune histoire disponible</string>
     <string name="no_team_courses">aucun cours d\'équipe disponible</string>
     <string name="no_team_resources">aucune ressource d\'équipe disponible</string>
     <string name="no_tasks">aucune tâche disponible</string>
@@ -1056,7 +933,6 @@
     <string name="no_links_available">Aucun lien disponible</string>
     <string name="user_requested_to_join_team">%1$s a demandé à rejoindre %2$s</string>
     <string name="join_request_prefix">Demande d\'adhésion :</string>
-    <string name="new_request_to_join">Nouvelle demande pour rejoindre %s</string>
     <string name="no_news">aucune nouvelle disponible</string>
     <string name="no_surveys">aucun sondage disponible</string>
     <string name="edit_image">modifier l\'image de profil</string>
@@ -1072,21 +948,17 @@
     <string name="location_colon">emplacement:&#160;</string>
     <string name="recurring_colon">récurrent:&#160;</string>
     <string name="created_by_colon">créé par:&#160;</string>
-    <string name="failed_to_get_configuration_id">Impossible de récupérer l\'identifiant de configuration. Veuillez contacter l\'administrateur</string>
     <string name="you_want_to_connect_to_a_different_server">Vous souhaitez vous connecter à un autre serveur. Effacez les données de l\'application pour continuer</string>
     <string name="are_you_sure_you_want_to_clear_data">Êtes-vous sûr de vouloir effacer toutes les données ?</string>
     <string name="feedback_list">liste des retours</string>
     <string name="enterprise_list">liste des entreprises</string>
     <string name="list_of_teams">liste des équipes</string>
-    <string name="sign_up_to_chat">Veuillez vous inscrire pour accéder au chat IA</string>
     <string name="share_chat">partager le chat</string>
     <string name="shared_chat">chat partagé</string>
     <string name="check_apk_version">vérification de la version app</string>
     <string name="checking_server">vérification du serveur</string>
-    <string name="below_min_apk">la version de l\'app est inférieure à celle autorisée. veuillez mettre à jour l\'application vers la dernière version.</string>
     <string name="add_note">Ajouter une note (optionnel)</string>
     <string name="no_teams">équipes non disponibles</string>
-    <string name="planet_name">%s planète</string>
     <string name="no_chats">aucune discussion précédente</string>
     <string name="no_feedback">aucun commentaire disponible</string>
     <string name="empty_text" />
@@ -1094,7 +966,6 @@
     <string name="reports">rapports</string>
     <string name="number_placeholder">%d</string>
     <string name="float_placeholder">%.1f</string>
-    <string name="date_range">%1$s à %2$s</string>
     <string name="string_range">%1$s - %2$s</string>
     <string name="team_financial_report">Rapport financier de %s</string>
     <string name="report_date_details">Rapport créé le : %1$s | Mis à jour le : %2$s</string>
@@ -1109,7 +980,6 @@
     <string name="resources_size">Ressources [%d]</string>
     <string name="user_role">- %s</string>
     <string name="user_name">%1$s (%2$s)</string>
-    <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>
     <string name="three_strings">%1$s %2$s %3$s</string>
     <string name="member_description">%1$s (%2$d visites)</string>
@@ -1119,11 +989,6 @@
     <string name="dark_mode_off">Désactivé</string>
     <string name="dark_mode_on">Activé</string>
     <string name="dark_mode_follow_system">Suivre le système</string>
-    <string-array name="dark_mode_options">
-        <item>@string/dark_mode_off</item>
-        <item>@string/dark_mode_on</item>
-        <item>@string/dark_mode_follow_system</item>
-    </string-array>
     <string name="are_you_sure_you_want_to_archive_these_courses">Etes-vous sûr de vouloir archiver ces cours ?</string>
     <string name="are_you_sure_you_want_to_archive_this_course">Êtes-vous sûr de vouloir archiver ce cours ?</string>
     <string name="manual">manuel</string>
@@ -1139,12 +1004,10 @@
     <string name="sync_ruiru">🇰🇪 planet ruiru</string>
     <string name="sync_embakasi">🇰🇪 planet embakasi</string>
     <string name="sync_cambridge">🇺🇸 planet cambridge</string>
-    <string name="sync_egdirbmac">🇺🇸 planet egdirbmac</string>
     <string name="surveys_to_complete">Vous avez %1$d %2$s à compléter</string>
     <string name="show_less">montrer moins</string>
     <string name="show_more">montrer plus</string>
     <string name="server_address_content_description">adresse du serveur : %1$s</string>
-    <string name="member_only_allowed">adhérez en tant que membre pour accéder à cette fonctionnalité</string>
     <string name="select_theme_mode">sélectionner le mode de thème</string>
     <string name="beta_resources_auto_download">Téléchargement automatique des ressources bêta</string>
     <string name="course_steps">Étapes du cours</string>
@@ -1168,20 +1031,6 @@
     <string name="chat_enter_message">Entrez le message</string>
     <string name="hour">heure</string>
     <string name="hours">heures</string>
-    <array name="material_calendar_months_array">
-        <item>Janvier</item>
-        <item>Février</item>
-        <item>Mars</item>
-        <item>Avril</item>
-        <item>Mai</item>
-        <item>Juin</item>
-        <item>Juillet</item>
-        <item>Août</item>
-        <item>Septembre</item>
-        <item>Octobre</item>
-        <item>Novembre</item>
-        <item>Décembre</item>
-    </array>
     <string name="switching_off_manual_configuration_to_clear_data">La désactivation de la configuration manuelle effacera toutes les données. Êtes-vous sûr de vouloir continuer?</string>
     <string name="switching_on_manual_configuration_to_clear_data">L\'activation de la configuration manuelle effacera toutes les données. Êtes-vous sûr de vouloir continuer?</string>
     <string name="chart_description">Graphique d\'Activité de Connexion</string>
@@ -1204,7 +1053,6 @@
     <string name="total_visits_overall">Total des Visites : </string>
     <string name="most_opened_resource">Ressource La Plus Consultée : </string>
     <string name="number_of_resources_opened">Nombre de Ressources Ouvertes : </string>
-    <string name="number_of_visits">Nombre de Visites</string>
     <string name="kindly_enter_reply_message">Veuillez entrer le message de réponse</string>
     <string name="start">démarrer</string>
     <string name="continuation">continuer</string>
@@ -1229,15 +1077,12 @@
     <string name="user_verification_in_progress">Vérification de l\'utilisateur en cours. Veuillez patienter pendant que nous traitons les données.</string>
     <string name="go_to_mylibrary">Aller à Ma Bibliothèque</string>
     <string name="choose_an_option">Choisissez une option</string>
-    <string name="welcome_back">Bienvenue %1$s</string>
     <string name="welcome">Bienvenue %1$s</string>
     <string name="edit_plan">Modifier le plan</string>
     <string name="show_additional_fields">afficher les champs supplémentaires</string>
     <string name="hide_additional_fields">masquer les champs supplémentaires</string>
-    <string name="age">àge</string>
     <string name="preparing_download">Préparation du téléchargement…</string>
     <string name="downloading_files">Téléchargement des fichiers</string>
-    <string name="member_of_planet">membre de planet</string>
     <string name="edit_mission_and_services">modifier la mission et les services</string>
     <string name="this_team_has_no_description_defined">cette équipe n\'a aucune description définie</string>
     <string name="contact_preference">contact preference</string>
@@ -1251,7 +1096,6 @@
     <string name="unable_to_save_user_please_sync">Impossible d\'enregistrer l\'utilisateur, veuillez synchroniser.</string>
     <string name="server_sync_successfully">Synchronisation du serveur réussie.</string>
     <string name="server_sync_has_failed">La synchronisation du serveur a échoué.</string>
-    <string name="no_resources_to_download">Aucune ressource à télécharger</string>
     <string name="response">Réponse</string>
     <string name="full_conversation_response">Réponse complète de la conversation</string>
     <string name="add_new_event">+ Nouvel événement</string>
@@ -1262,7 +1106,6 @@
     <string name="minutes">Minutes</string>
     <string name="days">Jours</string>
     <string name="set_reminder">Définir un rappel</string>
-    <string name="reminder_set_for">Rappel défini pour %1$s à partir de maintenant</string>
     <string name="reminder_surveys_to_complete">Rappel : Vous avez %1$d %2$s à compléter</string>
 
     <plurals name="minutes">
@@ -1311,8 +1154,6 @@
     <string name="syncing_achievements">Synchronisation des réalisations…</string>
     <string name="nation_leaders">dirigeants nationaux</string>
     <string name="filter_by_label">filtrer par étiquette</string>
-    <string name="community_board">tableau communautaire</string>
-    <string name="nation_board">tableau national</string>
     <string name="is_available">%1$s est disponible. Appuyez pour continuer à apprendre</string>
     <string name="failed_to_add_please_retry">Échec de l\'ajout. Veuillez réessayer</string>
     <string name="failed_to_mark_as_read">Échec du marquage comme lu. Veuillez réessayer</string>
@@ -1321,10 +1162,8 @@
     <string name="failed_to_save_chat">Échec de l\'enregistrement de la conversation. Veuillez réessayer.</string>
     <string name="failed_to_delete_report">Échec de la suppression du rapport. Veuillez réessayer</string>
     <string name="delete_report">Supprimer le rapport</string>
-    <string name="checking_server_availability">vérification de la disponibilité du serveur…</string>
     <string name="loading_courses">Chargement des cours…</string>
     <string name="loading_teams">Chargement des équipes…</string>
-    <string name="loading_enterprises">Chargement des entreprises…</string>
     <string name="year_of_birth">Année de naissance</string>
     <string name="year_of_birth_cannot_be_empty">l\'année de naissance ne peut pas être vide</string>
     <string name="please_enter_a_valid_year_of_birth">veuillez entrer une année de naissance valide</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -125,28 +125,22 @@
     <string name="clear_tags">स्पष्ट गर्नुहोस्</string>
     <string name="add_an_achievement">साधारणता थप्नुहोस्</string>
     <string name="add_a_reference">सन्दर्भ थप्नुहोस्</string>
-    <string name="show_filter">फिल्टर देखाउनुहोस्</string>
     <string name="subjects">विषयहरू</string>
     <string name="mediums">माध्यमहरू</string>
     <string name="levels">स्तरहरू*</string>
     <string name="languages">भाषाहरू</string>
     <string name="txt_myLife">मेरो जीवन</string>
     <string name="achievements">मेरो साधारणता</string>
-    <string name="news">समाचार</string>
     <string name="references">सन्दर्भहरू</string>
     <string name="maps">नक्सा</string>
     <string name="btn_guest_login">मेहमानको रूपमा लगइन गर्नुहोस्</string>
     <string name="enter_username">प्रयोगकर्तानाम प्रविष्ट गर्नुहोस्</string>
     <string name="login">लगइन</string>
     <string name="courses">पाठ्यक्रमहरू</string>
-    <string name="enter_message_here">यहाँ सन्देश प्रविष्ट गर्नुहोस्</string>
     <string name="what_would">तपाईंलाई के साझा गर्न चाहनुहुन्छ?</string>
     <string name="delete_record">के तपाईं यो हटाउन चाहनुहुन्छ?</string>
     <string name="edit_post">पोस्ट सम्पादन गर्नुहोस्</string>
-    <string name="search_user">प्रयोगकर्ता खोज्नुहोस्</string>
     <string name="get_started">सुरु गर्नुहोस्</string>
-    <string name="enter_password">पासवर्ड प्रविष्ट गर्नुहोस्</string>
-    <string name="managerial_login">प्रबन्धक लगइन</string>
     <string name="year">वर्ष</string>
     <string name="publisher">प्रकाशक</string>
     <string name="link_to_license">लाइसेन्समा लिङ्क</string>
@@ -159,15 +153,12 @@
     <string name="status">स्थिति</string>
     <string name="title_not_compulsary">शीर्षक</string>
     <string name="add_message">सन्देश थप्नुहोस्</string>
-    <string name="enter_message">तपाईंको सन्देश यहाँ प्रविष्ट गर्नुहोस्…</string>
     <string name="added_by">थपिएको</string>
     <string name="record_audio">आवाज रेकर्ड गर्नुहोस्</string>
     <string name="record_video">भिडियो रेकर्ड गर्नुहोस्</string>
     <string name="select_gallery">ग्यालरीबाट छान्नुहोस्</string>
     <string name="add_resource">स्रोत थप्नुहोस्:</string>
     <string name="reply">उत्तर दिनुहोस्</string>
-    <string name="show_reply">उत्तरहरू देखाउनुहोस्</string>
-    <string name="show_main_conversation">मुख्य बातचीत देखाउनुहोस्</string>
     <string name="https_protocol">https://</string>
     <string name="http_protocol">http://</string>
     <string name="showing_reply_of">उत्तर देखाउँदै:</string>
@@ -199,17 +190,6 @@
     <string name="nepali">नेपाली</string>
     <string name="arabic">عربى</string>
     <string name="french">français</string>
-
-    <string-array name="info_type">
-        <item>भाषाहरू</item>
-        <item>शिक्षा</item>
-        <item>रोजगार इतिहास</item>
-        <item>बैजहरू</item>
-        <item>प्रमाणपत्रहरू</item>
-        <item>इन्टर्नशिपहरू</item>
-        <item>पुरस्कारहरू</item>
-    </string-array>
-
     <string-array name="open_With">
         <item>HTML</item>
         <item>PDF.js</item>
@@ -272,32 +252,19 @@
         <item>पढिएको</item>
         <item>नपढिएको</item>
     </string-array>
-
-    <string name="feature_not">सुविधा उपलब्ध छैन</string>
     <string name="myhealth">मेरो स्वास्थ्य</string>
-    <string name="type_name_to_search">खोजी गर्नका लागि नाम प्रविष्ट गर्नुहोस्</string>
     <string name="action">कार्य</string>
     <string name="created_on">मा सिर्जना गरिएको</string>
     <string name="name_normal">नाम</string>
     <string name="mypersonals">मेरो व्यक्तिगत</string>
     <string name="capture_image">तस्वीर कप्चर गर्नुहोस्</string>
-    <string name="team_name">टिम नाम प्रविष्ट गर्नुहोस्</string>
     <string name="resources">स्रोतहरू</string>
     <string name="button_reject">अस्वीकार गर्नुहोस्</string>
     <string name="button_accept">स्वीकार गर्नुहोस्</string>
     <string name="plan">योजना</string>
     <string name="body_temperature">शरीर तापमान (°C)</string>
-    <string name="rectally">गुदामा</string>
-    <string name="axillary">किचकिचमा</string>
-    <string name="by_ear">कान बाट</string>
-    <string name="by_skin">त्वचाबाट</string>
-    <string name="temperature_taken">तापमान लिईएको:</string>
     <string name="pulse_rate">नाडी दर (bpm)</string>
-    <string name="respiration_rate">सास्ने दर</string>
-    <string name="systolic">सिस्टोलिक</string>
-    <string name="diastolic">डायास्टोलिक</string>
     <string name="blood_pressure">रक्त चाप (सिस्टोलिक / डायास्टोलिक)</string>
-    <string name="orally">मुखबाट</string>
     <string name="save">सुरक्षित गर्नुहोस्</string>
     <string name="task">कार्य (आवश्यक)</string>
     <string name="deadline_required">समयसीमा (आवश्यक)</string>
@@ -306,14 +273,12 @@
     <string name="select_member">टिम सदस्य छान्नुहोस्</string>
     <string name="assign_task_to">कार्य खाँचो दिइएको</string>
     <string name="leader_selected">नेता चयन गरिएको</string>
-    <string name="user_removed_from_team">टिमबाट प्रयोगकर्ता हटाइयो</string>
     <string name="remove">हटाउनुहोस्</string>
     <string name="make_leader">नेता बनाउनुहोस्</string>
     <string name="mission"><![CDATA[मिशन र सेवाहरू]]></string>
     <string name="team">टटिमहरू</string>
     <string name="applicants">आवेदकहरू</string>
     <string name="finances">वित्त</string>
-    <string name="messages">सन्देशहरू</string>
     <string name="nodata">कुनै डाटा उपलब्ध छैन</string>
     <string name="note">नोट *</string>
     <string name="amount">रकम</string>
@@ -331,7 +296,6 @@
     <string name="daily">दैनिक</string>
     <string name="weekly">साप्ताहिक</string>
     <string name="recurring_frequency">आवर्तीता आवद्धता</string>
-    <string name="filter_by_date">मिति फिल्टर</string>
     <string name="date_reset">मिति रिसेट गर्नुहोस्</string>
     <string name="emergency_contact">आपतकालीन सम्पर्क</string>
     <string name="emergency_contact_details">नाम: %1$s प्रकार: %2$s सम्पर्क: %3$s</string>
@@ -339,12 +303,8 @@
     <string name="special_needs">विशेष आवश्यकता</string>
     <string name="other_need">अन्य आवश्यकता</string>
     <string name="update_health_record">स्वास्थ्य रेकर्ड अद्यावधिक गर्नुहोस्</string>
-    <string name="vital_sign">महत्वपूर्ण चिन्ह</string>
-    <string name="examination">परिक्षा</string>
     <string name="add_examination">परिक्षा थप्नुहोस्</string>
-    <string name="new_patient">अर्को सदस्य</string>
     <string name="height">उचाई (सेमि)</string>
-    <string name="width">चौडाई</string>
     <string name="vision">दृष्टि</string>
     <string name="hearing">श्रवण</string>
     <string name="vitals">महत्वपूर्ण चिन्हहरू</string>
@@ -360,17 +320,12 @@
     <string name="referrals">रेफरल</string>
     <string name="full_name">पुरा नाम</string>
     <string name="weight">वजन (केजी)</string>
-    <string name="no_records">कुनै रेकर्ड भेटिएन</string>
-    <string name="chats">च्याटहरू</string>
     <string name="select_health_member">सदस्य छान्नुहोस्</string>
-    <string name="notifications">सूचनाहरू</string>
     <string name="incorrect_ans">तपाईंले गलत उत्तर दिएका छन्, कृपया पुन: प्रयास गर्नुहोस्</string>
     <string name="diagnosis_note">निदान नोट</string>
     <string name="menu_community">समुदाय</string>
     <string name="library">पुस्तकालय</string>
     <string name="device_name">उपकरणको नाम</string>
-    <string name="enter_title">शीर्षक प्रविष्ट गर्नुहोस्</string>
-    <string name="add_link">लिङ्क थप्नुहोस्</string>
     <string name="chat">च्याट</string>
     <string name="members">सदस्यहरू</string>
     <string name="tasks">कार्यहरू</string>
@@ -507,9 +462,6 @@
         <item>भिटामिन A को कमी</item>
         <item>जिका</item>
     </string-array>
-
-    <string name="add_story">गप्तप्रतिनिधि थप्नुहोस्</string>
-    <string name="txt_myprogress">मेरो प्रगति</string>
     <string name="more_action">फिल्टर</string>
     <string name="my_progress">मेरो प्रगति</string>
     <string name="my_activity">मेरो क्रियाकलाप</string>
@@ -523,7 +475,6 @@
     <string name="use_phone_number_as_password">फोन नम्बरलाई पासवर्डको रूपमा प्रयोग गर्नुहोस्</string>
     <string name="feedback">प्रतिक्रिया</string>
     <string name="add_member">सदस्य थप्नुहोस्</string>
-    <string name="exit">"निकास पुष्टि गर्नुहोस्"</string>
     <string name="confirm_exit">के तपाईं यस टिमबाट बाहिर निस्कन चाहानुहुन्छ?</string>
     <string name="update_profile_alert">कृपया पूर्ण फिचर प्रयोग गर्नका लागि तपाईंको प्रोफाइल पूरा गर्नुहोस्</string>
     <string name="other_notes">अन्य नोट</string>
@@ -536,12 +487,9 @@
     <string name="our_courses">हाम्रा कोर्सहरू</string>
     <string name="file">फाइल: %s</string>
     <string name="recording_audio">आवाज रेकर्ड गर्दै......</string>
-    <string name="show_replies">"जवाफहरू देखाउनुहोस् "</string>
     <string name="selected">"छानिएको: "</string>
     <string name="last_sync">सर्भरसँग अन्तिम समिकरण: %s</string>
     <string name="last_syncs">अन्तिमसर्वरसिङ्क</string>
-    <string name="login_user">लगइनप्रयोगकर्तानाम</string>
-    <string name="login_password">लगइनप्रयोगकर्तापासवर्ड</string>
     <string name="no_team_available">कुनै टिम/एन्टरप्राइज उपलब्ध छैन</string>
     <string name="last_sync_date">अन्तिम सिङ्क मिति: %s</string>
     <string name="no_assignee">कुनै निर्धारित व्यक्ति छैन</string>
@@ -571,20 +519,14 @@
     <string name="csv_filename">CSV फाईलको नाम</string>
     <string name="please_enter_reply">कृपया जवाफ टाइप गर्नुहोस्</string>
     <string name="image_filename">तस्बिर फाईलको नाम</string>
-    <string name="markdown_filename">मार्कडाउन फाईलको नाम</string>
-    <string name="select_login_mode">लगइन मोड छान्नुहोस्:</string>
-    <string name="normal_mode">साधारण मोड</string>
     <string name="select_date">मिति छान्नुहोस्</string>
     <string name="public_public">सार्वजनिक</string>
-    <string name="type_asterisk">टाइप गर्नुहोस्*</string>
     <string name="joined_members_colon">संलग्न गरिएका सदस्यहरू:</string>
     <string name="title">शीर्षक</string>
     <string name="source">स्रोत</string>
     <string name="cloud_url">बादल</string>
     <string name="interval">अन्तराल</string>
     <string name="autosync">अटोसिङ्क</string>
-    <string name="autosync_off">अटोसिङ्क बन्द छ!</string>
-    <string name="autosync_on">अटोसिङ्क चालू छ</string>
     <string name="attached_resources">संलग्न गरिएका संसाधनहरू:</string>
     <string name="edit">सम्पादन गर्नुहोस्</string>
     <string name="my_achievements">मेरा सफलताहरू</string>
@@ -603,9 +545,6 @@
     <string name="download_resources">संसाधनहरू डाउनलोड गर्नुहोस्</string>
     <string name="take_test">परीक्षा दिनुहोस् [%d]</string>
     <string name="search">खोज्नुहोस्</string>
-    <string name="for_ambulance">प्रहरी</string>
-    <string name="for_police">पुलिस</string>
-    <string name="for_emergency">आपतकालीन</string>
     <string name="submit_feedback">प्रतिक्रिया पेश गर्नुहोस्</string>
     <string name="media">मिडिया:</string>
     <string name="filter">फिल्टर</string>
@@ -613,7 +552,6 @@
     <string name="subject_level">विषय स्तर</string>
     <string name="order_by_date">मिति अनुसार आदेश गर्नुहोस्</string>
     <string name="order_by_title">शीर्षक अनुसार आदेश गर्नुहोस्</string>
-    <string name="vital_signs_record">जीवनमौली चिन्हहरू रेकर्ड</string>
     <string name="exams">परीक्षाहरू</string>
     <string name="survey">सर्वेक्षण</string>
     <string name="submitted_by">पेश गर्ने:</string>
@@ -627,7 +565,6 @@
     <string name="all_task">सबै कार्यहरू</string>
     <string name="my_task">मेरो कार्य</string>
     <string name="completed">सम्पन्न भएको</string>
-    <string name="add_profile_picture">प्रोफाइल तस्बिर थप्नुहोस्</string>
     <string name="two_dash">--</string>
     <string name="n_a">N/A</string>
     <string name="request_to_join">सामेल हुनका लागि अनुरोध गर्नुहोस्</string>
@@ -636,9 +573,6 @@
     <string name="mistakes">गल्तीहरू</string>
     <string name="take_survey">सर्वेक्षण लिनुहोस्</string>
     <string name="checkbox">चेक बक्सा</string>
-    <string name="offer">प्रस्ताव</string>
-    <string name="request_for_advice">सल्लाहका लागि अनुरोध गर्नुहोस्</string>
-    <string name="no_images_to_download">डाउनलोड गर्नका लागि तस्वीरहरू छैनन्।</string>
     <string name="this_file_type_is_currently_unsupported">यो फाइल प्रकार हालसम्म समर्थित छैन</string>
     <string name="unable_to_open_resource">स्रोत खोल्न सकिएन</string>
     <string name="select_resource_to_open">"खोल्नका लागि स्रोत छनौट गर्नुहोस्: "</string>
@@ -654,10 +588,6 @@
     <string name="removed_from_mylibrary">मेरो पुस्तकालयबाट हटाइयो</string>
     <string name="removed_from_mycourse">मेरो पाठ्यक्रमबाट हटाइयो</string>
     <string name="please_allow_usages_permission_to_myplanet_app">कृपया myPlanet अनुप्रयोगमा प्रयोगको अनुमति दिनुहोस्।</string>
-    <string name="permissions_granted">अनुमतिहरू प्रदान गरिएको</string>
-    <string name="permissions_denied">अनुमतिहरू निषेध गरिएको</string>
-    <string name="unable_to_upload_resource">स्रोत अपलोड गर्न सकिएन</string>
-    <string name="please_select_link_item_from_list">कृपया सूचीबाट लिंक वस्तु छनौट गर्नुहोस्</string>
     <string name="title_is_required">शीर्षक आवश्यक छ</string>
     <string name="no_data_available">कुनै डाटा उपलब्ध छैन</string>
     <string name="are_you_sure_you_want_to_leave_these_courses">के तपाइँ निश्चित हुनुहुन्छ तपाइँ यी पाठ्यक्रमहरू हटाउन चाहनुहुन्छ?</string>
@@ -670,39 +600,20 @@
     <string name="retake_test">पुन: टेस्ट दिनुहोस् [%d]</string>
     <string name="do_you_want_to_join_this_course">के तपाइँ यो पाठ्यक्रममा सामिल हुन चाहनुहुन्छ?</string>
     <string name="join_this_course">यो पाठ्यक्रममा सामिल होइनुहोस्</string>
-    <string name="resource_not_downloaded">स्रोत डाउनलोड गरिएन।</string>
-    <string name="bulk_resource_download">बल्क स्रोत डाउनलोड।</string>
-    <string name="pending_survey">पेन्डिङ सर्वेक्षण।</string>
-    <string name="download_news_images">समाचार तस्वीरहरू डाउनलोड गर्नुहोस्।</string>
-    <string name="tasks_due">नियत कार्यहरू</string>
-    <string name="storage_critically_low">"स्टोरेज गम्भीर रूपमा कम: "</string>
-    <string name="available_please_free_up_space">उपलब्ध। कृपया ठाउँ खाली पार्नुहोस्।</string>
     <string name="storage_running_low">"स्टोरेज गम्भीर रूपमा कम: "</string>
-    <string name="available">उपलब्ध।</string>
     <string name="storage_available">"स्टोरेज उपलब्ध: "</string>
-    <string name="health_record_not_available_click_to_sync">स्वास्थ्य रेकर्ड उपलब्ध छैन। क्लिक गरेर सिंक गर्नुहोस्।</string>
-    <string name="visits">भ्रमणहरू</string>
     <string name="please_select_starting_date">"कृपया सुरु मिति छनौट गर्नुहोस्: "</string>
     <string name="read_offline_news_from">"अफलाइन समाचार पढ्नुहोस्: "</string>
     <string name="downloading_started_please_check_notification">डाउनलोड सुरु भयो, कृपया सूचना जाँच गर्नुहोस्…</string>
     <string name="file_already_exists">फाइल पहिले नै अवस्थित छ…</string>
-    <string name="syncing_health_please_wait">स्वास्थ्य सिंक गर्दै, कृपया प्रतीक्षा गर्नुहोस्…</string>
-    <string name="myhealth_synced_successfully">मेरो स्वास्थ्य सफलतापूर्वक सिंक गरियो</string>
-    <string name="myhealth_synced_failed">मेरो स्वास्थ्य सिंक असफल भयो</string>
-    <string name="no_due_tasks">कुनै नियत कार्यहरू छैनन्</string>
-    <string name="due_tasks">नियत कार्यहरू</string>
-    <string name="feature_not_available_for_guest_user">अतिथि प्रयोगकर्ता को लागि विशेषता उपलब्ध छैन</string>
     <string name="feature_not_available">विशेषता उपलब्ध छैन</string>
-    <string name="health_record_not_available_sync_health_data">स्वास्थ्य रेकर्ड उपलब्ध छैन, स्वास्थ्य डाटा सिंक गर्नुहोस्?</string>
     <string name="sync">सिंक</string>
-    <string name="got_it">सम्म सम्म</string>
     <string name="session_expired">सत्र समाप्त भयो।</string>
     <string name="downloading_started_please_check_notificati">डाउनलोड सुरु भयो, कृपया सूचना जाँच गर्नुहोस्…</string>
     <string name="dictionary">शब्दकोश</string>
     <string name="list_size">सूची आकार %d</string>
     <string name="word_not_available_in_our_database">शब्द हाम्रो डाटाबेसमा उपलब्ध छैन।</string>
     <string name="description_is_required">विवरण आवश्यक छ</string>
-    <string name="start_time_is_required">समय आवश्यक छ</string>
     <string name="meetup_added">मिलन सम्मेलन थपियो</string>
     <string name="meetup_not_added">मिलन सम्मेलन होइन थपियो</string>
     <string name="add_transaction">लेखा थप्नुहोस्</string>
@@ -716,20 +627,14 @@
     <string name="complete">समाप्त</string>
     <string name="no_questions_available">कुनै प्रश्नहरू उपलब्ध छैन</string>
     <string name="please_select_write_your_answer_to_continue">कृपया जारी राख्नका लागि आफ्नो उत्तर चयन गर्नुहोस् / लेख्नुहोस्</string>
-    <string name="graded">ग्रेड गरिएको</string>
-    <string name="pending">पेन्डिङ</string>
     <string name="user_profile_updated">प्रयोगकर्ता प्रोफाइल अद्यावधिक गरियो</string>
     <string name="unable_to_update_user">प्रयोगकर्ता अपडेट गर्न सकिएन</string>
-    <string name="date_n_a">मिति: N/A</string>
     <string name="please_enter_feedback">कृपया प्रतिक्रिया दिनुहोस्।</string>
     <string name="feedback_priority_is_required">प्रतिक्रिया प्राथमिकता आवश्यक छ।</string>
     <string name="feedback_type_is_required">प्रतिक्रिया प्रकार आवश्यक छ।</string>
     <string name="thank_you_your_feedback_has_been_submitted">धन्यवाद, तपाईंको प्रतिक्रिया सबमिट गरिएको छ</string>
     <string name="feedback_saved">प्रतिक्रिया सुरक्षित गरियो…</string>
-    <string name="name_colon">"नाम: "</string>
     <string name="email_colon">"इमेल: "</string>
-    <string name="phone_number_colon">"फोन नंबर: "</string>
-    <string name="resource_saved_successfully">स्रोत सफलतापूर्वक सुरक्षित गरियो</string>
     <string name="level_is_required">स्तर आवश्यक छ</string>
     <string name="subject_is_required">विषय आवश्यक छ</string>
     <string name="enter_resource_detail">स्रोत विवरण राख्नुहोस्</string>
@@ -766,12 +671,6 @@
     प्रयोगशाला परीक्षण: %8$s\n
     अध्ययनहरू: %9$s\n
 </string>
-
-    <string name="diagnosis_colon">"निदान : "</string>
-    <string name="treatments_colon">"उपचारहरू: "</string>
-    <string name="medications_colon">"औषधि: "</string>
-    <string name="immunizations_colon">"प्रतिरक्षा टिका: "</string>
-    <string name="invalid_input">अमान्य इनपुट</string>
     <string name="blood_pressure_should_be_numeric_systolic_diastolic">रक्तचाप अंशांकीय हुनुपर्छ सिस्टोलिक/डायस्टोलिक</string>
     <string name="blood_pressure_should_be_systolic_diastolic">रक्तचाप सिस्टोलिक/डायस्टोलिक हुनुपर्छ</string>
     <string name="bp_must_be_between_60_40_and_300_200">रक्तचाप ६०/४० र ३००/२०० को बीचमा हुनुपर्छ</string>
@@ -795,14 +694,11 @@
     <string name="no_data_available_please_click_button_to_add_new_resource_in_mypersonal">कुनै डाटा उपलब्ध छैन, कृपया मेरो व्यक्तिगतमा नयाँ स्रोत थप्नका लागि + बटनमा क्लिक गर्नुहोस्।</string>
     <string name="label_added">लेबल थपियो।</string>
     <string name="please_enter_message">कृपया सन्देश लेख्नुहोस्</string>
-    <string name="new_not_available">नयाँ उपलब्ध छैन</string>
-    <string name="hide_add_story">कथा थप्नुहोस् लुकाउनुहोस्</string>
     <string name="no_items">कुनै वस्तुहरू छैनन्</string>
     <string name="record_survey">सर्वेक्षण रेकर्ड गर्नुहोस्</string>
     <string name="survey_sent_to_users">सर्वेक्षण सदस्यहरूलाई पठाइयो</string>
     <string name="wifi_is_turned_off_saving_battery_power">वाईफाई बन्द गरिएको छ। बैट्री शक्ति बचाउँदै</string>
     <string name="turning_on_wifi_please_wait">वाईफाई चालू गर्दैछ। कृपया प्रतीक्षा गर्नुहोस्…</string>
-    <string name="unable_to_connect_to_planet_wifi">प्लानेट वाईफाईसँग सम्बन्ध स्थापित गर्न सकिएन।</string>
     <string name="you_are_now_connected">"तपाईं अब सम्बन्धित छन् "</string>
     <string name="press_back_again_to_exit">बाहिर निस्कनको लागि पुन: प्रेस गर्नुहोस्</string>
     <string name="it_has_been_more_than">"यो भन्दा बढी समय भएको छ "</string>
@@ -811,7 +707,6 @@
     <string name="okay">ठिक छ</string>
     <string name="connect_to_the_server_over_wifi_and_sync_your_device_to_continue">जारी राख्नका लागि WiFi मार्फत सर्भरसँग कनेक्ट गर्नुहोस् र आफ्नो डिभाइस सिंक गर्नुहोस्</string>
     <string name="please_enter_server_url_first">कृपया पहिलोमा सर्भर URL लेख्नुहोस्।</string>
-    <string name="this_device_not_configured_properly_please_check_and_sync">यो डिभाइस सही ढंगले कन्फिगर गरिएको छैन। कृपया जाँच गर्नुहोस् र सिंक गर्नुहोस्।</string>
     <string name="username_cannot_be_empty">प्रयोगकर्ता नाम खाली हुनसक्दैन</string>
     <string name="unable_to_login">लगइन गर्न सकिएन</string>
     <string name="planet_server_not_reachable">प्लानेट सर्भर सम्पर्क गर्न सकिएन।</string>
@@ -820,14 +715,11 @@
     <string name="please_wait">कृपया प्रतीक्षा गर्नुहोस्…</string>
     <string name="update_later">पछील्लो अद्यावधिक गर्नुहोस्</string>
     <string name="checking_version">संस्करण जाँच गर्दै…</string>
-    <string name="please_enter_your_password">कृपया आफ्नो पासवर्ड लेख्नुहोस्</string>
     <string name="downloading">"डाउनलोड गर्दै… "</string>
     <string name="pin_is_required">पिन आवश्यक छ।</string>
     <string name="invalid_url">अमान्य URL</string>
     <string name="please_enter_valid_url_to_continue">कृपया जारी राख्नका लागि वैध URL लेख्नुहोस्।</string>
     <string name="uploading_data_to_server_please_wait">सर्भरमा डाटा अपलोड गर्दै, कृपया प्रतीक्षा गर्नुहोस्…</string>
-    <string name="uploading_activities_to_server_please_wait">सर्भरमा गतिविधिहरू अपलोड गर्दै, कृपया प्रतीक्षा गर्नुहोस्…</string>
-    <string name="connecting_to_server">सर्भरसँग कनेक्ट गर्दै…</string>
     <string name="check_the_server_address_again_what_i_connected_to_wasn_t_the_planet_server">कृपया पुन: सर्भर ठेगाना जाँच गर्नुहोस्। म जुन सर्भरसँग कनेक्ट गरें भनेर थिएन त्यो प्लानेट सर्भर थिएन</string>
     <string name="device_couldn_t_reach_local_server">डिभाइसले सर्भरसम्म पुग्न सकेन। स्थानीय सर्भर (समुदाय) को लागि तपाईं सही Wi-Fi नेटवर्कमा जडित हुनुहुन्छ कि छैन जाँच गर्नुहोस्।</string>
     <string name="device_couldn_t_reach_nation_server">डिभाइसले सर्भरसम्म पुग्न सकेन। इन्टरनेटमा जडित हुनुहुन्छ कि छैन जाँच गर्नुहोस् र पुन: प्रयास गर्नुहोस्।</string>
@@ -835,7 +727,6 @@
     <string name="syncing_data_please_wait">डाटा सिंक गरिंदै, कृपया प्रतीक्षा गर्नुहोस्…</string>
     <string name="sync_failed">सिंक असफल भयो</string>
     <string name="sync_completed">सिंक सम्पन्न भयो</string>
-    <string name="message_is_required">सन्देश आवश्यक छ</string>
     <string name="team_leader">टिम नेता</string>
     <string name="select_resource">"स्रोत छान्नुहोस्: "</string>
     <string name="add">थप्नुहोस्</string>
@@ -850,7 +741,6 @@
     <string name="task_s_successfully">काम %s सफलतापूर्वक</string>
     <string name="task_deleted_successfully">काम सफलतापूर्वक हटाइयो</string>
     <string name="requested">अनुरोध गरियो</string>
-    <string name="resources_colon">"स्रोतहरू: "</string>
     <string name="left_team">टोलीबाट बाहिर गएको</string>
     <string name="enter_enterprise_s_name">उद्यमको नाम लेख्नुहोस्</string>
     <string name="what_is_your_team_s_plan">तपाईंको टोलीको योजना के हो?</string>
@@ -861,7 +751,6 @@
     <string name="name_is_required">नाम आवश्यक छ</string>
     <string name="team_created">टोली सिर्जना गरियो</string>
     <string name="please_select_gender">कृपया लिङ्ग चयन गर्नुहोस्</string>
-    <string name="please_enter_a_username">कृपया प्रयोगकर्ता नाम लेख्नुहोस्</string>
     <string name="invalid_username">अमान्य प्रयोगकर्ता नाम</string>
     <string name="please_enter_a_password">कृपया पासवर्ड लेख्नुहोस्</string>
     <string name="password_doesn_t_match">पासवर्ड मेल खाँदैन</string>
@@ -870,9 +759,7 @@
     <string name="add_reference">संदर्भ थप्नुहोस्</string>
     <string name="add_achievement">साफल्य थप्नुहोस्</string>
     <string name="select_resources">"स्रोतहरू छान्नुहोस्: "</string>
-    <string name="user_not_available_in_our_database">हाम्रो डाटाबेसमा प्रयोगकर्ता उपलब्ध छैन</string>
     <string name="date_of_birth">"जन्म मिति: "</string>
-    <string name="unable_to_play_audio">अडियो प्ले गर्न सकिएन।</string>
     <string name="unable_to_load">"लोड गर्न सकिएन "</string>
     <string name="recording_started">रेकर्डिंग सुरु भयो....</string>
     <string name="ole_is_recording_audio">ओले अडियो रेकर्ड गर्दैछ</string>
@@ -981,30 +868,22 @@
     <string name="auto_sync_device">स्वचालित सिङ्क यन्त्र</string>
     <string name="beta_functionality">बीटा कार्यक्षमता</string>
     <string name="main_controls">मुख्य नियन्त्रणहरू</string>
-    <string name ="select_user_to_login"> लगइन गर्न प्रयोगकर्ता चयन गर्नुहोस्</string>
     <string name ="dismiss"> खारेज गर्नुहोस्</string>
-    <string name="gps_is_settings">GPS सेटिङहरू हो</string>
-    <string name="gps_is_not_enabled_do_you_want_to_go_to_settings_menu">GPS सक्षम गरिएको छैन। के तपाईँ सेटिङ मेनुमा जान चाहनुहुन्छ?</string>
     <string name="available_space_colon">उपलब्ध ठाउँ: </string>
     <string name="community_leaders">सामुदायिक नेताहरू</string>
     <string name="services">सेवाहरू</string>
-    <string name="survey_taken">सर्वेक्षण लिइएको</string>
     <plurals name="survey_taken_count">
         <item quantity="one">सर्वेक्षण %d पटक लिइयो</item>
         <item quantity="other">सर्वेक्षण %d पटक लिइयो</item>
     </plurals>
-    <string name="times">पल्टीहरू</string>
-    <string name="time">समय</string>
     <string name="ai_chat">AI Chat</string>
     <string name="kindly_give_a_rating">कृपया मूल्याङ्कन दिनुहोस्</string>
     <string name="must_start_with_letter_or_number">पात्र वा नम्बरसँग सुरु गर्नु पर्दछ</string>
     <string name="only_letters_numbers_and_are_allowed">केवल अक्षरहरू a- z, नम्बर र "_" , "." , "-" पार्स्याद छ</string>
-    <string name="config_not_available">कन्फिगरेसन उपलब्ध छैन।</string>
     <string name="unselect_all">सबै चयन गर्दिन</string>
     <string name="select_all">सबै चयन गर्नुहोस्</string>
     <string name="request_failed_please_retry">अनुरोध असफल भयो, कृपया पुन: प्रयास गर्नुहोस्</string>
     <string name="confirm_removal">हटाउनु हेरदैछ</string>
-    <string name="returning_user">पुनराबृत्ति गर्ने प्रयोगकर्ता</string>
     <string name="send_to_nation">तपाइको उपलब्धिहरूलाई देशसँग साझा गर्न अनुमति दिनुहोस्</string>
     <string name="image_resource">तस्वीर स्रोत</string>
     <string name="play_audio">आडियो प्ले गर्नुहोस्</string>
@@ -1039,7 +918,6 @@
     <string name="trial_period_ended">अनुमति अवधि समाप्त भयो! निरन्तरताको लागि दर्ता पूरा गर्नुहोस्</string>
     <string name="drag">%1$s तान्नुहोस्</string>
     <string name="visibility_of">%1$s को दृश्यता टगल गर्नुहोस्</string>
-    <string name="actions_menu">क्रियाहरूको मेनु</string>
     <string name="icon">%1$s आइकन</string>
     <string name="select_res_course">%1$s चयन गर्नुहोस्</string>
     <string name="kindly_enter_message">कृपया सन्देश प्रविष्ट गर्नुहोस्</string>
@@ -1047,7 +925,6 @@
     <string name="no_courses">कुनै पाठ्यक्रम उपलब्ध छैन</string>
     <string name="no_resources">कुनै स्रोतहरू उपलब्ध छैनन्</string>
     <string name="no_finance_record">वित्तीय रेकर्ड उपलब्ध छैन</string>
-    <string name="no_stories">कुनै कथाहरू उपलब्ध छैनन्</string>
     <string name="no_team_courses">कुनै टिम पाठ्यक्रमहरू उपलब्ध छैनन्</string>
     <string name="no_team_resources">कुनै टिम स्रोतहरू उपलब्ध छैनन्</string>
     <string name="no_tasks">कुनै कामहरू उपलब्ध छैनन्</string>
@@ -1056,7 +933,6 @@
     <string name="no_links_available">लिङ्कहरू उपलब्ध छैनन्</string>
     <string name="user_requested_to_join_team">%1$s ले %2$s मा सामेल हुन अनुरोध गरेको छ</string>
     <string name="join_request_prefix">सामेल हुने अनुरोध:</string>
-    <string name="new_request_to_join">%s मा सामेल हुने नयाँ अनुरोध</string>
     <string name="no_news">समाचार उपलब्ध छैन</string>
     <string name="no_surveys">सर्वेक्षण उपलब्ध छैन</string>
     <string name="edit_image">प्रोफाइल तस्वीर सम्पादन गर्नुहोस्</string>
@@ -1072,21 +948,17 @@
     <string name="location_colon">स्थान:&#160;</string>
     <string name="recurring_colon">आवर्तमान:&#160;</string>
     <string name="created_by_colon">बनाएको:&#160;</string>
-    <string name="failed_to_get_configuration_id">बनावट आईडी प्राप्त गर्न असफल भयो। कृपया व्यवस्थापकसँग सम्पर्क गर्नुहोस्।</string>
     <string name="you_want_to_connect_to_a_different_server">तपाईं अर्को सर्भरमा जडान गर्न चाहनुहुन्छ। अगाडि बढ्नका लागि एपको डेटा मेटाउनुहोस्</string>
     <string name="are_you_sure_you_want_to_clear_data">के तपाईं सबै डाटा हटाउन निश्चित हुनुहुन्छ?</string>
     <string name="feedback_list">प्रतिक्रिया सूची</string>
     <string name="enterprise_list">उद्यम सूची</string>
     <string name="list_of_teams">टोलीहरूको सूची</string>
-    <string name="sign_up_to_chat">कृपया एआई च्याटमा पहुँच गर्न साइन अप गर्नुहोस्।</string>
     <string name="share_chat">च्याट साझेदारी गर्नुहोस्</string>
     <string name="shared_chat">साझेदारी गरिएको कुराकानी</string>
     <string name="check_apk_version">एप संस्करण जाँच गर्दै</string>
     <string name="checking_server">सर्भर जाँच गर्दै</string>
-    <string name="below_min_apk">एप संस्करण अनुमत संस्करणभन्दा कम छ। कृपया अनुप्रयोगलाई नवीनतम संस्करणमा अद्यावधिक गर्नुहोस्।</string>
     <string name="add_note">नोट थप्नुहोस् (वैकल्पिक)</string>
     <string name="no_teams">टोलीहरू उपलब्ध छैनन्</string>
-    <string name="planet_name">%s ग्रह</string>
     <string name="no_chats">अघिल्ला कुराकानीहरू छैनन्</string>
     <string name="no_feedback">कुनै प्रतिक्रिया उपलब्ध छैन</string>
     <string name="empty_text" />
@@ -1094,7 +966,6 @@
     <string name="reports">रिपोर्टहरू</string>
     <string name="number_placeholder">%d</string>
     <string name="float_placeholder">%.1f</string>
-    <string name="date_range">%1$s देखि %2$s</string>
     <string name="string_range">%1$s - %2$s</string>
     <string name="team_financial_report">%s वित्तीय रिपोर्ट</string>
     <string name="report_date_details">%1$s मा बनाइएको रिपोर्ट | %2$s मा अद्यावधिक गरिएको</string>
@@ -1109,7 +980,6 @@
     <string name="resources_size">स्रोतहरू [%d]</string>
     <string name="user_role">- %s</string>
     <string name="user_name">%1$s (%2$s)</string>
-    <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>
     <string name="three_strings">%1$s %2$s %3$s</string>
     <string name="member_description">%1$s (%2$d भ्रमण)</string>
@@ -1119,11 +989,6 @@
     <string name="dark_mode_off">बन्द</string>
     <string name="dark_mode_on">खुला</string>
     <string name="dark_mode_follow_system">प्रणालीको पालना गर्नुहोस्</string>
-    <string-array name="dark_mode_options">
-        <item>@string/dark_mode_off</item>
-        <item>@string/dark_mode_on</item>
-        <item>@string/dark_mode_follow_system</item>
-    </string-array>
     <string name="are_you_sure_you_want_to_archive_these_courses">के तपाइँ यी पाठ्यक्रमहरू संग्रह गर्न निश्चित हुनुहुन्छ?</string>
     <string name="are_you_sure_you_want_to_archive_this_course">के तपाइँ निश्चित हुनुहुन्छ कि तपाइँ यो पाठ्यक्रम संग्रह गर्न चाहनुहुन्छ?</string>
     <string name="manual">हस्तपुस्तिका</string>
@@ -1139,12 +1004,10 @@
     <string name="sync_ruiru">🇰🇪 planet ruiru</string>
     <string name="sync_embakasi">🇰🇪 planet embakasi</string>
     <string name="sync_cambridge">🇺🇸 planet cambridge</string>
-    <string name="sync_egdirbmac">🇺🇸 planet egdirbmac</string>
     <string name="surveys_to_complete">तपाईंको %1$d %2$s पूरा गर्न बाँकी छ</string>
     <string name="show_less">कम देखाउनुहोस्</string>
     <string name="show_more">थप देखाउनुहोस्</string>
     <string name="server_address_content_description">सर्भर ठेगाना: %1$s</string>
-    <string name="member_only_allowed">यो सुविधा प्रयोग गर्न सदस्यको रूपमा सामेल हुनुहोस्</string>
     <string name="select_theme_mode">थिम मोड चयन गर्नुहोस्</string>
     <string name="beta_resources_auto_download">बीटा स्रोतहरू स्वत: डाउनलोड</string>
     <string name="course_steps">पाठ्यक्रम चरणहरू</string>
@@ -1168,20 +1031,6 @@
     <string name="chat_enter_message">सन्देश प्रविष्ट गर्नुहोस्</string>
     <string name="hour">घण्टा</string>
     <string name="hours">घण्टा</string>
-    <array name="material_calendar_months_array">
-        <item>जनवरी</item>
-        <item>फेब्रुअरी</item>
-        <item>मार्च</item>
-        <item>अप्रिल</item>
-        <item>मई</item>
-        <item>जुन</item>
-        <item>जुलाई</item>
-        <item>अगस्ट</item>
-        <item>सेप्टेम्बर</item>
-        <item>अक्टोबर</item>
-        <item>नोभेम्बर</item>
-        <item>डिसेम्बर</item>
-    </array>
     <string name="switching_off_manual_configuration_to_clear_data">म्यानुअल कन्फिगरेसन बन्द गर्दा सबै डाटा मेटिनेछ, के तपाईं निश्चित रूपमा जारी राख्न चाहनुहुन्छ?</string>
     <string name="switching_on_manual_configuration_to_clear_data">म्यानुअल कन्फिगरेसन सुरु गर्दा सबै डाटा मेटिनेछ, के तपाईं निश्चित रूपमा जारी राख्न चाहनुहुन्छ?</string>
     <string name="chart_description">लगइन गतिविधि चार्ट</string>
@@ -1204,7 +1053,6 @@
     <string name="total_visits_overall">कुल भ्रमण : </string>
     <string name="most_opened_resource">सबैभन्दा धेरै खोलेको स्रोत : </string>
     <string name="number_of_resources_opened">खोलिएका स्रोतहरूको संख्या : </string>
-    <string name="number_of_visits">भ्रमणहरूको संख्या</string>
     <string name="kindly_enter_reply_message">कृपया प्रतिक्रिया सन्देश प्रवेश गर्नुहोस्</string>
     <string name="start">सुरु गर्नुहोस्</string>
     <string name="continuation">जारी राख्नुहोस्</string>
@@ -1229,15 +1077,12 @@
     <string name="user_verification_in_progress">प्रयोगकर्ता प्रमाणीकरण प्रक्रिया भइरहेको छ। कृपया डेटा प्रशोधन भइरहेसम्म प्रतीक्षा गर्नुहोस्।</string>
     <string name="go_to_mylibrary">मेरो पुस्तकालयमा जानुहोस्</string>
     <string name="choose_an_option">एउटा विकल्प छान्नुहोस्</string>
-    <string name="welcome_back">स्वागतम् %1$s</string>
     <string name="welcome">स्वागतम् %1$s</string>
     <string name="edit_plan">योजना सम्पादन गर्नुहोस्</string>
     <string name="show_additional_fields">थप क्षेत्रहरू देखाउनुहोस्</string>
     <string name="hide_additional_fields">थप क्षेत्रहरू लुकाउनुहोस्</string>
-    <string name="age">उमेर</string>
     <string name="preparing_download">डाउनलोडको तयारी गर्दै…</string>
     <string name="downloading_files">फाइलहरू डाउनलोड हुँदैछन्</string>
-    <string name="member_of_planet">planet को सदस्य</string>
     <string name="edit_mission_and_services">मिशन र सेवाहरू सम्पादन गर्नुहोस्</string>
     <string name="this_team_has_no_description_defined">यस टिमको कुनै विवरण परिभाषित गरिएको छैन</string>
     <string name="contact_preference">contact preference</string>
@@ -1251,7 +1096,6 @@
     <string name="unable_to_save_user_please_sync">प्रयोगकर्ता बचत गर्न सकिएन, कृपया सिंक गर्नुहोस्।</string>
     <string name="server_sync_successfully">सर्भर सफलतापूर्वक समिकरण गरियो।</string>
     <string name="server_sync_has_failed">सर्भर समिकरण असफल भयो।</string>
-    <string name="no_resources_to_download">डाउनलोड गर्न कुनै स्रोत छैन</string>
     <string name="response">उत्तर</string>
     <string name="full_conversation_response">पूर्ण वार्तालाप उत्तर</string>
     <string name="add_new_event">+ नयाँ कार्यक्रम</string>
@@ -1262,7 +1106,6 @@
     <string name="minutes">Daqiiqado</string>
     <string name="days">Maalmaha</string>
     <string name="set_reminder">Deji xasuusin</string>
-    <string name="reminder_set_for">Xasuusin ayaa loo dejiyay %1$s laga bilaabo hadda</string>
     <string name="reminder_surveys_to_complete">Xasuusin: Waxaad haysataa %1$d %2$s oo la buuxinayo</string>
 
     <plurals name="minutes">
@@ -1311,8 +1154,6 @@
     <string name="syncing_achievements">उपलब्धिहरू समिकरण गर्दै…</string>
     <string name="nation_leaders">राष्ट्रका नेता</string>
     <string name="filter_by_label">लेबलद्वारा फिल्टर गर्नुहोस्</string>
-    <string name="community_board">समुदाय बोर्ड</string>
-    <string name="nation_board">राष्ट्रिय बोर्ड</string>
     <string name="is_available">%1$s उपलब्ध छ। सिकाइ जारी राख्न ट्याप गर्नुहोस्।</string>
     <string name="failed_to_add_please_retry">थप गर्न असफल भयो। कृपया फेरि प्रयास गर्नुहोस्</string>
     <string name="failed_to_mark_as_read">पढिएको रूपमा चिन्ह लगाउन असफल भयो। कृपया फेरि प्रयास गर्नुहोस्</string>
@@ -1321,10 +1162,8 @@
     <string name="failed_to_save_chat">कुराकानी सुरक्षित गर्न असफल भयो। कृपया फेरि प्रयास गर्नुहोस्।</string>
     <string name="failed_to_delete_report">प्रतिवेदन मेटाउन असफल भयो। कृपया फेरि प्रयास गर्नुहोस्</string>
     <string name="delete_report">प्रतिवेदन मेटाउनुहोस्</string>
-    <string name="checking_server_availability">सर्भर उपलब्धता जाँच गर्दै…</string>
     <string name="loading_courses">पाठ्यक्रमहरू लोड हुँदैछन्…</string>
     <string name="loading_teams">टीमहरू लोड गर्दै…</string>
-    <string name="loading_enterprises">उद्यमहरू लोड गर्दै…</string>
     <string name="year_of_birth">जन्म वर्ष</string>
     <string name="year_of_birth_cannot_be_empty">जन्म वर्ष खाली हुन सक्दैन</string>
     <string name="please_enter_a_valid_year_of_birth">कृपया मान्य जन्म वर्ष प्रविष्ट गर्नुहोस्</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -125,28 +125,22 @@
     <string name="clear_tags">Nadiifi</string>
     <string name="add_an_achievement">Kudar Guul</string>
     <string name="add_a_reference">Kudar Tixraac</string>
-    <string name="show_filter">Show Filter</string>
     <string name="subjects">Mawduucyo</string>
     <string name="mediums">Mediums</string>
     <string name="levels">Heerarka*</string>
     <string name="languages">Luqadaha</string>
     <string name="txt_myLife">Nolosheyda</string>
     <string name="achievements">Dhamaanada</string>
-    <string name="news">Wararka</string>
     <string name="references">Tixraacyo</string>
     <string name="maps">Maps</string>
     <string name="btn_guest_login">Marti ahaan u soo gal</string>
     <string name= "enter_username">Geli Magaca isticmaalaha</string>
     <string name="login">Giri</string>
     <string name="courses">Koorsooyin</string>
-    <string name="enter_message_here">halkan ku gali fariinta</string>
     <string name="what_would">maxaad jeceshahay inaad wadaagto?</string>
     <string name="delete_record">Ma hubtaa inaad rabto inaad tirtirto kuwa soo socda?</string>
     <string name="edit_post">wax ka beddel boostada</string>
-    <string name="search_user">raadiye isticmaale</string>
     <string name="get_started">BILAAB</string>
-    <string name="enter_password">Geli Password</string>
-    <string name="managerial_login">Maareeyaha Soo gal</string>
     <string name="year">Sannad</string>
     <string name="publisher">Daabace</string>
     <string name="link_to_license">Link to shatiga</string>
@@ -159,15 +153,12 @@
     <string name="status">xaalad</string>
     <string name="title_not_compulsary">Cuqaal</string>
     <string name="add_message">Ku dar fariin</string>
-    <string name="enter_message">halkan ku geli fariintaada..</string>
     <string name="added_by">Waxaa ku daray</string>
     <string name="record_audio">Maqalka duubi</string>
     <string name="record_video">Diiwaangeli Video</string>
     <string name="select_gallery">Ka dooro Gallery</string>
     <string name="add_resource">Kudar Ilaha:</string>
     <string name="reply">jawaab</string>
-    <string name="show_reply">muuji jawaabaha</string>
-    <string name="show_main_conversation">muuji wada hadalka ugu muhiimsan</string>
     <string name="https_protocol">https://</string>
     <string name="http_protocol">http://</string>
     <string name="showing_reply_of">muujinaya jawaabta:</string>
@@ -199,17 +190,6 @@
     <string name="nepali">नेपाली</string>
     <string name="arabic">عربى</string>
     <string name="french">français</string>
-
-    <string-array name="info_type">
-        <item>Afka</item>
-        <item>Waxbarashada</item>
-        <item>Taariikhda Shaqada</item>
-        <item>Lambarada</item>
-        <item>Dhameystirada</item>
-        <item>Maqal</item>
-        <item>Dhamaan</item>
-    </string-array>
-
     <string-array name="open_With">
         <item>HTML</item>
         <item>PDF.js</item>
@@ -272,32 +252,19 @@
         <item>la akhriyey</item>
         <item>aan la akhriyin</item>
     </string-array>
-
-    <string name="feature_not">Heerkaan lama helin</string>
     <string name="myhealth">Caafimaadkaan</string>
-    <string name="type_name_to_search">Geli magaca si aad u raadto</string>
     <string name="action">Hawlgal</string>
     <string name="created_on">Lagu sameeyey</string>
     <string name="name_normal">Magaca</string>
     <string name="mypersonals">Dhamaan xogtaaga caafimaadka</string>
     <string name="capture_image">Sawir ku xir</string>
-    <string name="team_name">Geli magaca kooxda</string>
     <string name="resources">Vifijo</string>
     <string name="button_reject">Diida</string>
     <string name="button_accept">Qabto</string>
     <string name="plan">Qorshe</string>
     <string name="body_temperature">Dhererka Badan (°C)</string>
-    <string name="rectally">Dherer (Geedho)</string>
-    <string name="axillary">Dherer (Xoogga)</string>
-    <string name="by_ear">Dherer (Cilmiga)</string>
-    <string name="by_skin">Dherer (Guriyaha)</string>
-    <string name="temperature_taken">Dhererka lagu qaaday:</string>
     <string name="pulse_rate">Dhererka Calaamadda (bpm)</string>
-    <string name="respiration_rate">Dhererka Helay</string>
-    <string name="systolic">Dhererka xiran</string>
-    <string name="diastolic">Dhererka hoostooda</string>
     <string name="blood_pressure">Dhererka Dhiiga (Xiran/Hoostooda)</string>
-    <string name="orally">Dherer (Go\'do)</string>
     <string name="save">Keyd</string>
     <string name="task">Hawlo (lazim)</string>
     <string name="deadline_required">Dib-u-heshiisi (lazim)</string>
@@ -306,14 +273,12 @@
     <string name="select_member">Dooro Xubin Kooxda</string>
     <string name="assign_task_to">Hawlo Laga Soo Diray</string>
     <string name="leader_selected">Ra\'is lagu doortay</string>
-    <string name="user_removed_from_team">User ka baxsaday kooxda</string>
     <string name="remove">Ka saar</string>
     <string name="make_leader">Gacan-siin</string>
     <string name="mission"><![CDATA[Mission & Adeegyada]]></string>
     <string name="team">Kooxaha</string>
     <string name="applicants">Loo baahan yahay</string>
     <string name="finances">Maaliyadda</string>
-    <string name="messages">Fariimaha</string>
     <string name="nodata">Wax ma jirin</string>
     <string name="note">Fariin *</string>
     <string name="amount">Masaafad</string>
@@ -331,7 +296,6 @@
     <string name="daily">Maalinle</string>
     <string name="weekly">Toddobaad</string>
     <string name="recurring_frequency">Inta soo bixiyay oo socota</string>
-    <string name="filter_by_date">Filtiirka Tariikhda</string>
     <string name="date_reset">Dib-u-eegis Taariikhda</string>
     <string name="emergency_contact">Xiriirka Degdegga ah</string>
     <string name="emergency_contact_details">Magaca: %1$s Nooca: %2$s Xiriir: %3$s</string>
@@ -339,12 +303,8 @@
     <string name="special_needs">Dib-u-xuso</string>
     <string name="other_need">Dib-u-heshiisi kale</string>
     <string name="update_health_record">Cusbooneysiinta Dabeecada Caafimaadka</string>
-    <string name="vital_sign">Calaamadaha Dhererka</string>
-    <string name="examination">Baaris</string>
     <string name="add_examination">Kudar Baaris</string>
-    <string name="new_patient">Qof kasta oo cusub</string>
     <string name="height">Dhamaan (cm)</string>
-    <string name="width">Wiil (cm)</string>
     <string name="vision">Ruuxa</string>
     <string name="hearing">Gurinaan</string>
     <string name="vitals">Calaamaddaha</string>
@@ -360,17 +320,12 @@
     <string name="referrals">Dabaqyo</string>
     <string name="full_name">Magaca Buugaagta oo Dhan</string>
     <string name="weight">Cirka (kg)</string>
-    <string name="no_records">Wax ma jirin</string>
-    <string name="chats">Sawiro</string>
     <string name="select_health_member">Dooro Xubin</string>
-    <string name="notifications">Ciidamo</string>
     <string name="incorrect_ans">Jawaab aan sax ahayn, fadlan isku day</string>
     <string name="diagnosis_note">Fariin Baaris</string>
     <string name="menu_community">Bulshada</string>
     <string name="library">Maktabada</string>
     <string name="device_name">Magaca Qalabka</string>
-    <string name="enter_title">Geli lambarka</string>
-    <string name="add_link">Kudar Xiriir</string>
     <string name="chat">Sawir</string>
     <string name="members">Xubinayaasha</string>
     <string name="tasks">Hawlgalaha</string>
@@ -507,9 +462,6 @@
         <item>Vitamin A La’aan</item>
         <item>Zika</item>
     </string-array>
-
-    <string name="add_story">Ku Dar Hees</string>
-    <string name="txt_myprogress">Halistaaga</string>
     <string name="more_action">Gaaji</string>
     <string name="my_progress">Halistaaga</string>
     <string name="my_activity">Halistaagayga</string>
@@ -523,7 +475,6 @@
     <string name="use_phone_number_as_password">Isticmaal Lambarka Taleefonka Sirta</string>
     <string name="feedback">Rajayn</string>
     <string name="add_member">Ku Dar Xubin</string>
-    <string name="exit">"Xaqiiji Bixinta"</string>
     <string name="confirm_exit">Ma hubtaa inaad ka tashato kooxan?</string>
     <string name="update_profile_alert">Fadlan Buuxi Profaylkaaga si aad u hesho tallaabooyin oo dhan</string>
     <string name="other_notes">Fikirro Kale</string>
@@ -536,12 +487,9 @@
     <string name="our_courses">Koorsadayaashay</string>
     <string name="file">Faylka: %s</string>
     <string name="recording_audio">Furayaasha Sireyska......</string>
-    <string name="show_replies">"Muuqaalka Jawaabo "</string>
     <string name="selected">"La Xulo: "</string>
     <string name="last_sync">Iswaafajintii ugu dambeysay ee server-ka: %s</string>
     <string name="last_syncs">Halkan jeedadda ee Hore</string>
-    <string name="login_user">Magaca Login</string>
-    <string name="login_password">Furaha Erayga Login</string>
     <string name="no_team_available">Koox / Mashruuc la jira ma jiro</string>
     <string name="last_sync_date">Taariikhda Hore ee Iskaashiga: %s</string>
     <string name="no_assignee">Qof oo xoolo aan la yeelan</string>
@@ -571,20 +519,14 @@
     <string name="csv_filename">Magaca Faylasha CSV</string>
     <string name="please_enter_reply">Fadlan geli jawaab</string>
     <string name="image_filename">Magaca Faylasha Sawirka</string>
-    <string name="markdown_filename">Magaca Faylasha Markdown</string>
-    <string name="select_login_mode">Xulo Habka Loginka:</string>
-    <string name="normal_mode">Habka Caadi</string>
     <string name="select_date">Xulo Taariikhda</string>
     <string name="public_public">Ciidamo</string>
-    <string name="type_asterisk">Nooc*</string>
     <string name="joined_members_colon">Xubinayaasha la kufsaday:</string>
     <string name="title">Cinwaanka</string>
     <string name="source">Soo Saar</string>
     <string name="cloud_url">daruur</string>
     <string name="interval">Dhibic</string>
     <string name="autosync">Iskaashiga Hore</string>
-    <string name="autosync_off">Iskaashiga Off!</string>
-    <string name="autosync_on">Iskaashiga On</string>
     <string name="attached_resources">Adeegyada la dhamaystiray:</string>
     <string name="edit">Tafatir</string>
     <string name="my_achievements">Halistaaga</string>
@@ -603,9 +545,6 @@
     <string name="download_resources">Dhig Resources</string>
     <string name="take_test">Barto Imtixaan [%d]</string>
     <string name="search">Raadi</string>
-    <string name="for_ambulance">Ciidanka Masaajid</string>
-    <string name="for_police">Ciidanka Boolis</string>
-    <string name="for_emergency">Ciidamada Daryeelka</string>
     <string name="submit_feedback">Rajayn Qoraalka</string>
     <string name="media">Warbaahinta:</string>
     <string name="filter">Gaaji</string>
@@ -613,7 +552,6 @@
     <string name="subject_level">Darajo Mawduuc</string>
     <string name="order_by_date">Ku qoraalka Taariikhda</string>
     <string name="order_by_title">Ku qoraalka Cinwaanka</string>
-    <string name="vital_signs_record">Dastuurka Xalinta Asaasiga ah</string>
     <string name="exams">Imtixaanada</string>
     <string name="survey">Soo Gudbi</string>
     <string name="submitted_by">La Diyaariyay</string>
@@ -627,7 +565,6 @@
     <string name="all_task">Dhammaan Xogta</string>
     <string name="my_task">Xogtaagayga</string>
     <string name="completed">La Dhameystiray</string>
-    <string name="add_profile_picture">Ku Dar Sawirka Profaylka</string>
     <string name="two_dash">--</string>
     <string name="n_a">N/A</string>
     <string name="request_to_join">Codso Inaad Ku Dhaqmeyso</string>
@@ -636,9 +573,6 @@
     <string name="mistakes">Khalad</string>
     <string name="take_survey">Ku Dar Survey</string>
     <string name="checkbox">Furaha Qalbigan</string>
-    <string name="offer">Ku Dar Hawl</string>
-    <string name="request_for_advice">Codso Fikir</string>
-    <string name="no_images_to_download">Ma jiraan sawirro si aad kuugu diiwaangasho.</string>
     <string name="this_file_type_is_currently_unsupported">Nooca faylkaan waa hadda aan taageerinno.</string>
     <string name="unable_to_open_resource">Lama oggola in aad furto ilaha xogta.</string>
     <string name="select_resource_to_open">"Xulasho ka doona xogta si aad u furato: "</string>
@@ -654,10 +588,6 @@
     <string name="removed_from_mylibrary">Ka tirtiray Maktabaddayda</string>
     <string name="removed_from_mycourse">Ka tirtiray kursiga kayga</string>
     <string name="please_allow_usages_permission_to_myplanet_app">Fadlan ogow xidhiidhka adeegga myPlanet.</string>
-    <string name="permissions_granted">Xidhiidhka Lagu Celiyay</string>
-    <string name="permissions_denied">Xidhiidhka Lagu Midan</string>
-    <string name="unable_to_upload_resource">Ma awoodi doontid inaad ku diiwaangashid xogta.</string>
-    <string name="please_select_link_item_from_list">Fadlan xulo xogta isku xirka listka.</string>
     <string name="title_is_required">Magaca waa loo baahan yahay</string>
     <string name="no_data_available">Wax macluumaad ah ayaa lama helin</string>
     <string name="are_you_sure_you_want_to_leave_these_courses">Ma hubtaa inaad ka baxdo ka dhamaan kursiyadaan?</string>
@@ -670,39 +600,20 @@
     <string name="retake_test">Dib u habayn Imtixaanka [%d]</string>
     <string name="do_you_want_to_join_this_course">Ma rabtaa inaad ka qaadato kursigaan?</string>
     <string name="join_this_course">Ka qaad kursigaan</string>
-    <string name="resource_not_downloaded">Xogta ma la diyaariyay.</string>
-    <string name="bulk_resource_download">Soo deg diyaarinta xogta oo dhan.</string>
-    <string name="pending_survey">Raadinta hadda la kordhin</string>
-    <string name="download_news_images">Soo deg sawirro wararka.</string>
-    <string name="tasks_due">Hawsha due ah.</string>
-    <string name="storage_critically_low">"Xaddida maaliyadeed waa ku xoogaa: "</string>
-    <string name="available_please_free_up_space">habeen aan waxba kaga helin. Fadlan fal khadkaada.</string>
     <string name="storage_running_low">"Xaddida maaliyadeed waa tagaa: "</string>
-    <string name="available">habeen aan waxba kaga helin.</string>
     <string name="storage_available">"Xaddida maaliyadeed waa heli kara: "</string>
-    <string name="health_record_not_available_click_to_sync">Diiwaanka caafimaadka lama helin. Guji si aad u iska saarto.</string>
-    <string name="visits">Dabooliyo</string>
     <string name="please_select_starting_date">"Fadlan dooro taariikhda hore : "</string>
     <string name="read_offline_news_from">"Akhri wararka gudaha ka hor : "</string>
     <string name="downloading_started_please_check_notification">Degsaday soo degista, fadlan check notifikishanka…</string>
     <string name="file_already_exists">Faylku horey ayaa jira…</string>
-    <string name="syncing_health_please_wait">Dib u bilaabma caafimaadka, fadlan sug…</string>
-    <string name="myhealth_synced_successfully">Caafimaadkaygii ayaa la isku dejiyey si guul ah</string>
-    <string name="myhealth_synced_failed">Caafimaadkaygii ayaa la isku dhejiyey si aanan guulin</string>
-    <string name="no_due_tasks">Hawsho kama jiraan</string>
-    <string name="due_tasks">Hawshooyin la jira</string>
-    <string name="feature_not_available_for_guest_user">Fayraska aan la heli karin xubnaha khaas ah</string>
     <string name="feature_not_available">Fayraska Ma heli karaan</string>
-    <string name="health_record_not_available_sync_health_data">Diiwaanka caafimaadka lama helin, dib u hagrees data caafimaadka?</string>
     <string name="sync">Dib u hagrees</string>
-    <string name="got_it">GUUL</string>
     <string name="session_expired">Ku dhacday wakhti la isla xiriiray.</string>
     <string name="downloading_started_please_check_notificati">Degsaday soo degista, fadlan check notifikishanka…</string>
     <string name="dictionary">Qaamuus</string>
     <string name="list_size">Cabbirka liiska %d</string>
     <string name="word_not_available_in_our_database">Ereyadan ma haysano daabacaadkeena.</string>
     <string name="description_is_required">Sharraxaad waa loo baahan yahay</string>
-    <string name="start_time_is_required">Waqtiga bilaabid waa loo baahan yahay</string>
     <string name="meetup_added">Ku daray la isku day</string>
     <string name="meetup_not_added">Meetup lama darin</string>
     <string name="add_transaction">Ku daray Hawlaha</string>
@@ -716,20 +627,14 @@
     <string name="complete">Buuxi</string>
     <string name="no_questions_available">Suuqyada ma haysano</string>
     <string name="please_select_write_your_answer_to_continue">Fadlan dooro / qor jawaabtaada si aad u sii wadato</string>
-    <string name="graded">Isku diiwaangelin</string>
-    <string name="pending">Inta aan dib u celin</string>
     <string name="user_profile_updated">Macluumaadka isticmaalaha oo la cusboonaysiin</string>
     <string name="unable_to_update_user">Lama heli karo isticmaalaha cusbooneysan</string>
-    <string name="date_n_a">Taariikh: M/H</string>
     <string name="please_enter_feedback">Fadlan geli warbixinteeda</string>
     <string name="feedback_priority_is_required">Tabinta faahfaahinta waa loo baahan yahay</string>
     <string name="feedback_type_is_required">Nooca faahfaahinta waa loo baahan yahay</string>
     <string name="thank_you_your_feedback_has_been_submitted">Waad ku mahadsan tahay, warbixinteeda waa la soo diray</string>
     <string name="feedback_saved">Warbixinta lagu kayd geliyay…</string>
-    <string name="name_colon">"Magac: "</string>
     <string name="email_colon">"Email: "</string>
-    <string name="phone_number_colon">"Lambarka taleefonka: "</string>
-    <string name="resource_saved_successfully">Khadka lagu keydiyey si guul ah</string>
     <string name="level_is_required">Heerka waa loo baahan yahay</string>
     <string name="subject_is_required">Mawduuca waa loo baahan yahay</string>
     <string name="enter_resource_detail">Geli faahfaahinta khadka</string>
@@ -766,12 +671,6 @@
     Baaritaanka Laboratooriga: %8$s\n
     Daraasaadka: %9$s\n
 </string>
-
-    <string name="diagnosis_colon">"Dib u dhigaasho: "</string>
-    <string name="treatments_colon">"Dib-u-helidda: "</string>
-    <string name="medications_colon">"Ciidammada: "</string>
-    <string name="immunizations_colon">"Ciidammada ka hortagga: "</string>
-    <string name="invalid_input">Kalluun aan sax ahayn</string>
     <string name="blood_pressure_should_be_numeric_systolic_diastolic">Dhacdo dheecaanka waa in uu noocan yahay (systolic/diastolic)</string>
     <string name="blood_pressure_should_be_systolic_diastolic">Dhacdo dheecaanka waa in uu noocan yahay (systolic/diastolic)</string>
     <string name="bp_must_be_between_60_40_and_300_200">Dhacdo dheecaan waa in uu ka dhiman yahay 60/40 ilaa 300/200</string>
@@ -795,14 +694,11 @@
     <string name="no_data_available_please_click_button_to_add_new_resource_in_mypersonal">Macluumaad waxba ma haysano, fadlan guji xidiga + si aad u dhejiso khadka cusub ee ku jira maktabaddayda.</string>
     <string name="label_added">Dabool halkan loo dejinayey</string>
     <string name="please_enter_message">Fadlan geli farriimaha</string>
-    <string name="new_not_available">Xogta cusub ma haysano</string>
-    <string name="hide_add_story">Soo saar sheeko cusub</string>
     <string name="no_items">Qeybtaan ma jiro</string>
     <string name="record_survey">Gali suuragal</string>
     <string name="survey_sent_to_users">Suuragal loo diray isticmaale</string>
     <string name="wifi_is_turned_off_saving_battery_power">Wifi waxaa la soo casishay. Khaariidka betareegee ku sug</string>
     <string name="turning_on_wifi_please_wait">Wifi lagu daboolo, fadlan sug…</string>
-    <string name="unable_to_connect_to_planet_wifi">Lama soo galin karo wifi-ka Geedka.</string>
     <string name="you_are_now_connected">Hadda waxaad la xiriirayaa</string>
     <string name="press_back_again_to_exit">Daboolka BACK wixii hore ugu celi</string>
     <string name="it_has_been_more_than">waxaa ka badan </string>
@@ -811,7 +707,6 @@
     <string name="okay">Waayo</string>
     <string name="connect_to_the_server_over_wifi_and_sync_your_device_to_continue">Ku xiran serverka oo ku sug WiFi si aad u hagreesid qalabkaaga si aad uga sii wadato</string>
     <string name="please_enter_server_url_first">Fadlan geli URL-ka serverka ee ugu horaysa.</string>
-    <string name="this_device_not_configured_properly_please_check_and_sync">Qalabkanan lama hagaagin dib-u-hagreeska, fadlan hagaaj dheeri</string>
     <string name="username_cannot_be_empty">Magaca isticmaasha waa in lagu jiro waxaan kusoo haysano</string>
     <string name="unable_to_login">Lama helayno gashad</string>
     <string name="planet_server_not_reachable">Serverka Geedka lama heli karo</string>
@@ -820,14 +715,11 @@
     <string name="please_wait">Fadlan sug....</string>
     <string name="update_later">Guji dib iminka</string>
     <string name="checking_version">Rajoo marka</string>
-    <string name="please_enter_your_password">Fadlan geli ereygaaga sirta</string>
     <string name="downloading">Soo degsado.... "</string>
     <string name="pin_is_required">Pini waa loo baahan yahay</string>
     <string name="invalid_url">URL-ka ma jiro</string>
     <string name="please_enter_valid_url_to_continue">Fadlan geli URL-ka sax ah si aad uga sii wadato.</string>
     <string name="uploading_data_to_server_please_wait">Qiimeynta data-ka ee serverka, fadlan sug.....</string>
-    <string name="uploading_activities_to_server_please_wait">Qiimeynta waxqabadkiisa ee serverka, fadlan sug…</string>
-    <string name="connecting_to_server">Ku xiran serverka....</string>
     <string name="check_the_server_address_again_what_i_connected_to_wasn_t_the_planet_server">Xaqiij marka hore cinwaankaga serverka ah, waxaana aan la xiriirnay seriver Geed ah.</string>
     <string name="device_couldn_t_reach_local_server">qalabku ma uusan gaari karin server-ka. hubi inaad ku xiran tahay shabakadda Wi-Fi-ga saxda ah ee server-ka maxalliga ah (bulshada).</string>
     <string name="device_couldn_t_reach_nation_server">qalabku ma uusan gaari karin server-ka. hubi inaad ku xiran tahay internetka oo dib isku day.</string>
@@ -835,7 +727,6 @@
     <string name="syncing_data_please_wait">Dib-u-hagreeska macluumaadka, fadlan sug…</string>
     <string name="sync_failed">Dib-u-hagreeska khaatimay</string>
     <string name="sync_completed">Dib-u-hagreeska la kahadsanayaa</string>
-    <string name="message_is_required">Farriin waa loo baahan yahay</string>
     <string name="team_leader">Xoghayaha kooxda</string>
     <string name="select_resource">Xulo khadka</string>
     <string name="add">Ku dar</string>
@@ -850,7 +741,6 @@
     <string name="task_s_successfully">Xog %s oo keliya</string>
     <string name="task_deleted_successfully">Xog la tirtiray si guul ah</string>
     <string name="requested">Waqti ku dejiyey</string>
-    <string name="resources_colon">"Muujiyaha: "</string>
     <string name="left_team">Kooxda iska saaray</string>
     <string name="enter_enterprise_s_name">Fadlan geli magaca shirkadda</string>
     <string name="what_is_your_team_s_plan">Ninka kooxdaada waa maxay qorsheheeda?</string>
@@ -861,7 +751,6 @@
     <string name="name_is_required">Magacu waa loo baahan yahay</string>
     <string name="team_created">Kooxda loo sameeyay</string>
     <string name="please_select_gender">Fadlan xulo jinsiga</string>
-    <string name="please_enter_a_username">Fadlan geli magaca isticmaalaha</string>
     <string name="invalid_username">Magac isticmaalaha aan sax ahayn</string>
     <string name="please_enter_a_password">Fadlan geli ereyga sirta ah</string>
     <string name="password_doesn_t_match">Ereyga sirta ah ayaa hore u dhigay</string>
@@ -870,9 +759,7 @@
     <string name="add_reference">Ku dar rasmiga ah</string>
     <string name="add_achievement">Ku dar guulaysta</string>
     <string name="select_resources">"Xullo khadka: "</string>
-    <string name="user_not_available_in_our_database">Isticmaale aan la helin data base-nayagu</string>
     <string name="date_of_birth">"Taariikhda dhalashada: "</string>
-    <string name="unable_to_play_audio">Lama helin qaab dhismeedka</string>
     <string name="unable_to_load">"Lama helin "</string>
     <string name="recording_started">Xog ku dhamaystiran....</string>
     <string name="ole_is_recording_audio">Ole wuxuu kayd dhigayaa qoraallo</string>
@@ -981,30 +868,22 @@
     <string name="auto_sync_device">Shidka saxda ah</string>
     <string name="beta_functionality">Waxqabadka Beta</string>
     <string name="main_controls">Xakamaynta ugu weyn</string>
-    <string name="select_user_to_login">Dooro isticmaale si aad u gasho</string>
     <string name="dismiss">saar</string>
-    <string name="gps_is_settings">GPS waa Settings</string>
-    <string name="gps_is_not_enabled_do_you_want_to_go_to_settings_menu">GPS lama hawlgelin. Ma rabtaa inaad aado menu settings?</string>
     <string name="available_space_colon">Boos la heli karo: </string>
     <string name="community_leaders">Hogaamiyayaasha bulshada</string>
     <string name="services">adeegyo</string>
-    <string name="survey_taken">Soo dhaweyn laga qaadayo</string>
     <plurals name="survey_taken_count">
         <item quantity="one">Sahan ayaa la qaaday %d jeer</item>
         <item quantity="other">Sahan ayaa la qaaday %d jeer</item>
     </plurals>
-    <string name="times">magaalada</string>
-    <string name="time">waqtiga</string>
     <string name="ai_chat">AI Chat</string>
     <string name="kindly_give_a_rating">si naxariis leh u bixi rating</string>
     <string name="must_start_with_letter_or_number">Waa in la bilaabo lambarka ama tirada</string>
     <string name="only_letters_numbers_and_are_allowed">Waa kaliya luuqadaha a-z, lambarka, "_", ".", iyo "-" ayaa la oggolaaday</string>
-    <string name="config_not_available">Configuración no disponible.</string>
     <string name="unselect_all">Dhammaad Maareey</string>
     <string name="select_all">Dhammaad Dhammaadee</string>
     <string name="request_failed_please_retry">Codka lama yimaado, fadlan dib ugu ciyaar</string>
     <string name="confirm_removal">Xaqiiji tirtirka</string>
-    <string name="returning_user">Isticmaale sare leh</string>
     <string name="send_to_nation">Geli codbixiyeyaashaaga qaranka</string>
     <string name="image_resource">deriska sawirka</string>
     <string name="play_audio">bixi codka</string>
@@ -1039,7 +918,6 @@
     <string name="trial_period_ended">Muddadii tijaabada ahayd way dhammaatay! Fadlan dhammaystir diiwaangelinta si aad u sii wadato</string>
     <string name="drag">jiid %1$s</string>
     <string name="visibility_of">toggle muuqashada %1$s</string>
-    <string name="actions_menu">menu falalka</string>
     <string name="icon">astan %1$s</string>
     <string name="select_res_course">xulo %1$s</string>
     <string name="kindly_enter_message">Fadlan geli farriinta</string>
@@ -1047,7 +925,6 @@
     <string name="no_courses">ma jiro koorsad la helin</string>
     <string name="no_resources">ma jiraan ilaha la heli karo</string>
     <string name="no_finance_record">hisaabka ma jiro</string>
-    <string name="no_stories">sheekooyinka ma jiraan</string>
     <string name="no_team_courses">koorsadaha kooxiga ma jiraan</string>
     <string name="no_team_resources">ilaha kooxiga ma jiraan</string>
     <string name="no_tasks">tallabada ma jiraan</string>
@@ -1056,7 +933,6 @@
     <string name="no_links_available">Isku xirka lama heli karo</string>
     <string name="user_requested_to_join_team">%1$s ayaa codsaday ku biirista %2$s</string>
     <string name="join_request_prefix">Codsi ku biirid:</string>
-    <string name="new_request_to_join">Codsi cusub oo lagu biirayo %s</string>
     <string name="no_news">warka ma jiraan</string>
     <string name="no_surveys">saamayn ma jiraan</string>
     <string name="edit_image">tubinta sawirka xogta muuqaalka</string>
@@ -1072,21 +948,17 @@
     <string name="location_colon">goobta:&#160;</string>
     <string name="recurring_colon">ku dhaqan:&#160;</string>
     <string name="created_by_colon">lagu sameeyay:&#160;</string>
-    <string name="failed_to_get_configuration_id">Ma jirin ID-ka qaababka. Fadlan la xiriir maamulaha</string>
     <string name="you_want_to_connect_to_a_different_server">Waxaad rabtaa inaad ku xirto server kale. Tirtir xogta barnaamijka si aad u sii wadato</string>
     <string name="are_you_sure_you_want_to_clear_data">Ma hubtaa inaad diiwaangelisid dhammaan xogta?</string>
     <string name="feedback_list">liiska raadinta</string>
     <string name="enterprise_list">liiska ganacsiyada</string>
     <string name="list_of_teams">liiska kooxaha</string>
-    <string name="sign_up_to_chat">Fadlan isdiiwaangeli si aad u hesho sheekada AI.</string>
     <string name="share_chat">la wadaag sheekaysiga</string>
     <string name="shared_chat">sheeko wadaag ah</string>
     <string name="check_apk_version">hubinta nooca app</string>
     <string name="checking_server">hubinta server-ka</string>
-    <string name="below_min_apk">nooca app-ga waa ka hooseeyaa kan la oggol yahay. fadlan cusbooneysii app-ka nooca ugu dambeeya.</string>
     <string name="add_note">Ku dar falanqeey (ixtiyaacsi ah)</string>
     <string name="no_teams">kooxaha aan la heli karin</string>
-    <string name="planet_name">%s Meerah</string>
     <string name="no_chats">ma jiraan wada sheekaysi hore</string>
     <string name="no_feedback">wax jawaab celin ah lama hayo</string>
     <string name="empty_text" />
@@ -1094,7 +966,6 @@
     <string name="reports">warbixino</string>
     <string name="number_placeholder">%d</string>
     <string name="float_placeholder">%.1f</string>
-    <string name="date_range">%1$s ilaa %2$s</string>
     <string name="string_range">%1$s - %2$s</string>
     <string name="team_financial_report">Warbixin lacagta ee %s</string>
     <string name="report_date_details">Warbixin lagu sameeyay: %1$s | La cusbooneysiiyay: %2$s</string>
@@ -1109,7 +980,6 @@
     <string name="resources_size">Xogta [%d]</string>
     <string name="user_role">- %s</string>
     <string name="user_name">%1$s (%2$s)</string>
-    <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>
     <string name="three_strings">%1$s %2$s %3$s</string>
     <string name="member_description">%1$s (%2$d booqasho)</string>
@@ -1119,11 +989,6 @@
     <string name="dark_mode_off">Dami</string>
     <string name="dark_mode_on">Shidi</string>
     <string name="dark_mode_follow_system">Raac Nidaamka</string>
-    <string-array name="dark_mode_options">
-        <item>@string/dark_mode_off</item>
-        <item>@string/dark_mode_on</item>
-        <item>@string/dark_mode_follow_system</item>
-    </string-array>
     <string name="are_you_sure_you_want_to_archive_these_courses">Ma hubtaa inaad rabto inaad kaydiso koorsooyinkan?</string>
     <string name="are_you_sure_you_want_to_archive_this_course">Ma hubtaa inaad rabto inaad kaydiso koorsadan?</string>
     <string name="manual">buug</string>
@@ -1139,12 +1004,10 @@
     <string name="sync_ruiru">🇰🇪 planet ruiru</string>
     <string name="sync_embakasi">🇰🇪 planet embakasi</string>
     <string name="sync_cambridge">🇺🇸 planet cambridge</string>
-    <string name="sync_egdirbmac">🇺🇸 planet egdirbmac</string>
     <string name="surveys_to_complete">Waxaad haysataa %1$d %2$s oo ay tahay inaad dhammaystirto</string>
     <string name="show_less">tus wax yar</string>
     <string name="show_more">tus wax badan</string>
     <string name="server_address_content_description">cinwaanka serverka: %1$s</string>
-    <string name="member_only_allowed">ku biir xubin ahaan si aad u hesho astaamahan</string>
     <string name="select_theme_mode">dooro qaabka mawduuca</string>
     <string name="beta_resources_auto_download">Soo dejinta otomaatiga ah ee khayraadka beta</string>
     <string name="course_steps">Talaabooyinka Koorsada</string>
@@ -1168,20 +1031,6 @@
     <string name="chat_enter_message">Geli fariin</string>
     <string name="hour">saac</string>
     <string name="hours">saacadood</string>
-    <array name="material_calendar_months_array">
-        <item>Janaayo</item>
-        <item>Febraayo</item>
-        <item>Maarso</item>
-        <item>Abriil</item>
-        <item>May</item>
-        <item>Juun</item>
-        <item>Luulyo</item>
-        <item>Agoosto</item>
-        <item>Sebtember</item>
-        <item>Oktoobar</item>
-        <item>Noofembar</item>
-        <item>Disembar</item>
-    </array>
     <string name="switching_off_manual_configuration_to_clear_data">daminta habka gacanta ah waxay tirtiri doontaa dhammaan xogta, ma hubtaa inaad rabto inaad sii waddo?</string>
     <string name="switching_on_manual_configuration_to_clear_data">furista habka gacanta ah waxay tirtiri doontaa dhammaan xogta, ma hubtaa inaad rabto inaad sii waddo?</string>
     <string name="chart_description">Shaxda Waxqabadka Gelitaanka</string>
@@ -1204,7 +1053,6 @@
     <string name="total_visits_overall">Tirada Booqashooyinka : </string>
     <string name="most_opened_resource">Kheyraadka Ugu Badan ee La Furay : </string>
     <string name="number_of_resources_opened">Tirada Kheyraadka La Furay : </string>
-    <string name="number_of_visits">Tirada Booqashooyinka</string>
     <string name="kindly_enter_reply_message">Fadlan geli farriinta jawaabta</string>
     <string name="start">bilow</string>
     <string name="continuation">sii wad</string>
@@ -1229,15 +1077,12 @@
     <string name="user_verification_in_progress">Hubinta isticmaalaha ayaa socota. Fadlan sug inta aan xogta ka shaqeynayno.</string>
     <string name="go_to_mylibrary">Tag Maktabaddayda</string>
     <string name="choose_an_option">Dooro ikhtiyaar</string>
-    <string name="welcome_back">Soo dhawoow %1$s</string>
     <string name="welcome">Soo dhawoow %1$s</string>
     <string name="edit_plan">Wax ka beddel qorshaha</string>
     <string name="show_additional_fields">muuji beeraha dheeraadka ah</string>
     <string name="hide_additional_fields">qari beeraha dheeraadka ah</string>
-    <string name="age">da\'da</string>
     <string name="preparing_download">Diyaarinaya soo dejinta…</string>
     <string name="downloading_files">Faylasha ayaa la soo dejinayaa</string>
-    <string name="member_of_planet">xubin ka mid ah planet</string>
     <string name="edit_mission_and_services">wax ka beddel himilada iyo adeegyada</string>
     <string name="this_team_has_no_description_defined">kooxdani ma laha sharaxaad la cayimay</string>
     <string name="contact_preference">contact preference</string>
@@ -1251,7 +1096,6 @@
     <string name="unable_to_save_user_please_sync">Lama kaydin karo isticmaalaha, fadlan isku dheelli tir.</string>
     <string name="server_sync_successfully">Adeegaha si guul leh ayuu u hagaagay.</string>
     <string name="server_sync_has_failed">Isku-dubbaridka server-ka wuu fashilmay.</string>
-    <string name="no_resources_to_download">Ma jiro ilo la soo dejiyo</string>
     <string name="response">Jawaab</string>
     <string name="full_conversation_response">Jawaabta wada hadalka oo dhameystiran</string>
     <string name="add_new_event">+ Dhacdo cusub</string>
@@ -1262,7 +1106,6 @@
     <string name="minutes">मिनेटहरू</string>
     <string name="days">दिनहरू</string>
     <string name="set_reminder">रिमाइन्डर सेट गर्नुहोस्</string>
-    <string name="reminder_set_for">अहिलेबाट %1$s को लागि रिमाइन्डर सेट गरियो</string>
     <string name="reminder_surveys_to_complete">रिमाइन्डर: तपाईंसँग %1$d %2$s पूरा गर्न बाँकी छ</string>
 
     <plurals name="minutes">
@@ -1311,8 +1154,6 @@
     <string name="syncing_achievements">Waxaa la daabacayaa guulaha…</string>
     <string name="nation_leaders">hoggaamiyeyaasha qaranka</string>
     <string name="filter_by_label">shaandhee calaamadda</string>
-    <string name="community_board">guddiga bulshada</string>
-    <string name="nation_board">guddiga qaranka</string>
     <string name="is_available">%1$s waa la heli karaa. Taabo si aad u sii wadato barashada</string>
     <string name="failed_to_add_please_retry">Ku guuldareystay in lagu daro. Fadlan isku day mar kale</string>
     <string name="failed_to_mark_as_read">Ku guuldareystay calaamadeynta sidii la akhriyey. Fadlan isku day mar kale</string>
@@ -1321,10 +1162,8 @@
     <string name="failed_to_save_chat">Ku guuldareystay kaydinta wada hadalka. Fadlan isku day mar kale.</string>
     <string name="failed_to_delete_report">Ku guuldareystay tirtiridda warbixinta. Fadlan isku day mar kale</string>
     <string name="delete_report">Tirtir warbixinta</string>
-    <string name="checking_server_availability">la hubiyo helitaanka serverka…</string>
     <string name="loading_courses">Koorsada ayaa la rarayaa…</string>
     <string name="loading_teams">Soo rarxarida kooxaha…</string>
-    <string name="loading_enterprises">Soo rarxarida ganacsiyada…</string>
     <string name="year_of_birth">Sannadka dhalashada</string>
     <string name="year_of_birth_cannot_be_empty">sannadka dhalashada ma noqon karo mid madhan</string>
     <string name="please_enter_a_valid_year_of_birth">fadlan geli sannad dhalasho oo sax ah</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,28 +125,22 @@
     <string name="clear_tags">Clear</string>
     <string name="add_an_achievement">Add an Achievement</string>
     <string name="add_a_reference">Add a Reference</string>
-    <string name="show_filter">Show Filter</string>
     <string name="subjects">Subjects</string>
     <string name="mediums">Mediums</string>
     <string name="levels">Levels*</string>
     <string name="languages">Languages</string>
     <string name="txt_myLife">myLife</string>
     <string name="achievements">myAchievements</string>
-    <string name="news">News</string>
     <string name="references">References</string>
     <string name="maps">Maps</string>
     <string name="btn_guest_login">Login As Guest</string>
     <string name="enter_username">Enter Username</string>
     <string name="login">Login</string>
     <string name="courses">Courses</string>
-    <string name="enter_message_here">Enter message here</string>
     <string name="what_would">What would you like to share?</string>
     <string name="delete_record">Are you sure you want to delete the following ?</string>
     <string name="edit_post">Edit Post</string>
-    <string name="search_user">Search user</string>
     <string name="get_started">GET STARTED</string>
-    <string name="enter_password">Enter Password</string>
-    <string name="managerial_login">Manager Login</string>
     <string name="year">Year</string>
     <string name="publisher">Publisher</string>
     <string name="link_to_license">Link to license</string>
@@ -159,15 +153,12 @@
     <string name="status">Status</string>
     <string name="title_not_compulsary">Title</string>
     <string name="add_message">Add Message</string>
-    <string name="enter_message">Enter your message here..</string>
     <string name="added_by">Added By</string>
     <string name="record_audio">Record Audio</string>
     <string name="record_video">Record Video</string>
     <string name="select_gallery">Select From Gallery</string>
     <string name="add_resource">Add Resource:</string>
     <string name="reply">Reply</string>
-    <string name="show_reply">Show Replies</string>
-    <string name="show_main_conversation">Show main conversation</string>
     <string name="https_protocol">https://</string>
     <string name="http_protocol">http://</string>
     <string name="showing_reply_of">Showing reply of:</string>
@@ -199,17 +190,6 @@
     <string name="nepali">नेपाली</string>
     <string name="arabic">عربى</string>
     <string name="french">français</string>
-
-    <string-array name="info_type">
-        <item>Languages</item>
-        <item>Education</item>
-        <item>Employment History</item>
-        <item>Badges</item>
-        <item>Certificates</item>
-        <item>Internships</item>
-        <item>Awards</item>
-    </string-array>
-
     <string-array name="open_With">
         <item>HTML</item>
         <item>PDF.js</item>
@@ -272,32 +252,19 @@
         <item>read</item>
         <item>unread</item>
     </string-array>
-
-    <string name="feature_not">Feature not available</string>
     <string name="myhealth">myHealth</string>
-    <string name="type_name_to_search">Type name to search</string>
     <string name="action">Action</string>
     <string name="created_on">Created On</string>
     <string name="name_normal">Name</string>
     <string name="mypersonals">myPersonals</string>
     <string name="capture_image">Capture Image</string>
-    <string name="team_name">Enter Team Name</string>
     <string name="resources">Resources</string>
     <string name="button_reject">Reject</string>
     <string name="button_accept">Accept</string>
     <string name="plan">Plan</string>
     <string name="body_temperature">Body Temperature (°C)</string>
-    <string name="rectally">Rectally</string>
-    <string name="axillary">Axillary</string>
-    <string name="by_ear">By ear</string>
-    <string name="by_skin">By skin</string>
-    <string name="temperature_taken">Temperature taken:</string>
     <string name="pulse_rate">Pulse Rate (bpm)</string>
-    <string name="respiration_rate">Respiration Rate</string>
-    <string name="systolic">Systolic</string>
-    <string name="diastolic">Diastolic</string>
     <string name="blood_pressure">Blood Pressure (Systolic/Diastolic)</string>
-    <string name="orally">Orally</string>
     <string name="save">Save</string>
     <string name="task">Task (required)</string>
     <string name="deadline_required">Deadline (required)</string>
@@ -306,14 +273,12 @@
     <string name="select_member">Select Team Member</string>
     <string name="assign_task_to">Task Assigned to</string>
     <string name="leader_selected">Leader selected</string>
-    <string name="user_removed_from_team">User removed from team</string>
     <string name="remove">Remove</string>
     <string name="make_leader">Make Leader</string>
     <string name="mission"><![CDATA[Mission & Services]]></string>
     <string name="team">Teams</string>
     <string name="applicants">Applicants</string>
     <string name="finances">Finances</string>
-    <string name="messages">messages</string>
     <string name="nodata">No data available</string>
     <string name="note">Note *</string>
     <string name="amount">Amount</string>
@@ -331,7 +296,6 @@
     <string name="daily">Daily</string>
     <string name="weekly">Weekly</string>
     <string name="recurring_frequency">Recurring Frequency</string>
-    <string name="filter_by_date">Date Filter</string>
     <string name="date_reset">Date Reset</string>
     <string name="emergency_contact">Emergency Contact</string>
     <string name="emergency_contact_details">Name: %1$s Type: %2$s Contact: %3$s</string>
@@ -339,12 +303,8 @@
     <string name="special_needs">Special Needs</string>
     <string name="other_need">Other Needs</string>
     <string name="update_health_record">Update Health Record</string>
-    <string name="vital_sign">Vital Signs</string>
-    <string name="examination">Examination</string>
     <string name="add_examination">Add Examination</string>
-    <string name="new_patient">Next Member</string>
     <string name="height">Height (cm)</string>
-    <string name="width">Width</string>
     <string name="vision">Vision</string>
     <string name="hearing">Hearing</string>
     <string name="vitals">Vitals</string>
@@ -360,17 +320,12 @@
     <string name="referrals">Referrals</string>
     <string name="full_name">Full Name</string>
     <string name="weight">Weight (kg)</string>
-    <string name="no_records">No records found</string>
-    <string name="chats">Chats</string>
     <string name="select_health_member">Select Member</string>
-    <string name="notifications">Notifications</string>
     <string name="incorrect_ans">Incorrect answer, please try again</string>
     <string name="diagnosis_note">Diagnosis Notes</string>
     <string name="menu_community">Community</string>
     <string name="library">Library</string>
     <string name="device_name">device name</string>
-    <string name="enter_title">Enter title</string>
-    <string name="add_link">Add Link</string>
     <string name="chat">Chat</string>
     <string name="members">Members</string>
     <string name="tasks">Tasks</string>
@@ -507,9 +462,6 @@
         <item>Vitamin A Deficiency</item>
         <item>Zika</item>
     </string-array>
-
-    <string name="add_story">Add Story</string>
-    <string name="txt_myprogress">myProgress</string>
     <string name="more_action">Filter</string>
     <string name="my_progress">My Progress</string>
     <string name="my_activity">My Activity</string>
@@ -523,7 +475,6 @@
     <string name="use_phone_number_as_password">Use phone number as password</string>
     <string name="feedback">Feedback</string>
     <string name="add_member">Add member</string>
-    <string name="exit">Confirm Exit</string>
     <string name="confirm_exit">Are you sure you want to leave this team?</string>
     <string name="update_profile_alert">Please complete your profile to enjoy full features</string>
     <string name="other_notes">Other Notes</string>
@@ -536,12 +487,9 @@
     <string name="our_courses">Our Courses</string>
     <string name="file">File: %s</string>
     <string name="recording_audio">Recording audio…</string>
-    <string name="show_replies">"Show replies "</string>
     <string name="selected">"Selected: "</string>
     <string name="last_sync">Last sync with server: %s</string>
     <string name="last_syncs">LastSync</string>
-    <string name="login_user">loginUserName</string>
-    <string name="login_password">loginUserPassword</string>
     <string name="no_team_available">No team / enterprise available</string>
     <string name="last_sync_date">last sync: %s</string>
     <string name="no_assignee">No assignee</string>
@@ -571,20 +519,14 @@
     <string name="csv_filename">CSV Filename</string>
     <string name="please_enter_reply">Please enter reply</string>
     <string name="image_filename">Image Filename</string>
-    <string name="markdown_filename">Markdown Filename</string>
-    <string name="select_login_mode">Select Login Mode:</string>
-    <string name="normal_mode">Normal Mode</string>
     <string name="select_date">Select Date</string>
     <string name="public_public">Public</string>
-    <string name="type_asterisk">Type*</string>
     <string name="joined_members_colon">Joined Members:</string>
     <string name="title">Title</string>
     <string name="source">Source</string>
     <string name="cloud_url">cloud</string>
     <string name="interval">interval</string>
     <string name="autosync">autosync</string>
-    <string name="autosync_off">autosync off!</string>
-    <string name="autosync_on">autosync on</string>
     <string name="attached_resources">Attached resources:</string>
     <string name="edit">Edit</string>
     <string name="my_achievements">My Achievements</string>
@@ -603,9 +545,6 @@
     <string name="download_resources">download Resources</string>
     <string name="take_test">take test [%d]</string>
     <string name="search">search</string>
-    <string name="for_ambulance">For Ambulance</string>
-    <string name="for_police">For Police</string>
-    <string name="for_emergency">For Emergency</string>
     <string name="submit_feedback">Submit Feedback</string>
     <string name="media">Media:</string>
     <string name="filter">Filter</string>
@@ -613,7 +552,6 @@
     <string name="subject_level">Subject Level</string>
     <string name="order_by_date">Order by Date</string>
     <string name="order_by_title">Order by Title</string>
-    <string name="vital_signs_record">Vital Signs Record</string>
     <string name="exams">Exams</string>
     <string name="survey">Survey</string>
     <string name="submitted_by">Submitted by</string>
@@ -627,7 +565,6 @@
     <string name="all_task">All Task</string>
     <string name="my_task">My task</string>
     <string name="completed">Completed</string>
-    <string name="add_profile_picture">Add Profile Picture</string>
     <string name="two_dash">--</string>
     <string name="n_a">N/A</string>
     <string name="request_to_join">Request to join</string>
@@ -636,9 +573,6 @@
     <string name="mistakes">Mistakes</string>
     <string name="take_survey">Take Survey</string>
     <string name="checkbox">CheckBox</string>
-    <string name="offer">Offer</string>
-    <string name="request_for_advice">Request for advice</string>
-    <string name="no_images_to_download">No images to download.</string>
     <string name="this_file_type_is_currently_unsupported">This file type is currently unsupported</string>
     <string name="unable_to_open_resource">Unable to open resource</string>
     <string name="select_resource_to_open">"Select resource to open : "</string>
@@ -654,10 +588,6 @@
     <string name="removed_from_mylibrary">Removed from myLibrary</string>
     <string name="removed_from_mycourse">Removed from myCourse</string>
     <string name="please_allow_usages_permission_to_myplanet_app">Please allow usages permission to myPlanet app.</string>
-    <string name="permissions_granted">Permissions Granted</string>
-    <string name="permissions_denied">Permissions Denied</string>
-    <string name="unable_to_upload_resource">Unable to upload resource</string>
-    <string name="please_select_link_item_from_list">Please select link item from list</string>
     <string name="title_is_required">Title is required</string>
     <string name="no_data_available">No data available</string>
     <string name="are_you_sure_you_want_to_leave_these_courses">Are you sure you want to leave these courses?</string>
@@ -670,39 +600,20 @@
     <string name="retake_test">Retake Test [%d]</string>
     <string name="do_you_want_to_join_this_course">Do you want to join this course?</string>
     <string name="join_this_course">Join this course</string>
-    <string name="resource_not_downloaded">resource not downloaded.</string>
-    <string name="bulk_resource_download">Bulk resource download.</string>
-    <string name="pending_survey">pending survey.</string>
-    <string name="download_news_images">Download news images.</string>
-    <string name="tasks_due">tasks due.</string>
-    <string name="storage_critically_low">"Storage critically low: "</string>
-    <string name="available_please_free_up_space">available. Please free up space.</string>
     <string name="storage_running_low">"Storage running low: "</string>
-    <string name="available">available.</string>
     <string name="storage_available">"Storage available: "</string>
-    <string name="health_record_not_available_click_to_sync">Health record not available. Click to sync.</string>
-    <string name="visits">visits</string>
     <string name="please_select_starting_date">"Please select starting date : "</string>
     <string name="read_offline_news_from">"Read offline news from: "</string>
     <string name="downloading_started_please_check_notification">Downloading started, please check notification…</string>
     <string name="file_already_exists">File already exists…</string>
-    <string name="syncing_health_please_wait">Syncing health, please wait…</string>
-    <string name="myhealth_synced_successfully">myHealth synced successfully</string>
-    <string name="myhealth_synced_failed">myHealth synced failed</string>
-    <string name="no_due_tasks">No due tasks</string>
-    <string name="due_tasks">Due tasks</string>
-    <string name="feature_not_available_for_guest_user">Feature not available for guest user</string>
     <string name="feature_not_available">Feature Not Available</string>
-    <string name="health_record_not_available_sync_health_data">Health record not available, Sync health data?</string>
     <string name="sync">sync</string>
-    <string name="got_it">GOT IT</string>
     <string name="session_expired">Session expired.</string>
     <string name="downloading_started_please_check_notificati">Downloading started, please check notification…</string>
     <string name="dictionary">Dictionary</string>
     <string name="list_size">List size %d</string>
     <string name="word_not_available_in_our_database">Word not available in our database.</string>
     <string name="description_is_required">Description is required</string>
-    <string name="start_time_is_required">Start time is required</string>
     <string name="meetup_added">Meetup added</string>
     <string name="meetup_not_added">Meetup not added</string>
     <string name="add_transaction">Add Transaction</string>
@@ -716,20 +627,14 @@
     <string name="complete">complete</string>
     <string name="no_questions_available">No questions available</string>
     <string name="please_select_write_your_answer_to_continue">Please select / write your answer to continue</string>
-    <string name="graded">graded</string>
-    <string name="pending">pending</string>
     <string name="user_profile_updated">User profile updated</string>
     <string name="unable_to_update_user">Unable to update user</string>
-    <string name="date_n_a">Date : N/A</string>
     <string name="please_enter_feedback">Please enter feedback.</string>
     <string name="feedback_priority_is_required">Feedback priority is required.</string>
     <string name="feedback_type_is_required">Feedback type is required.</string>
     <string name="thank_you_your_feedback_has_been_submitted">Thank you, your feedback has been submitted</string>
     <string name="feedback_saved">Feedback Saved..</string>
-    <string name="name_colon">"Name: "</string>
     <string name="email_colon">"Email: "</string>
-    <string name="phone_number_colon">"Phone Number: "</string>
-    <string name="resource_saved_successfully">Resource saved successfully</string>
     <string name="level_is_required">Level is required</string>
     <string name="subject_is_required">Subject is required</string>
     <string name="enter_resource_detail">Enter resource detail</string>
@@ -766,12 +671,6 @@
     Lab Tests: %8$s\n
     Studies: %9$s\n
 </string>
-
-    <string name="diagnosis_colon">"Diagnosis : "</string>
-    <string name="treatments_colon">"Treatments: "</string>
-    <string name="medications_colon">"Medications: "</string>
-    <string name="immunizations_colon">"Immunizations: "</string>
-    <string name="invalid_input">Invalid input</string>
     <string name="blood_pressure_should_be_numeric_systolic_diastolic">Blood Pressure should be numeric systolic/diastolic</string>
     <string name="blood_pressure_should_be_systolic_diastolic">Blood Pressure should be systolic/diastolic</string>
     <string name="bp_must_be_between_60_40_and_300_200">Bp must be between 60/40 and 300/200</string>
@@ -795,14 +694,11 @@
     <string name="no_data_available_please_click_button_to_add_new_resource_in_mypersonal">No data available, please click + button to add new resource in myPersonal.</string>
     <string name="label_added">Label added.</string>
     <string name="please_enter_message">Please enter message</string>
-    <string name="new_not_available">New not available</string>
-    <string name="hide_add_story">Hide Add Story</string>
     <string name="no_items">No items</string>
     <string name="record_survey">Record Survey</string>
     <string name="survey_sent_to_users">Survey sent to users</string>
     <string name="wifi_is_turned_off_saving_battery_power">Wifi is turned Off. Saving battery power</string>
     <string name="turning_on_wifi_please_wait">Turning on Wifi. Please wait…</string>
-    <string name="unable_to_connect_to_planet_wifi">Unable to connect to planet wifi.</string>
     <string name="you_are_now_connected">"You are now connected "</string>
     <string name="press_back_again_to_exit">Press BACK again to exit</string>
     <string name="it_has_been_more_than">"It has been more than "</string>
@@ -811,7 +707,6 @@
     <string name="okay">Okay</string>
     <string name="connect_to_the_server_over_wifi_and_sync_your_device_to_continue">Connect to the server over WiFi and sync your device to continue</string>
     <string name="please_enter_server_url_first">Please enter server url first.</string>
-    <string name="this_device_not_configured_properly_please_check_and_sync">This device not configured properly. Please check and sync.</string>
     <string name="username_cannot_be_empty">Username cannot be empty</string>
     <string name="unable_to_login">Unable to login</string>
     <string name="planet_server_not_reachable">Planet server not reachable.</string>
@@ -820,14 +715,11 @@
     <string name="please_wait">Please wait…</string>
     <string name="update_later">Update Later</string>
     <string name="checking_version">Checking version…</string>
-    <string name="please_enter_your_password">Please enter your password</string>
     <string name="downloading">"Downloading… "</string>
     <string name="pin_is_required">Pin is required.</string>
     <string name="invalid_url">Invalid Url</string>
     <string name="please_enter_valid_url_to_continue">Please enter valid url to continue.</string>
     <string name="uploading_data_to_server_please_wait">Uploading data to server, please wait.....</string>
-    <string name="uploading_activities_to_server_please_wait">Uploading activities to server, please wait…</string>
-    <string name="connecting_to_server">Connecting to server....</string>
     <string name="check_the_server_address_again_what_i_connected_to_wasn_t_the_planet_server">Check the server address again. What i connected to wasn\'t the Planet Server</string>
     <string name="device_couldn_t_reach_local_server">device couldn\'t reach the server. check if you are connected to the correct Wi-Fi network for the local server (community).</string>
     <string name="device_couldn_t_reach_nation_server">device couldn’t reach the server. check if you are connected to the internet and try again</string>
@@ -835,7 +727,6 @@
     <string name="syncing_data_please_wait">Syncing data, Please wait…</string>
     <string name="sync_failed">Sync Failed</string>
     <string name="sync_completed">Sync Completed</string>
-    <string name="message_is_required">Message is required</string>
     <string name="team_leader">Team Leader</string>
     <string name="select_resource">"Select Resource: "</string>
     <string name="add">Add</string>
@@ -850,7 +741,6 @@
     <string name="task_s_successfully">Task %s successfully</string>
     <string name="task_deleted_successfully">Task deleted successfully</string>
     <string name="requested">Requested</string>
-    <string name="resources_colon">"Resources: "</string>
     <string name="left_team">Left team</string>
     <string name="enter_enterprise_s_name">Enter enterprise\'s name</string>
     <string name="what_is_your_team_s_plan">What is your team\'s plan?</string>
@@ -861,7 +751,6 @@
     <string name="name_is_required">Name is required</string>
     <string name="team_created">Team Created</string>
     <string name="please_select_gender">Please select gender</string>
-    <string name="please_enter_a_username">Please enter a username</string>
     <string name="invalid_username">Invalid username</string>
     <string name="please_enter_a_password">Please enter a password</string>
     <string name="password_doesn_t_match">Password doesn\'t match</string>
@@ -870,9 +759,7 @@
     <string name="add_reference">Add Reference</string>
     <string name="add_achievement">Add Achievement</string>
     <string name="select_resources">"Select resources: "</string>
-    <string name="user_not_available_in_our_database">User not available in our database</string>
     <string name="date_of_birth">"Date of birth: "</string>
-    <string name="unable_to_play_audio">Unable to play audio.</string>
     <string name="unable_to_load">"Unable to load "</string>
     <string name="recording_started">Recording started....</string>
     <string name="ole_is_recording_audio">Ole is recording audio</string>
@@ -981,30 +868,22 @@
     <string name="auto_sync_device">auto sync device</string>
     <string name="beta_functionality">beta functionality</string>
     <string name="main_controls">main controls</string>
-    <string name="select_user_to_login">Select User To Login</string>
     <string name="dismiss">Dismiss</string>
-    <string name="gps_is_settings">GPS is settings</string>
-    <string name="gps_is_not_enabled_do_you_want_to_go_to_settings_menu">GPS is not enabled. Do you want to go to settings menu?</string>
     <string name="available_space_colon">available space: </string>
     <string name="community_leaders">Community Leaders</string>
     <string name="services">Services</string>
-    <string name="survey_taken">Survey taken</string>
     <plurals name="survey_taken_count">
         <item quantity="one">Survey taken %d time</item>
         <item quantity="other">Survey taken %d times</item>
     </plurals>
-    <string name="times">times</string>
-    <string name="time">time</string>
     <string name="ai_chat">AI Chat</string>
     <string name="kindly_give_a_rating">Kindly give a rating</string>
     <string name="must_start_with_letter_or_number">Must start with letter or number</string>
     <string name="only_letters_numbers_and_are_allowed">Only letters a-z, numbers and "_" , ".", "-" are allowed</string>
-    <string name="config_not_available">Config not available.</string>
     <string name="unselect_all">Unselect All</string>
     <string name="select_all">Select All</string>
     <string name="request_failed_please_retry">Request failed, please retry</string>
     <string name="confirm_removal">Confirm removal</string>
-    <string name="returning_user">Returning user</string>
     <string name="send_to_nation">Allow your achievements to be shared with the nation</string>
     <string name="image_resource">image resource</string>
     <string name="play_audio">play audio</string>
@@ -1039,7 +918,6 @@
     <string name="trial_period_ended">Trial period ended! Kindly complete registration to continue</string>
     <string name="drag">drag %1$s</string>
     <string name="visibility_of">toggle visibility of %1$s</string>
-    <string name="actions_menu">actions menu</string>
     <string name="icon">%1$s icon</string>
     <string name="select_res_course">select %1$s</string>
     <string name="kindly_enter_message">Kindly enter message</string>
@@ -1047,7 +925,6 @@
     <string name="no_courses">no courses available</string>
     <string name="no_resources">no resources available</string>
     <string name="no_finance_record">finance record not available</string>
-    <string name="no_stories">stories not available</string>
     <string name="no_team_courses">team courses not available</string>
     <string name="no_team_resources">team resources not available</string>
     <string name="no_tasks">tasks not available</string>
@@ -1056,7 +933,6 @@
     <string name="no_links_available">No links available</string>
     <string name="user_requested_to_join_team">%1$s has requested to join %2$s</string>
     <string name="join_request_prefix">Join Request:</string>
-    <string name="new_request_to_join">New request to join %s</string>
     <string name="no_news">news not available</string>
     <string name="no_surveys">surveys not available</string>
     <string name="edit_image">edit profile image</string>
@@ -1072,21 +948,17 @@
     <string name="location_colon">location:&#160;</string>
     <string name="recurring_colon">recurring:&#160;</string>
     <string name="created_by_colon">created by:&#160;</string>
-    <string name="failed_to_get_configuration_id">failed to get configuration id. kindly contact admin</string>
     <string name="you_want_to_connect_to_a_different_server">Are you sure you want to change the configuration? This action will clear the app data.</string>
     <string name="are_you_sure_you_want_to_clear_data">are you sure you want to clear all data?</string>
     <string name="feedback_list">list of feedback</string>
     <string name="enterprise_list">list of enterprises</string>
     <string name="list_of_teams">list of teams</string>
-    <string name="sign_up_to_chat">Please sign up to access AI chat</string>
     <string name="share_chat">share chat</string>
     <string name="shared_chat">shared chat</string>
     <string name="check_apk_version">checking app version</string>
     <string name="checking_server">checking server</string>
-    <string name="below_min_apk">app is below allowed version. please update the app to the latest version.</string>
     <string name="add_note">add a note (optional)</string>
     <string name="no_teams">teams not available</string>
-    <string name="planet_name">%s\'s Planet</string>
     <string name="no_chats">no previous chats</string>
     <string name="no_feedback">no feedback available</string>
     <string name="empty_text" />
@@ -1094,7 +966,6 @@
     <string name="reports">Reports</string>
     <string name="number_placeholder">%d</string>
     <string name="float_placeholder">%.1f</string>
-    <string name="date_range">%1$s to %2$s</string>
     <string name="string_range">%1$s - %2$s</string>
     <string name="team_financial_report">%s Financial Report</string>
     <string name="report_date_details">Report created on: %1$s | Updated on: %2$s</string>
@@ -1109,7 +980,6 @@
     <string name="resources_size">Resources [%d]</string>
     <string name="user_role">- %s</string>
     <string name="user_name">%1$s (%2$s)</string>
-    <string name="visit_count">%1$s (%2$d %3$s)</string>
     <string name="two_strings">%1$s %2$s</string>
     <string name="three_strings">%1$s %2$s %3$s</string>
     <string name="member_description">%1$s (%2$d visits)</string>
@@ -1119,11 +989,6 @@
     <string name="dark_mode_off">off</string>
     <string name="dark_mode_on">on</string>
     <string name="dark_mode_follow_system">follow system</string>
-    <string-array name="dark_mode_options">
-        <item>@string/dark_mode_off</item>
-        <item>@string/dark_mode_on</item>
-        <item>@string/dark_mode_follow_system</item>
-    </string-array>
     <string name="are_you_sure_you_want_to_archive_these_courses">Are you sure you want to archive these courses?</string>
     <string name="are_you_sure_you_want_to_archive_this_course">Are you sure you want to archive this course?</string>
     <string name="manual">manual</string>
@@ -1139,12 +1004,10 @@
     <string name="sync_ruiru">🇰🇪 planet ruiru</string>
     <string name="sync_embakasi">🇰🇪 planet embakasi</string>
     <string name="sync_cambridge">🇺🇸 planet cambridge</string>
-    <string name="sync_egdirbmac">🇺🇸 planet egdirbmac</string>
     <string name="surveys_to_complete">You have %1$d %2$s to complete</string>
     <string name="show_less">show less</string>
     <string name="show_more">show more</string>
     <string name="server_address_content_description">server address: %1$s</string>
-    <string name="member_only_allowed">join as a member to access this feature</string>
     <string name="select_theme_mode">select theme mode</string>
     <string name="beta_resources_auto_download">Beta resources auto download</string>
     <string name="course_steps">Course Steps</string>
@@ -1168,20 +1031,6 @@
     <string name="chat_enter_message">Enter Message</string>
     <string name="hour">hour</string>
     <string name="hours">hours</string>
-    <array name="material_calendar_months_array">
-        <item>January</item>
-        <item>February</item>
-        <item>March</item>
-        <item>April</item>
-        <item>May</item>
-        <item>June</item>
-        <item>July</item>
-        <item>August</item>
-        <item>September</item>
-        <item>October</item>
-        <item>November</item>
-        <item>December</item>
-    </array>
     <string name="switching_off_manual_configuration_to_clear_data">switching off manual configuration will clear all data, are you sure you want to continue?</string>
     <string name="switching_on_manual_configuration_to_clear_data">switching on manual configuration will clear all data, are you sure you want to continue?</string>
     <string name="chart_description">Login Activity Chart</string>
@@ -1204,7 +1053,6 @@
     <string name="total_visits_overall">Total Visits : </string>
     <string name="most_opened_resource">Most Opened Resource : </string>
     <string name="number_of_resources_opened">Number of Resources Opened : </string>
-    <string name="number_of_visits">Number of Visits</string>
     <string name="kindly_enter_reply_message">Kindly enter reply message</string>
     <string name="start">start</string>
     <string name="continuation">continue</string>
@@ -1229,15 +1077,12 @@
     <string name="user_verification_in_progress">User verification in progress. Please wait while we process the data.</string>
     <string name="go_to_mylibrary">Go To MyLibrary</string>
     <string name="choose_an_option">Choose an option</string>
-    <string name="welcome_back">Welcome back %1$s !</string>
     <string name="welcome">Welcome %1$s</string>
     <string name="edit_plan">Edit Plan</string>
     <string name="show_additional_fields">show additional fields</string>
     <string name="hide_additional_fields">hide additional fields</string>
-    <string name="age">age</string>
     <string name="preparing_download">Preparing download…</string>
     <string name="downloading_files">Downloading files</string>
-    <string name="member_of_planet">member of planet</string>
     <string name="edit_mission_and_services">edit mission and services</string>
     <string name="this_team_has_no_description_defined">this team has no description defined</string>
     <string name="contact_preference">contact preference</string>
@@ -1251,7 +1096,6 @@
     <string name="unable_to_save_user_please_sync">Unable to save user, please sync.</string>
     <string name="server_sync_successfully">Server synced successfully.</string>
     <string name="server_sync_has_failed">Server synced has failed.</string>
-    <string name="no_resources_to_download">No resources to download</string>
     <string name="response">Response</string>
     <string name="full_conversation_response">Full conversation response</string>
     <string name="add_new_event">+ new event</string>
@@ -1262,7 +1106,6 @@
     <string name="minutes">Minutes</string>
     <string name="days">Days</string>
     <string name="set_reminder">Set Reminder</string>
-    <string name="reminder_set_for">Reminder set for %1$s from now</string>
     <string name="reminder_surveys_to_complete">Reminder: You have %1$d %2$s to complete</string>
 
     <plurals name="minutes">
@@ -1312,8 +1155,6 @@
     <string name="syncing_achievements">Syncing achievements…</string>
     <string name="nation_leaders">nation leaders</string>
     <string name="filter_by_label">filter by label</string>
-    <string name="community_board">community board</string>
-    <string name="nation_board">nation board</string>
     <string name="is_available">%1$s is available. Tap to continue learning</string>
     <string name="failed_to_add_please_retry">Failed to add. Please retry</string>
     <string name="failed_to_mark_as_read">Failed to mark as read. Please retry</string>
@@ -1322,9 +1163,7 @@
     <string name="failed_to_save_chat">Failed to save chat. Please retry.</string>
     <string name="failed_to_delete_report">Failed to delete report. Please retry</string>
     <string name="delete_report">Delete report</string>
-    <string name="checking_server_availability">checking server availability…</string>
     <string name="loading_teams">Loading teams…</string>
-    <string name="loading_enterprises">Loading enterprises…</string>
     <string name="year_of_birth">Year of birth</string>
     <string name="year_of_birth_cannot_be_empty">year of birth cannot be empty</string>
     <string name="please_enter_a_valid_year_of_birth">please enter a valid year of birth</string>

--- a/reports/dead_code_report.md
+++ b/reports/dead_code_report.md
@@ -1,0 +1,176 @@
+# Dead Code Analysis Report
+
+_Generated on 2025-11-11T08:39:50Z_
+
+## Tooling and Inputs
+- `./gradlew lint` (defaultDebug variant) to detect unused resources and namespaces.
+- Custom Python scan for Kotlin/Java type definitions to flag unreferenced classes/objects.
+- Manual `rg` queries to confirm dependency usage signals.
+
+## Kotlin / Java Findings
+- No top-level classes were reported unused. A custom scan highlighted the following Hilt modules, but they are retained because the Hilt annotation processor loads them reflectively:
+  - `org.ole.planet.myplanet.di.DatabaseModule`
+  - `org.ole.planet.myplanet.di.NetworkModule`
+  - `org.ole.planet.myplanet.di.RepositoryModule`
+  - `org.ole.planet.myplanet.di.ServiceModule`
+  - `org.ole.planet.myplanet.di.SharedPreferencesModule`
+- No Kotlin/Java members were flagged by lint tooling; further IDE-based inspection may be required for fine-grained method/property pruning.
+
+## XML Resource Findings
+The following resources were reported unused by Android Lint (defaultDebug):
+
+| Resource | File | Line |
+| --- | --- | --- |
+| `R.array.dark_mode_options` | `app/src/main/res/values/strings.xml` | 1122 |
+| `R.array.info_type` | `app/src/main/res/values/strings.xml` | 203 |
+| `R.array.material_calendar_months_array` | `app/src/main/res/values/strings.xml` | 1171 |
+| `R.string.actions_menu` | `app/src/main/res/values/strings.xml` | 1042 |
+| `R.string.add_link` | `app/src/main/res/values/strings.xml` | 373 |
+| `R.string.add_profile_picture` | `app/src/main/res/values/strings.xml` | 630 |
+| `R.string.add_story` | `app/src/main/res/values/strings.xml` | 511 |
+| `R.string.age` | `app/src/main/res/values/strings.xml` | 1237 |
+| `R.string.autosync_off` | `app/src/main/res/values/strings.xml` | 586 |
+| `R.string.autosync_on` | `app/src/main/res/values/strings.xml` | 587 |
+| `R.string.available` | `app/src/main/res/values/strings.xml` | 681 |
+| `R.string.available_please_free_up_space` | `app/src/main/res/values/strings.xml` | 679 |
+| `R.string.axillary` | `app/src/main/res/values/strings.xml` | 291 |
+| `R.string.below_min_apk` | `app/src/main/res/values/strings.xml` | 1086 |
+| `R.string.bulk_resource_download` | `app/src/main/res/values/strings.xml` | 674 |
+| `R.string.by_ear` | `app/src/main/res/values/strings.xml` | 292 |
+| `R.string.by_skin` | `app/src/main/res/values/strings.xml` | 293 |
+| `R.string.chats` | `app/src/main/res/values/strings.xml` | 364 |
+| `R.string.checking_server_availability` | `app/src/main/res/values/strings.xml` | 1325 |
+| `R.string.community_board` | `app/src/main/res/values/strings.xml` | 1315 |
+| `R.string.config_not_available` | `app/src/main/res/values/strings.xml` | 1002 |
+| `R.string.connecting_to_server` | `app/src/main/res/values/strings.xml` | 830 |
+| `R.string.date_n_a` | `app/src/main/res/values/strings.xml` | 723 |
+| `R.string.date_range` | `app/src/main/res/values/strings.xml` | 1097 |
+| `R.string.diagnosis_colon` | `app/src/main/res/values/strings.xml` | 770 |
+| `R.string.diastolic` | `app/src/main/res/values/strings.xml` | 298 |
+| `R.string.download_news_images` | `app/src/main/res/values/strings.xml` | 676 |
+| `R.string.due_tasks` | `app/src/main/res/values/strings.xml` | 693 |
+| `R.string.enter_message` | `app/src/main/res/values/strings.xml` | 162 |
+| `R.string.enter_message_here` | `app/src/main/res/values/strings.xml` | 142 |
+| `R.string.enter_password` | `app/src/main/res/values/strings.xml` | 148 |
+| `R.string.enter_title` | `app/src/main/res/values/strings.xml` | 372 |
+| `R.string.examination` | `app/src/main/res/values/strings.xml` | 343 |
+| `R.string.exit` | `app/src/main/res/values/strings.xml` | 526 |
+| `R.string.failed_to_get_configuration_id` | `app/src/main/res/values/strings.xml` | 1075 |
+| `R.string.feature_not` | `app/src/main/res/values/strings.xml` | 276 |
+| `R.string.feature_not_available_for_guest_user` | `app/src/main/res/values/strings.xml` | 694 |
+| `R.string.filter_by_date` | `app/src/main/res/values/strings.xml` | 334 |
+| `R.string.for_ambulance` | `app/src/main/res/values/strings.xml` | 606 |
+| `R.string.for_emergency` | `app/src/main/res/values/strings.xml` | 608 |
+| `R.string.for_police` | `app/src/main/res/values/strings.xml` | 607 |
+| `R.string.got_it` | `app/src/main/res/values/strings.xml` | 698 |
+| `R.string.gps_is_not_enabled_do_you_want_to_go_to_settings_menu` | `app/src/main/res/values/strings.xml` | 987 |
+| `R.string.gps_is_settings` | `app/src/main/res/values/strings.xml` | 986 |
+| `R.string.graded` | `app/src/main/res/values/strings.xml` | 719 |
+| `R.string.health_record_not_available_click_to_sync` | `app/src/main/res/values/strings.xml` | 683 |
+| `R.string.health_record_not_available_sync_health_data` | `app/src/main/res/values/strings.xml` | 696 |
+| `R.string.hide_add_story` | `app/src/main/res/values/strings.xml` | 799 |
+| `R.string.immunizations_colon` | `app/src/main/res/values/strings.xml` | 773 |
+| `R.string.invalid_input` | `app/src/main/res/values/strings.xml` | 774 |
+| `R.string.loading_enterprises` | `app/src/main/res/values/strings.xml` | 1327 |
+| `R.string.login_password` | `app/src/main/res/values/strings.xml` | 544 |
+| `R.string.login_user` | `app/src/main/res/values/strings.xml` | 543 |
+| `R.string.managerial_login` | `app/src/main/res/values/strings.xml` | 149 |
+| `R.string.markdown_filename` | `app/src/main/res/values/strings.xml` | 574 |
+| `R.string.medications_colon` | `app/src/main/res/values/strings.xml` | 772 |
+| `R.string.member_of_planet` | `app/src/main/res/values/strings.xml` | 1240 |
+| `R.string.member_only_allowed` | `app/src/main/res/values/strings.xml` | 1147 |
+| `R.string.message_is_required` | `app/src/main/res/values/strings.xml` | 838 |
+| `R.string.messages` | `app/src/main/res/values/strings.xml` | 316 |
+| `R.string.myhealth_synced_failed` | `app/src/main/res/values/strings.xml` | 691 |
+| `R.string.myhealth_synced_successfully` | `app/src/main/res/values/strings.xml` | 690 |
+| `R.string.name_colon` | `app/src/main/res/values/strings.xml` | 729 |
+| `R.string.nation_board` | `app/src/main/res/values/strings.xml` | 1316 |
+| `R.string.new_not_available` | `app/src/main/res/values/strings.xml` | 798 |
+| `R.string.new_patient` | `app/src/main/res/values/strings.xml` | 345 |
+| `R.string.new_request_to_join` | `app/src/main/res/values/strings.xml` | 1059 |
+| `R.string.news` | `app/src/main/res/values/strings.xml` | 135 |
+| `R.string.no_due_tasks` | `app/src/main/res/values/strings.xml` | 692 |
+| `R.string.no_images_to_download` | `app/src/main/res/values/strings.xml` | 641 |
+| `R.string.no_records` | `app/src/main/res/values/strings.xml` | 363 |
+| `R.string.no_resources_to_download` | `app/src/main/res/values/strings.xml` | 1254 |
+| `R.string.no_stories` | `app/src/main/res/values/strings.xml` | 1050 |
+| `R.string.normal_mode` | `app/src/main/res/values/strings.xml` | 576 |
+| `R.string.notifications` | `app/src/main/res/values/strings.xml` | 366 |
+| `R.string.number_of_visits` | `app/src/main/res/values/strings.xml` | 1207 |
+| `R.string.offer` | `app/src/main/res/values/strings.xml` | 639 |
+| `R.string.orally` | `app/src/main/res/values/strings.xml` | 300 |
+| `R.string.pending` | `app/src/main/res/values/strings.xml` | 720 |
+| `R.string.pending_survey` | `app/src/main/res/values/strings.xml` | 675 |
+| `R.string.permissions_denied` | `app/src/main/res/values/strings.xml` | 658 |
+| `R.string.permissions_granted` | `app/src/main/res/values/strings.xml` | 657 |
+| `R.string.phone_number_colon` | `app/src/main/res/values/strings.xml` | 731 |
+| `R.string.planet_name` | `app/src/main/res/values/strings.xml` | 1089 |
+| `R.string.please_enter_a_username` | `app/src/main/res/values/strings.xml` | 864 |
+| `R.string.please_enter_your_password` | `app/src/main/res/values/strings.xml` | 823 |
+| `R.string.please_select_link_item_from_list` | `app/src/main/res/values/strings.xml` | 660 |
+| `R.string.rectally` | `app/src/main/res/values/strings.xml` | 290 |
+| `R.string.reminder_set_for` | `app/src/main/res/values/strings.xml` | 1265 |
+| `R.string.request_for_advice` | `app/src/main/res/values/strings.xml` | 640 |
+| `R.string.resource_not_downloaded` | `app/src/main/res/values/strings.xml` | 673 |
+| `R.string.resource_saved_successfully` | `app/src/main/res/values/strings.xml` | 732 |
+| `R.string.resources_colon` | `app/src/main/res/values/strings.xml` | 853 |
+| `R.string.respiration_rate` | `app/src/main/res/values/strings.xml` | 296 |
+| `R.string.returning_user` | `app/src/main/res/values/strings.xml` | 1007 |
+| `R.string.search_user` | `app/src/main/res/values/strings.xml` | 146 |
+| `R.string.select_login_mode` | `app/src/main/res/values/strings.xml` | 575 |
+| `R.string.select_user_to_login` | `app/src/main/res/values/strings.xml` | 984 |
+| `R.string.show_filter` | `app/src/main/res/values/strings.xml` | 128 |
+| `R.string.show_main_conversation` | `app/src/main/res/values/strings.xml` | 170 |
+| `R.string.show_replies` | `app/src/main/res/values/strings.xml` | 539 |
+| `R.string.show_reply` | `app/src/main/res/values/strings.xml` | 169 |
+| `R.string.sign_up_to_chat` | `app/src/main/res/values/strings.xml` | 1081 |
+| `R.string.start_time_is_required` | `app/src/main/res/values/strings.xml` | 705 |
+| `R.string.storage_critically_low` | `app/src/main/res/values/strings.xml` | 678 |
+| `R.string.survey_taken` | `app/src/main/res/values/strings.xml` | 991 |
+| `R.string.sync_egdirbmac` | `app/src/main/res/values/strings.xml` | 1142 |
+| `R.string.syncing_health_please_wait` | `app/src/main/res/values/strings.xml` | 689 |
+| `R.string.systolic` | `app/src/main/res/values/strings.xml` | 297 |
+| `R.string.tasks_due` | `app/src/main/res/values/strings.xml` | 677 |
+| `R.string.team_name` | `app/src/main/res/values/strings.xml` | 284 |
+| `R.string.temperature_taken` | `app/src/main/res/values/strings.xml` | 294 |
+| `R.string.this_device_not_configured_properly_please_check_and_sync` | `app/src/main/res/values/strings.xml` | 814 |
+| `R.string.time` | `app/src/main/res/values/strings.xml` | 997 |
+| `R.string.times` | `app/src/main/res/values/strings.xml` | 996 |
+| `R.string.treatments_colon` | `app/src/main/res/values/strings.xml` | 771 |
+| `R.string.txt_myprogress` | `app/src/main/res/values/strings.xml` | 512 |
+| `R.string.type_asterisk` | `app/src/main/res/values/strings.xml` | 579 |
+| `R.string.type_name_to_search` | `app/src/main/res/values/strings.xml` | 278 |
+| `R.string.unable_to_connect_to_planet_wifi` | `app/src/main/res/values/strings.xml` | 805 |
+| `R.string.unable_to_play_audio` | `app/src/main/res/values/strings.xml` | 875 |
+| `R.string.unable_to_upload_resource` | `app/src/main/res/values/strings.xml` | 659 |
+| `R.string.uploading_activities_to_server_please_wait` | `app/src/main/res/values/strings.xml` | 829 |
+| `R.string.user_not_available_in_our_database` | `app/src/main/res/values/strings.xml` | 873 |
+| `R.string.user_removed_from_team` | `app/src/main/res/values/strings.xml` | 309 |
+| `R.string.visit_count` | `app/src/main/res/values/strings.xml` | 1112 |
+| `R.string.visits` | `app/src/main/res/values/strings.xml` | 684 |
+| `R.string.vital_sign` | `app/src/main/res/values/strings.xml` | 342 |
+| `R.string.vital_signs_record` | `app/src/main/res/values/strings.xml` | 616 |
+| `R.string.welcome_back` | `app/src/main/res/values/strings.xml` | 1232 |
+| `R.string.width` | `app/src/main/res/values/strings.xml` | 347 |
+
+Total unused resources flagged: **131**
+
+### Additional XML Warnings
+- `app/src/main/res/layout/add_meetup.xml`: redundant `xmlns:android` declaration.
+- `app/src/main/res/layout/fragment_edit_achievement.xml`: redundant `xmlns:android` and `xmlns:app` declarations.
+
+## Gradle Dependency/Plugin Review
+| Dependency | Status | Notes |
+| --- | --- | --- |
+| `androidx.multidex:multidex:2.0.1` | Unused | No direct references; minSdk 26 enables native multidex support, so the runtime dependency is redundant. |
+| `org.jetbrains:annotations:26.0.2` | Unused | No `org.jetbrains.annotations.*` imports found; Kotlin code already ships nullability metadata. |
+| `androidx.legacy:legacy-support-v4:1.0.0` | Partially used | Only required for `LocalBroadcastManager`; replace with `androidx.localbroadcastmanager:localbroadcastmanager` before removal. |
+
+## Potential False Positives / Dynamic References
+- Hilt modules above are instantiated via annotation processing and must be retained despite lacking direct call sites.
+- String resources are not referenced through `getIdentifier` or reflection in the codebase, reducing the risk of hidden usages. Still, review with feature owners before removing messaging-related strings.
+
+## Next Steps
+- Delete the unused string and array resources listed above (including localized translations).
+- Remove redundant namespace declarations from the noted layout files.
+- Drop `androidx.multidex` and `org.jetbrains:annotations` dependencies; swap `androidx.legacy:legacy-support-v4` with `androidx.localbroadcastmanager:localbroadcastmanager` if legacy APIs are otherwise unused.


### PR DESCRIPTION
## Summary
- add a lint-based dead code analysis report outlining unused resources and dependencies
- prune unused string/array resources across base and localized `strings.xml` files and clean redundant XML namespaces
- replace the legacy support bundle with the standalone `localbroadcastmanager` artifact and drop redundant annotations/multidex dependencies

## Testing
- `./gradlew lint --console=plain --stacktrace --no-daemon`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f121d828832ba06d21362a6a9d41)