### PR TITLE
Refactor UploadManager.uploadNews Realm queries into VoicesRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -68,9 +68,10 @@ object ServiceModule {
         userRepository: org.ole.planet.myplanet.repository.UserRepository,
         chatRepository: org.ole.planet.myplanet.repository.ChatRepository,
         uploadConfigs: org.ole.planet.myplanet.services.upload.UploadConfigs,
-        teamsRepository: Lazy<org.ole.planet.myplanet.repository.TeamsRepository>
+        teamsRepository: Lazy<org.ole.planet.myplanet.repository.TeamsRepository>,
+        voicesRepository: org.ole.planet.myplanet.repository.VoicesRepository
     ): UploadManager {
-        return UploadManager(context, databaseService, submissionsRepository, preferences, gson, uploadCoordinator, personalsRepository, userRepository, chatRepository, uploadConfigs, teamsRepository)
+        return UploadManager(context, databaseService, submissionsRepository, preferences, gson, uploadCoordinator, personalsRepository, userRepository, chatRepository, uploadConfigs, teamsRepository, voicesRepository)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepository.kt
@@ -6,6 +6,15 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUser
 
+
+data class NewsUploadData(
+    val id: String?,
+    val _id: String?,
+    val message: String?,
+    val imageUrls: List<String>,
+    val newsJson: com.google.gson.JsonObject
+)
+
 interface VoicesRepository {
     suspend fun getLibraryResource(resourceId: String): RealmMyLibrary?
     suspend fun getCommunityNews(userIdentifier: String): Flow<List<RealmNews>>
@@ -28,4 +37,6 @@ interface VoicesRepository {
     suspend fun getNewsById(id: String): RealmNews?
     suspend fun postReply(message: String, news: RealmNews, currentUser: RealmUser, imageList: io.realm.RealmList<String>?)
     suspend fun editPost(newsId: String, message: String, imagesToRemove: Set<String>, newImages: io.realm.RealmList<String>?)
+    suspend fun getPendingNews(chatRepository: ChatRepository): List<NewsUploadData>
+    suspend fun markNewsUploaded(newsId: String, responseId: String, responseRev: String, imagesJson: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepositoryImpl.kt
@@ -421,4 +421,34 @@ class VoicesRepositoryImpl @Inject constructor(
     private fun getDateFromTimestamp(timestamp: Long): String {
         return dateFormat.get()!!.format(java.util.Date(timestamp))
     }
+
+    override suspend fun getPendingNews(chatRepository: ChatRepository): List<NewsUploadData> {
+        return databaseService.withRealm { realm ->
+            realm.where(RealmNews::class.java)
+                .findAll()
+                .mapNotNull { news ->
+                    if (news.userId?.startsWith("guest") == true) null
+                    else NewsUploadData(
+                        id = news.id,
+                        _id = news._id,
+                        message = news.message,
+                        imageUrls = news.imageUrls?.toList() ?: emptyList(),
+                        newsJson = chatRepository.serializeNews(news)
+                    )
+                }
+        }
+    }
+
+    override suspend fun markNewsUploaded(newsId: String, responseId: String, responseRev: String, imagesJson: String) {
+        databaseService.executeTransactionAsync { realm ->
+            realm.where(RealmNews::class.java)
+                .equalTo("id", newsId)
+                .findFirst()?.let { managedNews ->
+                    managedNews.imageUrls?.clear()
+                    managedNews._id = responseId
+                    managedNews._rev = responseRev
+                    managedNews.images = imagesJson
+                }
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -72,7 +72,8 @@ class UploadManager @Inject constructor(
     private val userRepository: UserRepository,
     private val chatRepository: ChatRepository,
     private val uploadConfigs: UploadConfigs,
-    private val teamsRepository: Lazy<TeamsRepository>
+    private val teamsRepository: Lazy<TeamsRepository>,
+    private val voicesRepository: org.ole.planet.myplanet.repository.VoicesRepository
 ) : FileUploader() {
 
     private suspend fun uploadNewsActivities() {
@@ -599,28 +600,7 @@ class UploadManager @Inject constructor(
         val apiInterface = client.create(ApiInterface::class.java)
         val user = userRepository.getUserModelSuspending()
 
-        data class NewsUploadData(
-            val id: String?,
-            val _id: String?,
-            val message: String?,
-            val imageUrls: List<String>,
-            val newsJson: JsonObject
-        )
-
-        val newsItems = databaseService.withRealm { realm ->
-            realm.where(RealmNews::class.java)
-                .findAll()
-                .mapNotNull { news ->
-                    if (news.userId?.startsWith("guest") == true) null
-                    else NewsUploadData(
-                        id = news.id,
-                        _id = news._id,
-                        message = news.message,
-                        imageUrls = news.imageUrls?.toList() ?: emptyList(),
-                        newsJson = chatRepository.serializeNews(news)
-                    )
-                }
-        }
+        val newsItems = voicesRepository.getPendingNews(chatRepository)
 
         withContext(Dispatchers.IO) {
             newsItems.chunked(BATCH_SIZE).forEach { batch ->
@@ -691,16 +671,13 @@ class UploadManager @Inject constructor(
 
                         // Update database on success
                         if (newsResponse.isSuccessful && newsResponse.body() != null) {
-                            databaseService.executeTransactionAsync { realm ->
-                                realm.where(RealmNews::class.java)
-                                    .equalTo("id", news.id)
-                                    .findFirst()?.let { managedNews ->
-                                        managedNews.imageUrls?.clear()
-                                        managedNews._id = getString("id", newsResponse.body())
-                                        managedNews._rev = getString("rev", newsResponse.body())
-                                        managedNews.images = gson.toJson(imagesArray)
-                                    }
-                            }
+                            val responseBody = newsResponse.body()
+                            voicesRepository.markNewsUploaded(
+                                news.id!!,
+                                getString("id", responseBody),
+                                getString("rev", responseBody),
+                                gson.toJson(imagesArray)
+                            )
                         }
                     } catch (e: Exception) {
                         e.printStackTrace()


### PR DESCRIPTION
This refactor extracts the raw Realm database queries previously located in `UploadManager.uploadNews` and moves them into the `VoicesRepository` layer. A new DTO, `NewsUploadData`, has been created to safely pass the necessary fields and the serialized JSON (via `chatRepository`) back to the `UploadManager`. Additionally, the database modifications required after a successful upload have been abstracted into `VoicesRepository.markNewsUploaded(...)`. This aligns with the repository pattern and keeps database coupling out of the service layer.

---
*PR created automatically by Jules for task [15545347176171038591](https://jules.google.com/task/15545347176171038591) started by @dogi*