### PR TITLE
Refactor TeamCoursesAdapter to use Repository for data

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonObject
 import kotlinx.coroutines.flow.Flow
+import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamTask
@@ -138,4 +139,6 @@ interface TeamsRepository {
 
     suspend fun updateTeamLeader(teamId: String, newLeaderId: String): Boolean
     suspend fun getNextLeaderCandidate(teamId: String, excludeUserId: String?): RealmUser?
+    suspend fun getTeamCreator(teamId: String): String?
+    suspend fun getCourses(teamId: String): List<RealmMyCourse>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -24,6 +24,7 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiClient.client
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.AppPreferences
+import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmTeamLog
@@ -1093,5 +1094,19 @@ class TeamsRepositoryImpl @Inject constructor(
         }
 
         return successorMember?.userId?.let { id -> userMap[id] }
+    }
+
+    override suspend fun getTeamCreator(teamId: String): String? {
+        val team = getTeamById(teamId)
+        return team?.userId
+    }
+
+    override suspend fun getCourses(teamId: String): List<RealmMyCourse> {
+        val team = getTeamById(teamId) ?: return emptyList()
+        val courseIds = team.courses?.toList() ?: emptyList()
+        if (courseIds.isEmpty()) return emptyList()
+        return queryList(RealmMyCourse::class.java) {
+            `in`("id", courseIds.toTypedArray())
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesAdapter.kt
@@ -1,36 +1,28 @@
 package org.ole.planet.myplanet.ui.teams.courses
 
 import android.content.Context
-import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import io.realm.Realm
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.RowTeamResourceBinding
 import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmMyTeam.Companion.getTeamCreator
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
 
 class TeamCoursesAdapter(
     private val context: Context,
-    private var list: MutableList<RealmMyCourse>,
-    mRealm: Realm?,
-    teamId: String?,
-    settings: SharedPreferences
+    private val list: List<RealmMyCourse>,
+    private val teamCreatorId: String?,
+    private val currentUserId: String?
 ) : RecyclerView.Adapter<TeamCoursesAdapter.ViewHolder>() {
     private var listener: OnHomeItemClickListener? = null
-    private val settings: SharedPreferences
-    private val teamCreator: String
 
     init {
         if (context is OnHomeItemClickListener) {
             listener = context
         }
-        this.settings = settings
-        teamCreator = getTeamCreator(teamId, mRealm)
     }
 
     fun getList(): List<RealmMyCourse> = list
@@ -51,7 +43,7 @@ class TeamCoursesAdapter(
                 listener?.openCallFragment(TakeCourseFragment.newInstance(b))
             }
         }
-        if (!settings.getString("userId", "--").equals(teamCreator, ignoreCase = true)) {
+        if (!currentUserId.equals(teamCreatorId, ignoreCase = true)) {
             holder.binding.ivRemove.visibility = View.GONE
         }
     }

--- a/compile_output.txt
+++ b/compile_output.txt
@@ -1,0 +1,157 @@
+Calculating task graph as configuration cache cannot be reused because environment variable 'ANDROID_HOME' has changed.
+Gradle cache: GRADLE_BUILD_CACHE_URL=http://34.134.219.48:5071/cache/
+
+> Configure project :app
+WARNING: The option setting 'android.builtInKotlin=false' is deprecated.
+The current default is 'true'.
+It will be removed in version 10.0 of the Android Gradle plugin.
+WARNING: The option setting 'android.newDsl=false' is deprecated.
+The current default is 'true'.
+It will be removed in version 10.0 of the Android Gradle plugin.
+WARNING: The option setting 'android.enableJetifier=true' is deprecated.
+The current default is 'false'.
+It will be removed in version 10.0 of the Android Gradle plugin.
+w: [33m[1m⚠️ Deprecated 'org.jetbrains.kotlin.android' plugin usage[0m[0m
+The 'org.jetbrains.kotlin.android' plugin in project ':app' is no longer required for Kotlin support since AGP 9.0.
+[32m[1mSolution:[0m[0m
+[32m[3mRemove both `android.builtInKotlin=true` and `android.newDsl=false` from `gradle.properties`, then migrate to built-in Kotlin.[0m[0m
+[36mSee [0m[34mhttps://kotl.in/gradle/agp-built-in-kotlin[0m[36m for more details.[0m
+
+Problem found: Deprecated 'org.jetbrains.kotlin.android' plugin usage (id: KOTLIN:KGP:DEPRECATION:DeprecatedKotlinAndroidPlugin)
+  Deprecated 'org.jetbrains.kotlin.android' plugin usage
+    The 'org.jetbrains.kotlin.android' plugin in project ':app' is no longer required for Kotlin support since AGP 9.0.
+    Solution: Remove both `android.builtInKotlin=true` and `android.newDsl=false` from `gradle.properties`, then migrate to built-in Kotlin.
+    Documentation: https://kotl.in/gradle/agp-built-in-kotlin
+
+> Task :app:checkKotlinGradlePluginConfigurationErrors SKIPPED
+> Task :app:generateVersionsXml UP-TO-DATE
+> Task :app:preBuild UP-TO-DATE
+> Task :app:preDefaultDebugBuild UP-TO-DATE
+> Task :app:generateDefaultDebugBuildConfig UP-TO-DATE
+> Task :app:dataBindingTriggerDefaultDebug UP-TO-DATE
+> Task :app:generateDefaultDebugResources UP-TO-DATE
+> Task :app:processDefaultDebugNavigationResources UP-TO-DATE
+> Task :app:dataBindingMergeDependencyArtifactsDefaultDebug UP-TO-DATE
+> Task :app:packageDefaultDebugResources UP-TO-DATE
+> Task :app:mergeDefaultDebugResources UP-TO-DATE
+> Task :app:parseDefaultDebugLocalResources UP-TO-DATE
+> Task :app:dataBindingGenBaseClassesDefaultDebug UP-TO-DATE
+> Task :app:generateDefaultDebugRFile UP-TO-DATE
+> Task :app:kspDefaultDebugKotlin
+Could not load entry a33e244b04c7bbc9d8eb8627e085d34d from remote build cache: Connect to 34.134.219.48:5071 [/34.134.219.48] failed: Connect timed out
+
+Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: Cannot invoke "ksp.com.intellij.openapi.application.Application.getService(java.lang.Class)" because the return value of "ksp.com.intellij.openapi.application.ApplicationManager.getApplication()" is null
+	at ksp.com.intellij.openapi.fileEditor.FileDocumentManager.getInstance(FileDocumentManager.java:35)
+	at ksp.com.intellij.openapi.fileTypes.BinaryFileTypeDecompilers.lambda$notifyDecompilerSetChange$1(BinaryFileTypeDecompilers.java:29)
+	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
+	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
+	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
+	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
+	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
+	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
+	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
+	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
+	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
+	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
+	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
+	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
+	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
+
+> Task :app:kaptGenerateStubsDefaultDebugKotlin
+
+> Task :app:kaptDefaultDebugKotlin
+Note: Processing class RealmMyTeam
+Note: Processing class RealmHealthExamination
+Note: Processing class RealmResourceActivity
+Note: Processing class RealmRetryOperation
+Note: Processing class RealmSubmitPhotos
+Note: Processing class RealmAttachment
+Note: Processing class RealmTeamLog
+Note: Processing class RealmChatHistory
+Note: Processing class RealmCourseActivity
+Note: Processing class RealmCommunity
+Note: Processing class RealmFeedback
+Note: Processing class RealmSearchActivity
+Note: Processing class RealmMeetup
+Note: Processing class RealmUserChallengeActions
+Note: Processing class RealmNewsLog
+Note: Processing class RealmRating
+Note: Processing class RealmOfflineActivity
+Note: Processing class RealmConversation
+Note: Processing class RealmTeamTask
+Note: Processing class RealmSubmission
+Note: Processing class RealmTag
+Note: Processing class RealmMyCourse
+Note: Processing class RealmMyPersonal
+Note: Processing class RealmStepExam
+Note: Processing class RealmExamQuestion
+Note: Processing class RealmMembershipDoc
+Note: Processing class RealmCourseStep
+Note: Processing class RealmNotification
+Note: Processing class RealmAnswer
+Note: Processing class RealmCertification
+Note: Processing class RealmApkLog
+Note: Processing class RealmMyLife
+Note: Processing class RealmTeamReference
+Note: Processing class RealmRemovedLog
+Note: Processing class RealmAchievement
+Note: Processing class RealmUser
+Note: Processing class RealmCourseProgress
+Note: Processing class RealmNews
+Note: Processing class RealmMyLibrary
+Note: Processing class RealmTeamNotification
+Note: Processing class RealmDictionary
+Note: Creating DefaultRealmModule
+
+> Task :app:compileDefaultDebugKotlin
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt:61:20 'fun getSerializable(p0: String?): Serializable?' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerParentFragment.kt:69:116 No cast needed.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt:156:34 'fun setWifiEnabled(p0: Boolean): Boolean' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt:191:20 'fun getMyLibraryByUserId(userId: String?, libs: List<RealmMyLibrary>, mRealm: Realm): List<RealmMyLibrary>' is deprecated. Use ResourcesRepository.getLibraryByUserId instead.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt:172:39 Unnecessary non-null assertion (!!) on a non-null receiver of type 'String'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepositoryImpl.kt:20:61 No cast needed.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt:271:26 This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/services/ChallengePrompter.kt:67:84 Unnecessary safe call on a non-null receiver of type 'RealmUser'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/services/sync/LoginSyncManager.kt:163:29 Condition is always 'true'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt:532:36 'val connectionInfo: WifiInfo!' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt:213:57 'fun serializeNews(news: RealmNews): JsonObject' is deprecated. Use ChatRepository.serializeNews instead.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt:44:32 Unnecessary safe call on a non-null receiver of type 'UserSessionManager'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt:679:41 'static fun getActionView(p0: MenuItem!): View!' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt:175:33 'fun getNetworkInfo(p0: Int): NetworkInfo?' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt:175:68 'static field TYPE_WIFI: Int' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt:178:20 'val isConnected: Boolean' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt:179:18 'var isWifiEnabled: Boolean' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt:187:18 'var isWifiEnabled: Boolean' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt:205:33 'val configuredNetworks: (Mutable)List<WifiConfiguration!>!' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt:206:21 'field networkId: Int' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt:206:43 'field networkId: Int' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt:207:29 'field networkId: Int' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt:208:29 'fun enableNetwork(p0: Int, p1: Boolean): Boolean' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt:323:9 This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsFragment.kt:123:46 Unchecked cast of 'Serializable?' to 'Triple<String, String?, String?>'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt:131:40 The corresponding parameter in the supertype 'OnTagClickListener' is named 'tag'. This may cause problems when calling this function with named arguments.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt:226:106 Unnecessary safe call on a non-null receiver of type 'UserSessionManager'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt:243:37 Unnecessary safe call on a non-null receiver of type 'UserSessionManager'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionViewModel.kt:44:80 This declaration needs opt-in. Its usage should be marked with '@kotlinx.coroutines.ExperimentalCoroutinesApi' or '@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)'
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionViewModel.kt:59:21 Unnecessary safe call on a non-null receiver of type 'RealmStepExam'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt:303:34 Elvis operator (?:) always returns the left operand of non-nullable type 'SharedPreferences'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt:85:30 Unchecked cast of '(ListAdapter<*, *> & RecyclerView.Adapter<RecyclerView.ViewHolder!>..ListAdapter<*, *>)' to 'ListAdapter<Any, *>'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/teams/PlanFragment.kt:249:36 Unnecessary safe call on a non-null receiver of type 'Long'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt:147:36 The corresponding parameter in the supertype 'CreateUserCallback' is named 'message'. This may cause problems when calling this function with named arguments.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt:334:42 'val adapterPosition: Int' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt:326:61 Unchecked cast of 'SpinnerAdapter!' to 'ArrayAdapter<String>'.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/utils/ANRWatchdog.kt:57:44 'val id: Long' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/utils/EdgeToEdgeUtils.kt:40:9 'var statusBarColor: Int' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/utils/EdgeToEdgeUtils.kt:41:9 'var navigationBarColor: Int' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt:157:58 'val connectionInfo: WifiInfo!' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/utils/SecurePrefs.kt:7:8 'class EncryptedSharedPreferences : Any, SharedPreferences' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/utils/SecurePrefs.kt:8:8 'class MasterKey : Any' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/utils/SecurePrefs.kt:37:14 'fun <P : Any!> getPrimitive(targetClassObject: Class<P!>!): P!' is deprecated. Deprecated in Java.
+w: file:///app/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt:87:39 Unnecessary safe call on a non-null receiver of type 'String'.
+
+[Incubating] Problems report is available at: file:///app/build/reports/problems/problems-report.html
+
+BUILD SUCCESSFUL in 3m 53s
+15 actionable tasks: 4 executed, 11 up-to-date
+Configuration cache entry stored.
+The remote build cache was disabled during the build due to errors.


### PR DESCRIPTION
This change refactors `TeamCoursesAdapter` to eliminate direct dependencies on Realm and SharedPreferences, aligning with the project's goal of moving data operations to the Repository layer.

Key changes:
- `TeamsRepository`: Added `getTeamCreator(teamId)` and `getCourses(teamId)` to abstract data retrieval.
- `TeamsRepositoryImpl`: Implemented the new methods, querying `RealmMyTeam` for creator ID and `RealmMyCourse` for courses.
- `TeamCoursesFragment`: Now fetches courses and team creator ID using `teamsRepository` in a coroutine and passes them to the adapter. This removes the direct Realm query from the fragment (except for `mRealm` usage in other parts of `BaseTeamFragment` which was not scope of this task).
- `TeamCoursesAdapter`: Now takes `teamCreatorId` and `currentUserId` as constructor arguments. Logic for hiding the remove button now relies on these passed strings. Removed `Realm` and `SharedPreferences` from the adapter.

This ensures better separation of concerns and makes the adapter easier to test and maintain.

---
*PR created automatically by Jules for task [10551082232707700307](https://jules.google.com/task/10551082232707700307) started by @dogi*