### PR TITLE
Remove redundant Elvis operator in ProcessUserDataActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -300,7 +300,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
     }
 
     fun saveUserInfoPref(settings: SharedPreferences, password: String?, user: RealmUser?) {
-        this.settings = settings ?: appPreferences
+        this.settings = settings
         settings.edit {
             putString("userId", user?.id)
             putString("name", user?.name)


### PR DESCRIPTION
Removed redundant Elvis operator in `ProcessUserDataActivity.kt` as `settings` parameter is non-nullable. Verified by compiling the project.

---
*PR created automatically by Jules for task [2962840155690578483](https://jules.google.com/task/2962840155690578483) started by @dogi*