### PR TITLE
Refactor attachment URL resolution to ResourcesRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -33,4 +33,11 @@ interface ResourcesRepository {
         filterPayload: String
     )
     suspend fun downloadResources(resources: List<RealmMyLibrary>): Boolean
+    suspend fun getAttachmentUrls(resourceId: String): AttachmentResult
+}
+
+sealed class AttachmentResult {
+    data class Success(val urls: List<String>) : AttachmentResult()
+    object ResourceNotFound : AttachmentResult()
+    object NoAttachments : AttachmentResult()
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -12,6 +12,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.utilities.DownloadUtils
 import org.ole.planet.myplanet.utilities.FileUtils
+import org.ole.planet.myplanet.utilities.UrlUtils
 
 class ResourcesRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -217,6 +218,25 @@ class ResourcesRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             e.printStackTrace()
             false
+        }
+    }
+
+    override suspend fun getAttachmentUrls(resourceId: String): AttachmentResult {
+        val resource = getLibraryItemByResourceId(resourceId) ?: return AttachmentResult.ResourceNotFound
+        val attachments = resource.attachments
+        if (attachments.isNullOrEmpty()) {
+            return AttachmentResult.NoAttachments
+        }
+        val urls = attachments?.mapNotNull { attachment ->
+            attachment.name?.let { name ->
+                UrlUtils.getUrl(resourceId, name)
+            }
+        } ?: emptyList()
+
+        return if (urls.isNotEmpty()) {
+            AttachmentResult.Success(urls)
+        } else {
+            AttachmentResult.NoAttachments
         }
     }
 }


### PR DESCRIPTION
Moved the logic for resolving attachment URLs from BaseContainerFragment to ResourcesRepository. Defined AttachmentResult sealed class to handle success, resource not found, and no attachments states. Updated BaseContainerFragment to use the new repository method and handle the result. Removed redundant directory creation logic in BaseContainerFragment as DownloadService handles path resolution (albeit flattened).

---
https://jules.google.com/session/3413399564719965713