### PR TITLE
Centralize shared upload call list and ensure synchronous execution

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/AutoSyncWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/AutoSyncWorker.kt
@@ -91,23 +91,7 @@ class AutoSyncWorker @AssistedInject constructor(
                 MainApplication.applicationScope.let { scope ->
                     scope.launch {
                         try {
-                            uploadManager.uploadExamResult(this@AutoSyncWorker)
-                            uploadManager.uploadFeedback()
-                            uploadManager.uploadAchievement()
-                            uploadManager.uploadResourceActivities("")
-                            uploadManager.uploadUserActivities(this@AutoSyncWorker)
-                            uploadManager.uploadCourseActivities()
-                            uploadManager.uploadSearchActivity()
-                            uploadManager.uploadRating()
-                            uploadManager.uploadResource(this@AutoSyncWorker)
-                            uploadManager.uploadNews()
-                            uploadManager.uploadTeams()
-                            uploadManager.uploadTeamTask()
-                            uploadManager.uploadMeetups()
-                            uploadManager.uploadAdoptedSurveys()
-                            uploadManager.uploadCrashLog()
-                            uploadManager.uploadSubmissions()
-                            uploadManager.uploadActivities(null)
+                            uploadManager.uploadEverything(this@AutoSyncWorker)
                         } catch (e: CancellationException) {
                             throw e
                         } catch (e: Exception) {

--- a/app/src/main/java/org/ole/planet/myplanet/services/FileUploader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/FileUploader.kt
@@ -3,10 +3,8 @@ package org.ole.planet.myplanet.services
 import com.google.gson.JsonObject
 import java.io.File
 import java.io.IOException
-import kotlinx.coroutines.launch
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
-import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.data.api.ApiClient
 import org.ole.planet.myplanet.data.api.ApiInterface
@@ -18,7 +16,7 @@ import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.UrlUtils
 
 open class FileUploader {
-    fun uploadAttachment(id: String, rev: String, personal: RealmMyPersonal, listener: OnSuccessListener) {
+    suspend fun uploadAttachment(id: String, rev: String, personal: RealmMyPersonal, listener: OnSuccessListener) {
         val f = personal.path?.let { File(it) }
         val name = FileUtils.getFileNameFromUrl(personal.path)
         if (f != null) {
@@ -26,7 +24,7 @@ open class FileUploader {
         }
     }
 
-    fun uploadAttachment(id: String, rev: String, personal: RealmMyLibrary, listener: OnSuccessListener) {
+    suspend fun uploadAttachment(id: String, rev: String, personal: RealmMyLibrary, listener: OnSuccessListener) {
         val f = personal.resourceLocalAddress?.let { File(it) }
         val name = FileUtils.getFileNameFromLocalAddress(personal.resourceLocalAddress)
         if (f != null) {
@@ -34,7 +32,7 @@ open class FileUploader {
         }
     }
 
-    fun uploadAttachment(id: String, rev: String, personal: RealmSubmitPhotos, listener: OnSuccessListener) {
+    suspend fun uploadAttachment(id: String, rev: String, personal: RealmSubmitPhotos, listener: OnSuccessListener) {
         val f = personal.photoLocation?.let { File(it) }
         val name = FileUtils.getFileNameFromUrl(personal.photoLocation)
         if (f != null) {
@@ -42,26 +40,25 @@ open class FileUploader {
         }
     }
 
-    private fun uploadDoc(id: String, rev: String, format: String, f: File, name: String, listener: OnSuccessListener) {
+    private suspend fun uploadDoc(id: String, rev: String, format: String, f: File, name: String, listener: OnSuccessListener) {
         val apiInterface = ApiClient.client.create(ApiInterface::class.java)
-        MainApplication.applicationScope.launch {
-            try {
-                val connection = f.toURI().toURL().openConnection()
-                val mimeType = connection.contentType
-                val body = FileUtils.fullyReadFileToBytes(f)
-                    .toRequestBody("application/octet-stream".toMediaTypeOrNull())
-                val url = String.format(format, UrlUtils.getUrl(), id, name)
 
-                try {
-                    val response = apiInterface.uploadResource(getHeaderMap(mimeType, rev), url, body)
-                    onDataReceived(response.body(), listener)
-                } catch (t: Exception) {
-                    listener.onSuccess("Unable to upload resource")
-                }
-            } catch (e: IOException) {
-                e.printStackTrace()
+        try {
+            val connection = f.toURI().toURL().openConnection()
+            val mimeType = connection.contentType
+            val body = FileUtils.fullyReadFileToBytes(f)
+                .toRequestBody("application/octet-stream".toMediaTypeOrNull())
+            val url = String.format(format, UrlUtils.getUrl(), id, name)
+
+            try {
+                val response = apiInterface.uploadResource(getHeaderMap(mimeType, rev), url, body)
+                onDataReceived(response.body(), listener)
+            } catch (t: Exception) {
                 listener.onSuccess("Unable to upload resource")
             }
+        } catch (e: IOException) {
+            e.printStackTrace()
+            listener.onSuccess("Unable to upload resource")
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -72,79 +72,101 @@ class UploadManager @Inject constructor(
     private val uploadConfigs: UploadConfigs
 ) : FileUploader() {
 
+    suspend fun uploadEverything(listener: OnSuccessListener?) {
+        uploadAchievement()
+        uploadNews()
+        uploadResourceActivities("")
+        uploadCourseActivities()
+        uploadSearchActivity()
+        uploadRating()
+        uploadTeamTask()
+        uploadMeetups()
+        uploadAdoptedSurveys()
+        uploadSubmissions()
+        uploadCrashLog()
+
+        val safeListener = listener ?: object : OnSuccessListener { override fun onSuccess(success: String?) {} }
+
+        uploadExamResult(safeListener)
+        uploadFeedback()
+        uploadUserActivities(safeListener)
+        uploadResource(safeListener)
+        uploadTeams()
+        uploadSubmitPhotos(safeListener)
+        uploadActivities(safeListener)
+    }
+
     private suspend fun uploadNewsActivities() {
         uploadCoordinator.upload(uploadConfigs.NewsActivities)
     }
 
-    fun uploadActivities(listener: OnSuccessListener?) {
+    suspend fun uploadActivities(listener: OnSuccessListener?) {
         val apiInterface = client.create(ApiInterface::class.java)
 
-        MainApplication.applicationScope.launch {
-            val model = userRepository.getUserModelSuspending() ?: run {
-                withContext(Dispatchers.Main) {
-                    listener?.onSuccess("Cannot upload activities: user model is null")
-                }
-                return@launch
+        val model = userRepository.getUserModelSuspending() ?: run {
+            withContext(Dispatchers.Main) {
+                listener?.onSuccess("Cannot upload activities: user model is null")
+            }
+            return
+        }
+
+        if (model.isManager()) {
+            withContext(Dispatchers.Main) {
+                listener?.onSuccess("Skipping activities upload for manager")
+            }
+            return
+        }
+
+        try {
+            try {
+                apiInterface.postDoc(
+                    UrlUtils.header,
+                    "application/json",
+                    "${UrlUtils.getUrl()}/myplanet_activities",
+                    MyPlanet.getNormalMyPlanetActivities(MainApplication.context, pref, model)
+                )
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
 
-            if (model.isManager()) {
-                withContext(Dispatchers.Main) {
-                    listener?.onSuccess("Skipping activities upload for manager")
-                }
-                return@launch
+            val response = try {
+                apiInterface.getJsonObject(
+                    UrlUtils.header,
+                    "${UrlUtils.getUrl()}/myplanet_activities/${getAndroidId(MainApplication.context)}@${NetworkUtils.getUniqueIdentifier()}"
+                )
+            } catch (e: Exception) {
+                null
+            }
+
+            var `object` = response?.body()
+
+            if (`object` != null) {
+                val usages = `object`.getAsJsonArray("usages")
+                usages.addAll(MyPlanet.getTabletUsages(context))
+                `object`.add("usages", usages)
+            } else {
+                `object` = MyPlanet.getMyPlanetActivities(context, pref, model)
             }
 
             try {
-                try {
-                    apiInterface.postDoc(
-                        UrlUtils.header,
-                        "application/json",
-                        "${UrlUtils.getUrl()}/myplanet_activities",
-                        MyPlanet.getNormalMyPlanetActivities(MainApplication.context, pref, model)
-                    )
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-
-                val response = try {
-                    apiInterface.getJsonObject(
-                        UrlUtils.header,
-                        "${UrlUtils.getUrl()}/myplanet_activities/${getAndroidId(MainApplication.context)}@${NetworkUtils.getUniqueIdentifier()}"
-                    )
-                } catch (e: Exception) {
-                    null
-                }
-
-                var `object` = response?.body()
-
-                if (`object` != null) {
-                    val usages = `object`.getAsJsonArray("usages")
-                    usages.addAll(MyPlanet.getTabletUsages(context))
-                    `object`.add("usages", usages)
-                } else {
-                    `object` = MyPlanet.getMyPlanetActivities(context, pref, model)
-                }
-
-                try {
-                    apiInterface.postDoc(
-                        UrlUtils.header,
-                        "application/json",
-                        "${UrlUtils.getUrl()}/myplanet_activities",
-                        `object`
-                    )
-                    withContext(Dispatchers.Main) {
-                        listener?.onSuccess("My planet activities uploaded successfully")
-                    }
-                } catch (e: Exception) {
-                    withContext(Dispatchers.Main) {
-                        listener?.onSuccess("Failed to upload activities: ${e.message}")
-                    }
+                apiInterface.postDoc(
+                    UrlUtils.header,
+                    "application/json",
+                    "${UrlUtils.getUrl()}/myplanet_activities",
+                    `object`
+                )
+                withContext(Dispatchers.Main) {
+                    listener?.onSuccess("My planet activities uploaded successfully")
                 }
             } catch (e: Exception) {
-                e.printStackTrace()
                 withContext(Dispatchers.Main) {
                     listener?.onSuccess("Failed to upload activities: ${e.message}")
                 }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            withContext(Dispatchers.Main) {
+                listener?.onSuccess("Failed to upload activities: ${e.message}")
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -219,12 +219,12 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
         customProgressDialog.show()
 
         applicationScope.launch(Dispatchers.IO) {
-            val asyncOperationsCounter = AtomicInteger(0)
-            val totalAsyncOperations = 6
             val activity = this@ProcessUserDataActivity
 
-            suspend fun checkAllOperationsComplete() {
-                if (asyncOperationsCounter.incrementAndGet() == totalAsyncOperations) {
+            uploadToShelfService.uploadUserData {
+                uploadToShelfService.uploadHealth()
+                applicationScope.launch(Dispatchers.IO) {
+                    uploadManager.uploadEverything(null)
                     withContext(Dispatchers.Main) {
                         if (!activity.isFinishing && !activity.isDestroyed) {
                             customProgressDialog.dismiss()
@@ -233,72 +233,6 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
                     }
                 }
             }
-
-            uploadManager.uploadAchievement()
-            uploadManager.uploadNews()
-            uploadManager.uploadResourceActivities("")
-            uploadManager.uploadCourseActivities()
-            uploadManager.uploadSearchActivity()
-            uploadManager.uploadTeams()
-            uploadManager.uploadRating()
-            uploadManager.uploadTeamTask()
-            uploadManager.uploadMeetups()
-            uploadManager.uploadAdoptedSurveys()
-            uploadManager.uploadSubmissions()
-            uploadManager.uploadCrashLog()
-
-            uploadToShelfService.uploadUserData {
-                uploadToShelfService.uploadHealth()
-                applicationScope.launch {
-                    checkAllOperationsComplete()
-                }
-            }
-
-            uploadManager.uploadUserActivities(object : OnSuccessListener {
-                override fun onSuccess(success: String?) {
-                    applicationScope.launch {
-                        checkAllOperationsComplete()
-                    }
-                }
-            })
-
-            uploadManager.uploadExamResult(object : OnSuccessListener {
-                override fun onSuccess(success: String?) {
-                    applicationScope.launch {
-                        checkAllOperationsComplete()
-                    }
-                }
-            })
-
-            applicationScope.launch(Dispatchers.IO) {
-                val success = uploadManager.uploadFeedback()
-                checkAllOperationsComplete()
-            }
-
-            uploadManager.uploadResource(object : OnSuccessListener {
-                override fun onSuccess(success: String?) {
-                    applicationScope.launch(Dispatchers.IO) {
-                        uploadManager.uploadTeams()
-                        checkAllOperationsComplete()
-                    }
-                }
-            })
-
-            uploadManager.uploadSubmitPhotos(object : OnSuccessListener {
-                override fun onSuccess(success: String?) {
-                    applicationScope.launch {
-                        checkAllOperationsComplete()
-                    }
-                }
-            })
-
-            uploadManager.uploadActivities(object : OnSuccessListener {
-                override fun onSuccess(success: String?) {
-                    applicationScope.launch {
-                        checkAllOperationsComplete()
-                    }
-                }
-            })
         }
     }
 


### PR DESCRIPTION
This change centralizes the duplicated upload logic found in `AutoSyncWorker` and `ProcessUserDataActivity` into a new `uploadEverything` method in `UploadManager`. It also refactors `FileUploader` and `uploadActivities` to be `suspend` functions, ensuring that the upload process is fully synchronous and reliable, preventing race conditions where the sync dialog might be dismissed before file uploads complete.

---
*PR created automatically by Jules for task [15812170591645086112](https://jules.google.com/task/15812170591645086112) started by @dogi*