### PR TITLE
Rename mAdapter to usersAdapter in LoginActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -64,7 +64,7 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
     private lateinit var nameWatcher2: TextWatcher
     private var guest = false
     var users: List<RealmUser>? = null
-    private var mAdapter: UsersAdapter? = null
+    private var usersAdapter: UsersAdapter? = null
     private var backPressedTime: Long = 0
     private val backPressedInterval: Long = 2000
     private var teamList = java.util.ArrayList<String?>()
@@ -466,12 +466,12 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
                 prefData.setSavedUsers(updatedUserList)
             }
 
-            if (mAdapter == null) {
-                mAdapter = UsersAdapter(this@LoginActivity)
+            if (usersAdapter == null) {
+                usersAdapter = UsersAdapter(this@LoginActivity)
                 binding.recyclerView.layoutManager = LinearLayoutManager(this@LoginActivity)
-                binding.recyclerView.adapter = mAdapter
+                binding.recyclerView.adapter = usersAdapter
             }
-            mAdapter?.submitList(prefData.getSavedUsers().toMutableList())
+            usersAdapter?.submitList(prefData.getSavedUsers().toMutableList())
 
             binding.recyclerView.isNestedScrollingEnabled = true
             binding.recyclerView.scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY


### PR DESCRIPTION
Renamed the `mAdapter` field to `usersAdapter` in `LoginActivity.kt` to follow idiomatic Kotlin naming conventions and improve code readability.
Verified that all references were updated and no other adapters (e.g., `teamAdapter`) were affected.

---
*PR created automatically by Jules for task [18190948331390307767](https://jules.google.com/task/18190948331390307767) started by @dogi*