### PR TITLE
Migrate to AGP built-in Kotlin support and KSP

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,8 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'com.google.devtools.ksp'
-apply plugin: 'dagger.hilt.android.plugin'
+plugins {
+    id 'com.android.application'
+    id 'com.google.devtools.ksp'
+    id 'com.google.dagger.hilt.android'
+}
 apply plugin: 'realm-android'
 android {
     compileSdk = 36
@@ -61,10 +61,6 @@ android {
     compileOptions {
         targetCompatibility JavaVersion.VERSION_17
         sourceCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     lintOptions {
@@ -179,7 +175,7 @@ dependencies {
     implementation(libs.constraintlayout)
     implementation(libs.core.ktx)
     implementation(libs.hilt.work)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.media3.exoplayer)
     implementation(libs.media3.ui)
     implementation(libs.media3.common)
@@ -199,8 +195,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.gson)
     implementation(libs.hilt.android)
-    kapt(libs.hilt.android.compiler)
-    kapt(libs.kotlin.metadata.jvm)
+    ksp(libs.hilt.android.compiler)
     implementation(libs.toggle.button.group)
     implementation(libs.materialdrawer) { transitive = true }
     implementation(libs.opencsv) { exclude group: 'commons-logging', module: 'commons-logging' }
@@ -221,8 +216,4 @@ dependencies {
 }
 realm {
     syncEnabled = true
-}
-kapt {
-    correctErrorTypes = true
-    useBuildCache = true
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
@@ -13,7 +13,6 @@ import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
-import io.realm.kotlin.where
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.model.RealmMyLibrary.Companion.createStepResource
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.insertCourseStepsExams

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=true
-android.builtInKotlin=false
 android.newDsl=false
 
 PLANET_LEARNING_URL=planet.learning.ole.org


### PR DESCRIPTION
This change migrates the project to use the built-in Kotlin support provided by Android Gradle Plugin (AGP) 9.0, removing the need for explicit `kotlin-android` and `kotlin-kapt` plugins. Hilt usage is migrated from KAPT to KSP. Realm Java support is maintained by reapplying the legacy Realm plugin and adjusting imports. Legacy DSL support is enabled to resolve compatibility issues between Hilt and AGP 9.0.

---
*PR created automatically by Jules for task [565530986452604300](https://jules.google.com/task/565530986452604300) started by @dogi*