### PR TITLE
Refactor: Move getLastVisit from RealmTeamLog to TeamsRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
@@ -29,15 +29,6 @@ open class RealmTeamLog : RealmObject() {
         }
 
         @JvmStatic
-        fun getLastVisit(realm: Realm, userName: String?, teamId: String?): Long? {
-            return realm.where(RealmTeamLog::class.java)
-                .equalTo("type", "teamVisit")
-                .equalTo("user", userName)
-                .equalTo("teamId", teamId)
-                .max("time")?.toLong()
-        }
-
-        @JvmStatic
         fun serializeTeamActivities(log: RealmTeamLog, context: Context): JsonObject {
             val ob = JsonObject()
             ob.addProperty("user", log.user)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -150,4 +150,5 @@ interface TeamsRepository {
     suspend fun getNextLeaderCandidate(teamId: String, excludeUserId: String?): RealmUser?
     suspend fun getTeamCreator(teamId: String): String?
     suspend fun getAvailableResourcesToAdd(teamId: String): List<RealmMyLibrary>
+    suspend fun getLastTeamVisit(userName: String?, teamId: String?): Long?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -1171,4 +1171,14 @@ class TeamsRepositoryImpl @Inject constructor(
 
         return allLibraryItems.filter { it._id !in existingIds }
     }
+
+    override suspend fun getLastTeamVisit(userName: String?, teamId: String?): Long? {
+        return databaseService.withRealmAsync { realm ->
+            realm.where(RealmTeamLog::class.java)
+                .equalTo("type", "teamVisit")
+                .equalTo("user", userName)
+                .equalTo("teamId", teamId)
+                .max("time")?.toLong()
+        }
+    }
 }


### PR DESCRIPTION
Moved `getLastVisit` query from `RealmTeamLog` model to `TeamsRepository` interface and implementation.

---
*PR created automatically by Jules for task [11157855764398138788](https://jules.google.com/task/11157855764398138788) started by @dogi*