### PR TITLE
Refactor userModel usage in BaseResourceFragment receiver (fixes #11423)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -125,7 +125,7 @@ abstract class BaseResourceFragment : Fragment() {
             this@BaseResourceFragment.lifecycleScope.launch {
                 try {
                     val list = resourcesRepository.getDownloadSuggestionList(
-                        profileDbHandler.userModel?.id
+                        profileDbHandler.getUserModel()?.id
                     )
                     showDownloadDialog(list)
                 } finally {


### PR DESCRIPTION
Refactor userModel usage in BaseResourceFragment receiver

Replaced deprecated `profileDbHandler.userModel?.id` with `profileDbHandler.getUserModel()?.id` inside the `BroadcastReceiver`'s `lifecycleScope.launch` block in `BaseResourceFragment.kt`. This ensures the user model is retrieved asynchronously, avoiding potential issues with synchronous property access.

---
*PR created automatically by Jules for task [2232816436718065667](https://jules.google.com/task/2232816436718065667) started by @dogi*