### PR TITLE
Refactor TeamCoursesFragment to use CoursesRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
@@ -14,6 +14,7 @@ interface CoursesRepository {
     suspend fun getCourseOnlineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseOfflineResources(courseId: String?): List<RealmMyLibrary>
     suspend fun getCourseOfflineResources(courseIds: List<String>): List<RealmMyLibrary>
+    suspend fun getCoursesByIds(courseIds: List<String>): List<RealmMyCourse>
     suspend fun getCourseExamCount(courseId: String?): Int
     suspend fun getCourseSteps(courseId: String?): List<RealmCourseStep>
     suspend fun markCourseAdded(courseId: String, userId: String?): Boolean

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -79,6 +79,15 @@ class CoursesRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getCoursesByIds(courseIds: List<String>): List<RealmMyCourse> {
+        if (courseIds.isEmpty()) {
+            return emptyList()
+        }
+        return queryList(RealmMyCourse::class.java) {
+            `in`("id", courseIds.toTypedArray())
+        }
+    }
+
     override suspend fun getCourseExamCount(courseId: String?): Int {
         if (courseId.isNullOrEmpty()) {
             return 0

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
@@ -4,12 +4,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseTeamFragment
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.repository.CoursesRepository
 
+@AndroidEntryPoint
 class TeamCoursesFragment : BaseTeamFragment() {
     private var _binding: FragmentTeamCourseBinding? = null
     private val binding get() = _binding!!
@@ -26,12 +31,15 @@ class TeamCoursesFragment : BaseTeamFragment() {
     }
     
     private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { TeamCoursesAdapter(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
-        binding.rvCourse.layoutManager = LinearLayoutManager(activity)
-        binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+        lifecycleScope.launch {
+            val courseIds = team?.courses?.toList() ?: emptyList()
+            val courses = coursesRepository.getCoursesByIds(courseIds)
+            adapterTeamCourse = settings?.let { TeamCoursesAdapter(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
+            binding.rvCourse.layoutManager = LinearLayoutManager(activity)
+            binding.rvCourse.adapter = adapterTeamCourse
+            adapterTeamCourse?.let {
+                showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+            }
         }
     }
     override fun onNewsItemClick(news: RealmNews?) {}


### PR DESCRIPTION
- Added `getCoursesByIds` to `CoursesRepository` and implemented it in `CoursesRepositoryImpl` using `queryList`.
- Refactored `TeamCoursesFragment` to inject `CoursesRepository` (inherited) and use `lifecycleScope` for fetching courses asynchronously.
- Removed direct Realm query in `TeamCoursesFragment` in favor of repository call.
- Added `@AndroidEntryPoint` to `TeamCoursesFragment` to support Hilt injection.

---
https://jules.google.com/session/6851462226320472794