### PR TITLE
Move base fragments to ui/base subpackage

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseMemberFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseMemberFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.databinding.FragmentMembersBinding
 import org.ole.planet.myplanet.model.RealmUserModel
-import org.ole.planet.myplanet.ui.teams.BaseTeamFragment
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 
 abstract class BaseMemberFragment : BaseTeamFragment() {
     abstract val list: List<RealmUserModel?>

--- a/app/src/main/java/org/ole/planet/myplanet/ui/base/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/base/BaseDashboardFragment.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.dashboard
+package org.ole.planet.myplanet.ui.base
 
 import android.app.DatePickerDialog
 import android.content.Intent
@@ -38,6 +38,8 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.TeamNotificationInfo
 import org.ole.planet.myplanet.service.sync.TransactionSyncManager
+import org.ole.planet.myplanet.ui.dashboard.DashboardPluginFragment
+import org.ole.planet.myplanet.ui.dashboard.DashboardViewModel
 import org.ole.planet.myplanet.ui.exam.UserInformationFragment
 import org.ole.planet.myplanet.ui.health.UserSelectionAdapter
 import org.ole.planet.myplanet.ui.teams.TeamDetailFragment

--- a/app/src/main/java/org/ole/planet/myplanet/ui/base/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/base/BaseTeamFragment.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.teams
+package org.ole.planet.myplanet.ui.base
 
 import android.os.Bundle
 import androidx.lifecycle.lifecycleScope
@@ -14,7 +14,6 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.TeamsRepository
-import org.ole.planet.myplanet.ui.voices.BaseVoicesFragment
 
 @AndroidEntryPoint
 abstract class BaseTeamFragment : BaseVoicesFragment() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/base/BaseVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/base/BaseVoicesFragment.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.voices
+package org.ole.planet.myplanet.ui.base
 
 import android.app.Activity
 import android.content.Context
@@ -32,6 +32,9 @@ import org.ole.planet.myplanet.callback.OnNewsItemClickListener
 import org.ole.planet.myplanet.databinding.ImageThumbBinding
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUserModel
+import org.ole.planet.myplanet.ui.voices.ReplyActivity
+import org.ole.planet.myplanet.ui.voices.VoicesActions
+import org.ole.planet.myplanet.ui.voices.VoicesAdapter
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.FileUtils.getFileNameFromUrl
 import org.ole.planet.myplanet.utils.FileUtils.getRealPathFromURI

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
@@ -11,7 +11,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentCommunityServicesBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.ui.teams.BaseTeamFragment
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 import org.ole.planet.myplanet.ui.teams.TeamDetailFragment
 import org.ole.planet.myplanet.utils.MarkdownUtils.prependBaseUrlToImages
 import org.ole.planet.myplanet.utils.MarkdownUtils.setMarkdownText

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -40,6 +40,7 @@ import org.ole.planet.myplanet.ui.submissions.SubmissionsAdapter
 import org.ole.planet.myplanet.ui.submissions.SubmissionsFragment
 import org.ole.planet.myplanet.ui.teams.TeamDetailFragment
 import org.ole.planet.myplanet.ui.teams.TeamFragment
+import org.ole.planet.myplanet.ui.base.BaseDashboardFragment
 import org.ole.planet.myplanet.utils.DialogUtils.guestDialog
 
 @AndroidEntryPoint

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesFragment.kt
@@ -21,7 +21,7 @@ import org.ole.planet.myplanet.databinding.AddTransactionBinding
 import org.ole.planet.myplanet.databinding.FragmentFinanceBinding
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.Transaction
-import org.ole.planet.myplanet.ui.teams.BaseTeamFragment
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 import org.ole.planet.myplanet.utils.TimeUtils.formatDateTZ
 import org.ole.planet.myplanet.utils.Utilities
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsFragment.kt
@@ -34,7 +34,7 @@ import org.ole.planet.myplanet.databinding.DialogAddReportBinding
 import org.ole.planet.myplanet.databinding.FragmentReportsBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.ui.teams.BaseTeamFragment
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 import org.ole.planet.myplanet.utils.SharedPrefManager
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/PlanFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/PlanFragment.kt
@@ -21,6 +21,7 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 
 class PlanFragment : BaseTeamFragment() {
     private var _binding: FragmentPlanBinding? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarFragment.kt
@@ -41,6 +41,7 @@ import org.ole.planet.myplanet.repository.EventsRepository
 import org.ole.planet.myplanet.ui.events.EventsAdapter
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 
 @AndroidEntryPoint
 class TeamCalendarFragment : BaseTeamFragment() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
@@ -49,6 +49,7 @@ import org.ole.planet.myplanet.ui.teams.TeamPageConfig.TeamPage
 import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.SharedPrefManager
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 
 @AndroidEntryPoint
 class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpdateListener {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.ui.teams.BaseTeamFragment
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 
 class TeamCoursesFragment : BaseTeamFragment() {
     private var _binding: FragmentTeamCourseBinding? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
@@ -27,7 +27,7 @@ import org.ole.planet.myplanet.databinding.MyLibraryAlertdialogBinding
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.components.CheckboxListView
-import org.ole.planet.myplanet.ui.teams.BaseTeamFragment
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 
 @AndroidEntryPoint
 class TeamResourcesFragment : BaseTeamFragment(), OnTeamPageListener, OnResourcesUpdateListener {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
@@ -34,7 +34,7 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.ui.health.UserSelectionAdapter
-import org.ole.planet.myplanet.ui.teams.BaseTeamFragment
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 import org.ole.planet.myplanet.utils.TimeUtils.formatDateTZ

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
@@ -21,7 +21,7 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.service.UserSessionManager
 import org.ole.planet.myplanet.ui.chat.ChatDetailFragment
-import org.ole.planet.myplanet.ui.teams.BaseTeamFragment
+import org.ole.planet.myplanet.ui.base.BaseTeamFragment
 import org.ole.planet.myplanet.ui.voices.VoicesAdapter
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.NavigationHelper

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
@@ -37,6 +37,7 @@ import org.ole.planet.myplanet.utils.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utils.NavigationHelper
 import org.ole.planet.myplanet.utils.SharedPrefManager
 import org.ole.planet.myplanet.utils.textChanges
+import org.ole.planet.myplanet.ui.base.BaseVoicesFragment
 
 @AndroidEntryPoint
 class VoicesFragment : BaseVoicesFragment() {


### PR DESCRIPTION
Moved BaseDashboardFragment, BaseTeamFragment, and BaseVoicesFragment to org.ole.planet.myplanet.ui.base to improve project structure. Updated package declarations and imports in all referencing files. Fixed an import issue in BaseDashboardFragment.kt.

---
https://jules.google.com/session/18015454008787779004