### PR TITLE
refactor: Move user search to UserRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -57,6 +57,7 @@ interface UserRepository {
         currentUser: RealmUserModel
     ): HealthRecord?
 
+    suspend fun searchUsers(query: String): List<RealmUserModel>
     fun getUserModel(): RealmUserModel?
     suspend fun getUserModelSuspending(): RealmUserModel?
     fun getActiveUserId(): String

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -368,4 +368,18 @@ class UserRepositoryImpl @Inject constructor(
         }
         HealthRecord(mh, mm, list, userMap)
     }
+
+    override suspend fun searchUsers(query: String): List<RealmUserModel> {
+        return withRealm { realm ->
+            val results = realm.where(RealmUserModel::class.java)
+                .contains("firstName", query, io.realm.Case.INSENSITIVE)
+                .or()
+                .contains("lastName", query, io.realm.Case.INSENSITIVE)
+                .or()
+                .contains("name", query, io.realm.Case.INSENSITIVE)
+                .sort("joinDate", io.realm.Sort.DESCENDING)
+                .findAll()
+            realm.copyFromRealm(results)
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/myhealth/MyHealthFragment.kt
@@ -78,7 +78,6 @@ class MyHealthFragment : Fragment() {
     private lateinit var alertMyPersonalBinding: AlertMyPersonalBinding
     private var alertHealthListBinding: AlertHealthListBinding? = null
     var userId: String? = null
-    lateinit var mRealm: Realm
     var userModel: RealmUserModel? = null
     lateinit var userModelList: List<RealmUserModel>
     lateinit var adapter: UserListArrayAdapter
@@ -102,7 +101,6 @@ class MyHealthFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentVitalSignBinding.inflate(inflater, container, false)
-        mRealm = databaseService.realmInstance
         return binding.root
     }
 
@@ -350,16 +348,7 @@ class MyHealthFragment : Fragment() {
                         lv.visibility = View.GONE
                     }
 
-                    val userModelList = withContext(Dispatchers.IO) {
-                        databaseService.withRealm { realm ->
-                            val results = realm.where(RealmUserModel::class.java)
-                                .contains("firstName", editable.toString(), Case.INSENSITIVE).or()
-                                .contains("lastName", editable.toString(), Case.INSENSITIVE).or()
-                                .contains("name", editable.toString(), Case.INSENSITIVE)
-                                .sort("joinDate", Sort.DESCENDING).findAll()
-                            realm.copyFromRealm(results)
-                        }
-                    }
+                    val userModelList = userRepository.searchUsers(editable.toString())
 
                     loadingJob.cancel()
                     if (isAdded) {
@@ -488,9 +477,6 @@ class MyHealthFragment : Fragment() {
     override fun onDestroy() {
         customProgressDialog?.dismiss()
         customProgressDialog = null
-        if (this::mRealm.isInitialized && !mRealm.isClosed) {
-            mRealm.close()
-        }
         super.onDestroy()
     }
 }


### PR DESCRIPTION
- Add `searchUsers(query: String)` method to the `UserRepository` interface and implement it in `UserRepositoryImpl`.
- The implementation encapsulates the Realm query for searching users by first name, last name, or full name.
- Replace the direct Realm query in `MyHealthFragment`'s search functionality with a call to the new repository method.
- Remove the now-unused `mRealm` instance and its associated lifecycle management code from `MyHealthFragment`, cleaning up the fragment and centralizing data access.

---
https://jules.google.com/session/17254127052689420593