### PR TITLE
Refactor DatabaseService to use DispatcherProvider for DI

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -8,12 +8,12 @@ import io.realm.RealmQuery
 import io.realm.log.LogLevel
 import io.realm.log.RealmLog
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.BuildConfig
+import org.ole.planet.myplanet.di.DispatcherProvider
 
-class DatabaseService(context: Context) {
-    val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+class DatabaseService(context: Context, private val dispatcherProvider: DispatcherProvider) {
+    val ioDispatcher: CoroutineDispatcher = dispatcherProvider.io
 
     init {
         Realm.init(context)

--- a/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
@@ -15,8 +15,8 @@ object DatabaseModule {
 
     @Provides
     @Singleton
-    fun provideDatabaseService(@ApplicationContext context: Context): DatabaseService {
-        return DatabaseService(context)
+    fun provideDatabaseService(@ApplicationContext context: Context, dispatcherProvider: DispatcherProvider): DatabaseService {
+        return DatabaseService(context, dispatcherProvider)
     }
 
     // Realm initialization is handled in DatabaseService

--- a/app/src/main/java/org/ole/planet/myplanet/di/DefaultDispatcherProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DefaultDispatcherProvider.kt
@@ -1,0 +1,14 @@
+package org.ole.planet.myplanet.di
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Inject
+
+class DefaultDispatcherProvider @Inject constructor() : DispatcherProvider {
+    override val main: CoroutineDispatcher
+        get() = Dispatchers.Main
+    override val io: CoroutineDispatcher
+        get() = Dispatchers.IO
+    override val default: CoroutineDispatcher
+        get() = Dispatchers.Default
+}

--- a/app/src/main/java/org/ole/planet/myplanet/di/DispatcherProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DispatcherProvider.kt
@@ -1,0 +1,9 @@
+package org.ole.planet.myplanet.di
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+interface DispatcherProvider {
+    val main: CoroutineDispatcher
+    val io: CoroutineDispatcher
+    val default: CoroutineDispatcher
+}

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.di
 import android.content.Context
 import android.content.SharedPreferences
 import com.google.gson.Gson
+import dagger.Binds
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
@@ -29,60 +30,65 @@ annotation class ApplicationScope
 
 @Module
 @InstallIn(SingletonComponent::class)
-object ServiceModule {
+abstract class ServiceModule {
 
-    @Provides
-    @Singleton
-    @ApplicationScope
-    fun provideApplicationScope(): CoroutineScope {
-        return CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    }
+    @Binds
+    abstract fun bindDispatcherProvider(impl: DefaultDispatcherProvider): DispatcherProvider
 
-    @Provides
-    @Singleton
-    fun provideSyncManager(
-        @ApplicationContext context: Context,
-        databaseService: DatabaseService,
-        @AppPreferences preferences: SharedPreferences,
-        apiInterface: ApiInterface,
-        improvedSyncManager: Lazy<ImprovedSyncManager>,
-        transactionSyncManager: TransactionSyncManager,
-        @ApplicationScope scope: CoroutineScope
-    ): SyncManager {
-        return SyncManager(context, databaseService, preferences, apiInterface, improvedSyncManager, transactionSyncManager, scope)
-    }
+    companion object {
+        @Provides
+        @Singleton
+        @ApplicationScope
+        fun provideApplicationScope(): CoroutineScope {
+            return CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        }
 
-    @Provides
-    @Singleton
-    fun provideUploadManager(
-        @ApplicationContext context: Context,
-        databaseService: DatabaseService,
-        submissionsRepository: SubmissionsRepository,
-        @AppPreferences preferences: SharedPreferences,
-        gson: Gson,
-        uploadCoordinator: org.ole.planet.myplanet.service.upload.UploadCoordinator
-    ): UploadManager {
-        return UploadManager(context, databaseService, submissionsRepository, preferences, gson, uploadCoordinator)
-    }
+        @Provides
+        @Singleton
+        fun provideSyncManager(
+            @ApplicationContext context: Context,
+            databaseService: DatabaseService,
+            @AppPreferences preferences: SharedPreferences,
+            apiInterface: ApiInterface,
+            improvedSyncManager: Lazy<ImprovedSyncManager>,
+            transactionSyncManager: TransactionSyncManager,
+            @ApplicationScope scope: CoroutineScope
+        ): SyncManager {
+            return SyncManager(context, databaseService, preferences, apiInterface, improvedSyncManager, transactionSyncManager, scope)
+        }
 
-    @Provides
-    @Singleton
-    fun provideUploadToShelfService(
-        @ApplicationContext context: Context,
-        databaseService: DatabaseService,
-        @AppPreferences preferences: SharedPreferences
-    ): UploadToShelfService {
-        return UploadToShelfService(context, databaseService, preferences)
-    }
+        @Provides
+        @Singleton
+        fun provideUploadManager(
+            @ApplicationContext context: Context,
+            databaseService: DatabaseService,
+            submissionsRepository: SubmissionsRepository,
+            @AppPreferences preferences: SharedPreferences,
+            gson: Gson,
+            uploadCoordinator: org.ole.planet.myplanet.service.upload.UploadCoordinator
+        ): UploadManager {
+            return UploadManager(context, databaseService, submissionsRepository, preferences, gson, uploadCoordinator)
+        }
 
-    @Provides
-    @Singleton
-    fun provideTransactionSyncManager(
-        apiInterface: ApiInterface,
-        databaseService: DatabaseService,
-        @ApplicationContext context: Context,
-        @ApplicationScope scope: CoroutineScope
-    ): TransactionSyncManager {
-        return TransactionSyncManager(apiInterface, databaseService, context, scope)
+        @Provides
+        @Singleton
+        fun provideUploadToShelfService(
+            @ApplicationContext context: Context,
+            databaseService: DatabaseService,
+            @AppPreferences preferences: SharedPreferences
+        ): UploadToShelfService {
+            return UploadToShelfService(context, databaseService, preferences)
+        }
+
+        @Provides
+        @Singleton
+        fun provideTransactionSyncManager(
+            apiInterface: ApiInterface,
+            databaseService: DatabaseService,
+            @ApplicationContext context: Context,
+            @ApplicationScope scope: CoroutineScope
+        ): TransactionSyncManager {
+            return TransactionSyncManager(apiInterface, databaseService, context, scope)
+        }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/di/TestDispatcherProvider.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/di/TestDispatcherProvider.kt
@@ -1,0 +1,15 @@
+package org.ole.planet.myplanet.di
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+
+class TestDispatcherProvider : DispatcherProvider {
+    val testDispatcher = TestCoroutineDispatcher()
+
+    override val main: CoroutineDispatcher
+        get() = testDispatcher
+    override val io: CoroutineDispatcher
+        get() = testDispatcher
+    override val default: CoroutineDispatcher
+        get() = testDispatcher
+}


### PR DESCRIPTION
Introduced DispatcherProvider interface and DefaultDispatcherProvider implementation. Refactored ServiceModule to bind the provider and injected it into DatabaseService, replacing hardcoded Dispatchers.IO. Added TestDispatcherProvider for testing purposes.

---
https://jules.google.com/session/11781835222945193962