### PR TITLE
Refactor VoicesAdapter to use NewsViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
@@ -4,17 +4,86 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.repository.VoicesRepository
+import org.ole.planet.myplanet.services.UserSessionManager
 
 @HiltViewModel
 class NewsViewModel @Inject constructor(
-    private val resourcesRepository: ResourcesRepository
+    private val resourcesRepository: ResourcesRepository,
+    private val voicesRepository: VoicesRepository,
+    private val userRepository: UserRepository,
+    private val teamsRepository: TeamsRepository,
+    private val userSessionManager: UserSessionManager
 ) : ViewModel() {
+
+    private val _isTeamLeader = MutableStateFlow(false)
+    val isTeamLeader = _isTeamLeader.asStateFlow()
+
     fun getPrivateImageUrlsCreatedAfter(timestamp: Long, callback: (List<String>) -> Unit) {
         viewModelScope.launch {
             val urls = resourcesRepository.getPrivateImageUrlsCreatedAfter(timestamp)
             callback(urls)
         }
+    }
+
+    fun checkTeamLeader(teamId: String?) {
+        if (teamId == null) {
+            _isTeamLeader.value = false
+            return
+        }
+        viewModelScope.launch {
+            val user = userSessionManager.userModel
+            val isLeader = teamsRepository.isTeamLeader(teamId, user?.id)
+            _isTeamLeader.value = isLeader
+        }
+    }
+
+    suspend fun getUser(userId: String): RealmUser? {
+        return userRepository.getUserById(userId)
+    }
+
+    suspend fun getReplyCount(newsId: String): Int {
+        return voicesRepository.getReplies(newsId).size
+    }
+
+    fun deletePost(newsId: String, teamName: String) {
+        viewModelScope.launch {
+            voicesRepository.deletePost(newsId, teamName)
+        }
+    }
+
+    suspend fun shareNews(newsId: String, userId: String, planetCode: String, parentCode: String, teamName: String): Result<Unit> {
+        return voicesRepository.shareNewsToCommunity(newsId, userId, planetCode, parentCode, teamName)
+    }
+
+    suspend fun getLibraryResource(resourceId: String): RealmMyLibrary? {
+        return voicesRepository.getLibraryResource(resourceId)
+    }
+
+    fun toggleLike(news: RealmNews) {
+        val newsId = news.id ?: return
+        val labels = news.labels
+        val isLiked = labels?.contains("Like") == true
+
+        viewModelScope.launch {
+            if (isLiked) {
+                voicesRepository.removeLabel(newsId, "Like")
+            } else {
+                voicesRepository.addLabel(newsId, "Like")
+            }
+        }
+    }
+
+    suspend fun getNewsWithReplies(newsId: String): Pair<RealmNews?, List<RealmNews>> {
+        return voicesRepository.getNewsWithReplies(newsId)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
@@ -36,6 +36,7 @@ import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.VoicesLabelManager
+import org.ole.planet.myplanet.ui.voices.NewsViewModel
 import org.ole.planet.myplanet.ui.voices.VoicesActions
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.FileUtils.getFileNameFromUrl
@@ -54,7 +55,7 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
     private lateinit var newsAdapter: VoicesAdapter
     var user: RealmUser? = null
 
-    private val viewModel: ReplyViewModel by viewModels()
+    private val viewModel: NewsViewModel by viewModels()
     
     @Inject
     lateinit var userSessionManager: UserSessionManager
@@ -109,14 +110,7 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
                     teamId = null,
                     userSessionManager = userSessionManager,
                     scope = lifecycleScope,
-                    isTeamLeaderFn = { false },
-                    getUserFn = { userId -> userRepository.getUserById(userId) },
-                    getReplyCountFn = { newsId -> voicesRepository.getReplies(newsId).size },
-                    deletePostFn = { newsId -> voicesRepository.deletePost(newsId, "") },
-                    shareNewsFn = { newsId, userId, planetCode, parentCode, teamName ->
-                        voicesRepository.shareNewsToCommunity(newsId, userId, planetCode, parentCode, teamName)
-                    },
-                    getLibraryResourceFn = { resourceId -> voicesRepository.getLibraryResource(resourceId) },
+                    viewModel = viewModel,
                     labelManager = labelManager
                 )
                 newsAdapter.sharedPrefManager = sharedPrefManager

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
@@ -10,6 +10,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.EditText
 import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -54,6 +55,8 @@ class VoicesFragment : BaseVoicesFragment() {
     lateinit var teamsRepository: TeamsRepository
     @Inject
     lateinit var sharedPrefManager: SharedPrefManager
+    private val viewModel: NewsViewModel by viewModels()
+
     private var filteredNewsList: List<RealmNews?> = listOf()
     private var searchFilteredList: List<RealmNews?> = listOf()
     private var labelFilteredList: List<RealmNews?> = listOf()
@@ -106,6 +109,8 @@ class VoicesFragment : BaseVoicesFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        viewModel.checkTeamLeader(null)
+
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 voicesRepository.getCommunityNews(getUserIdentifier()).collect { news ->
@@ -214,14 +219,7 @@ class VoicesFragment : BaseVoicesFragment() {
                 teamId = null,
                 userSessionManager = userSessionManager,
                 scope = viewLifecycleOwner.lifecycleScope,
-                isTeamLeaderFn = { false },
-                getUserFn = { userId -> userRepository.getUserById(userId) },
-                getReplyCountFn = { newsId -> voicesRepository.getReplies(newsId).size },
-                deletePostFn = { newsId -> voicesRepository.deletePost(newsId, "") },
-                shareNewsFn = { newsId, userId, planetCode, parentCode, teamName ->
-                    voicesRepository.shareNewsToCommunity(newsId, userId, planetCode, parentCode, teamName)
-                },
-                getLibraryResourceFn = { resourceId -> voicesRepository.getLibraryResource(resourceId) },
+                viewModel = viewModel,
                 labelManager = labelManager
             )
             adapterNews?.sharedPrefManager = sharedPrefManager

--- a/app/src/main/res/layout/row_news.xml
+++ b/app/src/main/res/layout/row_news.xml
@@ -155,9 +155,19 @@
                 android:text="@string/reply"
                 android:textColor="@color/daynight_textColor"
                 android:theme="@style/PrimaryFlatButton"
-                app:layout_constraintEnd_toStartOf="@+id/btn_show_reply"
+                app:layout_constraintEnd_toStartOf="@+id/btn_like"
                 app:layout_constraintHorizontal_chainStyle="spread_inside"
                 app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+            <Button
+                android:id="@+id/btn_like"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="Like"
+                android:textColor="@color/daynight_textColor"
+                android:theme="@style/PrimaryFlatButton"
+                app:layout_constraintEnd_toStartOf="@+id/btn_show_reply"
+                app:layout_constraintStart_toEndOf="@+id/btn_reply"
                 app:layout_constraintTop_toTopOf="parent" />
             <Button
                 android:id="@+id/btn_show_reply"
@@ -172,7 +182,7 @@
                 android:textColor="@color/daynight_textColor"
                 android:theme="@style/PrimaryFlatButton"
                 app:layout_constraintEnd_toStartOf="@+id/btn_add_label"
-                app:layout_constraintStart_toEndOf="@+id/btn_reply"
+                app:layout_constraintStart_toEndOf="@+id/btn_like"
                 app:layout_constraintTop_toTopOf="parent" />
             <Button
                 android:id="@+id/btn_add_label"


### PR DESCRIPTION
This PR refactors `VoicesAdapter` to adhere to MVVM principles by removing suspend callbacks and delegating logic to a newly created `NewsViewModel`.

Key changes:
- Created `NewsViewModel` which centralizes logic for:
    - Checking team leader status (exposed as `StateFlow`).
    - Handling "Like" toggle (via labels).
    - Deleting, sharing, and fetching details for news items.
- Updated `VoicesAdapter`:
    - Removed suspend function parameters from constructor.
    - Accepts `NewsViewModel`.
    - Observes `isTeamLeader` state.
    - Added "Like" button binding logic.
- Updated `row_news.xml`:
    - Added a "Like" button to the UI.
- Updated Consumers (`VoicesFragment`, `TeamsVoicesFragment`, `ReplyActivity`):
    - Inject `NewsViewModel`.
    - Pass it to the adapter.
    - Trigger team leader checks where appropriate.

---
*PR created automatically by Jules for task [8108404386846480353](https://jules.google.com/task/8108404386846480353) started by @dogi*