### PR TITLE
Refactor CourseStepFragment to use CoursesRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
@@ -5,6 +5,7 @@ import org.ole.planet.myplanet.model.CourseProgressData
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmStepExam
 
 interface CoursesRepository {
     fun getMyCourses(userId: String?, courses: List<RealmMyCourse>): List<RealmMyCourse>
@@ -17,6 +18,9 @@ interface CoursesRepository {
     suspend fun getCourseOfflineResources(courseIds: List<String>): List<RealmMyLibrary>
     suspend fun getCourseExamCount(courseId: String?): Int
     suspend fun getCourseSteps(courseId: String?): List<RealmCourseStep>
+    suspend fun getCourseStepById(stepId: String): RealmCourseStep?
+    suspend fun getStepResources(stepId: String): List<RealmMyLibrary>
+    suspend fun getStepExams(stepId: String, type: String): List<RealmStepExam>
     suspend fun markCourseAdded(courseId: String, userId: String?): Boolean
     suspend fun joinCourse(courseId: String, userId: String)
     suspend fun leaveCourse(courseId: String, userId: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -104,6 +104,28 @@ class CoursesRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getCourseStepById(stepId: String): RealmCourseStep? {
+        return withRealm { realm ->
+            val step = realm.where(RealmCourseStep::class.java)
+                .equalTo("id", stepId)
+                .findFirst()
+            step?.let { realm.copyFromRealm(it) }
+        }
+    }
+
+    override suspend fun getStepResources(stepId: String): List<RealmMyLibrary> {
+        return queryList(RealmMyLibrary::class.java) {
+            equalTo("stepId", stepId)
+        }
+    }
+
+    override suspend fun getStepExams(stepId: String, type: String): List<RealmStepExam> {
+        return queryList(RealmStepExam::class.java) {
+            equalTo("stepId", stepId)
+            equalTo("type", type)
+        }
+    }
+
     override suspend fun markCourseAdded(courseId: String, userId: String?): Boolean {
         if (courseId.isBlank()) {
             return false

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -40,13 +40,6 @@ private data class CourseStepData(
     val userHasCourse: Boolean
 )
 
-private data class IntermediateStepData(
-    val step: RealmCourseStep,
-    val resources: List<RealmMyLibrary>,
-    val stepExams: List<RealmStepExam>,
-    val stepSurvey: List<RealmStepExam>
-)
-
 @AndroidEntryPoint
 class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     @Inject
@@ -97,33 +90,16 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
     }
 
     private suspend fun loadStepData(): CourseStepData {
-        val intermediateData = databaseService.withRealmAsync { realm ->
-            val step = realm.where(RealmCourseStep::class.java)
-                .equalTo("id", stepId)
-                .findFirst()
-                ?.let { realm.copyFromRealm(it) }!!
-            val resources = realm.where(RealmMyLibrary::class.java)
-                .equalTo("stepId", stepId)
-                .findAll()
-                .let { realm.copyFromRealm(it) }
-            val stepExams = realm.where(RealmStepExam::class.java)
-                .equalTo("stepId", stepId)
-                .equalTo("type", "courses")
-                .findAll()
-                .let { realm.copyFromRealm(it) }
-            val stepSurvey = realm.where(RealmStepExam::class.java)
-                .equalTo("stepId", stepId)
-                .equalTo("type", "surveys")
-                .findAll()
-                .let { realm.copyFromRealm(it) }
-            IntermediateStepData(step, resources, stepExams, stepSurvey)
-        }
-        val userHasCourse = coursesRepository.isMyCourse(user?.id, intermediateData.step.courseId)
+        val step = coursesRepository.getCourseStepById(stepId!!)!!
+        val resources = coursesRepository.getStepResources(stepId!!)
+        val stepExams = coursesRepository.getStepExams(stepId!!, "courses")
+        val stepSurvey = coursesRepository.getStepExams(stepId!!, "surveys")
+        val userHasCourse = coursesRepository.isMyCourse(user?.id, step.courseId)
         return CourseStepData(
-            step = intermediateData.step,
-            resources = intermediateData.resources,
-            stepExams = intermediateData.stepExams,
-            stepSurvey = intermediateData.stepSurvey,
+            step = step,
+            resources = resources,
+            stepExams = stepExams,
+            stepSurvey = stepSurvey,
             userHasCourse = userHasCourse
         )
     }


### PR DESCRIPTION
This PR refactors `CourseStepFragment` to adhere to the repository pattern by moving direct Realm database access to `CoursesRepository`. 

Key changes:
- Added `getCourseStepById`, `getStepResources`, and `getStepExams` to `CoursesRepository` interface.
- Implemented these methods in `CoursesRepositoryImpl` ensuring thread safety with `Dispatchers.IO`.
- Refactored `CourseStepFragment.loadStepData` to call the repository methods instead of executing Realm transactions directly.
- Removed the now unused `IntermediateStepData` data class from `CourseStepFragment`.

This change improves testability and separation of concerns by decoupling the UI from the database implementation.

---
*PR created automatically by Jules for task [11167362630483075060](https://jules.google.com/task/11167362630483075060) started by @dogi*