### PR TITLE
Refactor uploadUserActivities queries out of UploadManager

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -68,9 +68,10 @@ object ServiceModule {
         userRepository: org.ole.planet.myplanet.repository.UserRepository,
         chatRepository: org.ole.planet.myplanet.repository.ChatRepository,
         uploadConfigs: org.ole.planet.myplanet.services.upload.UploadConfigs,
-        teamsRepository: Lazy<org.ole.planet.myplanet.repository.TeamsRepository>
+        teamsRepository: Lazy<org.ole.planet.myplanet.repository.TeamsRepository>,
+        activitiesRepository: org.ole.planet.myplanet.repository.ActivitiesRepository
     ): UploadManager {
-        return UploadManager(context, databaseService, submissionsRepository, preferences, gson, uploadCoordinator, personalsRepository, userRepository, chatRepository, uploadConfigs, teamsRepository)
+        return UploadManager(context, databaseService, submissionsRepository, preferences, gson, uploadCoordinator, personalsRepository, userRepository, chatRepository, uploadConfigs, teamsRepository, activitiesRepository)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
@@ -1,7 +1,15 @@
 package org.ole.planet.myplanet.repository
 
+import android.content.Context
+import com.google.gson.JsonObject
 import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.model.RealmOfflineActivity
+
+data class ActivityData(
+    val activityId: String?,
+    val userId: String?,
+    val serialized: JsonObject
+)
 
 interface ActivitiesRepository {
     suspend fun getOfflineActivities(userName: String, type: String): List<RealmOfflineActivity>
@@ -17,4 +25,6 @@ interface ActivitiesRepository {
     suspend fun logResourceOpen(userName: String?, parentCode: String?, planetCode: String?, title: String?, resourceId: String?, type: String?)
     suspend fun getResourceOpenCount(userName: String, type: String): Long
     suspend fun getMostOpenedResource(userName: String, type: String): Pair<String, Int>?
+    suspend fun getPendingLoginActivities(context: Context): List<ActivityData>
+    suspend fun markActivityUploaded(activityId: String?, responseJson: JsonObject?)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package org.ole.planet.myplanet.repository
 
+import android.content.Context
+import com.google.gson.JsonObject
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
@@ -168,6 +170,33 @@ class ActivitiesRepositoryImpl @Inject constructor(
             } else {
                 Pair(maxEntry.value.second!!, maxEntry.value.first)
             }
+        }
+    }
+
+    override suspend fun getPendingLoginActivities(context: Context): List<ActivityData> {
+        return withRealm { realm ->
+            val activities = realm.where(RealmOfflineActivity::class.java)
+                .isNull("_rev").equalTo("type", "login").findAll()
+
+            activities.mapNotNull { activity ->
+                if (activity.userId?.startsWith("guest") == true) {
+                    null
+                } else {
+                    ActivityData(
+                        activityId = activity.id,
+                        userId = activity.userId,
+                        serialized = RealmOfflineActivity.serializeLoginActivities(activity, context)
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun markActivityUploaded(activityId: String?, responseJson: JsonObject?) {
+        executeTransaction { transactionRealm ->
+            transactionRealm.where(RealmOfflineActivity::class.java)
+                .equalTo("id", activityId)
+                .findFirst()?.changeRev(responseJson)
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -36,6 +36,7 @@ import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmSubmitPhotos
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUser
+import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.ChatRepository
 import org.ole.planet.myplanet.repository.PersonalsRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
@@ -72,7 +73,8 @@ class UploadManager @Inject constructor(
     private val userRepository: UserRepository,
     private val chatRepository: ChatRepository,
     private val uploadConfigs: UploadConfigs,
-    private val teamsRepository: Lazy<TeamsRepository>
+    private val teamsRepository: Lazy<TeamsRepository>,
+    private val activitiesRepository: ActivitiesRepository
 ) : FileUploader() {
 
     private suspend fun uploadNewsActivities() {
@@ -481,28 +483,7 @@ class UploadManager @Inject constructor(
         }
 
         try {
-            data class ActivityData(
-                val activityId: String?,
-                val userId: String?,
-                val serialized: JsonObject
-            )
-
-            val activitiesToUpload = databaseService.withRealm { realm ->
-                val activities = realm.where(RealmOfflineActivity::class.java)
-                    .isNull("_rev").equalTo("type", "login").findAll()
-
-                activities.mapNotNull { activity ->
-                    if (activity.userId?.startsWith("guest") == true) {
-                        null
-                    } else {
-                        ActivityData(
-                            activityId = activity.id,
-                            userId = activity.userId,
-                            serialized = RealmOfflineActivity.serializeLoginActivities(activity, context)
-                        )
-                    }
-                }
-            }
+            val activitiesToUpload = activitiesRepository.getPendingLoginActivities(context)
 
             activitiesToUpload.chunked(BATCH_SIZE).forEach { batch ->
                 batch.forEach { activityData ->
@@ -512,11 +493,7 @@ class UploadManager @Inject constructor(
                             "${UrlUtils.getUrl()}/login_activities", activityData.serialized
                         ).body()
 
-                        databaseService.executeTransactionAsync { transactionRealm ->
-                            transactionRealm.where(RealmOfflineActivity::class.java)
-                                .equalTo("id", activityData.activityId)
-                                .findFirst()?.changeRev(`object`)
-                        }
+                        activitiesRepository.markActivityUploaded(activityData.activityId, `object`)
                     } catch (e: IOException) {
                         e.printStackTrace()
                     }

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,20 @@
+1. **Create ActivityData DTO**
+   - Create a new data class `ActivityData` in `org.ole.planet.myplanet.repository.ActivitiesRepository` interface (or a separate file if needed, but it's small so inside the file is fine) that contains `activityId`, `userId`, and `serialized` (JsonObject).
+
+2. **Update ActivitiesRepository Interface**
+   - Add a suspend function `getPendingLoginActivities(context: Context): List<ActivityData>` to the `ActivitiesRepository` interface.
+   - Add a suspend function `markActivityUploaded(activityId: String?, responseJson: JsonObject)` to the `ActivitiesRepository` interface.
+
+3. **Update ActivitiesRepositoryImpl**
+   - Implement `getPendingLoginActivities(context: Context)` which will use `databaseService.withRealm` to find pending login activities (`isNull("_rev")` and `equalTo("type", "login")`), filter out guests, and map them to `ActivityData`.
+   - Implement `markActivityUploaded(activityId: String?, responseJson: JsonObject)` which will use `databaseService.executeTransactionAsync` to update the activity's `_id` and `_rev` using `changeRev` (or similar logic).
+
+4. **Update UploadManager.uploadUserActivities**
+   - Modify `uploadUserActivities` to call `activitiesRepository.getPendingLoginActivities(context)` instead of directly querying Realm.
+   - Modify the loop inside `uploadUserActivities` to call `activitiesRepository.markActivityUploaded(activityData.activityId, responseBody)` instead of the direct Realm transaction async block.
+
+5. **Run Pre-commit Checks**
+   - Call `pre_commit_instructions` and follow them to ensure tests pass and everything is good.
+
+6. **Submit Code**
+   - Commit and submit.


### PR DESCRIPTION
This refactors `UploadManager.uploadUserActivities` by delegating the database queries and updates to `ActivitiesRepository`.

Specifically:
- Adds an `ActivityData` DTO in `ActivitiesRepository` to hold the data required for API upload.
- Implements `getPendingLoginActivities` to return unuploaded login activities.
- Implements `markActivityUploaded` to change the `_rev` and `_id` after successful upload.
- Modifies `UploadManager` to use these new methods, removing raw Realm logic from the service layer.
- Updates dependency injection (`ServiceModule`) to include `ActivitiesRepository` in `UploadManager`.

---
*PR created automatically by Jules for task [2456253909184980172](https://jules.google.com/task/2456253909184980172) started by @dogi*