### PR TITLE
Annotate deprecated override in TeamsRepositoryImpl

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -299,6 +299,7 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
 
+    @Deprecated("Use getTeamTransactionsWithBalance instead", ReplaceWith("getTeamTransactionsWithBalance(teamId, startDate, endDate, sortAscending)"))
     override suspend fun getTeamTransactions(
         teamId: String,
         startDate: Long?,


### PR DESCRIPTION
Annotated the `getTeamTransactions` method in `TeamsRepositoryImpl` with `@Deprecated` to resolve a compiler warning. The annotation matches the one defined in the `TeamsRepository` interface.

---
*PR created automatically by Jules for task [882732624089177683](https://jules.google.com/task/882732624089177683) started by @dogi*