### PR TITLE
Replace deprecated getUserModel in UserSessionManager

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -236,8 +236,8 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     fun showPendingSurveyDialog() {
-        model = profileDbHandler.userModel
         viewLifecycleOwner.lifecycleScope.launch {
+            model = profileDbHandler.getUserModel()
             val list = submissionsRepository.getPendingSurveys(model?.id)
             if (list.isEmpty()) return@launch
             val exams = submissionsRepository.getExamMap(list)
@@ -371,12 +371,13 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     fun removeFromShelf(`object`: RealmObject) {
-        val userId = profileDbHandler.userModel?.id ?: model?.id
-        if (userId.isNullOrEmpty()) {
-            return
-        }
-
         lifecycleScope.launch {
+            val userModel = profileDbHandler.getUserModel()
+            val userId = userModel?.id ?: model?.id
+            if (userId.isNullOrEmpty()) {
+                return@launch
+            }
+
             if (`object` is RealmMyLibrary) {
                 val resourceId = `object`.resourceId
                 if (resourceId != null) {
@@ -415,9 +416,9 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     fun addAllToLibrary(libraryItems: List<RealmMyLibrary?>) {
-        val userId = profileDbHandler.userModel?.id ?: return
-        val validLibraryItems = libraryItems.filterNotNull()
         lifecycleScope.launch {
+            val userId = profileDbHandler.getUserModel()?.id ?: return@launch
+            val validLibraryItems = libraryItems.filterNotNull()
             resourcesRepository.addAllResourcesToUserLibrary(validLibraryItems, userId)
             Utilities.toast(activity, getString(R.string.added_to_my_library))
         }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
@@ -39,9 +39,11 @@ class UserSessionManager @Inject constructor(
     }
 
     @Deprecated("Use getUserModel() suspend function instead")
+    @get:Suppress("DEPRECATION")
     val userModel: RealmUser? get() = userRepository.getUserModel()
 
     @Deprecated("Use getUserModel() suspend function instead")
+    @Suppress("DEPRECATION")
     fun getUserModelCopy(): RealmUser? {
         return userRepository.getUserModel()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailFragment.kt
@@ -41,13 +41,13 @@ class CourseDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentCourseDetailBinding.inflate(inflater, container, false)
-        user = profileDbHandler.userModel
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewLifecycleOwner.lifecycleScope.launch {
+            user = profileDbHandler.getUserModel()
             courses = id?.takeIf { it.isNotBlank() }?.let { coursesRepository.getCourseByCourseId(it) }
             initRatingView("course", id ?: courses?.courseId, courses?.courseTitle, this@CourseDetailFragment)
             courses?.let { bindCourseData(it) }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -65,7 +65,6 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     private lateinit var orderByDate: Button
     private lateinit var orderByTitle: Button
     private lateinit var selectAll: CheckBox
-    var userModel: RealmUser ?= null
     lateinit var spnGrade: Spinner
     lateinit var spnSubject: Spinner
     lateinit var searchTags: MutableList<RealmTag>
@@ -215,7 +214,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                 adapterCourses = CoursesAdapter(
                     requireActivity(),
                     map,
-                    userModel,
+                    model,
                     tagsRepository
                 )
                 adapterCourses.submitList(sortedCourseList)
@@ -249,7 +248,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         val map = HashMap<String?, com.google.gson.JsonObject>()
         val progressMap = HashMap<String?, com.google.gson.JsonObject>()
 
-        adapterCourses = CoursesAdapter(requireActivity(), map, userModel, tagsRepository)
+        adapterCourses = CoursesAdapter(requireActivity(), map, model, tagsRepository)
         adapterCourses.submitList(courseList) {
             if (isAdded && view != null && ::selectAll.isInitialized) {
                 selectedItems?.clear()
@@ -269,7 +268,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         additionalSetup()
         setupMyProgressButton()
         viewLifecycleOwner.lifecycleScope.launch {
-            userModel = userSessionManager.getUserModel()
+            model = userSessionManager.getUserModel()
             searchTags = ArrayList()
             initializeView()
             setupButtonVisibility()
@@ -440,7 +439,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
 
     private fun setupSelectAll() {
         selectAll = requireView().findViewById(R.id.selectAllCourse)
-        if (userModel?.isGuest() == true) {
+        if (model?.isGuest() == true) {
             tvAddToLib.visibility = View.GONE
             btnRemove.visibility = View.GONE
             btnArchive.visibility = View.GONE
@@ -491,7 +490,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             etSearch.visibility = View.VISIBLE
             requireView().findViewById<View>(R.id.filter).visibility = View.VISIBLE
             val allMyCourses = adapterCourses.currentList.all { it.isMyCourse }
-            if (userModel?.isGuest() == false) {
+            if (model?.isGuest() == false) {
                 selectAll.visibility = if (allMyCourses) View.GONE else View.VISIBLE
             }
         }
@@ -569,7 +568,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         builder.setMessage(msg)
         builder.setCancelable(true)
             .setPositiveButton(R.string.go_to_mycourses) { dialog: DialogInterface, _: Int ->
-                if (userModel?.id?.startsWith("guest") == true) {
+                if (model?.id?.startsWith("guest") == true) {
                     DialogUtils.guestDialog(requireContext(), profileDbHandler)
                 } else {
                     val fragment = CoursesFragment().apply {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -61,7 +61,6 @@ class BellDashboardFragment : BaseDashboardFragment() {
         val view = binding.root
         declareElements()
         onLoaded(view)
-        user = profileDbHandler.userModel
         return binding.root
     }
 
@@ -71,12 +70,15 @@ class BellDashboardFragment : BaseDashboardFragment() {
         binding.cardProfileBell.txtCommunityName.text = model?.planetCode
         setupNetworkStatusMonitoring()
         (activity as DashboardActivity?)?.supportActionBar?.hide()
-        observeCompletedCourses()
-        if((user?.id?.startsWith("guest") != true) && !DashboardActivity.isFromNotificationAction) {
-            checkPendingSurveys()
-        }
-        if (model?.id?.startsWith("guest") == false && TextUtils.isEmpty(model?.key)) {
-            syncKeyId()
+        viewLifecycleOwner.lifecycleScope.launch {
+            user = profileDbHandler.getUserModel()
+            observeCompletedCourses()
+            if ((user?.id?.startsWith("guest") != true) && !DashboardActivity.isFromNotificationAction) {
+                checkPendingSurveys()
+            }
+            if (model?.id?.startsWith("guest") == false && TextUtils.isEmpty(model?.key)) {
+                syncKeyId()
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -141,18 +141,18 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         postponeEnterTransition()
-        user = userSessionManager.userModel
         initViews()
         notificationManager = NotificationUtils.getInstance(this)
-        checkUser()
-        updateAppTitle()
-        if (handleGuestAccess()) return
-
-        handleInitialFragment()
-        addBackPressCallback()
-        collectUiState()
 
         lifecycleScope.launch {
+            user = userSessionManager.getUserModel()
+            checkUser()
+            updateAppTitle()
+            if (handleGuestAccess()) return@launch
+
+            handleInitialFragment()
+            addBackPressCallback()
+            collectUiState()
             initializeDashboard()
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -616,23 +616,26 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
                 prefData.setSavedUsers(existingUsers)
             }
         } else if (source === "member") {
-            var userProfile = profileDbHandler.userModel?.userImage
-            val userName: String? = profileDbHandler.userModel?.name
-            if (userProfile == null) {
-                userProfile = ""
-            }
-            val newUser = User(userName, name, password, userProfile, "member")
-            val existingUsers: MutableList<User> = ArrayList(prefData.getSavedUsers())
-            var newUserExists = false
-            for ((fullName1) in existingUsers) {
-                if (fullName1 == newUser.fullName?.trim { it <= ' ' }) {
-                    newUserExists = true
-                    break
+            lifecycleScope.launch {
+                val userModel = profileDbHandler.getUserModel()
+                var userProfile = userModel?.userImage
+                val userName: String? = userModel?.name
+                if (userProfile == null) {
+                    userProfile = ""
                 }
-            }
-            if (!newUserExists) {
-                existingUsers.add(newUser)
-                prefData.setSavedUsers(existingUsers)
+                val newUser = User(userName, name, password, userProfile, "member")
+                val existingUsers: MutableList<User> = ArrayList(prefData.getSavedUsers())
+                var newUserExists = false
+                for ((fullName1) in existingUsers) {
+                    if (fullName1 == newUser.fullName?.trim { it <= ' ' }) {
+                        newUserExists = true
+                        break
+                    }
+                }
+                if (!newUserExists) {
+                    existingUsers.add(newUser)
+                    prefData.setSavedUsers(existingUsers)
+                }
             }
         }
     }


### PR DESCRIPTION
This PR addresses the deprecation of `UserSessionManager.userModel` and `UserSessionManager.getUserModelCopy()` by migrating call sites to the suspend function `getUserModel()`.

Key changes:
- Suppressed deprecation warnings in `UserSessionManager` for backward compatibility.
- Updated `DashboardActivity` to initialize `user` asynchronously in `onCreate`.
- Updated `BellDashboardFragment` and `CourseDetailFragment` to initialize `user` asynchronously in `onViewCreated`.
- Updated `LoginActivity.saveUsers` to use `lifecycleScope.launch`.
- Updated `BaseResourceFragment` methods (`showPendingSurveyDialog`, `removeFromShelf`, `addAllToLibrary`) to use `lifecycleScope`.
- Refactored `CoursesFragment` to remove redundant `userModel` property and use the inherited `model` property which is populated by `BaseRecyclerFragment`.


---
*PR created automatically by Jules for task [14619969206325487087](https://jules.google.com/task/14619969206325487087) started by @dogi*