### PR TITLE
Fix: Prevent ANR in CoursesFragment by moving Realm queries to background thread

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -41,7 +41,7 @@ import org.ole.planet.myplanet.utilities.Utilities
 class AdapterCourses(
     private val context: Context,
     private var courseList: List<RealmMyCourse?>,
-    private val map: HashMap<String?, JsonObject>,
+    private var map: HashMap<String?, JsonObject>,
     private val userProfileDbHandler: UserProfileDbHandler,
     private val tagRepository: TagRepository,
     private val lifecycleOwner: LifecycleOwner
@@ -149,6 +149,10 @@ class AdapterCourses(
         isAscending = !isAscending
         val sortedList = sortCourseList(courseList)
         dispatchDiff(sortedList)
+    }
+
+    fun setRatingsMap(ratingsMap: HashMap<String?, JsonObject>) {
+        this.map = ratingsMap
     }
 
     fun setProgressMap(progressMap: HashMap<String?, JsonObject>?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -230,19 +230,9 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         viewLifecycleOwner.lifecycleScope.launch {
             try {
                 val data = loadCourseDataAsync()
-                adapterCourses = AdapterCourses(
-                    requireActivity(),
-                    data.courses,
-                    data.ratings,
-                    userProfileDbHandler,
-                    tagRepository,
-                    this@CoursesFragment
-                ).apply {
-                    setProgressMap(data.progress)
-                    setListener(this@CoursesFragment)
-                    setRatingChangeListener(this@CoursesFragment)
-                }
-                recyclerView.adapter = adapterCourses
+                adapterCourses.setRatingsMap(data.ratings)
+                adapterCourses.setProgressMap(data.progress)
+                adapterCourses.setCourseList(data.courses)
                 if (isMyCourseLib) {
                     resources = data.resources
                 }
@@ -739,20 +729,9 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                 } else {
                     filterCourseByTag(etSearch.text.toString(), searchTags)
                 }
-
-                adapterCourses = AdapterCourses(
-                    requireActivity(),
-                    filteredCourseList,
-                    data.ratings,
-                    userProfileDbHandler,
-                    tagRepository,
-                    this@CoursesFragment
-                ).apply {
-                    setProgressMap(data.progress)
-                    setListener(this@CoursesFragment)
-                    setRatingChangeListener(this@CoursesFragment)
-                }
-                recyclerView.adapter = adapterCourses
+                adapterCourses.setRatingsMap(data.ratings)
+                adapterCourses.setProgressMap(data.progress)
+                adapterCourses.setCourseList(filteredCourseList)
             } catch (e: Exception) {
                 e.printStackTrace()
             }


### PR DESCRIPTION
Refactored CoursesFragment to move synchronous Realm database queries from the main thread to a background thread using Kotlin coroutines.

This resolves a potential ANR (Application Not Responding) issue when loading the courses list.

- Introduced a 'loadCourseDataAsync' suspend function to encapsulate all Realm queries and data transformations.
- This function runs on Dispatchers.IO and uses 'copyFromRealm' to return thread-safe data.
- The 'getAdapter', 'refreshCoursesData', and 'onRatingChanged' methods were updated to call this asynchronous function and update the UI upon completion.

---
https://jules.google.com/session/14311765278767171982