### PR TITLE
Refactor CourseStepFragment data loading to CoursesRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/CourseStepData.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/CourseStepData.kt
@@ -1,0 +1,8 @@
+package org.ole.planet.myplanet.model
+
+data class CourseStepData(
+    val step: RealmCourseStep,
+    val resources: List<RealmMyLibrary>,
+    val stepExams: List<RealmStepExam>,
+    val stepSurvey: List<RealmStepExam>
+)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.repository
 
 import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.model.CourseProgressData
+import org.ole.planet.myplanet.model.CourseStepData
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
@@ -17,6 +18,7 @@ interface CoursesRepository {
     suspend fun getCourseOfflineResources(courseIds: List<String>): List<RealmMyLibrary>
     suspend fun getCourseExamCount(courseId: String?): Int
     suspend fun getCourseSteps(courseId: String?): List<RealmCourseStep>
+    suspend fun getCourseStepData(stepId: String): CourseStepData
     suspend fun markCourseAdded(courseId: String, userId: String?): Boolean
     suspend fun joinCourse(courseId: String, userId: String)
     suspend fun leaveCourse(courseId: String, userId: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -10,6 +10,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.model.CourseProgressData
+import org.ole.planet.myplanet.model.CourseStepData
 import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmExamQuestion
@@ -101,6 +102,35 @@ class CoursesRepositoryImpl @Inject constructor(
         }
         return queryList(RealmCourseStep::class.java) {
             equalTo("courseId", courseId)
+        }
+    }
+
+    override suspend fun getCourseStepData(stepId: String): CourseStepData {
+        return withRealm { realm ->
+            val step = realm.where(RealmCourseStep::class.java)
+                .equalTo("id", stepId)
+                .findFirst()
+                ?.let { realm.copyFromRealm(it) }
+                ?: throw IllegalStateException("Step not found")
+
+            val resources = realm.where(RealmMyLibrary::class.java)
+                .equalTo("stepId", stepId)
+                .findAll()
+                .let { realm.copyFromRealm(it) }
+
+            val stepExams = realm.where(RealmStepExam::class.java)
+                .equalTo("stepId", stepId)
+                .equalTo("type", "courses")
+                .findAll()
+                .let { realm.copyFromRealm(it) }
+
+            val stepSurvey = realm.where(RealmStepExam::class.java)
+                .equalTo("stepId", stepId)
+                .equalTo("type", "surveys")
+                .findAll()
+                .let { realm.copyFromRealm(it) }
+
+            CourseStepData(step, resources, stepExams, stepSurvey)
         }
     }
 


### PR DESCRIPTION
Refactored data loading in `CourseStepFragment` to use `CoursesRepository.getCourseStepData`. 
Created `CourseStepData` in `org.ole.planet.myplanet.model`.
Added `getCourseStepData` to `CoursesRepository` interface and implementation.
Removed direct Realm queries from `CourseStepFragment`.

---
*PR created automatically by Jules for task [14404618590786698050](https://jules.google.com/task/14404618590786698050) started by @dogi*