### PR TITLE
refactor: Decouple AdapterResource from Realm

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -72,7 +72,7 @@ abstract class BaseResourceFragment : Fragment() {
     @Inject
     lateinit var userRepository: UserRepository
     @Inject
-    lateinit var libraryRepository: LibraryRepository
+    open lateinit var libraryRepository: LibraryRepository
     @Inject
     lateinit var courseRepository: CourseRepository
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AdapterResource.kt
@@ -403,14 +403,7 @@ class AdapterResource(
     }
 
     override fun refreshWithDiff() {
-        (context as? LifecycleOwner)?.lifecycleScope?.launch {
-            val newLibraryList = withContext(Dispatchers.IO) {
-                Realm.getDefaultInstance().use { realm ->
-                    realm.copyFromRealm(realm.where(RealmMyLibrary::class.java).findAll())
-                }
-            }
-            triggerDiff(newLibraryList)
-        }
+        (context as? ResourcesFragment)?.refreshResourcesData()
     }
 
     private fun triggerDiff(newList: List<RealmMyLibrary?>) {


### PR DESCRIPTION
Moved the Realm query from `AdapterResource.refreshWithDiff` to a new `getAllLibraryItems` method in the `LibraryRepository`.

The `ResourcesFragment` is now responsible for fetching the data from the repository and passing it to the adapter. This change decouples the adapter from the data layer, improving the separation of concerns and making the code more maintainable.

The `AdapterResource.refreshWithDiff` method has been updated to delegate the data refresh back to the fragment, ensuring that the fragment remains the single source of truth for the data. All filtering and data refresh operations within the fragment now call a centralized `refreshResourcesData` method, which uses the `LibraryRepository` to fetch the latest data.

---
https://jules.google.com/session/17495756847260811804