### PR TITLE
Refactored UserInformationFragment to use MainApplication.application…

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -320,8 +320,9 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
         // Capture syncStartTime before launching coroutine to preserve it across lifecycle changes
         val capturedSyncStartTime = syncStartTime
 
-        // Use GlobalScope to survive fragment lifecycle - this upload must complete even after UI is destroyed
-        GlobalScope.launch(Dispatchers.IO) {
+        // Use MainApplication.applicationScope to survive fragment lifecycle.
+        // This ensures the upload completes even after the UI is destroyed, without using GlobalScope.
+        MainApplication.applicationScope.launch(Dispatchers.IO) {
             Log.d("UserInformationFragment", "GlobalScope coroutine started, will not be cancelled by fragment lifecycle")
             Log.d("UserInformationFragment", "Starting server reachability checks (15s timeout each)")
             val checkStartTime = System.currentTimeMillis()


### PR DESCRIPTION
…Scope instead of GlobalScope for launching a background task.

This change follows best practices for structured concurrency in Android by using a managed, application-level CoroutineScope. This ensures the background task can survive the fragment's lifecycle without resorting to GlobalScope, improving testability and reducing the risk of orphaned coroutines.

---
https://jules.google.com/session/10230391491254824079