### PR TITLE
feat: Migrate TeamCoursesAdapter to ListAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesAdapter.kt
@@ -6,34 +6,26 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import io.realm.Realm
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.RowTeamResourceBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getTeamCreator
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
+import org.ole.planet.myplanet.utilities.DiffUtils
 
 class TeamCoursesAdapter(
     private val context: Context,
-    private var list: MutableList<RealmMyCourse>,
-    mRealm: Realm?,
-    teamId: String?,
-    settings: SharedPreferences
-) : RecyclerView.Adapter<TeamCoursesAdapter.ViewHolder>() {
-    private var listener: OnHomeItemClickListener? = null
-    private val settings: SharedPreferences
+    private val settings: SharedPreferences,
     private val teamCreator: String
+) : ListAdapter<RealmMyCourse, TeamCoursesAdapter.ViewHolder>(COURSE_DIFF_CALLBACK) {
+    private var listener: OnHomeItemClickListener? = null
 
     init {
         if (context is OnHomeItemClickListener) {
             listener = context
         }
-        this.settings = settings
-        teamCreator = getTeamCreator(teamId, mRealm)
     }
-
-    fun getList(): List<RealmMyCourse> = list
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = RowTeamResourceBinding.inflate(LayoutInflater.from(context), parent, false)
@@ -41,7 +33,7 @@ class TeamCoursesAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val course = list[position]
+        val course = getItem(position)
         holder.binding.tvTitle.text = course.courseTitle
         holder.binding.tvDescription.text = course.description
         holder.binding.root.setOnClickListener {
@@ -56,9 +48,12 @@ class TeamCoursesAdapter(
         }
     }
 
-    override fun getItemCount(): Int {
-        return list.size
-    }
-
     class ViewHolder(val binding: RowTeamResourceBinding) : RecyclerView.ViewHolder(binding.root)
+
+    companion object {
+        private val COURSE_DIFF_CALLBACK = DiffUtils.itemCallback<RealmMyCourse>(
+            areItemsTheSame = { oldItem, newItem -> oldItem.courseId == newItem.courseId },
+            areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
+        )
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
+import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.teams.BaseTeamFragment
 
@@ -26,14 +27,20 @@ class TeamCoursesFragment : BaseTeamFragment() {
     }
     
     private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { TeamCoursesAdapter(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
+        val teamCreator = RealmMyTeam.getTeamCreator(teamId, mRealm)
+        val courses = mRealm.where(RealmMyCourse::class.java)
+            .`in`("id", team?.courses?.toTypedArray() ?: emptyArray())
+            .findAll()
+        val courseList = mRealm.copyFromRealm(courses)
+
+        adapterTeamCourse = settings?.let { TeamCoursesAdapter(requireActivity(), it, teamCreator) }
         binding.rvCourse.layoutManager = LinearLayoutManager(activity)
         binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
-        }
+        adapterTeamCourse?.submitList(courseList)
+
+        showNoData(binding.tvNodata, courseList.size, "teamCourses")
     }
+
     override fun onNewsItemClick(news: RealmNews?) {}
     override fun clearImages() {
         imageList.clear()


### PR DESCRIPTION
Refactored `TeamCoursesAdapter` to extend `ListAdapter`, leveraging its `DiffUtil` capabilities for more efficient RecyclerView updates.

Key changes:
- Changed the superclass of `TeamCoursesAdapter` to `ListAdapter`.
- Implemented a `DiffUtil.ItemCallback` to compare course items.
- Removed the direct dependency on Realm from the adapter's constructor.
- Updated `TeamCoursesFragment` to create an unmanaged copy of the Realm data before submitting it to the adapter via `submitList()`. This prevents thread-confinement issues with Realm.

---
https://jules.google.com/session/10967384819566126893