### PR TITLE
refactor(upload): Make submission uploads fully asynchronous

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/Submission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Submission.kt
@@ -1,0 +1,10 @@
+package org.ole.planet.myplanet.model
+
+import com.google.gson.JsonObject
+
+data class Submission(
+    val id: String?,
+    val _id: String?,
+    val _rev: String?,
+    val requestBody: JsonObject
+)

--- a/app/src/main/java/org/ole/planet/myplanet/service/ServerReachabilityWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/ServerReachabilityWorker.kt
@@ -183,9 +183,7 @@ class ServerReachabilityWorker(context: Context, workerParams: WorkerParameters)
     private suspend fun uploadSubmissions() {
         try {
             if (submissionRepository.hasPendingOfflineSubmissions()) {
-                withContext(Dispatchers.IO) {
-                    uploadManager.uploadSubmissions()
-                }
+                uploadManager.uploadSubmissions()
             }
             uploadExamResultWrapper()
         } catch (e: Exception) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -330,9 +330,7 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
 
     private suspend fun uploadSubmissions() {
         try {
-            withContext(Dispatchers.IO) {
-                uploadManager.uploadSubmissions()
-            }
+            uploadManager.uploadSubmissions()
             uploadExamResultWrapper()
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
Refactored `uploadSubmissions` in `UploadManager.kt` to be a `suspend` function, preventing it from blocking the main thread and causing ANRs.

- Replaced the unreliable `Looper.myLooper()` check with a unified, non-blocking coroutine-based approach using `withContext(Dispatchers.IO)`.
- Decoupled database reads from network operations by mapping Realm objects to an unmanaged `Submission` data class, avoiding thread-confinement issues.
- Batched all database updates into a single transaction after network requests are complete, improving performance and ensuring atomicity.
- Updated all call sites to correctly invoke the new `suspend` function.

---
https://jules.google.com/session/14219985702868966709