### PR TITLE
Refactor repository methods to be suspend functions

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/NewsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NewsRepository.kt
@@ -6,7 +6,7 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
 
 interface NewsRepository {
-    fun getCommunityNews(userIdentifier: String): Flow<List<RealmNews>>
+    suspend fun getCommunityNews(userIdentifier: String): Flow<List<RealmNews>>
     suspend fun getNewsWithReplies(newsId: String): Pair<RealmNews?, List<RealmNews>>
     suspend fun getCommunityVisibleNews(userIdentifier: String): List<RealmNews>
     suspend fun createNews(map: HashMap<String?, String>, user: RealmUserModel?): RealmNews

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NewsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NewsRepositoryImpl.kt
@@ -74,7 +74,7 @@ class NewsRepositoryImpl @Inject constructor(
             false
         }
     }
-    override fun getCommunityNews(userIdentifier: String): Flow<List<RealmNews>> {
+    override suspend fun getCommunityNews(userIdentifier: String): Flow<List<RealmNews>> {
         val allNewsFlow = queryListFlow(RealmNews::class.java) {
             isEmpty("replyTo")
             equalTo("docType", "message", Case.INSENSITIVE)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepository.kt
@@ -38,7 +38,7 @@ interface TeamRepository {
     suspend fun setTaskCompletion(taskId: String, completed: Boolean)
     suspend fun getPendingTasksForUser(userId: String, start: Long, end: Long): List<RealmTeamTask>
     suspend fun markTasksNotified(taskIds: Collection<String>)
-    fun getTasksByTeamId(teamId: String): Flow<List<RealmTeamTask>>
+    suspend fun getTasksByTeamId(teamId: String): Flow<List<RealmTeamTask>>
     suspend fun addReport(report: JsonObject)
     suspend fun updateReport(reportId: String, payload: JsonObject)
     suspend fun archiveReport(reportId: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamRepositoryImpl.kt
@@ -424,7 +424,7 @@ class TeamRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getTasksByTeamId(teamId: String): Flow<List<RealmTeamTask>> {
+    override suspend fun getTasksByTeamId(teamId: String): Flow<List<RealmTeamTask>> {
         return queryListFlow(RealmTeamTask::class.java) {
             equalTo("teamId", teamId)
             notEqualTo("status", "archived")


### PR DESCRIPTION
- Made `getCommunityNews` in `NewsRepository` and `NewsRepositoryImpl` a suspend function to allow it to call the suspend function `queryListFlow`.
- Made `getTasksByTeamId` in `TeamRepository` and `TeamRepositoryImpl` a suspend function for the same reason.
- Verified that the call sites for these functions were already using coroutines, so no further changes were needed.