### PR TITLE
Refactor DashboardActivity to use SurveysRepository for survey lookup

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepository.kt
@@ -7,6 +7,7 @@ import org.ole.planet.myplanet.ui.surveys.SurveyFormState
 
 interface SurveysRepository {
     suspend fun getExamQuestions(examId: String): List<RealmExamQuestion>
+    suspend fun getSurveyByName(name: String): RealmStepExam?
     suspend fun getSurveySubmissionCount(userId: String?): Int
     suspend fun getTeamOwnedSurveys(teamId: String?): List<RealmStepExam>
     suspend fun getAdoptableTeamSurveys(teamId: String?): List<RealmStepExam>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
@@ -33,6 +33,10 @@ class SurveysRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getSurveyByName(name: String): RealmStepExam? {
+        return findByField(RealmStepExam::class.java, "name", name)
+    }
+
     override suspend fun adoptSurvey(examId: String, userId: String?, teamId: String?, isTeam: Boolean) {
         databaseService.withRealmAsync { realm ->
             realm.executeTransaction { transactionRealm ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -67,6 +67,7 @@ import org.ole.planet.myplanet.repository.NotificationsRepository
 import org.ole.planet.myplanet.repository.ProgressRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
+import org.ole.planet.myplanet.repository.SurveysRepository
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.service.UserSessionManager
@@ -122,6 +123,8 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     lateinit var voicesRepository: VoicesRepository
     @Inject
     override lateinit var resourcesRepository: ResourcesRepository
+    @Inject
+    lateinit var surveysRepository: SurveysRepository
     @Inject
     lateinit var submissionsRepository: SubmissionsRepository
     @Inject
@@ -509,12 +512,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     
     private suspend fun handleSurveyNavigation(surveyId: String?) {
         if (surveyId != null) {
-            val currentStepExam = databaseService.withRealmAsync { realm ->
-                realm.where(RealmStepExam::class.java).equalTo("name", surveyId)
-                    .findFirst()?.let {
-                        realm.copyFromRealm(it)
-                    }
-            }
+            val currentStepExam = surveysRepository.getSurveyByName(surveyId)
             SubmissionsAdapter.openSurvey(this, currentStepExam?.id, false, false, "")
         }
     }


### PR DESCRIPTION
Moved the RealmStepExam query logic from DashboardActivity's handleSurveyNavigation method to SurveysRepository. Injected SurveysRepository into DashboardActivity. Replaced the direct databaseService.withRealmAsync call with surveysRepository.getSurveyByName. This improves separation of concerns and testability by moving data access logic to the repository layer.

---
https://jules.google.com/session/5593918403914116000