### PR TITLE
Refactor UploadToShelfService to use User/Health repositories

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -81,9 +81,10 @@ object ServiceModule {
         @AppPreferences preferences: SharedPreferences,
         resourcesRepository: org.ole.planet.myplanet.repository.ResourcesRepository,
         coursesRepository: org.ole.planet.myplanet.repository.CoursesRepository,
-        userRepository: org.ole.planet.myplanet.repository.UserRepository
+        userRepository: org.ole.planet.myplanet.repository.UserRepository,
+        healthRepository: org.ole.planet.myplanet.repository.HealthRepository
     ): UploadToShelfService {
-        return UploadToShelfService(context, databaseService, preferences, resourcesRepository, coursesRepository, userRepository)
+        return UploadToShelfService(context, databaseService, preferences, resourcesRepository, coursesRepository, userRepository, healthRepository)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
@@ -9,4 +9,6 @@ interface HealthRepository {
     suspend fun getExaminationById(id: String): RealmHealthExamination?
     suspend fun initHealth(): RealmMyHealth
     suspend fun saveExamination(examination: RealmHealthExamination?, pojo: RealmHealthExamination?, user: RealmUser?)
+    suspend fun updateHealthUserId(modelId: String, userId: String?)
+    suspend fun updateHealthRevAndUpdatedStatus(pojoId: String, rev: String?, isUpdated: Boolean)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -53,4 +53,20 @@ class HealthRepositoryImpl @Inject constructor(
             examination?.let { realm.copyToRealmOrUpdate(it) }
         }
     }
+
+    override suspend fun updateHealthUserId(modelId: String, userId: String?) {
+        executeTransaction { realm ->
+            val list = realm.where(RealmHealthExamination::class.java).equalTo("_id", modelId).findAll()
+            for (p in list) {
+                p.userId = userId
+            }
+        }
+    }
+
+    override suspend fun updateHealthRevAndUpdatedStatus(pojoId: String, rev: String?, isUpdated: Boolean) {
+        update(RealmHealthExamination::class.java, "_id", pojoId) { managedPojo ->
+            managedPojo._rev = rev
+            managedPojo.isUpdated = isUpdated
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -25,6 +25,10 @@ interface UserRepository {
         endMillis: Long,
     ): Map<Int, Int>
     suspend fun saveUser(jsonDoc: JsonObject?, settings: SharedPreferences, key: String? = null, iv: String? = null): RealmUser?
+    suspend fun updateUserIdAndRev(modelId: String, id: String?, rev: String?)
+    suspend fun updateUserRevAndUpdatedStatus(modelId: String, rev: String?, isUpdated: Boolean)
+    suspend fun updateUserSecurityKeys(modelId: String, keyString: String?, iv: String?)
+
     suspend fun ensureUserSecurityKeys(userId: String): RealmUser?
     suspend fun updateSecurityData(
         name: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -157,6 +157,27 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun updateUserIdAndRev(modelId: String, id: String?, rev: String?) {
+        update(RealmUser::class.java, "id", modelId) { managedModel ->
+            managedModel._id = id
+            managedModel._rev = rev
+        }
+    }
+
+    override suspend fun updateUserRevAndUpdatedStatus(modelId: String, rev: String?, isUpdated: Boolean) {
+        update(RealmUser::class.java, "id", modelId) { managedModel ->
+            managedModel._rev = rev
+            managedModel.isUpdated = isUpdated
+        }
+    }
+
+    override suspend fun updateUserSecurityKeys(modelId: String, keyString: String?, iv: String?) {
+        update(RealmUser::class.java, "id", modelId) { managedModel ->
+            managedModel.key = keyString
+            managedModel.iv = iv
+        }
+    }
+
     override suspend fun ensureUserSecurityKeys(userId: String): RealmUser? {
         return withRealm { realm ->
             val user = realm.where(RealmUser::class.java).equalTo("id", userId).findFirst()

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.model.RealmMeetup.Companion.getMyMeetUpIds
 import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.removedIds
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.HealthRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.generateIv
@@ -46,9 +47,9 @@ class UploadToShelfService @Inject constructor(
     @AppPreferences private val sharedPreferences: SharedPreferences,
     private val resourcesRepository: ResourcesRepository,
     private val coursesRepository: CoursesRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val healthRepository: HealthRepository
 ) {
-    lateinit var mRealm: Realm
 
     fun uploadUserData(listener: OnSuccessListener) {
         val apiInterface = client.create(ApiInterface::class.java)
@@ -141,15 +142,7 @@ class UploadToShelfService @Inject constructor(
                 model._rev = rev
                 
                 // Persist _id and _rev to database
-                dbService.executeTransactionAsync { realm ->
-                    val managedModel = realm.where(RealmUser::class.java).equalTo("id", model.id).findFirst()
-                    if (managedModel != null) {
-                        managedModel._id = id
-                        managedModel._rev = rev
-                    } else {
-                        android.util.Log.e("UploadToShelfService", "Failed to find user model with id: ${model.id} for persisting _id and _rev")
-                    }
-                }
+                userRepository.updateUserIdAndRev(model.id ?: "", id, rev)
                 
                 processUserAfterCreation(apiInterface, model, obj)
             }
@@ -171,9 +164,7 @@ class UploadToShelfService @Inject constructor(
                 model.iterations = getString("iterations", fetchDataResponse.body())
                 saveKeyIv(apiInterface, model, obj)
 
-                dbService.executeTransactionAsync { realm ->
-                    updateHealthData(realm, model)
-                }
+                updateHealthData(model)
             }
         } catch (e: Exception) {
             e.printStackTrace()
@@ -199,11 +190,7 @@ class UploadToShelfService @Inject constructor(
 
                 if (updateResponse.isSuccessful) {
                     val updatedRev = updateResponse.body()?.get("rev")?.asString
-                    dbService.executeTransactionAsync { realm ->
-                        val managedModel = realm.where(RealmUser::class.java).equalTo("id", model.id).findFirst()
-                        managedModel?._rev = updatedRev
-                        managedModel?.isUpdated = false
-                    }
+                    userRepository.updateUserRevAndUpdatedStatus(model.id ?: "", updatedRev, false)
                 }
             }
         } catch (e: Exception) {
@@ -220,11 +207,8 @@ class UploadToShelfService @Inject constructor(
         return "$protocol://$replacedUrl"
     }
 
-    private fun updateHealthData(realm: Realm, model: RealmUser) {
-        val list: List<RealmHealthExamination> = realm.where(RealmHealthExamination::class.java).equalTo("_id", model.id).findAll()
-        for (p in list) {
-            p.userId = model._id
-        }
+    private suspend fun updateHealthData(model: RealmUser) {
+        healthRepository.updateHealthUserId(model.id ?: "", model._id)
     }
 
     suspend fun saveKeyIv(apiInterface: ApiInterface, model: RealmUser, obj: JsonObject) {
@@ -270,11 +254,7 @@ class UploadToShelfService @Inject constructor(
         if (response?.isSuccessful == true && response.body() != null) {
             changeUserSecurity(model, obj)
 
-            dbService.executeTransactionAsync { realm ->
-                val managedModel = realm.where(RealmUser::class.java).equalTo("id", model.id).findFirst()
-                managedModel?.key = keyString
-                managedModel?.iv = iv
-            }
+            userRepository.updateUserSecurityKeys(model.id ?: "", keyString, iv)
         } else {
             throw IOException("Failed to save key/IV after $maxAttempts attempts")
         }
@@ -297,11 +277,7 @@ class UploadToShelfService @Inject constructor(
 
                     if (res.body() != null && res.body()?.has("id") == true) {
                         val rev = res.body()?.get("rev")?.asString
-                        dbService.executeTransactionAsync { realm ->
-                            val managedPojo = realm.where(RealmHealthExamination::class.java).equalTo("_id", pojo._id).findFirst()
-                            managedPojo?._rev = rev
-                            managedPojo?.isUpdated = false
-                        }
+                        healthRepository.updateHealthRevAndUpdatedStatus(pojo._id ?: "", rev, false)
                     }
                 } catch (e: Exception) {
                     e.printStackTrace()
@@ -335,11 +311,7 @@ class UploadToShelfService @Inject constructor(
 
                         if (res.body() != null && res.body()?.has("id") == true) {
                             val rev = res.body()?.get("rev")?.asString
-                            dbService.executeTransactionAsync { realm ->
-                                val managedPojo = realm.where(RealmHealthExamination::class.java).equalTo("_id", pojo._id).findFirst()
-                                managedPojo?._rev = rev
-                                managedPojo?.isUpdated = false
-                            }
+                            healthRepository.updateHealthRevAndUpdatedStatus(pojo._id ?: "", rev, false)
                         }
                     } catch (e: Exception) {
                         e.printStackTrace()


### PR DESCRIPTION
Extracted database write transactions in `UploadToShelfService` to specific repository methods (`updateUserIdAndRev`, `updateUserSecurityKeys`, `updateHealthUserId`, etc.) to enforce the domain boundary, eliminating direct usage of `executeTransactionAsync`. The external API requests remain unchanged.

---
*PR created automatically by Jules for task [18431185917959300196](https://jules.google.com/task/18431185917959300196) started by @dogi*