### PR TITLE
fix(teams): Move courses query to background thread

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
@@ -4,7 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmNews
@@ -26,12 +30,21 @@ class TeamCoursesFragment : BaseTeamFragment() {
     }
     
     private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { TeamCoursesAdapter(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
         binding.rvCourse.layoutManager = LinearLayoutManager(activity)
-        binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+        lifecycleScope.launch {
+            val courses = withContext(Dispatchers.IO) {
+                val teamCourses = team?.courses?.toTypedArray() ?: emptyArray()
+                val courseList = mRealm.where(RealmMyCourse::class.java).`in`("id", teamCourses).findAll()
+                mRealm.copyFromRealm(courseList)
+            }
+
+            adapterTeamCourse = settings?.let {
+                TeamCoursesAdapter(requireActivity(), courses.toMutableList(), mRealm, teamId, it)
+            }
+            binding.rvCourse.adapter = adapterTeamCourse
+            adapterTeamCourse?.let {
+                showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+            }
         }
     }
     override fun onNewsItemClick(news: RealmNews?) {}


### PR DESCRIPTION
The database query in TeamCoursesFragment was running on the main thread, which could cause Application Not Responding (ANR) errors on devices with large datasets.

This change refactors the data fetching logic to use a coroutine. The Realm query is now executed on the IO dispatcher, and the results are copied to an unmanaged list for thread safety before updating the UI on the main thread.

---
https://jules.google.com/session/11774723145437342793