### PR TITLE
Refactor: Move dto package content to model package

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseTeamFragment.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUser
-import org.ole.planet.myplanet.model.dto.Team
+import org.ole.planet.myplanet.model.Team
 import org.ole.planet.myplanet.repository.TeamsRepository
 
 @AndroidEntryPoint

--- a/app/src/main/java/org/ole/planet/myplanet/model/ChatShareTargets.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ChatShareTargets.kt
@@ -1,7 +1,5 @@
 package org.ole.planet.myplanet.model
 
-import org.ole.planet.myplanet.model.dto.Team
-
 data class ChatShareTargets(
     val community: Team?,
     val teams: List<RealmMyTeam>,

--- a/app/src/main/java/org/ole/planet/myplanet/model/Member.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Member.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.model.dto
+package org.ole.planet.myplanet.model
 
 data class Member(
     val id: String?,

--- a/app/src/main/java/org/ole/planet/myplanet/model/ModelMappers.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ModelMappers.kt
@@ -1,8 +1,6 @@
-package org.ole.planet.myplanet.model.dto
+package org.ole.planet.myplanet.model
 
 import io.realm.RealmList
-import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.model.RealmUser
 
 fun RealmMyTeam.toDto(): Team {
     return Team(

--- a/app/src/main/java/org/ole/planet/myplanet/model/Team.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Team.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.model.dto
+package org.ole.planet.myplanet.model
 
 data class Team(
     val _id: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -38,7 +38,7 @@ interface TeamsRepository {
     suspend fun getTeamByDocumentIdOrTeamId(id: String): RealmMyTeam?
     suspend fun getTeamByIdOrTeamId(id: String): RealmMyTeam?
     suspend fun getTeamLinks(): List<RealmMyTeam>
-    suspend fun getTeamById(teamId: String): org.ole.planet.myplanet.model.dto.Team?
+    suspend fun getTeamById(teamId: String): org.ole.planet.myplanet.model.Team?
     suspend fun getTaskTeamInfo(taskId: String): Triple<String, String, String>?
     suspend fun getJoinRequestTeamId(requestId: String): String?
     suspend fun getTaskNotifications(userId: String?): List<Triple<String, String, String>>
@@ -121,7 +121,7 @@ interface TeamsRepository {
     ): Result<Unit>
     suspend fun respondToMemberRequest(teamId: String, userId: String, accept: Boolean): Result<Unit>
     suspend fun getTeamType(teamId: String): String?
-    suspend fun getJoinedMembers(teamId: String): List<org.ole.planet.myplanet.model.dto.Member>
+    suspend fun getJoinedMembers(teamId: String): List<org.ole.planet.myplanet.model.Member>
     suspend fun getJoinedMembersWithVisitInfo(teamId: String): List<JoinedMemberData>
     suspend fun getJoinedMemberCount(teamId: String): Int
     suspend fun getAssignee(userId: String): RealmUser?

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -31,11 +31,11 @@ import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.Transaction
-import org.ole.planet.myplanet.model.dto.Member
-import org.ole.planet.myplanet.model.dto.Team
-import org.ole.planet.myplanet.model.dto.toDto
-import org.ole.planet.myplanet.model.dto.toMemberDto
-import org.ole.planet.myplanet.model.dto.toRealmUser
+import org.ole.planet.myplanet.model.Member
+import org.ole.planet.myplanet.model.Team
+import org.ole.planet.myplanet.model.toDto
+import org.ole.planet.myplanet.model.toMemberDto
+import org.ole.planet.myplanet.model.toRealmUser
 import org.ole.planet.myplanet.services.UploadManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryAdapter.kt
@@ -24,7 +24,7 @@ import org.ole.planet.myplanet.model.RealmConversation
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUser
-import org.ole.planet.myplanet.model.dto.Team
+import org.ole.planet.myplanet.model.Team
 import org.ole.planet.myplanet.ui.teams.TeamsSelectionAdapter
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.JsonUtils

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardViewModel.kt
@@ -108,7 +108,7 @@ class BellDashboardViewModel @Inject constructor(
         return reachable
     }
 
-    suspend fun getTeamById(teamId: String): org.ole.planet.myplanet.model.dto.Team? = teamsRepository.getTeamById(teamId)
+    suspend fun getTeamById(teamId: String): org.ole.planet.myplanet.model.Team? = teamsRepository.getTeamById(teamId)
 }
 
 data class CourseCompletion(val courseId: String?, val courseTitle: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -40,7 +40,7 @@ import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.User
-import org.ole.planet.myplanet.model.dto.Member
+import org.ole.planet.myplanet.model.Member
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.services.ThemeManager
 import org.ole.planet.myplanet.ui.community.HomeCommunityDialogFragment

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/PlanFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/PlanFragment.kt
@@ -20,8 +20,8 @@ import org.ole.planet.myplanet.databinding.AlertCreateTeamBinding
 import org.ole.planet.myplanet.databinding.FragmentPlanBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.dto.Team
-import org.ole.planet.myplanet.model.dto.toDto
+import org.ole.planet.myplanet.model.Team
+import org.ole.planet.myplanet.model.toDto
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 import org.ole.planet.myplanet.utils.Utilities
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
@@ -29,8 +29,8 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TableDataUpdate
-import org.ole.planet.myplanet.model.dto.Team
-import org.ole.planet.myplanet.model.dto.toDto
+import org.ole.planet.myplanet.model.Team
+import org.ole.planet.myplanet.model.toDto
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
@@ -34,8 +34,8 @@ import org.ole.planet.myplanet.databinding.FragmentTeamsTasksBinding
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUser
-import org.ole.planet.myplanet.model.dto.Member
-import org.ole.planet.myplanet.model.dto.toMemberDto
+import org.ole.planet.myplanet.model.Member
+import org.ole.planet.myplanet.model.toMemberDto
 import org.ole.planet.myplanet.ui.user.MemberArrayAdapter
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
@@ -19,8 +19,8 @@ import org.ole.planet.myplanet.base.BaseTeamFragment
 import org.ole.planet.myplanet.databinding.FragmentDiscussionListBinding
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.dto.Team
-import org.ole.planet.myplanet.model.dto.toDto
+import org.ole.planet.myplanet.model.Team
+import org.ole.planet.myplanet.model.toDto
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/MemberArrayAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/MemberArrayAdapter.kt
@@ -11,7 +11,7 @@ import android.widget.TextView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.model.dto.Member
+import org.ole.planet.myplanet.model.Member
 import org.ole.planet.myplanet.utils.TimeUtils
 
 class MemberArrayAdapter(activity: Activity, val view: Int, var list: List<Member>) : ArrayAdapter<Member>(activity, view, list) {


### PR DESCRIPTION
Moved Member.kt, Team.kt, and ModelMappers.kt from org.ole.planet.myplanet.model.dto to org.ole.planet.myplanet.model. Updated package declarations and imports throughout the codebase. Removed the now empty dto directory.