### PR TITLE
Refactor UploadToShelfService DB writes to repositories

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -80,9 +80,10 @@ object ServiceModule {
         @AppPreferences preferences: SharedPreferences,
         resourcesRepository: org.ole.planet.myplanet.repository.ResourcesRepository,
         coursesRepository: org.ole.planet.myplanet.repository.CoursesRepository,
-        userRepository: org.ole.planet.myplanet.repository.UserRepository
+        userRepository: org.ole.planet.myplanet.repository.UserRepository,
+        healthRepository: org.ole.planet.myplanet.repository.HealthRepository
     ): UploadToShelfService {
-        return UploadToShelfService(context, databaseService, preferences, resourcesRepository, coursesRepository, userRepository)
+        return UploadToShelfService(context, databaseService, preferences, resourcesRepository, coursesRepository, userRepository, healthRepository)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
@@ -6,4 +6,6 @@ import org.ole.planet.myplanet.model.RealmUser
 interface HealthRepository {
     suspend fun getHealthEntry(userId: String): Pair<RealmUser?, RealmHealthExamination?>
     suspend fun getExaminationById(id: String): RealmHealthExamination?
+    suspend fun updateHealthUserId(localUserId: String, serverUserId: String)
+    suspend fun updateHealthRev(id: String, rev: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -29,4 +29,25 @@ class HealthRepositoryImpl @Inject constructor(
             if (exam != null) realm.copyFromRealm(exam) else null
         }
     }
+
+    override suspend fun updateHealthUserId(localUserId: String, serverUserId: String) {
+        withRealm { realm ->
+            realm.executeTransaction {
+                val list = realm.where(RealmHealthExamination::class.java).equalTo("_id", localUserId).findAll()
+                list.forEach { p ->
+                    p.userId = serverUserId
+                }
+            }
+        }
+    }
+
+    override suspend fun updateHealthRev(id: String, rev: String) {
+        withRealm { realm ->
+            realm.executeTransaction {
+                val managedPojo = realm.where(RealmHealthExamination::class.java).equalTo("_id", id).findFirst()
+                managedPojo?._rev = rev
+                managedPojo?.isUpdated = false
+            }
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -26,6 +26,9 @@ interface UserRepository {
     ): Map<Int, Int>
     suspend fun saveUser(jsonDoc: JsonObject?, settings: SharedPreferences, key: String? = null, iv: String? = null): RealmUser?
     suspend fun ensureUserSecurityKeys(userId: String): RealmUser?
+    suspend fun updateUserIdAndRev(localUserId: String, serverUserId: String, rev: String)
+    suspend fun updateUserRev(localUserId: String, rev: String)
+    suspend fun updateUserSecurityKeys(localUserId: String, key: String, iv: String)
     suspend fun updateSecurityData(
         name: String,
         userId: String?,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -167,6 +167,36 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun updateUserIdAndRev(localUserId: String, serverUserId: String, rev: String) {
+        withRealm { realm ->
+            realm.executeTransaction {
+                val managedModel = realm.where(RealmUser::class.java).equalTo("id", localUserId).findFirst()
+                managedModel?._id = serverUserId
+                managedModel?._rev = rev
+            }
+        }
+    }
+
+    override suspend fun updateUserRev(localUserId: String, rev: String) {
+        withRealm { realm ->
+            realm.executeTransaction {
+                val managedModel = realm.where(RealmUser::class.java).equalTo("id", localUserId).findFirst()
+                managedModel?._rev = rev
+                managedModel?.isUpdated = false
+            }
+        }
+    }
+
+    override suspend fun updateUserSecurityKeys(localUserId: String, key: String, iv: String) {
+        withRealm { realm ->
+            realm.executeTransaction {
+                val managedModel = realm.where(RealmUser::class.java).equalTo("id", localUserId).findFirst()
+                managedModel?.key = key
+                managedModel?.iv = iv
+            }
+        }
+    }
+
     override suspend fun updateSecurityData(
         name: String,
         userId: String?,

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.model.RealmMeetup.Companion.getMyMeetUpIds
 import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.removedIds
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.HealthRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.generateIv
@@ -46,9 +47,9 @@ class UploadToShelfService @Inject constructor(
     @AppPreferences private val sharedPreferences: SharedPreferences,
     private val resourcesRepository: ResourcesRepository,
     private val coursesRepository: CoursesRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val healthRepository: HealthRepository
 ) {
-    lateinit var mRealm: Realm
 
     fun uploadUserData(listener: OnSuccessListener) {
         val apiInterface = client.create(ApiInterface::class.java)
@@ -141,14 +142,10 @@ class UploadToShelfService @Inject constructor(
                 model._rev = rev
                 
                 // Persist _id and _rev to database
-                dbService.executeTransactionAsync { realm ->
-                    val managedModel = realm.where(RealmUser::class.java).equalTo("id", model.id).findFirst()
-                    if (managedModel != null) {
-                        managedModel._id = id
-                        managedModel._rev = rev
-                    } else {
-                        android.util.Log.e("UploadToShelfService", "Failed to find user model with id: ${model.id} for persisting _id and _rev")
-                    }
+                if (!TextUtils.isEmpty(id) && !TextUtils.isEmpty(rev) && model.id != null) {
+                    userRepository.updateUserIdAndRev(model.id!!, id!!, rev!!)
+                } else {
+                    android.util.Log.e("UploadToShelfService", "Failed to persist _id and _rev: id or rev is null")
                 }
                 
                 processUserAfterCreation(apiInterface, model, obj)
@@ -171,8 +168,8 @@ class UploadToShelfService @Inject constructor(
                 model.iterations = getString("iterations", fetchDataResponse.body())
                 saveKeyIv(apiInterface, model, obj)
 
-                dbService.executeTransactionAsync { realm ->
-                    updateHealthData(realm, model)
+                if (!TextUtils.isEmpty(model._id) && model.id != null) {
+                    healthRepository.updateHealthUserId(model.id!!, model._id!!)
                 }
             }
         } catch (e: Exception) {
@@ -199,10 +196,8 @@ class UploadToShelfService @Inject constructor(
 
                 if (updateResponse.isSuccessful) {
                     val updatedRev = updateResponse.body()?.get("rev")?.asString
-                    dbService.executeTransactionAsync { realm ->
-                        val managedModel = realm.where(RealmUser::class.java).equalTo("id", model.id).findFirst()
-                        managedModel?._rev = updatedRev
-                        managedModel?.isUpdated = false
+                    if (!TextUtils.isEmpty(updatedRev) && model.id != null) {
+                        userRepository.updateUserRev(model.id!!, updatedRev!!)
                     }
                 }
             }
@@ -218,13 +213,6 @@ class UploadToShelfService @Inject constructor(
         val protocolIndex = url.indexOf("://")
         val protocol = url.substring(0, protocolIndex)
         return "$protocol://$replacedUrl"
-    }
-
-    private fun updateHealthData(realm: Realm, model: RealmUser) {
-        val list: List<RealmHealthExamination> = realm.where(RealmHealthExamination::class.java).equalTo("_id", model.id).findAll()
-        for (p in list) {
-            p.userId = model._id
-        }
     }
 
     suspend fun saveKeyIv(apiInterface: ApiInterface, model: RealmUser, obj: JsonObject) {
@@ -270,10 +258,8 @@ class UploadToShelfService @Inject constructor(
         if (response?.isSuccessful == true && response.body() != null) {
             changeUserSecurity(model, obj)
 
-            dbService.executeTransactionAsync { realm ->
-                val managedModel = realm.where(RealmUser::class.java).equalTo("id", model.id).findFirst()
-                managedModel?.key = keyString
-                managedModel?.iv = iv
+            if (!TextUtils.isEmpty(keyString) && !TextUtils.isEmpty(iv) && model.id != null) {
+                userRepository.updateUserSecurityKeys(model.id!!, keyString!!, iv!!)
             }
         } else {
             throw IOException("Failed to save key/IV after $maxAttempts attempts")
@@ -297,10 +283,8 @@ class UploadToShelfService @Inject constructor(
 
                     if (res.body() != null && res.body()?.has("id") == true) {
                         val rev = res.body()?.get("rev")?.asString
-                        dbService.executeTransactionAsync { realm ->
-                            val managedPojo = realm.where(RealmHealthExamination::class.java).equalTo("_id", pojo._id).findFirst()
-                            managedPojo?._rev = rev
-                            managedPojo?.isUpdated = false
+                        if (!TextUtils.isEmpty(rev) && pojo._id != null) {
+                            healthRepository.updateHealthRev(pojo._id!!, rev!!)
                         }
                     }
                 } catch (e: Exception) {
@@ -335,10 +319,8 @@ class UploadToShelfService @Inject constructor(
 
                         if (res.body() != null && res.body()?.has("id") == true) {
                             val rev = res.body()?.get("rev")?.asString
-                            dbService.executeTransactionAsync { realm ->
-                                val managedPojo = realm.where(RealmHealthExamination::class.java).equalTo("_id", pojo._id).findFirst()
-                                managedPojo?._rev = rev
-                                managedPojo?.isUpdated = false
+                            if (!TextUtils.isEmpty(rev) && pojo._id != null) {
+                                healthRepository.updateHealthRev(pojo._id!!, rev!!)
                             }
                         }
                     } catch (e: Exception) {


### PR DESCRIPTION
This change refactors `UploadToShelfService` to delegate Realm database write operations to `UserRepository` and `HealthRepository`. This aligns with the repository pattern, reducing direct database dependency in the service and improving testability and maintainability.

Key changes:
- `UserRepository` now handles user ID/revision updates and security key persistence.
- `HealthRepository` now handles updating health record user IDs and revisions.
- `UploadToShelfService` no longer performs inline `executeTransactionAsync` calls for these operations.
- `ServiceModule` updated to provide `HealthRepository` to `UploadToShelfService`.


---
*PR created automatically by Jules for task [13330559371604769175](https://jules.google.com/task/13330559371604769175) started by @dogi*