### PR TITLE
Remove unnecessary safe call in SyncTimeLogger

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
@@ -87,7 +87,7 @@ object SyncTimeLogger {
                 mapping.alternativeUrl?.let { MainApplication.isServerReachable(it) } == true
 
             if (!primaryAvailable && alternativeAvailable) {
-                mapping.alternativeUrl?.let { alternativeUrl ->
+                mapping.alternativeUrl!!.let { alternativeUrl ->
                     val uri = updateUrl.toUri()
                     val editor = settings.edit()
 


### PR DESCRIPTION
Removed unnecessary safe call in `SyncTimeLogger.kt`.
In the block `if (!primaryAvailable && alternativeAvailable)`, `alternativeAvailable` being true implies `mapping.alternativeUrl` is not null.
Changed `mapping.alternativeUrl?.let` to `mapping.alternativeUrl!!.let` to reflect this and remove redundancy.

---
*PR created automatically by Jules for task [13976009987514966988](https://jules.google.com/task/13976009987514966988) started by @dogi*