### PR TITLE
Refactor adapter joined member to listadapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/AdapterJoinedMember.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowJoinedUserBinding

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/JoinedMemberFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamMember/JoinedMemberFragment.kt
@@ -77,7 +77,6 @@ class JoinedMemberFragment : BaseMemberFragment() {
                 val isLeader = members.any { it.user.id == currentUserId && it.isLeader }
                 adapterJoined = AdapterJoinedMember(
                     requireActivity(),
-                    members.toMutableList(),
                     isLeader,
                     object : AdapterJoinedMember.MemberActionListener {
                         override fun onRemoveMember(member: JoinedMemberData, position: Int) {
@@ -88,7 +87,9 @@ class JoinedMemberFragment : BaseMemberFragment() {
                             member.user.id?.let { handleMakeLeader(it) }
                         }
                     }
-                )
+                ).also {
+                    it.updateData(members, isLeader)
+                }
             }
             return adapterJoined as AdapterJoinedMember
         }


### PR DESCRIPTION
I've completed the refactor to migrate AdapterJoinedMember to ListAdapter. Here is a summary of my changes:
I refactored `AdapterJoinedMember` from a standard `RecyclerView.Adapter` to `ListAdapter` to leverage `DiffUtil` for more efficient list updates.

- I changed the superclass to `ListAdapter<JoinedMemberData, ViewHolderUser>`.
- I added a `DiffUtil.ItemCallback` to handle item and content comparisons.
- I replaced manual `MutableList` management by passing new lists to the adapter, ensuring they are handled immutably.
- I updated the `removeMember`, `updateLeadership`, and `updateData` methods to create new lists and pass them to the adapter, which triggers efficient, fine-grained UI updates.
- This change eliminates whole-list redraws caused by `notifyDataSetChanged()`, improving performance and simplifying the adapter's logic.

---
https://jules.google.com/session/287979654384248177