### PR TITLE
Refactor: Decouple AdapterTeamCourse from Realm

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/AdapterTeamCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/AdapterTeamCourse.kt
@@ -18,8 +18,7 @@ import org.ole.planet.myplanet.ui.team.teamCourse.AdapterTeamCourse.ViewHolderTe
 class AdapterTeamCourse(
     private val context: Context,
     private var list: MutableList<RealmMyCourse>,
-    mRealm: Realm?,
-    teamId: String?,
+    private val teamCreatorId: String,
     settings: SharedPreferences
 ) : RecyclerView.Adapter<ViewHolderTeamCourse>() {
     private var listener: OnHomeItemClickListener? = null
@@ -31,7 +30,7 @@ class AdapterTeamCourse(
             listener = context
         }
         this.settings = settings
-        teamCreator = getTeamCreator(teamId, mRealm)
+        teamCreator = teamCreatorId
     }
     
     fun getList(): List<RealmMyCourse> = list

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
@@ -27,7 +27,10 @@ class TeamCourseFragment : BaseTeamFragment() {
     
     private fun setupCoursesList() {
         val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { AdapterTeamCourse(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
+        val teamCreatorId = team?.createdBy ?: ""
+        adapterTeamCourse = settings?.let {
+            AdapterTeamCourse(requireActivity(), courses.toMutableList(), teamCreatorId, it)
+        }
         binding.rvCourse.layoutManager = LinearLayoutManager(activity)
         binding.rvCourse.adapter = adapterTeamCourse
         adapterTeamCourse?.let {


### PR DESCRIPTION
Removes the `mRealm` dependency from `AdapterTeamCourse` by passing the `teamCreatorId` directly into the constructor.

- The adapter constructor no longer accepts a `Realm?` instance or a `teamId`.
- `TeamCourseFragment` now retrieves the creator's ID from the `team` object and provides it to the adapter.

This change improves the separation of concerns, moving data logic out of the UI component and making the adapter more focused on its view-binding responsibilities.

---
https://jules.google.com/session/10041674385137931495