### PR TITLE
Rename ProgressGridAdapter to CoursesProgressGridAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
@@ -64,7 +64,7 @@ class CourseProgressActivity : BaseActivity() {
             data.current.toString(),
             data.max.toString()
         )
-        binding.rvProgress.adapter = ProgressGridAdapter(this, data.steps)
+        binding.rvProgress.adapter = CoursesProgressGridAdapter(this, data.steps)
     }
 
     private suspend fun loadData(courseId: String, userId: String?): CourseProgressData? {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressGridAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressGridAdapter.kt
@@ -9,7 +9,7 @@ import com.google.gson.JsonArray
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowMyProgressGridBinding
 
-class ProgressGridAdapter(private val context: Context, private val list: JsonArray) :
+class CoursesProgressGridAdapter(private val context: Context, private val list: JsonArray) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private lateinit var rowMyProgressGridBinding: RowMyProgressGridBinding
 


### PR DESCRIPTION
Renamed `ProgressGridAdapter` to `CoursesProgressGridAdapter` and updated usages in `CourseProgressActivity`. This change aligns the adapter name with the specific context of course progress.

---
https://jules.google.com/session/17478723618006894242