### PR TITLE
fix(app): Resolve ANR by correcting ANRWatchdog initialization (fixes #9644)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -195,7 +195,9 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
             loadAndApplyTheme()
             ensureApiClientInitialized()
             initializeDatabaseConnection()
-            setupAnrWatchdog()
+        }
+        setupAnrWatchdog()
+        applicationScope.launch {
             scheduleWorkersOnStart()
             observeNetworkForDownloads()
         }
@@ -245,17 +247,15 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks {
         }
     }
 
-    private suspend fun setupAnrWatchdog() {
-        withContext(Dispatchers.Default) {
-            anrWatchdog = ANRWatchdog(timeout = 5000L, listener = object : ANRWatchdog.ANRListener {
-                override fun onAppNotResponding(message: String, blockedThread: Thread, duration: Long) {
-                    applicationScope.launch {
-                        createLog("anr", "ANR detected! Duration: ${duration}ms\n $message")
-                    }
+    private fun setupAnrWatchdog() {
+        anrWatchdog = ANRWatchdog(timeout = 5000L, listener = object : ANRWatchdog.ANRListener {
+            override fun onAppNotResponding(message: String, blockedThread: Thread, duration: Long) {
+                applicationScope.launch {
+                    createLog("anr", "ANR detected! Duration: ${duration}ms\n $message")
                 }
-            })
-            anrWatchdog.start()
-        }
+            }
+        })
+        anrWatchdog.start()
     }
 
     private suspend fun scheduleWorkersOnStart() {


### PR DESCRIPTION
https://github.com/open-learning-exchange/myplanet/issues/9644

The ANRWatchdog was being initialized within a coroutine using withContext(Dispatchers.Default), which caused a deadlock during application startup.

This change refactors the setupAnrWatchdog function to be a standard, non-suspending function and calls it directly from the main thread in onCreate. This ensures the watchdog is initialized correctly without thread contention, resolving the startup ANR.

---
https://jules.google.com/session/16439669607252734497