### PR TITLE
Fix Player.Listener leak in AudioPlayerActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/reader/AudioPlayerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/reader/AudioPlayerActivity.kt
@@ -29,6 +29,7 @@ class AudioPlayerActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityAudioPlayerBinding
     private var exoPlayer: ExoPlayer? = null
+    private var playerListener: Player.Listener? = null
     private var filePath: String? = null
     private var isFullPath = false
     private lateinit var playButton: ImageButton
@@ -107,7 +108,7 @@ class AudioPlayerActivity : AppCompatActivity() {
                     setUnplayedColor(ContextCompat.getColor(this@AudioPlayerActivity, R.color.disable_color))
                 }
 
-                player.addListener(object : Player.Listener {
+                playerListener = object : Player.Listener {
                     override fun onPlayerError(error: PlaybackException) {
                         Utilities.toast(this@AudioPlayerActivity, "Unable to play audio.")
                     }
@@ -117,7 +118,8 @@ class AudioPlayerActivity : AppCompatActivity() {
                             player.seekTo(0)
                         }
                     }
-                })
+                }
+                player.addListener(playerListener!!)
             }
         } catch (e: Exception) {
             Utilities.toast(this, "Unable to play audio.")
@@ -184,8 +186,10 @@ class AudioPlayerActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         binding.playerView.player = null
+        playerListener?.let { exoPlayer?.removeListener(it) }
         exoPlayer?.release()
         exoPlayer = null
+        playerListener = null
         super.onDestroy()
     }
 }


### PR DESCRIPTION
The anonymous Player.Listener created in `initializeExoPlayer` was not being removed when the activity was destroyed. This could lead to a memory leak, as the listener would hold a reference to the activity.

This commit fixes the leak by:
1. Storing the Player.Listener as a class property (`playerListener`).
2. Assigning the listener object to this property in `initializeExoPlayer()`.
3. In `onDestroy()`, calling `exoPlayer?.removeListener(playerListener)` before `exoPlayer?.release()`.
4. Setting `playerListener` to `null` after removal to aid garbage collection.

---
https://jules.google.com/session/8064457084466219974