### PR TITLE
Rename PlanFragment to TeamsPlanFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamPageConfig.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamPageConfig.kt
@@ -21,11 +21,11 @@ sealed class TeamPageConfig(val id: String, @StringRes val titleRes: Int) {
     }
 
     object PlanPage : TeamPageConfig("PLAN", R.string.plan) {
-        override fun createFragment() = PlanFragment()
+        override fun createFragment() = TeamsPlanFragment()
     }
 
     object MissionPage : TeamPageConfig("MISSION", R.string.mission) {
-        override fun createFragment() = PlanFragment()
+        override fun createFragment() = TeamsPlanFragment()
     }
 
     object TeamPage : TeamPageConfig("TEAM", R.string.team) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamPagerAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamPagerAdapter.kt
@@ -68,7 +68,7 @@ class TeamPagerAdapter(
             else -> {}
         }
 
-        if (fragment is PlanFragment) {
+        if (fragment is TeamsPlanFragment) {
             fragment.setTeamUpdateListener(teamUpdateListener)
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamsPlanFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamsPlanFragment.kt
@@ -16,14 +16,14 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnTeamUpdateListener
 import org.ole.planet.myplanet.databinding.AlertCreateTeamBinding
-import org.ole.planet.myplanet.databinding.FragmentPlanBinding
+import org.ole.planet.myplanet.databinding.FragmentTeamPlanBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.utilities.TimeUtils.formatDate
 import org.ole.planet.myplanet.utilities.Utilities
 
-class PlanFragment : BaseTeamFragment() {
-    private var _binding: FragmentPlanBinding? = null
+class TeamsPlanFragment : BaseTeamFragment() {
+    private var _binding: FragmentTeamPlanBinding? = null
     private val binding get() = _binding!!
     private var isEnterprise: Boolean = false
     private var teamUpdateListener: OnTeamUpdateListener? = null
@@ -33,7 +33,7 @@ class PlanFragment : BaseTeamFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentPlanBinding.inflate(inflater, container, false)
+        _binding = FragmentTeamPlanBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -191,7 +191,7 @@ class PlanFragment : BaseTeamFragment() {
 
                 if (wasUpdated) {
                     val refreshedTeam = teamsRepository.getTeamByDocumentIdOrTeamId(teamIdentifier)
-                        ?: (this@PlanFragment.team ?: team)
+                        ?: (this@TeamsPlanFragment.team ?: team)
 
                     refreshedTeam.apply {
                         this.name = name
@@ -204,7 +204,7 @@ class PlanFragment : BaseTeamFragment() {
                         this.updated = true
                     }
 
-                    this@PlanFragment.team = refreshedTeam
+                    this@TeamsPlanFragment.team = refreshedTeam
                     updateUIWithTeamDetails(refreshedTeam)
                     teamUpdateListener?.onTeamDetailsUpdated()
                     Utilities.toast(requireContext(), context.getString(R.string.added_successfully))

--- a/app/src/main/res/layout/fragment_team_plan.xml
+++ b/app/src/main/res/layout/fragment_team_plan.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/secondary_bg"
-    tools:context=".ui.team.PlanFragment">
+    tools:context=".ui.teams.TeamsPlanFragment">
 
     <ScrollView
             android:layout_width="match_parent"


### PR DESCRIPTION
Renamed `PlanFragment` to `TeamsPlanFragment` and its layout `fragment_plan.xml` to `fragment_team_plan.xml`. Updated all references in `TeamPagerAdapter` and `TeamPageConfig`. Updated XML `tools:context` and ViewBinding usage.

---
https://jules.google.com/session/1707585212116391233