### PR TITLE
Refactor exam submission creation to SubmissionsRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -24,6 +24,7 @@ interface SubmissionsRepository {
     ): Boolean
     suspend fun hasPendingOfflineSubmissions(): Boolean
     suspend fun hasPendingExamResults(): Boolean
+    suspend fun createExamSubmission(examId: String, userId: String?, type: String?, teamId: String?): RealmSubmission
     suspend fun createSurveySubmission(examId: String, userId: String?)
     suspend fun saveSubmission(submission: RealmSubmission)
     suspend fun markSubmissionComplete(id: String, payload: com.google.gson.JsonObject)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
@@ -18,21 +18,16 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.gson.JsonObject
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Realm
-import io.realm.RealmList
-import java.util.Date
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.json.JSONObject
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseExamFragment
 import org.ole.planet.myplanet.databinding.FragmentExamTakingBinding
 import org.ole.planet.myplanet.model.RealmCertification.Companion.isCourseCertified
 import org.ole.planet.myplanet.model.RealmExamQuestion
-import org.ole.planet.myplanet.model.RealmMembershipDoc
 import org.ole.planet.myplanet.model.RealmSubmission
-import org.ole.planet.myplanet.model.RealmSubmission.Companion.createSubmission
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.repository.SurveysRepository
 import org.ole.planet.myplanet.services.UserSessionManager
@@ -94,14 +89,26 @@ class ExamTakingFragment : BaseExamFragment(), View.OnClickListener, CompoundBut
             if ((questions?.size ?: 0) > 0) {
                 if (type == "exam") {
                     clearAllExistingAnswers {
-                        createSubmission()
+                        viewLifecycleOwner.lifecycleScope.launch {
+                            val examId = exam?.id
+                            val userId = user?.id
+                            if (examId != null) {
+                                sub = submissionsRepository.createExamSubmission(examId, userId, type, teamId)
+                                currentIndex = 0
+                                startExam(questions?.get(currentIndex))
+                                updateNavButtons()
+                            }
+                        }
+                    }
+                } else {
+                    val examId = exam?.id
+                    val userId = user?.id
+                    if (examId != null) {
+                        sub = submissionsRepository.createExamSubmission(examId, userId, type, teamId)
+                        currentIndex = 0
                         startExam(questions?.get(currentIndex))
                         updateNavButtons()
                     }
-                } else {
-                    createSubmission()
-                    startExam(questions?.get(currentIndex))
-                    updateNavButtons()
                 }
             } else {
                 binding.container.visibility = View.GONE
@@ -234,95 +241,6 @@ class ExamTakingFragment : BaseExamFragment(), View.OnClickListener, CompoundBut
         }
     }
 
-    private fun createSubmission() {
-        mRealm.beginTransaction()
-        try {
-            sub = createSubmission(null, mRealm)
-            setParentId()
-            setParentJson()
-            sub?.userId = user?.id
-            sub?.status = "pending"
-            sub?.type = type
-            sub?.startTime = Date().time
-            sub?.lastUpdateTime = Date().time
-            if (sub?.answers == null) {
-                sub?.answers = RealmList()
-            }
-
-            currentIndex = 0
-            if (isTeam && teamId != null) {
-                addTeamInformation(mRealm)
-            }
-            mRealm.commitTransaction()
-        } catch (e: Exception) {
-            mRealm.cancelTransaction()
-            throw e
-        }
-    }
-
-    private fun setParentId() {
-        sub?.parentId = when {
-            !TextUtils.isEmpty(exam?.id) -> if (!TextUtils.isEmpty(exam?.courseId)) {
-                "${exam?.id}@${exam?.courseId}"
-            } else {
-                exam?.id
-            }
-            !TextUtils.isEmpty(id) -> if (!TextUtils.isEmpty(exam?.courseId)) {
-                "$id@${exam?.courseId}"
-            } else {
-                id
-            }
-            else -> sub?.parentId
-        }
-    }
-
-    private fun setParentJson() {
-        try {
-            val parentJsonString = JSONObject().apply {
-                put("_id", exam?.id ?: id)
-                put("name", exam?.name ?: "")
-                put("courseId", exam?.courseId ?: "")
-                put("sourcePlanet", exam?.sourcePlanet ?: "")
-                put("teamShareAllowed", exam?.isTeamShareAllowed ?: false)
-                put("noOfQuestions", exam?.noOfQuestions ?: 0)
-                put("isFromNation", exam?.isFromNation ?: false)
-            }.toString()
-            sub?.parent = parentJsonString
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
-    private fun addTeamInformation(realm: Realm) {
-        val team = realm.where(org.ole.planet.myplanet.model.RealmMyTeam::class.java)
-            .equalTo("_id", teamId)
-            .findFirst()
-
-        if (team != null) {
-            val teamRef = realm.createObject(org.ole.planet.myplanet.model.RealmTeamReference::class.java)
-            teamRef._id = team._id
-            teamRef.name = team.name
-            teamRef.type = team.type ?: "team"
-            sub?.teamObject = teamRef
-        }
-
-        val membershipDoc = realm.createObject(RealmMembershipDoc::class.java)
-        membershipDoc.teamId = teamId
-        sub?.membershipDoc = membershipDoc
-
-        val userModel = userSessionManager.userModel
-        try {
-            val userJson = JSONObject()
-            userJson.put("age", userModel?.dob ?: "")
-            userJson.put("gender", userModel?.gender ?: "")
-            val membershipJson = JSONObject()
-            membershipJson.put("teamId", teamId)
-            userJson.put("membershipDoc", membershipJson)
-            sub?.user = userJson.toString()
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
 
     override fun startExam(question: RealmExamQuestion?) {
         binding.tvQuestionCount.text = getString(R.string.Q, currentIndex + 1, questions?.size)


### PR DESCRIPTION
Moved submission creation logic from ExamTakingFragment to SubmissionsRepository.
- Added `createExamSubmission` to SubmissionsRepository interface and implementation.
- Updated `ExamTakingFragment` to use the repository method.
- Removed manual Realm transaction management from `ExamTakingFragment`.
- Cleaned up unused private methods and imports in `ExamTakingFragment`.
- Ensured proper threading by using suspend functions and passing IDs instead of Realm objects.

---
https://jules.google.com/session/18363958806788673135