### PR TITLE
Migrate RealmMyTeam queries to TeamsRepository and refactor RealmMyLibrary

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
@@ -184,14 +184,13 @@ open class RealmMyLibrary : RealmObject() {
     }
 
     companion object {
-        fun getMyLibraryByUserId(mRealm: Realm, settings: SharedPreferences?): List<RealmMyLibrary> {
+        fun getMyLibraryByUserId(mRealm: Realm, settings: SharedPreferences?, resourceIds: List<String>): List<RealmMyLibrary> {
             val libs = mRealm.where(RealmMyLibrary::class.java).findAll()
-            return getMyLibraryByUserId(settings?.getString("userId", "--"), libs, mRealm)
+            return getMyLibraryByUserId(settings?.getString("userId", "--"), libs, resourceIds)
         }
 
-        fun getMyLibraryByUserId(userId: String?, libs: List<RealmMyLibrary>, mRealm: Realm): List<RealmMyLibrary> {
-            val ids = RealmMyTeam.getResourceIdsByUser(userId, mRealm)
-            return libs.filter { it.userId?.contains(userId) == true || it.resourceId in ids }
+        fun getMyLibraryByUserId(userId: String?, libs: List<RealmMyLibrary>, resourceIds: List<String>): List<RealmMyLibrary> {
+            return libs.filter { it.userId?.contains(userId) == true || it.resourceId in resourceIds }
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -163,6 +163,7 @@ open class RealmMyTeam : RealmObject() {
             return ids
         }
 
+        @Deprecated("Use TeamsRepository.getResourceIdsByUser instead")
         @JvmStatic
         fun getResourceIdsByUser(userId: String?, realm: Realm): MutableList<String> {
             val list = realm.where(RealmMyTeam::class.java)
@@ -199,11 +200,13 @@ open class RealmMyTeam : RealmObject() {
             insertMyTeams(doc, mRealm)
         }
 
+        @Deprecated("Use TeamsRepository.getRequestedMembers instead")
         @JvmStatic
         fun getRequestedMember(teamId: String, realm: Realm): MutableList<RealmUser> {
             return getUsers(teamId, realm, "request")
         }
 
+        @Deprecated("Use TeamsRepository.getJoinedMembers instead")
         @JvmStatic
         fun getJoinedMember(teamId: String, realm: Realm): MutableList<RealmUser> {
             return getUsers(teamId, realm, "membership")
@@ -226,6 +229,7 @@ open class RealmMyTeam : RealmObject() {
             return team != null
         }
 
+        @Deprecated("Use TeamsRepository.getTeamUsers instead")
         @JvmStatic
         fun getUsers(teamId: String?, mRealm: Realm, docType: String): MutableList<RealmUser> {
             var query = mRealm.where(RealmMyTeam::class.java).equalTo("teamId", teamId)
@@ -292,6 +296,7 @@ open class RealmMyTeam : RealmObject() {
             return JsonParser.parseString(JsonUtils.gson.toJson(`object`)).asJsonObject
         }
 
+        @Deprecated("Use TeamsRepository.getMyTeamsByUserId instead")
         fun getMyTeamsByUserId(mRealm: Realm, settings: SharedPreferences?): RealmResults<RealmMyTeam> {
             val userId = settings?.getString("userId", "--") ?: "--"
             val list = mRealm.where(RealmMyTeam::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -138,4 +138,7 @@ interface TeamsRepository {
 
     suspend fun updateTeamLeader(teamId: String, newLeaderId: String): Boolean
     suspend fun getNextLeaderCandidate(teamId: String, excludeUserId: String?): RealmUser?
+    suspend fun getResourceIdsByUser(userId: String): List<String>
+    suspend fun getTeamUsers(teamId: String, docType: String): List<RealmUser>
+    suspend fun getMyTeamsByUserId(userId: String): List<RealmMyTeam>
 }


### PR DESCRIPTION
Migrated `RealmMyTeam` companion query methods to `TeamsRepository` to follow the repository pattern and remove direct Realm access. Refactored `RealmMyLibrary.getMyLibraryByUserId` to accept `resourceIds` directly, eliminating the dependency on `RealmMyTeam` and `Realm` within the model class. Implemented repository methods using `withRealm` to ensure thread safety and proper object detachment. Deprecated the old companion methods in `RealmMyTeam`. This change addresses the request to migrate `RealmMyTeam` methods and update `RealmMyLibrary` to break cross-feature data leaks.

---
*PR created automatically by Jules for task [11635623907399867821](https://jules.google.com/task/11635623907399867821) started by @dogi*