### PR TITLE
Remove tvFragmentInfo from BaseRecyclerFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -41,7 +41,6 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     var subjectLevel = ""
     lateinit var recyclerView: RecyclerView
     lateinit var tvMessage: TextView
-    lateinit var tvFragmentInfo: TextView
     var tvDelete: TextView? = null
     var list: MutableList<LI>? = null
     var resources: List<RealmMyLibrary>? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -55,6 +55,7 @@ import org.ole.planet.myplanet.ui.components.FragmentNavigator
 @AndroidEntryPoint
 class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSelectedListener, OnTagClickListener, RealtimeSyncMixin {
 
+    private lateinit var tvFragmentInfo: TextView
     private lateinit var tvAddToLib: TextView
     private lateinit var tvSelected: TextView
     private lateinit var etSearch: EditText

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -237,8 +237,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         changeButtonStatus()
         additionalSetup()
 
-        tvFragmentInfo = binding.tvFragmentInfo
-        if (isMyCourseLib) tvFragmentInfo.setText(R.string.txt_myLibrary)
+        if (isMyCourseLib) binding.tvFragmentInfo.setText(R.string.txt_myLibrary)
         checkList()
 
         if (userModel?.id != null) {


### PR DESCRIPTION
Removed `tvFragmentInfo` field from `BaseRecyclerFragment`.
Refactored `CoursesFragment` to include a local `tvFragmentInfo` property since it relied on the base class field but initialized it locally.
Refactored `ResourcesFragment` to use `binding.tvFragmentInfo` directly, removing the need for the property.
Verified that `SubmissionsFragment` and `TeamFragment` are unaffected as they extend `Fragment` directly and use ViewBinding.

---
*PR created automatically by Jules for task [326746509101017141](https://jules.google.com/task/326746509101017141) started by @dogi*