### PR TITLE
Refactor DataService config checks to ConfigurationRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -19,6 +19,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.EntryPointAccessors
 import io.realm.Realm
 import io.realm.RealmObject
 import io.realm.RealmResults
@@ -28,10 +29,9 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
-import org.ole.planet.myplanet.data.DataService
-import org.ole.planet.myplanet.data.DataService.PlanetAvailableListener
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
+import org.ole.planet.myplanet.di.RepositoryEntryPoint
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.getMyCourse
@@ -43,6 +43,7 @@ import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmSubmission.Companion.getExamMap
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.repository.ConfigurationRepository
 import org.ole.planet.myplanet.repository.CoursesRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
@@ -77,6 +78,8 @@ abstract class BaseResourceFragment : Fragment() {
     lateinit var submissionsRepository: SubmissionsRepository
     @Inject
     lateinit var databaseService: DatabaseService
+    @Inject
+    lateinit var configurationRepository: ConfigurationRepository
     @Inject
     lateinit var profileDbHandler: UserSessionManager
     @Inject
@@ -207,7 +210,7 @@ abstract class BaseResourceFragment : Fragment() {
                 .setTitle(R.string.download_suggestion)
                 .setPositiveButton(R.string.download_selected) { _: DialogInterface?, _: Int ->
                     lifecycleScope.launch {
-                        DataService(requireContext()).isPlanetAvailable(object : PlanetAvailableListener {
+                        configurationRepository.checkServerAvailability(object : ConfigurationRepository.PlanetAvailableListener {
                             override fun isAvailable() {
                                 lifecycleScope.launch {
                                     lv?.selectedItemsList?.let {
@@ -226,7 +229,7 @@ abstract class BaseResourceFragment : Fragment() {
                     }
                 }.setNeutralButton(R.string.download_all) { _: DialogInterface?, _: Int ->
                     lifecycleScope.launch {
-                        DataService(requireContext()).isPlanetAvailable(object : PlanetAvailableListener {
+                        configurationRepository.checkServerAvailability(object : ConfigurationRepository.PlanetAvailableListener {
                             override fun isAvailable() {
                                 lifecycleScope.launch {
                                     addAllToLibrary(librariesForDialog)
@@ -527,7 +530,8 @@ abstract class BaseResourceFragment : Fragment() {
         }
 
         fun backgroundDownload(urls: ArrayList<String>, context: Context) {
-            DataService(context).isPlanetAvailable(object : PlanetAvailableListener {
+            val repositoryEntryPoint = EntryPointAccessors.fromApplication(context, RepositoryEntryPoint::class.java)
+            repositoryEntryPoint.configurationRepository().checkServerAvailability(object : ConfigurationRepository.PlanetAvailableListener {
                 override fun isAvailable() {
                     if (urls.isNotEmpty()) {
                         DownloadUtils.openDownloadService(context, urls, false)

--- a/app/src/main/java/org/ole/planet/myplanet/data/DataService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DataService.kt
@@ -2,53 +2,32 @@ package org.ole.planet.myplanet.data
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.core.content.edit
-import androidx.core.net.toUri
-import com.google.gson.JsonObject
 import dagger.hilt.android.EntryPointAccessors
 import java.io.IOException
-import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import okhttp3.ResponseBody
-import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.callback.OnSecurityDataListener
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.di.ApiInterfaceEntryPoint
 import org.ole.planet.myplanet.di.ApplicationScope
 import org.ole.planet.myplanet.di.ApplicationScopeEntryPoint
 import org.ole.planet.myplanet.di.AutoSyncEntryPoint
 import org.ole.planet.myplanet.di.DatabaseServiceEntryPoint
-import org.ole.planet.myplanet.di.RepositoryEntryPoint
-import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.model.RealmCommunity
-import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.service.UploadToShelfService
-import org.ole.planet.myplanet.service.sync.ServerUrlMapper
-import org.ole.planet.myplanet.ui.sync.ProcessUserDataActivity
 import org.ole.planet.myplanet.ui.sync.SyncActivity
 import org.ole.planet.myplanet.utilities.Constants
 import org.ole.planet.myplanet.utilities.FileUtils
 import org.ole.planet.myplanet.utilities.JsonUtils
-import org.ole.planet.myplanet.utilities.NetworkUtils
 import org.ole.planet.myplanet.utilities.Sha256Utils
 import org.ole.planet.myplanet.utilities.UrlUtils
-import org.ole.planet.myplanet.utilities.Utilities
-import org.ole.planet.myplanet.utilities.VersionUtils
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
 
 class DataService constructor(
     private val context: Context,
     private val retrofitInterface: ApiInterface,
     private val databaseService: DatabaseService,
     @ApplicationScope private val serviceScope: CoroutineScope,
-    private val userRepository: UserRepository,
     private val uploadToShelfService: UploadToShelfService,
 ) {
     constructor(context: Context) : this(
@@ -67,69 +46,13 @@ class DataService constructor(
         ).applicationScope(),
         EntryPointAccessors.fromApplication(
             context.applicationContext,
-            RepositoryEntryPoint::class.java
-        ).userRepository(),
-        EntryPointAccessors.fromApplication(
-            context.applicationContext,
             AutoSyncEntryPoint::class.java
         ).uploadToShelfService(),
     )
 
     private val preferences: SharedPreferences = context.getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE)
-    private val serverAvailabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
     private val configurationManager =
         ConfigurationManager(context, preferences, retrofitInterface)
-
-    @Deprecated("Use ConfigurationRepository.checkHealth instead")
-    fun healthAccess(listener: OnSuccessListener) {
-        try {
-            val healthUrl = UrlUtils.getHealthAccessUrl(preferences)
-            if (healthUrl.isBlank()) {
-                listener.onSuccess("")
-                return
-            }
-
-            retrofitInterface.healthAccess(healthUrl).enqueue(object : Callback<ResponseBody> {
-                override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
-                    try {
-                        when (response.code()) {
-                            200 -> listener.onSuccess(context.getString(R.string.server_sync_successfully))
-                            401 -> listener.onSuccess("Unauthorized - Invalid credentials")
-                            404 -> listener.onSuccess("Server endpoint not found")
-                            500 -> listener.onSuccess("Server internal error")
-                            502 -> listener.onSuccess("Bad gateway - Server unavailable")
-                            503 -> listener.onSuccess("Service temporarily unavailable")
-                            504 -> listener.onSuccess("Gateway timeout")
-                            else -> listener.onSuccess("Server error: ${response.code()}")
-                        }
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                        listener.onSuccess("")
-                    }
-                }
-
-                override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
-                    try {
-                        t.printStackTrace()
-                        val errorMsg = when (t) {
-                            is java.net.UnknownHostException -> "Server not reachable"
-                            is java.net.SocketTimeoutException -> "Connection timeout"
-                            is java.net.ConnectException -> "Unable to connect to server"
-                            is java.io.IOException -> "Network connection error"
-                            else -> "Network error: ${t.localizedMessage ?: "Unknown error"}"
-                        }
-                        listener.onSuccess(errorMsg)
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                        listener.onSuccess("Health check failed")
-                    }
-                }
-            })
-        } catch (e: Exception) {
-            e.printStackTrace()
-            listener.onSuccess("Health access initialization failed")
-        }
-    }
 
     suspend fun checkCheckSum(path: String?): Boolean = withContext(Dispatchers.IO) {
         try {
@@ -148,150 +71,6 @@ class DataService constructor(
         } catch (e: IOException) {
             e.printStackTrace()
             false
-        }
-    }
-
-    @Deprecated("Use ConfigurationRepository.checkVersion instead")
-    fun checkVersion(callback: CheckVersionCallback, settings: SharedPreferences) {
-        if (shouldPromptForSettings(settings)) return
-
-        serviceScope.launch {
-            withContext(Dispatchers.Main) {
-                callback.onCheckingVersion()
-            }
-            try {
-                val planetInfo = fetchVersionInfo(settings)
-                if (planetInfo == null) {
-                    withContext(Dispatchers.Main) {
-                        callback.onError(context.getString(R.string.version_not_found), true)
-                    }
-                    return@launch
-                }
-
-                preferences.edit {
-                    putLong("last_version_check_timestamp", System.currentTimeMillis())
-                    putInt("LastWifiID", NetworkUtils.getCurrentNetworkId(context))
-                    putString("versionDetail", JsonUtils.gson.toJson(planetInfo))
-                }
-
-                val rawApkVersion = fetchApkVersionString(settings)
-                val versionStr = JsonUtils.gson.fromJson(rawApkVersion, String::class.java)
-                if (versionStr.isNullOrEmpty()) {
-                    withContext(Dispatchers.Main) {
-                        callback.onError(context.getString(R.string.planet_is_up_to_date), false)
-                    }
-                    return@launch
-                }
-
-                val apkVersion = parseApkVersionString(versionStr)
-                    ?: run {
-                        withContext(Dispatchers.Main) {
-                            callback.onError(
-                                context.getString(R.string.new_apk_version_required_but_not_found_on_server),
-                                false
-                            )
-                        }
-                        return@launch
-                    }
-
-                handleVersionEvaluation(planetInfo, apkVersion, callback)
-            } catch (e: Exception) {
-                e.printStackTrace()
-                withContext(Dispatchers.Main) {
-                    callback.onError(context.getString(R.string.connection_failed), true)
-                }
-            }
-        }
-    }
-
-    @Deprecated("Use ConfigurationRepository.checkServerAvailability instead")
-    fun isPlanetAvailable(callback: PlanetAvailableListener?) {
-        val updateUrl = "${preferences.getString("serverURL", "")}"
-        serverAvailabilityCache[updateUrl]?.let { (available, timestamp) ->
-            if (System.currentTimeMillis() - timestamp < 30000) {
-                if (available) {
-                    callback?.isAvailable()
-                } else {
-                    callback?.notAvailable()
-                }
-                return
-            }
-        }
-
-        val serverUrlMapper = ServerUrlMapper()
-        val mapping = serverUrlMapper.processUrl(updateUrl)
-
-        serviceScope.launch {
-            withContext(Dispatchers.IO) {
-                val primaryReachable = isServerReachable(mapping.primaryUrl)
-                val alternativeReachable = mapping.alternativeUrl?.let { isServerReachable(it) } == true
-
-                if (!primaryReachable && alternativeReachable) {
-                    mapping.alternativeUrl?.let { alternativeUrl ->
-                        val uri = updateUrl.toUri()
-                        val editor = preferences.edit()
-
-                        serverUrlMapper.updateUrlPreferences(
-                            editor,
-                            uri,
-                            alternativeUrl,
-                            mapping.primaryUrl,
-                            preferences
-                        )
-                    }
-                }
-            }
-
-            retrofitInterface.isPlanetAvailable(UrlUtils.getUpdateUrl(preferences)).enqueue(object : Callback<ResponseBody?> {
-                override fun onResponse(call: Call<ResponseBody?>, response: Response<ResponseBody?>) {
-                    val isAvailable = callback != null && response.code() == 200
-                    serverAvailabilityCache[updateUrl] = Pair(isAvailable, System.currentTimeMillis())
-                    serviceScope.launch {
-                        withContext(Dispatchers.Main) {
-                            if (isAvailable) {
-                                callback.isAvailable()
-                            } else {
-                                callback?.notAvailable()
-                            }
-                        }
-                    }
-                }
-
-                override fun onFailure(call: Call<ResponseBody?>, t: Throwable) {
-                    serverAvailabilityCache[updateUrl] = Pair(false, System.currentTimeMillis())
-                    serviceScope.launch {
-                        withContext(Dispatchers.Main) {
-                            callback?.notAvailable()
-                        }
-                    }
-                }
-            })
-        }
-    }
-
-    fun becomeMember(obj: JsonObject, callback: CreateUserCallback, securityCallback: OnSecurityDataListener? = null) {
-        serviceScope.launch {
-            val result = userRepository.becomeMember(obj)
-            withContext(Dispatchers.Main) {
-                if (result.first) { // success
-                    if (context is ProcessUserDataActivity) {
-                        val userName = obj["name"].asString
-                        context.startUpload("becomeMember", userName, securityCallback)
-                    }
-
-                    // Handle offline logic regardless of context
-                    if (result.second == context.getString(R.string.not_connect_to_planet_created_user_offline)) {
-                        Utilities.toast(MainApplication.context, result.second)
-                        securityCallback?.onSecurityDataUpdated()
-                    }
-
-                    callback.onSuccess(result.second)
-                } else {
-                    // failure
-                    callback.onSuccess(result.second)
-                    securityCallback?.onSecurityDataUpdated()
-                }
-            }
         }
     }
 
@@ -355,94 +134,6 @@ class DataService constructor(
 
     fun getMinApk(listener: ConfigurationIdListener?, url: String, pin: String, activity: SyncActivity, callerActivity: String) {
         configurationManager.getMinApk(listener, url, pin, activity, callerActivity)
-    }
-
-    private fun shouldPromptForSettings(settings: SharedPreferences): Boolean {
-        if (!settings.getBoolean("isAlternativeUrl", false)) {
-            if (settings.getString("couchdbURL", "").isNullOrEmpty()) {
-                (context as? SyncActivity)?.settingDialog()
-                return true
-            }
-        }
-        return false
-    }
-
-    private suspend fun fetchVersionInfo(settings: SharedPreferences): MyPlanet? =
-        withContext(Dispatchers.IO) {
-            val result = ApiClient.executeWithResult {
-                retrofitInterface.checkVersion(UrlUtils.getUpdateUrl(settings))
-            }
-            when (result) {
-                is NetworkResult.Success -> result.data
-                else -> null
-            }
-        }
-
-    private suspend fun fetchApkVersionString(settings: SharedPreferences): String? =
-        withContext(Dispatchers.IO) {
-            val result = ApiClient.executeWithResult {
-                retrofitInterface.getApkVersion(UrlUtils.getApkVersionUrl(settings))
-            }
-            when (result) {
-                is NetworkResult.Success -> result.data.string()
-                else -> null
-            }
-        }
-
-    private fun parseApkVersionString(raw: String?): Int? {
-        if (raw.isNullOrEmpty()) return null
-        var vsn = raw.replace("v".toRegex(), "")
-        vsn = vsn.replace("\\.".toRegex(), "")
-        val cleaned = if (vsn.startsWith("0")) vsn.replaceFirst("0", "") else vsn
-        return cleaned.toIntOrNull()
-    }
-
-    private fun handleVersionEvaluation(info: MyPlanet, apkVersion: Int, callback: CheckVersionCallback) {
-        val currentVersion = VersionUtils.getVersionCode(context)
-        if (Constants.showBetaFeature(Constants.KEY_UPGRADE_MAX, context) && info.latestapkcode > currentVersion) {
-            serviceScope.launch {
-                withContext(Dispatchers.Main) {
-                    callback.onUpdateAvailable(info, false)
-                }
-            }
-            return
-        }
-        if (apkVersion > currentVersion) {
-            serviceScope.launch {
-                withContext(Dispatchers.Main) {
-                    callback.onUpdateAvailable(info, currentVersion >= info.minapkcode)
-                }
-            }
-            return
-        }
-        if (currentVersion < info.minapkcode && apkVersion < info.minapkcode) {
-            serviceScope.launch {
-                withContext(Dispatchers.Main) {
-                    callback.onUpdateAvailable(info, true)
-                }
-            }
-        } else {
-            serviceScope.launch {
-                withContext(Dispatchers.Main) {
-                    callback.onError(context.getString(R.string.planet_is_up_to_date), false)
-                }
-            }
-        }
-    }
-
-    interface CheckVersionCallback {
-        fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean)
-        fun onCheckingVersion()
-        fun onError(msg: String, blockSync: Boolean)
-    }
-
-    interface CreateUserCallback {
-        fun onSuccess(message: String)
-    }
-
-    interface PlanetAvailableListener {
-        fun isAvailable()
-        fun notAvailable()
     }
 
     interface ConfigurationIdListener {

--- a/app/src/main/java/org/ole/planet/myplanet/di/DataServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DataServiceModule.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.CoroutineScope
 import org.ole.planet.myplanet.data.ApiInterface
 import org.ole.planet.myplanet.data.DataService
 import org.ole.planet.myplanet.data.DatabaseService
-import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.service.UploadToShelfService
 
 @Module
@@ -23,7 +22,6 @@ object DataServiceModule {
         apiInterface: ApiInterface,
         databaseService: DatabaseService,
         @ApplicationScope scope: CoroutineScope,
-        userRepository: UserRepository,
         uploadToShelfService: UploadToShelfService
     ): DataService {
         return DataService(
@@ -31,7 +29,6 @@ object DataServiceModule {
             apiInterface,
             databaseService,
             scope,
-            userRepository,
             uploadToShelfService
         )
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryEntryPoint.kt
@@ -3,10 +3,12 @@ package org.ole.planet.myplanet.di
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import org.ole.planet.myplanet.repository.ConfigurationRepository
 import org.ole.planet.myplanet.repository.UserRepository
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
 interface RepositoryEntryPoint {
     fun userRepository(): UserRepository
+    fun configurationRepository(): ConfigurationRepository
 }

--- a/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/service/AutoSyncWorker.kt
@@ -17,9 +17,10 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.data.DataService
-import org.ole.planet.myplanet.data.DataService.CheckVersionCallback
 import org.ole.planet.myplanet.di.AutoSyncEntryPoint
+import org.ole.planet.myplanet.di.RepositoryEntryPoint
 import org.ole.planet.myplanet.model.MyPlanet
+import org.ole.planet.myplanet.repository.ConfigurationRepository
 import org.ole.planet.myplanet.service.sync.SyncManager
 import org.ole.planet.myplanet.ui.sync.LoginActivity
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
@@ -30,18 +31,21 @@ import org.ole.planet.myplanet.utilities.Utilities
 class AutoSyncWorker(
     private val context: Context,
     workerParams: WorkerParameters
-) : Worker(context, workerParams), OnSyncListener, CheckVersionCallback, OnSuccessListener {
+) : Worker(context, workerParams), OnSyncListener, ConfigurationRepository.CheckVersionCallback, OnSuccessListener {
     private lateinit var preferences: SharedPreferences
     private lateinit var syncManager: SyncManager
     private lateinit var uploadManager: UploadManager
     private lateinit var uploadToShelfService: UploadToShelfService
+    private lateinit var configurationRepository: ConfigurationRepository
     private val workerScope = CoroutineScope(Dispatchers.IO)
     override fun doWork(): Result {
         val entryPoint = EntryPointAccessors.fromApplication(context, AutoSyncEntryPoint::class.java)
+        val repositoryEntryPoint = EntryPointAccessors.fromApplication(context, RepositoryEntryPoint::class.java)
         preferences = entryPoint.sharedPreferences()
         syncManager = entryPoint.syncManager()
         uploadManager = entryPoint.uploadManager()
         uploadToShelfService = entryPoint.uploadToShelfService()
+        configurationRepository = repositoryEntryPoint.configurationRepository()
         val lastSync = preferences.getLong("LastSync", 0)
         val currentTime = System.currentTimeMillis()
         val syncInterval = preferences.getInt("autoSyncInterval", 60 * 60)
@@ -49,7 +53,7 @@ class AutoSyncWorker(
             if (isAppInForeground(context)) {
                 Utilities.toast(context, "Syncing started...")
             }
-            DataService(context).checkVersion(this, preferences)
+            configurationRepository.checkVersion(this, preferences)
         }
         return Result.success()
     }
@@ -75,7 +79,7 @@ class AutoSyncWorker(
         if (!blockSync) {
             syncManager.start(this, "upload")
             uploadToShelfService.uploadUserData {
-                DataService(MainApplication.context).healthAccess {
+                configurationRepository.checkHealth {
                     uploadToShelfService.uploadHealth()
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
@@ -19,7 +19,6 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseActivity
 import org.ole.planet.myplanet.callback.OnSecurityDataListener
-import org.ole.planet.myplanet.data.DataService
 import org.ole.planet.myplanet.databinding.ActivityBecomeMemberBinding
 import org.ole.planet.myplanet.ui.sync.LoginActivity
 import org.ole.planet.myplanet.utilities.Constants.PREFS_NAME
@@ -140,18 +139,33 @@ class BecomeMemberActivity : BaseActivity() {
             show()
         }
 
-        DataService(this).becomeMember(obj, object : DataService.CreateUserCallback {
-            override fun onSuccess(success: String) {
-                runOnUiThread { Utilities.toast(this@BecomeMemberActivity, success) }
-            }
-        }, object : OnSecurityDataListener {
+        val securityCallback = object : OnSecurityDataListener {
             override fun onSecurityDataUpdated() {
                 runOnUiThread {
                     customProgressDialog.dismiss()
                     autoLoginNewMember(info.username, info.password)
                 }
             }
-        })
+        }
+
+        lifecycleScope.launch {
+            val result = userRepository.becomeMember(obj)
+            withContext(Dispatchers.Main) {
+                if (result.first) {
+                    startUpload("becomeMember", info.username, securityCallback)
+
+                    if (result.second == getString(R.string.not_connect_to_planet_created_user_offline)) {
+                        Utilities.toast(this@BecomeMemberActivity, result.second)
+                        securityCallback.onSecurityDataUpdated()
+                    }
+
+                    Utilities.toast(this@BecomeMemberActivity, result.second)
+                } else {
+                    Utilities.toast(this@BecomeMemberActivity, result.second)
+                    securityCallback.onSecurityDataUpdated()
+                }
+            }
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
Moved deprecated configuration checks (healthAccess, checkVersion, isPlanetAvailable) from DataService to ConfigurationRepository. Migrated AutoSyncWorker and BaseResourceFragment to use ConfigurationRepository. Refactored BecomeMemberActivity to implement becomeMember logic directly, removing DataService dependency. Removed RepositoryEntryPoint and UserRepository dependencies from DataService. Cleaned up DataService by removing migrated methods.

---
https://jules.google.com/session/3154741071874237714