### PR TITLE
Replace GIF loading indicator with native ProgressBar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -215,7 +215,6 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.android)
-    implementation(libs.android.gif.drawable)
 }
 realm {
     syncEnabled = true

--- a/app/src/main/res/layout/fragment_chat_detail.xml
+++ b/app/src/main/res/layout/fragment_chat_detail.xml
@@ -85,14 +85,14 @@
             android:textColor="@color/daynight_textColor"
             android:textColorHint="@color/hint_color"
             tools:ignore="Autofill" />
-        <pl.droidsonroids.gif.GifImageView
+        <ProgressBar
             android:id="@+id/image_gchat_loading"
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:layout_centerVertical="true"
             android:layout_marginEnd="4dp"
             android:layout_toStartOf="@+id/button_gchat_send"
-            android:src="@drawable/ic_loading"
+            android:indeterminate="true"
             android:visibility="invisible" />
         <ImageView
             android:id="@+id/button_gchat_send"

--- a/app/src/main/res/layout/fragment_chat_detail.xml
+++ b/app/src/main/res/layout/fragment_chat_detail.xml
@@ -85,7 +85,7 @@
             android:textColor="@color/daynight_textColor"
             android:textColorHint="@color/hint_color"
             tools:ignore="Autofill" />
-        <ProgressBar
+        <com.google.android.material.progressindicator.CircularProgressIndicator
             android:id="@+id/image_gchat_loading"
             android:layout_width="40dp"
             android:layout_height="40dp"
@@ -93,7 +93,9 @@
             android:layout_marginEnd="4dp"
             android:layout_toStartOf="@+id/button_gchat_send"
             android:indeterminate="true"
-            android:visibility="invisible" />
+            android:visibility="invisible"
+            app:indicatorColor="@color/mainColor"
+            app:indicatorSize="36dp" />
         <ImageView
             android:id="@+id/button_gchat_send"
             android:layout_width="30dp"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,6 @@ pbkdf2 = "1.1.4"
 osmdroidAndroid = "6.1.20"
 kotlinxSerializationJson = "1.9.0"
 kotlinxCoroutinesAndroid = "1.10.2"
-androidGifDrawable = "1.2.29"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
@@ -89,7 +88,6 @@ osmdroid-android = { module = "org.osmdroid:osmdroid-android", version.ref = "os
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
-android-gif-drawable = { module = "pl.droidsonroids.gif:android-gif-drawable", version.ref = "androidGifDrawable" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
## Summary
- replace the chat detail loading indicator with a native indeterminate `ProgressBar` instead of a GIF view
- remove the unused `pl.droidsonroids.gif:android-gif-drawable` dependency and its catalog entry to reduce the dependency footprint

## Testing
- `./gradlew --console=plain :app:assembleDebug` *(fails: missing Android SDK Build-Tools 35 and Platform 36 in the CI image)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddf284428832baf8926ce92a79101)