### PR TITLE
Refactor build.gradle to use Version Catalog aliases

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id 'com.android.application'
+    alias(libs.plugins.android.application)
     alias(libs.plugins.legacy.kapt)
-    id 'com.google.devtools.ksp'
-    id 'com.google.dagger.hilt.android'
-    id 'realm-android'
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.dagger.hilt.android)
+    alias(libs.plugins.realm.android)
 }
 realm {
     syncEnabled = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,11 +41,13 @@ webkit = "1.15.0"
 tink = "1.20.0"
 
 [plugins]
-android-application = { id = "com.android.application", version.ref = "gradle" }
+# Versions for plugins applied via root buildscript (AGP, KSP, Hilt, Realm) are managed by [libraries]
+# entries used in buildscript classpath. Omitting versions here prevents conflicts in subprojects.
+android-application = { id = "com.android.application" }
 legacy-kapt = { id = "com.android.legacy-kapt", version.ref = "gradle" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-realm-android = { id = "io.realm.android", version.ref = "realm" }
+ksp = { id = "com.google.devtools.ksp" }
+dagger-hilt-android = { id = "com.google.dagger.hilt.android" }
+realm-android = { id = "realm-android" }
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "gradle" }


### PR DESCRIPTION
This PR refactors `app/build.gradle` to utilize Gradle Version Catalogs for plugin management, improving consistency and maintainability.

**Changes:**
1.  **`app/build.gradle`**:
    - Replaced legacy `id 'com.android.application'` etc. with type-safe `alias(libs.plugins.android.application)`.
    - Applied to Android Application, KSP, Hilt, and Realm plugins.

2.  **`gradle/libs.versions.toml`**:
    - Modified plugin definitions for `android-application`, `ksp`, `dagger-hilt-android`, and `realm-android`.
    - Removed `version.ref` from these entries because the plugins are already added to the classpath by the root project's `buildscript` block (which uses `[libraries]` entries). Using `alias` with a version in this context causes Gradle to fail with an "unknown version" error because it conflicts with the classpath-loaded plugin. Removing the version allows `alias` to apply the ID correctly while using the version from the classpath.
    - Changed `realm-android` plugin ID from `io.realm.android` to `realm-android` as the specific version of the Realm plugin in use (10.19.0) exports the legacy ID `realm-android`.

**Verification:**
- ran `./gradlew help` (Successful)
- ran `./gradlew assembleDebug --dry-run` (Successful)

---
*PR created automatically by Jules for task [1000242613620639662](https://jules.google.com/task/1000242613620639662) started by @dogi*