### PR TITLE
Refactor: Convert ResourcesAdapter to use ListAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -38,8 +38,11 @@ import org.ole.planet.myplanet.utilities.Markdown.setMarkdownText
 import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import org.ole.planet.myplanet.utilities.Utilities
 
+import io.realm.Realm
+
 class ResourcesAdapter(
     private val context: Context,
+    private val realm: Realm,
     private var ratingMap: HashMap<String?, JsonObject>,
     private val resourcesRepository: ResourcesRepository,
     private val tagsRepository: TagsRepository,
@@ -71,7 +74,7 @@ class ResourcesAdapter(
     }
 
     fun setLibraryList(libraryList: List<RealmMyLibrary>, onComplete: (() -> Unit)? = null) {
-        submitList(libraryList.toMutableList(), onComplete)
+        submitList(libraryList, onComplete)
     }
 
     fun setListener(listener: OnLibraryItemSelected?) {
@@ -366,7 +369,7 @@ class ResourcesAdapter(
     override fun refreshWithDiff() {
         (context as? LifecycleOwner)?.lifecycleScope?.launch {
             val newLibraryList = resourcesRepository.getAllLibraryItems()
-            submitList(newLibraryList)
+            submitList(realm.copyFromRealm(newLibraryList))
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -189,7 +189,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
                     applyFilter(filterLibraryByTag(searchQuery, currentSearchTags))
                 }
 
-            adapterLibrary.setLibraryList(filteredLibraryList)
+            adapterLibrary.setLibraryList(mRealm.copyFromRealm(filteredLibraryList))
             adapterLibrary.setRatingMap(map!!)
             checkList()
             showNoData(tvMessage, adapterLibrary.itemCount, "resources")
@@ -202,8 +202,8 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     override fun getAdapter(): RecyclerView.Adapter<*> {
         map = getRatings(mRealm, "resource", model?.id)
         val libraryList: List<RealmMyLibrary> = getList(RealmMyLibrary::class.java).filterIsInstance<RealmMyLibrary>()
-        adapterLibrary = ResourcesAdapter(requireActivity(), map!!, resourcesRepository, tagsRepository, profileDbHandler?.userModel)
-        adapterLibrary.setLibraryList(libraryList)
+        adapterLibrary = ResourcesAdapter(requireActivity(), mRealm, map!!, resourcesRepository, tagsRepository, profileDbHandler?.userModel)
+        adapterLibrary.setLibraryList(mRealm.copyFromRealm(libraryList))
         adapterLibrary.setRatingChangeListener(this)
         adapterLibrary.setListener(this)
         return adapterLibrary
@@ -288,11 +288,11 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 adapterLibrary.setLibraryList(
-                    applyFilter(
+                    mRealm.copyFromRealm(applyFilter(
                         filterLibraryByTag(
                             etSearch.text.toString().trim(), searchTags
                         )
-                    )
+                    ))
                 ) {
                     recyclerView.scrollToPosition(0)
                 }
@@ -434,7 +434,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
             mediums.clear()
             subjects.clear()
             languages.clear()
-            adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag("", searchTags))) {
+            adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag("", searchTags)))) {
                 recyclerView.scrollToPosition(0)
             }
             showNoData(tvMessage, adapterLibrary.itemCount, "resources")
@@ -454,7 +454,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         chipCloud.setDeleteListener(this)
         if (!searchTags.any { it.name == realmTag.name }) searchTags.add(realmTag)
         chipCloud.addChips(searchTags)
-        adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags))) {
+        adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags)))) {
             recyclerView.scrollToPosition(0)
         }
         showTagText(searchTags, tvSelected)
@@ -467,7 +467,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         li.add(tag)
         searchTags = li
         tvSelected.text = getString(R.string.tag_selected, tag.name)
-        adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag(etSearch.text.toString(), li))) {
+        adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag(etSearch.text.toString(), li)))) {
             recyclerView.scrollToPosition(0)
         }
         showNoData(tvMessage, adapterLibrary.itemCount, "resources")
@@ -476,7 +476,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     override fun onOkClicked(list: List<RealmTag>?) {
         if (list?.isEmpty() == true) {
             searchTags.clear()
-            adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags))) {
+            adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags)))) {
                 recyclerView.scrollToPosition(0)
             }
             showNoData(tvMessage, adapterLibrary.itemCount, "resources")
@@ -500,7 +500,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     override fun chipDeleted(i: Int, s: String) {
         searchTags.removeAt(i)
-        adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags))) {
+        adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags)))) {
             recyclerView.scrollToPosition(0)
         }
         showNoData(tvMessage, adapterLibrary.itemCount, "resources")
@@ -511,7 +511,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         this.languages = languages
         this.mediums = mediums
         this.levels = levels
-        adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag(etSearch.text.toString().trim { it <= ' ' }, searchTags))) {
+        adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag(etSearch.text.toString().trim { it <= ' ' }, searchTags)))) {
             recyclerView.scrollToPosition(0)
         }
         showNoData(tvMessage, adapterLibrary.itemCount, "resources")


### PR DESCRIPTION
Refactored `ResourcesAdapter` from a `RecyclerView.Adapter` to a `ListAdapter` to improve efficiency and simplify the code.

- Implemented `DiffUtil.ItemCallback` to handle list diffing automatically, comparing items by `_id`, `_rev`, and `uploadDate`.
- Removed the manual, coroutine-based diffing logic (`diffJob` and `updateList`).
- Updated `ResourcesFragment` to instantiate the adapter without a list and use `submitList` to provide data.
- Implemented `getChangePayload` to handle partial updates for ratings and tags.
- Fixed a `ClassCastException` in `onBindViewHolder` by safely handling different payload types.

---
https://jules.google.com/session/16267580418211838221