### PR TITLE
Fix compilation errors in RetryQueueWorker by using correct API metho…

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueueWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueueWorker.kt
@@ -182,14 +182,14 @@ class RetryQueueWorker(
             }
 
             val response = if (operation.httpMethod == "PUT" && !operation.dbId.isNullOrEmpty()) {
-                apiInterface.putDocSuspend(
+                apiInterface.putDoc(
                     UrlUtils.header,
                     "application/json",
                     requestUrl,
                     payload
                 )
             } else {
-                apiInterface.postDocSuspend(
+                apiInterface.postDoc(
                     UrlUtils.header,
                     "application/json",
                     requestUrl,


### PR DESCRIPTION
…d names

Renamed `putDocSuspend` to `putDoc` and `postDocSuspend` to `postDoc` in `RetryQueueWorker.kt`. The `ApiInterface` defines standard suspend functions `putDoc` and `postDoc` which return `Response<JsonObject>`, causing unresolved reference errors with the previous names. This change also resolves downstream compilation errors regarding `response.code()` and `response.isSuccessful` which were due to type inference failure.