### PR TITLE
Fix LifeFragment crash by initializing adapter synchronously

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
@@ -45,7 +45,7 @@ class LifeFragment : BaseRecyclerFragment<RealmMyLife?>(), OnStartDragListener {
         return view
     }
 
-    override suspend fun getAdapter(): RecyclerView.Adapter<*> {
+    private fun setupAdapter() {
         lifeAdapter = LifeAdapter(requireContext(), this,
             visibilityCallback = { myLife, isVisible ->
                 myLife._id?.let { id ->
@@ -70,10 +70,19 @@ class LifeFragment : BaseRecyclerFragment<RealmMyLife?>(), OnStartDragListener {
                 }
             }
         )
+    }
+
+    override suspend fun getAdapter(): RecyclerView.Adapter<*> {
+        if (!::lifeAdapter.isInitialized) {
+            setupAdapter()
+        }
         return lifeAdapter
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        if (!::lifeAdapter.isInitialized) {
+            setupAdapter()
+        }
         super.onViewCreated(view, savedInstanceState)
         refreshList()
         recyclerView.setHasFixedSize(true)


### PR DESCRIPTION
Fixes `kotlin.UninitializedPropertyAccessException: lateinit property lifeAdapter has not been initialized` in `LifeFragment`.

The crash occurred because `LifeFragment` attempted to access `lifeAdapter` in `onViewCreated` (to set up `ItemTouchHelper`) before it was initialized. The base class `BaseRecyclerFragment` initializes the adapter asynchronously via a coroutine calling `getAdapter()`.

Changes:
- Extracted `LifeAdapter` initialization into a private `setupAdapter()` method.
- Called `setupAdapter()` at the beginning of `onViewCreated()` to ensure the adapter is ready before use.
- Updated `getAdapter()` to use `setupAdapter()` if the adapter is not yet initialized, ensuring consistency and safety.

---
*PR created automatically by Jules for task [940132807138109477](https://jules.google.com/task/940132807138109477) started by @dogi*