### PR TITLE
Fix: Use viewLifecycleOwner.lifecycleScope in BellDashboardFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -233,7 +233,7 @@ class BellDashboardFragment : BaseDashboardFragment() {
 
     private fun startReminderCheck() {
         surveyReminderJob?.cancel()
-        surveyReminderJob = lifecycleScope.launch {
+        surveyReminderJob = viewLifecycleOwner.lifecycleScope.launch {
             while (isActive) {
                 checkScheduledReminders()
                 delay(60000)


### PR DESCRIPTION
Replaced `lifecycleScope` with `viewLifecycleOwner.lifecycleScope` for launching the `surveyReminderJob`. This ensures the polling coroutine is correctly tied to the fragment's view lifecycle and is automatically cancelled when the view is destroyed, preventing potential memory leaks.

Verified that the existing `surveyReminderJob?.cancel()` in `onDestroyView()` provides redundant but harmless cancellation. The primary fix is the scope change.

---
https://jules.google.com/session/4545204467419563214