### PR TITLE
Refactor TeamsRepositoryImpl to use suspending UserSessionManager methods

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -696,7 +696,7 @@ class TeamsRepositoryImpl @Inject constructor(
         if (task.sync.isNullOrBlank()) {
             val syncObj = JsonObject().apply {
                 addProperty("type", "local")
-                addProperty("planetCode", userSessionManager.getUserModel()?.planetCode)
+                addProperty("planetCode", userSessionManager.getUserModelSuspending()?.planetCode)
             }
             task.sync = gson.toJson(syncObj)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
@@ -50,6 +50,10 @@ class UserSessionManager @Inject constructor(
         return userRepository.getUserModelSuspending()
     }
 
+    suspend fun getUserModelSuspending(): RealmUser? {
+        return userRepository.getUserModelSuspending()
+    }
+
     fun onLogin() {
         onLoginAsync()
     }


### PR DESCRIPTION
This PR updates `TeamsRepositoryImpl` to use the suspending `getUserModelSuspending` method from `UserSessionManager` in `upsertTask`. It also adds `getUserModelSuspending` to `UserSessionManager` which delegates to `UserRepository`. Additionally, verified that `getJoinedMembersWithVisitInfo` correctly utilizes suspending functions for visit data retrieval.

---
*PR created automatically by Jules for task [1865392180185273950](https://jules.google.com/task/1865392180185273950) started by @dogi*