### PR TITLE
🧪 Add tests for DatabaseService async functions

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/data/DatabaseServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/DatabaseServiceTest.kt
@@ -1,0 +1,68 @@
+package org.ole.planet.myplanet.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class DatabaseServiceTest {
+
+    private lateinit var context: Context
+    private lateinit var databaseService: DatabaseService
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        Realm.init(context)
+        val testConfig = RealmConfiguration.Builder()
+            .inMemory()
+            .name("test-realm")
+            .build()
+        Realm.setDefaultConfiguration(testConfig)
+
+        databaseService = DatabaseService(context)
+    }
+
+    @After
+    fun tearDown() {
+        val realm = Realm.getDefaultInstance()
+        realm.executeTransaction { it.deleteAll() }
+        realm.close()
+    }
+
+    @Test
+    fun `withRealmAsync executes operation successfully and returns value`() = runTest {
+        val result = databaseService.withRealmAsync { realm ->
+            assertFalse(realm.isClosed)
+            "success_async"
+        }
+
+        assertEquals("success_async", result)
+    }
+
+    @Test
+    fun `executeTransactionAsync executes transaction block successfully`() = runTest {
+        var transactionExecuted = false
+
+        databaseService.executeTransactionAsync { realm ->
+            assertTrue(realm.isInTransaction)
+            transactionExecuted = true
+        }
+
+        assertTrue(transactionExecuted, "Transaction block was not executed")
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The public functions `withRealmAsync` and `executeTransactionAsync` in `DatabaseService.kt` were completely untested. Because these are critical coroutine-based abstractions used heavily throughout the app's repository layer to interact with Realm asynchronously, they are prime targets for unit testing to prevent future regressions.

📊 **Coverage:** What scenarios are now tested
A new test class, `DatabaseServiceTest.kt` was added utilizing Robolectric and an in-memory Realm configuration. The following scenarios are now covered:
- `withRealmAsync`: Verifies the block successfully runs with an active Realm instance and returns a mapped value.
- `executeTransactionAsync`: Verifies the block successfully runs while inside a database transaction (`realm.isInTransaction`).

✨ **Result:** The improvement in test coverage
Coverage for `DatabaseService.kt` async operations has improved. Future refactors to `DatabaseService` or its dispatchers will immediately break these tests if async execution logic changes inappropriately, providing a safety net for developers.

---
*PR created automatically by Jules for task [12541349744645063750](https://jules.google.com/task/12541349744645063750) started by @dogi*