### PR TITLE
sync: smoother submissions uploading (fixes #9268)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/service/ServerReachabilityWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/ServerReachabilityWorker.kt
@@ -204,10 +204,7 @@ class ServerReachabilityWorker(context: Context, workerParams: WorkerParameters)
                     // No UI updates required for background sync completion.
                 }
             }
-
-            withContext(Dispatchers.IO) {
-                uploadManager.uploadExamResult(successListener)
-            }
+            uploadManager.uploadExamResult(successListener)
         } catch (e: Exception) {
             e.printStackTrace()
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -320,34 +320,34 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
                         serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, mapping.primaryUrl, settings)
                     }
                 }
-
-                uploadSubmissions()
-            } catch (e: Exception) {
-                uploadSubmissions()
-            }
-        }
-    }
-
-    private fun uploadSubmissions() {
-        MainApplication.applicationScope.launch {
-            try {
-                withContext(Dispatchers.IO) {
-                    uploadManager.uploadSubmissions()
-                    uploadExamResultWrapper()
-                }
             } catch (e: Exception) {
                 e.printStackTrace()
+            } finally {
+                uploadSubmissions()
             }
         }
     }
 
-    private fun uploadExamResultWrapper() {
-        val successListener = object : SuccessListener {
-            override fun onSuccess(success: String?) {
+    private suspend fun uploadSubmissions() {
+        try {
+            withContext(Dispatchers.IO) {
+                uploadManager.uploadSubmissions()
             }
+            uploadExamResultWrapper()
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
+    }
 
-        uploadManager.uploadExamResult(successListener)
+    private suspend fun uploadExamResultWrapper() {
+        try {
+            val successListener = object : SuccessListener {
+                override fun onSuccess(success: String?) {}
+            }
+            uploadManager.uploadExamResult(successListener)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     private fun showDatePickerDialog() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -243,13 +243,11 @@ abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
                 }
             })
 
-            launch(Dispatchers.IO) {
-                uploadManager.uploadExamResult(object : SuccessListener {
-                    override fun onSuccess(success: String?) {
-                        checkAllOperationsComplete()
-                    }
-                })
-            }
+            uploadManager.uploadExamResult(object : SuccessListener {
+                override fun onSuccess(success: String?) {
+                    checkAllOperationsComplete()
+                }
+            })
 
             uploadManager.uploadFeedback(object : SuccessListener {
                 override fun onSuccess(success: String?) {


### PR DESCRIPTION
Refactored `UploadManager.uploadExamResult` to be a `suspend` function, moving synchronous network calls to a background thread using `withContext(Dispatchers.IO)`.

Updated all call sites to use coroutines, ensuring that the UI is not blocked during the upload process. This resolves a potential ANR (Application Not Responding) error.

Specifically, the call site in `UserInformationFragment` was updated to ensure that the UI is not updated until after the background upload is complete, preventing a race condition.

---
https://jules.google.com/session/15103503651480283131