### PR TITLE
Refactor UserSessionManager to use getUserModelSuspending

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -120,7 +120,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
                 val settings = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
                 try {
                     val databaseService = (context.applicationContext as MainApplication).databaseService
-                    val model = userSessionManager.getUserModel()
+                    val model = userSessionManager.getUserModelSuspending()
                     databaseService.executeTransactionAsync { r ->
                         val log = r.createObject(RealmApkLog::class.java, "${UUID.randomUUID()}")
                         log.parentCode = settings.getString("parentCode", "")

--- a/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
@@ -38,15 +38,20 @@ class UserSessionManager @Inject constructor(
         }
     }
 
-    @Deprecated("Use getUserModel() suspend function instead")
+    @Deprecated("Use getUserModelSuspending() suspend function instead")
     val userModel: RealmUser? get() = userRepository.getUserModel()
 
-    @Deprecated("Use getUserModel() suspend function instead")
+    @Deprecated("Use getUserModelSuspending() suspend function instead")
     fun getUserModelCopy(): RealmUser? {
         return userRepository.getUserModel()
     }
 
+    @Deprecated("Use getUserModelSuspending() suspend function instead")
     suspend fun getUserModel(): RealmUser? {
+        return userRepository.getUserModelSuspending()
+    }
+
+    suspend fun getUserModelSuspending(): RealmUser? {
         return userRepository.getUserModelSuspending()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/PDFReaderActivity.kt
@@ -119,7 +119,7 @@ class PDFReaderActivity : AppCompatActivity(), OnAudioRecordListener {
         cancelAll(this)
         updateTranslation(outputFile)
         lifecycleScope.launch {
-            val userModel = userSessionManager.getUserModel()
+            val userModel = userSessionManager.getUserModelSuspending()
             if (userModel != null) {
                 AddResourceFragment.showAlert(
                     this@PDFReaderActivity,


### PR DESCRIPTION
This PR updates `UserSessionManager` to provide a clear `getUserModelSuspending()` method for asynchronous user model retrieval, replacing the ambiguous `getUserModel()` suspend function and deprecated property access. It also updates `MainApplication` and `PDFReaderActivity` to use this new method, ensuring safe and correct asynchronous user data access.


---
*PR created automatically by Jules for task [12136495957024135872](https://jules.google.com/task/12136495957024135872) started by @dogi*