### PR TITLE
all: less submission exam map is more (fixes #11704)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,13 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-<<<<<<< fix-unused-getexammap-6790978603293595486
         versionCode = 4766
         versionName = "0.47.66"
-=======
-        versionCode = 4765
-        versionName = "0.47.65"
->>>>>>> master
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
🎯 **What:** Removed the unused and deprecated `getExamMap` method from `RealmSubmission.kt`. Also removed the private helper method `checkParentId` which was only used by `getExamMap`.

💡 **Why:** `getExamMap` was deprecated in favor of `SubmissionsRepository.getExamMap` and had no active usages in the codebase. Removing it cleans up dead code, improving codebase maintainability and readability.

✅ **Verification:**
- Ran `./gradlew :app:testDefaultDebugUnitTest --offline` which passed successfully.
- Conducted code review and ensured the removal was safe and didn't touch other unrelated methods.
- Searched codebase to ensure no remaining usages of `getExamMap` from `RealmSubmission.kt` or the `checkParentId` helper existed.

✨ **Result:** A cleaner `RealmSubmission.kt` file with deprecated/dead code successfully removed, lowering complexity and eliminating potential confusion for future contributors.

---
*PR created automatically by Jules for task [6790978603293595486](https://jules.google.com/task/6790978603293595486) started by @dogi*