### PR TITLE
Refactor: Move SurveyAdapter to survey package

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -36,6 +36,7 @@ import org.ole.planet.myplanet.ui.mylife.LifeFragment
 import org.ole.planet.myplanet.ui.resources.ResourcesFragment
 import org.ole.planet.myplanet.ui.submission.AdapterMySubmission
 import org.ole.planet.myplanet.ui.submission.MySubmissionFragment
+import org.ole.planet.myplanet.ui.survey.SurveyTitlesAdapter
 import org.ole.planet.myplanet.ui.team.TeamFragment
 import org.ole.planet.myplanet.utilities.DialogUtils.guestDialog
 
@@ -321,7 +322,7 @@ class BellDashboardFragment : BaseDashboardFragment() {
             .setNegativeButton(getString(R.string.cancel)) { dialog, _ -> dialog.dismiss() }
             .create()
 
-        val adapter = SurveyAdapter({ position ->
+        val adapter = SurveyTitlesAdapter({ position ->
             val selectedSurvey = pendingSurveys[position].id
             AdapterMySubmission.openSurvey(homeItemClickListener, selectedSurvey, true, false, "")
         }, surveyListDialog!!)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyTitlesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/survey/SurveyTitlesAdapter.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.dashboard
+package org.ole.planet.myplanet.ui.survey
 
 import android.view.LayoutInflater
 import android.view.View
@@ -11,10 +11,10 @@ import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.utilities.DiffUtils
 
-class SurveyAdapter(
+class SurveyTitlesAdapter(
     private val onItemClick: (Int) -> Unit,
     private val dialog: AlertDialog
-) : ListAdapter<String, SurveyAdapter.SurveyViewHolder>(DIFF_CALLBACK) {
+) : ListAdapter<String, SurveyTitlesAdapter.SurveyViewHolder>(DIFF_CALLBACK) {
 
     inner class SurveyViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val textView: TextView = itemView.findViewById(android.R.id.text1)


### PR DESCRIPTION
Moved the SurveyAdapter used in BellDashboardFragment from the `dashboard` package to the more appropriate `survey` package.

To avoid a name collision with the existing `SurveyAdapter` in the `survey` package, the moved adapter has been renamed to `SurveyTitlesAdapter`, as its purpose is to display a list of survey titles in a dialog.

The package declaration and the import statement in `BellDashboardFragment` have been updated accordingly.

---
https://jules.google.com/session/13445432412223672264