### PR TITLE
Rename mListener to feedbackSubmittedListener in FeedbackFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -30,9 +30,9 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
     private var model: RealmUser ?= null
     var user: String? = ""
 
-    private var mListener: OnFeedbackSubmittedListener? = null
+    private var feedbackSubmittedListener: OnFeedbackSubmittedListener? = null
     fun setOnFeedbackSubmittedListener(listener: OnFeedbackSubmittedListener?) {
-        mListener = listener
+        feedbackSubmittedListener = listener
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -89,7 +89,7 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
             Utilities.toast(activity, getString(R.string.feedback_saved))
         }
         Toast.makeText(activity, R.string.thank_you_your_feedback_has_been_submitted, Toast.LENGTH_SHORT).show()
-        mListener?.onFeedbackSubmitted()
+        feedbackSubmittedListener?.onFeedbackSubmitted()
         dismiss()
     }
 


### PR DESCRIPTION
Renamed the listener field in FeedbackFragment to follow Kotlin conventions.

---
*PR created automatically by Jules for task [6754598514240503934](https://jules.google.com/task/6754598514240503934) started by @dogi*