### PR TITLE
Refactor BaseResourceFragment to remove mRealm and use Repositories

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerParentFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerParentFragment.kt
@@ -3,32 +3,33 @@ package org.ole.planet.myplanet.base
 import com.google.gson.JsonArray
 import io.realm.RealmModel
 import io.realm.Sort
+import javax.inject.Inject
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmStepExam
+import org.ole.planet.myplanet.repository.SurveysRepository
 
 abstract class BaseRecyclerParentFragment<LI> : BaseResourceFragment() {
     var isMyCourseLib: Boolean = false
 
+    @Inject
+    lateinit var surveysRepository: SurveysRepository
+
     @Suppress("UNCHECKED_CAST")
-    fun getList(c: Class<*>): List<LI> {
+    suspend fun getList(c: Class<*>): List<LI> {
         return when {
             c == RealmStepExam::class.java -> {
-                mRealm.where(c).equalTo("type", "surveys").findAll().toList() as List<LI>
+                surveysRepository.getAllSurveys() as List<LI>
             }
             isMyCourseLib -> {
                 getMyLibItems(c as Class<out RealmModel>)
             }
             c == RealmMyLibrary::class.java -> {
-                RealmMyLibrary.getOurLibrary(model?.id, mRealm.where(c).equalTo("isPrivate", false).findAll().toList()) as List<LI>
+                resourcesRepository.getFilteredPublicLibraryItems(model?.id) as List<LI>
             }
             else -> {
                 val myLibItems = getMyLibItems(c as Class<out RealmModel>)
-                val results: List<RealmMyCourse> = mRealm.where(RealmMyCourse::class.java)
-                    .isNotEmpty("courseTitle")
-                    .findAll()
-                    .toList()
-                val ourCourseItems = RealmMyCourse.getOurCourse(model?.id, results)
+                val ourCourseItems = coursesRepository.getFilteredCourses(model?.id)
 
                 when (c) {
                     RealmMyCourse::class.java -> {
@@ -54,41 +55,71 @@ abstract class BaseRecyclerParentFragment<LI> : BaseResourceFragment() {
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun getList(c: Class<*>, orderBy: String? = null, sort: Sort = Sort.ASCENDING): List<LI> {
-        return when {
+    suspend fun getList(c: Class<*>, orderBy: String? = null, sort: Sort = Sort.ASCENDING): List<LI> {
+        var list: List<Any?> = when {
             c == RealmStepExam::class.java -> {
-                mRealm.where(c).equalTo("type", "surveys").sort(orderBy ?: "", sort).findAll().toList() as List<LI>
+                surveysRepository.getAllSurveys()
             }
             isMyCourseLib -> {
-                getMyLibItems(c as Class<out RealmModel>, orderBy)
+                getMyLibItems(c as Class<out RealmModel>)
             }
             c == RealmMyLibrary::class.java -> {
-                RealmMyLibrary.getOurLibrary(model?.id, mRealm.where(c).equalTo("isPrivate", false).sort(orderBy ?: "", sort).findAll().toList()) as List<LI>
+                resourcesRepository.getFilteredPublicLibraryItems(model?.id)
             }
             else -> {
-                val results = mRealm.where(RealmMyCourse::class.java).sort(orderBy ?: "", sort).findAll().toList() as List<RealmMyCourse>
-                RealmMyCourse.getOurCourse(model?.id, results) as List<LI>
+                val myLibItems = getMyLibItems(c as Class<out RealmModel>)
+                val ourCourseItems = coursesRepository.getFilteredCourses(model?.id)
+                val combinedList = mutableListOf<RealmMyCourse>()
+                (myLibItems as List<RealmMyCourse>).forEach { course ->
+                    course.isMyCourse = true
+                    combinedList.add(course)
+                }
+                ourCourseItems.forEach { course ->
+                    if (!combinedList.any { it.id == course.id }) {
+                        course.isMyCourse = false
+                        combinedList.add(course)
+                    }
+                }
+                combinedList
             }
         }
+
+        if (orderBy != null) {
+             list = sortList(list, orderBy, sort)
+        }
+
+        return list as List<LI>
     }
+
+    private fun sortList(list: List<Any?>, orderBy: String, sort: Sort): List<Any?> {
+         return if (sort == Sort.ASCENDING) {
+             when (orderBy) {
+                 "title" -> list.sortedBy { (it as? RealmMyLibrary)?.title ?: (it as? RealmMyCourse)?.courseTitle ?: "" }
+                 "createdDate" -> list.sortedBy { (it as? RealmMyLibrary)?.createdDate ?: (it as? RealmMyCourse)?.createdDate ?: 0L }
+                 else -> list
+             }
+         } else {
+             when (orderBy) {
+                 "title" -> list.sortedByDescending { (it as? RealmMyLibrary)?.title ?: (it as? RealmMyCourse)?.courseTitle ?: "" }
+                 "createdDate" -> list.sortedByDescending { (it as? RealmMyLibrary)?.createdDate ?: (it as? RealmMyCourse)?.createdDate ?: 0L }
+                 else -> list
+             }
+         }
+    }
+
     @Suppress("UNCHECKED_CAST")
-    private fun <T : RealmModel> getMyLibItems(c: Class<T>, orderBy: String? = null): List<LI> {
-        val query = mRealm.where(c)
-        val realmResults = if (orderBy != null) {
-            query.sort(orderBy).findAll()
-        } else {
-            query.findAll()
+    private suspend fun <T : RealmModel> getMyLibItems(c: Class<T>, orderBy: String? = null): List<LI> {
+        val results: List<T> = when (c) {
+             RealmMyLibrary::class.java -> {
+                 resourcesRepository.getMyLibrary(model?.id) as List<T>
+             }
+             RealmMyCourse::class.java -> {
+                 coursesRepository.getUserCourses(model?.id) as List<T>
+             }
+             else -> throw IllegalArgumentException("Unsupported class: ${c.simpleName}")
         }
-        val results: List<T> = realmResults.toList()
-        return when (c) {
-            RealmMyLibrary::class.java -> {
-                RealmMyLibrary.getMyLibraryByUserId(model?.id, results as? List<RealmMyLibrary> ?: emptyList()) as List<LI>
-            }
-            RealmMyCourse::class.java -> {
-                RealmMyCourse.getMyCourseByUserId(model?.id, results as? List<RealmMyCourse> ?: emptyList()) as List<LI>
-            }
-            else -> throw IllegalArgumentException("Unsupported class: ${c.simpleName}")
-        }
+
+        return results as List<LI>
     }
 
     fun getJsonArrayFromList(list: Set<String>): JsonArray {

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -19,9 +19,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
-import io.realm.Realm
 import io.realm.RealmObject
-import io.realm.RealmResults
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
@@ -34,12 +32,9 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmMyCourse.Companion.getMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.onRemove
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
-import org.ole.planet.myplanet.model.RealmSubmission.Companion.getExamMap
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.repository.CoursesRepository
@@ -61,7 +56,6 @@ import org.ole.planet.myplanet.utils.Utilities
 abstract class BaseResourceFragment : Fragment() {
     var homeItemClickListener: OnHomeItemClickListener? = null
     var model: RealmUserModel? = null
-    protected lateinit var mRealm: Realm
     var editor: SharedPreferences.Editor? = null
     var lv: CheckboxListView? = null
     var convertView: View? = null
@@ -88,17 +82,6 @@ abstract class BaseResourceFragment : Fragment() {
     private var pendingSurveyDialog: AlertDialog? = null
     private var stayOnlineDialog: AlertDialog? = null
     private var broadcastJob: Job? = null
-
-    protected fun requireRealmInstance(): Realm {
-        if (!isRealmInitialized()) {
-            mRealm = databaseService.realmInstance
-        }
-        return mRealm
-    }
-
-    protected fun isRealmInitialized(): Boolean {
-        return ::mRealm.isInitialized && !mRealm.isClosed
-    }
 
     private fun isFragmentActive(): Boolean {
         return isAdded && activity != null &&
@@ -259,8 +242,8 @@ abstract class BaseResourceFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             val list = submissionsRepository.getPendingSurveys(model?.id)
             if (list.isEmpty()) return@launch
-            val exams = getExamMap(mRealm, list)
-            val arrayAdapter = createSurveyAdapter(list, exams)
+            val exams = submissionsRepository.getExamMapForSubmissions(list)
+            val arrayAdapter = createSurveyAdapter(list, exams as HashMap<String?, RealmStepExam>)
             pendingSurveyDialog?.dismiss()
             pendingSurveyDialog = AlertDialog.Builder(requireActivity()).setTitle("Pending Surveys")
                 .setAdapter(arrayAdapter) { _: DialogInterface?, i: Int ->
@@ -374,7 +357,6 @@ abstract class BaseResourceFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        mRealm = databaseService.realmInstance
         prgDialog = getProgressDialog(requireActivity())
         editor = settings.edit()
     }
@@ -389,19 +371,18 @@ abstract class BaseResourceFragment : Fragment() {
         homeItemClickListener = null
     }
 
-    fun removeFromShelf(`object`: RealmObject) {
+    suspend fun removeFromShelf(`object`: RealmObject) {
+        val userId = profileDbHandler.userModel?.id ?: return
         if (`object` is RealmMyLibrary) {
-            val myObject = mRealm.where(RealmMyLibrary::class.java).equalTo("resourceId", `object`.resourceId).findFirst()
-            myObject?.removeUserId(model?.id)
-            model?.id?.let { `object`.resourceId?.let { it1 ->
-                onRemove(mRealm, "resources", it, it1)
-            } }
-            Utilities.toast(activity, getString(R.string.removed_from_mylibrary))
+            `object`.resourceId?.let { resourceId ->
+                resourcesRepository.updateUserLibrary(resourceId, userId, false)
+                Utilities.toast(activity, getString(R.string.removed_from_mylibrary))
+            }
         } else {
-            val myObject = getMyCourse(mRealm, (`object` as RealmMyCourse).courseId)
-            myObject?.removeUserId(model?.id)
-            model?.id?.let { `object`.courseId?.let { it1 -> onRemove(mRealm, "courses", it, it1) } }
-            Utilities.toast(activity, getString(R.string.removed_from_mycourse))
+            (`object` as RealmMyCourse).courseId?.let { courseId ->
+                coursesRepository.leaveCourse(courseId, userId)
+                Utilities.toast(activity, getString(R.string.removed_from_mycourse))
+            }
         }
     }
 
@@ -411,7 +392,7 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     fun showTagText(list: List<RealmTag>, tvSelected: TextView?) {
-        val selected = list.joinToString(separator = ",", prefix = getString(R.string.selected)) { it.name.orEmpty() }
+        val selected = list.joinToString(separator = ",", prefix = getString(R.string.selected)) { it.name ?: "" }
         tvSelected?.text = selected
     }
 
@@ -449,32 +430,6 @@ abstract class BaseResourceFragment : Fragment() {
         super.onDestroyView()
     }
 
-    override fun onDestroy() {
-        cleanupRealm()
-        super.onDestroy()
-    }
-
-    private fun cleanupRealm() {
-        if (isRealmInitialized()) {
-            try {
-                mRealm.removeAllChangeListeners()
-                if (mRealm.isInTransaction) {
-                    try {
-                        mRealm.commitTransaction()
-                    } catch (e: Exception) {
-                        mRealm.cancelTransaction()
-                    }
-                }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            } finally {
-                if (!mRealm.isClosed) {
-                    mRealm.close()
-                }
-            }
-        }
-    }
-
     companion object {
         var auth = ""
 
@@ -488,16 +443,6 @@ abstract class BaseResourceFragment : Fragment() {
 
                 override fun notAvailable() {}
             })
-        }
-
-        private fun getLibraries(l: RealmResults<RealmMyLibrary>): List<RealmMyLibrary> {
-            val libraries: MutableList<RealmMyLibrary> = ArrayList()
-            for (lib in l) {
-                if (lib.needToUpdate()) {
-                    libraries.add(lib)
-                }
-            }
-            return libraries
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
@@ -8,6 +8,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 
 interface CoursesRepository {
     fun getMyCourses(userId: String?, courses: List<RealmMyCourse>): List<RealmMyCourse>
+    suspend fun getUserCourses(userId: String?): List<RealmMyCourse>
     suspend fun getMyCoursesFlow(userId: String): Flow<List<RealmMyCourse>>
     suspend fun getCourseById(courseId: String): RealmMyCourse?
     suspend fun getCourseByCourseId(courseId: String?): RealmMyCourse?
@@ -26,6 +27,7 @@ interface CoursesRepository {
         subjectLevel: String,
         tagNames: List<String>
     ): List<RealmMyCourse>
+    suspend fun getFilteredCourses(userId: String?): List<RealmMyCourse>
     suspend fun saveSearchActivity(
         searchText: String,
         userName: String,
@@ -37,4 +39,5 @@ interface CoursesRepository {
     )
     suspend fun getCourseProgress(courseId: String, userId: String?): CourseProgressData?
     suspend fun getCourseTitleById(courseId: String): String?
+    suspend fun isCourseCertified(courseId: String): Boolean
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -310,4 +310,24 @@ class CoursesRepositoryImpl @Inject constructor(
                 .findFirst()?.courseTitle
         }
     }
+
+    override suspend fun getUserCourses(userId: String?): List<RealmMyCourse> {
+        if (userId == null) return emptyList()
+        return queryList(RealmMyCourse::class.java) {
+            equalTo("userId", userId)
+        }
+    }
+
+    override suspend fun getFilteredCourses(userId: String?): List<RealmMyCourse> {
+        val results = queryList(RealmMyCourse::class.java) {
+            isNotEmpty("courseTitle")
+        }
+        return results.filter { it.userId?.contains(userId) == false }
+    }
+
+    override suspend fun isCourseCertified(courseId: String): Boolean {
+        return count(org.ole.planet.myplanet.model.RealmCertification::class.java) {
+            contains("courseIds", courseId)
+        } > 0
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepository.kt
@@ -19,4 +19,5 @@ interface ProgressRepository {
         passed: Boolean?
     )
     suspend fun hasUserCompletedSync(userId: String): Boolean
+    suspend fun deleteCourseProgress(courseId: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
@@ -174,4 +174,13 @@ class ProgressRepositoryImpl @Inject constructor(databaseService: DatabaseServic
             equalTo("actionType", "sync")
         } > 0
     }
+
+    override suspend fun deleteCourseProgress(courseId: String) {
+        executeTransaction { realm ->
+            realm.where(RealmCourseProgress::class.java)
+                .equalTo("courseId", courseId)
+                .findAll()
+                .deleteAllFromRealm()
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepository.kt
@@ -1,8 +1,11 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonObject
+
 interface RatingsRepository {
-    suspend fun getRatingsById(type: String, resourceId: String?, userId: String?): com.google.gson.JsonObject?
-    suspend fun getCourseRatings(userId: String?): HashMap<String?, com.google.gson.JsonObject>
+    suspend fun getRatingsById(type: String, resourceId: String?, userId: String?): JsonObject?
+    suspend fun getCourseRatings(userId: String?): HashMap<String?, JsonObject>
+    suspend fun getResourceRatings(userId: String?): HashMap<String?, JsonObject>
     suspend fun getRatingSummary(type: String, itemId: String, userId: String): RatingSummary
 
     suspend fun submitRating(

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepositoryImpl.kt
@@ -27,6 +27,12 @@ class RatingsRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getResourceRatings(userId: String?): HashMap<String?, JsonObject> {
+        return withRealmAsync { realm ->
+            RealmRating.getRatings(realm, "resource", userId)
+        }
+    }
+
     override suspend fun getRatingSummary(
         type: String,
         itemId: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -6,6 +6,7 @@ import org.ole.planet.myplanet.model.RealmTag
 
 interface ResourcesRepository {
     suspend fun getAllLibraryItems(): List<RealmMyLibrary>
+    suspend fun getFilteredPublicLibraryItems(userId: String?): List<RealmMyLibrary>
     suspend fun getLibraryItemById(id: String): RealmMyLibrary?
     suspend fun getLibraryItemByResourceId(resourceId: String): RealmMyLibrary?
     suspend fun getLibraryItemsByIds(ids: Collection<String>): List<RealmMyLibrary>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -31,6 +31,11 @@ class ResourcesRepositoryImpl @Inject constructor(
         return queryList(RealmMyLibrary::class.java)
     }
 
+    override suspend fun getFilteredPublicLibraryItems(userId: String?): List<RealmMyLibrary> {
+        val allItems = queryList(RealmMyLibrary::class.java)
+        return RealmMyLibrary.getOurLibrary(userId, allItems)
+    }
+
     override suspend fun getLibraryItemById(id: String): RealmMyLibrary? {
         return findByField(RealmMyLibrary::class.java, "id", id)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -37,4 +37,5 @@ interface SubmissionsRepository {
     suspend fun hasUnfinishedSurveys(courseId: String, userId: String?): Boolean
     suspend fun generateSubmissionPdf(context: android.content.Context, submissionId: String): java.io.File?
     suspend fun generateMultipleSubmissionsPdf(context: android.content.Context, submissionIds: List<String>, examTitle: String): java.io.File?
+    suspend fun deleteCourseSubmissions(courseId: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -415,4 +415,16 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     ): java.io.File? {
         return submissionsRepositoryExporter.generateMultipleSubmissionsPdf(context, submissionIds, examTitle)
     }
+
+    override suspend fun deleteCourseSubmissions(courseId: String) {
+        executeTransaction { realm ->
+            val submissions = realm.where(RealmSubmission::class.java)
+                .contains("parentId", courseId)
+                .findAll()
+            submissions.forEach { submission ->
+                submission.answers?.deleteAllFromRealm()
+            }
+            submissions.deleteAllFromRealm()
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepository.kt
@@ -11,6 +11,7 @@ interface SurveysRepository {
     suspend fun getTeamOwnedSurveys(teamId: String?): List<RealmStepExam>
     suspend fun getAdoptableTeamSurveys(teamId: String?): List<RealmStepExam>
     suspend fun getIndividualSurveys(): List<RealmStepExam>
+    suspend fun getAllSurveys(): List<RealmStepExam>
     suspend fun getSurveyInfos(
         isTeam: Boolean,
         teamId: String?,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
@@ -243,6 +243,12 @@ class SurveysRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getAllSurveys(): List<RealmStepExam> {
+        return queryList(RealmStepExam::class.java) {
+            equalTo("type", "surveys")
+        }
+    }
+
     private suspend fun getTeamSubmissionExamIds(teamId: String): Set<String> {
         val submissions = queryList(RealmSubmission::class.java) {
             isNotNull("membershipDoc")

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
@@ -8,4 +8,5 @@ interface TagsRepository {
     suspend fun getTagsForResource(resourceId: String): List<RealmTag>
     suspend fun getTagsForCourse(courseId: String): List<RealmTag>
     suspend fun getTagsForResources(resourceIds: List<String>): Map<String, List<RealmTag>>
+    suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<RealmTag>>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
@@ -43,6 +43,10 @@ class TagsRepositoryImpl @Inject constructor(
         return getLinkedTagsBulk("resources", resourceIds)
     }
 
+    override suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<RealmTag>> {
+        return getLinkedTagsBulk("courses", courseIds)
+    }
+
     private suspend fun getLinkedTagsBulk(db: String, linkIds: List<String>): Map<String, List<RealmTag>> {
         if (linkIds.isEmpty()) {
             return emptyMap()

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -123,6 +123,7 @@ interface TeamsRepository {
     suspend fun getJoinedMembers(teamId: String): List<RealmUserModel>
     suspend fun getJoinedMembersWithVisitInfo(teamId: String): List<JoinedMemberData>
     suspend fun getJoinedMemberCount(teamId: String): Int
+    suspend fun getTeamCreator(teamId: String?): String
     suspend fun getAssignee(userId: String): RealmUserModel?
     suspend fun getRequestedMembers(teamId: String): List<RealmUserModel>
     suspend fun isTeamNameExists(name: String, type: String, excludeTeamId: String? = null): Boolean

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -983,6 +983,10 @@ class TeamsRepositoryImpl @Inject constructor(
         }.toInt()
     }
 
+    override suspend fun getTeamCreator(teamId: String?): String {
+        return findByField(RealmMyTeam::class.java, "teamId", teamId ?: "")?.userId ?: ""
+    }
+
     override suspend fun getAssignee(userId: String): RealmUserModel? {
         return findByField(RealmUserModel::class.java, "id", userId)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseDashboardFragment
 import org.ole.planet.myplanet.databinding.FragmentHomeBellBinding
-import org.ole.planet.myplanet.model.RealmCertification
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
@@ -386,12 +385,12 @@ class BellDashboardFragment : BaseDashboardFragment() {
     }
 
     private fun setColor(courseId: String?, star: ImageView) {
-        val isRealmReady = isRealmInitialized()
-
-        if (isRealmReady && RealmCertification.isCourseCertified(mRealm, courseId)) {
-            star.setColorFilter(ContextCompat.getColor(requireContext(), R.color.colorPrimary))
-        } else {
-            star.setColorFilter(ContextCompat.getColor(requireContext(), R.color.md_blue_grey_300))
+        viewLifecycleOwner.lifecycleScope.launch {
+            if (courseId != null && coursesRepository.isCourseCertified(courseId)) {
+                star.setColorFilter(ContextCompat.getColor(requireContext(), R.color.colorPrimary))
+            } else {
+                star.setColorFilter(ContextCompat.getColor(requireContext(), R.color.md_blue_grey_300))
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
@@ -45,7 +45,7 @@ class LifeFragment : BaseRecyclerFragment<RealmMyLife?>(), OnStartDragListener {
         return view
     }
 
-    override fun getAdapter(): RecyclerView.Adapter<*> {
+    override suspend fun getAdapter(): RecyclerView.Adapter<*> {
         lifeAdapter = LifeAdapter(requireContext(), this,
             visibilityCallback = { myLife, isVisible ->
                 myLife._id?.let { id ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -271,12 +271,6 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
         }
     }
     override fun onDestroy() {
-        try {
-            if (!mRealm.isClosed) {
-                mRealm.close()
-            }
-        } catch (_: UninitializedPropertyAccessException) {
-        }
         super.onDestroy()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -37,11 +37,10 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyLibrary.Companion.getArrayList
 import org.ole.planet.myplanet.model.RealmMyLibrary.Companion.getLevels
 import org.ole.planet.myplanet.model.RealmMyLibrary.Companion.getSubjects
-import org.ole.planet.myplanet.model.RealmRating.Companion.getRatings
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUserModel
 import org.ole.planet.myplanet.model.TableDataUpdate
-import org.ole.planet.myplanet.repository.TagsRepository
+import org.ole.planet.myplanet.repository.RatingsRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.services.sync.SyncManager
@@ -84,7 +83,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     lateinit var syncManager: SyncManager
 
     @Inject
-    lateinit var tagsRepository: TagsRepository
+    lateinit var ratingsRepository: RatingsRepository
 
     @Inject
     lateinit var serverUrlMapper: ServerUrlMapper
@@ -177,7 +176,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
         lifecycleScope.launch {
             try {
-                map = getRatings(mRealm, "resource", model?.id)
+                map = ratingsRepository.getResourceRatings(model?.id)
                 val libraryList: List<RealmMyLibrary> = getList(RealmMyLibrary::class.java).filterIsInstance<RealmMyLibrary>()
                 val currentSearchTags = if (::searchTags.isInitialized) searchTags else emptyList()
                 val searchQuery = etSearch.text?.toString()?.trim().orEmpty()
@@ -192,7 +191,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
                 tagsMap = tagsRepository.getTagsForResources(resourceIds)
 
                 if (::adapterLibrary.isInitialized) {
-                    adapterLibrary.setLibraryList(mRealm.copyFromRealm(filteredLibraryList))
+                    adapterLibrary.setLibraryList(filteredLibraryList)
                     adapterLibrary.setRatingMap(map!!)
                     adapterLibrary.setTagsMap(tagsMap)
                 }
@@ -205,11 +204,11 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         }
     }
 
-    override fun getAdapter(): RecyclerView.Adapter<*> {
-        map = getRatings(mRealm, "resource", model?.id)
+    override suspend fun getAdapter(): RecyclerView.Adapter<*> {
+        map = ratingsRepository.getResourceRatings(model?.id)
         val libraryList: List<RealmMyLibrary> = getList(RealmMyLibrary::class.java).filterIsInstance<RealmMyLibrary>()
         adapterLibrary = ResourcesAdapter(requireActivity(), map!!, resourcesRepository, profileDbHandler?.userModel, emptyMap(), emptySet())
-        adapterLibrary.setLibraryList(mRealm.copyFromRealm(libraryList))
+        adapterLibrary.setLibraryList(libraryList)
         adapterLibrary.setRatingChangeListener(this)
         adapterLibrary.setListener(this)
         return adapterLibrary
@@ -229,7 +228,8 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
         setupGuestUserRestrictions()
 
-        showNoData(tvMessage, adapterLibrary.itemCount, "resources")
+        // showNoData will be updated when adapter is set
+        // showNoData(tvMessage, adapterLibrary.itemCount, "resources")
         clearTagsButton()
         setupUI(binding.myLibraryParentLayout, requireActivity())
         changeButtonStatus()
@@ -237,7 +237,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
         tvFragmentInfo = binding.tvFragmentInfo
         if (isMyCourseLib) tvFragmentInfo.setText(R.string.txt_myLibrary)
-        checkList()
+        // checkList() // called after adapter set
 
         if (userModel?.id != null) {
             lifecycleScope.launch {
@@ -303,12 +303,13 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         searchTextWatcher = object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-                val filteredList = applyFilter(filterLibraryByTag(etSearch.text.toString().trim(), searchTags))
-                val resourceIds = filteredList.mapNotNull { it?.id }
                 lifecycleScope.launch {
+                    val filteredList = applyFilter(filterLibraryByTag(etSearch.text.toString().trim(), searchTags))
+                    val resourceIds = filteredList.mapNotNull { it?.id }
+
                     tagsMap = tagsRepository.getTagsForResources(resourceIds)
                     adapterLibrary.setTagsMap(tagsMap)
-                    adapterLibrary.setLibraryList(mRealm.copyFromRealm(filteredList)) {
+                    adapterLibrary.setLibraryList(filteredList) {
                         recyclerView.scrollToPosition(0)
                     }
                     showNoData(tvMessage, adapterLibrary.itemCount, "resources")
@@ -450,10 +451,12 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
             mediums.clear()
             subjects.clear()
             languages.clear()
-            adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag("", searchTags)))) {
-                recyclerView.scrollToPosition(0)
+            lifecycleScope.launch {
+                adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag("", searchTags))) {
+                    recyclerView.scrollToPosition(0)
+                }
+                showNoData(tvMessage, adapterLibrary.itemCount, "resources")
             }
-            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
         }
     }
 
@@ -470,11 +473,13 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         chipCloud.setDeleteListener(this)
         if (!searchTags.any { it.name == realmTag.name }) searchTags.add(realmTag)
         chipCloud.addChips(searchTags)
-        adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags)))) {
-            recyclerView.scrollToPosition(0)
+        lifecycleScope.launch {
+            adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags))) {
+                recyclerView.scrollToPosition(0)
+            }
+            showTagText(searchTags, tvSelected)
+            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
         }
-        showTagText(searchTags, tvSelected)
-        showNoData(tvMessage, adapterLibrary.itemCount, "resources")
     }
 
     override fun onTagSelected(tag: RealmTag) {
@@ -483,19 +488,23 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         li.add(tag)
         searchTags = li
         tvSelected.text = getString(R.string.tag_selected, tag.name)
-        adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag(etSearch.text.toString(), li)))) {
-            recyclerView.scrollToPosition(0)
+        lifecycleScope.launch {
+            adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag(etSearch.text.toString(), li))) {
+                recyclerView.scrollToPosition(0)
+            }
+            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
         }
-        showNoData(tvMessage, adapterLibrary.itemCount, "resources")
     }
 
     override fun onOkClicked(list: List<RealmTag>?) {
         if (list?.isEmpty() == true) {
             searchTags.clear()
-            adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags)))) {
-                recyclerView.scrollToPosition(0)
+            lifecycleScope.launch {
+                adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags))) {
+                    recyclerView.scrollToPosition(0)
+                }
+                showNoData(tvMessage, adapterLibrary.itemCount, "resources")
             }
-            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
         } else {
             for (tag in list ?: emptyList()) {
                 onTagClicked(tag)
@@ -516,10 +525,12 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     override fun chipDeleted(i: Int, s: String) {
         searchTags.removeAt(i)
-        adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags)))) {
-            recyclerView.scrollToPosition(0)
+        lifecycleScope.launch {
+            adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag(etSearch.text.toString(), searchTags))) {
+                recyclerView.scrollToPosition(0)
+            }
+            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
         }
-        showNoData(tvMessage, adapterLibrary.itemCount, "resources")
     }
 
     override fun filter(subjects: MutableSet<String>, languages: MutableSet<String>, mediums: MutableSet<String>, levels: MutableSet<String>) {
@@ -527,10 +538,12 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         this.languages = languages
         this.mediums = mediums
         this.levels = levels
-        adapterLibrary.setLibraryList(mRealm.copyFromRealm(applyFilter(filterLibraryByTag(etSearch.text.toString().trim { it <= ' ' }, searchTags)))) {
-            recyclerView.scrollToPosition(0)
+        lifecycleScope.launch {
+            adapterLibrary.setLibraryList(applyFilter(filterLibraryByTag(etSearch.text.toString().trim { it <= ' ' }, searchTags))) {
+                recyclerView.scrollToPosition(0)
+            }
+            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
         }
-        showNoData(tvMessage, adapterLibrary.itemCount, "resources")
     }
 
     override fun getData(): Map<String, Set<String>> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
@@ -52,8 +52,7 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), OnSurveyAdoptList
 
     @Inject
     lateinit var syncManager: SyncManager
-    @Inject
-    lateinit var surveysRepository: SurveysRepository
+
     private lateinit var realtimeSyncHelper: RealtimeSyncHelper
     private val serverUrl: String
         get() = settings.getString("serverURL", "") ?: ""
@@ -169,7 +168,7 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), OnSurveyAdoptList
         }
     }
 
-    override fun getAdapter(): RecyclerView.Adapter<*> = adapter
+    override suspend fun getAdapter(): RecyclerView.Adapter<*> = adapter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
@@ -4,12 +4,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseTeamFragment
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
-import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmNews
 
+@AndroidEntryPoint
 class TeamCoursesFragment : BaseTeamFragment() {
     private var _binding: FragmentTeamCourseBinding? = null
     private val binding get() = _binding!!
@@ -26,12 +29,17 @@ class TeamCoursesFragment : BaseTeamFragment() {
     }
     
     private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = settings?.let { TeamCoursesAdapter(requireActivity(), courses.toMutableList(), mRealm, teamId, it) }
-        binding.rvCourse.layoutManager = LinearLayoutManager(activity)
-        binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+        viewLifecycleOwner.lifecycleScope.launch {
+            val courses = team?.courses?.mapNotNull { courseId ->
+                coursesRepository.getCourseById(courseId)
+            } ?: emptyList()
+
+            adapterTeamCourse = settings.let { TeamCoursesAdapter(requireActivity(), courses.toMutableList(), teamsRepository, teamId, it) }
+            binding.rvCourse.layoutManager = LinearLayoutManager(activity)
+            binding.rvCourse.adapter = adapterTeamCourse
+            adapterTeamCourse?.let {
+                showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+            }
         }
     }
     override fun onNewsItemClick(news: RealmNews?) {}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
@@ -199,9 +199,6 @@ class TeamsVoicesFragment : BaseTeamFragment() {
     }
 
     override fun onDestroyView() {
-        if (isRealmInitialized()) {
-            mRealm.close()
-        }
         _binding = null
         super.onDestroyView()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
@@ -90,14 +90,6 @@ class VoicesFragment : BaseVoicesFragment() {
             binding.llAddNews.visibility = View.GONE
         }
 
-        if (mRealm.isInTransaction) {
-            try {
-                mRealm.commitTransaction()
-            } catch (_: Exception) {
-                mRealm.cancelTransaction()
-            }
-        }
-
         setupSearchTextListener()
         setupLabelFilter()
 
@@ -168,8 +160,8 @@ class VoicesFragment : BaseVoicesFragment() {
         if (defaultUserIdentifier.isNotEmpty() && defaultUserIdentifier != "@") {
             return defaultUserIdentifier
         }
-        val planetCode = settings?.getString("planetCode", "") ?: ""
-        val parentCode = settings?.getString("parentCode", "") ?: ""
+        val planetCode = settings.getString("planetCode", "") ?: ""
+        val parentCode = settings.getString("parentCode", "") ?: ""
         return "$planetCode@$parentCode"
     }
 
@@ -412,9 +404,6 @@ class VoicesFragment : BaseVoicesFragment() {
     override fun onDestroyView() {
         binding.filterByLabel.onItemSelectedListener = null
         adapterNews?.unregisterAdapterDataObserver(observer)
-        if (isRealmInitialized()) {
-            mRealm.close()
-        }
         _binding = null
         super.onDestroyView()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1179,5 +1179,8 @@
     <string name="team_surveys">Team surveys</string>
     <string name="enterprise_created">Enterprise created</string>
     <string name="image_already_added">This image has already been added</string>
+    <string name="edit_team">Edit Team</string>
+    <string name="team_updated">Team updated successfully</string>
+    <string name="unable_to_update_team">Unable to update team</string>
 
 </resources>


### PR DESCRIPTION
Removed `mRealm` and helper methods from `BaseResourceFragment` and updated subclasses to use injected Repositories. Updated `BaseRecyclerFragment` to make `getAdapter()` suspend, allowing asynchronous data loading. Updated `ResourcesRepository`, `CoursesRepository`, `SurveysRepository`, `RatingsRepository` and their implementations with new methods needed for the refactor (`getFilteredPublicLibraryItems`, `getUserCourses`, `getFilteredCourses`, `isCourseCertified`, `getAllSurveys`, `getResourceRatings`). Updated `ResourcesFragment`, `CoursesFragment`, `SurveyFragment`, `LifeFragment` to use suspend `getAdapter` and repository calls. Fixed `PlanFragment` resource IDs and method calls (`onTeamDetailsUpdated`). Resolved duplicate dependency injection in `TeamCoursesFragment`. Fixed compilation errors related to generic types in `BaseRecyclerParentFragment`.

---
https://jules.google.com/session/4990902262792222791