### PR TITLE
logs for debugging

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -84,9 +84,15 @@ open class RealmRepository(protected val databaseService: DatabaseService) {
         }
 
     protected suspend fun <T : RealmObject> save(item: T) {
+        val saveStartTime = System.currentTimeMillis()
+        android.util.Log.d("RatingPerformance", "[${saveStartTime}] RealmRepository.save() called")
         executeTransaction { realm ->
+            val copyStartTime = System.currentTimeMillis()
+            android.util.Log.d("RatingPerformance", "[${copyStartTime}] About to call realm.copyToRealmOrUpdate")
             realm.copyToRealmOrUpdate(item)
+            android.util.Log.d("RatingPerformance", "[${copyStartTime}] realm.copyToRealmOrUpdate completed in ${System.currentTimeMillis() - copyStartTime}ms")
         }
+        android.util.Log.d("RatingPerformance", "[${saveStartTime}] RealmRepository.save() total: ${System.currentTimeMillis() - saveStartTime}ms")
     }
 
     protected suspend fun <T : RealmObject, V : Any> update(

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/AdapterCourses.kt
@@ -261,12 +261,16 @@ class AdapterCourses(
 
     private fun setupRatingBar(holder: ViewHoldercourse, course: RealmMyCourse) {
         holder.rowCourseBinding.ratingBar.setOnTouchListener { _: View?, event: MotionEvent ->
-            if (event.action == MotionEvent.ACTION_UP) homeItemClickListener?.showRatingDialog(
-                "course",
-                course.courseId,
-                course.courseTitle,
-                ratingChangeListener
-            )
+            if (event.action == MotionEvent.ACTION_UP) {
+                val ratingFlowId = System.currentTimeMillis()
+                android.util.Log.d("RatingPerformance", "[${ratingFlowId}] STEP 1: Rating bar touched - showing dialog")
+                homeItemClickListener?.showRatingDialog(
+                    "course",
+                    course.courseId,
+                    course.courseTitle,
+                    ratingChangeListener
+                )
+            }
             true
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/rating/RatingFragment.kt
@@ -119,8 +119,12 @@ class RatingFragment : DialogFragment() {
                     currentSubmitState = state
                     when (state) {
                         is RatingViewModel.SubmitState.Success -> {
+                            val callbackTime = System.currentTimeMillis()
+                            android.util.Log.d("RatingPerformance", "[${callbackTime}] STEP 6: Success callback received - calling onRatingChanged")
                             Utilities.toast(activity, "Thank you, your rating is submitted.")
                             ratingListener?.onRatingChanged()
+                            val dismissTime = System.currentTimeMillis()
+                            android.util.Log.d("RatingPerformance", "[${dismissTime}] STEP 7: Callback completed, dismissing dialog (callback took ${dismissTime - callbackTime}ms)")
                             dismiss()
                         }
                         is RatingViewModel.SubmitState.Error -> {
@@ -148,6 +152,9 @@ class RatingFragment : DialogFragment() {
     }
 
     private fun submitRating() {
+        val submitStartTime = System.currentTimeMillis()
+        android.util.Log.d("RatingPerformance", "[${submitStartTime}] STEP 2: Submit button clicked - starting submission")
+
         val comment = binding.etComment.text.toString()
         val rating = binding.ratingBar.rating
         val userId = settings.getString("userId", "") ?: ""


### PR DESCRIPTION
```
All of these transactions were waiting for the SAME lock. They all executed around timestamp 946xxx after waiting 20-40+ seconds.

What This Means
Something started a transaction BEFORE you even clicked the rating button (before timestamp 903520) and held the database lock for ~43 seconds, blocking:
  - Tag loading
  - Progress updates
  - UI refreshes
  - And your rating save

The Culprit
stack traces only show the generic DatabaseService.executeTransactionAsync path, which doesn't tell us which function called it
```