### PR TITLE
Refactor: Move MyHealthFragment Realm queries to HealthRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
@@ -1,0 +1,40 @@
+package org.ole.planet.myplanet.repository
+
+import io.realm.Case
+import io.realm.Sort
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyHealthPojo
+import org.ole.planet.myplanet.model.RealmUserModel
+import javax.inject.Inject
+
+class HealthRepository @Inject constructor(databaseService: DatabaseService) : RealmRepository(databaseService) {
+
+    fun getSortedUsers(sortBy: String, sort: Sort): List<RealmUserModel> {
+        val realm = databaseService.realmInstance
+        return realm.where(RealmUserModel::class.java).sort(sortBy, sort).findAll()
+    }
+
+    fun searchUsers(query: String): List<RealmUserModel> {
+        val realm = databaseService.realmInstance
+        return realm.where(RealmUserModel::class.java)
+            .contains("firstName", query, Case.INSENSITIVE).or()
+            .contains("lastName", query, Case.INSENSITIVE).or()
+            .contains("name", query, Case.INSENSITIVE)
+            .sort("joinDate", Sort.DESCENDING).findAll()
+    }
+
+    fun getHealthPojo(userId: String?): RealmMyHealthPojo? {
+        if (userId.isNullOrEmpty()) return null
+        val realm = databaseService.realmInstance
+        var mh = realm.where(RealmMyHealthPojo::class.java).equalTo("_id", userId).findFirst()
+        if (mh == null) {
+            mh = realm.where(RealmMyHealthPojo::class.java).equalTo("userId", userId).findFirst()
+        }
+        return mh
+    }
+
+    fun getExaminations(userKey: String?): List<RealmMyHealthPojo> {
+        val realm = databaseService.realmInstance
+        return realm.where(RealmMyHealthPojo::class.java).equalTo("profileId", userKey).findAll()
+    }
+}


### PR DESCRIPTION
- Created a new `HealthRepository` to encapsulate all health-related database queries.
- Moved five distinct Realm queries from `MyHealthFragment` into the new repository.
- Updated `MyHealthFragment` to use the `HealthRepository` for all health-related data access.
- This change cleans up the fragment, improves separation of concerns, and prepares the codebase for a future ViewModel implementation.

---
https://jules.google.com/session/17498526680754883410