### PR TITLE
Add UserRepository.hasAnyUser() and usage in SyncActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -73,4 +73,5 @@ interface UserRepository {
     suspend fun cleanupDuplicateUsers()
     fun authenticateUser(username: String?, password: String?, isManagerMode: Boolean): RealmUser?
     fun hasAtLeastOneUser(): Boolean
+    suspend fun hasAnyUser(): Boolean
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -575,4 +575,10 @@ class UserRepositoryImpl @Inject constructor(
     override fun hasAtLeastOneUser(): Boolean {
         return databaseService.withRealm { realm -> !realm.isEmpty }
     }
+
+    override suspend fun hasAnyUser(): Boolean {
+        return withRealm { realm ->
+            realm.where(RealmUser::class.java).count() > 0
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -491,10 +491,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
             var attempt = 0
             val maxAttempts = 3 // Maximum 3 seconds wait
             while (attempt < maxAttempts) {
-                val hasUser = databaseService.withRealmAsync { realm ->
-                    realm.where(RealmUser::class.java).findAll().isNotEmpty()
-                }
-                if (hasUser) {
+                if (userRepository.hasAnyUser()) {
                     break
                 }
                 attempt++


### PR DESCRIPTION
This PR adds a `hasAnyUser()` method to the `UserRepository` to encapsulate the check for existing users in the Realm database. This method is then used in `SyncActivity`'s `onSyncComplete` method, replacing a direct `databaseService.withRealmAsync` call. This change aligns with the repository pattern and improves code testability and maintainability.

---
*PR created automatically by Jules for task [15062975671958963965](https://jules.google.com/task/15062975671958963965) started by @dogi*