### PR TITLE
Fix compilation errors in ConfigurationsRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
@@ -8,7 +8,6 @@ interface ConfigurationsRepository {
     fun checkHealth(listener: OnSuccessListener)
     fun checkVersion(callback: CheckVersionCallback, settings: SharedPreferences)
     suspend fun isPlanetAvailable(): Boolean
-    fun checkServerAvailability(callback: PlanetAvailableListener?)
     suspend fun checkCheckSum(path: String): Boolean
 
     interface CheckVersionCallback {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -210,48 +210,6 @@ class ConfigurationsRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun checkServerAvailability(callback: ConfigurationsRepository.PlanetAvailableListener?) {
-        val updateUrl = "${preferences.getString("serverURL", "")}"
-        serverAvailabilityCache[updateUrl]?.let { (available, timestamp) ->
-            if (System.currentTimeMillis() - timestamp < 30000) {
-                return available
-            }
-        }
-
-        val serverUrlMapper = ServerUrlMapper()
-        val mapping = serverUrlMapper.processUrl(updateUrl)
-
-        withContext(Dispatchers.IO) {
-            val primaryReachable = isServerReachable(mapping.primaryUrl)
-            val alternativeReachable = mapping.alternativeUrl?.let { isServerReachable(it) } == true
-
-            if (!primaryReachable && alternativeReachable) {
-                mapping.alternativeUrl?.let { alternativeUrl ->
-                    val uri = updateUrl.toUri()
-                    val editor = preferences.edit()
-
-                    serverUrlMapper.updateUrlPreferences(
-                        editor,
-                        uri,
-                        alternativeUrl,
-                        mapping.primaryUrl,
-                        preferences
-                    )
-                }
-            }
-        }
-
-        return try {
-            val response = apiInterface.isPlanetAvailable(UrlUtils.getUpdateUrl(preferences))
-            val isAvailable = response.code() == 200
-            serverAvailabilityCache[updateUrl] = Pair(isAvailable, System.currentTimeMillis())
-            isAvailable
-        } catch (e: Exception) {
-            serverAvailabilityCache[updateUrl] = Pair(false, System.currentTimeMillis())
-            false
-        }
-    }
-
     private suspend fun fetchVersionInfo(settings: SharedPreferences): MyPlanet? =
         withContext(Dispatchers.IO) {
             val result = ApiClient.executeWithResult {


### PR DESCRIPTION
This change fixes a build failure in the `lite` flavor (and likely others) caused by a broken method `checkServerAvailability` in `ConfigurationsRepository`.

The `checkServerAvailability` method was:
1.  Referencing a non-existent `PlanetAvailableListener` interface.
2.  Defined as a non-suspend function but attempting to call suspend functions (`withContext`) and return a value (Boolean) where `Unit` was expected.
3.  Redundant, as `isPlanetAvailable()` provides the correct, suspend-based implementation for checking server availability.

The fix involves removing the method signature from the interface and the implementation from the class.

Verified by successfully compiling the `lite` debug build (`:app:compileLiteDebugKotlin`).

---
*PR created automatically by Jules for task [11322706116973044634](https://jules.google.com/task/11322706116973044634) started by @dogi*