### PR TITLE
Delegate TransactionSyncManager user operations to UsersRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -15,6 +15,7 @@ interface UserRepository {
     suspend fun getUserByAnyId(id: String): RealmUser?
     suspend fun getUserByName(name: String): RealmUser?
     suspend fun getAllUsers(): List<RealmUser>
+    suspend fun getAllUsersWithIds(): List<RealmUser>
     suspend fun getUsersSortedBy(fieldName: String, sortOrder: Sort): List<RealmUser>
     suspend fun getMonthlyLoginCounts(
         userId: String,
@@ -22,6 +23,7 @@ interface UserRepository {
         endMillis: Long,
     ): Map<Int, Int>
     suspend fun saveUser(jsonDoc: JsonObject?, settings: SharedPreferences, key: String? = null, iv: String? = null): RealmUser?
+    suspend fun updateUserLastSync(userId: String, key: String, iv: String)
     suspend fun updateSecurityData(
         name: String,
         userId: String?,


### PR DESCRIPTION
Refactored TransactionSyncManager to use UserRepository for user operations.
- Injected UserRepository into TransactionSyncManager.
- Added getAllUsersWithIds() and updateUserLastSync() to UserRepository.
- Replaced direct Realm usage in TransactionSyncManager with repository methods.

---
*PR created automatically by Jules for task [10417750979712103497](https://jules.google.com/task/10417750979712103497) started by @dogi*