### PR TITLE
Fix compilation error in TransactionSyncManager

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -311,12 +311,12 @@ class TransactionSyncManager @Inject constructor(
             }
         }
 
-        val settings = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
         documentList.forEach { jsonDoc ->
-            continueInsert(mRealm, table, jsonDoc, settings)
+            continueInsert(mRealm, table, jsonDoc)
         }
 
-        saveConcatenatedLinksToPrefs()
+        saveConcatenatedLinksToPrefs(sharedPrefManager)
     }
 
     private fun continueInsert(mRealm: Realm, table: String, jsonDoc: JsonObject) {


### PR DESCRIPTION
Fix compilation error in TransactionSyncManager where PREFS_NAME was unresolved.
1. Remove `settings` parameter, which is unused and caused an argument mismatch in `continueInsert`.
2. Provide missing `SharedPrefManager` to `saveConcatenatedLinksToPrefs`.

---
*PR created automatically by Jules for task [13120522807475103937](https://jules.google.com/task/13120522807475103937) started by @dogi*