### PR TITLE
Refactor LoginActivity to use UserRepository and TeamsRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -30,6 +30,7 @@ data class JoinRequestNotification(
 )
 
 interface TeamsRepository {
+    suspend fun getAllActiveTeams(): List<RealmMyTeam>
     suspend fun getMyTeamsFlow(userId: String): Flow<List<RealmMyTeam>>
     suspend fun getShareableTeams(): List<RealmMyTeam>
     suspend fun getShareableEnterprises(): List<RealmMyTeam>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -100,6 +100,13 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getAllActiveTeams(): List<RealmMyTeam> {
+        return queryList(RealmMyTeam::class.java) {
+            isEmpty("teamId")
+            equalTo("status", "active")
+        }
+    }
+
     override suspend fun getMyTeamsFlow(userId: String): Flow<List<RealmMyTeam>> {
         return queryListFlow(RealmMyTeam::class.java) {
             equalTo("userId", userId)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -64,4 +64,5 @@ interface UserRepository {
     fun getActiveUserId(): String
     suspend fun validateUsername(username: String): String?
     suspend fun cleanupDuplicateUsers()
+    suspend fun createGuestUser(username: String, settings: SharedPreferences): RealmUserModel?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -435,4 +435,10 @@ class UserRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    override suspend fun createGuestUser(username: String, settings: SharedPreferences): RealmUserModel? {
+        return withRealm { realm ->
+            RealmUserModel.createGuestUser(username, realm, settings)?.let { realm.copyFromRealm(it) }
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -393,7 +393,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         editor.apply()
     }
 
-    fun authenticateUser(settings: SharedPreferences?, username: String?, password: String?, isManagerMode: Boolean): Boolean {
+    suspend fun authenticateUser(settings: SharedPreferences?, username: String?, password: String?, isManagerMode: Boolean): Boolean {
         return try {
             if (settings != null) {
                 this.settings = settings
@@ -411,11 +411,9 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         }
     }
 
-    private fun checkName(username: String?, password: String?, isManagerMode: Boolean): Boolean {
+    private suspend fun checkName(username: String?, password: String?, isManagerMode: Boolean): Boolean {
         try {
-            val user = databaseService.withRealm { realm ->
-                realm.where(RealmUserModel::class.java).equalTo("name", username).findFirst()?.let { realm.copyFromRealm(it) }
-            }
+            val user = username?.let { userRepository.getUserByName(it) }
             user?.let {
                 if (it._id?.isEmpty() == true) {
                     if (username == it.name && password == it.password) {


### PR DESCRIPTION
Replaced direct Realm database queries in LoginActivity and SyncActivity with repository calls. Added `createGuestUser` to UserRepository.
Added `getAllActiveTeams` to TeamsRepository.
Refactored `SyncActivity.authenticateUser` and `SyncActivity.checkName` to be suspend functions. Refactored `AuthUtils.login` to support suspend authentication calls. Injected `TeamsRepository` into `LoginActivity`.
Removed unnecessary casting in `LoginActivity`.

---
https://jules.google.com/session/11236755932355983809