### PR TITLE
Refactor UploadToShelfService to use UserRepository for shelf data assembly

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -19,6 +19,8 @@ interface UserRepository {
     suspend fun getAllUsers(): List<RealmUser>
     suspend fun getUsersSortedBy(fieldName: String, sortOrder: Sort): List<RealmUser>
     suspend fun getPendingSyncUsers(limit: Int): List<RealmUser>
+    suspend fun getAllSyncableUsers(): List<RealmUser>
+    suspend fun buildShelfData(userId: String, jsonDoc: JsonObject?, myLibs: com.google.gson.JsonArray, myCourseIds: com.google.gson.JsonArray): JsonObject
     suspend fun getMonthlyLoginCounts(
         userId: String,
         startMillis: Long,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -22,10 +22,13 @@ import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.di.ApplicationScope
 import org.ole.planet.myplanet.model.HealthRecord
+import com.google.gson.JsonArray
 import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.RealmMeetup.Companion.getMyMeetUpIds
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmMyHealth.RealmMyHealthProfile
 import org.ole.planet.myplanet.model.RealmOfflineActivity
+import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.removedIds
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.RealmUser.Companion.populateUsersTable
 import org.ole.planet.myplanet.model.RealmUserChallengeActions
@@ -93,6 +96,15 @@ class UserRepositoryImpl @Inject constructor(
                 .isEmpty("_id").or().equalTo("isUpdated", true)
                 .findAll()
             realm.copyFromRealm(results.take(limit))
+        }
+    }
+
+    override suspend fun getAllSyncableUsers(): List<RealmUser> {
+        return withRealm { realm ->
+            val results = realm.where(RealmUser::class.java)
+                .isNotEmpty("_id")
+                .findAll()
+            realm.copyFromRealm(results)
         }
     }
 
@@ -627,5 +639,37 @@ class UserRepositoryImpl @Inject constructor(
             equalTo("actionType", "sync")
         }
         return actions.isNotEmpty()
+    }
+
+    override suspend fun buildShelfData(
+        userId: String,
+        jsonDoc: JsonObject?,
+        myLibs: JsonArray,
+        myCourseIds: JsonArray
+    ): JsonObject {
+        return withRealm { realm ->
+            val myMeetups = getMyMeetUpIds(realm, userId)
+            val removedResources = listOf(*removedIds(realm, "resources", userId))
+            val removedCourses = listOf(*removedIds(realm, "courses", userId))
+            val mergedResourceIds = mergeJsonArray(myLibs, JsonUtils.getJsonArray("resourceIds", jsonDoc), removedResources)
+            val mergedCourseIds = mergeJsonArray(myCourseIds, JsonUtils.getJsonArray("courseIds", jsonDoc), removedCourses)
+            val `object` = JsonObject()
+            `object`.addProperty("_id", settings.getString("userId", ""))
+            `object`.add("meetupIds", mergeJsonArray(myMeetups, JsonUtils.getJsonArray("meetupIds", jsonDoc), removedResources))
+            `object`.add("resourceIds", mergedResourceIds)
+            `object`.add("courseIds", mergedCourseIds)
+            `object`
+        }
+    }
+
+    private fun mergeJsonArray(array1: JsonArray?, array2: JsonArray, removedIds: List<String>): JsonArray {
+        val array = JsonArray()
+        array.addAll(array1)
+        for (e in array2) {
+            if (!array.contains(e) && !removedIds.contains(e.asString)) {
+                array.add(e)
+            }
+        }
+        return array
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
@@ -359,11 +359,7 @@ class UploadToShelfService @Inject constructor(
     private fun uploadToShelf(listener: OnSuccessListener) {
         val apiInterface = client.create(ApiInterface::class.java)
         MainApplication.applicationScope.launch(Dispatchers.IO) {
-            val unmanagedUsers = dbService.withRealm { realm ->
-                realm.where(RealmUser::class.java).isNotEmpty("_id").findAll().let {
-                    realm.copyFromRealm(it)
-                }
-            }
+            val unmanagedUsers = userRepository.getAllSyncableUsers()
 
             if (unmanagedUsers.isEmpty()) {
                 withContext(Dispatchers.Main) {
@@ -379,9 +375,7 @@ class UploadToShelfService @Inject constructor(
                         val jsonDoc = apiInterface.getJsonObject(UrlUtils.header, "${UrlUtils.getUrl()}/shelf/${model._id}").body()
                         val myLibs = resourcesRepository.getMyLibIds(model.id ?: "")
                         val myCourseIds = coursesRepository.getMyCourseIds(model.id ?: "")
-                        val shelfData = dbService.withRealm { backgroundRealm ->
-                            getShelfData(backgroundRealm, model.id, jsonDoc, myLibs, myCourseIds)
-                        }
+                        val shelfData = userRepository.buildShelfData(model.id ?: "", jsonDoc, myLibs, myCourseIds)
                         shelfData.addProperty("_rev", getString("_rev", jsonDoc))
                         apiInterface.putDoc(
                             UrlUtils.header,
@@ -409,23 +403,15 @@ class UploadToShelfService @Inject constructor(
         val apiInterface = client.create(ApiInterface::class.java)
         MainApplication.applicationScope.launch(Dispatchers.IO) {
             try {
-                val model = dbService.withRealm { realm ->
-                    realm.where(RealmUser::class.java)
-                        .equalTo("name", userName)
-                        .isNotEmpty("_id")
-                        .findFirst()
-                        ?.let { realm.copyFromRealm(it) }
-                }
+                val model = if (userName != null) userRepository.getUserByName(userName) else null
 
-                if (model != null) {
+                if (model != null && model._id?.isNotEmpty() == true) {
                     if (model.id?.startsWith("guest") != true) {
                         val shelfUrl = "${UrlUtils.getUrl()}/shelf/${model._id}"
                         val jsonDoc = apiInterface.getJsonObject(UrlUtils.header, shelfUrl).body()
                         val myLibs = resourcesRepository.getMyLibIds(model.id ?: "")
                         val myCourseIds = coursesRepository.getMyCourseIds(model.id ?: "")
-                        val shelfObject = dbService.withRealm { realm ->
-                            getShelfData(realm, model.id, jsonDoc, myLibs, myCourseIds)
-                        }
+                        val shelfObject = userRepository.buildShelfData(model.id ?: "", jsonDoc, myLibs, myCourseIds)
                         shelfObject.addProperty("_rev", getString("_rev", jsonDoc))
 
                         val targetUrl = "${UrlUtils.getUrl()}/shelf/${sharedPreferences.getString("userId", "")}"
@@ -442,31 +428,6 @@ class UploadToShelfService @Inject constructor(
                 }
             }
         }
-    }
-
-    private fun getShelfData(realm: Realm?, userId: String?, jsonDoc: JsonObject?, myLibs: JsonArray, myCourseIds: JsonArray): JsonObject {
-        val myMeetups = getMyMeetUpIds(realm, userId)
-        val removedResources = listOf(*removedIds(realm, "resources", userId))
-        val removedCourses = listOf(*removedIds(realm, "courses", userId))
-        val mergedResourceIds = mergeJsonArray(myLibs, getJsonArray("resourceIds", jsonDoc), removedResources)
-        val mergedCourseIds = mergeJsonArray(myCourseIds, getJsonArray("courseIds", jsonDoc), removedCourses)
-        val `object` = JsonObject()
-        `object`.addProperty("_id", sharedPreferences.getString("userId", ""))
-        `object`.add("meetupIds", mergeJsonArray(myMeetups, getJsonArray("meetupIds", jsonDoc), removedResources))
-        `object`.add("resourceIds", mergedResourceIds)
-        `object`.add("courseIds", mergedCourseIds)
-        return `object`
-    }
-
-    private fun mergeJsonArray(array1: JsonArray?, array2: JsonArray, removedIds: List<String>): JsonArray {
-        val array = JsonArray()
-        array.addAll(array1)
-        for (e in array2) {
-            if (!array.contains(e) && !removedIds.contains(e.asString)) {
-                array.add(e)
-            }
-        }
-        return array
     }
 
     companion object {


### PR DESCRIPTION
This pull request moves the logic for assembling shelf data out of `UploadToShelfService` and into the more appropriate `UserRepository`.

This abstracts away raw Realm instance operations from the service class, utilizing internal repository methods for `RealmMeetup` and `RealmRemovedLog` queries.

---
*PR created automatically by Jules for task [9091401644095974310](https://jules.google.com/task/9091401644095974310) started by @dogi*