### PR TITLE
⚡ Optimize N+1 Query in CoursesRepositoryImpl getExamObject

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -305,31 +305,74 @@ class CoursesRepositoryImpl @Inject constructor(
 
     private fun getExamObject(
         realm: io.realm.Realm,
-        exams: io.realm.RealmResults<RealmStepExam>,
+        exams: Iterable<RealmStepExam>,
         ob: com.google.gson.JsonObject,
         userId: String?
     ) {
-        exams.forEach { it ->
-            it.id?.let { it1 ->
-                realm.where(org.ole.planet.myplanet.model.RealmSubmission::class.java).equalTo("userId", userId)
-                    .contains("parentId", it1).equalTo("type", "exam").findAll()
-            }?.map {
-                val answers = realm.where(org.ole.planet.myplanet.model.RealmAnswer::class.java).equalTo("submissionId", it.id).findAll()
-                var examId = it.parentId
-                if (it.parentId?.contains("@") == true) {
-                    examId = it.parentId!!.split("@")[0]
+        val examIds = exams.mapNotNull { it.id }.filter { it.isNotBlank() }
+        if (examIds.isEmpty()) return
+
+        val submissions = realm.where(org.ole.planet.myplanet.model.RealmSubmission::class.java)
+            .equalTo("userId", userId)
+            .equalTo("type", "exam")
+            .beginGroup()
+            .apply {
+                examIds.forEachIndexed { index, id ->
+                    if (index > 0) or()
+                    contains("parentId", id)
                 }
-                val questions = realm.where(org.ole.planet.myplanet.model.RealmExamQuestion::class.java).equalTo("examId", examId).findAll()
-                val questionCount = questions.size
-                if (questionCount == 0) {
-                    ob.addProperty("completed", false)
-                    ob.addProperty("percentage", 0)
-                } else {
-                    ob.addProperty("completed", answers.size == questionCount)
-                    val percentage = (answers.size.toDouble() / questionCount) * 100
-                    ob.addProperty("percentage", percentage)
+            }
+            .endGroup()
+            .findAll()
+
+        val submissionIds = submissions.mapNotNull { it.id }.filter { it.isNotBlank() }
+        val answersBySubmissionId = if (submissionIds.isNotEmpty()) {
+            realm.where(org.ole.planet.myplanet.model.RealmAnswer::class.java)
+                .`in`("submissionId", submissionIds.toTypedArray())
+                .findAll()
+                .groupBy { it.submissionId }
+        } else {
+            emptyMap()
+        }
+
+        val parsedExamIds = submissions.mapNotNull {
+            var examId = it.parentId
+            if (examId?.contains("@") == true) {
+                examId = examId.split("@")[0]
+            }
+            examId
+        }.filter { it.isNotBlank() }.distinct()
+
+        val questionsByExamId = if (parsedExamIds.isNotEmpty()) {
+            realm.where(org.ole.planet.myplanet.model.RealmExamQuestion::class.java)
+                .`in`("examId", parsedExamIds.toTypedArray())
+                .findAll()
+                .groupBy { it.examId }
+        } else {
+            emptyMap()
+        }
+
+        exams.forEach { stepExam ->
+            stepExam.id?.let { stepExamId ->
+                submissions.filter { it.parentId?.contains(stepExamId) == true }.forEach { submission ->
+                    val answers = answersBySubmissionId[submission.id] ?: emptyList()
+                    var examId = submission.parentId
+                    if (examId?.contains("@") == true) {
+                        examId = examId!!.split("@")[0]
+                    }
+                    val questions = questionsByExamId[examId] ?: emptyList()
+                    val questionCount = questions.size
+
+                    if (questionCount == 0) {
+                        ob.addProperty("completed", false)
+                        ob.addProperty("percentage", 0)
+                    } else {
+                        ob.addProperty("completed", answers.size == questionCount)
+                        val percentage = (answers.size.toDouble() / questionCount) * 100
+                        ob.addProperty("percentage", percentage)
+                    }
+                    ob.addProperty("status", submission.status)
                 }
-                ob.addProperty("status", it.status)
             }
         }
     }


### PR DESCRIPTION
💡 **What:**
Optimized `getExamObject` in `CoursesRepositoryImpl.kt` by removing heavily nested database loops. Instead, pre-fetched items with Realm batched `.in()` queries into memory grouped dictionary maps for O(1) loop lookups.

🎯 **Why:**
The previous implementation suffered from severe N+1 nested DB query performance degradation:
- Outer loop iterated over each `RealmStepExam`.
- Inside this loop, it dynamically queried submissions.
- For each submission, it dynamically queried all its answers and all corresponding exam questions.
This meant that fetching course progress for a user on a course with several steps could generate hundreds of separate blocking database operations on the UI thread.

📊 **Measured Improvement:**
While Robolectric local benchmark tests could not be effectively built in this test suite due to missing Java/Gradle compilation toolchains locally, the performance optimization is highly reliable mathematically. We eliminated O(N*M) blocking database lookups inside the loop completely, bringing it down from roughly `N*M + 1` queries down to just `3` batched queries (plus grouping operations into in-memory dictionary maps). The time complexity for database access shifts from `O(N * M)` down to `O(1)` query execution + local `O(N)` Hash Map lookups.

---
*PR created automatically by Jules for task [10402844422174342582](https://jules.google.com/task/10402844422174342582) started by @dogi*