### PR TITLE
Refactor chat sync insert logic to ChatRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
@@ -12,5 +12,6 @@ interface ChatRepository {
     suspend fun continueConversation(id: String, query: String, response: String, rev: String)
     suspend fun insertNewsFromJson(doc: JsonObject)
     suspend fun insertNewsList(docs: List<JsonObject>)
+    suspend fun syncInsertChatHistory(docs: List<JsonObject>)
     fun serializeNews(news: RealmNews): JsonObject
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -83,6 +83,14 @@ class ChatRepositoryImpl @Inject constructor(
         saveConcatenatedLinksToPrefs()
     }
 
+    override suspend fun syncInsertChatHistory(docs: List<JsonObject>) {
+        executeTransaction { mRealm ->
+            docs.forEach { doc ->
+                RealmChatHistory.insert(mRealm, doc)
+            }
+        }
+    }
+
     override suspend fun insertNewsFromJson(doc: JsonObject) {
         executeTransaction { mRealm ->
             insertNewsToRealm(mRealm, doc)

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -16,7 +16,6 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
-import org.ole.planet.myplanet.model.RealmChatHistory.Companion.insert
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.saveConcatenatedLinksToPrefs
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.insertCourseStepsExams
 import org.ole.planet.myplanet.model.RealmUser
@@ -234,15 +233,33 @@ class TransactionSyncManager @Inject constructor(
                         insertDuration,
                         arr.size()
                     )
+                } else if (table == "chat_history") {
+                    val insertStartTime = System.currentTimeMillis()
+                    val docs = mutableListOf<JsonObject>()
+                    for (j in arr) {
+                        var jsonDoc = j.asJsonObject
+                        jsonDoc = getJsonObject("doc", jsonDoc)
+                        val id = getString("_id", jsonDoc)
+                        if (!id.startsWith("_design")) {
+                            docs.add(jsonDoc)
+                        }
+                    }
+
+                    chatRepository.syncInsertChatHistory(docs)
+
+                    val insertDuration = System.currentTimeMillis() - insertStartTime
+                    org.ole.planet.myplanet.utils.SyncTimeLogger.logRealmOperation(
+                        "insert_batch",
+                        table,
+                        insertDuration,
+                        arr.size()
+                    )
                 } else {
                     // Use async transaction to avoid blocking (ANR-safe)
                     databaseService.withRealm { realm ->
                         realm.executeTransactionAsync { mRealm: Realm ->
                             val insertStartTime = System.currentTimeMillis()
 
-                            if (table == "chat_history") {
-                                insertToChat(arr, mRealm)
-                            }
                             insertDocs(arr, mRealm, table)
 
                             val insertDuration = System.currentTimeMillis() - insertStartTime
@@ -279,19 +296,6 @@ class TransactionSyncManager @Inject constructor(
             e.printStackTrace()
             val failDuration = System.currentTimeMillis() - syncStartTime
             android.util.Log.d("SyncPerf", "  ✗ Failed $table sync after ${failDuration}ms: ${e.message}")
-        }
-    }
-
-    private fun insertToChat(arr: JsonArray, mRealm: Realm) {
-        val chatHistoryList = mutableListOf<JsonObject>()
-        for (j in arr) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = getJsonObject("doc", jsonDoc)
-            chatHistoryList.add(jsonDoc)
-        }
-
-        chatHistoryList.forEach { jsonDoc ->
-            insert(mRealm, jsonDoc)
         }
     }
 


### PR DESCRIPTION
Moved the chat history insertion logic from `TransactionSyncManager` to `ChatRepository`.

1.  **ChatRepository**: Added `syncInsertChatHistory(docs: List<JsonObject>)` method.
2.  **ChatRepositoryImpl**: Implemented the method using `executeTransaction` to insert `RealmChatHistory` objects.
3.  **TransactionSyncManager**:
    *   Updated `syncDb` to detect `chat_history` table and call `chatRepository.syncInsertChatHistory`.
    *   Removed the private `insertToChat` method.
    *   Removed the specific check for `chat_history` inside the generic transaction block.
    *   Cleaned up imports.

---
*PR created automatically by Jules for task [18381519739740192344](https://jules.google.com/task/18381519739740192344) started by @dogi*