### PR TITLE
Refactor LoginSyncManager to use UserRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -6,8 +6,11 @@ import io.realm.Sort
 import org.ole.planet.myplanet.model.HealthRecord
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
+import retrofit2.Response
 
 interface UserRepository {
+    suspend fun getUserDoc(authHeader: String, userUrl: String): Response<JsonObject>
+    suspend fun getAdminDocs(header: String, url: String, body: JsonObject): Response<JsonObject>
     suspend fun getHealthProfile(userId: String): RealmMyHealth?
     suspend fun updateUserHealthProfile(userId: String, userData: Map<String, Any?>)
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -32,6 +32,7 @@ import org.ole.planet.myplanet.utils.AndroidDecrypter
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.UrlUtils
+import retrofit2.Response
 
 class UserRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
@@ -41,6 +42,14 @@ class UserRepositoryImpl @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val configurationsRepository: ConfigurationsRepository
 ) : RealmRepository(databaseService), UserRepository {
+    override suspend fun getUserDoc(authHeader: String, userUrl: String): Response<JsonObject> {
+        return apiInterface.getJsonObject(authHeader, userUrl)
+    }
+
+    override suspend fun getAdminDocs(header: String, url: String, body: JsonObject): Response<JsonObject> {
+        return apiInterface.findDocs(header, "application/json", url, body)
+    }
+
     override suspend fun getUserById(userId: String): RealmUser? {
         return withRealm { realm ->
             realm.where(RealmUser::class.java)

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/LoginSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/LoginSyncManager.kt
@@ -40,8 +40,6 @@ class LoginSyncManager @Inject constructor(
 
                 withContext(Dispatchers.Main) { listener.onSyncStarted() }
 
-                val apiInterface = ApiClient.client.create(ApiInterface::class.java)
-
                 val authHeader = try {
                     "Basic " + Base64.encodeToString("$userName:$password".toByteArray(), Base64.NO_WRAP)
                 } catch (e: Exception) {
@@ -59,7 +57,7 @@ class LoginSyncManager @Inject constructor(
                 }
 
                 try {
-                    val response = apiInterface.getJsonObject(authHeader, userUrl)
+                    val response = userRepository.getUserDoc(authHeader, userUrl)
                     when {
                         !response.isSuccessful -> {
                             val errorMsg = when (response.code()) {
@@ -133,8 +131,6 @@ class LoginSyncManager @Inject constructor(
                 selector.addProperty("isUserAdmin", true)
                 `object`.add("selector", selector)
 
-                val apiInterface = ApiClient.client.create(ApiInterface::class.java)
-
                 val header = UrlUtils.header
                 if (header.isBlank()) {
                     return@launch
@@ -148,7 +144,7 @@ class LoginSyncManager @Inject constructor(
                 }
 
                 try {
-                    val response = apiInterface.findDocs(header, "application/json", url, `object`)
+                    val response = userRepository.getAdminDocs(header, url, `object`)
                     if (response.isSuccessful && response.body() != null) {
                         val responseBody = response.body()
                         settings.edit { putString("communityLeaders", "$responseBody") }


### PR DESCRIPTION
Moved `getUserDoc` and `getAdminDocs` logic from `LoginSyncManager` to `UserRepository` and `UserRepositoryImpl`.
Updated `LoginSyncManager` to use injected `UserRepository` methods instead of creating `ApiClient` directly.
This change encapsulates network calls within the repository layer.

---
*PR created automatically by Jules for task [13073931877500791897](https://jules.google.com/task/13073931877500791897) started by @dogi*