### PR TITLE
feat: Enable ANRWatchdog only in debug builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,10 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Exclude ANRWatchdog from release builds
+-assumenosideeffects class org.ole.planet.myplanet.utilities.ANRWatchdog {
+    <init>(...);
+    void start();
+    void stop();
+}

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -195,7 +195,9 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
             initApp()
             ensureApiClientInitialized()
             initializeDatabaseConnection()
-            setupAnrWatchdog()
+            if (BuildConfig.DEBUG) {
+                setupAnrWatchdog()
+            }
             scheduleWorkersOnStart()
             observeNetworkForDownloads()
         }
@@ -247,7 +249,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
 
     private suspend fun setupAnrWatchdog() {
         withContext(Dispatchers.Default) {
-            anrWatchdog = ANRWatchdog(timeout = 5000L, listener = object : ANRWatchdog.ANRListener {
+            anrWatchdog = ANRWatchdog(timeout = 10000L, listener = object : ANRWatchdog.ANRListener {
                 override fun onAppNotResponding(message: String, blockedThread: Thread, duration: Long) {
                     applicationScope.launch {
                         createLog("anr", "ANR detected! Duration: ${duration}ms\n $message")


### PR DESCRIPTION
- Wraps the `setupAnrWatchdog()` call in `MainApplication.kt` with an `if (BuildConfig.DEBUG)` check to ensure it only runs in debug builds.
- Increases the watchdog interval from 5s to 10s to reduce main-thread interruptions during development.
- Adds ProGuard rules to completely remove the `ANRWatchdog` class from release builds, eliminating any production overhead.

---
https://jules.google.com/session/16785554410948328896