### PR TITLE
feat: Defer locale loading from attachBaseContext

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utilities/LocaleHelper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/LocaleHelper.kt
@@ -5,21 +5,32 @@ import android.content.res.Configuration
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 object LocaleHelper {
     private const val SELECTED_LANGUAGE = "Locale.Helper.Selected.Language"
+    var currentLanguage: String? = null
+        private set
 
     fun onAttach(context: Context): Context {
-        val lang = getPersistedData(context, Locale.getDefault().language)
-        return setLocale(context, lang)
+        val defaultLanguage = Locale.getDefault().language
+        return setLocale(context, defaultLanguage, persist = false)
+    }
+
+    suspend fun loadPersistedLocale(context: Context): String = withContext(Dispatchers.IO) {
+        getPersistedData(context, Locale.getDefault().language)
     }
 
     fun getLanguage(context: Context): String {
         return getPersistedData(context, Locale.getDefault().language)
     }
 
-    fun setLocale(context: Context, language: String): Context {
-        persist(context, language)
+    fun setLocale(context: Context, language: String, persist: Boolean = true): Context {
+        currentLanguage = language
+        if (persist) {
+            persist(context, language)
+        }
 
         val locale = Locale(language)
         Locale.setDefault(locale)


### PR DESCRIPTION
This commit refactors the locale loading mechanism to improve application startup performance.

Key changes:
- The synchronous `SharedPreferences` read has been removed from `LocaleHelper.onAttach` to avoid blocking I/O in `attachBaseContext`.
- The application now initially loads with the system's default locale.
- A coroutine is launched in `MainApplication.onCreate` to asynchronously load the user's persisted locale preference from `SharedPreferences` on a background thread.
- If the persisted locale is different from the default, the current activity is recreated to apply the correct language.
- A `Trace` section has been added around `attachBaseContext` to monitor its performance.
- The `currentActivity` tracking in `MainApplication` has been simplified by removing a redundant assignment.

---
https://jules.google.com/session/9904182791517804738