### PR TITLE
Refactor UI files to use DatabaseService threading for Realm operations

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -125,7 +125,7 @@ class ChatDetailFragment : Fragment() {
         refreshInputState()
         viewLifecycleOwner.lifecycleScope.launch {
             val userId = settings.getString("userId", "") ?: ""
-            user = withContext(Dispatchers.IO) { userRepository.getUserById(userId) }
+            user = userRepository.getUserById(userId)
             isUserLoaded = true
             refreshInputState()
         }
@@ -328,17 +328,15 @@ class ChatDetailFragment : Fragment() {
 
         val mapping = serverUrlMapper.processUrl(serverUrl)
 
-        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleOwner.lifecycleScope.launch {
             updateServerIfNecessary(mapping)
-            withContext(Dispatchers.Main) {
-                chatApiService.fetchAiProviders { providers ->
-                    sharedViewModel.setAiProvidersLoading(false)
-                    if (providers == null || providers.values.all { !it }) {
-                        sharedViewModel.setAiProvidersError(true)
-                        sharedViewModel.setAiProviders(null)
-                    } else {
-                        sharedViewModel.setAiProviders(providers)
-                    }
+            chatApiService.fetchAiProviders { providers ->
+                sharedViewModel.setAiProvidersLoading(false)
+                if (providers == null || providers.values.all { !it }) {
+                    sharedViewModel.setAiProvidersError(true)
+                    sharedViewModel.setAiProviders(null)
+                } else {
+                    sharedViewModel.setAiProviders(providers)
                 }
             }
         }
@@ -446,7 +444,7 @@ class ChatDetailFragment : Fragment() {
         disableUI()
         val mapping = processServerUrl()
         viewLifecycleOwner.lifecycleScope.launch {
-            withContext(Dispatchers.IO) { updateServerIfNecessary(mapping) }
+            updateServerIfNecessary(mapping)
             sendChatRequest(content, query, id, id == null)
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
@@ -258,16 +258,14 @@ class ChatHistoryFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             val cachedUser = user
             val cachedTargets = memoizedShareTargets
-            val (currentUser, newsMessages, chatHistory, targets) = withContext(Dispatchers.IO) {
-                val currentUser = cachedUser ?: loadCurrentUser(settings.getString("userId", ""))
-                val newsMessages = chatRepository.getPlanetNewsMessages(currentUser?.planetCode)
-                val chatHistory = chatRepository.getChatHistoryForUser(currentUser?.name)
-                val targets = cachedTargets ?: loadShareTargets(
-                    settings.getString("parentCode", ""),
-                    settings.getString("communityName", "")
-                )
-                Quartet(currentUser, newsMessages, chatHistory, targets)
-            }
+
+            val currentUser = cachedUser ?: loadCurrentUser(settings.getString("userId", ""))
+            val newsMessages = chatRepository.getPlanetNewsMessages(currentUser?.planetCode)
+            val chatHistory = chatRepository.getChatHistoryForUser(currentUser?.name)
+            val targets = cachedTargets ?: loadShareTargets(
+                settings.getString("parentCode", ""),
+                settings.getString("communityName", "")
+            )
 
             user = currentUser
             sharedNewsMessages = newsMessages
@@ -356,17 +354,15 @@ class ChatHistoryFragment : Fragment() {
 
         val mapping = serverUrlMapper.processUrl(serverUrl)
 
-        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleOwner.lifecycleScope.launch {
             updateServerIfNecessary(mapping)
-            withContext(Dispatchers.Main) {
-                chatApiService.fetchAiProviders { providers ->
-                    sharedViewModel.setAiProvidersLoading(false)
-                    if (providers == null || providers.values.all { !it }) {
-                        sharedViewModel.setAiProvidersError(true)
-                        sharedViewModel.setAiProviders(null)
-                    } else {
-                        sharedViewModel.setAiProviders(providers)
-                    }
+            chatApiService.fetchAiProviders { providers ->
+                sharedViewModel.setAiProvidersLoading(false)
+                if (providers == null || providers.values.all { !it }) {
+                    sharedViewModel.setAiProvidersError(true)
+                    sharedViewModel.setAiProviders(null)
+                } else {
+                    sharedViewModel.setAiProviders(providers)
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -11,10 +11,8 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
@@ -98,8 +96,8 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
         saveInProgress?.invokeOnCompletion { saveInProgress = null }
     }
 
-    private suspend fun loadStepData(): CourseStepData = withContext(Dispatchers.IO) {
-        val intermediateData = databaseService.withRealm { realm ->
+    private suspend fun loadStepData(): CourseStepData {
+        val intermediateData = databaseService.withRealmAsync { realm ->
             val step = realm.where(RealmCourseStep::class.java)
                 .equalTo("id", stepId)
                 .findFirst()
@@ -121,7 +119,7 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
             IntermediateStepData(step, resources, stepExams, stepSurvey)
         }
         val userHasCourse = coursesRepository.isMyCourse(user?.id, intermediateData.step.courseId)
-        return@withContext CourseStepData(
+        return CourseStepData(
             step = intermediateData.step,
             resources = intermediateData.resources,
             stepExams = intermediateData.stepExams,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -504,12 +504,10 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         val tagNames = searchTags.mapNotNull { it.name }
 
         lifecycleScope.launch {
-            val (filteredCourses, map, progressMap) = withContext(Dispatchers.IO) {
-                val courses = coursesRepository.filterCourses(searchText, selectedGrade, selectedSubject, tagNames)
-                val ratings = ratingsRepository.getCourseRatings(model?.id)
-                val progress = progressRepository.getCourseProgress(model?.id)
-                Triple(courses, ratings, progress)
-            }
+            val filteredCourses = coursesRepository.filterCourses(searchText, selectedGrade, selectedSubject, tagNames)
+            val map = ratingsRepository.getCourseRatings(model?.id)
+            val progressMap = progressRepository.getCourseProgress(model?.id)
+
             adapterCourses.updateData(filteredCourses, map, progressMap)
             scrollToTop()
             showNoData(tvMessage, adapterCourses.itemCount, "courses")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesStepsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesStepsAdapter.kt
@@ -8,10 +8,8 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowStepsBinding
 import org.ole.planet.myplanet.model.StepItem
@@ -74,9 +72,7 @@ class CoursesStepsAdapter(private val context: Context, private val submissionsR
                     rowStepsBinding.tvDescription.text = context.getString(R.string.test_size, cachedCount)
                 } else {
                     loadJob = lifecycleOwner.lifecycleScope.launch {
-                        val size = withContext(Dispatchers.IO) {
-                            submissionsRepository.getExamQuestionCount(stepId)
-                        }
+                        val size = submissionsRepository.getExamQuestionCount(stepId)
                         examQuestionCountCache[stepId] = size
                         if (bindingAdapterPosition == RecyclerView.NO_POSITION) {
                             return@launch

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -93,15 +93,13 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
             currentCourse = course
             binding.tvCourseTitle.text = currentCourse?.courseTitle
 
-            withContext(Dispatchers.IO) {
-                steps = coursesRepository.getCourseSteps(courseId)
+            steps = coursesRepository.getCourseSteps(courseId)
 
-                if (cachedCourseProgress == null && isFetchingProgress.compareAndSet(false, true)) {
-                    try {
-                        cachedCourseProgress = getCourseProgress()
-                    } finally {
-                        isFetchingProgress.set(false)
-                    }
+            if (cachedCourseProgress == null && isFetchingProgress.compareAndSet(false, true)) {
+                try {
+                    cachedCourseProgress = getCourseProgress()
+                } finally {
+                    isFetchingProgress.set(false)
                 }
             }
 
@@ -221,18 +219,16 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
             val detachedUserModel = userModel
             val detachedCurrentCourse = currentCourse
 
-            withContext(Dispatchers.IO) {
-                try {
-                    coursesRepository.logCourseVisit(
-                        detachedUserModel?.name,
-                        detachedCurrentCourse?.courseId,
-                        detachedCurrentCourse?.courseTitle,
-                        detachedUserModel?.planetCode,
-                        detachedUserModel?.parentCode
-                    )
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
+            try {
+                coursesRepository.logCourseVisit(
+                    detachedUserModel?.name,
+                    detachedCurrentCourse?.courseId,
+                    detachedCurrentCourse?.courseTitle,
+                    detachedUserModel?.planetCode,
+                    detachedUserModel?.parentCode
+                )
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
 
             withContext(Dispatchers.Main) {
@@ -336,10 +332,8 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     private fun addRemoveCourse() {
         viewLifecycleOwner.lifecycleScope.launch {
             try {
-                val isJoined = withContext(Dispatchers.IO) {
-                    val course = courseId?.let { coursesRepository.getCourseById(it) }
-                    course?.userId?.contains(userModel?.id) == true
-                }
+                val course = courseId?.let { coursesRepository.getCourseById(it) }
+                val isJoined = course?.userId?.contains(userModel?.id) == true
 
                 userModel?.id?.let { userId ->
                     courseId?.let { cId ->
@@ -351,11 +345,9 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
                     }
                 }
 
-                withContext(Dispatchers.IO) {
-                    val updatedCourse = courseId?.let { coursesRepository.getCourseById(it) }
-                    if (updatedCourse != null) {
-                        currentCourse = updatedCourse
-                    }
+                val updatedCourse = courseId?.let { coursesRepository.getCourseById(it) }
+                if (updatedCourse != null) {
+                    currentCourse = updatedCourse
                 }
 
                 val statusMessage = if (isJoined) {
@@ -376,11 +368,9 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     }
 
     private suspend fun getCourseProgress(): Int {
-        return withContext(Dispatchers.IO) {
-            val user = userSessionManager.userModel
-            val courseProgressMap = progressRepository.getCourseProgress(user?.id)
-            courseProgressMap[courseId]?.asJsonObject?.get("current")?.asInt ?: 0
-        }
+        val user = userSessionManager.userModel
+        val courseProgressMap = progressRepository.getCourseProgress(user?.id)
+        return courseProgressMap[courseId]?.asJsonObject?.get("current")?.asInt ?: 0
     }
 
     private fun checkSurveyCompletion() = viewLifecycleOwner.lifecycleScope.launch {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ChallengeHelper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ChallengeHelper.kt
@@ -39,9 +39,7 @@ class ChallengeHelper(
         val courseId = "4e6b78800b6ad18b4e8b0e1e38a98cac"
         activity.lifecycleScope.launch(Dispatchers.Main) {
             try {
-                val courseData = withContext(Dispatchers.IO) {
-                    progressRepository.fetchCourseData(user?.id)
-                }
+                val courseData = progressRepository.fetchCourseData(user?.id)
 
                 val uniqueDates = voicesRepository.getCommunityVoiceDates(startTime, endTime, user?.id)
                 val allUniqueDates = voicesRepository.getCommunityVoiceDates(startTime, endTime, null)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesViewModel.kt
@@ -16,21 +16,15 @@ class EnterprisesViewModel @Inject constructor(
 ) : ViewModel() {
 
     suspend fun addReport(doc: JsonObject) {
-        withContext(Dispatchers.IO) {
-            teamsRepository.addReport(doc)
-        }
+        teamsRepository.addReport(doc)
     }
 
     suspend fun updateReport(reportId: String, doc: JsonObject) {
-        withContext(Dispatchers.IO) {
-            teamsRepository.updateReport(reportId, doc)
-        }
+        teamsRepository.updateReport(reportId, doc)
     }
 
     suspend fun archiveReport(reportId: String) {
-        withContext(Dispatchers.IO) {
-            teamsRepository.archiveReport(reportId)
-        }
+        teamsRepository.archiveReport(reportId)
     }
 
     suspend fun getReportsFlow(teamId: String): Flow<List<RealmMyTeam>> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -252,9 +252,7 @@ class MyHealthFragment : Fragment() {
             val fetchedUser = if (normalizedId.isNullOrEmpty()) {
                 null
             } else {
-                withContext(Dispatchers.IO) {
-                    userRepository.getUserByAnyId(normalizedId)
-                }
+                userRepository.getUserByAnyId(normalizedId)
             }
             if (!isAdded || _binding == null) {
                 return@launch
@@ -315,9 +313,7 @@ class MyHealthFragment : Fragment() {
                         2 -> "name" to Sort.ASCENDING
                         else -> "name" to Sort.DESCENDING
                     }
-                    val sortedList = withContext(Dispatchers.IO) {
-                        userRepository.getUsersSortedBy(sortBy, sort)
-                    }
+                    val sortedList = userRepository.getUsersSortedBy(sortBy, sort)
                     if (isAdded) {
                         userModelList = sortedList
                         adapter.clear()
@@ -343,9 +339,7 @@ class MyHealthFragment : Fragment() {
                         lv.visibility = View.GONE
                     }
 
-                    val userModelList = withContext(Dispatchers.IO) {
-                        userRepository.searchUsers(editable.toString(), "joinDate", Sort.DESCENDING)
-                    }
+                    val userModelList = userRepository.searchUsers(editable.toString(), "joinDate", Sort.DESCENDING)
 
                     loadingJob.cancel()
                     if (isAdded) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -11,9 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import com.google.gson.JsonObject
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
@@ -59,14 +57,12 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             }
             val userId = profileDbHandler.userModel?.id
             try {
-                val updatedLibrary = withContext(Dispatchers.IO) {
-                    val backgroundLibrary = fetchLibrary(libraryId!!)
-                    when {
-                        backgroundLibrary == null -> null
-                        backgroundLibrary.userId?.contains(userId) != true && userId != null ->
-                            resourcesRepository.updateUserLibrary(libraryId!!, userId, true)
-                        else -> backgroundLibrary
-                    }
+                val backgroundLibrary = fetchLibrary(libraryId!!)
+                val updatedLibrary = when {
+                    backgroundLibrary == null -> null
+                    backgroundLibrary.userId?.contains(userId) != true && userId != null ->
+                        resourcesRepository.updateUserLibrary(libraryId!!, userId, true)
+                    else -> backgroundLibrary
                 }
                 if (updatedLibrary != null) {
                     library = updatedLibrary
@@ -145,9 +141,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
                 return@launch
             }
             try {
-                withContext(Dispatchers.IO) {
-                    profileDbHandler.setResourceOpenCount(library)
-                }
+                profileDbHandler.setResourceOpenCount(library)
             } catch (ex: Exception) {
                 ex.printStackTrace()
             }
@@ -226,17 +220,15 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
                 if (!isAdded) {
                     return@launch
                 }
-                val updatedLibrary = withContext(Dispatchers.IO) {
-                    try {
-                        if (userId != null) {
-                            resourcesRepository.updateUserLibrary(libraryId!!, userId, isAdd)
-                        } else {
-                            null
-                        }
-                    } catch (e: Exception) {
-                        e.printStackTrace()
+                val updatedLibrary = try {
+                    if (userId != null) {
+                        resourcesRepository.updateUserLibrary(libraryId!!, userId, isAdd)
+                    } else {
                         null
                     }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    null
                 }
                 try {
                     if (updatedLibrary != null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
@@ -286,21 +286,19 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), OnSurveyAdoptList
         loadSurveysJob = viewLifecycleOwner.lifecycleScope.launch {
             binding.loadingSpinner.visibility = View.VISIBLE
             try {
-                val (surveys, infos, data) = withContext(Dispatchers.IO) {
-                    val currentSurveys = when {
-                        isTeam && useTeamShareAllowed -> surveysRepository.getAdoptableTeamSurveys(teamId)
-                        isTeam -> surveysRepository.getTeamOwnedSurveys(teamId)
-                        else -> surveysRepository.getIndividualSurveys()
-                    }
-                    val surveyInfos = surveysRepository.getSurveyInfos(
-                        isTeam,
-                        teamId,
-                        userProfileModel?.id,
-                        currentSurveys
-                    )
-                    val bindingData = surveysRepository.getSurveyFormState(currentSurveys, teamId)
-                    Triple(currentSurveys, surveyInfos, bindingData)
+                val currentSurveysList = when {
+                    isTeam && useTeamShareAllowed -> surveysRepository.getAdoptableTeamSurveys(teamId)
+                    isTeam -> surveysRepository.getTeamOwnedSurveys(teamId)
+                    else -> surveysRepository.getIndividualSurveys()
                 }
+                val surveyInfos = surveysRepository.getSurveyInfos(
+                    isTeam,
+                    teamId,
+                    userProfileModel?.id,
+                    currentSurveysList
+                )
+                val bindingData = surveysRepository.getSurveyFormState(currentSurveysList, teamId)
+                val (surveys, infos, data) = Triple(currentSurveysList, surveyInfos, bindingData)
                 currentSurveys = surveys.sortedByDescending { survey ->
                     if (survey.sourceSurveyId != null) {
                         if (survey.adoptionDate > 0) survey.adoptionDate else survey.createdDate

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -894,13 +894,9 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         private val urlProtocolRegex by lazy { Regex("^https?://") }
 
         suspend fun clearRealmDb() {
-            withContext(Dispatchers.IO) {
-                val databaseService = (context.applicationContext as MainApplication).databaseService
-                databaseService.withRealm { realm ->
-                    realm.executeTransaction { transactionRealm ->
-                        transactionRealm.deleteAll()
-                    }
-                }
+            val databaseService = (context.applicationContext as MainApplication).databaseService
+            databaseService.executeTransactionAsync { transactionRealm ->
+                transactionRealm.deleteAll()
             }
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
@@ -12,7 +12,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -207,9 +206,7 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
         val mapping = serverUrlMapper.processUrl(serverUrl)
 
         lifecycleScope.launch {
-            withContext(kotlinx.coroutines.Dispatchers.IO) {
-                updateServerIfNecessary(mapping)
-            }
+            updateServerIfNecessary(mapping)
             startSyncManager()
         }
     }
@@ -270,9 +267,7 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
 
         team?._id?.let { id ->
             viewLifecycleOwner.lifecycleScope.launch {
-                val memberCount = withContext(Dispatchers.IO) {
-                    teamsRepository.getJoinedMemberCount(id)
-                }
+                val memberCount = teamsRepository.getJoinedMemberCount(id)
                 if (memberCount <= 1 && isMyTeam) {
                     binding.btnLeave.visibility = View.GONE
                 }
@@ -429,9 +424,7 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
                 binding.subtitle.text = updatedTeam.type
 
                 team?._id?.let { id ->
-                    val memberCount = withContext(Dispatchers.IO) {
-                        teamsRepository.getJoinedMemberCount(id)
-                    }
+                    val memberCount = teamsRepository.getJoinedMemberCount(id)
                     if (memberCount <= 1 && isMyTeam) {
                         binding.btnLeave.visibility = View.GONE
                     } else {
@@ -449,9 +442,7 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
         _binding?.let { binding ->
             val teamId = team?._id ?: return@let
             viewLifecycleOwner.lifecycleScope.launch {
-                val joinedCount = withContext(Dispatchers.IO) {
-                    teamsRepository.getJoinedMemberCount(teamId)
-                }
+                val joinedCount = teamsRepository.getJoinedMemberCount(teamId)
                 binding.btnLeave.visibility = if (joinedCount <= 1) {
                     View.GONE
                 } else {
@@ -488,15 +479,13 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
         val teamType = getEffectiveTeamType()
 
         viewLifecycleOwner.lifecycleScope.launch {
-            withContext(kotlinx.coroutines.Dispatchers.IO) {
-                teamsRepository.logTeamVisit(
-                    teamId = getEffectiveTeamId(),
-                    userName = userName,
-                    userPlanetCode = userPlanetCode,
-                    userParentCode = userParentCode,
-                    teamType = teamType,
-                )
-            }
+            teamsRepository.logTeamVisit(
+                teamId = getEffectiveTeamId(),
+                userName = userName,
+                userPlanetCode = userPlanetCode,
+                userParentCode = userParentCode,
+                teamType = teamType,
+            )
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
@@ -92,20 +92,18 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
             Utilities.toast(activity, getString(R.string.saving))
 
             lifecycleScope.launch {
-                withContext(Dispatchers.IO) {
-                    databaseService.withRealmAsync { realm ->
-                        realm.executeTransaction { transactionRealm ->
-                            val achievement = transactionRealm.where(RealmAchievement::class.java)
-                                .equalTo("_id", achievementId)
-                                .findFirst()
-                            if (achievement != null) {
-                                achievement.achievementsHeader = header
-                                achievement.goals = goals
-                                achievement.purpose = purpose
-                                achievement.sendToNation = sendToNation
-                                achievement.setAchievements(JsonUtils.gson.fromJson(achievementsJson, JsonArray::class.java))
-                                achievement.setReferences(JsonUtils.gson.fromJson(referencesJson, JsonArray::class.java))
-                            }
+                databaseService.withRealmAsync { realm ->
+                    realm.executeTransaction { transactionRealm ->
+                        val achievement = transactionRealm.where(RealmAchievement::class.java)
+                            .equalTo("_id", achievementId)
+                            .findFirst()
+                        if (achievement != null) {
+                            achievement.achievementsHeader = header
+                            achievement.goals = goals
+                            achievement.purpose = purpose
+                            achievement.sendToNation = sendToNation
+                            achievement.setAchievements(JsonUtils.gson.fromJson(achievementsJson, JsonArray::class.java))
+                            achievement.setReferences(JsonUtils.gson.fromJson(referencesJson, JsonArray::class.java))
                         }
                     }
                 }


### PR DESCRIPTION
Replaced direct usage of `Dispatchers.IO` with `databaseService.withRealmAsync` or `databaseService.executeTransactionAsync` in UI components to ensure consistent threading and safe Realm usage. Removed redundant `withContext(Dispatchers.IO)` calls around suspending repository methods that already handle threading. Cleaned up unused imports.

Key changes:
- `SyncActivity`: Refactored `clearRealmDb` to use `executeTransactionAsync`.
- `LoginActivity`: Updated to use `withRealmAsync` and refactored `createGuestUser` logic.
- `CoursesFragment`, `TakeCourseFragment`, `CoursesStepsAdapter`: Removed redundant dispatcher switching.
- `CourseStepFragment`: Updated to use `withRealmAsync` with proper object detachment.
- `EditAchievementFragment`, `AchievementFragment`, `ResourceDetailFragment`, `TeamDetailFragment`, `DictionaryActivity`, `MyHealthFragment`: Updated to use safer threading patterns.
- `SurveyFragment`, `ChatDetailFragment`, `ChatHistoryFragment`, `ChallengeHelper`, `EnterprisesViewModel`: Removed redundant dispatcher switching.

---
https://jules.google.com/session/7247188148589501061