### PR TITLE
Refactor: Rename CommunityPagerAdapter to CommunityTabsAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
@@ -34,9 +34,9 @@ class CommunityTabFragment : Fragment() {
         val communityName = settings.getString("communityName", "").orEmpty()
         val user = userSessionManager.userModel
         val planetCode = user?.planetCode.orEmpty()
-        binding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), "$planetCode@$parentCode", false, settings)
+        binding.viewPager2.adapter = CommunityTabsAdapter(requireActivity(), "$planetCode@$parentCode", false, settings)
         TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->
-            tab.text = (binding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
+            tab.text = (binding.viewPager2.adapter as CommunityTabsAdapter).getPageTitle(position)
         }.attach()
         binding.title.text = if (planetCode.isEmpty()) communityName else planetCode
         binding.subtitle.text = settings.getString("planetType", "")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabsAdapter.kt
@@ -11,7 +11,7 @@ import org.ole.planet.myplanet.ui.enterprises.EnterprisesReportsFragment
 import org.ole.planet.myplanet.ui.teams.TeamCalendarFragment
 import org.ole.planet.myplanet.ui.voices.VoicesFragment
 
-class CommunityPagerAdapter(private val fm: FragmentActivity, private val id: String, private var fromLogin: Boolean, val settings: SharedPreferences) : FragmentStateAdapter(fm) {
+class CommunityTabsAdapter(private val fm: FragmentActivity, private val id: String, private var fromLogin: Boolean, val settings: SharedPreferences) : FragmentStateAdapter(fm) {
     override fun createFragment(position: Int): Fragment {
         val fragment: Fragment = when (position) {
             0 -> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
@@ -80,9 +80,9 @@ class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
         val settings = requireActivity().getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
         val sParentcode = settings.getString("parentCode", "")
         val communityName = settings.getString("communityName", "")
-        binding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), "$communityName@$sParentcode", true, settings)
+        binding.viewPager2.adapter = CommunityTabsAdapter(requireActivity(), "$communityName@$sParentcode", true, settings)
         TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->
-            tab.text = (binding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
+            tab.text = (binding.viewPager2.adapter as CommunityTabsAdapter).getPageTitle(position)
         }.attach()
         binding.title.text = communityName
         binding.title.setTextColor(ContextCompat.getColor(requireContext(), R.color.daynight_textColor))


### PR DESCRIPTION
Renamed CommunityPagerAdapter.kt and the class to CommunityTabsAdapter. Updated usages in the community UI package to reference the renamed adapter. Updated imports to match the new class name.

---
https://jules.google.com/session/389770571770439452