### PR TITLE
Refactor: Remove unused tvFragmentInfo from BaseRecyclerFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -41,7 +41,6 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     var subjectLevel = ""
     lateinit var recyclerView: RecyclerView
     lateinit var tvMessage: TextView
-    lateinit var tvFragmentInfo: TextView
     var tvDelete: TextView? = null
     var list: MutableList<LI>? = null
     var resources: List<RealmMyLibrary>? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -267,7 +267,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         }
         setupUI(requireView().findViewById(R.id.my_course_parent_layout), requireActivity())
 
-        if (!isMyCourseLib) tvFragmentInfo.setText(R.string.our_courses)
+        if (!isMyCourseLib) requireView().findViewById<TextView>(R.id.tv_fragment_info).setText(R.string.our_courses)
         additionalSetup()
         setupMyProgressButton()
 
@@ -406,7 +406,6 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         spnSubject = requireView().findViewById(R.id.spn_subject)
         tvMessage = requireView().findViewById(R.id.tv_message)
         requireView().findViewById<View>(R.id.tl_tags).visibility = View.GONE
-        tvFragmentInfo = requireView().findViewById(R.id.tv_fragment_info)
 
         setupSpinners()
         setupSelectAll()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -263,8 +263,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         setupUI(binding.myLibraryParentLayout, requireActivity())
         additionalSetup()
 
-        tvFragmentInfo = binding.tvFragmentInfo
-        if (isMyCourseLib) tvFragmentInfo.setText(R.string.txt_myLibrary)
+        if (isMyCourseLib) binding.tvFragmentInfo.setText(R.string.txt_myLibrary)
 
         if (userModel?.id != null) {
             lifecycleScope.launch {


### PR DESCRIPTION
Removed unused `tvFragmentInfo` property from `BaseRecyclerFragment` and updated subclasses (`CoursesFragment`, `ResourcesFragment`) to access the view locally or via ViewBinding. This removes an unused field from the base class and improves code cleanliness.

---
*PR created automatically by Jules for task [408856881832133175](https://jules.google.com/task/408856881832133175) started by @dogi*