### PR TITLE
Refactor(team): Rename task package to tasks

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamPageConfig.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/TeamPageConfig.kt
@@ -11,7 +11,7 @@ import org.ole.planet.myplanet.ui.team.discussion.DiscussionListFragment
 import org.ole.planet.myplanet.ui.team.member.MemberFragment
 import org.ole.planet.myplanet.ui.team.member.MembersFragment
 import org.ole.planet.myplanet.ui.team.resources.TeamResourcesFragment
-import org.ole.planet.myplanet.ui.team.task.TeamTaskFragment
+import org.ole.planet.myplanet.ui.team.tasks.TeamTaskFragment
 
 sealed class TeamPageConfig(val id: String, @StringRes val titleRes: Int) {
     abstract fun createFragment(): Fragment

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/tasks/TeamTaskAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/tasks/TeamTaskAdapter.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.team.task
+package org.ole.planet.myplanet.ui.team.tasks
 
 import android.app.AlertDialog
 import android.content.Context
@@ -17,7 +17,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowTaskBinding
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.repository.UserRepository
-import org.ole.planet.myplanet.ui.team.task.TeamTaskAdapter.ViewHolderTask
+import org.ole.planet.myplanet.ui.team.tasks.TeamTaskAdapter.ViewHolderTask
 import org.ole.planet.myplanet.utilities.DiffUtils
 import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/team/tasks/TeamTaskFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/team/tasks/TeamTaskFragment.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.team.task
+package org.ole.planet.myplanet.ui.team.tasks
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
@@ -34,7 +34,7 @@ import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.ui.myhealth.UserListArrayAdapter
 import org.ole.planet.myplanet.ui.team.BaseTeamFragment
-import org.ole.planet.myplanet.ui.team.task.TeamTaskAdapter.OnCompletedListener
+import org.ole.planet.myplanet.ui.team.tasks.TeamTaskAdapter.OnCompletedListener
 import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import org.ole.planet.myplanet.utilities.TimeUtils.formatDateTZ


### PR DESCRIPTION
This commit renames the `task` package to `tasks` within the `ui/team` directory.

The following changes were made:
- Renamed the directory `app/src/main/java/org/ole/planet/myplanet/ui/team/task` to `app/src/main/java/org/ole/planet/myplanet/ui/team/tasks`.
- Updated the package declarations in `TeamTaskAdapter.kt` and `TeamTaskFragment.kt`.
- Updated the import statement in `TeamPageConfig.kt` to reference the new package.

---
https://jules.google.com/session/14843399370456649313