### PR TITLE
Migrate SubmissionListAdapter to ListAdapter with DiffUtil

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/submission/SubmissionItem.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submission/SubmissionItem.kt
@@ -1,8 +1,0 @@
-package org.ole.planet.myplanet.ui.submission
-
-data class SubmissionItem(
-    val id: String?,
-    val lastUpdateTime: Long,
-    val status: String,
-    val uploaded: Boolean
-)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submission/SubmissionListAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submission/SubmissionListAdapter.kt
@@ -5,18 +5,19 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.ItemSubmissionBinding
+import org.ole.planet.myplanet.model.RealmSubmission
+import org.ole.planet.myplanet.utilities.DiffUtils
 import org.ole.planet.myplanet.utilities.TimeUtils
 
 class SubmissionListAdapter(
     private val context: Context,
     private val listener: OnHomeItemClickListener?,
     private val onGeneratePdf: (String?) -> Unit
-) : ListAdapter<SubmissionItem, SubmissionListAdapter.ViewHolder>(USER_COMPARATOR) {
+) : ListAdapter<RealmSubmission, SubmissionListAdapter.ViewHolder>(DIFF_CALLBACK) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = ItemSubmissionBinding.inflate(LayoutInflater.from(context), parent, false)
@@ -29,10 +30,10 @@ class SubmissionListAdapter(
     }
 
     inner class ViewHolder(private val binding: ItemSubmissionBinding) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(submission: SubmissionItem, number: Int) {
+        fun bind(submission: RealmSubmission, number: Int) {
             binding.tvSubmissionNumber.text = "#$number"
             binding.tvSubmissionDate.text = TimeUtils.getFormattedDateWithTime(submission.lastUpdateTime)
-            binding.tvSubmissionStatus.text = submission.status
+            binding.tvSubmissionStatus.text = submission.status ?: ""
 
             binding.tvSyncStatus.text = if (submission.uploaded) "✅" else "❌"
 
@@ -55,14 +56,14 @@ class SubmissionListAdapter(
     }
 
     companion object {
-        private val USER_COMPARATOR = object : DiffUtil.ItemCallback<SubmissionItem>() {
-            override fun areItemsTheSame(oldItem: SubmissionItem, newItem: SubmissionItem): Boolean {
-                return oldItem.id == newItem.id
+        private val DIFF_CALLBACK = DiffUtils.itemCallback<RealmSubmission>(
+            areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id },
+            areContentsTheSame = { oldItem, newItem ->
+                oldItem.id == newItem.id &&
+                oldItem.lastUpdateTime == newItem.lastUpdateTime &&
+                oldItem.status == newItem.status &&
+                oldItem.uploaded == newItem.uploaded
             }
-
-            override fun areContentsTheSame(oldItem: SubmissionItem, newItem: SubmissionItem): Boolean {
-                return oldItem == newItem
-            }
-        }
+        )
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submission/SubmissionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submission/SubmissionListFragment.kt
@@ -76,15 +76,8 @@ class SubmissionListFragment : Fragment() {
                 .sort("lastUpdateTime", Sort.DESCENDING)
                 .findAll()
 
-            val submissionItems = submissions.map {
-                SubmissionItem(
-                    id = it.id,
-                    lastUpdateTime = it.lastUpdateTime,
-                    status = it.status ?: "",
-                    uploaded = it.uploaded
-                )
-            }
-            adapter.submitList(submissionItems)
+            // Pass unmanaged copies to the adapter to allow background diffing
+            adapter.submitList(realm.copyFromRealm(submissions))
 
             binding.btnDownloadReport.setOnClickListener {
                 generateReport(submissions.toList())


### PR DESCRIPTION
- Migrated SubmissionListAdapter to use RealmSubmission objects directly instead of SubmissionItem DTO.
- Replaced custom DiffUtil.ItemCallback implementation with DiffUtils.itemCallback helper.
- Removed unused SubmissionItem class.
- Updated SubmissionListFragment to map Realm objects to unmanaged copies and pass them to the adapter.

---
https://jules.google.com/session/4684009504859476682