### PR TITLE
Refactor: Rename UserProfileDbHandler to UserProfileService

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
@@ -32,7 +32,7 @@ import org.ole.planet.myplanet.base.BasePermissionActivity.Companion.hasInstallP
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.service.UserProfileDbHandler.Companion.KEY_RESOURCE_DOWNLOAD
+import org.ole.planet.myplanet.service.UserProfileService.Companion.KEY_RESOURCE_DOWNLOAD
 import org.ole.planet.myplanet.ui.reader.WebViewActivity
 import org.ole.planet.myplanet.utilities.CourseRatingUtils
 import org.ole.planet.myplanet.utilities.FileUtils

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -48,7 +48,7 @@ import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.service.DownloadService
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.components.CheckboxListView
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.submissions.SubmissionsAdapter
@@ -80,7 +80,7 @@ abstract class BaseResourceFragment : Fragment() {
     @Inject
     lateinit var databaseService: DatabaseService
     @Inject
-    lateinit var profileDbHandler: UserProfileDbHandler
+    lateinit var profileDbHandler: UserProfileService
     @Inject
     @AppPreferences
     lateinit var settings: SharedPreferences

--- a/app/src/main/java/org/ole/planet/myplanet/di/WorkerDependenciesEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/WorkerDependenciesEntryPoint.kt
@@ -7,13 +7,13 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.service.UploadManager
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
 interface WorkerDependenciesEntryPoint {
     fun databaseService(): DatabaseService
-    fun userProfileDbHandler(): UserProfileDbHandler
+    fun userProfileDbHandler(): UserProfileService
     fun uploadManager(): UploadManager
     fun teamsRepository(): TeamsRepository
     fun submissionsRepository(): SubmissionsRepository

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
@@ -7,7 +7,7 @@ import io.realm.RealmObject
 import io.realm.Sort
 import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.JsonUtils
 import org.ole.planet.myplanet.utilities.NetworkUtils
 
@@ -58,7 +58,7 @@ open class RealmOfflineActivity : RealmObject() {
         @JvmStatic
         fun getRecentLogin(mRealm: Realm): RealmOfflineActivity? {
             return mRealm.where(RealmOfflineActivity::class.java)
-                .equalTo("type", UserProfileDbHandler.KEY_LOGIN).sort("loginTime", Sort.DESCENDING)
+                .equalTo("type", UserProfileService.KEY_LOGIN).sort("loginTime", Sort.DESCENDING)
                 .findFirst()
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivityRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivityRepositoryImpl.kt
@@ -4,7 +4,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.model.RealmOfflineActivity
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 
 class ActivityRepositoryImpl @Inject constructor(
     databaseService: DatabaseService
@@ -19,7 +19,7 @@ class ActivityRepositoryImpl @Inject constructor(
     override suspend fun getOfflineLogins(userName: String): Flow<List<RealmOfflineActivity>> {
         return queryListFlow(RealmOfflineActivity::class.java) {
             equalTo("userName", userName)
-            equalTo("type", UserProfileDbHandler.KEY_LOGIN)
+            equalTo("type", UserProfileService.KEY_LOGIN)
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
@@ -16,7 +16,7 @@ import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import android.content.SharedPreferences
 import org.ole.planet.myplanet.model.RealmMembershipDoc
 import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.di.DefaultPreferences
 import org.ole.planet.myplanet.utilities.TimeUtils.getFormattedDateWithTime
 import java.util.UUID
@@ -24,7 +24,7 @@ import java.util.UUID
 class SurveysRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     databaseService: DatabaseService,
-    private val userProfileDbHandler: UserProfileDbHandler,
+    private val userProfileDbHandler: UserProfileService,
     @DefaultPreferences private val settings: SharedPreferences,
 ) : RealmRepository(databaseService), SurveysRepository {
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -29,7 +29,7 @@ import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.Transaction
 import org.ole.planet.myplanet.service.UploadManager
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.service.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.AndroidDecrypter
 import org.ole.planet.myplanet.utilities.JsonUtils
@@ -37,7 +37,7 @@ import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 
 class TeamsRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
-    private val userProfileDbHandler: UserProfileDbHandler,
+    private val userProfileDbHandler: UserProfileService,
     private val uploadManager: UploadManager,
     private val gson: Gson,
     @AppPreferences private val preferences: SharedPreferences,

--- a/app/src/main/java/org/ole/planet/myplanet/service/UserProfileService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/UserProfileService.kt
@@ -25,7 +25,7 @@ import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Utilities
 
-class UserProfileDbHandler @Inject constructor(
+class UserProfileService @Inject constructor(
     @ApplicationContext private val context: Context,
     private val realmService: DatabaseService,
     @AppPreferences private val settings: SharedPreferences,

--- a/app/src/main/java/org/ole/planet/myplanet/service/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/sync/TransactionSyncManager.kt
@@ -21,7 +21,7 @@ import org.ole.planet.myplanet.model.RealmMyCourse.Companion.saveConcatenatedLin
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.insertCourseStepsExams
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.RealmUserModel.Companion.populateUsersTable
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.JsonUtils.getJsonArray
@@ -95,7 +95,7 @@ class TransactionSyncManager @Inject constructor(
         mRealm: Realm,
         settings: SharedPreferences,
         listener: SyncListener,
-        userProfileDbHandler: UserProfileDbHandler
+        userProfileDbHandler: UserProfileService
     ) {
         listener.onSyncStarted()
         val model = userProfileDbHandler.userModel

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityLeadersAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityLeadersAdapter.kt
@@ -10,14 +10,14 @@ import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowJoinedUserBinding
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.teams.member.MemberDetailFragment
 import org.ole.planet.myplanet.utilities.DiffUtils
 import org.ole.planet.myplanet.utilities.NavigationHelper
 
 internal class CommunityLeadersAdapter(
     var context: Context,
-    private val userProfileDbHandler: UserProfileDbHandler
+    private val userProfileDbHandler: UserProfileService
 ) : ListAdapter<RealmUserModel, CommunityLeadersAdapter.ViewHolderLeader>(
     DiffUtils.itemCallback(
         areItemsTheSame = { oldItem, newItem -> oldItem.name == newItem.name },

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
@@ -11,7 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 import org.ole.planet.myplanet.di.AppPreferences
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 
 @AndroidEntryPoint
 class CommunityTabFragment : Fragment() {
@@ -21,7 +21,7 @@ class CommunityTabFragment : Fragment() {
     @AppPreferences
     lateinit var settings: SharedPreferences
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentTeamDetailBinding.inflate(inflater, container, false)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/LeadersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/LeadersFragment.kt
@@ -13,7 +13,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentMembersBinding
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 
 @AndroidEntryPoint
 class LeadersFragment : Fragment() {
@@ -22,7 +22,7 @@ class LeadersFragment : Fragment() {
     @AppPreferences
     lateinit var settings: SharedPreferences
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentMembersBinding.inflate(inflater, container, false)
         return binding!!.root

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseProgressActivity.kt
@@ -22,14 +22,14 @@ import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils
 
 @AndroidEntryPoint
 class CourseProgressActivity : BaseActivity() {
     private lateinit var binding: ActivityCourseProgressBinding
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     var user: RealmUserModel? = null
     lateinit var courseId: String
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -46,7 +46,7 @@ import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmTag.Companion.getTagsArray
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.TagsRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.service.sync.ServerUrlMapper
 import org.ole.planet.myplanet.service.sync.SyncManager
 import org.ole.planet.myplanet.ui.resources.CollectionsFragment
@@ -90,7 +90,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     lateinit var syncManager: SyncManager
 
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
 
     @Inject
     lateinit var tagsRepository: TagsRepository

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/ProgressViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/ProgressViewModel.kt
@@ -9,12 +9,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.repository.ProgressRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 
 @HiltViewModel
 class ProgressViewModel @Inject constructor(
     private val progressRepository: ProgressRepository,
-    private val userProfileDbHandler: UserProfileDbHandler
+    private val userProfileDbHandler: UserProfileService
 ) : ViewModel() {
 
     private val _courseData = MutableStateFlow<JsonArray?>(null)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -39,7 +39,7 @@ import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmSubmission.Companion.isStepCompleted
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.CoursesRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.DialogUtils.getDialog
 import org.ole.planet.myplanet.utilities.NavigationHelper
 import org.ole.planet.myplanet.utilities.Utilities
@@ -51,7 +51,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     @Inject
     lateinit var databaseService: DatabaseService
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     @Inject
     lateinit var coursesRepository: CoursesRepository
     lateinit var mRealm: Realm

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -69,7 +69,7 @@ import org.ole.planet.myplanet.repository.ProgressRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.repository.TeamsRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.chat.ChatHistoryFragment
 import org.ole.planet.myplanet.ui.community.CommunityTabFragment
 import org.ole.planet.myplanet.ui.courses.CoursesFragment
@@ -110,7 +110,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     private val dashboardViewModel: DashboardViewModel by viewModels()
     private lateinit var tabSelectedListener: OnTabSelectedListener
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     @Inject
     lateinit var teamsRepository: TeamsRepository
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/MyActivityFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/MyActivityFragment.kt
@@ -20,14 +20,14 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentMyActivityBinding
 import org.ole.planet.myplanet.repository.UserRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 
 @AndroidEntryPoint
 class MyActivityFragment : Fragment() {
     private var _binding: FragmentMyActivityBinding? = null
     private val binding get() = _binding!!
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     @Inject
     lateinit var userRepository: UserRepository
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDetailFragment.kt
@@ -20,7 +20,7 @@ import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMeetup.Companion.getHashMap
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.EventsRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.Constants.showBetaFeature
 
@@ -30,7 +30,7 @@ class EventsDetailFragment : Fragment(), View.OnClickListener {
     private val binding get() = _binding!!
     private var meetups: RealmMeetup? = null
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     @Inject
     lateinit var eventsRepository: EventsRepository
     private var meetUpId: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
@@ -37,7 +37,7 @@ import org.ole.planet.myplanet.model.RealmMembershipDoc
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmSubmission.Companion.createSubmission
 import org.ole.planet.myplanet.repository.SubmissionsRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.CameraUtils.ImageCaptureCallback
 import org.ole.planet.myplanet.utilities.CameraUtils.capturePhoto
 import org.ole.planet.myplanet.utilities.JsonUtils
@@ -57,7 +57,7 @@ class ExamTakingFragment : BaseExamFragment(), View.OnClickListener, CompoundBut
     private val answerCache = mutableMapOf<String, AnswerData>()
 
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
 
     @Inject
     lateinit var submissionsRepository: SubmissionsRepository

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -36,7 +36,7 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.service.UploadManager
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.service.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.NavigationHelper
@@ -52,7 +52,7 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
     @Inject
     lateinit var userRepository: UserRepository
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     var userModel: RealmUserModel? = null
     var shouldHideElements: Boolean? = null
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -15,7 +15,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentFeedbackBinding
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.FeedbackRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
@@ -25,7 +25,7 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
     @Inject
     lateinit var feedbackRepository: FeedbackRepository
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     private var model: RealmUserModel ?= null
     var user: String? = ""
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -26,7 +26,7 @@ import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.FeedbackRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.service.sync.RealtimeSyncCoordinator
 import org.ole.planet.myplanet.service.sync.ServerUrlMapper
 import org.ole.planet.myplanet.service.sync.SyncManager
@@ -48,7 +48,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     @Inject
     lateinit var feedbackRepository: FeedbackRepository
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     private val serverUrlMapper = ServerUrlMapper()
     
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/AddExaminationActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/AddExaminationActivity.kt
@@ -28,7 +28,7 @@ import org.ole.planet.myplanet.model.RealmHealthExamination
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmMyHealth.RealmMyHealthProfile
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.AndroidDecrypter.Companion.decrypt
 import org.ole.planet.myplanet.utilities.AndroidDecrypter.Companion.encrypt
 import org.ole.planet.myplanet.utilities.AndroidDecrypter.Companion.generateIv
@@ -47,7 +47,7 @@ class AddExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedChan
     @Inject
     lateinit var databaseService: DatabaseService
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     private lateinit var binding: ActivityAddExaminationBinding
     lateinit var mRealm: Realm
     var userId: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -45,7 +45,7 @@ import org.ole.planet.myplanet.databinding.AlertMyPersonalBinding
 import org.ole.planet.myplanet.databinding.FragmentVitalSignBinding
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.UserRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.service.sync.RealtimeSyncCoordinator
 import org.ole.planet.myplanet.service.sync.ServerUrlMapper
 import org.ole.planet.myplanet.service.sync.SyncManager
@@ -60,7 +60,7 @@ import org.ole.planet.myplanet.utilities.Utilities
 class MyHealthFragment : Fragment() {
 
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
 
     @Inject
     lateinit var syncManager: SyncManager

--- a/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsFragment.kt
@@ -19,7 +19,7 @@ import org.ole.planet.myplanet.databinding.FragmentMyPersonalsBinding
 import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.repository.PersonalsRepository
 import org.ole.planet.myplanet.service.UploadManager
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.resources.AddResourceFragment
 import org.ole.planet.myplanet.utilities.DialogUtils
 import org.ole.planet.myplanet.utilities.Utilities
@@ -37,7 +37,7 @@ class PersonalsFragment : Fragment(), OnSelectedMyPersonal {
     @Inject
     lateinit var personalsRepository: PersonalsRepository
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentMyPersonalsBinding.inflate(inflater, container, false)
         pg = DialogUtils.getCustomProgressDialog(requireContext())

--- a/app/src/main/java/org/ole/planet/myplanet/ui/reader/PDFReaderActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/reader/PDFReaderActivity.kt
@@ -21,7 +21,7 @@ import org.ole.planet.myplanet.repository.PersonalsRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.service.AudioRecorderService
 import org.ole.planet.myplanet.service.AudioRecorderService.AudioRecordListener
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.resources.AddResourceFragment
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utilities.FileUtils
@@ -40,7 +40,7 @@ class PDFReaderActivity : AppCompatActivity(), AudioRecordListener {
     @Inject
     lateinit var resourcesRepository: ResourcesRepository
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     private lateinit var library: RealmMyLibrary
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -23,7 +23,7 @@ import org.ole.planet.myplanet.databinding.ActivityAddResourceBinding
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.ResourcesRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.components.CheckboxListView
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utilities.LocaleUtils
@@ -32,7 +32,7 @@ import org.ole.planet.myplanet.utilities.Utilities.toast
 @AndroidEntryPoint
 class AddResourceActivity : AppCompatActivity() {
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     @Inject
     lateinit var resourcesRepository: ResourcesRepository
     private lateinit var binding: ActivityAddResourceBinding

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -43,7 +43,7 @@ import org.ole.planet.myplanet.databinding.FragmentAddResourceBinding
 import org.ole.planet.myplanet.repository.PersonalsRepository
 import org.ole.planet.myplanet.service.AudioRecorderService
 import org.ole.planet.myplanet.service.AudioRecorderService.AudioRecordListener
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
@@ -64,7 +64,7 @@ class AddResourceFragment : BottomSheetDialogFragment() {
     @Inject
     lateinit var personalsRepository: PersonalsRepository
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingActivity.kt
@@ -43,7 +43,7 @@ import org.ole.planet.myplanet.di.DefaultPreferences
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.ResourcesRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.sync.SyncActivity.Companion.clearRealmDb
 import org.ole.planet.myplanet.ui.sync.SyncActivity.Companion.clearSharedPref
@@ -106,7 +106,7 @@ class SettingActivity : AppCompatActivity() {
     @AndroidEntryPoint
     class SettingFragment : PreferenceFragmentCompat() {
         @Inject
-        lateinit var profileDbHandler: UserProfileDbHandler
+        lateinit var profileDbHandler: UserProfileService
         @Inject
         lateinit var databaseService: DatabaseService
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.databinding.FragmentMySubmissionBinding
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 
 @AndroidEntryPoint
 class SubmissionsFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
@@ -28,7 +28,7 @@ class SubmissionsFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
     private val viewModel: SubmissionViewModel by viewModels()
 
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
 
     private lateinit var textWatcher: TextWatcher
     private lateinit var adapter: SubmissionsAdapter

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -63,7 +63,7 @@ import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.ServerAddress
 import org.ole.planet.myplanet.repository.ConfigurationRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.service.sync.SyncManager
 import org.ole.planet.myplanet.service.sync.TransactionSyncManager
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
@@ -114,7 +114,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationRepository
     lateinit var syncIconDrawable: AnimationDrawable
     lateinit var prefData: SharedPrefManager
     @Inject
-    lateinit var profileDbHandler: UserProfileDbHandler
+    lateinit var profileDbHandler: UserProfileService
     lateinit var spnCloud: Spinner
     lateinit var protocolCheckIn: RadioGroup
     lateinit var serverUrl: EditText

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
@@ -27,7 +27,7 @@ import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getJoinedMemberCount
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.service.sync.RealtimeSyncCoordinator
 import org.ole.planet.myplanet.service.sync.ServerUrlMapper
 import org.ole.planet.myplanet.service.sync.SyncManager
@@ -54,7 +54,7 @@ import org.ole.planet.myplanet.utilities.Utilities
 class TeamDetailFragment : BaseTeamFragment(), MemberChangeListener, TeamUpdateListener {
     
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     
     @Inject
     lateinit var syncManager: SyncManager

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
@@ -25,7 +25,7 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.TeamDetails
 import org.ole.planet.myplanet.repository.TeamsRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.SharedPrefManager
 import org.ole.planet.myplanet.callback.OnTeamActionsListener
 import org.ole.planet.myplanet.callback.OnUpdateCompleteListener
@@ -40,7 +40,7 @@ class TeamFragment : Fragment(), TeamListAdapter.OnClickTeamItem, OnUpdateComple
     @Inject
     lateinit var teamsRepository: TeamsRepository
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     @Inject
     lateinit var sharedPrefManager: SharedPrefManager
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/discussion/DiscussionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/discussion/DiscussionListFragment.kt
@@ -20,7 +20,7 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNews.Companion.createNews
 import org.ole.planet.myplanet.repository.VoicesRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.chat.ChatDetailFragment
 import org.ole.planet.myplanet.ui.teams.BaseTeamFragment
 import org.ole.planet.myplanet.ui.voices.NewsAdapter
@@ -36,7 +36,7 @@ class DiscussionListFragment : BaseTeamFragment() {
     @Inject
     lateinit var voicesRepository: VoicesRepository
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     @Inject
     lateinit var sharedPrefManager: SharedPrefManager
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/member/MembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/member/MembersFragment.kt
@@ -16,13 +16,13 @@ import org.ole.planet.myplanet.base.BaseMemberFragment
 import org.ole.planet.myplanet.callback.MemberChangeListener
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 
 @AndroidEntryPoint
 class MembersFragment : BaseMemberFragment() {
 
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
 
     private val viewModel: MembersViewModel by viewModels()
     private lateinit var currentUser: RealmUserModel

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/member/MembersViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/member/MembersViewModel.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.TeamsRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 
 data class MembersUiState(
     val members: List<RealmUserModel> = emptyList(),
@@ -24,7 +24,7 @@ data class MembersUiState(
 @HiltViewModel
 class MembersViewModel @Inject constructor(
     private val teamsRepository: TeamsRepository,
-    private val userProfileDbHandler: UserProfileDbHandler
+    private val userProfileDbHandler: UserProfileService
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MembersUiState())

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileFragment.kt
@@ -61,7 +61,7 @@ import org.ole.planet.myplanet.databinding.EditProfileDialogBinding
 import org.ole.planet.myplanet.databinding.FragmentUserProfileBinding
 import org.ole.planet.myplanet.databinding.RowStatBinding
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utilities.TimeUtils
 import org.ole.planet.myplanet.utilities.Utilities
@@ -74,7 +74,7 @@ class UserProfileFragment : Fragment() {
     private lateinit var rowStatBinding: RowStatBinding
     private lateinit var settings: SharedPreferences
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     private var model: RealmUserModel? = null
     private var editProfileDialog: Dialog? = null
     private lateinit var pickImageLauncher: ActivityResultLauncher<Intent>

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.UserRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 
 sealed class ProfileUpdateState {
     object Idle : ProfileUpdateState()
@@ -21,7 +21,7 @@ sealed class ProfileUpdateState {
 @HiltViewModel
 class UserProfileViewModel @Inject constructor(
     private val userRepository: UserRepository,
-    private val userProfileDbHandler: UserProfileDbHandler,
+    private val userProfileDbHandler: UserProfileService,
 ) : ViewModel() {
 
     private val _userModel = MutableStateFlow<RealmUserModel?>(null)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsActions.kt
@@ -23,7 +23,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNews.Companion.createNews
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.callback.OnNewsItemClickListener
 import org.ole.planet.myplanet.ui.teams.member.MemberDetailFragment
 import org.ole.planet.myplanet.utilities.JsonUtils
@@ -234,7 +234,7 @@ object NewsActions {
 
     fun showMemberDetails(
         userModel: RealmUserModel?,
-        profileDbHandler: UserProfileDbHandler
+        profileDbHandler: UserProfileService
     ): MemberDetailFragment? {
         if (userModel == null) return null
         val userName = "${userModel.firstName} ${userModel.lastName}".trim().ifBlank { userModel.name }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsAdapter.kt
@@ -47,7 +47,7 @@ import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.callback.OnNewsItemClickListener
 import org.ole.planet.myplanet.ui.chat.ChatAdapter
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
@@ -61,7 +61,7 @@ import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import org.ole.planet.myplanet.utilities.Utilities
 import org.ole.planet.myplanet.utilities.makeExpandable
 
-class NewsAdapter(var context: Context, private var currentUser: RealmUserModel?, private val parentNews: RealmNews?, private val teamName: String = "", private val teamId: String? = null, private val userProfileDbHandler: UserProfileDbHandler, private val scope: CoroutineScope, private val userRepository: UserRepository, private val voicesRepository: VoicesRepository, private val teamsRepository: TeamsRepository) : ListAdapter<RealmNews?, RecyclerView.ViewHolder?>(
+class NewsAdapter(var context: Context, private var currentUser: RealmUserModel?, private val parentNews: RealmNews?, private val teamName: String = "", private val teamId: String? = null, private val userProfileDbHandler: UserProfileService, private val scope: CoroutineScope, private val userRepository: UserRepository, private val voicesRepository: VoicesRepository, private val teamsRepository: TeamsRepository) : ListAdapter<RealmNews?, RecyclerView.ViewHolder?>(
     DiffUtils.itemCallback(
         areItemsTheSame = { oldItem, newItem ->
             if (oldItem === newItem) return@itemCallback true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsFragment.kt
@@ -30,7 +30,7 @@ import org.ole.planet.myplanet.model.RealmNews.Companion.createNews
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.chat.ChatDetailFragment
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.FileUtils
@@ -48,7 +48,7 @@ class NewsFragment : BaseNewsFragment() {
     var user: RealmUserModel? = null
     
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     @Inject
     lateinit var voicesRepository: VoicesRepository
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
@@ -31,7 +31,7 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.voices.NewsActions
 import org.ole.planet.myplanet.callback.OnNewsItemClickListener
 import org.ole.planet.myplanet.utilities.EdgeToEdgeUtils
@@ -55,7 +55,7 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
     private val viewModel: ReplyViewModel by viewModels()
     
     @Inject
-    lateinit var userProfileDbHandler: UserProfileDbHandler
+    lateinit var userProfileDbHandler: UserProfileService
     @Inject
     lateinit var userRepository: org.ole.planet.myplanet.repository.UserRepository
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/DialogUtils.kt
@@ -18,7 +18,7 @@ import org.ole.planet.myplanet.data.DataService
 import org.ole.planet.myplanet.databinding.DialogProgressBinding
 import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.service.DownloadService
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.sync.SyncActivity
 import org.ole.planet.myplanet.ui.user.BecomeMemberActivity
 
@@ -35,7 +35,7 @@ object DialogUtils {
         return prgDialog
     }
 
-    fun guestDialog(context: Context, profileDbHandler: UserProfileDbHandler) {
+    fun guestDialog(context: Context, profileDbHandler: UserProfileService) {
         val builder = android.app.AlertDialog.Builder(context, R.style.CustomAlertDialog)
         builder.setTitle(context.getString(R.string.become_a_member))
         builder.setMessage(context.getString(R.string.to_access_this_feature_become_a_member))

--- a/app/src/main/java/org/ole/planet/myplanet/utilities/ResourceOpener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utilities/ResourceOpener.kt
@@ -8,7 +8,7 @@ import android.widget.Toast
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseResourceFragment
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.service.UserProfileDbHandler
+import org.ole.planet.myplanet.service.UserProfileService
 import org.ole.planet.myplanet.ui.reader.AudioPlayerActivity
 import org.ole.planet.myplanet.ui.reader.CSVViewerActivity
 import org.ole.planet.myplanet.ui.reader.ImageViewerActivity
@@ -90,13 +90,13 @@ object ResourceOpener {
         activity.startActivity(intent)
     }
 
-    fun openFileType(activity: Activity, items: RealmMyLibrary, videoType: String, profileDbHandler: UserProfileDbHandler) {
+    fun openFileType(activity: Activity, items: RealmMyLibrary, videoType: String, profileDbHandler: UserProfileService) {
         val mimetype = Utilities.getMimeType(resourcePath(items))
         if (mimetype == null) {
             Utilities.toast(activity, activity.getString(R.string.unable_to_open_resource))
             return
         }
-        profileDbHandler.setResourceOpenCount(items, UserProfileDbHandler.KEY_RESOURCE_OPEN)
+        profileDbHandler.setResourceOpenCount(items, UserProfileService.KEY_RESOURCE_OPEN)
         if (mimetype.startsWith("video")) {
             playVideo(activity, videoType, items)
         } else {


### PR DESCRIPTION
Renamed the UserProfileDbHandler class to UserProfileService for better semantic clarity. This change affects the file name, class name, and all its usages throughout the application.

- Renamed `UserProfileDbHandler.kt` to `UserProfileService.kt`.
- Renamed the class `UserProfileDbHandler` to `UserProfileService`.
- Updated all injection sites, variable declarations, and other references to use the new class name.

---
https://jules.google.com/session/2556693984806145450