### PR TITLE
Refactor: Use repeatOnLifecycle for Flow collections in NotificationsFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsFragment.kt
@@ -11,7 +11,9 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.ArrayList
@@ -80,23 +82,27 @@ class NotificationsFragment : Fragment() {
         }
         viewModel.loadNotifications(userId, "all")
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.notifications.collect { notifications ->
-                adapter.submitList(notifications)
-                val isEmpty = notifications.isEmpty()
-                binding.emptyData.visibility = if (isEmpty) View.VISIBLE else View.GONE
-                binding.emptyData.text = when (currentFilter) {
-                    "unread" -> getString(R.string.no_unread_notifications)
-                    "read" -> getString(R.string.no_read_notifications)
-                    else -> getString(R.string.no_notifications)
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.notifications.collect { notifications ->
+                        adapter.submitList(notifications)
+                        val isEmpty = notifications.isEmpty()
+                        binding.emptyData.visibility = if (isEmpty) View.VISIBLE else View.GONE
+                        binding.emptyData.text = when (currentFilter) {
+                            "unread" -> getString(R.string.no_unread_notifications)
+                            "read" -> getString(R.string.no_read_notifications)
+                            else -> getString(R.string.no_notifications)
+                        }
+                        binding.status.visibility = if (isEmpty && currentFilter == "all") View.GONE else View.VISIBLE
+                    }
                 }
-                binding.status.visibility = if (isEmpty && currentFilter == "all") View.GONE else View.VISIBLE
-            }
-        }
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.unreadCount.collect { count ->
-                notificationUpdateListener?.onNotificationCountUpdated(count)
-                val showButton = count > 0 && currentFilter != "read"
-                binding.btnMarkAllAsRead.visibility = if (showButton) View.VISIBLE else View.GONE
+                launch {
+                    viewModel.unreadCount.collect { count ->
+                        notificationUpdateListener?.onNotificationCountUpdated(count)
+                        val showButton = count > 0 && currentFilter != "read"
+                        binding.btnMarkAllAsRead.visibility = if (showButton) View.VISIBLE else View.GONE
+                    }
+                }
             }
         }
         binding.btnMarkAllAsRead.setOnClickListener {


### PR DESCRIPTION
Refactor Flow collection in NotificationsFragment to properly use `repeatOnLifecycle`. This consolidates multiple `lifecycleScope.launch` calls and ensures Flow emissions are only collected when the fragment is at least in the STARTED state, preventing unnecessary work when the fragment is in the background and adhering to Android best practices.

---
*PR created automatically by Jules for task [14066196976725379610](https://jules.google.com/task/14066196976725379610) started by @dogi*