### PR TITLE
refactor: Use lazy initialization for SharedPreferences.Editor

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -65,7 +65,7 @@ abstract class BaseResourceFragment : Fragment() {
     var homeItemClickListener: OnHomeItemClickListener? = null
     var model: RealmUserModel? = null
     protected lateinit var mRealm: Realm
-    var editor: SharedPreferences.Editor? = null
+    private val editor by lazy { settings.edit() }
     var lv: CheckboxListView? = null
     var convertView: View? = null
     internal lateinit var prgDialog: DialogUtils.CustomProgressDialog
@@ -348,10 +348,10 @@ abstract class BaseResourceFragment : Fragment() {
         prgDialog.setNegativeButton("disabling", isVisible = false){ prgDialog.dismiss() }
 
         if (settings.getBoolean("isAlternativeUrl", false)) {
-            editor?.putString("alternativeUrl", "")
-            editor?.putString("processedAlternativeUrl", "")
-            editor?.putBoolean("isAlternativeUrl", false)
-            editor?.apply()
+            editor.putString("alternativeUrl", "")
+            editor.putString("processedAlternativeUrl", "")
+            editor.putBoolean("isAlternativeUrl", false)
+            editor.apply()
         }
     }
 
@@ -392,7 +392,6 @@ abstract class BaseResourceFragment : Fragment() {
         super.onCreate(savedInstanceState)
         mRealm = databaseService.realmInstance
         prgDialog = getProgressDialog(requireActivity())
-        editor = settings.edit()
     }
 
     override fun onPause() {


### PR DESCRIPTION
Refactored the `SharedPreferences.Editor` in `BaseResourceFragment` to use lazy initialization.

This change converts the nullable `var` to a non-nullable `private val`, improving code safety and adhering to Kotlin best practices. The redundant initialization in `onCreate` has been removed, and all usages have been updated to reflect the non-nullable type.

---
https://jules.google.com/session/1446496967611425515