### PR TITLE
Refactor RetryQueue to use RetryOperationRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -45,6 +45,8 @@ import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.UserRepositoryImpl
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.repository.VoicesRepositoryImpl
+import org.ole.planet.myplanet.repository.RetryOperationRepository
+import org.ole.planet.myplanet.repository.RetryOperationRepositoryImpl
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -129,4 +131,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindVoicesRepository(impl: VoicesRepositoryImpl): VoicesRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindRetryOperationRepository(impl: RetryOperationRepositoryImpl): RetryOperationRepository
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RetryOperationRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RetryOperationRepository.kt
@@ -1,0 +1,28 @@
+package org.ole.planet.myplanet.repository
+
+import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.services.upload.UploadError
+
+interface RetryOperationRepository {
+    suspend fun findPending(itemId: String, uploadType: String): RealmRetryOperation?
+    suspend fun getPendingOperations(): List<RealmRetryOperation>
+    suspend fun getPendingCount(): Long
+    suspend fun addOperation(
+        uploadType: String,
+        error: UploadError,
+        payload: String,
+        endpoint: String,
+        httpMethod: String,
+        dbId: String?,
+        modelClassName: String,
+        userId: String?
+    )
+    suspend fun updateOperation(operation: RealmRetryOperation)
+    suspend fun markInProgress(id: String)
+    suspend fun markCompleted(id: String)
+    suspend fun markFailed(id: String, errorMessage: String?, httpCode: Int?)
+    suspend fun cleanupCompleted()
+    suspend fun resetAllPending()
+    suspend fun clearQueue()
+    suspend fun recoverStuck()
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RetryOperationRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RetryOperationRepositoryImpl.kt
@@ -1,0 +1,123 @@
+package org.ole.planet.myplanet.repository
+
+import javax.inject.Inject
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.services.upload.UploadError
+
+class RetryOperationRepositoryImpl @Inject constructor(
+    databaseService: DatabaseService
+) : RealmRepository(databaseService), RetryOperationRepository {
+
+    override suspend fun findPending(itemId: String, uploadType: String): RealmRetryOperation? {
+        return queryList(RealmRetryOperation::class.java) {
+            equalTo("itemId", itemId)
+            equalTo("uploadType", uploadType)
+            notEqualTo("status", RealmRetryOperation.STATUS_COMPLETED)
+            notEqualTo("status", RealmRetryOperation.STATUS_ABANDONED)
+        }.firstOrNull()
+    }
+
+    override suspend fun getPendingOperations(): List<RealmRetryOperation> {
+        return withRealm { realm ->
+            RealmRetryOperation.getPendingOperations(realm)
+        }
+    }
+
+    override suspend fun getPendingCount(): Long {
+        return withRealm { realm ->
+            RealmRetryOperation.getFailedOperationsCount(realm)
+        }
+    }
+
+    override suspend fun addOperation(
+        uploadType: String,
+        error: UploadError,
+        payload: String,
+        endpoint: String,
+        httpMethod: String,
+        dbId: String?,
+        modelClassName: String,
+        userId: String?
+    ) {
+        executeTransaction { realm ->
+            RealmRetryOperation.createFromUploadError(
+                realm, uploadType, error, payload, endpoint,
+                httpMethod, dbId, modelClassName, userId
+            )
+        }
+    }
+
+    override suspend fun updateOperation(operation: RealmRetryOperation) {
+        save(operation)
+    }
+
+    override suspend fun markInProgress(id: String) {
+        update(RealmRetryOperation::class.java, "id", id) { op ->
+            op.status = RealmRetryOperation.STATUS_IN_PROGRESS
+        }
+    }
+
+    override suspend fun markCompleted(id: String) {
+        update(RealmRetryOperation::class.java, "id", id) { op ->
+            op.status = RealmRetryOperation.STATUS_COMPLETED
+            op.lastAttemptTime = System.currentTimeMillis()
+        }
+    }
+
+    override suspend fun markFailed(id: String, errorMessage: String?, httpCode: Int?) {
+        update(RealmRetryOperation::class.java, "id", id) { op ->
+            op.attemptCount += 1
+            op.lastAttemptTime = System.currentTimeMillis()
+            op.errorMessage = errorMessage
+            op.httpCode = httpCode
+
+            if (op.attemptCount >= op.maxAttempts) {
+                op.status = RealmRetryOperation.STATUS_ABANDONED
+            } else {
+                op.status = RealmRetryOperation.STATUS_PENDING
+                op.nextRetryTime = RealmRetryOperation.calculateNextRetryTime(op.attemptCount)
+            }
+        }
+    }
+
+    override suspend fun cleanupCompleted() {
+        executeTransaction { realm ->
+            RealmRetryOperation.cleanupCompletedOperations(realm)
+        }
+    }
+
+    override suspend fun resetAllPending() {
+        executeTransaction { realm ->
+            val pending = realm.where(RealmRetryOperation::class.java)
+                .equalTo("status", RealmRetryOperation.STATUS_PENDING)
+                .findAll()
+            for (op in pending) {
+                op.nextRetryTime = System.currentTimeMillis()
+            }
+        }
+    }
+
+    override suspend fun clearQueue() {
+        executeTransaction { realm ->
+            realm.where(RealmRetryOperation::class.java)
+                .equalTo("status", RealmRetryOperation.STATUS_PENDING)
+                .or()
+                .equalTo("status", RealmRetryOperation.STATUS_ABANDONED)
+                .findAll()
+                .deleteAllFromRealm()
+        }
+    }
+
+    override suspend fun recoverStuck() {
+        executeTransaction { realm ->
+            val stuck = realm.where(RealmRetryOperation::class.java)
+                .equalTo("status", RealmRetryOperation.STATUS_IN_PROGRESS)
+                .findAll()
+            for (op in stuck) {
+                op.status = RealmRetryOperation.STATUS_PENDING
+                op.nextRetryTime = System.currentTimeMillis() + 60_000
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueue.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueue.kt
@@ -9,13 +9,13 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.repository.RetryOperationRepository
 import org.ole.planet.myplanet.services.upload.UploadError
 
 @Singleton
 class RetryQueue @Inject constructor(
-    private val databaseService: DatabaseService,
+    private val retryOperationRepository: RetryOperationRepository,
     @ApplicationContext private val context: Context
 ) {
     companion object {
@@ -46,41 +46,26 @@ class RetryQueue @Inject constructor(
             return
         }
 
-        val existingOperation = databaseService.withRealmAsync { realm ->
-            realm.where(RealmRetryOperation::class.java)
-                .equalTo("itemId", error.itemId)
-                .equalTo("uploadType", uploadType)
-                .notEqualTo("status", RealmRetryOperation.STATUS_COMPLETED)
-                .notEqualTo("status", RealmRetryOperation.STATUS_ABANDONED)
-                .findFirst()
-                ?.let { realm.copyFromRealm(it) }
-        }
+        val existingOperation = retryOperationRepository.findPending(error.itemId, uploadType)
 
         if (existingOperation != null) {
-            databaseService.executeTransactionAsync { realm ->
-                realm.where(RealmRetryOperation::class.java)
-                    .equalTo("id", existingOperation.id)
-                    .findFirst()?.let { op ->
-                        op.attemptCount += 1
-                        op.lastAttemptTime = System.currentTimeMillis()
-                        op.nextRetryTime = RealmRetryOperation.calculateNextRetryTime(op.attemptCount)
-                        op.errorMessage = error.message
-                        op.httpCode = error.httpCode
+            existingOperation.attemptCount += 1
+            existingOperation.lastAttemptTime = System.currentTimeMillis()
+            existingOperation.nextRetryTime = RealmRetryOperation.calculateNextRetryTime(existingOperation.attemptCount)
+            existingOperation.errorMessage = error.message
+            existingOperation.httpCode = error.httpCode
 
-                        if (op.attemptCount >= op.maxAttempts) {
-                            op.status = RealmRetryOperation.STATUS_ABANDONED
-                            Log.w(TAG, "Operation ${op.id} abandoned after ${op.maxAttempts} attempts")
-                        }
-                    }
+            if (existingOperation.attemptCount >= existingOperation.maxAttempts) {
+                existingOperation.status = RealmRetryOperation.STATUS_ABANDONED
+                Log.w(TAG, "Operation ${existingOperation.id} abandoned after ${existingOperation.maxAttempts} attempts")
             }
+            retryOperationRepository.updateOperation(existingOperation)
             Log.d(TAG, "Updated existing retry operation for item ${error.itemId}")
         } else {
-            databaseService.executeTransactionAsync { realm ->
-                RealmRetryOperation.createFromUploadError(
-                    realm, uploadType, error, payload.toString(), endpoint,
-                    httpMethod, dbId, modelClassName, userId
-                )
-            }
+            retryOperationRepository.addOperation(
+                uploadType, error, payload.toString(), endpoint,
+                httpMethod, dbId, modelClassName, userId
+            )
             Log.i(TAG, "RETRY_QUEUE: Queued new operation - type=$uploadType, itemId=${error.itemId}, error=${error.message}")
         }
     }
@@ -109,75 +94,32 @@ class RetryQueue @Inject constructor(
     }
 
     suspend fun getPendingOperations(): List<RealmRetryOperation> {
-        return databaseService.withRealmAsync { realm ->
-            RealmRetryOperation.getPendingOperations(realm)
-        }
+        return retryOperationRepository.getPendingOperations()
     }
 
     suspend fun getPendingCount(): Long {
-        return databaseService.withRealmAsync { realm ->
-            RealmRetryOperation.getFailedOperationsCount(realm)
-        }
+        return retryOperationRepository.getPendingCount()
     }
 
     suspend fun markInProgress(operationId: String) {
-        databaseService.executeTransactionAsync { realm ->
-            realm.where(RealmRetryOperation::class.java)
-                .equalTo("id", operationId)
-                .findFirst()?.let { op ->
-                    op.status = RealmRetryOperation.STATUS_IN_PROGRESS
-                }
-        }
+        retryOperationRepository.markInProgress(operationId)
     }
 
     suspend fun markCompleted(operationId: String) {
-        databaseService.executeTransactionAsync { realm ->
-            realm.where(RealmRetryOperation::class.java)
-                .equalTo("id", operationId)
-                .findFirst()?.let { op ->
-                    op.status = RealmRetryOperation.STATUS_COMPLETED
-                    op.lastAttemptTime = System.currentTimeMillis()
-                }
-        }
+        retryOperationRepository.markCompleted(operationId)
         Log.d(TAG, "Marked operation $operationId as completed")
     }
 
     suspend fun markFailed(operationId: String, errorMessage: String?, httpCode: Int?) {
-        databaseService.executeTransactionAsync { realm ->
-            realm.where(RealmRetryOperation::class.java)
-                .equalTo("id", operationId)
-                .findFirst()?.let { op ->
-                    op.attemptCount += 1
-                    op.lastAttemptTime = System.currentTimeMillis()
-                    op.errorMessage = errorMessage
-                    op.httpCode = httpCode
-
-                    if (op.attemptCount >= op.maxAttempts) {
-                        op.status = RealmRetryOperation.STATUS_ABANDONED
-                        Log.w(TAG, "Operation $operationId abandoned after ${op.maxAttempts} attempts")
-                    } else {
-                        op.status = RealmRetryOperation.STATUS_PENDING
-                        op.nextRetryTime = RealmRetryOperation.calculateNextRetryTime(op.attemptCount)
-                    }
-                }
-        }
+        retryOperationRepository.markFailed(operationId, errorMessage, httpCode)
     }
 
     suspend fun cleanup() {
-        databaseService.executeTransactionAsync { realm ->
-            RealmRetryOperation.cleanupCompletedOperations(realm)
-        }
+        retryOperationRepository.cleanupCompleted()
     }
 
     suspend fun resetAllPending() {
-        databaseService.executeTransactionAsync { realm ->
-            realm.where(RealmRetryOperation::class.java)
-                .equalTo("status", RealmRetryOperation.STATUS_PENDING)
-                .findAll()
-                .forEach { op ->
-                    op.nextRetryTime = System.currentTimeMillis()
-                }
-        }
+        retryOperationRepository.resetAllPending()
     }
 
     /**
@@ -196,15 +138,7 @@ class RetryQueue @Inject constructor(
                 return@withLock false
             }
 
-            databaseService.executeTransactionAsync { realm ->
-                // Only delete pending and abandoned, not in_progress or completed
-                realm.where(RealmRetryOperation::class.java)
-                    .equalTo("status", RealmRetryOperation.STATUS_PENDING)
-                    .or()
-                    .equalTo("status", RealmRetryOperation.STATUS_ABANDONED)
-                    .findAll()
-                    .deleteAllFromRealm()
-            }
+            retryOperationRepository.clearQueue()
             Log.i(TAG, "Queue cleared successfully")
             true
         }
@@ -215,14 +149,6 @@ class RetryQueue @Inject constructor(
      * Called on app startup to recover from crashes.
      */
     suspend fun recoverStuckOperations() {
-        databaseService.executeTransactionAsync { realm ->
-            realm.where(RealmRetryOperation::class.java)
-                .equalTo("status", RealmRetryOperation.STATUS_IN_PROGRESS)
-                .findAll()
-                .forEach { op ->
-                    op.status = RealmRetryOperation.STATUS_PENDING
-                    op.nextRetryTime = System.currentTimeMillis() + 60_000 // Retry in 1 minute
-                }
-        }
+        retryOperationRepository.recoverStuck()
     }
 }


### PR DESCRIPTION
Refactor RetryQueue to use RealmRepository base methods

1. Created `repository/RetryOperationRepository.kt` interface.
2. Created `repository/RetryOperationRepositoryImpl.kt` extending `RealmRepository`.
3. Added `@Binds` binding in `di/RepositoryModule.kt`.
4. Injected `RetryOperationRepository` into `RetryQueue` and replaced all raw Realm blocks.
5. Kept `RetryQueue` as the orchestration/business-logic layer.

---
*PR created automatically by Jules for task [9732247684226916380](https://jules.google.com/task/9732247684226916380) started by @dogi*