### PR TITLE
courses: smoother model adapting (fixes #11594)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnCourseItemSelectedListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnCourseItemSelectedListener.kt
@@ -1,10 +1,10 @@
 package org.ole.planet.myplanet.callback
 
-import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.Course
+import org.ole.planet.myplanet.model.Tag
 
 interface OnCourseItemSelectedListener {
     @JvmSuppressWildcards
-    fun onSelectedListChange(list: MutableList<RealmMyCourse?>)
-    fun onTagClicked(tag: RealmTag)
+    fun onSelectedListChange(list: MutableList<Course?>)
+    fun onTagClicked(tag: Tag)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/Course.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Course.kt
@@ -1,0 +1,13 @@
+package org.ole.planet.myplanet.model
+
+data class Course(
+    val id: String?,
+    val courseId: String?,
+    val courseTitle: String?,
+    val description: String?,
+    val gradeLevel: String?,
+    val subjectLevel: String?,
+    val createdDate: Long,
+    var isMyCourse: Boolean = false,
+    val numberOfSteps: Int
+)

--- a/app/src/main/java/org/ole/planet/myplanet/model/Tag.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Tag.kt
@@ -1,0 +1,6 @@
+package org.ole.planet.myplanet.model
+
+data class Tag(
+    val id: String?,
+    val name: String?
+)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -27,10 +27,8 @@ import org.ole.planet.myplanet.callback.OnCourseItemSelectedListener
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.databinding.RowCourseBinding
-import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmTag
-import org.ole.planet.myplanet.model.RealmUser
-import org.ole.planet.myplanet.repository.TagsRepository
+import org.ole.planet.myplanet.model.Course
+import org.ole.planet.myplanet.model.Tag
 import org.ole.planet.myplanet.utils.CourseRatingUtils
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.JsonUtils.getInt
@@ -43,11 +41,11 @@ import org.ole.planet.myplanet.utils.Utilities
 class CoursesAdapter(
     private val context: Context,
     private val map: HashMap<String?, JsonObject>,
-    private var userModel: RealmUser?,
-    private val tagsRepository: TagsRepository,
-    var isMyCourseLib: Boolean = false
-) : ListAdapter<RealmMyCourse, RecyclerView.ViewHolder>(
-    DiffUtils.itemCallback<RealmMyCourse>(
+    private val isGuest: Boolean,
+    var isMyCourseLib: Boolean = false,
+    private val getTags: suspend (String) -> List<Tag>
+) : ListAdapter<Course, RecyclerView.ViewHolder>(
+    DiffUtils.itemCallback<Course>(
         areItemsTheSame = { old, new -> old.courseId == new.courseId },
         areContentsTheSame = { old, new ->
             old.courseTitle == new.courseTitle &&
@@ -56,11 +54,11 @@ class CoursesAdapter(
                     old.subjectLevel == new.subjectLevel &&
                     old.createdDate == new.createdDate &&
                     old.isMyCourse == new.isMyCourse &&
-                    old.getNumberOfSteps() == new.getNumberOfSteps()
+                    old.numberOfSteps == new.numberOfSteps
         }
     )
 ) {
-    private val selectedItems: MutableList<RealmMyCourse?> = ArrayList()
+    private val selectedItems: MutableList<Course?> = ArrayList()
     private var listener: OnCourseItemSelectedListener? = null
     private var homeItemClickListener: OnHomeItemClickListener? = null
     private var progressMap: HashMap<String?, JsonObject>? = null
@@ -69,7 +67,7 @@ class CoursesAdapter(
     private var isAscending = true
     private var isTitleAscending = false
     private var areAllSelected = false
-    private val tagCache: MutableMap<String, List<RealmTag>> = mutableMapOf()
+    private val tagCache: MutableMap<String, List<Tag>> = mutableMapOf()
     private val activeJobs: MutableMap<String, Job> = mutableMapOf()
 
     companion object {
@@ -90,7 +88,7 @@ class CoursesAdapter(
     }
 
     fun updateData(
-        newCourseList: List<RealmMyCourse>,
+        newCourseList: List<Course>,
         newMap: HashMap<String?, JsonObject>,
         newProgressMap: HashMap<String?, JsonObject>?
     ) {
@@ -105,7 +103,7 @@ class CoursesAdapter(
         }
     }
 
-    private fun sortCourseListByTitle(list: List<RealmMyCourse>): List<RealmMyCourse> {
+    private fun sortCourseListByTitle(list: List<Course>): List<Course> {
         return list.sortedWith { course1, course2 ->
             if (isTitleAscending) {
                 course1.courseTitle?.compareTo(course2.courseTitle ?: "", ignoreCase = true) ?: 0
@@ -129,7 +127,7 @@ class CoursesAdapter(
         }
     }
 
-    private fun sortCourseList(list: List<RealmMyCourse>): List<RealmMyCourse> {
+    private fun sortCourseList(list: List<Course>): List<Course> {
         return list.sortedWith { course1, course2 ->
             if (isAscending) {
                 course1.createdDate.compareTo(course2.createdDate)
@@ -190,10 +188,9 @@ class CoursesAdapter(
             holder.rowCourseBinding.subjectLevel,
             context.getString(R.string.subject_level_colon)
         )
-        holder.rowCourseBinding.courseProgress.max = course.getNumberOfSteps()
+        holder.rowCourseBinding.courseProgress.max = course.numberOfSteps
         displayTagCloud(holder, position)
 
-        val isGuest = userModel?.isGuest() ?: true
         if (!isGuest) setupRatingBar(holder, course)
         setupCheckbox(holder, course, position, isGuest)
 
@@ -208,7 +205,7 @@ class CoursesAdapter(
         }
     }
 
-    private fun updateVisibilityForMyCourse(holder: CoursesViewHolder, course: RealmMyCourse) {
+    private fun updateVisibilityForMyCourse(holder: CoursesViewHolder, course: Course) {
         if (isMyCourseLib) {
             holder.rowCourseBinding.isMyCourse.visibility = View.GONE
             holder.rowCourseBinding.checkbox.visibility = View.VISIBLE
@@ -223,7 +220,7 @@ class CoursesAdapter(
         }
     }
 
-    private fun configureDescription(holder: CoursesViewHolder, course: RealmMyCourse, position: Int) {
+    private fun configureDescription(holder: CoursesViewHolder, course: Course, position: Int) {
         holder.rowCourseBinding.description.apply {
             text = course.description
             val markdownContentWithLocalPaths = prependBaseUrlToImages(
@@ -245,7 +242,7 @@ class CoursesAdapter(
         }
     }
 
-    private fun configureDateViews(holder: CoursesViewHolder, course: RealmMyCourse) {
+    private fun configureDateViews(holder: CoursesViewHolder, course: Course) {
         if (course.gradeLevel.isNullOrEmpty() && course.subjectLevel.isNullOrEmpty()) {
             holder.rowCourseBinding.holder.visibility = View.VISIBLE
             holder.rowCourseBinding.tvDate2.visibility = View.VISIBLE
@@ -267,7 +264,7 @@ class CoursesAdapter(
         }
     }
 
-    private fun setupRatingBar(holder: CoursesViewHolder, course: RealmMyCourse) {
+    private fun setupRatingBar(holder: CoursesViewHolder, course: Course) {
         holder.rowCourseBinding.ratingBar.setOnTouchListener { _: View?, event: MotionEvent ->
             if (event.action == MotionEvent.ACTION_UP) homeItemClickListener?.showRatingDialog(
                 "course",
@@ -279,7 +276,7 @@ class CoursesAdapter(
         }
     }
 
-    private fun setupCheckbox(holder: CoursesViewHolder, course: RealmMyCourse, position: Int, isGuest: Boolean) {
+    private fun setupCheckbox(holder: CoursesViewHolder, course: Course, position: Int, isGuest: Boolean) {
         if (!isGuest) {
             val showCheckbox = isMyCourseLib || !course.isMyCourse
             if (showCheckbox) {
@@ -391,7 +388,7 @@ class CoursesAdapter(
 
         val job = holder.itemView.findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
             try {
-                val tags = tagsRepository.getTagsForCourse(courseId)
+                val tags = getTags(courseId)
                 tagCache[courseId] = tags
                 val adapterPosition = holder.bindingAdapterPosition
                 if (adapterPosition != RecyclerView.NO_POSITION) {
@@ -408,7 +405,7 @@ class CoursesAdapter(
         }
     }
 
-    private fun renderTagCloud(flexboxDrawable: FlexboxLayout, tags: List<RealmTag>) {
+    private fun renderTagCloud(flexboxDrawable: FlexboxLayout, tags: List<Tag>) {
         flexboxDrawable.removeAllViews()
         if (tags.isEmpty()) {
             return
@@ -460,11 +457,11 @@ class CoursesAdapter(
         }
     }
 
-    private fun openCourse(realmMyCourses: RealmMyCourse?, step: Int) {
+    private fun openCourse(course: Course?, step: Int) {
         if (homeItemClickListener != null) {
             val f: Fragment = TakeCourseFragment()
             val b = Bundle()
-            b.putString("id", realmMyCourses?.courseId)
+            b.putString("id", course?.courseId)
             b.putInt("position", step)
             f.arguments = b
             homeItemClickListener?.openCallFragment(f)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -36,10 +36,12 @@ import org.ole.planet.myplanet.callback.OnCourseItemSelectedListener
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.callback.OnTagClickListener
+import org.ole.planet.myplanet.model.Course
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TableDataUpdate
+import org.ole.planet.myplanet.model.Tag
 import org.ole.planet.myplanet.repository.ProgressRepository
 import org.ole.planet.myplanet.repository.RatingsRepository
 import org.ole.planet.myplanet.repository.TagsRepository
@@ -55,7 +57,7 @@ import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.KeyboardUtils.setupUI
 
 @AndroidEntryPoint
-class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSelectedListener, OnTagClickListener, RealtimeSyncMixin {
+class CoursesFragment : BaseRecyclerFragment<Course?>(), OnCourseItemSelectedListener, OnTagClickListener, RealtimeSyncMixin {
     private lateinit var tvAddToLib: TextView
     private lateinit var tvSelected: TextView
     private lateinit var etSearch: EditText
@@ -203,10 +205,18 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             .filterIsInstance<RealmMyCourse>()
             .filter { !it.courseTitle.isNullOrBlank() }
 
-        val courseList: List<RealmMyCourse> = mRealm.copyFromRealm(managedCourses).also { copiedList ->
-            copiedList.forEachIndexed { index, course ->
-                course.isMyCourse = if (isMyCourseLib) true else managedCourses[index].isMyCourse
-            }
+        val courseList: List<Course> = managedCourses.map { realmCourse ->
+            Course(
+                realmCourse.id,
+                realmCourse.courseId,
+                realmCourse.courseTitle,
+                realmCourse.description,
+                realmCourse.gradeLevel,
+                realmCourse.subjectLevel,
+                realmCourse.createdDate,
+                if (isMyCourseLib) true else realmCourse.isMyCourse,
+                realmCourse.getNumberOfSteps()
+            )
         }
 
         val sortedCourseList = if (isMyCourseLib) {
@@ -227,7 +237,14 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             Pair(ratingsDeferred.await(), progressDeferred.await())
         }
 
-        adapterCourses = CoursesAdapter(requireActivity(), map, userModel, tagsRepository, isMyCourseLib)
+        adapterCourses = CoursesAdapter(
+            requireActivity(),
+            map,
+            userModel?.isGuest() ?: true,
+            isMyCourseLib
+        ) { courseId ->
+            tagsRepository.getTagsForCourse(courseId).map { Tag(it.id, it.name) }
+        }
         adapterCourses.submitList(sortedCourseList) {
             if (isAdded && view != null && ::selectAll.isInitialized) {
                 selectedItems?.clear()
@@ -526,7 +543,22 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                 }
                 val ratings = ratingsRepository.getCourseRatings(userId)
                 val progress = progressRepository.getCourseProgress(userId)
-                Triple(finalCourses, ratings, progress)
+
+                val pojoCourses = finalCourses.map { realmCourse ->
+                    Course(
+                        realmCourse.id,
+                        realmCourse.courseId,
+                        realmCourse.courseTitle,
+                        realmCourse.description,
+                        realmCourse.gradeLevel,
+                        realmCourse.subjectLevel,
+                        realmCourse.createdDate,
+                        realmCourse.isMyCourse,
+                        realmCourse.getNumberOfSteps()
+                    )
+                }
+
+                Triple(pojoCourses, ratings, progress)
             }
             adapterCourses.updateData(filteredCourses, map, progressMap)
             scrollToTop()
@@ -572,15 +604,19 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         return builder.create()
     }
 
-    override fun onSelectedListChange(list: MutableList<RealmMyCourse?>) {
+    override fun onSelectedListChange(list: MutableList<Course?>) {
         selectedItems = list
         changeButtonStatus()
         hideButtons()
     }
 
-    override fun onTagClicked(tag: RealmTag) {
+    override fun onTagClicked(tag: Tag) {
+        val realmTag = RealmTag()
+        realmTag.name = tag.name
+        realmTag.id = tag.id
+
         if (!searchTags.any { it.name == tag.name }) {
-            searchTags.add(tag)
+            searchTags.add(realmTag)
         }
         filterCoursesAndUpdateUi()
         showTagText(searchTags, tvSelected)
@@ -713,10 +749,18 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                     val managedCourseList: List<RealmMyCourse> = getList(RealmMyCourse::class.java)
                         .filterIsInstance<RealmMyCourse>()
                         .filter { !it.courseTitle.isNullOrBlank() }
-                    val courseList: List<RealmMyCourse> = mRealm.copyFromRealm(managedCourseList).also { copiedList ->
-                        copiedList.forEachIndexed { index, course ->
-                            course.isMyCourse = if (isMyCourseLib) true else managedCourseList[index].isMyCourse
-                        }
+                    val courseList: List<Course> = managedCourseList.map { realmCourse ->
+                        Course(
+                            realmCourse.id,
+                            realmCourse.courseId,
+                            realmCourse.courseTitle,
+                            realmCourse.description,
+                            realmCourse.gradeLevel,
+                            realmCourse.subjectLevel,
+                            realmCourse.createdDate,
+                            if (isMyCourseLib) true else realmCourse.isMyCourse,
+                            realmCourse.getNumberOfSteps()
+                        )
                     }
                     val sortedCourseList = if (isMyCourseLib) {
                         courseList.sortedBy { it.courseTitle }


### PR DESCRIPTION
This change decouples `CoursesAdapter` from the Realm database library by replacing Realm model objects with Plain Old Java/Kotlin Objects (POJOs) (`Course` and `Tag`). This improves separation of concerns and testability.

Key changes:
- Created `Course` and `Tag` data classes.
- Refactored `CoursesAdapter` to use `Course` instead of `RealmMyCourse` and `Tag` instead of `RealmTag`.
- Updated `CoursesFragment` to handle the mapping from `RealmMyCourse` to `Course` and implementation of tag fetching logic.
- Updated `OnCourseItemSelectedListener` interface signatures.
- Removed `RealmUser` dependency from `CoursesAdapter`, replacing it with a simple `isGuest` boolean.

---
*PR created automatically by Jules for task [7505057903264205868](https://jules.google.com/task/7505057903264205868) started by @dogi*