### PR TITLE
Remove deprecated RealmMyLibrary.removeDeletedResource (fixes #11596)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
@@ -194,43 +194,6 @@ open class RealmMyLibrary : RealmObject() {
             return list.map { it.resourceId }.toTypedArray()
         }
 
-        @Deprecated("Use ResourcesRepository.removeDeletedResources instead")
-        @JvmStatic
-        fun removeDeletedResource(newIds: List<String?>, mRealm: Realm) {
-            val startTime = System.currentTimeMillis()
-            val syncedResources = mRealm.where(RealmMyLibrary::class.java)
-                .isNotNull("_rev")
-                .equalTo("isPrivate", false)
-                .findAll()
-            val ids = syncedResources.map { it.resourceId }.toTypedArray()
-
-            val idsToDelete = ids.filterNot { it in newIds }
-
-            if (idsToDelete.isEmpty()) {
-                Log.d("PerformanceTest", "removeDeletedResource: No resources to delete")
-                return
-            }
-
-            Log.d("PerformanceTest", "removeDeletedResource: Starting batch delete of ${idsToDelete.size} resources")
-
-            // Single transaction for all deletes - massive performance improvement
-            val deleteStartTime = System.currentTimeMillis()
-            mRealm.executeTransaction { realm ->
-                idsToDelete.forEach { id ->
-                    realm.where(RealmMyLibrary::class.java)
-                        .equalTo("resourceId", id)
-                        .findAll()
-                        .deleteAllFromRealm()
-                }
-            }
-            val deleteEndTime = System.currentTimeMillis()
-
-            val totalTime = deleteEndTime - startTime
-            val transactionTime = deleteEndTime - deleteStartTime
-            Log.d("PerformanceTest", "removeDeletedResource: Completed in ${totalTime}ms (transaction: ${transactionTime}ms) for ${idsToDelete.size} items")
-            Log.d("PerformanceTest", "removeDeletedResource: Average ${totalTime / idsToDelete.size.coerceAtLeast(1)}ms per item")
-        }
-
         @JvmStatic
         fun serialize(personal: RealmMyLibrary, user: RealmUser?): JsonObject {
             return JsonObject().apply {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -377,7 +377,10 @@ class ResourcesRepositoryImpl @Inject constructor(
     override suspend fun removeDeletedResources(currentIds: List<String?>) {
         val validCurrentIds = currentIds.filterNotNull().toSet()
         executeTransaction { realm ->
-            val allResources = realm.where(RealmMyLibrary::class.java).findAll()
+            val allResources = realm.where(RealmMyLibrary::class.java)
+                .isNotNull("_rev")
+                .equalTo("isPrivate", false)
+                .findAll()
             val idsToDelete = allResources.mapNotNull { it.resourceId }.filter { it !in validCurrentIds }
 
             if (idsToDelete.isNotEmpty()) {


### PR DESCRIPTION
This PR removes the deprecated `RealmMyLibrary.removeDeletedResource` method as requested.
It also updates the replacement method `ResourcesRepositoryImpl.removeDeletedResources` to include necessary filters (`_rev` is not null and `isPrivate` is false) which were present in the deprecated method but missing in the repository implementation. This prevents potential data loss of local or private resources during sync.
Verified that the project compiles successfully with `compileLiteDebugKotlin`.

---
*PR created automatically by Jules for task [8268031560627764974](https://jules.google.com/task/8268031560627764974) started by @dogi*