### PR TITLE
Refactor: Rename ui/reader to ui/viewer

### DIFF
--- a/app/src/lite/AndroidManifest.xml
+++ b/app/src/lite/AndroidManifest.xml
@@ -89,7 +89,7 @@
         <activity
             android:name=".ui.resources.AddResourceActivity"
             android:theme="@style/AppTheme" />
-        <activity android:name=".ui.reader.AudioPlayerActivity"
+        <activity android:name=".ui.viewer.AudioPlayerActivity"
             android:configChanges="orientation|screenSize" />
         <activity
             android:name=".ui.feedback.FeedbackDetailActivity"
@@ -100,19 +100,19 @@
             android:label="@string/title_activity_dashboard"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/FullscreenTheme" />
-        <activity android:name=".ui.reader.PDFReaderActivity"
+        <activity android:name=".ui.viewer.PDFReaderActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.WebViewActivity"
+        <activity android:name=".ui.viewer.WebViewActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.VideoViewerActivity"
+        <activity android:name=".ui.viewer.VideoViewerActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.ImageViewerActivity"
+        <activity android:name=".ui.viewer.ImageViewerActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.TextFileViewerActivity"
+        <activity android:name=".ui.viewer.TextFileViewerActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.MarkdownViewerActivity"
+        <activity android:name=".ui.viewer.MarkdownViewerActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.CSVViewerActivity"
+        <activity android:name=".ui.viewer.CSVViewerActivity"
             android:configChanges="orientation|screenSize" />
         <activity
             android:name=".ui.dictionary.DictionaryActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,7 @@
         <activity
             android:name=".ui.resources.AddResourceActivity"
             android:theme="@style/AppTheme" />
-        <activity android:name=".ui.reader.AudioPlayerActivity"
+        <activity android:name=".ui.viewer.AudioPlayerActivity"
             android:configChanges="orientation|screenSize" />
         <activity
             android:name=".ui.feedback.FeedbackDetailActivity"
@@ -100,19 +100,19 @@
             android:label="@string/title_activity_dashboard"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/FullscreenTheme" />
-        <activity android:name=".ui.reader.PDFReaderActivity"
+        <activity android:name=".ui.viewer.PDFReaderActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.WebViewActivity"
+        <activity android:name=".ui.viewer.WebViewActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.VideoViewerActivity"
+        <activity android:name=".ui.viewer.VideoViewerActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.ImageViewerActivity"
+        <activity android:name=".ui.viewer.ImageViewerActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.TextFileViewerActivity"
+        <activity android:name=".ui.viewer.TextFileViewerActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.MarkdownViewerActivity"
+        <activity android:name=".ui.viewer.MarkdownViewerActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.reader.CSVViewerActivity"
+        <activity android:name=".ui.viewer.CSVViewerActivity"
             android:configChanges="orientation|screenSize" />
         <activity
             android:name=".ui.dictionary.DictionaryActivity"

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseContainerFragment.kt
@@ -32,7 +32,7 @@ import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.services.UserSessionManager.Companion.KEY_RESOURCE_DOWNLOAD
-import org.ole.planet.myplanet.ui.reader.WebViewActivity
+import org.ole.planet.myplanet.ui.viewer.WebViewActivity
 import org.ole.planet.myplanet.utils.CourseRatingUtils
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils

--- a/app/src/main/java/org/ole/planet/myplanet/ui/components/CustomClickableSpan.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/components/CustomClickableSpan.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.text.style.ClickableSpan
 import android.view.View
 import android.widget.Toast
