### PR TITLE
refactor: Move syncPlanetServers to a repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/Service.kt
@@ -30,8 +30,8 @@ import org.ole.planet.myplanet.di.AutoSyncEntryPoint
 import org.ole.planet.myplanet.di.DatabaseServiceEntryPoint
 import org.ole.planet.myplanet.di.RepositoryEntryPoint
 import org.ole.planet.myplanet.model.MyPlanet
-import org.ole.planet.myplanet.model.RealmCommunity
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.PlanetRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.service.UploadToShelfService
 import org.ole.planet.myplanet.ui.sync.ProcessUserDataActivity
@@ -58,6 +58,7 @@ class Service @Inject constructor(
     @ApplicationScope private val serviceScope: CoroutineScope,
     private val userRepository: UserRepository,
     private val uploadToShelfService: UploadToShelfService,
+    private val planetRepository: PlanetRepository
 ) {
     constructor(context: Context) : this(
         context,
@@ -81,6 +82,10 @@ class Service @Inject constructor(
             context.applicationContext,
             AutoSyncEntryPoint::class.java
         ).uploadToShelfService(),
+        EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            RepositoryEntryPoint::class.java
+        ).planetRepository()
     )
 
     private val preferences: SharedPreferences = context.getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE)
@@ -403,62 +408,8 @@ class Service @Inject constructor(
         }
     }
 
