### PR TITLE
Refactor DiscussionListFragment to use TeamsRepository for team lookup

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/discussion/DiscussionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/discussion/DiscussionListFragment.kt
@@ -104,19 +104,8 @@ class DiscussionListFragment : BaseTeamFragment() {
         }
 
         if (shouldQueryTeamFromRealm()) {
-            team = try {
-                mRealm.where(RealmMyTeam::class.java).equalTo("_id", teamId).findFirst()
-            } catch (e: Exception) {
-                e.printStackTrace()
-                null
-            }
-
-            if (team == null) {
-                try {
-                    team = mRealm.where(RealmMyTeam::class.java).equalTo("teamId", teamId).findFirst()
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
+            lifecycleScope.launch {
+                team = teamsRepository.getTeamById(teamId)
             }
         }
         binding.addMessage.isVisible = false


### PR DESCRIPTION
Replaces direct synchronous Realm queries with an asynchronous repository call using `lifecycleScope.launch`, improving main thread performance and decoupling the fragment from database implementation details.

---
https://jules.google.com/session/5273478678756763557