### PR TITLE
feat: Reuse shared realm access for patient list loading

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -10,6 +10,7 @@ interface UserRepository {
     suspend fun getUserByName(name: String): RealmUserModel?
     suspend fun getAllUsers(): List<RealmUserModel>
     suspend fun getUsers(sortBy: String, sort: io.realm.Sort): List<RealmUserModel>
+    suspend fun searchUsers(query: String): List<RealmUserModel>
     suspend fun getMonthlyLoginCounts(
         userId: String,
         startMillis: Long,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -37,6 +37,17 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun searchUsers(query: String): List<RealmUserModel> {
+        return queryList(RealmUserModel::class.java) {
+            contains("firstName", query, io.realm.Case.INSENSITIVE)
+            or()
+            contains("lastName", query, io.realm.Case.INSENSITIVE)
+            or()
+            contains("name", query, io.realm.Case.INSENSITIVE)
+            sort("joinDate", io.realm.Sort.DESCENDING)
+        }
+    }
+
     override suspend fun getMonthlyLoginCounts(
         userId: String,
         startMillis: Long,


### PR DESCRIPTION
Refactors `MyHealthFragment` to use `UserRepository` for fetching the user list, replacing direct `Realm.getDefaultInstance().use` calls.

This change:
- Centralizes user data access in `UserRepository`.
- Eliminates duplicate Realm query logic in the fragment.
- Ensures database operations are performed on a background thread.

---
https://jules.google.com/session/16304829960843160137