### PR TITLE
Optimize Gradle daemon memory settings for CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: myPlanet build
     runs-on: ubuntu-24.04
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +43,9 @@ jobs:
           cache-disabled: false
           cache-read-only: false
           cache-write-only: false
+
+      - name: Check memory
+        run: free -m
 
       - name: build debug as test
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         build: [default, lite]
     env:
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
       OUTPUTS: |
         .apk
         .apk.sha256
@@ -43,6 +44,9 @@ jobs:
           cache-disabled: false
           cache-read-only: false
           cache-write-only: false
+
+      - name: Check memory
+        run: free -m
 
       - name: set release version
         run: echo ANDROID_VERSION=$(grep -oP 'versionName = "\K[^\"]+' app/build.gradle) >> $GITHUB_ENV


### PR DESCRIPTION
Configure GRADLE_OPTS in GitHub Actions workflows to set explicit heap sizes (4GB for build, 6GB for release) and add memory monitoring steps.

- Modify `.github/workflows/build.yml` to set `-Xmx4g` and add memory check.
- Modify `.github/workflows/release.yml` to set `-Xmx6g` and add memory check.
- Ensure strict adherence to user request for explicit configuration.

---
*PR created automatically by Jules for task [17863629849956742913](https://jules.google.com/task/17863629849956742913) started by @dogi*