### PR TITLE
Refactor My Life load and seed logic into LifeRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepository.kt
@@ -6,4 +6,6 @@ interface LifeRepository {
     suspend fun updateVisibility(isVisible: Boolean, myLifeId: String)
     suspend fun updateMyLifeListOrder(list: List<RealmMyLife>)
     suspend fun getMyLifeByUserId(userId: String?): List<RealmMyLife>
+    suspend fun getVisibleMyLifeByUserId(userId: String?): List<RealmMyLife>
+    suspend fun seedMyLifeIfNeeded(userId: String?, defaultList: List<RealmMyLife>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.repository
 
+import java.util.UUID
 import javax.inject.Inject
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyLife
@@ -27,5 +28,29 @@ class LifeRepositoryImpl @Inject constructor(databaseService: DatabaseService) :
         return queryList(RealmMyLife::class.java) {
             equalTo("userId", userId)
         }.sortedBy { it.weight }
+    }
+
+    override suspend fun getVisibleMyLifeByUserId(userId: String?): List<RealmMyLife> {
+        return queryList(RealmMyLife::class.java) {
+            equalTo("userId", userId)
+            equalTo("isVisible", true)
+        }.sortedBy { it.weight }
+    }
+
+    override suspend fun seedMyLifeIfNeeded(userId: String?, defaultList: List<RealmMyLife>) {
+        executeTransaction { realm ->
+            val count = realm.where(RealmMyLife::class.java).equalTo("userId", userId).count()
+            if (count == 0L) {
+                var weight = 1
+                defaultList.forEach { item ->
+                    val ml = realm.createObject(RealmMyLife::class.java, UUID.randomUUID().toString())
+                    ml.title = item.title
+                    ml.imageId = item.imageId
+                    ml.weight = weight++
+                    ml.userId = userId
+                    ml.isVisible = true
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR moves the business logic for loading and seeding the "My Life" dashboard section from the UI layer (`BaseDashboardFragment`) to the data layer (`LifeRepository`).

Changes:
- **LifeRepository**: Added `getVisibleMyLifeByUserId(userId)` which returns a sorted, unmanaged list of visible items. Added `seedMyLifeIfNeeded(userId, defaultList)` which transactionally seeds the database if empty.
- **LifeRepositoryImpl**: Implemented the new methods using `RealmRepository` helpers (`queryList`, `executeTransaction`).
- **BaseDashboardFragment**: Injected `LifeRepository`. Updated `myLifeListInit` and `setUpMyLife` to delegate to the repository, removing direct dependencies on `Realm` and `RealmMyLife` static helpers.


---
*PR created automatically by Jules for task [13264806399736498156](https://jules.google.com/task/13264806399736498156) started by @dogi*