### PR TITLE
Refactor Health Upload Realm Queries to HealthRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -81,9 +81,10 @@ object ServiceModule {
         @AppPreferences preferences: SharedPreferences,
         resourcesRepository: org.ole.planet.myplanet.repository.ResourcesRepository,
         coursesRepository: org.ole.planet.myplanet.repository.CoursesRepository,
-        userRepository: org.ole.planet.myplanet.repository.UserRepository
+        userRepository: org.ole.planet.myplanet.repository.UserRepository,
+        healthRepository: org.ole.planet.myplanet.repository.HealthRepository
     ): UploadToShelfService {
-        return UploadToShelfService(context, databaseService, preferences, resourcesRepository, coursesRepository, userRepository)
+        return UploadToShelfService(context, databaseService, preferences, resourcesRepository, coursesRepository, userRepository, healthRepository)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
@@ -9,4 +9,6 @@ interface HealthRepository {
     suspend fun getExaminationById(id: String): RealmHealthExamination?
     suspend fun initHealth(): RealmMyHealth
     suspend fun saveExamination(examination: RealmHealthExamination?, pojo: RealmHealthExamination?, user: RealmUser?)
+    suspend fun getUpdatedHealthExaminations(userId: String? = null): List<RealmHealthExamination>
+    suspend fun markHealthUploaded(examinationId: String, rev: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -53,4 +53,24 @@ class HealthRepositoryImpl @Inject constructor(
             examination?.let { realm.copyToRealmOrUpdate(it) }
         }
     }
+
+    override suspend fun getUpdatedHealthExaminations(userId: String?): List<RealmHealthExamination> {
+        return withRealm { realm ->
+            val query = realm.where(RealmHealthExamination::class.java).equalTo("isUpdated", true)
+            if (userId.isNullOrEmpty()) {
+                query.notEqualTo("userId", "")
+            } else {
+                query.equalTo("userId", userId)
+            }
+            query.findAll().map { realm.copyFromRealm(it) }
+        }
+    }
+
+    override suspend fun markHealthUploaded(examinationId: String, rev: String) {
+        databaseService.executeTransactionAsync { realm ->
+            val managedPojo = realm.where(RealmHealthExamination::class.java).equalTo("_id", examinationId).findFirst()
+            managedPojo?._rev = rev
+            managedPojo?.isUpdated = false
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.model.RealmMeetup.Companion.getMyMeetUpIds
 import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.removedIds
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.HealthRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.generateIv
@@ -46,7 +47,8 @@ class UploadToShelfService @Inject constructor(
     @AppPreferences private val sharedPreferences: SharedPreferences,
     private val resourcesRepository: ResourcesRepository,
     private val coursesRepository: CoursesRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val healthRepository: HealthRepository
 ) {
     lateinit var mRealm: Realm
 
@@ -283,13 +285,7 @@ class UploadToShelfService @Inject constructor(
     fun uploadHealth() {
         val apiInterface = client.create(ApiInterface::class.java)
         MainApplication.applicationScope.launch(Dispatchers.IO) {
-            val myHealths = dbService.withRealm { realm ->
-                realm.where(RealmHealthExamination::class.java)
-                    .equalTo("isUpdated", true)
-                    .notEqualTo("userId", "")
-                    .findAll()
-                    .map { realm.copyFromRealm(it) }
-            }
+            val myHealths = healthRepository.getUpdatedHealthExaminations()
 
             myHealths.forEach { pojo ->
                 try {
@@ -297,10 +293,9 @@ class UploadToShelfService @Inject constructor(
 
                     if (res.body() != null && res.body()?.has("id") == true) {
                         val rev = res.body()?.get("rev")?.asString
-                        dbService.executeTransactionAsync { realm ->
-                            val managedPojo = realm.where(RealmHealthExamination::class.java).equalTo("_id", pojo._id).findFirst()
-                            managedPojo?._rev = rev
-                            managedPojo?.isUpdated = false
+                        val id = pojo._id
+                        if (rev != null && id != null) {
+                            healthRepository.markHealthUploaded(id, rev)
                         }
                     }
                 } catch (e: Exception) {
@@ -316,13 +311,7 @@ class UploadToShelfService @Inject constructor(
             try {
                 if (userId.isNullOrEmpty()) return@launch
 
-                val myHealths = dbService.withRealm { realm ->
-                    realm.where(RealmHealthExamination::class.java)
-                        .equalTo("isUpdated", true)
-                        .equalTo("userId", userId)
-                        .findAll()
-                        .map { realm.copyFromRealm(it) }
-                }
+                val myHealths = healthRepository.getUpdatedHealthExaminations(userId)
 
                 myHealths.forEach { pojo ->
                     try {
@@ -335,10 +324,9 @@ class UploadToShelfService @Inject constructor(
 
                         if (res.body() != null && res.body()?.has("id") == true) {
                             val rev = res.body()?.get("rev")?.asString
-                            dbService.executeTransactionAsync { realm ->
-                                val managedPojo = realm.where(RealmHealthExamination::class.java).equalTo("_id", pojo._id).findFirst()
-                                managedPojo?._rev = rev
-                                managedPojo?.isUpdated = false
+                            val id = pojo._id
+                            if (rev != null && id != null) {
+                                healthRepository.markHealthUploaded(id, rev)
                             }
                         }
                     } catch (e: Exception) {


### PR DESCRIPTION
Refactors UploadToShelfService to remove direct Realm access for health data uploads, delegating these operations to HealthRepository.

---
*PR created automatically by Jules for task [13185437995499689068](https://jules.google.com/task/13185437995499689068) started by @dogi*