### PR TITLE
Rename ConfigurationRepository to ConfigurationsRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/DataService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DataService.kt
@@ -80,7 +80,7 @@ class DataService constructor(
     private val configurationManager =
         ConfigurationManager(context, preferences, retrofitInterface)
 
-    @Deprecated("Use ConfigurationRepository.checkHealth instead")
+    @Deprecated("Use ConfigurationsRepository.checkHealth instead")
     fun healthAccess(listener: SuccessListener) {
         try {
             val healthUrl = UrlUtils.getHealthAccessUrl(preferences)
@@ -151,7 +151,7 @@ class DataService constructor(
         }
     }
 
-    @Deprecated("Use ConfigurationRepository.checkVersion instead")
+    @Deprecated("Use ConfigurationsRepository.checkVersion instead")
     fun checkVersion(callback: CheckVersionCallback, settings: SharedPreferences) {
         if (shouldPromptForSettings(settings)) return
 
@@ -204,7 +204,7 @@ class DataService constructor(
         }
     }
 
-    @Deprecated("Use ConfigurationRepository.checkServerAvailability instead")
+    @Deprecated("Use ConfigurationsRepository.checkServerAvailability instead")
     fun isPlanetAvailable(callback: PlanetAvailableListener?) {
         val updateUrl = "${preferences.getString("serverURL", "")}"
         serverAvailabilityCache[updateUrl]?.let { (available, timestamp) ->

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -9,8 +9,8 @@ import org.ole.planet.myplanet.repository.ActivityRepository
 import org.ole.planet.myplanet.repository.ActivityRepositoryImpl
 import org.ole.planet.myplanet.repository.ChatRepository
 import org.ole.planet.myplanet.repository.ChatRepositoryImpl
-import org.ole.planet.myplanet.repository.ConfigurationRepository
-import org.ole.planet.myplanet.repository.ConfigurationRepositoryImpl
+import org.ole.planet.myplanet.repository.ConfigurationsRepository
+import org.ole.planet.myplanet.repository.ConfigurationsRepositoryImpl
 import org.ole.planet.myplanet.repository.CoursesRepository
 import org.ole.planet.myplanet.repository.CoursesRepositoryImpl
 import org.ole.planet.myplanet.repository.EventsRepository
@@ -56,7 +56,7 @@ abstract class RepositoryModule {
 
     @Binds
     @Singleton
-    abstract fun bindConfigurationRepository(impl: ConfigurationRepositoryImpl): ConfigurationRepository
+    abstract fun bindConfigurationsRepository(impl: ConfigurationsRepositoryImpl): ConfigurationsRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
@@ -4,7 +4,7 @@ import android.content.SharedPreferences
 import org.ole.planet.myplanet.callback.SuccessListener
 import org.ole.planet.myplanet.model.MyPlanet
 
-interface ConfigurationRepository {
+interface ConfigurationsRepository {
     fun checkHealth(listener: SuccessListener)
     fun checkVersion(callback: CheckVersionCallback, settings: SharedPreferences)
     fun checkServerAvailability(callback: PlanetAvailableListener?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -31,12 +31,12 @@ import retrofit2.Response
 
 import org.ole.planet.myplanet.di.AppPreferences
 
-class ConfigurationRepositoryImpl @Inject constructor(
+class ConfigurationsRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val apiInterface: ApiInterface,
     @ApplicationScope private val serviceScope: CoroutineScope,
     @AppPreferences private val preferences: SharedPreferences
-) : ConfigurationRepository {
+) : ConfigurationsRepository {
     private val serverAvailabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
 
     override fun checkHealth(listener: SuccessListener) {
@@ -89,7 +89,7 @@ class ConfigurationRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun checkVersion(callback: ConfigurationRepository.CheckVersionCallback, settings: SharedPreferences) {
+    override fun checkVersion(callback: ConfigurationsRepository.CheckVersionCallback, settings: SharedPreferences) {
         serviceScope.launch {
             val lastCheckTime = preferences.getLong("last_version_check_timestamp", 0)
             val currentTime = System.currentTimeMillis()
@@ -159,7 +159,7 @@ class ConfigurationRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun checkServerAvailability(callback: ConfigurationRepository.PlanetAvailableListener?) {
+    override fun checkServerAvailability(callback: ConfigurationsRepository.PlanetAvailableListener?) {
         val updateUrl = "${preferences.getString("serverURL", "")}"
         serverAvailabilityCache[updateUrl]?.let { (available, timestamp) ->
             if (System.currentTimeMillis() - timestamp < 30000) {
@@ -253,7 +253,7 @@ class ConfigurationRepositoryImpl @Inject constructor(
         return cleaned.toIntOrNull()
     }
 
-    private fun handleVersionEvaluation(info: MyPlanet, apkVersion: Int, callback: ConfigurationRepository.CheckVersionCallback) {
+    private fun handleVersionEvaluation(info: MyPlanet, apkVersion: Int, callback: ConfigurationsRepository.CheckVersionCallback) {
         val currentVersion = VersionUtils.getVersionCode(context)
         if (Constants.showBetaFeature(Constants.KEY_UPGRADE_MAX, context) && info.latestapkcode > currentVersion) {
             serviceScope.launch {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -63,7 +63,7 @@ import org.ole.planet.myplanet.databinding.DialogServerUrlBinding
 import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.ServerAddress
-import org.ole.planet.myplanet.repository.ConfigurationRepository
+import org.ole.planet.myplanet.repository.ConfigurationsRepository
 import org.ole.planet.myplanet.service.UserSessionManager
 import org.ole.planet.myplanet.service.sync.SyncManager
 import org.ole.planet.myplanet.service.sync.TransactionSyncManager
@@ -91,7 +91,7 @@ import org.ole.planet.myplanet.utilities.UrlUtils
 import org.ole.planet.myplanet.utilities.Utilities
 
 @AndroidEntryPoint
-abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationRepository.CheckVersionCallback,
+abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepository.CheckVersionCallback,
     ConfigurationIdListener {
     private var serverDialogBinding: DialogServerUrlBinding? = null
     private lateinit var syncDate: TextView
@@ -140,7 +140,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationRepository
     var serverListAddresses: List<ServerAddress> = emptyList()
     private var isProgressDialogShowing = false
     @Inject
-    lateinit var configurationRepository: ConfigurationRepository
+    lateinit var configurationRepository: ConfigurationsRepository
 
     @Inject
     lateinit var syncManager: SyncManager


### PR DESCRIPTION
Renamed ConfigurationRepository and its implementation to ConfigurationsRepository to follow the plural naming convention used in other repositories. Updated all references in SyncActivity, RepositoryModule, and DataService (deprecated messages).

---
https://jules.google.com/session/11258314257897175291