### PR TITLE
all: smoother file uploading (fixes #11004)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ myplanet/
 | `repository/` | Repository pattern implementations | 18 repositories with Interface + Impl pairs |
 | `service/` | Background services | sync/SyncManager.kt, UploadManager.kt, AutoSyncWorker |
 | `ui/` | User interface components | 28 feature packages (courses, resources, teams, chat, etc.) |
-| `utilities/` | Helper functions | NetworkUtils, ImageUtils, DialogUtils, FileUploadService |
+| `utilities/` | Helper functions | NetworkUtils, ImageUtils, DialogUtils, FileUploader |
 
 ### Critical Files to Understand
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/FileUploader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/FileUploader.kt
@@ -17,7 +17,7 @@ import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.UrlUtils
 
-open class FileUploadService {
+open class FileUploader {
     fun uploadAttachment(id: String, rev: String, personal: RealmMyPersonal, listener: OnSuccessListener) {
         val f = personal.path?.let { File(it) }
         val name = FileUtils.getFileNameFromUrl(personal.path)

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -65,7 +65,7 @@ class UploadManager @Inject constructor(
     private val uploadCoordinator: UploadCoordinator,
     private val personalsRepository: PersonalsRepository,
     private val userRepository: UserRepository
-) : FileUploadService() {
+) : FileUploader() {
 
     private suspend fun uploadNewsActivities() {
         uploadCoordinator.upload(UploadConfigs.NewsActivities)


### PR DESCRIPTION
Renamed `FileUploadService` to `FileUploader` to avoid ambiguity with Android Service components. Updated `UploadManager` to inherit from the renamed class and updated documentation.

---
*PR created automatically by Jules for task [8455402434536032540](https://jules.google.com/task/8455402434536032540) started by @dogi*