### PR TITLE
Migrate to AGP built-in Kotlin support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.devtools.ksp'
 apply plugin: 'com.google.dagger.hilt.android'
 apply plugin: 'realm-android'
@@ -64,10 +62,6 @@ android {
     compileOptions {
         targetCompatibility JavaVersion.VERSION_17
         sourceCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     lintOptions {
@@ -224,8 +218,4 @@ dependencies {
 }
 realm {
     syncEnabled = true
-}
-kapt {
-    correctErrorTypes = true
-    useBuildCache = true
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
@@ -13,7 +13,6 @@ import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
-import io.realm.kotlin.where
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.model.RealmMyLibrary.Companion.createStepResource
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.insertCourseStepsExams

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ buildscript {
         classpath(libs.android.gradle.plugin)
         classpath(libs.realm.gradle.plugin)
         classpath(libs.hilt.android.gradle.plugin)
-        classpath(libs.kotlin.gradle.plugin)
         classpath(libs.kotlin.serialization)
         classpath(libs.ksp.symbol.processing.gradle.plugin)
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=true
-android.builtInKotlin=false
 android.newDsl=false
 
 PLANET_LEARNING_URL=planet.learning.ole.org

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,8 +95,6 @@ tink-android = { module = "com.google.crypto.tink:tink-android", version = "1.10
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 realm-android = { id = "io.realm.android", version.ref = "realmGradlePlugin" }


### PR DESCRIPTION
Migrated the project to use Android Gradle Plugin's built-in Kotlin support.

Key changes:
1.  **Enabled Built-in Kotlin**: Removed `android.builtInKotlin=false` from `gradle.properties`.
2.  **Removed Plugins**: Removed `kotlin-android` and `kotlin-kapt` plugins. `kotlin-kapt` was removed because it is explicitly incompatible with built-in Kotlin support (causing build failures). Verified that the project uses KSP (Hilt, Glide) and `realm-android` plugin (which handles its own processing), and has no direct `kapt` dependencies.
3.  **Cleaned Configuration**: Removed `kotlinOptions` block from `app/build.gradle` because it caused "Could not find method kotlinOptions" error with the new setup. `compileOptions` is set to Java 17, ensuring correct target.
4.  **Fixed Compilation**: Removed `import io.realm.kotlin.where` from `RealmMyCourse.kt` because the `io.realm.kotlin` package was not resolved (likely due to missing transitive dependency from the removed plugin), and the import was unused/redundant as the code uses `Realm.where(Class)` (Java API) which works correctly.
5.  **Cleaned Dependencies**: Removed unused Kotlin Gradle plugin classpath and versions.

Verified with `./gradlew clean assembleDebug` and `./gradlew test`. Build and tests passed.

---
*PR created automatically by Jules for task [3127336584977821208](https://jules.google.com/task/3127336584977821208) started by @dogi*