### PR TITLE
refactor: Use viewLifecycleOwner.lifecycleScope in fragments

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -126,7 +126,7 @@ abstract class BaseResourceFragment : Fragment() {
     private var receiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             val pendingResult = goAsync()
-            this@BaseResourceFragment.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.launch {
                 try {
                     val list = libraryRepository.getLibraryListForUser(
                         settings.getString("userId", "--")
@@ -149,7 +149,7 @@ abstract class BaseResourceFragment : Fragment() {
                     pendingResult.finish()
                 }
                 .setNegativeButton(R.string.no) { _, _ ->
-                    lifecycleScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                    viewLifecycleOwner.lifecycleScope.launch(kotlinx.coroutines.Dispatchers.IO) {
                         try {
                             val wifi = requireContext().applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
                             wifi.setWifiEnabled(false)
@@ -368,7 +368,7 @@ abstract class BaseResourceFragment : Fragment() {
 
     private fun registerReceiver() {
         broadcastJob?.cancel()
-        broadcastJob = lifecycleScope.launch {
+        broadcastJob = viewLifecycleOwner.lifecycleScope.launch {
             broadcastService.events.collect { intent ->
                 if (isActive) {
                     when (intent.action) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
@@ -118,7 +118,7 @@ class MyHealthFragment : Fragment() {
     private fun checkServerAndStartSync() {
         val mapping = serverUrlMapper.processUrl(serverUrl)
 
-        lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
             updateServerIfNecessary(mapping)
             withContext(Dispatchers.Main) {
                 startSyncManager()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyFragment.kt
@@ -104,7 +104,7 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), SurveyAdoptListen
     private fun checkServerAndStartSync() {
         val mapping = serverUrlMapper.processUrl(serverUrl)
 
-        lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
             updateServerIfNecessary(mapping)
             withContext(Dispatchers.Main) {
                 startSyncManager()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/userprofile/AchievementFragment.kt
@@ -103,7 +103,7 @@ class AchievementFragment : BaseContainerFragment() {
     private fun checkServerAndStartSync() {
         val mapping = serverUrlMapper.processUrl(serverUrl)
 
-        lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
             updateServerIfNecessary(mapping)
             withContext(Dispatchers.Main) {
                 startSyncManager()


### PR DESCRIPTION
Replaced lifecycleScope with viewLifecycleOwner.lifecycleScope in BaseResourceFragment, AchievementFragment, SurveyFragment, and MyHealthFragment to align with Android best practices and prevent potential memory leaks by tying coroutine lifecycles to the view's lifecycle.

---
https://jules.google.com/session/13553912098218774768