### PR TITLE
feat: Migrate AdapterTeamCourse to ListAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/AdapterTeamCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/AdapterTeamCourse.kt
@@ -6,35 +6,27 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import io.realm.Realm
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.RowTeamResourceBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getTeamCreator
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
 import org.ole.planet.myplanet.ui.team.teamCourse.AdapterTeamCourse.ViewHolderTeamCourse
 
 class AdapterTeamCourse(
     private val context: Context,
-    private var list: MutableList<RealmMyCourse>,
-    mRealm: Realm?,
-    teamId: String?,
-    settings: SharedPreferences
-) : RecyclerView.Adapter<ViewHolderTeamCourse>() {
-    private var listener: OnHomeItemClickListener? = null
+    private val teamCreator: String,
     private val settings: SharedPreferences
-    private val teamCreator: String
+) : ListAdapter<RealmMyCourse, ViewHolderTeamCourse>(DIFF_CALLBACK) {
+    private var listener: OnHomeItemClickListener? = null
 
     init {
         if (context is OnHomeItemClickListener) {
             listener = context
         }
-        this.settings = settings
-        teamCreator = getTeamCreator(teamId, mRealm)
     }
-    
-    fun getList(): List<RealmMyCourse> = list
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderTeamCourse {
         val binding = RowTeamResourceBinding.inflate(LayoutInflater.from(context), parent, false)
@@ -42,7 +34,7 @@ class AdapterTeamCourse(
     }
 
     override fun onBindViewHolder(holder: ViewHolderTeamCourse, position: Int) {
-        val course = list[position]
+        val course = getItem(position)
         holder.binding.tvTitle.text = course.courseTitle
         holder.binding.tvDescription.text = course.description
         holder.binding.root.setOnClickListener {
@@ -57,10 +49,18 @@ class AdapterTeamCourse(
         }
     }
 
-    override fun getItemCount(): Int {
-        return list.size
-    }
-
     class ViewHolderTeamCourse(val binding: RowTeamResourceBinding) :
         RecyclerView.ViewHolder(binding.root)
+
+    companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<RealmMyCourse>() {
+            override fun areItemsTheSame(oldItem: RealmMyCourse, newItem: RealmMyCourse): Boolean {
+                return oldItem.courseId == newItem.courseId
+            }
+
+            override fun areContentsTheSame(oldItem: RealmMyCourse, newItem: RealmMyCourse): Boolean {
+                return oldItem.courseTitle == newItem.courseTitle && oldItem.description == newItem.description
+            }
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
@@ -22,17 +22,22 @@ class TeamCourseFragment : BaseTeamFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setupCoursesList()
-    }
-    
-    private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { AdapterTeamCourse(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
+        val teamCreator = team?.userId ?: ""
+        adapterTeamCourse = settings?.let {
+            AdapterTeamCourse(requireActivity(), teamCreator, it)
+        }
         binding.rvCourse.layoutManager = LinearLayoutManager(activity)
         binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
-        }
+        setupCoursesList()
+    }
+
+    private fun setupCoursesList() {
+        val courses = mRealm.where(RealmMyCourse::class.java)
+            .`in`("id", team?.courses?.toTypedArray<String>())
+            .findAll()
+        val courseList = mRealm.copyFromRealm(courses)
+        adapterTeamCourse?.submitList(courseList)
+        showNoData(binding.tvNodata, courseList.size, "teamCourses")
     }
     override fun onNewsItemClick(news: RealmNews?) {}
     override fun clearImages() {


### PR DESCRIPTION
Refactored `AdapterTeamCourse` from a standard `RecyclerView.Adapter` to `ListAdapter` to leverage `DiffUtil` for more efficient list updates.

- Changed the class signature to extend `ListAdapter`.
- Implemented a `DiffUtil.ItemCallback` to compare `RealmMyCourse` objects.
- Removed manual list management from the adapter.
- Updated `TeamCourseFragment` to use `submitList()` with a copy of the RealmResults to avoid threading issues.

---
https://jules.google.com/session/15634515503818775851