### PR TITLE
Refactor BaseRecyclerFragment to add onDeleteSelected and onAddToMyList hooks

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -105,7 +105,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     private fun initDeleteButton() {
         tvDelete?.let {
             it.visibility = View.VISIBLE
-            it.setOnClickListener { deleteSelected(false) }
+            it.setOnClickListener { onDeleteSelected(false) }
         }
     }
 
@@ -116,6 +116,10 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     }
 
     fun addToMyList() {
+        onAddToMyList()
+    }
+
+    open fun onAddToMyList() {
         if (!isRealmInitialized() || isAddInProgress) return
 
         val itemsToAdd = selectedItems?.toList() ?: emptyList()
@@ -194,7 +198,12 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         }
     }
 
+    @Deprecated("Use onDeleteSelected instead")
     fun deleteSelected(deleteProgress: Boolean) {
+        onDeleteSelected(deleteProgress)
+    }
+
+    open fun onDeleteSelected(deleteProgress: Boolean) {
         selectedItems?.forEach { item ->
             try {
                 if (!mRealm.isInTransaction) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -324,7 +324,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             }
             alertDialogBuilder.setMessage(message)
                 .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
-                    deleteSelected(true)
+                    onDeleteSelected(true)
                     clearAllSelections()
                     loadDataAsync()
                 }
@@ -340,7 +340,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             }
             alertDialogBuilder.setMessage(message)
                 .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
-                    deleteSelected(true)
+                    onDeleteSelected(true)
                     clearAllSelections()
                     loadDataAsync()
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -321,7 +321,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
             AlertDialog.Builder(this.context, R.style.AlertDialogTheme)
                 .setMessage(R.string.confirm_removal)
                 .setPositiveButton(R.string.yes) { _, _ ->
-                    deleteSelected(true)
+                    onDeleteSelected(true)
                     val newFragment = ResourcesFragment()
                     recreateFragment(newFragment)
                 }


### PR DESCRIPTION
This PR refactors `BaseRecyclerFragment` to introduce `onDeleteSelected` and `onAddToMyList` hooks, allowing subclasses to override and customize the behavior of these actions. The legacy `deleteSelected` method is deprecated and now delegates to the new `onDeleteSelected` hook. Calls in `CoursesFragment` and `ResourcesFragment` have been updated to use the new `onDeleteSelected` method. `addToMyList` has also been updated to delegate to `onAddToMyList`.

---
*PR created automatically by Jules for task [10300467759098893296](https://jules.google.com/task/10300467759098893296) started by @dogi*