### PR TITLE
⚡ Optimize Course Exams Fetch Query

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -292,10 +292,18 @@ class CoursesRepositoryImpl @Inject constructor(
             val title = course?.courseTitle
 
             val array = com.google.gson.JsonArray()
+            val stepIds = stepsList.mapNotNull { it.id }.toTypedArray()
+            val allExams = if (stepIds.isNotEmpty()) {
+                realm.where(RealmStepExam::class.java).`in`("stepId", stepIds).findAll()
+            } else {
+                emptyList()
+            }
+            val examsByStepId = allExams.groupBy { it.stepId }
+
             stepsList.forEach { step ->
                 val ob = com.google.gson.JsonObject()
                 ob.addProperty("stepId", step.id)
-                val exams = realm.where(RealmStepExam::class.java).equalTo("stepId", step.id).findAll()
+                val exams = examsByStepId[step.id] ?: emptyList()
                 getExamObject(realm, exams, ob, userId)
                 array.add(ob)
             }
@@ -305,7 +313,7 @@ class CoursesRepositoryImpl @Inject constructor(
 
     private fun getExamObject(
         realm: io.realm.Realm,
-        exams: io.realm.RealmResults<RealmStepExam>,
+        exams: Iterable<RealmStepExam>,
         ob: com.google.gson.JsonObject,
         userId: String?
     ) {


### PR DESCRIPTION
💡 **What:** The optimization implemented is refactoring `getCourseProgress` to replace individual `findAll()` calls inside the iteration with a single fetch for all relevant `RealmStepExam` objects matching the step IDs using the `in` operator, and grouping them in memory.
🎯 **Why:** The previous implementation executed a database query inside the loop to fetch `RealmStepExam` for each course step, resulting in a severe N+1 query performance bottleneck. This fix addresses that directly.
📊 **Measured Improvement:** We were unable to show a meaningful performance improvement because of offline dependencies issues when running robolectric-based local database unit tests. Nonetheless, removing a query call from within a loop inherently transforms time complexity from O(N * Q) to O(1 * Q), ensuring much more robust database access and significantly reduced execution time, particularly for courses with lots of steps.

---
*PR created automatically by Jules for task [2083039482242482110](https://jules.google.com/task/2083039482242482110) started by @dogi*