### PR TITLE
refactor: Modernize threading in DashboardElementActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -438,10 +438,12 @@ open class BaseDashboardFragment : BaseDashboardFragmentPlugin(), NotificationCa
     }
 
     override fun syncKeyId() {
-        if (model?.getRoleAsString()?.contains("health") == true) {
-            settings?.let { transactionSyncManager.syncAllHealthData(realm, it, this) }
-        } else {
-            settings?.let { transactionSyncManager.syncKeyIv(realm, it, this, profileDbHandler) }
+        viewLifecycleOwner.lifecycleScope.launch {
+            if (model?.getRoleAsString()?.contains("health") == true) {
+                settings?.let { transactionSyncManager.syncAllHealthData(it, this@BaseDashboardFragment) }
+            } else {
+                settings?.let { transactionSyncManager.syncKeyIv(it, this@BaseDashboardFragment, profileDbHandler) }
+            }
         }
     }
 


### PR DESCRIPTION
Refactored the syncKeyId data synchronization methods to use lifecycle-aware Kotlin coroutines.

- Replaced the legacy `executeTransactionAsync` calls in `TransactionSyncManager` with `suspend` functions that perform database and network operations on the `Dispatchers.IO` context.
- Updated the call site in `BaseDashboardFragment` to launch these `suspend` functions within a `viewLifecycleOwner.lifecycleScope`, ensuring the operations are automatically canceled when the view is destroyed.
- Ensured UI-updating `SyncListener` callbacks are dispatched back to the main thread.

---
https://jules.google.com/session/6627444007835281763