### PR TITLE
Refactor: Use lifecycle-aware scope for server reachability check

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -20,9 +20,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -294,13 +292,12 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun checkAvailableServer(settings: SharedPreferences) {
         val updateUrl = "${settings.getString("serverURL", "")}"
         val serverUrlMapper = ServerUrlMapper()
         val mapping = serverUrlMapper.processUrl(updateUrl)
 
-        GlobalScope.launch(Dispatchers.IO) {
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
             var primaryAvailable = false
             var alternativeAvailable = false
 


### PR DESCRIPTION
Replaced GlobalScope.launch with viewLifecycleOwner.lifecycleScope.launch in the `checkAvailableServer` function of `UserInformationFragment`.

This change ties the server reachability check to the fragment's lifecycle, preventing resource leaks and unnecessary network work when the UI is no longer visible.

---
https://jules.google.com/session/14338044115922749493