-import org.ole.planet.myplanet.ui.reader.WebViewActivity
+import org.ole.planet.myplanet.ui.viewer.WebViewActivity
 
 class CustomClickableSpan(private val url: String, private val title: String, private val context: Context) : ClickableSpan() {
     override fun onClick(widget: View) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsAdapter.kt
@@ -13,9 +13,9 @@ import org.ole.planet.myplanet.callback.OnPersonalSelectedListener
 import org.ole.planet.myplanet.databinding.RowMyPersonalBinding
 import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.ui.personals.PersonalsAdapter.PersonalsViewHolder
-import org.ole.planet.myplanet.ui.reader.ImageViewerActivity
-import org.ole.planet.myplanet.ui.reader.PDFReaderActivity
-import org.ole.planet.myplanet.ui.reader.VideoViewerActivity
+import org.ole.planet.myplanet.ui.viewer.ImageViewerActivity
+import org.ole.planet.myplanet.ui.viewer.PDFReaderActivity
+import org.ole.planet.myplanet.ui.viewer.VideoViewerActivity
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.IntentUtils.openAudioFile
 import org.ole.planet.myplanet.utils.TimeUtils.getFormattedDate

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/AudioPlayerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/AudioPlayerActivity.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.reader
+package org.ole.planet.myplanet.ui.viewer
 
 import android.content.res.Configuration
 import android.os.Bundle

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/CSVViewerActivity.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.reader
+package org.ole.planet.myplanet.ui.viewer
 
 import android.os.Bundle
 import android.text.Spannable

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ImageViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ImageViewerActivity.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.reader
+package org.ole.planet.myplanet.ui.viewer
 
 import android.os.Bundle
 import android.view.View

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/MarkdownViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/MarkdownViewerActivity.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.reader
+package org.ole.planet.myplanet.ui.viewer
 
 import android.os.Bundle
 import android.view.View

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.reader
+package org.ole.planet.myplanet.ui.viewer
 
 import android.graphics.pdf.PdfRenderer
 import android.os.Bundle

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/TextFileViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/TextFileViewerActivity.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.reader
+package org.ole.planet.myplanet.ui.viewer
 
 import android.os.Bundle
 import android.view.View

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/VideoViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/VideoViewerActivity.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.reader
+package org.ole.planet.myplanet.ui.viewer
 
 import android.content.BroadcastReceiver
 import android.content.Context

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.reader
+package org.ole.planet.myplanet.ui.viewer
 
 import android.content.pm.ActivityInfo
 import android.graphics.Bitmap

--- a/app/src/main/java/org/ole/planet/myplanet/utils/IntentUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/IntentUtils.kt
@@ -4,7 +4,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
-import org.ole.planet.myplanet.ui.reader.AudioPlayerActivity
+import org.ole.planet.myplanet.ui.viewer.AudioPlayerActivity
 
 object IntentUtils {
     @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/utils/ResourceOpener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ResourceOpener.kt
@@ -9,13 +9,13 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseResourceFragment
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.services.UserSessionManager
-import org.ole.planet.myplanet.ui.reader.AudioPlayerActivity
-import org.ole.planet.myplanet.ui.reader.CSVViewerActivity
-import org.ole.planet.myplanet.ui.reader.ImageViewerActivity
-import org.ole.planet.myplanet.ui.reader.MarkdownViewerActivity
-import org.ole.planet.myplanet.ui.reader.PDFReaderActivity
-import org.ole.planet.myplanet.ui.reader.TextFileViewerActivity
-import org.ole.planet.myplanet.ui.reader.VideoViewerActivity
+import org.ole.planet.myplanet.ui.viewer.AudioPlayerActivity
+import org.ole.planet.myplanet.ui.viewer.CSVViewerActivity
+import org.ole.planet.myplanet.ui.viewer.ImageViewerActivity
+import org.ole.planet.myplanet.ui.viewer.MarkdownViewerActivity
+import org.ole.planet.myplanet.ui.viewer.PDFReaderActivity
+import org.ole.planet.myplanet.ui.viewer.TextFileViewerActivity
+import org.ole.planet.myplanet.ui.viewer.VideoViewerActivity
 
 object ResourceOpener {
     private fun resourcePath(item: RealmMyLibrary): String {

--- a/app/src/main/res/layout/activity_csvviewer.xml
+++ b/app/src/main/res/layout/activity_csvviewer.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context="org.ole.planet.myplanet.ui.reader.CSVViewerActivity"
+    tools:context="org.ole.planet.myplanet.ui.viewer.CSVViewerActivity"
     android:background="@color/light_dark">
 
     <TextView

--- a/app/src/main/res/layout/activity_exo_player_video.xml
+++ b/app/src/main/res/layout/activity_exo_player_video.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="org.ole.planet.myplanet.ui.reader.VideoViewerActivity">
+    tools:context="org.ole.planet.myplanet.ui.viewer.VideoViewerActivity">
 
     <androidx.media3.ui.PlayerView
         android:id="@+id/exo_player_simple"

--- a/app/src/main/res/layout/activity_image_viewer.xml
+++ b/app/src/main/res/layout/activity_image_viewer.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context="org.ole.planet.myplanet.ui.reader.ImageViewerActivity">
+    tools:context="org.ole.planet.myplanet.ui.viewer.ImageViewerActivity">
 
     <TextView
         android:id="@+id/imageFileName"

--- a/app/src/main/res/layout/activity_markdown_viewer.xml
+++ b/app/src/main/res/layout/activity_markdown_viewer.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:background="@color/background_color"
-    tools:context="org.ole.planet.myplanet.ui.reader.MarkdownViewerActivity">
+    tools:context="org.ole.planet.myplanet.ui.viewer.MarkdownViewerActivity">
 
     <TextView
         android:id="@+id/markdownFileName"

--- a/app/src/main/res/layout/activity_pdfreader.xml
+++ b/app/src/main/res/layout/activity_pdfreader.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context="org.ole.planet.myplanet.ui.reader.PDFReaderActivity">
+    tools:context="org.ole.planet.myplanet.ui.viewer.PDFReaderActivity">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_textfile_viewer.xml
+++ b/app/src/main/res/layout/activity_textfile_viewer.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context="org.ole.planet.myplanet.ui.reader.TextFileViewerActivity">
+    tools:context="org.ole.planet.myplanet.ui.viewer.TextFileViewerActivity">
 
     <TextView
         android:id="@+id/textFileName"


### PR DESCRIPTION
Renamed the package `org.ole.planet.myplanet.ui.reader` to `org.ole.planet.myplanet.ui.viewer` to better reflect its purpose as a container for file viewer activities.

Changes:
- Moved all activities from `ui/reader` to `ui/viewer`.
- Updated package declarations in Kotlin files.
- Updated references in `AndroidManifest.xml` (main and lite).
- Updated references in layout files and other classes (`ResourceOpener`, `IntentUtils`, etc.).

---
https://jules.google.com/session/3379376120172925651