### PR TITLE
Rename mAdapter to moveListener in ItemReorderHelper

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/ItemReorderHelper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ItemReorderHelper.kt
@@ -6,7 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.callback.OnItemDragStateListener
 import org.ole.planet.myplanet.callback.OnItemMoveListener
 
-class ItemReorderHelper(private val mAdapter: OnItemMoveListener) :
+class ItemReorderHelper(private val moveListener: OnItemMoveListener) :
     ItemTouchHelper.Callback() {
     override fun isLongPressDragEnabled(): Boolean {
         return true
@@ -35,7 +35,7 @@ class ItemReorderHelper(private val mAdapter: OnItemMoveListener) :
         }
 
         // Notify the adapter of the move
-        mAdapter.onItemMove(source.bindingAdapterPosition, target.bindingAdapterPosition)
+        moveListener.onItemMove(source.bindingAdapterPosition, target.bindingAdapterPosition)
         return true
     }
 


### PR DESCRIPTION
Renamed `mAdapter` to `moveListener` in `ItemReorderHelper` class and updated its usage in `onMove` method. This improves code readability and naming consistency. Validated by verifying the call sites in `LifeFragment` and manual code inspection.

---
*PR created automatically by Jules for task [16210348815898346886](https://jules.google.com/task/16210348815898346886) started by @dogi*