### PR TITLE
Add repeatOnLifecycle to SyncActivity broadcast Flow collector

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -772,9 +772,11 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
 
     fun registerReceiver() {
         lifecycleScope.launch {
-            broadcastService.events.collect { intent ->
-                if (intent.action == DashboardActivity.MESSAGE_PROGRESS) {
-                    broadcastReceiver.onReceive(this@SyncActivity, intent)
+            repeatOnLifecycle(androidx.lifecycle.Lifecycle.State.STARTED) {
+                broadcastService.events.collect { intent ->
+                    if (intent.action == DashboardActivity.MESSAGE_PROGRESS) {
+                        broadcastReceiver.onReceive(this@SyncActivity, intent)
+                    }
                 }
             }
         }


### PR DESCRIPTION
This change wraps the `broadcastService.events.collect` call within `SyncActivity.registerReceiver` in a `repeatOnLifecycle(Lifecycle.State.STARTED)` block. This ensures that the flow is only collected when the activity is in the STARTED state, preventing potential crashes and resource waste when the activity is in the background. This aligns with Android's best practices for collecting flows in the UI layer.

---
*PR created automatically by Jules for task [4562689263749894929](https://jules.google.com/task/4562689263749894929) started by @dogi*