### PR TITLE
Shift resource construction into ResourcesRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -19,6 +19,24 @@ interface ResourcesRepository {
     suspend fun getPrivateImagesCreatedAfter(timestamp: Long): List<RealmMyLibrary>
     suspend fun countLibrariesNeedingUpdate(userId: String?): Int
     suspend fun saveLibraryItem(item: RealmMyLibrary)
+    suspend fun addResource(
+        title: String,
+        addedBy: String,
+        author: String,
+        year: String,
+        description: String,
+        publisher: String,
+        linkToLicense: String,
+        openWith: String,
+        language: String,
+        mediaType: String,
+        resourceType: String,
+        subjects: List<String>,
+        levels: List<String>,
+        resourceFor: List<String>,
+        resourceUrl: String?,
+        userId: String?
+    )
     suspend fun markResourceAdded(userId: String?, resourceId: String)
     suspend fun updateUserLibrary(resourceId: String, userId: String, isAdd: Boolean): RealmMyLibrary?
     suspend fun updateLibraryItem(id: String, updater: (RealmMyLibrary) -> Unit)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import io.realm.RealmList
 import io.realm.Sort
 import java.util.Calendar
 import java.util.UUID
@@ -96,6 +97,53 @@ class ResourcesRepositoryImpl @Inject constructor(
 
     override suspend fun saveLibraryItem(item: RealmMyLibrary) {
         save(item)
+    }
+
+    override suspend fun addResource(
+        title: String,
+        addedBy: String,
+        author: String,
+        year: String,
+        description: String,
+        publisher: String,
+        linkToLicense: String,
+        openWith: String,
+        language: String,
+        mediaType: String,
+        resourceType: String,
+        subjects: List<String>,
+        levels: List<String>,
+        resourceFor: List<String>,
+        resourceUrl: String?,
+        userId: String?
+    ) {
+        val id = UUID.randomUUID().toString()
+        val resource = RealmMyLibrary().apply {
+            this.id = id
+            this.resourceId = id
+            this.title = title
+            this.addedBy = addedBy
+            this.author = author
+            this.year = year
+            this.description = description
+            this.publisher = publisher
+            this.linkToLicense = linkToLicense
+            this.openWith = openWith
+            this.language = language
+            this.mediaType = mediaType
+            this.resourceType = resourceType
+            this.subject = RealmList<String>().apply { addAll(subjects) }
+            this.level = RealmList<String>().apply { addAll(levels) }
+            this.resourceFor = RealmList<String>().apply { addAll(resourceFor) }
+            this.createdDate = Calendar.getInstance().timeInMillis
+            this.resourceLocalAddress = resourceUrl
+            this.resourceOffline = true
+            this.filename = resourceUrl?.let { it.substring(it.lastIndexOf("/")) }
+            setUserId(RealmList())
+            setUserId(userId)
+        }
+        save(resource)
+        activitiesRepository.markResourceAdded(userId, id)
     }
 
     override suspend fun markResourceAdded(userId: String?, resourceId: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -84,41 +84,42 @@ class AddResourceActivity : AppCompatActivity() {
     private fun saveResource() {
         val title = binding.etTitle.text.toString().trim { it <= ' ' }
         if (!validate(title)) return
-        val id = UUID.randomUUID().toString()
-        val resource = RealmMyLibrary().apply {
-            this.id = id
-            this.title = title
-            createResource(this, id)
-            setUserId(userModel?.id)
-        }
+        val addedBy = binding.tvAddedBy.text.toString().trim { it <= ' ' }
+        val author = binding.etAuthor.text.toString().trim { it <= ' ' }
+        val year = binding.etYear.text.toString().trim { it <= ' ' }
+        val description = binding.etDescription.text.toString().trim { it <= ' ' }
+        val publisher = binding.etPublisher.text.toString().trim { it <= ' ' }
+        val linkToLicense = binding.etLinkToLicense.text.toString().trim { it <= ' ' }
+        val openWith = binding.spnOpenWith.selectedItem.toString()
+        val language = binding.spnLang.selectedItem.toString()
+        val mediaType = binding.spnMedia.selectedItem.toString()
+        val resourceType = binding.spnResourceType.selectedItem.toString()
+        val subjectList = subjects?.toList() ?: emptyList()
+        val levelList = levels?.toList() ?: emptyList()
+        val resourceForList = resourceFor?.toList() ?: emptyList()
+
         lifecycleScope.launch {
-            resourcesRepository.saveLibraryItem(resource)
-            resourcesRepository.markResourceAdded(userModel?.id, id)
+            resourcesRepository.addResource(
+                title,
+                addedBy,
+                author,
+                year,
+                description,
+                publisher,
+                linkToLicense,
+                openWith,
+                language,
+                mediaType,
+                resourceType,
+                subjectList,
+                levelList,
+                resourceForList,
+                resourceUrl,
+                userModel?.id
+            )
             toast(this@AddResourceActivity, getString(R.string.added_to_my_library))
             finish()
         }
-    }
-
-    private fun createResource(resource: RealmMyLibrary, id: String) {
-        resource.addedBy = binding.tvAddedBy.text.toString().trim { it <= ' ' }
-        resource.author = binding.etAuthor.text.toString().trim { it <= ' ' }
-        resource.resourceId = id
-        resource.year = binding.etYear.text.toString().trim { it <= ' ' }
-        resource.description = binding.etDescription.text.toString().trim { it <= ' ' }
-        resource.publisher = binding.etPublisher.text.toString().trim { it <= ' ' }
-        resource.linkToLicense = binding.etLinkToLicense.text.toString().trim { it <= ' ' }
-        resource.openWith = binding.spnOpenWith.selectedItem.toString()
-        resource.language = binding.spnLang.selectedItem.toString()
-        resource.mediaType = binding.spnMedia.selectedItem.toString()
-        resource.resourceType = binding.spnResourceType.selectedItem.toString()
-        resource.subject = subjects
-        resource.setUserId(RealmList())
-        resource.level = levels
-        resource.createdDate = Calendar.getInstance().timeInMillis
-        resource.resourceFor = resourceFor
-        resource.resourceLocalAddress = resourceUrl
-        resource.resourceOffline = true
-        resource.filename = resourceUrl?.let { it.substring(it.lastIndexOf("/")) }
     }
 
     private fun validate(title: String): Boolean {


### PR DESCRIPTION
Refactor `AddResourceActivity` to move the logic of constructing and saving `RealmMyLibrary` objects into `ResourcesRepository`. This improves separation of concerns and reduces UI logic complexity.

Changes:
- Added `addResource` method to `ResourcesRepository` interface and implementation.
- `ResourcesRepositoryImpl` now handles the creation of `RealmMyLibrary` objects, including ID generation, field assignment, and persistence.
- Refactored `AddResourceActivity` to collect inputs and call `ResourcesRepository.addResource`.
- Removed `createResource` method from `AddResourceActivity`.

---
https://jules.google.com/session/5589300666648428486