### PR TITLE
Enable ProGuard/R8 for release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled = false
+            minifyEnabled = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         debug {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -5,17 +5,87 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Preserve the line number information for debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# --- Android ---
+-keep public class * extends android.app.Activity
+-keep public class * extends android.app.Application
+-keep public class * extends android.app.Service
+-keep public class * extends android.content.BroadcastReceiver
+-keep public class * extends android.content.ContentProvider
+-keep public class * extends android.preference.Preference
+-keep public class * extends androidx.fragment.app.Fragment
+
+# --- Realm ---
+-keep class io.realm.annotations.RealmModule
+-keep @io.realm.annotations.RealmModule class *
+-keep class io.realm.internal.Keep
+-keep @io.realm.internal.Keep class * { *; }
+-dontwarn io.realm.**
+
+# --- Retrofit ---
+-dontwarn retrofit2.**
+-keep class retrofit2.** { *; }
+-keepattributes Signature
+-keepattributes Exceptions
+-keepclasseswithmembers class * {
+    @retrofit2.http.* <methods>;
+}
+
+# --- Gson ---
+-keepattributes Signature
+-keepattributes *Annotation*
+-dontwarn sun.misc.**
+-keep class com.google.gson.** { *; }
+
+# --- OkHttp ---
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn javax.annotation.**
+
+# --- Glide ---
+-keep public class * implements com.bumptech.glide.module.GlideModule
+-keep public class * extends com.bumptech.glide.module.AppGlideModule
+-keep public enum com.bumptech.glide.load.ImageHeaderParser$ImageType {
+  **[] $VALUES;
+  public *;
+}
+-keep public enum com.bumptech.glide.load.resource.bitmap.ImageHeaderParser$ImageType {
+  **[] $VALUES;
+  public *;
+}
+
+# --- Hilt / Dagger ---
+-keep class com.google.dagger.** { *; }
+-keep class dagger.** { *; }
+-keep class hilt_aggregated_deps.** { *; }
+
+# --- MPAndroidChart ---
+-keep class com.github.mikephil.charting.** { *; }
+
+# --- MaterialDrawer ---
+-keep class com.mikepenz.materialdrawer.** { *; }
+
+# --- Markwon ---
+-keep class io.noties.markwon.** { *; }
+
+# --- OpenCSV ---
+-keep class com.opencsv.** { *; }
+
+# --- Osmdroid ---
+-dontwarn org.osmdroid.**
+-keep class org.osmdroid.** { *; }
+
+# --- Application Models ---
+# Keep all models to ensure Gson and Realm work correctly with reflection
+-keep class org.ole.planet.myplanet.model.** { *; }
+-keepnames class org.ole.planet.myplanet.model.** { *; }
+
+# --- Kotlin Coroutines ---
+-dontwarn kotlinx.coroutines.**
+-keep class kotlinx.coroutines.** { *; }


### PR DESCRIPTION
Enables minification (R8) for release builds to reduce APK size and obfuscate code. Added comprehensive ProGuard rules to ensure libraries like Realm, Retrofit, Gson, and Hilt continue to function correctly. Verified configuration syntax. Note: Full build verification in the sandbox environment was limited by timeout constraints, but the configuration follows best practices for the used libraries.

---
*PR created automatically by Jules for task [10077686423928337415](https://jules.google.com/task/10077686423928337415) started by @dogi*