### PR TITLE
Refactor VoicesAdapter to use extracted DiffUtils.itemCallback

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -76,37 +76,43 @@ class VoicesAdapter(
     private val shareNewsFn: suspend (String, String, String, String, String) -> Result<Unit>,
     private val getLibraryResourceFn: suspend (String) -> RealmMyLibrary?,
     private val labelManager: VoicesLabelManager
-) : ListAdapter<RealmNews?, RecyclerView.ViewHolder?>(
-    DiffUtils.itemCallback(
-        areItemsTheSame = { oldItem, newItem ->
-            if (oldItem === newItem) return@itemCallback true
-            if (oldItem == null || newItem == null) return@itemCallback oldItem == newItem
+) : ListAdapter<RealmNews?, RecyclerView.ViewHolder?>(DIFF_CALLBACK) {
 
-            try {
-                val oId = oldItem.takeIf { it.isValid }?.id
-                val nId = newItem.takeIf { it.isValid }?.id
-                oId != null && oId == nId
-            } catch (e: Exception) {
-                false
+    companion object {
+        /**
+         * DiffUtil callback for RealmNews items.
+         * Using this pattern to keep the adapter constructor clean and consistent.
+         */
+        val DIFF_CALLBACK = DiffUtils.itemCallback<RealmNews?>(
+            areItemsTheSame = { oldItem, newItem ->
+                if (oldItem === newItem) return@itemCallback true
+                if (oldItem == null || newItem == null) return@itemCallback oldItem == newItem
+
+                try {
+                    val oId = oldItem.takeIf { it.isValid }?.id
+                    val nId = newItem.takeIf { it.isValid }?.id
+                    oId != null && oId == nId
+                } catch (e: Exception) {
+                    false
+                }
+            },
+            areContentsTheSame = { oldItem, newItem ->
+                if (oldItem === newItem) return@itemCallback true
+                if (oldItem == null || newItem == null) return@itemCallback oldItem == newItem
+
+                try {
+                    if (!oldItem.isValid || !newItem.isValid) return@itemCallback false
+
+                    oldItem.id == newItem.id && oldItem.time == newItem.time &&
+                            oldItem.isEdited == newItem.isEdited && oldItem.message == newItem.message &&
+                            oldItem.userName == newItem.userName && oldItem.userId == newItem.userId &&
+                            oldItem.sharedBy == newItem.sharedBy
+                } catch (e: Exception) {
+                    false
+                }
             }
-        },
-        areContentsTheSame = { oldItem, newItem ->
-            if (oldItem === newItem) return@itemCallback true
-            if (oldItem == null || newItem == null) return@itemCallback oldItem == newItem
-
-            try {
-                if (!oldItem.isValid || !newItem.isValid) return@itemCallback false
-
-                oldItem.id == newItem.id && oldItem.time == newItem.time &&
-                        oldItem.isEdited == newItem.isEdited && oldItem.message == newItem.message &&
-                        oldItem.userName == newItem.userName && oldItem.userId == newItem.userId &&
-                        oldItem.sharedBy == newItem.sharedBy
-            } catch (e: Exception) {
-                false
-            }
-        }
-    )
-) {
+        )
+    }
     private var listener: OnNewsItemClickListener? = null
     @Inject
     lateinit var sharedPrefManager: SharedPrefManager

--- a/app/src/main/java/org/ole/planet/myplanet/utils/DiffUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/DiffUtils.kt
@@ -3,15 +3,15 @@ package org.ole.planet.myplanet.utils
 import androidx.recyclerview.widget.DiffUtil as RecyclerDiffUtil
 
 object DiffUtils {
-    fun <T : Any> itemCallback(
+    fun <T> itemCallback(
         areItemsTheSame: (oldItem: T, newItem: T) -> Boolean,
         areContentsTheSame: (oldItem: T, newItem: T) -> Boolean,
         getChangePayload: ((oldItem: T, newItem: T) -> Any?)? = null
     ): RecyclerDiffUtil.ItemCallback<T> {
         return object : RecyclerDiffUtil.ItemCallback<T>() {
-            override fun areItemsTheSame(oldItem: T, newItem: T) = areItemsTheSame(oldItem, newItem)
-            override fun areContentsTheSame(oldItem: T, newItem: T) = areContentsTheSame(oldItem, newItem)
-            override fun getChangePayload(oldItem: T, newItem: T): Any? {
+            override fun areItemsTheSame(oldItem: T & Any, newItem: T & Any) = areItemsTheSame(oldItem, newItem)
+            override fun areContentsTheSame(oldItem: T & Any, newItem: T & Any) = areContentsTheSame(oldItem, newItem)
+            override fun getChangePayload(oldItem: T & Any, newItem: T & Any): Any? {
                 return getChangePayload?.invoke(oldItem, newItem)
             }
         }


### PR DESCRIPTION
This PR refactors `VoicesAdapter` to extract the inline `DiffUtil.ItemCallback` into a companion object property, improving code cleanliness. It also updates `DiffUtils.kt` to correctly support nullable types, fixing a limitation where `RealmNews?` could not be used with the helper. The `DiffUtils.itemCallback` now uses `T & Any` in overrides to bridge the gap between Kotlin's null safety and Android's Java-based `DiffUtil` API.

---
*PR created automatically by Jules for task [4501357129099624680](https://jules.google.com/task/4501357129099624680) started by @dogi*