### PR TITLE
Enable remote Gradle build cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,11 @@ jobs:
   build:
     name: myPlanet build
     runs-on: ubuntu-24.04
+    env:
+      GRADLE_BUILD_CACHE_URL: ${{ secrets.GRADLE_BUILD_CACHE_URL }}
+      GRADLE_BUILD_CACHE_USER: ${{ secrets.GRADLE_BUILD_CACHE_USER }}
+      GRADLE_BUILD_CACHE_PASSWORD: ${{ secrets.GRADLE_BUILD_CACHE_PASSWORD }}
+      GRADLE_BUILD_CACHE_PUSH: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
       matrix:
         build: [default, lite]
     env:
+      GRADLE_BUILD_CACHE_URL: ${{ secrets.GRADLE_BUILD_CACHE_URL }}
+      GRADLE_BUILD_CACHE_USER: ${{ secrets.GRADLE_BUILD_CACHE_USER }}
+      GRADLE_BUILD_CACHE_PASSWORD: ${{ secrets.GRADLE_BUILD_CACHE_PASSWORD }}
+      GRADLE_BUILD_CACHE_PUSH: true
       OUTPUTS: |
         .apk
         .apk.sha256

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 **myPlanet** is a mobile app designed to complement the [Open Learning Exchange](https://ole.org)’s Learning Management System, [Planet](https://github.com/open-learning-exchange/planet). Tailored for both offline and online use, myPlanet ensures continuous learning and community engagement even in areas with limited internet access. It seamlessly integrates with Planet's community and nation instances, offering a mobile platform to access user-created educational resources such as books, videos, and courses.
 
 - [Feature Highlights](#feature-highlights)
+- [Development](#development)
 - [About myPlanet](#about-myplanet)
 - [How To Use](#how-to-use)
 - [Contact](#contact)
@@ -20,6 +21,40 @@
 - **AI Chatbot**: Provides an AI-powered chatbot to assist users with navigating the app, finding resources, and answering questions.
 - **Teams and Enterprises**: Collaborate with other users, complete tasks and courses, and download resources to work on together.
 - **Multilingual Support**: Supports English, Arabic, Spanish, French, Nepali, and Somali
+
+## Development
+
+### Remote Build Cache
+
+This project supports using a remote Gradle build cache to speed up builds.
+
+**Configuration:**
+
+You can configure the remote cache using environment variables or `local.properties`.
+
+*   **Environment Variables** (Recommended for CI):
+    *   `GRADLE_BUILD_CACHE_URL`: URL of the remote cache (e.g., `http://localhost:5071/cache/`)
+    *   `GRADLE_BUILD_CACHE_USER`: Username for the cache
+    *   `GRADLE_BUILD_CACHE_PASSWORD`: Password for the cache
+    *   `GRADLE_BUILD_CACHE_PUSH`: Set to `true` to enable pushing to the cache (usually for master branch only), `false` for read-only.
+
+*   **`local.properties`** (For local development):
+    ```properties
+    gradle.buildCache.url=http://localhost:5071/cache/
+    gradle.buildCache.user=build
+    gradle.buildCache.pass=build
+    gradle.buildCache.push=true
+    ```
+
+**Local Cache Node:**
+
+For testing or local development, you can spin up a local cache node using Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+This starts a `gradle/build-cache-node` at `http://localhost:5071`. The default credentials are user: `build`, password: `build`.
 
 ## About myPlanet
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  build-cache-node:
+    image: gradle/build-cache-node:latest
+    ports:
+      - "5071:5071"
+    volumes:
+      - build-cache-data:/data
+    restart: unless-stopped
+
+volumes:
+  build-cache-data:

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,10 +6,11 @@ if (localPropsFile.exists()) {
     localPropsFile.withInputStream { localProps.load(it) }
 }
 
-def cacheUrl = localProps.getProperty('gradle.buildCache.url')
-def cacheUser = localProps.getProperty('gradle.buildCache.user')
-def cachePass = localProps.getProperty('gradle.buildCache.pass')
-def cachePush = localProps.getProperty('gradle.buildCache.push') == 'true'
+def cacheUrl = System.getenv('GRADLE_BUILD_CACHE_URL') ?: localProps.getProperty('gradle.buildCache.url')
+def cacheUser = System.getenv('GRADLE_BUILD_CACHE_USER') ?: localProps.getProperty('gradle.buildCache.user')
+def cachePass = System.getenv('GRADLE_BUILD_CACHE_PASSWORD') ?: localProps.getProperty('gradle.buildCache.pass')
+def envCachePush = System.getenv('GRADLE_BUILD_CACHE_PUSH')
+def cachePush = envCachePush != null ? envCachePush.toBoolean() : (localProps.getProperty('gradle.buildCache.push') == 'true')
 
 println "Gradle cache: GRADLE_BUILD_CACHE_URL=${cacheUrl ?: '(not set)'}"
 


### PR DESCRIPTION
This PR enables remote Gradle build cache support for the project.

Key changes:
1.  **`settings.gradle`**: Modified to prioritize environment variables for build cache configuration. This allows injecting cache credentials and settings via CI secrets.
2.  **CI Workflows**: Updated `build.yml` and `release.yml` to map GitHub Secrets to the Gradle environment variables. `build.yml` (PRs) is set to read-only, while `release.yml` (master) allows pushing to the cache.
3.  **Local Testing**: Added a `docker-compose.yml` file to easily spin up a local Gradle build cache node.
4.  **Documentation**: Added a "Development" section to `README.md` explaining the setup.

---
*PR created automatically by Jules for task [7422327592905081381](https://jules.google.com/task/7422327592905081381) started by @dogi*