### PR TITLE
Refactor: Move Feedback Saving to FeedbackRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
@@ -19,4 +19,12 @@ interface FeedbackRepository {
     suspend fun closeFeedback(id: String?)
     suspend fun addReply(id: String?, obj: JsonObject)
     suspend fun saveFeedback(feedback: RealmFeedback)
+    suspend fun saveFeedback(
+        feedbackBody: String,
+        user: RealmUserModel?,
+        urgent: String,
+        type: String,
+        item: String?,
+        state: String?
+    )
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -89,4 +89,16 @@ class FeedbackRepositoryImpl @Inject constructor(
     override suspend fun saveFeedback(feedback: RealmFeedback) {
         save(feedback)
     }
+
+    override suspend fun saveFeedback(
+        feedbackBody: String,
+        user: RealmUserModel?,
+        urgent: String,
+        type: String,
+        item: String?,
+        state: String?
+    ) {
+        val feedback = createFeedback(user?.name, urgent, type, feedbackBody, item, state)
+        save(feedback)
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -86,14 +86,16 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
         val type = rbType.text.toString()
         val item = arguments?.getString("item")
         val state = arguments?.getString("state")
-        val feedback = feedbackRepository.createFeedback(user, urgent, type, message, item, state)
         viewLifecycleOwner.lifecycleScope.launch {
-            feedbackRepository.saveFeedback(feedback)
-            Utilities.toast(activity, getString(R.string.feedback_saved))
+            feedbackRepository.saveFeedback(message, model, urgent, type, item, state)
+            Toast.makeText(
+                activity,
+                R.string.thank_you_your_feedback_has_been_submitted,
+                Toast.LENGTH_SHORT
+            ).show()
+            mListener?.onFeedbackSubmitted()
+            dismiss()
         }
-        Toast.makeText(activity, R.string.thank_you_your_feedback_has_been_submitted, Toast.LENGTH_SHORT).show()
-        mListener?.onFeedbackSubmitted()
-        dismiss()
     }
 
     private fun clearError() {


### PR DESCRIPTION
This change moves the database transaction logic for creating and inserting the RealmFeedback object from FeedbackFragment into a new repository method.

- Created a new `saveFeedback` suspend function in `FeedbackRepository`.
- Implemented the new function in `FeedbackRepositoryImpl`.
- Refactored `FeedbackFragment` to use the new repository function.
- Fixed a race condition by moving UI updates into the coroutine scope, ensuring they execute only after the feedback is saved.

---
https://jules.google.com/session/9792705363392271533