### PR TITLE
Follow-up: remove runBlocking from deprecated getActiveUserId

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -13,7 +13,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.ole.planet.myplanet.R
@@ -375,8 +374,8 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     @Deprecated("Use getActiveUserIdSuspending() instead")
-    override fun getActiveUserId(): String = runBlocking {
-        getActiveUserIdSuspending()
+    override fun getActiveUserId(): String {
+        return settings.getString("userId", null)?.takeUnless { it.isBlank() } ?: ""
     }
 
     override suspend fun getActiveUserIdSuspending(): String {


### PR DESCRIPTION
### Motivation
- Remove unnecessary `runBlocking` usage in the deprecated synchronous API `getActiveUserId()` to avoid blocking threads while preserving the existing synchronous contract.

### Description
- Changed `UserRepositoryImpl.getActiveUserId()` to return the persisted active user id directly from `SharedPreferences` via `settings.getString("userId", ...)` instead of calling the suspending API with `runBlocking`.
- Removed the now-unused `kotlinx.coroutines.runBlocking` import.

### Testing
- Ran `./gradlew :app:compileDebugKotlin` to validate compilation; the build failed in this environment due to an unresolved Gradle plugin (`org.gradle.toolchains.foojay-resolver-convention:1.0.0`) unrelated to the code change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1d9245b8832bbe4de93db9e3b83a)