### PR TITLE
Migrate InlineResourceAdapter to ListAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -165,9 +165,10 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
         fragmentCourseStepBinding.tvResourcesHeader.visibility = View.VISIBLE
         fragmentCourseStepBinding.rvInlineResources.visibility = View.VISIBLE
 
-        inlineResourceAdapter = InlineResourceAdapter(resources) { library ->
+        inlineResourceAdapter = InlineResourceAdapter { library ->
             openResource(library)
         }
+        inlineResourceAdapter?.submitList(resources)
         fragmentCourseStepBinding.rvInlineResources.apply {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = inlineResourceAdapter

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -9,6 +9,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.graphics.createBitmap
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -25,9 +27,18 @@ import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
 
 class InlineResourceAdapter(
-    private var resources: List<RealmMyLibrary>,
     private val onResourceClick: (RealmMyLibrary) -> Unit
-) : RecyclerView.Adapter<InlineResourceAdapter.ViewHolder>() {
+) : ListAdapter<RealmMyLibrary, InlineResourceAdapter.ViewHolder>(DiffCallback) {
+
+    object DiffCallback : DiffUtil.ItemCallback<RealmMyLibrary>() {
+        override fun areItemsTheSame(oldItem: RealmMyLibrary, newItem: RealmMyLibrary): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: RealmMyLibrary, newItem: RealmMyLibrary): Boolean {
+            return oldItem._rev == newItem._rev
+        }
+    }
 
     class ViewHolder(val binding: ItemInlineResourceBinding) : RecyclerView.ViewHolder(binding.root)
 
@@ -39,7 +50,7 @@ class InlineResourceAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val resource = resources[position]
+        val resource = getItem(position)
         val context = holder.itemView.context
         val binding = holder.binding
 
@@ -200,10 +211,7 @@ class InlineResourceAdapter(
         }
     }
 
-    override fun getItemCount(): Int = resources.size
-
     fun updateResources(newResources: List<RealmMyLibrary>) {
-        resources = newResources
-        notifyDataSetChanged()
+        submitList(newResources)
     }
 }


### PR DESCRIPTION
This PR migrates `InlineResourceAdapter` to use `ListAdapter` and `DiffUtil` for efficient list updates. This replaces the previous `RecyclerView.Adapter` implementation which relied on `notifyDataSetChanged`. The adapter now compares items based on `id` and `_rev`. Callers in `CourseStepFragment` have been updated to use `submitList`.

---
*PR created automatically by Jules for task [16826337188593635157](https://jules.google.com/task/16826337188593635157) started by @dogi*