### PR TITLE
feat: Refactor uploadResource to be non-blocking

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -257,11 +257,13 @@ abstract class ProcessUserDataActivity : PermissionActivity(), SuccessListener {
                 }
             }
 
-            uploadManager.uploadResource(object : SuccessListener {
-                override fun onSuccess(success: String?) {
-                    checkAllOperationsComplete()
-                }
-            })
+            lifecycleScope.launch(Dispatchers.IO) {
+                uploadManager.uploadResource(object : SuccessListener {
+                    override fun onSuccess(success: String?) {
+                        checkAllOperationsComplete()
+                    }
+                })
+            }
 
             uploadManager.uploadSubmitPhotos(object : SuccessListener {
                 override fun onSuccess(success: String?) {


### PR DESCRIPTION
Refactored `uploadResource` to prevent blocking I/O on the main thread and holding a Realm transaction open during network requests.

The original implementation executed a network call within a Realm transaction, which could lead to ANRs and poor performance.

This change detaches the necessary data from Realm using `copyFromRealm`, performs the network upload outside of any Realm transaction, and then updates the local database records in granular write transactions only after successful uploads. The function has been converted to a `suspend` function and now runs on a background thread using `withContext(Dispatchers.IO)`.

---
https://jules.google.com/session/3847830487058605563