### PR TITLE
Refactor TeamCoursesFragment to use TeamsRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonObject
 import kotlinx.coroutines.flow.Flow
+import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamTask
@@ -34,6 +35,7 @@ interface TeamsRepository {
     suspend fun getMyTeamsFlow(userId: String): Flow<List<RealmMyTeam>>
     suspend fun getShareableTeams(): List<RealmMyTeam>
     suspend fun getShareableEnterprises(): List<RealmMyTeam>
+    suspend fun getCoursesForTeam(teamId: String): List<RealmMyCourse>
     suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
     suspend fun getTeamByDocumentIdOrTeamId(id: String): RealmMyTeam?
     suspend fun getTeamByIdOrTeamId(id: String): RealmMyTeam?

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -24,6 +24,7 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiClient.client
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.AppPreferences
+import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamLog
@@ -140,6 +141,18 @@ class TeamsRepositoryImpl @Inject constructor(
             isEmpty("teamId")
             notEqualTo("status", "archived")
             equalTo("type", "enterprise")
+        }
+    }
+
+    override suspend fun getCoursesForTeam(teamId: String): List<RealmMyCourse> {
+        val team = findByField(RealmMyTeam::class.java, "_id", teamId)
+            ?: findByField(RealmMyTeam::class.java, "teamId", teamId)
+
+        val courseIds = team?.courses?.map { it }?.toTypedArray() ?: emptyArray()
+        if (courseIds.isEmpty()) return emptyList()
+
+        return queryList(RealmMyCourse::class.java) {
+            `in`("id", courseIds)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseTeamFragment
 import org.ole.planet.myplanet.databinding.FragmentTeamCourseBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
@@ -26,12 +28,14 @@ class TeamCoursesFragment : BaseTeamFragment() {
     }
     
     private fun setupCoursesList() {
-        val courses = mRealm.where(RealmMyCourse::class.java).`in`("id", team?.courses?.toTypedArray<String>()).findAll()
-        adapterTeamCourse = TeamCoursesAdapter(requireActivity(), courses.toMutableList(), mRealm, teamId, settings)
-        binding.rvCourse.layoutManager = LinearLayoutManager(activity)
-        binding.rvCourse.adapter = adapterTeamCourse
-        adapterTeamCourse?.let {
-            showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+        viewLifecycleOwner.lifecycleScope.launch {
+            val courses = teamsRepository.getCoursesForTeam(teamId)
+            adapterTeamCourse = TeamCoursesAdapter(requireActivity(), courses.toMutableList(), mRealm, teamId, settings)
+            binding.rvCourse.layoutManager = LinearLayoutManager(activity)
+            binding.rvCourse.adapter = adapterTeamCourse
+            adapterTeamCourse?.let {
+                showNoData(binding.tvNodata, it.itemCount, "teamCourses")
+            }
         }
     }
     override fun onNewsItemClick(news: RealmNews?) {}

--- a/compile_log.txt
+++ b/compile_log.txt
@@ -1,0 +1,42 @@
+Starting a Gradle Daemon (subsequent builds will be faster)
+Calculating task graph as configuration cache cannot be reused because environment variable 'ANDROID_HOME' has changed.
+Gradle cache: GRADLE_BUILD_CACHE_URL=http://34.134.219.48:5071/cache/
+
+> Configure project :app
+WARNING: The option setting 'android.builtInKotlin=false' is deprecated.
+The current default is 'true'.
+It will be removed in version 10.0 of the Android Gradle plugin.
+WARNING: The option setting 'android.newDsl=false' is deprecated.
+The current default is 'true'.
+It will be removed in version 10.0 of the Android Gradle plugin.
+WARNING: The option setting 'android.enableJetifier=true' is deprecated.
+The current default is 'false'.
+It will be removed in version 10.0 of the Android Gradle plugin.
+w: [33m[1m⚠️ Deprecated 'org.jetbrains.kotlin.android' plugin usage[0m[0m
+The 'org.jetbrains.kotlin.android' plugin in project ':app' is no longer required for Kotlin support since AGP 9.0.
+[32m[1mSolution:[0m[0m
+[32m[3mRemove both `android.builtInKotlin=true` and `android.newDsl=false` from `gradle.properties`, then migrate to built-in Kotlin.[0m[0m
+[36mSee [0m[34mhttps://kotl.in/gradle/agp-built-in-kotlin[0m[36m for more details.[0m
+
+Problem found: Deprecated 'org.jetbrains.kotlin.android' plugin usage (id: KOTLIN:KGP:DEPRECATION:DeprecatedKotlinAndroidPlugin)
+  Deprecated 'org.jetbrains.kotlin.android' plugin usage
+    The 'org.jetbrains.kotlin.android' plugin in project ':app' is no longer required for Kotlin support since AGP 9.0.
+    Solution: Remove both `android.builtInKotlin=true` and `android.newDsl=false` from `gradle.properties`, then migrate to built-in Kotlin.
+    Documentation: https://kotl.in/gradle/agp-built-in-kotlin
+
+> Task :app:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :app:generateVersionsXml UP-TO-DATE
+> Task :app:preBuild UP-TO-DATE
+> Task :app:preDefaultDebugBuild UP-TO-DATE
+> Task :app:dataBindingTriggerDefaultDebug UP-TO-DATE
+> Task :app:generateDefaultDebugBuildConfig UP-TO-DATE
+> Task :app:generateDefaultDebugResources UP-TO-DATE
+> Task :app:packageDefaultDebugResources UP-TO-DATE
+> Task :app:processDefaultDebugNavigationResources UP-TO-DATE
+> Task :app:mergeDefaultDebugResources UP-TO-DATE
+> Task :app:parseDefaultDebugLocalResources UP-TO-DATE
+> Task :app:dataBindingMergeDependencyArtifactsDefaultDebug UP-TO-DATE
+> Task :app:generateDefaultDebugRFile UP-TO-DATE
+> Task :app:dataBindingGenBaseClassesDefaultDebug UP-TO-DATE
+> Task :app:kspDefaultDebugKotlin
+Could not load entry 0b5ea0aca6efdf12e3cfa5da20e43fc8 from remote build cache: Connect to 34.134.219.48:5071 [/34.134.219.48] failed: Connect timed out

--- a/compile_log_2.txt
+++ b/compile_log_2.txt
@@ -1,0 +1,18 @@
+Starting a Gradle Daemon (subsequent builds will be faster)
+Reusing configuration cache.
+> Task :app:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :app:generateVersionsXml UP-TO-DATE
+> Task :app:preBuild UP-TO-DATE
+> Task :app:preDefaultDebugBuild UP-TO-DATE
+> Task :app:dataBindingTriggerDefaultDebug UP-TO-DATE
+> Task :app:generateDefaultDebugBuildConfig UP-TO-DATE
+> Task :app:generateDefaultDebugResources UP-TO-DATE
+> Task :app:packageDefaultDebugResources UP-TO-DATE
+> Task :app:mergeDefaultDebugResources UP-TO-DATE
+> Task :app:processDefaultDebugNavigationResources UP-TO-DATE
+> Task :app:parseDefaultDebugLocalResources UP-TO-DATE
+> Task :app:dataBindingMergeDependencyArtifactsDefaultDebug UP-TO-DATE
+> Task :app:generateDefaultDebugRFile UP-TO-DATE
+> Task :app:dataBindingGenBaseClassesDefaultDebug UP-TO-DATE
+> Task :app:kspDefaultDebugKotlin
+Could not load entry a9ce05492a873b12f8fe2f1ee2750de2 from remote build cache: Connect to 34.134.219.48:5071 [/34.134.219.48] failed: Connect timed out


### PR DESCRIPTION
This PR refactors the data access in `TeamCoursesFragment`. Instead of directly querying the Realm database for courses associated with a team, it now uses a new method `getCoursesForTeam` in the `TeamsRepository`. This promotes the repository pattern and cleaner architecture. The fragment retrieves the data asynchronously using `viewLifecycleOwner.lifecycleScope` and updates the adapter on the main thread. The returned course objects are detached from Realm.

---
*PR created automatically by Jules for task [3158643284275577454](https://jules.google.com/task/3158643284275577454) started by @dogi*