### PR TITLE
Refactor deprecated Realm realmInstance usage

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -87,7 +87,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         super.onViewCreated(view, savedInstanceState)
         postponeEnterTransition()
         viewLifecycleOwner.lifecycleScope.launch {
-            mRealm = databaseService.realmInstance
+            mRealm = io.realm.Realm.getDefaultInstance()
             model = profileDbHandler.userModel
             val adapter = getAdapter()
             recyclerView.adapter = adapter

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -95,7 +95,7 @@ abstract class BaseResourceFragment : Fragment() {
 
     protected fun requireRealmInstance(): Realm {
         if (!isRealmInitialized()) {
-            mRealm = databaseService.realmInstance
+            mRealm = Realm.getDefaultInstance()
         }
         return mRealm
     }
@@ -362,7 +362,7 @@ abstract class BaseResourceFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        mRealm = databaseService.realmInstance
+        mRealm = Realm.getDefaultInstance()
         prgDialog = getProgressDialog(requireActivity())
         editor = settings.edit()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/RealmConnectionPool.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/RealmConnectionPool.kt
@@ -104,7 +104,7 @@ class RealmConnectionPool(
     }
     
     private fun createNewConnection(): PooledRealm {
-        val realm = databaseService.realmInstance
+        val realm = Realm.getDefaultInstance()
         return PooledRealm(
             realm = realm,
             createdAt = System.currentTimeMillis(),

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/ThreadSafeRealmManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/ThreadSafeRealmManager.kt
@@ -11,14 +11,14 @@ object ThreadSafeRealmManager {
         return try {
             // Get or create Realm instance for current thread
             val realm = threadLocalRealm.get() ?: run {
-                val newRealm = databaseService.realmInstance
+                val newRealm = Realm.getDefaultInstance()
                 threadLocalRealm.set(newRealm)
                 newRealm
             }
             
             if (realm.isClosed) {
                 // If realm is closed, create a new one
-                val newRealm = databaseService.realmInstance
+                val newRealm = Realm.getDefaultInstance()
                 threadLocalRealm.set(newRealm)
                 operation(newRealm)
             } else {


### PR DESCRIPTION
This PR replaces the deprecated `databaseService.realmInstance` property with `Realm.getDefaultInstance()` across the codebase to resolve deprecation warnings and align with modern Realm usage patterns.

Key changes:
- `RealmConnectionPool` and `ThreadSafeRealmManager` now acquire Realm instances using `Realm.getDefaultInstance()`.
- `BaseRecyclerFragment` and `BaseResourceFragment` initialize their `mRealm` property using `Realm.getDefaultInstance()`.
- `AddExaminationActivity` uses `Realm.getDefaultInstance()` for `mRealm` initialization.
- `AddExaminationActivity` query logic is refactored to use `databaseService.withRealm`, detaching the result with `copyFromRealm`. Data persistence is updated to use `copyToRealmOrUpdate` to handle detached objects correctly.

---
*PR created automatically by Jules for task [6291764492448257083](https://jules.google.com/task/6291764492448257083) started by @dogi*