### PR TITLE
⚡ Optimize Course Progress Exam Fetching (N+1 Query)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -292,10 +292,22 @@ class CoursesRepositoryImpl @Inject constructor(
             val title = course?.courseTitle
 
             val array = com.google.gson.JsonArray()
+
+            val stepIds = stepsList.mapNotNull { it.id }.toTypedArray()
+            val allExams = if (stepIds.isNotEmpty()) {
+                realm.where(RealmStepExam::class.java)
+                    .`in`("stepId", stepIds)
+                    .findAll()
+            } else {
+                emptyList()
+            }
+
+            val examsByStepId = allExams.groupBy { it.stepId }
+
             stepsList.forEach { step ->
                 val ob = com.google.gson.JsonObject()
                 ob.addProperty("stepId", step.id)
-                val exams = realm.where(RealmStepExam::class.java).equalTo("stepId", step.id).findAll()
+                val exams = examsByStepId[step.id] ?: emptyList()
                 getExamObject(realm, exams, ob, userId)
                 array.add(ob)
             }
@@ -305,7 +317,7 @@ class CoursesRepositoryImpl @Inject constructor(
 
     private fun getExamObject(
         realm: io.realm.Realm,
-        exams: io.realm.RealmResults<RealmStepExam>,
+        exams: Iterable<RealmStepExam>,
         ob: com.google.gson.JsonObject,
         userId: String?
     ) {


### PR DESCRIPTION
💡 **What:** Optimized the N+1 anti-pattern in `CoursesRepositoryImpl.kt:298` when fetching exams for a list of steps in `getCourseProgress`. By aggregating all step IDs into a single query using Realm's `.in` operator, we perform one bulk fetch and then use an in-memory map (via `groupBy`) to look up the correct exams for each step. The `getExamObject` function's signature was adjusted from `io.realm.RealmResults` to `Iterable` to handle the mapped data structure securely.

🎯 **Why:** Previously, the `getCourseProgress` function fired an individual Realm database query for `RealmStepExam` for every single course step returned by `getCourseSteps()`. If a course had 50 steps, this generated 50 sequential synchronous database queries. This was a classic N+1 database performance antipattern leading to degraded UI fluidity and higher device CPU consumption. The optimization consolidates it into exactly two queries (1 for steps, 1 for all exams).

📊 **Measured Improvement:** The optimization structurally reduces database round trips from N+1 down to 2. Though I did not run a granular benchmarking script (as a targeted test structure for this was missing locally), removing O(N) database reads inside a for-loop and replacing it with an O(1) read + O(N) memory mapping is universally accepted as an enormous performance improvement in mobile apps because database crossing calls are natively expensive compared to JVM native in-memory processing.

---
*PR created automatically by Jules for task [9961194260312743896](https://jules.google.com/task/9961194260312743896) started by @dogi*