### PR TITLE
Migrate UI selection to SelectionViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/components/SelectionViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/components/SelectionViewModel.kt
@@ -1,0 +1,54 @@
+package org.ole.planet.myplanet.ui.components
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.ole.planet.myplanet.model.Course
+import org.ole.planet.myplanet.model.ResourceItem
+
+class SelectionViewModel : ViewModel() {
+
+    private val _selectedCourses = MutableStateFlow<List<Course>>(emptyList())
+    val selectedCourses: StateFlow<List<Course>> = _selectedCourses.asStateFlow()
+
+    private val _selectedResources = MutableStateFlow<List<ResourceItem>>(emptyList())
+    val selectedResources: StateFlow<List<ResourceItem>> = _selectedResources.asStateFlow()
+
+    fun toggleCourseSelection(course: Course) {
+        _selectedCourses.update { current ->
+            if (current.any { it.courseId == course.courseId }) {
+                current.filter { it.courseId != course.courseId }
+            } else {
+                current + course
+            }
+        }
+    }
+
+    fun selectAllCourses(courses: List<Course>, select: Boolean) {
+        _selectedCourses.value = if (select) courses else emptyList()
+    }
+
+    fun clearCourseSelections() {
+        _selectedCourses.value = emptyList()
+    }
+
+    fun toggleResourceSelection(resource: ResourceItem) {
+        _selectedResources.update { current ->
+            if (current.any { it.id == resource.id }) {
+                current.filter { it.id != resource.id }
+            } else {
+                current + resource
+            }
+        }
+    }
+
+    fun selectAllResources(resources: List<ResourceItem>, select: Boolean) {
+        _selectedResources.value = if (select) resources else emptyList()
+    }
+
+    fun clearResourceSelections() {
+        _selectedResources.value = emptyList()
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -58,7 +58,7 @@ class CoursesAdapter(
         }
     )
 ) {
-    private val selectedItems: MutableList<Course?> = ArrayList()
+    private var selectedItems: List<Course> = emptyList()
     private var listener: OnCourseItemSelectedListener? = null
     private var homeItemClickListener: OnHomeItemClickListener? = null
     private var progressMap: HashMap<String?, JsonObject>? = null
@@ -291,8 +291,7 @@ class CoursesAdapter(
                         context.getString(R.string.select_res_course, course.courseTitle)
                     val adapterPosition = holder.bindingAdapterPosition
                     if (adapterPosition != RecyclerView.NO_POSITION) {
-                        SelectionUtils.handleCheck((view as CheckBox).isChecked, adapterPosition, selectedItems, currentList)
-                        listener?.onSelectedListChange(selectedItems)
+                        listener?.onSelectedListChange(mutableListOf(course))
                     }
                 }
             } else {
@@ -317,27 +316,14 @@ class CoursesAdapter(
         activeJobs.clear()
     }
 
-    fun areAllSelected(): Boolean {
-        val selectableCourses = currentList.filter { isMyCourseLib || !it.isMyCourse }
-        areAllSelected = selectedItems.size == selectableCourses.size && selectableCourses.isNotEmpty()
-        return areAllSelected
+    fun setSelectedItems(items: List<Course>) {
+        this.selectedItems = items
+        notifyDataSetChanged()
     }
 
-    fun selectAllItems(selectAll: Boolean) {
-        selectedItems.clear()
-
-        if (selectAll) {
-            val selectableCourses = currentList.filter { isMyCourseLib || !it.isMyCourse }
-            selectedItems.addAll(selectableCourses)
-        }
-
-        currentList.forEachIndexed { index, course ->
-            if (isMyCourseLib || !course.isMyCourse) {
-                notifyItemChanged(index)
-            }
-        }
-
-        listener?.onSelectedListChange(selectedItems)
+    fun areAllSelected(): Boolean {
+        val selectableCourses = currentList.filter { isMyCourseLib || !it.isMyCourse }
+        return selectedItems.size == selectableCourses.size && selectableCourses.isNotEmpty()
     }
 
     override fun onBindViewHolder(

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -46,8 +46,10 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.services.sync.SyncManager
+import androidx.fragment.app.activityViewModels
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.ui.resources.CollectionsFragment
+import org.ole.planet.myplanet.ui.components.SelectionViewModel
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncHelper
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
 import org.ole.planet.myplanet.utils.DialogUtils
@@ -73,6 +75,8 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
     private var searchTextWatcher: TextWatcher? = null
     private var searchJob: Job? = null
+
+    private val selectionViewModel: SelectionViewModel by activityViewModels()
 
     @Inject
     lateinit var prefManager: SharedPrefManager
@@ -269,8 +273,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         )
         adapterCourses.submitList(courses) {
             if (isAdded && view != null && ::selectAll.isInitialized) {
-                selectedItems?.clear()
-                clearAllSelections()
+                selectionViewModel.clearCourseSelections()
                 checkList()
             }
         }
@@ -298,6 +301,15 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                 showNoData(tvMessage, adapterCourses.itemCount, "courses")
             }
             updateCheckBoxState(false)
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            selectionViewModel.selectedCourses.collect { selected ->
+                if (::adapterCourses.isInitialized) {
+                    adapterCourses.setSelectedItems(selected)
+                }
+                changeButtonStatus()
+            }
         }
 
         realtimeSyncHelper = RealtimeSyncHelper(this, this)
@@ -334,17 +346,24 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
 
         btnRemove.setOnClickListener {
             val alertDialogBuilder = AlertDialog.Builder(ContextThemeWrapper(this.context, R.style.CustomAlertDialog))
-            val message = if (countSelected() == 1) {
+            val count = selectionViewModel.selectedCourses.value.size
+            val message = if (count == 1) {
                 R.string.are_you_sure_you_want_to_leave_this_course
             } else {
                 R.string.are_you_sure_you_want_to_leave_these_courses
             }
             alertDialogBuilder.setMessage(message)
                 .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
-                    val courseIdsToRemove = selectedItems?.mapNotNull { it?.courseId } ?: emptyList()
+                    val coursesToRemove = selectionViewModel.selectedCourses.value
+                    val courseIdsToRemove = coursesToRemove.map { it.courseId }
+                    // Populate base class selectedItems before calling deleteSelected
+                    selectedItems = coursesToRemove.mapNotNull { course ->
+                        mRealm.where(RealmMyCourse::class.java).equalTo("courseId", course.courseId).findFirst()
+                    }.toMutableList<RealmMyCourse?>()
+
                     viewLifecycleOwner.lifecycleScope.launch {
                         deleteSelected(true)
-                        clearAllSelections()
+                        selectionViewModel.clearCourseSelections()
                         adapterCourses.removeCourses(courseIdsToRemove)
                     }
                 }
@@ -353,17 +372,24 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
 
         btnArchive.setOnClickListener {
             val alertDialogBuilder = AlertDialog.Builder(ContextThemeWrapper(this.context, R.style.CustomAlertDialog))
-            val message = if (countSelected() == 1) {
+            val count = selectionViewModel.selectedCourses.value.size
+            val message = if (count == 1) {
                 R.string.are_you_sure_you_want_to_archive_this_course
             } else {
                 R.string.are_you_sure_you_want_to_archive_these_courses
             }
             alertDialogBuilder.setMessage(message)
                 .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
-                    val courseIdsToRemove = selectedItems?.mapNotNull { it?.courseId } ?: emptyList()
+                    val coursesToRemove = selectionViewModel.selectedCourses.value
+                    val courseIdsToRemove = coursesToRemove.map { it.courseId }
+                    // Populate base class selectedItems before calling deleteSelected
+                    selectedItems = coursesToRemove.mapNotNull { course ->
+                        mRealm.where(RealmMyCourse::class.java).equalTo("courseId", course.courseId).findFirst()
+                    }.toMutableList<RealmMyCourse?>()
+
                     viewLifecycleOwner.lifecycleScope.launch {
                         deleteSelected(true)
-                        clearAllSelections()
+                        selectionViewModel.clearCourseSelections()
                         adapterCourses.removeCourses(courseIdsToRemove)
                     }
                 }
@@ -430,7 +456,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     private fun initializeView() {
         tvAddToLib = requireView().findViewById(R.id.tv_add)
         tvAddToLib.setOnClickListener {
-            if ((selectedItems?.size ?: 0) > 0) {
+            if (selectionViewModel.selectedCourses.value.isNotEmpty()) {
                 confirmation = createAlertDialog()
                 confirmation.show()
             }
@@ -476,14 +502,15 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             if (isUpdatingSelectAllState) {
                 return@setOnCheckedChangeListener
             }
-            hideButtons()
-            adapterCourses.selectAllItems(isChecked)
-            selectAll.text = if (isChecked) getString(R.string.unselect_all) else getString(R.string.select_all)
+            if (::adapterCourses.isInitialized) {
+                val selectableCourses = adapterCourses.currentList.filter { isMyCourseLib || !it.isMyCourse }
+                selectionViewModel.selectAllCourses(selectableCourses, isChecked)
+            }
         }
     }
 
     private fun hideButtons() {
-        val count = selectedItems.orEmpty().size
+        val count = selectionViewModel.selectedCourses.value.size
         btnArchive.isEnabled = count != 0
         btnRemove.isEnabled = count != 0
         if (count != 0) {
@@ -584,16 +611,16 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     private fun createAlertDialog(): AlertDialog {
         val builder = AlertDialog.Builder(requireContext(), R.style.CustomAlertDialog)
         var msg = getString(R.string.success_you_have_added_the_following_courses)
-        val items = selectedItems.orEmpty()
+        val items = selectionViewModel.selectedCourses.value
         if (items.size <= 5) {
             for (i in items.indices) {
-                msg += " - ${items[i]?.courseTitle} \n"
+                msg += " - ${items[i].courseTitle} \n"
             }
         } else {
             for (i in 0..4) {
-                msg += " - ${selectedItems?.get(i)?.courseTitle} \n"
+                msg += " - ${items[i].courseTitle} \n"
             }
-            msg += "${getString(R.string.and)}${((selectedItems?.size ?: 0) - 5)}${getString(R.string.more_course_s)}"
+            msg += "${getString(R.string.and)}${(items.size - 5)}${getString(R.string.more_course_s)}"
         }
         msg += getString(R.string.return_to_the_home_tab_to_access_mycourses)
         builder.setMessage(msg)
@@ -614,40 +641,30 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                 dialog.cancel()
             }
             .setOnDismissListener {
+                // Populate base class selectedItems before calling addToMyList so it processes them
+                val realmCourses = items.mapNotNull { course ->
+                    var rc = mRealm.where(RealmMyCourse::class.java).equalTo("courseId", course.courseId).findFirst()
+                    if (rc == null) {
+                        rc = RealmMyCourse()
+                        rc.courseId = course.courseId
+                        rc.courseTitle = course.courseTitle
+                        rc.isMyCourse = course.isMyCourse
+                    }
+                    rc
+                }.toMutableList<RealmMyCourse?>()
+                selectedItems = realmCourses
                 addToMyList()
+                selectionViewModel.clearCourseSelections()
             }
 
         return builder.create()
     }
 
     override fun onSelectedListChange(list: MutableList<Course?>) {
-        val realmCourses = list.mapNotNull { course ->
-            course?.let {
-                // Find managed RealmMyCourse or use a dummy one for addToMyList/deletion?
-                // For addToMyList, we need managed object if we want to add relation?
-                // Actually addToMyList just extracts IDs.
-                // But deleteSelected uses `mRealm.beginTransaction()`.
-                // And `deleteCourseProgress` uses `object.courseId`.
-                // `removeFromShelf`?
-                // `BaseRecyclerFragment.removeFromShelf` checks `object is RealmMyCourse`.
-                // And calls `coursesRepository.removeCourseFromShelf(courseId, userId)`.
-
-                // So I can create an unmanaged RealmMyCourse with just ID and Title.
-                // But safer to try finding it.
-                var rc = mRealm.where(RealmMyCourse::class.java).equalTo("courseId", it.courseId).findFirst()
-                if (rc == null) {
-                    // Create unmanaged
-                    rc = RealmMyCourse()
-                    rc.courseId = it.courseId
-                    rc.courseTitle = it.courseTitle
-                    rc.isMyCourse = it.isMyCourse
-                }
-                rc
-            }
-        }.toMutableList<RealmMyCourse?>()
-        selectedItems = realmCourses
-        changeButtonStatus()
-        hideButtons()
+        // Now called with the single item that was toggled
+        list.firstOrNull()?.let { course ->
+            selectionViewModel.toggleCourseSelection(course)
+        }
     }
 
     override fun onTagClicked(tag: Tag) {
@@ -674,18 +691,11 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         isUpdatingSelectAllState = false
     }
 
-    private fun clearAllSelections() {
-        if (::adapterCourses.isInitialized) {
-            adapterCourses.selectAllItems(false)
-            updateCheckBoxState(false)
-            selectAll.text = getString(R.string.select_all)
-        }
-    }
-
     private fun changeButtonStatus() {
-        tvAddToLib.isEnabled = (selectedItems?.size ?: 0) > 0
-        btnRemove.isEnabled = (selectedItems?.size ?: 0) > 0
-        btnArchive.isEnabled = (selectedItems?.size ?: 0) > 0
+        val count = selectionViewModel.selectedCourses.value.size
+        tvAddToLib.isEnabled = count > 0
+        btnRemove.isEnabled = count > 0
+        btnArchive.isEnabled = count > 0
 
         if (::adapterCourses.isInitialized) {
             val allSelected = adapterCourses.areAllSelected()
@@ -745,7 +755,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     override fun onPause() {
         super.onPause()
         saveSearchActivity()
-        clearAllSelections()
+        selectionViewModel.clearCourseSelections()
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -40,7 +40,7 @@ class ResourcesAdapter(
     )
 ) {
 
-    private val selectedItems: MutableList<ResourceItem> = ArrayList()
+    private var selectedItems: List<ResourceItem> = emptyList()
     private var listener: OnLibraryItemSelectedListener? = null
     private val config: ChipCloudConfig = Utilities.getCloudConfig().selectMode(ChipCloud.SelectMode.single)
     private var homeItemClickListener: OnHomeItemClickListener? = null
@@ -132,15 +132,9 @@ class ResourcesAdapter(
                 holder.rowLibraryBinding.checkbox.setOnClickListener { view: View ->
                     holder.rowLibraryBinding.checkbox.contentDescription =
                         context.getString(R.string.select_res_course, library.title ?: "")
-                    val isChecked = (view as CheckBox).isChecked
-                    if (isChecked) {
-                        if (!selectedItems.contains(library)) {
-                            selectedItems.add(library)
-                        }
-                    } else {
-                        selectedItems.remove(library)
-                    }
-                    if (listener != null) listener?.onSelectedListChange(selectedItems)
+
+                    // The view model handles state logic, just pass the toggled item
+                    listener?.onSelectedListChange(listOf(library))
                 }
             } else {
                 holder.rowLibraryBinding.checkbox.visibility = View.GONE
@@ -148,21 +142,17 @@ class ResourcesAdapter(
         }
     }
 
+    fun setSelectedItems(items: List<ResourceItem>) {
+        this.selectedItems = items
+        notifyItemRangeChanged(0, currentList.size, SELECTION_PAYLOAD)
+    }
+
     fun areAllSelected(): Boolean {
         return currentList.isNotEmpty() && selectedItems.size == currentList.size
     }
 
     fun selectAllItems(selectAll: Boolean) {
-        if (selectAll) {
-            selectedItems.clear()
-            selectedItems.addAll(currentList)
-        } else {
-            selectedItems.clear()
-        }
-        notifyItemRangeChanged(0, currentList.size, SELECTION_PAYLOAD)
-        if (listener != null) {
-            listener?.onSelectedListChange(selectedItems)
-        }
+        // Handled by viewmodel, adapter shouldn't mutate its own state for selectAll anymore
     }
 
     private fun openLibrary(library: ResourceItem) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -40,10 +40,12 @@ import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.ResourceItem
 import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.model.TagItem
+import androidx.fragment.app.activityViewModels
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
+import org.ole.planet.myplanet.ui.components.SelectionViewModel
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncHelper
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
 import org.ole.planet.myplanet.utils.DialogUtils
@@ -74,6 +76,8 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     private var searchTextWatcher: TextWatcher? = null
     private var isFirstResume = true
     private var allLibraryItems: List<RealmMyLibrary> = emptyList()
+
+    private val selectionViewModel: SelectionViewModel by activityViewModels()
 
     @Inject
     lateinit var prefManager: SharedPrefManager
@@ -281,6 +285,16 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
             }
         }
 
+        viewLifecycleOwner.lifecycleScope.launch {
+            selectionViewModel.selectedResources.collect { selected ->
+                if (::adapterLibrary.isInitialized) {
+                    adapterLibrary.setSelectedItems(selected)
+                }
+                changeButtonStatus()
+                hideButton()
+            }
+        }
+
         if (::adapterLibrary.isInitialized) {
             showNoData(tvMessage, adapterLibrary.itemCount, "resources")
             changeButtonStatus()
@@ -323,7 +337,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     private fun setupAddToLibListener() {
         tvAddToLib.setOnClickListener {
-            if ((selectedItems?.size ?: 0) > 0) {
+            if (selectionViewModel.selectedResources.value.isNotEmpty()) {
                 confirmation = createAlertDialog()
                 confirmation?.show()
             }
@@ -374,7 +388,10 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         selectAll.setOnClickListener {
             hideButton()
             val allSelected = adapterLibrary.areAllSelected()
-            adapterLibrary.selectAllItems(!allSelected)
+
+            // Delegate to the ViewModel
+            selectionViewModel.selectAllResources(adapterLibrary.getLibraryList(), !allSelected)
+
             if (allSelected) {
                 selectAll.isChecked = false
                 selectAll.text = getString(R.string.select_all)
@@ -403,7 +420,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     }
 
     private fun hideButton(){
-        val count = selectedItems?.size ?: 0
+        val count = selectionViewModel.selectedResources.value.size
         tvDelete?.isEnabled = count != 0
         tvAddToLib.isEnabled = count != 0
         if (count != 0) {
@@ -460,23 +477,29 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
             dialog.cancel()
         }
         builder.setOnDismissListener {
+            val itemsToAdd = selectionViewModel.selectedResources.value
+            selectedItems = itemsToAdd.mapNotNull { item ->
+                allLibraryItems.find { it.id == item.id }
+            }.toMutableList<RealmMyLibrary?>()
+
             addToMyList()
+            selectionViewModel.clearResourceSelections()
         }
         return builder.create()
     }
 
     private fun buildAlertMessage(): String {
         var msg = getString(R.string.success_you_have_added_these_resources_to_your_mylibrary)
-        val items = selectedItems.orEmpty()
+        val items = selectionViewModel.selectedResources.value
         if (items.size <= 5) {
             for (i in items.indices) {
-                msg += " - " + items[i]?.title + "\n"
+                msg += " - " + items[i].title + "\n"
             }
         } else {
             for (i in 0..4) {
-                msg += " - " + selectedItems?.get(i)?.title + "\n"
+                msg += " - " + items[i].title + "\n"
             }
-            msg += getString(R.string.and) + ((selectedItems?.size ?: 0) - 5) +
+            msg += getString(R.string.and) + (items.size - 5) +
                 getString(R.string.more_resource_s)
         }
         msg += getString(R.string.return_to_the_home_tab_to_access_mylibrary) +
@@ -502,13 +525,10 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     }
 
     override fun onSelectedListChange(list: List<ResourceItem>) {
-        val newSelected = list.mapNotNull { item ->
-            allLibraryItems.find { it.id == item.id }
+        // Now called with the single item that was toggled
+        list.firstOrNull()?.let { resource ->
+            selectionViewModel.toggleResourceSelection(resource)
         }
-        selectedItems?.clear()
-        selectedItems?.addAll(newSelected)
-        changeButtonStatus()
-        hideButton()
     }
 
     override fun onTagClicked(tag: TagItem) {
@@ -566,8 +586,8 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     }
 
     private fun changeButtonStatus() {
-        tvAddToLib.isEnabled = (selectedItems?.size ?: 0) > 0
-        if (adapterLibrary.areAllSelected()) {
+        tvAddToLib.isEnabled = selectionViewModel.selectedResources.value.isNotEmpty()
+        if (::adapterLibrary.isInitialized && adapterLibrary.areAllSelected() && adapterLibrary.getLibraryList().isNotEmpty()) {
             selectAll.isChecked = true
             selectAll.text = getString(R.string.unselect_all)
         } else {
@@ -767,7 +787,8 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     override suspend fun deleteSelected(deleteProgress: Boolean) {
         val userId = userModel?.id
-        val itemsToDelete = selectedItems?.mapNotNull { it?.resourceId } ?: emptyList()
+        val selectedResources = selectionViewModel.selectedResources.value
+        val itemsToDelete = selectedResources.mapNotNull { it.resourceId }
 
         if (userId != null && itemsToDelete.isNotEmpty()) {
             withContext(Dispatchers.IO) {
@@ -778,9 +799,9 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
             if (_binding == null) return
             Utilities.toast(activity, getString(R.string.removed_from_mylibrary))
             refreshResourcesData()
-            selectedItems?.clear()
-            changeButtonStatus()
-            hideButton()
+
+            // Note: we let the viewmodel manage state, so we just clear it
+            selectionViewModel.clearResourceSelections()
         }
     }
 
@@ -795,9 +816,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
                     if (_binding == null) return@withContext
                     Utilities.toast(activity, getString(R.string.added_to_my_library))
                     refreshResourcesData()
-                    selectedItems?.clear()
-                    changeButtonStatus()
-                    hideButton()
+                    selectionViewModel.clearResourceSelections()
                 }
             }
         }


### PR DESCRIPTION
This commit addresses the issue of migrating UI selection state (specifically for lists of courses and resources) to a shared ViewModel. Previously, the `CoursesAdapter` and `ResourcesAdapter` maintained internal mutable lists to track selected items, and the Fragments synchronized this state via callbacks and internal reference tracking.

Now, a `SelectionViewModel` within the `ui/components` package serves as the single source of truth for selections. The adapters no longer maintain internal state but simply display the given selection state via a new `setSelectedItems()` method, while exposing click events upward. The Fragments observe the `StateFlow` from the ViewModel to reactively update both the adapter checkboxes and the visibility/enabled states of action buttons (such as 'Delete', 'Add to Library', and 'Archive').

---
*PR created automatically by Jules for task [9484863262801446151](https://jules.google.com/task/9484863262801446151) started by @dogi*