### PR TITLE
Add error callback to TransactionSyncManager health sync

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -55,10 +55,14 @@ class DatabaseService(context: Context) {
         }
     }
 
+    suspend fun executeTransactionAsync(transaction: (Realm) -> Unit) {
+        executeTransactionAsync(transaction, null, null)
+    }
+
     suspend fun executeTransactionAsync(
         transaction: (Realm) -> Unit,
-        onSuccess: (() -> Unit)? = null,
-        onError: ((Throwable) -> Unit)? = null
+        onSuccess: (() -> Unit)?,
+        onError: ((Throwable) -> Unit)?
     ) {
         withContext(realmDispatcher) {
             val realm = Realm.getDefaultInstance()

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -100,6 +100,7 @@ class TransactionSyncManager @Inject constructor(
                                 managedUser?.key = key
                                 managedUser?.iv = iv
                             },
+                            onSuccess = null,
                             onError = { error ->
                                 android.util.Log.e("TransactionSyncManager", "Failed to sync health key/iv", error)
                             }


### PR DESCRIPTION
Modified DatabaseService.executeTransactionAsync to accept optional onSuccess and onError callbacks.
Updated TransactionSyncManager.syncHealthData to use the error callback for logging failures during health key/iv sync.

---
https://jules.google.com/session/6096143620181545107