### PR TITLE
Fix Realm access from incorrect thread in SubmissionListAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/submission/SubmissionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submission/SubmissionListFragment.kt
@@ -78,7 +78,7 @@ class SubmissionListFragment : Fragment() {
 
             val submissionItems = submissions.map {
                 SubmissionItem(
-                    submission = it,
+                    submission = realm.copyFromRealm(it),
                     examName = examTitle,
                     submissionCount = 1,
                     userName = null
@@ -87,7 +87,7 @@ class SubmissionListFragment : Fragment() {
             adapter.submitList(submissionItems)
 
             binding.btnDownloadReport.setOnClickListener {
-                generateReport(submissions.toList())
+                generateReport(submissionItems.map { it.submission })
             }
         }
     }


### PR DESCRIPTION
This change fixes a crash where `SubmissionListAdapter` (via `AsyncListDiffer`) accessed thread-confined managed Realm objects on a background thread.

The fix involves using `realm.copyFromRealm()` to create unmanaged copies of `RealmSubmission` objects before passing them to the adapter. This ensures that the objects are thread-safe and can be accessed by the DiffUtil background thread.

Additionally, the report generation logic was updated to use these unmanaged objects, preventing potential issues with closed Realm instances in the click listener.