### PR TITLE
Rename ui/userprofile package to ui/user

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragment.kt
@@ -42,8 +42,8 @@ import org.ole.planet.myplanet.ui.exam.UserInformationFragment
 import org.ole.planet.myplanet.ui.health.UserListAdapter
 import org.ole.planet.myplanet.ui.news.NewsViewModel
 import org.ole.planet.myplanet.ui.team.TeamDetailFragment
-import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
-import org.ole.planet.myplanet.ui.userprofile.UserProfileFragment
+import org.ole.planet.myplanet.ui.user.BecomeMemberActivity
+import org.ole.planet.myplanet.ui.user.UserProfileFragment
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.DownloadUtils

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragmentPlugin.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BaseDashboardFragmentPlugin.kt
@@ -24,7 +24,7 @@ import org.ole.planet.myplanet.ui.personals.PersonalsFragment
 import org.ole.planet.myplanet.ui.references.ReferenceFragment
 import org.ole.planet.myplanet.ui.submissions.SubmissionsFragment
 import org.ole.planet.myplanet.ui.team.TeamDetailFragment
-import org.ole.planet.myplanet.ui.userprofile.AchievementFragment
+import org.ole.planet.myplanet.ui.user.AchievementFragment
 import org.ole.planet.myplanet.utilities.DialogUtils.guestDialog
 import org.ole.planet.myplanet.utilities.Utilities
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -86,7 +86,7 @@ import org.ole.planet.myplanet.ui.team.TeamDetailFragment
 import org.ole.planet.myplanet.ui.team.TeamFragment
 import org.ole.planet.myplanet.ui.team.TeamPageConfig.JoinRequestsPage
 import org.ole.planet.myplanet.ui.team.TeamPageConfig.TasksPage
-import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
+import org.ole.planet.myplanet.ui.user.BecomeMemberActivity
 import org.ole.planet.myplanet.utilities.Constants.isBetaWifiFeatureEnabled
 import org.ole.planet.myplanet.utilities.DialogUtils.guestDialog
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -49,7 +49,7 @@ import org.ole.planet.myplanet.service.SyncManager
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.service.sync.RealtimeSyncCoordinator
 import org.ole.planet.myplanet.service.sync.ServerUrlMapper
-import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
+import org.ole.planet.myplanet.ui.user.BecomeMemberActivity
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.SharedPrefManager

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeAdapter.kt
@@ -32,7 +32,7 @@ import org.ole.planet.myplanet.ui.personals.PersonalsFragment
 import org.ole.planet.myplanet.ui.references.ReferenceFragment
 import org.ole.planet.myplanet.ui.submissions.SubmissionsFragment
 import org.ole.planet.myplanet.ui.submissions.SubmissionsFragment.Companion.newInstance
-import org.ole.planet.myplanet.ui.userprofile.AchievementFragment
+import org.ole.planet.myplanet.ui.user.AchievementFragment
 import org.ole.planet.myplanet.utilities.DiffUtils
 import org.ole.planet.myplanet.utilities.Utilities
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -43,8 +43,8 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.User
 import org.ole.planet.myplanet.ui.community.HomeCommunityDialogFragment
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
-import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
-import org.ole.planet.myplanet.ui.userprofile.ProfileAdapter
+import org.ole.planet.myplanet.ui.user.BecomeMemberActivity
+import org.ole.planet.myplanet.ui.user.ProfileAdapter
 import org.ole.planet.myplanet.utilities.AuthUtils
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utilities.FileUtils

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/AchievementFragment.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.userprofile
+package org.ole.planet.myplanet.ui.user
 
 import android.content.Context
 import android.os.Bundle

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.userprofile
+package org.ole.planet.myplanet.ui.user
 
 import android.app.DatePickerDialog
 import android.content.Intent

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.userprofile
+package org.ole.planet.myplanet.ui.user
 
 import android.app.DatePickerDialog
 import android.content.DialogInterface

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/ProfileAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/ProfileAdapter.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.userprofile
+package org.ole.planet.myplanet.ui.user
 
 import android.view.LayoutInflater
 import android.view.ViewGroup

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/ReferencesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/ReferencesAdapter.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.userprofile
+package org.ole.planet.myplanet.ui.user
 
 import android.content.Context
 import android.view.LayoutInflater
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.google.gson.JsonObject
 import org.ole.planet.myplanet.databinding.RowOtherInfoBinding
-import org.ole.planet.myplanet.ui.userprofile.ReferencesAdapter.ViewHolderOtherInfo
+import org.ole.planet.myplanet.ui.user.ReferencesAdapter.ViewHolderOtherInfo
 import org.ole.planet.myplanet.utilities.DiffUtils
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.JsonUtils.getString

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileFragment.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.userprofile
+package org.ole.planet.myplanet.ui.user
 
 import android.Manifest
 import android.app.Activity.RESULT_OK

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileViewModel.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.userprofile
+package org.ole.planet.myplanet.ui.user
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -20,7 +20,7 @@ import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.service.MyDownloadService
 import org.ole.planet.myplanet.service.UserProfileDbHandler
 import org.ole.planet.myplanet.ui.sync.SyncActivity
-import org.ole.planet.myplanet.ui.userprofile.BecomeMemberActivity
+import org.ole.planet.myplanet.ui.user.BecomeMemberActivity
 
 object DialogUtils {
     @JvmStatic


### PR DESCRIPTION
Renamed the `ui/userprofile` package to `ui/user` to align with the desired project structure. This involved renaming the directory, updating package declarations in all Kotlin files within the new directory, and updating imports and references in `AndroidManifest.xml` and other dependent files. Verified the changes by compiling the project successfully.

---
https://jules.google.com/session/17510093484309361036