### PR TITLE
Refactor: Update deprecated user methods in UserRepositoryImpl

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -69,10 +69,6 @@ interface UserRepository {
         currentUser: RealmUser
     ): HealthRecord?
 
-    @Deprecated("Use getUserModelSuspending() instead")
-    fun getUserModel(): RealmUser?
-    @Deprecated("Use getUserModelSuspending() instead")
-    fun getCurrentUser(): RealmUser?
     suspend fun getUserModelSuspending(): RealmUser?
     suspend fun getUserProfile(): RealmUser?
     suspend fun getUserImageUrl(): String?

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -13,6 +13,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.ole.planet.myplanet.R
@@ -48,11 +49,6 @@ class UserRepositoryImpl @Inject constructor(
                 .findFirst()
                 ?.let { realm.copyFromRealm(it) }
         }
-    }
-
-    @Deprecated("Use getUserModelSuspending() instead")
-    override fun getCurrentUser(): RealmUser? {
-        return getUserModel()
     }
 
     override suspend fun getUserByAnyId(id: String): RealmUser? {
@@ -256,19 +252,6 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-    @Deprecated("Use getUserModelSuspending() instead")
-    override fun getUserModel(): RealmUser? {
-        val userId = settings.getString("userId", null)?.takeUnless { it.isBlank() } ?: return null
-        return databaseService.withRealm { realm ->
-            realm.where(RealmUser::class.java)
-                .equalTo("id", userId)
-                .or()
-                .equalTo("_id", userId)
-                .findFirst()
-                ?.let { realm.copyFromRealm(it) }
-        }
-    }
-
     override suspend fun getUserModelSuspending(): RealmUser? {
         val userId = settings.getString("userId", null)?.takeUnless { it.isBlank() } ?: return null
         return withRealm { realm ->
@@ -392,8 +375,8 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     @Deprecated("Use getActiveUserIdSuspending() instead")
-    override fun getActiveUserId(): String {
-        return getUserModel()?.id ?: ""
+    override fun getActiveUserId(): String = runBlocking {
+        getActiveUserIdSuspending()
     }
 
     override suspend fun getActiveUserIdSuspending(): String {

--- a/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
@@ -38,14 +38,6 @@ class UserSessionManager @Inject constructor(
         }
     }
 
-    @Deprecated("Use getUserModel() suspend function instead")
-    val userModel: RealmUser? get() = userRepository.getUserModel()
-
-    @Deprecated("Use getUserModel() suspend function instead")
-    fun getUserModelCopy(): RealmUser? {
-        return userRepository.getUserModel()
-    }
-
     suspend fun getUserModel(): RealmUser? {
         return userRepository.getUserModelSuspending()
     }


### PR DESCRIPTION
Refactored UserRepositoryImpl and UserSessionManager to remove unused deprecated methods (getCurrentUser, getUserModel) and updated getActiveUserId to delegate to its suspend equivalent. Removed unused userModel property and getUserModelCopy from UserSessionManager.

---
*PR created automatically by Jules for task [1698348558377168896](https://jules.google.com/task/1698348558377168896) started by @dogi*