### PR TITLE
Refactor SyncTimeLogger to use direct access for alternativeUrl

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
@@ -84,19 +84,18 @@ object SyncTimeLogger {
                 mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
 
             if (!primaryAvailable && alternativeAvailable) {
-                mapping.alternativeUrl?.let { alternativeUrl ->
-                    val uri = updateUrl.toUri()
-                    val editor = settings.edit()
+                val alternativeUrl = mapping.alternativeUrl!!
+                val uri = updateUrl.toUri()
+                val editor = settings.edit()
 
 
-                    serverUrlMapper.updateUrlPreferences(
-                        editor,
-                        uri,
-                        alternativeUrl,
-                        mapping.primaryUrl,
-                        settings
-                    )
-                }
+                serverUrlMapper.updateUrlPreferences(
+                    editor,
+                    uri,
+                    alternativeUrl,
+                    mapping.primaryUrl,
+                    settings
+                )
             }
             try {
                 uploadManager?.uploadCrashLog()


### PR DESCRIPTION
Refactored `SyncTimeLogger.saveSummaryToRealm` to remove an unnecessary safe call chain when accessing `mapping.alternativeUrl`. 
The `alternativeAvailable` boolean flag, calculated via `mapping.alternativeUrl?.let { ... } == true`, guarantees that `mapping.alternativeUrl` is non-null when true. 
Therefore, the nested `let` block was replaced with a direct assignment `val alternativeUrl = mapping.alternativeUrl!!`, flattening the conditional block.

---
*PR created automatically by Jules for task [8832980764460675651](https://jules.google.com/task/8832980764460675651) started by @dogi*