### PR TITLE
Refactor: Remove Realm access from AdapterMyLife

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/mylife/LifeFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mylife/LifeFragment.kt
@@ -10,16 +10,21 @@ import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.databinding.FragmentLifeBinding
+import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyLife.Companion.getMyLifeByUserId
 import org.ole.planet.myplanet.ui.mylife.helper.OnStartDragListener
 import org.ole.planet.myplanet.ui.mylife.helper.SimpleItemTouchHelperCallback
 import org.ole.planet.myplanet.utilities.KeyboardUtils.setupUI
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class LifeFragment : BaseRecyclerFragment<RealmMyLife?>(), OnStartDragListener {
     private lateinit var adapterMyLife: AdapterMyLife
     private var mItemTouchHelper: ItemTouchHelper? = null
     private var _binding: FragmentLifeBinding? = null
+    @Inject
+    lateinit var myLifeRepo: MyLifeRepo
     private val binding get() = checkNotNull(_binding)
     override fun getLayout(): Int = R.layout.fragment_life
 
@@ -37,7 +42,13 @@ class LifeFragment : BaseRecyclerFragment<RealmMyLife?>(), OnStartDragListener {
 
     override fun getAdapter(): RecyclerView.Adapter<*> {
         val myLifeList = getMyLifeByUserId(mRealm, model?.id)
-        adapterMyLife = AdapterMyLife(requireContext(), myLifeList, mRealm, this)
+        adapterMyLife = AdapterMyLife(
+            requireContext(),
+            myLifeList,
+            this,
+            { id, isVisible -> myLifeRepo.updateVisibility(id, isVisible) },
+            { id, weight, userId -> myLifeRepo.updateWeight(id, weight, userId) }
+        )
         return adapterMyLife
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/mylife/MyLifeRepo.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/mylife/MyLifeRepo.kt
@@ -1,0 +1,28 @@
+package org.ole.planet.myplanet.ui.mylife
+
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyLife
+import org.ole.planet.myplanet.repository.RealmRepository
+import javax.inject.Inject
+
+class MyLifeRepo @Inject constructor(
+    databaseService: DatabaseService
+) : RealmRepository(databaseService) {
+    fun updateVisibility(id: String, isVisible: Boolean) {
+        databaseService.withRealm {
+            it.executeTransaction {
+                val myLife = it.where(RealmMyLife::class.java).equalTo("_id", id).findFirst()
+                myLife?.isVisible = isVisible
+            }
+        }
+    }
+
+    fun updateWeight(id: String, weight: Int, userId: String) {
+        databaseService.withRealm {
+            it.executeTransaction {
+                val myLife = it.where(RealmMyLife::class.java).equalTo("_id", id).equalTo("userId", userId).findFirst()
+                myLife?.weight = weight
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit refactors `AdapterMyLife` to remove direct Realm access and improve the overall architecture.

Key changes:
- Introduced `MyLifeRepo` to handle all database operations related to `RealmMyLife` objects, centralizing database logic and improving separation of concerns.
- Modified `AdapterMyLife` to be stateless by removing the `Realm` instance and introducing callbacks for database operations (`updateVisibilityCallback` and `updateWeightCallback`). This makes the adapter more reusable and easier to test.
- Updated `LifeFragment` to use the new `MyLifeRepo` and pass the repository methods as callbacks to the adapter.
- Added `@AndroidEntryPoint` to `LifeFragment` to enable Hilt dependency injection.

---
https://jules.google.com/session/1964185200023636028