### PR TITLE
feat: Offload PDF generation to background thread

### DIFF
--- a/app/src/main/res/layout/fragment_submission_list.xml
+++ b/app/src/main/res/layout/fragment_submission_list.xml
@@ -18,10 +18,23 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1" />
-    <Button
-        android:id="@+id/btn_download_report"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Download Report"
-        android:layout_marginTop="16dp" />
+        android:layout_marginTop="16dp">
+
+        <Button
+            android:id="@+id/btn_download_report"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Download Report" />
+
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            style="?android:attr/progressBarStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="gone" />
+    </FrameLayout>
 </LinearLayout>


### PR DESCRIPTION
Moves the blocking PDF generation in `SubmissionListFragment` to a background thread using coroutines.

- Wraps the PDF creation logic in a `viewLifecycleOwner.lifecycleScope.launch` block.
- Switches to `Dispatchers.IO` for file I/O and database operations.
- Uses unmanaged Realm object copies to safely pass data to the background thread.
- Displays a progress bar and disables the download button during the operation to provide user feedback and prevent multiple clicks.
- Switches back to `Dispatchers.Main` to display a toast and open the generated PDF.

---
https://jules.google.com/session/5886120616428388616