### PR TITLE
teams: less realm news is more (fixes #11702)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,13 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-<<<<<<< refactor-remove-deprecated-news-insert-9654831351337210840
         versionCode = 4766
         versionName = "0.47.66"
-=======
-        versionCode = 4765
-        versionName = "0.47.65"
->>>>>>> master
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
🎯 **What:** Removed the unused deprecated `insert` and `serializeNews` methods from `RealmNews.kt`, along with their supporting private state and helper methods.
💡 **Why:** These methods were marked as deprecated in favor of `ChatRepository` equivalents and were no longer used anywhere in the codebase. Removing them improves maintainability and reduces dead code.
✅ **Verification:** Confirmed no external usages exist using `grep` and verified the file structure via manual review.
✨ **Result:** Cleaner and more maintainable `RealmNews` model.

---
*PR created automatically by Jules for task [9654831351337210840](https://jules.google.com/task/9654831351337210840) started by @dogi*