### PR TITLE
Refactor Feedback Sync Logic to ViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -14,6 +14,7 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.OnBaseRealtimeSyncListener
 import org.ole.planet.myplanet.callback.OnFeedbackSubmittedListener
@@ -100,11 +101,11 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.syncStatus.collect { status ->
                     when (status) {
-                        is FeedbackListViewModel.SyncStatus.Idle -> {
+                        is SyncManager.SyncStatus.Idle -> {
                             customProgressDialog?.dismiss()
                             customProgressDialog = null
                         }
-                        is FeedbackListViewModel.SyncStatus.Syncing -> {
+                        is SyncManager.SyncStatus.Syncing -> {
                             if (customProgressDialog == null) {
                                 customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
                                 customProgressDialog?.setText(getString(R.string.syncing_feedback))
@@ -113,11 +114,11 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
                                 customProgressDialog?.show()
                             }
                         }
-                        is FeedbackListViewModel.SyncStatus.Success -> {
+                        is SyncManager.SyncStatus.Success -> {
                             customProgressDialog?.dismiss()
                             customProgressDialog = null
                         }
-                        is FeedbackListViewModel.SyncStatus.Error -> {
+                        is SyncManager.SyncStatus.Error -> {
                             customProgressDialog?.dismiss()
                             customProgressDialog = null
                             Snackbar.make(binding.root, "Sync failed: ${status.message}", Snackbar.LENGTH_LONG)


### PR DESCRIPTION
Moved sync logic from `FeedbackListFragment` to `FeedbackListViewModel` to improve separation of concerns and testability.
The ViewModel now handles:
- Checking if sync is needed based on preferences.
- Checking server reachability.
- Starting `SyncManager`.
- Updating sync status and preferences on completion.

The Fragment now only observes the `syncStatus` StateFlow and updates the UI (ProgressDialog, Snackbar) accordingly.
Cleaned up unused dependencies in the Fragment.

---
*PR created automatically by Jules for task [16643255482502207681](https://jules.google.com/task/16643255482502207681) started by @dogi*