### PR TITLE
Refactor SubmissionsRepository to remove PDF generation (fixes #11565)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -38,8 +38,6 @@ interface SubmissionsRepository {
     suspend fun isStepCompleted(stepId: String?, userId: String?): Boolean
     suspend fun getSurveysByCourseId(courseId: String): List<RealmStepExam>
     suspend fun hasUnfinishedSurveys(courseId: String, userId: String?): Boolean
-    suspend fun generateSubmissionPdf(context: android.content.Context, submissionId: String): java.io.File?
-    suspend fun generateMultipleSubmissionsPdf(context: android.content.Context, submissionIds: List<String>, examTitle: String): java.io.File?
     suspend fun addSubmissionPhoto(submissionId: String?, examId: String?, courseId: String?, memberId: String?, photoPath: String?)
     suspend fun createExamSubmission(userId: String?, userDob: String?, userGender: String?, exam: org.ole.planet.myplanet.model.RealmStepExam, type: String?, teamId: String?): RealmSubmission?
     suspend fun saveExamAnswer(submission: RealmSubmission?, question: org.ole.planet.myplanet.model.RealmExamQuestion, ans: String, listAns: Map<String, String>?, otherText: String?, otherVisible: Boolean, type: String, index: Int, total: Int, isExplicitSubmission: Boolean): Boolean

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
@@ -17,7 +17,7 @@ import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.utils.TimeUtils
 
-internal class SubmissionsRepositoryExporter @Inject constructor(private val databaseService: DatabaseService) {
+class SubmissionsRepositoryExporter @Inject constructor(private val databaseService: DatabaseService) {
 
     companion object {
         private const val PAGE_WIDTH = 595

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -29,7 +29,6 @@ import org.ole.planet.myplanet.utils.NetworkUtils
 
 class SubmissionsRepositoryImpl @Inject internal constructor(
     databaseService: DatabaseService,
-    private val submissionsRepositoryExporter: SubmissionsRepositoryExporter,
     private val teamsRepositoryProvider: Provider<TeamsRepository>
 ) : RealmRepository(databaseService), SubmissionsRepository {
 
@@ -425,18 +424,6 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
             }
         }
         return false
-    }
-
-    override suspend fun generateSubmissionPdf(context: android.content.Context, submissionId: String): java.io.File? {
-        return submissionsRepositoryExporter.generateSubmissionPdf(context, submissionId)
-    }
-
-    override suspend fun generateMultipleSubmissionsPdf(
-        context: android.content.Context,
-        submissionIds: List<String>,
-        examTitle: String
-    ): java.io.File? {
-        return submissionsRepositoryExporter.generateMultipleSubmissionsPdf(context, submissionIds, examTitle)
     }
 
     override suspend fun addSubmissionPhoto(

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionListFragment.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentSubmissionListBinding
 import org.ole.planet.myplanet.repository.SubmissionsRepository
+import org.ole.planet.myplanet.repository.SubmissionsRepositoryExporter
 import org.ole.planet.myplanet.utils.FileUtils
 
 @AndroidEntryPoint
@@ -25,6 +26,8 @@ class SubmissionListFragment : Fragment() {
     private val binding get() = _binding!!
     @Inject
     lateinit var submissionsRepository: SubmissionsRepository
+    @Inject
+    lateinit var submissionsRepositoryExporter: SubmissionsRepositoryExporter
     private var parentId: String? = null
     private var examTitle: String? = null
     private var userId: String? = null
@@ -89,7 +92,7 @@ class SubmissionListFragment : Fragment() {
     private fun generateSubmissionPdf(submissionId: String) {
         viewLifecycleOwner.lifecycleScope.launch {
             binding.progressBar.visibility = View.VISIBLE
-            val file = submissionsRepository.generateSubmissionPdf(requireContext(), submissionId)
+            val file = submissionsRepositoryExporter.generateSubmissionPdf(requireContext(), submissionId)
             binding.progressBar.visibility = View.GONE
 
             if (file != null) {
@@ -104,7 +107,7 @@ class SubmissionListFragment : Fragment() {
     private fun generateReport(submissionIds: List<String>) {
         viewLifecycleOwner.lifecycleScope.launch {
             binding.progressBar.visibility = View.VISIBLE
-            val file = submissionsRepository.generateMultipleSubmissionsPdf(
+            val file = submissionsRepositoryExporter.generateMultipleSubmissionsPdf(
                 requireContext(),
                 submissionIds,
                 examTitle ?: "Submissions"


### PR DESCRIPTION
Moved PDF generation logic out of `SubmissionsRepository` and `SubmissionsRepositoryImpl`.
Made `SubmissionsRepositoryExporter` public and injected it directly into `SubmissionListFragment`.
Updated `SubmissionListFragment` to use `SubmissionsRepositoryExporter` for PDF generation.
This change reduces the responsibilities of `SubmissionsRepository`, adhering to the Single Responsibility Principle.

---
*PR created automatically by Jules for task [6927749737767809298](https://jules.google.com/task/6927749737767809298) started by @dogi*