### PR TITLE
feat: Replace `toggle-button-group` with `MaterialButtonToggleGroup`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -199,7 +199,6 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
-    implementation(libs.toggle.button.group)
     implementation(libs.materialdrawer) { transitive = true }
     implementation(libs.opencsv) { exclude group: 'commons-logging', module: 'commons-logging' }
     implementation(libs.retrofit)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamTask/TeamTaskFragment.kt
@@ -19,7 +19,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.nex3z.togglebuttongroup.SingleSelectToggleGroup
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Calendar
 import java.util.Date
@@ -224,9 +223,11 @@ class TeamTaskFragment : BaseTeamFragment(), OnCompletedListener {
         adapterTask = AdapterTask(requireContext(), !isMemberFlow.value, viewLifecycleOwner.lifecycleScope, userRepository)
         adapterTask.setListener(this)
         binding.rvTask.adapter = adapterTask
-        binding.taskToggle.setOnCheckedChangeListener { _: SingleSelectToggleGroup?, checkedId: Int ->
-            currentTab = checkedId
-            updateTasks()
+        binding.taskToggle.addOnButtonCheckedListener { _, checkedId, isChecked ->
+            if (isChecked) {
+                currentTab = checkedId
+                updateTasks()
+            }
         }
 
         viewLifecycleOwner.lifecycleScope.launch {

--- a/app/src/main/res/layout/fragment_team_task.xml
+++ b/app/src/main/res/layout/fragment_team_task.xml
@@ -8,34 +8,40 @@
     android:background="@color/secondary_bg"
     tools:context=".ui.team.teamTask.TeamTaskFragment">
 
-    <com.nex3z.togglebuttongroup.SingleSelectToggleGroup
+    <com.google.android.material.button.MaterialButtonToggleGroup
         android:id="@+id/task_toggle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:tbgCheckedButton="@+id/btn_all">
+        app:singleSelection="true"
+        app:checkedButton="@id/btn_all">
 
-        <com.nex3z.togglebuttongroup.button.LabelToggle
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_all"
+            style="?attr/materialButtonOutlinedStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="@dimen/padding_normal"
             android:text="@string/all_task"
             android:textColor="@color/toggle_text_color" />
-        <com.nex3z.togglebuttongroup.button.LabelToggle
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_my"
+            style="?attr/materialButtonOutlinedStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="@dimen/padding_normal"
             android:text="@string/my_task"
             android:textColor="@color/toggle_text_color" />
-        <com.nex3z.togglebuttongroup.button.LabelToggle
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_completed"
+            style="?attr/materialButtonOutlinedStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="@dimen/padding_normal"
             android:text="@string/completed"
             android:textColor="@color/toggle_text_color" />
-    </com.nex3z.togglebuttongroup.SingleSelectToggleGroup>
+    </com.google.android.material.button.MaterialButtonToggleGroup>
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ mpAndroidChart = "v3.1.0"
 circularProgressView = "0.1.2"
 material = "1.13.0"
 gson = "2.13.2"
-toggleButtonGroup = "1.2.3"
 materialdrawer = "6.1.1"
 opencsv = "5.12.0"
 okhttp = "5.3.2"
@@ -73,7 +72,6 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
-toggle-button-group = { module = "com.nex3z:toggle-button-group", version.ref = "toggleButtonGroup" }
 materialdrawer = { module = "com.mikepenz:materialdrawer", version.ref = "materialdrawer" }
 opencsv = { module = "com.opencsv:opencsv", version.ref = "opencsv" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit2" }


### PR DESCRIPTION
Replaced the single-use library `com.nex3z:toggle-button-group` with the native Android component `com.google.android.material.button.MaterialButtonToggleGroup` in `fragment_team_task.xml` and `TeamTaskFragment.kt`.

This change reduces the application's dependency footprint without any loss of functionality.

---
https://jules.google.com/session/12761036266094851188