### PR TITLE
Refactor: Convert TeamCoursesAdapter to ListAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesAdapter.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import io.realm.Realm
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
@@ -13,14 +14,14 @@ import org.ole.planet.myplanet.databinding.RowTeamResourceBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getTeamCreator
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
+import org.ole.planet.myplanet.utilities.DiffUtils
 
 class TeamCoursesAdapter(
     private val context: Context,
-    private var list: MutableList<RealmMyCourse>,
     mRealm: Realm?,
     teamId: String?,
     settings: SharedPreferences
-) : RecyclerView.Adapter<TeamCoursesAdapter.ViewHolder>() {
+) : ListAdapter<RealmMyCourse, TeamCoursesAdapter.ViewHolder>(DiffCallback) {
     private var listener: OnHomeItemClickListener? = null
     private val settings: SharedPreferences
     private val teamCreator: String
@@ -33,15 +34,13 @@ class TeamCoursesAdapter(
         teamCreator = getTeamCreator(teamId, mRealm)
     }
 
-    fun getList(): List<RealmMyCourse> = list
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = RowTeamResourceBinding.inflate(LayoutInflater.from(context), parent, false)
         return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val course = list[position]
+        val course = getItem(position)
         holder.binding.tvTitle.text = course.courseTitle
         holder.binding.tvDescription.text = course.description
         holder.binding.root.setOnClickListener {
@@ -56,9 +55,12 @@ class TeamCoursesAdapter(
         }
     }
 
-    override fun getItemCount(): Int {
-        return list.size
-    }
-
     class ViewHolder(val binding: RowTeamResourceBinding) : RecyclerView.ViewHolder(binding.root)
+
+    companion object {
+        val DiffCallback = DiffUtils.itemCallback<RealmMyCourse>(
+            { old, new -> old.courseId == new.courseId },
+            { old, new -> old.courseTitle == new.courseTitle && old.description == new.description }
+        )
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
@@ -27,12 +27,12 @@ class TeamCoursesFragment : BaseTeamFragment() {
     
     private fun setupCoursesList() {
         val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { TeamCoursesAdapter(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
+        val courseList = mRealm.copyFromRealm(courses)
+        adapterTeamCourse = settings?.let { TeamCoursesAdapter(requireActivity(), mRealm, teamId, it) }
         binding.rvCourse.layoutManager = LinearLayoutManager(activity)
         binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
-        }
+        adapterTeamCourse?.submitList(courseList)
+        showNoData(binding.tvNodata, courseList.size, "teamCourses")
     }
     override fun onNewsItemClick(news: RealmNews?) {}
     override fun clearImages() {


### PR DESCRIPTION
Converted TeamCoursesAdapter to extend ListAdapter, utilizing DiffUtil for more efficient RecyclerView updates.

- Implemented a DiffUtil.ItemCallback using the DiffUtils.itemCallback helper.
- Removed the manual list management from the adapter.
- Updated TeamCoursesFragment to use `submitList()` to provide data to the adapter, passing an unmanaged copy of the RealmResults to ensure thread safety during diffing.

---
https://jules.google.com/session/1286966375788260183