### PR TITLE
Align realtime listener callbacks with dataUpdateFlow

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/RealtimeSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/RealtimeSyncManager.kt
@@ -35,6 +35,7 @@ class RealtimeSyncManager {
     }
 
     fun notifyTableUpdated(update: TableDataUpdate) {
+        _dataUpdateFlow.tryEmit(update)
         synchronized(listeners) {
             listeners.toList()
         }.forEach { it.onTableDataUpdated(update) }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
@@ -30,24 +30,7 @@ class RealtimeSyncHelper(
     
     private val syncManagerInstance = RealtimeSyncManager.getInstance()
     
-    private val onRealtimeSyncListener = object : OnBaseRealtimeSyncListener() {
-        override fun onTableDataUpdated(update: TableDataUpdate) {
-            if (mixin.getWatchedTables().contains(update.table)) {
-                mixin.onDataUpdated(update.table, update)
-                if (mixin.shouldAutoRefresh(update.table)) {
-                    refreshRecyclerView()
-                }
-            }
-        }
-        
-        override fun onSyncStarted() {}
-        override fun onSyncComplete() {}
-        override fun onSyncFailed(msg: String?) {}
-    }
-    
     fun setupRealtimeSync() {
-        syncManagerInstance.addListener(onRealtimeSyncListener)
-
         fragment.viewLifecycleOwner.lifecycle.addObserver(object : LifecycleEventObserver {
             override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
                 if (event == Lifecycle.Event.ON_DESTROY) {
@@ -91,6 +74,5 @@ class RealtimeSyncHelper(
     }
     
     fun cleanup() {
-        syncManagerInstance.removeListener(onRealtimeSyncListener)
     }
 }


### PR DESCRIPTION
Modified RealtimeSyncManager to emit updates to dataUpdateFlow inside notifyTableUpdated. Refactored RealtimeSyncHelper (in RealtimeSyncMixin.kt) to rely solely on the flow for updates, removing the redundant listener logic. This aligns the realtime sync update mechanism with Kotlin Flow usage.

---
*PR created automatically by Jules for task [16206854347477252355](https://jules.google.com/task/16206854347477252355) started by @dogi*