### PR TITLE
refactor: Use injected DatabaseService in RealmRepository.queryListFlow

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -49,7 +49,8 @@ open class RealmRepository(protected val databaseService: DatabaseService) {
         clazz: Class<T>,
         builder: RealmQuery<T>.() -> Unit = {},
     ): Flow<List<T>> = callbackFlow {
-        val realm = Realm.getDefaultInstance()
+        @Suppress("DEPRECATION")
+        val realm = databaseService.realmInstance
         val results = realm.where(clazz).apply(builder).findAllAsync()
         val listener = RealmChangeListener<RealmResults<T>> {
             if (it.isLoaded && it.isValid) {


### PR DESCRIPTION
Refactored `RealmRepository.queryListFlow` to use the injected `DatabaseService` for obtaining Realm instances instead of calling `Realm.getDefaultInstance()` directly.

This change ensures that all Realm instance creation and management is handled through the centralized `DatabaseService`, adhering to the dependency injection pattern and improving testability. The lifecycle of the Realm instance is now correctly managed within the scope of the flow.

---
https://jules.google.com/session/18130053085473058939