### PR TITLE
Refactor(AdapterResource): Use DatabaseService and unify diffing

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -203,7 +203,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     override fun getAdapter(): RecyclerView.Adapter<*> {
         map = getRatings(mRealm, "resource", model?.id)
         val libraryList: List<RealmMyLibrary?> = getList(RealmMyLibrary::class.java).filterIsInstance<RealmMyLibrary?>()
-        adapterLibrary = AdapterResource(requireActivity(), libraryList, map!!, tagRepository, profileDbHandler?.userModel)
+        adapterLibrary = AdapterResource(requireActivity(), libraryList, map!!, tagRepository, profileDbHandler?.userModel, databaseService)
         adapterLibrary.setRatingChangeListener(this)
         adapterLibrary.setListener(this)
         return adapterLibrary


### PR DESCRIPTION
Injects `DatabaseService` into `AdapterResource` to handle database operations, replacing direct `Realm.getDefaultInstance()` calls. This improves testability and aligns with the project's dependency injection pattern.

Consolidates the `updateList` and `triggerDiff` methods into a single `dispatchDiff` function. This removes redundant code and uses a more robust `DiffUtil` comparison based on the full `RealmMyLibrary` object, simplifying the adapter's logic.

---
https://jules.google.com/session/15978242196097214453