### PR TITLE
refactor: Rename TeamPagerAdapter to TeamsTabsAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
@@ -292,7 +292,7 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, TeamUpdat
         }
 
         binding.viewPager2.adapter = null
-        binding.viewPager2.adapter = TeamPagerAdapter(
+        binding.viewPager2.adapter = TeamsTabsAdapter(
             requireActivity(),
             pageConfigs,
             team?._id,
@@ -303,7 +303,7 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, TeamUpdat
         binding.tabLayout.isInlineLabel = true
 
         TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->
-            val title = (binding.viewPager2.adapter as TeamPagerAdapter).getPageTitle(position)
+            val title = (binding.viewPager2.adapter as TeamsTabsAdapter).getPageTitle(position)
             val pageConfig = pageConfigs.getOrNull(position)
             tab.text = title
         }.attach()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamsTabsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamsTabsAdapter.kt
@@ -18,7 +18,7 @@ import org.ole.planet.myplanet.ui.teams.members.MembersFragment
 import org.ole.planet.myplanet.ui.teams.members.RequestsFragment
 import org.ole.planet.myplanet.ui.teams.resources.TeamResourcesFragment
 
-class TeamPagerAdapter(
+class TeamsTabsAdapter(
     private val fm: FragmentActivity,
     private val pages: List<TeamPageConfig>,
     private val teamId: String?,


### PR DESCRIPTION
- Renamed `TeamPagerAdapter.kt` to `TeamsTabsAdapter.kt`.
- Renamed the class `TeamPagerAdapter` to `TeamsTabsAdapter`.
- Updated usages in the teams UI package to reference the renamed adapter.
- Updated imports to match the new class name.

---
https://jules.google.com/session/2991380056738932179