### PR TITLE
feat: Move PDF generation to a background thread

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/submission/PdfGeneratorViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submission/PdfGeneratorViewModel.kt
@@ -1,0 +1,52 @@
+package org.ole.planet.myplanet.ui.submission
+
+import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.realm.Realm
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmSubmission
+import org.ole.planet.myplanet.utilities.SubmissionPdfGenerator
+import java.io.File
+import javax.inject.Inject
+
+class PdfGeneratorViewModel @Inject constructor(private val databaseService: DatabaseService) :
+    ViewModel() {
+
+    private val _pdfGenerationState = MutableLiveData<PdfGenerationState>()
+    val pdfGenerationState: LiveData<PdfGenerationState> = _pdfGenerationState
+
+    private var generationJob: Job? = null
+
+    fun generatePdf(context: Context, submission: RealmSubmission) {
+        generationJob?.cancel()
+        generationJob = viewModelScope.launch {
+            _pdfGenerationState.value = PdfGenerationState.Loading
+            try {
+                val file = SubmissionPdfGenerator.generateSubmissionPdfAsync(context, submission, databaseService)
+                _pdfGenerationState.value = file?.let { PdfGenerationState.Success(it) }
+                    ?: PdfGenerationState.Error("Failed to generate PDF")
+            } catch (e: Exception) {
+                _pdfGenerationState.value = PdfGenerationState.Error("Failed to generate PDF: ${e.message}")
+            }
+        }
+    }
+
+    fun cancel() {
+        generationJob?.cancel()
+        _pdfGenerationState.value = PdfGenerationState.Idle
+    }
+}
+
+sealed class PdfGenerationState {
+    object Idle : PdfGenerationState()
+    object Loading : PdfGenerationState()
+    data class Success(val file: File) : PdfGenerationState()
+    data class Error(val message: String) : PdfGenerationState()
+}

--- a/app/src/main/res/layout/fragment_submission_list.xml
+++ b/app/src/main/res/layout/fragment_submission_list.xml
@@ -9,19 +9,48 @@
         android:id="@+id/tv_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textSize="20sp"
-        android:textStyle="bold"
+        android:paddingBottom="16dp"
         android:textColor="@color/hint_color"
-        android:paddingBottom="16dp" />
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_submissions"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_submissions"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <LinearLayout
+            android:id="@+id/pdf_generation_container"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:visibility="gone">
+
+            <ProgressBar
+                style="?android:attr/progressBarStyleLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <Button
+                android:id="@+id/btn_cancel_pdf"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="Cancel" />
+        </LinearLayout>
+    </FrameLayout>
+
     <Button
         android:id="@+id/btn_download_report"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Download Report"
-        android:layout_marginTop="16dp" />
+        android:layout_marginTop="16dp"
+        android:text="Download Report" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_submission.xml
+++ b/app/src/main/res/layout/item_submission.xml
@@ -61,12 +61,5 @@
             android:layout_weight="1"
             android:text="Download PDF"
             android:layout_marginStart="4dp" />
-        <ProgressBar
-            android:id="@+id/progress_bar"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:visibility="gone"
-            android:layout_marginStart="8dp"/>
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Converts SubmissionPdfGenerator.generateSubmissionPdf to a suspend function.
The PDF generation logic is now wrapped in a withContext(Dispatchers.IO) block to run on a background thread, preventing UI freezes.
SubmissionListAdapter now uses lifecycleScope.launch to call the suspend function.
A progress indicator is displayed, and the download button is disabled during PDF generation to provide user feedback.
UI updates are now correctly handled on the main thread, fixing a potential crash.

---
https://jules.google.com/session/7793699415973032466