### PR TITLE
Refactor: Rename QuestionAnswerAdapter to SubmissionQuestionAnswerAda…

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionDetailFragment.kt
@@ -18,7 +18,7 @@ class SubmissionDetailFragment : Fragment() {
     private var _binding: FragmentSubmissionDetailBinding? = null
     private val binding get() = _binding!!
     private val viewModel: SubmissionDetailViewModel by viewModels()
-    private lateinit var adapter: QuestionAnswerAdapter
+    private lateinit var adapter: SubmissionQuestionAnswerAdapter
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentSubmissionDetailBinding.inflate(inflater, container, false)
@@ -32,7 +32,7 @@ class SubmissionDetailFragment : Fragment() {
     }
 
     private fun setupRecyclerView() {
-        adapter = QuestionAnswerAdapter()
+        adapter = SubmissionQuestionAnswerAdapter()
 
         // Use a LinearLayoutManager that forces full height calculation
         val layoutManager = object : LinearLayoutManager(context) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionQuestionAnswerAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionQuestionAnswerAdapter.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.databinding.ItemQuestionAnswerBinding
 
-class QuestionAnswerAdapter : ListAdapter<QuestionAnswer, QuestionAnswerAdapter.ViewHolder>(QuestionAnswerDiffCallback()) {
+class SubmissionQuestionAnswerAdapter : ListAdapter<QuestionAnswer, SubmissionQuestionAnswerAdapter.ViewHolder>(QuestionAnswerDiffCallback()) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = ItemQuestionAnswerBinding.inflate(
             LayoutInflater.from(parent.context),


### PR DESCRIPTION
…pter

Renamed the `QuestionAnswerAdapter` class and its corresponding file to `SubmissionQuestionAnswerAdapter` to improve clarity and better reflect its specific usage within the submissions feature.

Updated the adapter's usage in `SubmissionDetailFragment` to reflect the new class name. This is a pure refactoring with no functional changes.

---
https://jules.google.com/session/8078487297116757630