### PR TITLE
Refactor: Make isPlanetAvailable call non-blocking

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiInterface.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/datamanager/ApiInterface.kt
@@ -62,10 +62,7 @@ interface ApiInterface {
     fun getChecksum(@Url url: String?): Call<ResponseBody>
 
     @GET
-    fun isPlanetAvailable(@Url serverUrl: String?): Call<ResponseBody>
-
-    @GET
-    suspend fun isPlanetAvailableSuspend(@Url serverUrl: String?): Response<ResponseBody>
+    suspend fun isPlanetAvailable(@Url serverUrl: String?): Response<ResponseBody?>
 
     @POST
     fun chatGpt(@Url url: String?, @Body requestBody: RequestBody?): Call<ChatModel>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -222,13 +222,11 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun becomeMember(obj: JsonObject): Pair<Boolean, String> {
-        val isAvailable = withContext(Dispatchers.IO) {
-            try {
-                val response = apiInterface.isPlanetAvailableSuspend(UrlUtils.getUpdateUrl(settings))
-                response.code() == 200
-            } catch (e: Exception) {
-                false
-            }
+        val isAvailable = try {
+            val response = apiInterface.isPlanetAvailable(UrlUtils.getUpdateUrl(settings))
+            response?.code() == 200
+        } catch (e: Exception) {
+            false
         }
 
         if (isAvailable) {


### PR DESCRIPTION
Converted the `isPlanetAvailable` method in `Service.kt` from a callback-based implementation to a `suspend` function. This change ensures that the network call is non-blocking and uses modern Kotlin coroutines.

Updated all call sites in `SyncActivity.kt`, `BaseResourceFragment.kt`, and `UserRepositoryImpl.kt` to use the new suspend function within a `lifecycleScope` or `applicationScope` coroutine.

Removed the now-unused `PlanetAvailableListener` interface and the redundant `isPlanetAvailableSuspend` method from `ApiInterface.kt`.

---
https://jules.google.com/session/16255443225615880754