### PR TITLE
Refactor GlobalScope to lifecycleScope in UserInformationFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -20,9 +20,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -294,13 +292,12 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun checkAvailableServer(settings: SharedPreferences) {
         val updateUrl = "${settings.getString("serverURL", "")}"
         val serverUrlMapper = ServerUrlMapper()
         val mapping = serverUrlMapper.processUrl(updateUrl)
 
-        GlobalScope.launch(Dispatchers.IO) {
+        viewLifecycleOwnerLiveData.value?.lifecycleScope?.launch(Dispatchers.IO) {
             var primaryAvailable = false
             var alternativeAvailable = false
 


### PR DESCRIPTION
Replaced GlobalScope.launch with viewLifecycleOwnerLiveData.value?.lifecycleScope.launch in checkAvailableServer. This ensures that the coroutine is cancelled when the view is destroyed, preventing memory leaks, while safely handling the case where the view might already be destroyed (e.g. in onDismiss).

Removed unused GlobalScope and DelicateCoroutinesApi imports.

---
https://jules.google.com/session/3307825351489385165