### PR TITLE
Refactor isResourceOpened to remove Realm parameter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -38,7 +38,7 @@ interface ResourcesRepository {
         mediums: Set<String>
     )
     suspend fun downloadResources(resources: List<RealmMyLibrary>): Boolean
-    fun isResourceOpened(resourceId: String, mRealm: io.realm.Realm): Boolean
+    suspend fun isResourceOpened(resourceId: String): Boolean
     suspend fun getAllLibrariesToSync(): List<RealmMyLibrary>
     suspend fun addResourcesToUserLibrary(resourceIds: List<String>, userId: String)
     suspend fun addAllResourcesToUserLibrary(resources: List<RealmMyLibrary>, userId: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -12,6 +12,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.utilities.DownloadUtils
@@ -243,11 +244,11 @@ class ResourcesRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun isResourceOpened(resourceId: String, mRealm: io.realm.Realm): Boolean {
-        return mRealm.where(org.ole.planet.myplanet.model.RealmResourceActivity::class.java)
-            .equalTo("resourceId", resourceId)
-            .equalTo("type", "resource_opened")
-            .findFirst() != null
+    override suspend fun isResourceOpened(resourceId: String): Boolean {
+        return count(RealmResourceActivity::class.java) {
+            equalTo("resourceId", resourceId)
+            equalTo("type", "resource_opened")
+        } > 0
     }
 
     override suspend fun getAllLibrariesToSync(): List<RealmMyLibrary> {


### PR DESCRIPTION
- Updated `ResourcesRepository.isResourceOpened` to suspend function and removed Realm parameter.
- Updated `ResourcesRepositoryImpl.isResourceOpened` to use `count` from `RealmRepository` internally.
- Verified no callers needed updating as the method is currently unused.

---
https://jules.google.com/session/5055443527674610052