### PR TITLE
feat: Migrate AdapterTeamCourse to use DiffUtil

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/AdapterTeamCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/AdapterTeamCourse.kt
@@ -14,10 +14,11 @@ import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getTeamCreator
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
 import org.ole.planet.myplanet.ui.team.teamCourse.AdapterTeamCourse.ViewHolderTeamCourse
+import org.ole.planet.myplanet.utilities.DiffUtils
 
 class AdapterTeamCourse(
     private val context: Context,
-    private var list: MutableList<RealmMyCourse>,
+    private var list: List<RealmMyCourse>,
     mRealm: Realm?,
     teamId: String?,
     settings: SharedPreferences
@@ -33,8 +34,17 @@ class AdapterTeamCourse(
         this.settings = settings
         teamCreator = getTeamCreator(teamId, mRealm)
     }
-    
-    fun getList(): List<RealmMyCourse> = list
+
+    fun updateList(newList: List<RealmMyCourse>) {
+        val diffResult = DiffUtils.calculateDiff(
+            list,
+            newList,
+            areItemsTheSame = TEAM_COURSE_DIFF_CALLBACK::areItemsTheSame,
+            areContentsTheSame = TEAM_COURSE_DIFF_CALLBACK::areContentsTheSame
+        )
+        list = newList
+        diffResult.dispatchUpdatesTo(this)
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderTeamCourse {
         val binding = RowTeamResourceBinding.inflate(LayoutInflater.from(context), parent, false)
@@ -63,4 +73,13 @@ class AdapterTeamCourse(
 
     class ViewHolderTeamCourse(val binding: RowTeamResourceBinding) :
         RecyclerView.ViewHolder(binding.root)
+
+    companion object {
+        val TEAM_COURSE_DIFF_CALLBACK = DiffUtils.itemCallback<RealmMyCourse>(
+            areItemsTheSame = { oldItem, newItem -> oldItem.courseId == newItem.courseId },
+            areContentsTheSame = { oldItem, newItem ->
+                oldItem.courseTitle == newItem.courseTitle && oldItem.description == newItem.description
+            }
+        )
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/teamCourse/TeamCourseFragment.kt
@@ -5,6 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
+import io.realm.RealmChangeListener
+import io.realm.RealmResults
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmNews
@@ -14,6 +16,11 @@ class TeamCourseFragment : BaseTeamFragment() {
     private var _binding: FragmentTeamCourseBinding? = null
     private val binding get() = _binding!!
     private var adapterTeamCourse: AdapterTeamCourse? = null
+    private var courses: RealmResults<RealmMyCourse>? = null
+    private val courseChangeListener = RealmChangeListener<RealmResults<RealmMyCourse>> { results ->
+        adapterTeamCourse?.updateList(results)
+        showNoData(binding.tvNodata, results.size, "teamCourses")
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentTeamCourseBinding.inflate(inflater, container, false)
@@ -24,16 +31,22 @@ class TeamCourseFragment : BaseTeamFragment() {
         super.onViewCreated(view, savedInstanceState)
         setupCoursesList()
     }
-    
+
     private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { AdapterTeamCourse(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
+        courses = mRealm.where(RealmMyCourse::class.java)
+            .`in`("id", team?.courses?.toTypedArray<String>())
+            .findAllAsync()
+        courses?.addChangeListener(courseChangeListener)
+        adapterTeamCourse = settings?.let {
+            AdapterTeamCourse(requireActivity(), courses?.toList() ?: emptyList(), mRealm, teamId, it)
+        }
         binding.rvCourse.layoutManager = LinearLayoutManager(activity)
         binding.rvCourse.adapter = adapterTeamCourse
         adapterTeamCourse?.let {
             showNoData(binding.tvNodata, it.itemCount, "teamCourses")
         }
     }
+
     override fun onNewsItemClick(news: RealmNews?) {}
     override fun clearImages() {
         imageList.clear()
@@ -41,6 +54,7 @@ class TeamCourseFragment : BaseTeamFragment() {
     }
 
     override fun onDestroyView() {
+        courses?.removeChangeListener(courseChangeListener)
         _binding = null
         super.onDestroyView()
     }


### PR DESCRIPTION
This commit refactors the `AdapterTeamCourse` to use `DiffUtil` for more efficient list updates.

Key changes:
- A `DiffUtil.ItemCallback` is added to `AdapterTeamCourse` to compare `RealmMyCourse` objects.
- The adapter is updated to use an immutable list and an `updateList` method that dispatches updates calculated by `DiffUtil`.
- `TeamCourseFragment` is refactored to use `findAllAsync` and a `RealmChangeListener` to provide reactive updates to the adapter. This also improves performance by moving the initial query off the main thread.

---
https://jules.google.com/session/11925160207271045873