### PR TITLE
feat(myhealth): Use repository for data access

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -57,6 +57,7 @@ interface UserRepository {
         currentUser: RealmUserModel
     ): HealthRecord?
 
+    suspend fun searchUsers(query: String): List<RealmUserModel>
     fun getUserModel(): RealmUserModel?
     suspend fun getUserModelSuspending(): RealmUserModel?
     fun getActiveUserId(): String

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -19,6 +19,8 @@ import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.RealmUserModel.Companion.populateUsersTable
 import org.ole.planet.myplanet.service.UploadToShelfService
+import io.realm.Case
+import io.realm.Sort
 import org.ole.planet.myplanet.ui.myhealth.HealthRecord
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.UrlUtils
@@ -367,5 +369,19 @@ class UserRepositoryImpl @Inject constructor(
             realm.copyFromRealm(users).filter { it.id != null }.associateBy { it.id!! }
         }
         HealthRecord(mh, mm, list, userMap)
+    }
+
+    override suspend fun searchUsers(query: String): List<RealmUserModel> {
+        return withRealm { realm ->
+            val results = realm.where(RealmUserModel::class.java)
+                .contains("firstName", query, Case.INSENSITIVE)
+                .or()
+                .contains("lastName", query, Case.INSENSITIVE)
+                .or()
+                .contains("name", query, Case.INSENSITIVE)
+                .sort("joinDate", Sort.DESCENDING)
+                .findAll()
+            realm.copyFromRealm(results)
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
@@ -68,8 +68,6 @@ class MyHealthFragment : Fragment() {
     @Inject
     lateinit var syncManager: SyncManager
     @Inject
-    lateinit var databaseService: DatabaseService
-    @Inject
     lateinit var userRepository: UserRepository
     private val syncCoordinator = RealtimeSyncCoordinator.getInstance()
     private lateinit var realtimeSyncListener: BaseRealtimeSyncListener
@@ -78,7 +76,6 @@ class MyHealthFragment : Fragment() {
     private lateinit var alertMyPersonalBinding: AlertMyPersonalBinding
     private var alertHealthListBinding: AlertHealthListBinding? = null
     var userId: String? = null
-    lateinit var mRealm: Realm
     var userModel: RealmUserModel? = null
     lateinit var userModelList: List<RealmUserModel>
     lateinit var adapter: UserListArrayAdapter
@@ -102,7 +99,6 @@ class MyHealthFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentVitalSignBinding.inflate(inflater, container, false)
-        mRealm = databaseService.realmInstance
         return binding.root
     }
 
@@ -350,16 +346,7 @@ class MyHealthFragment : Fragment() {
                         lv.visibility = View.GONE
                     }
 
-                    val userModelList = withContext(Dispatchers.IO) {
-                        databaseService.withRealm { realm ->
-                            val results = realm.where(RealmUserModel::class.java)
-                                .contains("firstName", editable.toString(), Case.INSENSITIVE).or()
-                                .contains("lastName", editable.toString(), Case.INSENSITIVE).or()
-                                .contains("name", editable.toString(), Case.INSENSITIVE)
-                                .sort("joinDate", Sort.DESCENDING).findAll()
-                            realm.copyFromRealm(results)
-                        }
-                    }
+                    val userModelList = userRepository.searchUsers(editable.toString())
 
                     loadingJob.cancel()
                     if (isAdded) {
@@ -488,9 +475,6 @@ class MyHealthFragment : Fragment() {
     override fun onDestroy() {
         customProgressDialog?.dismiss()
         customProgressDialog = null
-        if (this::mRealm.isInitialized && !mRealm.isClosed) {
-            mRealm.close()
-        }
         super.onDestroy()
     }
 }


### PR DESCRIPTION
Refactors MyHealthFragment to delegate all user data operations to the UserRepository.

- Adds a `searchUsers` method to `UserRepository` to encapsulate the Realm query for searching users.
- Modifies `MyHealthFragment` to use the new repository method, removing the direct dependency on `DatabaseService`.
- Removes the manually managed `mRealm` instance from `MyHealthFragment`, improving lifecycle safety and reducing the risk of memory leaks.

---
https://jules.google.com/session/6954613112141171715