### PR TITLE
Refactor ExamTakingFragment to use Repositories for data access

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -36,4 +36,6 @@ interface SubmissionsRepository {
     suspend fun hasUnfinishedSurveys(courseId: String, userId: String?): Boolean
     suspend fun generateSubmissionPdf(context: android.content.Context, submissionId: String): java.io.File?
     suspend fun generateMultipleSubmissionsPdf(context: android.content.Context, submissionIds: List<String>, examTitle: String): java.io.File?
+    suspend fun getSubmissionForExam(examId: String, userId: String): RealmSubmission?
+    suspend fun createExamSubmission(sub: RealmSubmission?, userId: String?, type: String?, exam: RealmStepExam?, teamId: String?): RealmSubmission
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -137,4 +137,5 @@ interface TeamsRepository {
 
     suspend fun updateTeamLeader(teamId: String, newLeaderId: String): Boolean
     suspend fun getNextLeaderCandidate(teamId: String, excludeUserId: String?): RealmUserModel?
+    suspend fun getTeamForExam(teamId: String): RealmMyTeam?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -1067,4 +1067,8 @@ class TeamsRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    override suspend fun getTeamForExam(teamId: String): RealmMyTeam? {
+        return findByField(RealmMyTeam::class.java, "_id", teamId)
+    }
 }


### PR DESCRIPTION
Moved Realm submission creation and retrieval logic from ExamTakingFragment to SubmissionsRepository and TeamsRepository.
- Added `getSubmissionForExam` and `createExamSubmission` to `SubmissionsRepository`.
- Added `getTeamForExam` to `TeamsRepository`.
- Updated `ExamTakingFragment` to use these repository methods instead of direct Realm transactions and queries for submission management.
- Ensured thread safety by handling Realm object creation within repository transactions and passing unmanaged objects to the UI.
- Removed direct `mRealm.where` queries from `ExamTakingFragment`.

---
https://jules.google.com/session/13976195638558295528