### PR TITLE
Fix: Move blocking DB/IO off main in ReplyActivity#showData

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/news/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/news/ReplyActivity.kt
@@ -23,7 +23,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.realm.RealmList
 import java.io.File
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ActivityReplyBinding
 import org.ole.planet.myplanet.datamanager.DatabaseService
@@ -87,12 +89,13 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
     private fun showData(id: String?) {
         id ?: return
         lifecycleScope.launch {
-            val (news, list) = viewModel.getNewsWithReplies(id)
-            databaseService.withRealm { realm ->
+            val (news, list) = withContext(Dispatchers.IO) {
+                viewModel.getNewsWithReplies(id)
+            }
+            withContext(Dispatchers.Main) {
                 newsAdapter = AdapterNews(this@ReplyActivity, user, news, "", null, userProfileDbHandler, databaseService)
                 newsAdapter.sharedPrefManager = sharedPrefManager
                 newsAdapter.setListener(this@ReplyActivity)
-                newsAdapter.setmRealm(realm)
                 newsAdapter.setFromLogin(intent.getBooleanExtra("fromLogin", false))
                 newsAdapter.setNonTeamMember(intent.getBooleanExtra("nonTeamMember", false))
                 newsAdapter.setImageList(imageList)


### PR DESCRIPTION
Refactored `ReplyActivity#showData` to prevent blocking the main thread during data loading.

- Fetches news and replies on a background thread using `withContext(Dispatchers.IO)`.
- Instantiates and sets the `AdapterNews` on the main thread within `withContext(Dispatchers.Main)`.
- Removes an unnecessary `databaseService.withRealm` block that was incorrectly wrapping UI operations.

This change improves UI responsiveness and resolves a potential ANR risk.

---
https://jules.google.com/session/14266706784022223679