-    suspend fun syncPlanetServers(callback: SuccessListener) {
-        try {
-            val response = withContext(Dispatchers.IO) {
-                retrofitInterface.getJsonObject("", "https://planet.earth.ole.org/db/communityregistrationrequests/_all_docs?include_docs=true").execute()
-            }
-
-            if (response.isSuccessful && response.body() != null) {
-                val arr = JsonUtils.getJsonArray("rows", response.body())
-                val startTime = System.currentTimeMillis()
-                println("Realm transaction started")
-
-                val transactionResult = runCatching {
-                    withContext(Dispatchers.IO) {
-                        databaseService.withRealm { backgroundRealm ->
-                            backgroundRealm.executeTransaction { realm1 ->
-                                realm1.delete(RealmCommunity::class.java)
-                                for (j in arr) {
-                                    var jsonDoc = j.asJsonObject
-                                    jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
-                                    val id = JsonUtils.getString("_id", jsonDoc)
-                                    val community = realm1.createObject(RealmCommunity::class.java, id)
-                                    if (JsonUtils.getString("name", jsonDoc) == "learning") {
-                                        community.weight = 0
-                                    }
-                                    community.localDomain = JsonUtils.getString("localDomain", jsonDoc)
-                                    community.name = JsonUtils.getString("name", jsonDoc)
-                                    community.parentDomain = JsonUtils.getString("parentDomain", jsonDoc)
-                                    community.registrationRequest = JsonUtils.getString("registrationRequest", jsonDoc)
-                                }
-                            }
-                        }
-                    }
-                }
-
-                val endTime = System.currentTimeMillis()
-                println("Realm transaction finished in ${endTime - startTime}ms")
-
-                withContext(Dispatchers.Main) {
-                    transactionResult.onSuccess {
-                        callback.onSuccess(context.getString(R.string.server_sync_successfully))
-                    }.onFailure { e ->
-                        e.printStackTrace()
-                        callback.onSuccess(context.getString(R.string.server_sync_has_failed))
-                    }
-                }
-            } else {
-                withContext(Dispatchers.Main) {
-                    callback.onSuccess(context.getString(R.string.server_sync_has_failed))
-                }
-            }
-        } catch (t: Throwable) {
-            t.printStackTrace()
-            withContext(Dispatchers.Main) {
-                callback.onSuccess(context.getString(R.string.server_sync_has_failed))
-            }
-        }
+    suspend fun syncPlanetServers(): String {
+        return planetRepository.syncPlanetServers()
     }
 
     fun getMinApk(listener: ConfigurationIdListener?, url: String, pin: String, activity: SyncActivity, callerActivity: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryEntryPoint.kt
@@ -3,10 +3,12 @@ package org.ole.planet.myplanet.di
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import org.ole.planet.myplanet.repository.PlanetRepository
 import org.ole.planet.myplanet.repository.UserRepository
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
 interface RepositoryEntryPoint {
     fun userRepository(): UserRepository
+    fun planetRepository(): PlanetRepository
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -34,6 +34,8 @@ import org.ole.planet.myplanet.repository.SurveyRepositoryImpl
 import org.ole.planet.myplanet.repository.TagRepository
 import org.ole.planet.myplanet.repository.TagRepositoryImpl
 import org.ole.planet.myplanet.repository.TeamRepository
+import org.ole.planet.myplanet.repository.PlanetRepository
+import org.ole.planet.myplanet.repository.PlanetRepositoryImpl
 import org.ole.planet.myplanet.repository.TeamRepositoryImpl
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.UserRepositoryImpl
@@ -105,4 +107,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPlanetRepository(impl: PlanetRepositoryImpl): PlanetRepository
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PlanetRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PlanetRepository.kt
@@ -1,0 +1,5 @@
+package org.ole.planet.myplanet.repository
+
+interface PlanetRepository {
+    suspend fun syncPlanetServers(): String
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PlanetRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PlanetRepositoryImpl.kt
@@ -1,0 +1,63 @@
+package org.ole.planet.myplanet.repository
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.datamanager.ApiInterface
+import org.ole.planet.myplanet.datamanager.DatabaseService
+import org.ole.planet.myplanet.model.RealmCommunity
+import org.ole.planet.myplanet.utilities.JsonUtils
+import javax.inject.Inject
+
+class PlanetRepositoryImpl @Inject constructor(
+    private val apiInterface: ApiInterface,
+    private val databaseService: DatabaseService,
+    @ApplicationContext private val context: Context
+) : PlanetRepository {
+    override suspend fun syncPlanetServers(): String {
+        return try {
+            val response = withContext(Dispatchers.IO) {
+                apiInterface.getJsonObject("", "https://planet.earth.ole.org/db/communityregistrationrequests/_all_docs?include_docs=true").execute()
+            }
+
+            if (response.isSuccessful && response.body() != null) {
+                val arr = JsonUtils.getJsonArray("rows", response.body())
+                val transactionResult = runCatching {
+                    withContext(Dispatchers.IO) {
+                        databaseService.withRealm { backgroundRealm ->
+                            backgroundRealm.executeTransaction { realm1 ->
+                                realm1.delete(RealmCommunity::class.java)
+                                for (j in arr) {
+                                    var jsonDoc = j.asJsonObject
+                                    jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
+                                    val id = JsonUtils.getString("_id", jsonDoc)
+                                    val community = realm1.createObject(RealmCommunity::class.java, id)
+                                    if (JsonUtils.getString("name", jsonDoc) == "learning") {
+                                        community.weight = 0
+                                    }
+                                    community.localDomain = JsonUtils.getString("localDomain", jsonDoc)
+                                    community.name = JsonUtils.getString("name", jsonDoc)
+                                    community.parentDomain = JsonUtils.getString("parentDomain", jsonDoc)
+                                    community.registrationRequest = JsonUtils.getString("registrationRequest", jsonDoc)
+                                }
+                            }
+                        }
+                    }
+                }
+                if (transactionResult.isSuccess) {
+                    context.getString(R.string.server_sync_successfully)
+                } else {
+                    transactionResult.exceptionOrNull()?.printStackTrace()
+                    context.getString(R.string.server_sync_has_failed)
+                }
+            } else {
+                context.getString(R.string.server_sync_has_failed)
+            }
+        } catch (t: Throwable) {
+            t.printStackTrace()
+            context.getString(R.string.server_sync_has_failed)
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -297,9 +297,8 @@ class LoginActivity : SyncActivity(), TeamListAdapter.OnItemClickListener {
         setUpLanguageButton()
         if (NetworkUtils.isNetworkConnected) {
             lifecycleScope.launch {
-                service.syncPlanetServers { success: String? ->
-                    toast(this@LoginActivity, success)
-                }
+                val message = service.syncPlanetServers()
+                toast(this@LoginActivity, message)
             }
         }
         nameWatcher2 = object : TextWatcher {


### PR DESCRIPTION
- Create a new PlanetRepository to handle the synchronization of planet servers.
- Move the network call and Realm transaction logic from Service.kt into the new repository.
- Inject the PlanetRepository into Service.kt and update the implementation to call the repository.
- Update the call site in LoginActivity.kt to handle the new asynchronous nature of the function.

---
https://jules.google.com/session/2270940131143486271