### PR TITLE
refactor: Move library list lookup to ResourcesRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -24,6 +24,7 @@ interface ResourcesRepository {
     suspend fun markResourceOfflineByLocalAddress(localAddress: String)
     suspend fun getPrivateImageUrlsCreatedAfter(timestamp: Long): List<String>
     suspend fun markAllResourcesOffline(isOffline: Boolean)
+    suspend fun getLibraryForOffline(): List<RealmMyLibrary>
     suspend fun saveSearchActivity(
         userName: String,
         searchText: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -176,6 +176,12 @@ class ResourcesRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getLibraryForOffline(): List<RealmMyLibrary> {
+        return queryList(RealmMyLibrary::class.java) {
+            equalTo("resourceOffline", false)
+        }.filter { it.needToUpdate() }
+    }
+
     override suspend fun saveSearchActivity(
         userName: String,
         searchText: String,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingActivity.kt
@@ -36,7 +36,6 @@ import org.ole.planet.myplanet.BuildConfig
 import org.ole.planet.myplanet.MainApplication.Companion.createLog
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseResourceFragment.Companion.backgroundDownload
-import org.ole.planet.myplanet.base.BaseResourceFragment.Companion.getAllLibraryList
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.di.DefaultPreferences
@@ -162,10 +161,8 @@ class SettingActivity : AppCompatActivity() {
                     defaultPref.edit { putBoolean("beta_auto_download", true) }
                     lifecycleScope.launch {
                         try {
-                            val files = libraryList ?: withContext(Dispatchers.IO) {
-                                databaseService.withRealm { realm ->
-                                    realm.copyFromRealm(getAllLibraryList(realm)).also { libraryList = it }
-                                }
+                            val files = libraryList ?: resourcesRepository.getLibraryForOffline().also {
+                                libraryList = it
                             }
                             backgroundDownload(downloadAllFiles(files), requireContext())
                         } finally {


### PR DESCRIPTION
Moved the database logic for fetching the library list for offline downloads from SettingActivity to a new method, `getLibraryForOffline`, in ResourcesRepository.

This change improves the separation of concerns by removing direct database access from the UI layer and encapsulating it within the data layer.

---
https://jules.google.com/session/4134960913481714257