### PR TITLE
🧪 test: cover error body parsing exception in ApiClient

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/data/api/ApiClientTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/api/ApiClientTest.kt
@@ -1,0 +1,36 @@
+package org.ole.planet.myplanet.data.api
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.ole.planet.myplanet.data.NetworkResult
+import retrofit2.Response
+
+class ApiClientTest {
+
+    @Test
+    fun `executeWithResult returns Error with null body when errorBody string throws exception`() = runTest {
+        val errorBody = mockk<ResponseBody>()
+        val response = mockk<Response<Any>>()
+
+        // Setup a response that is not successful and will iterate 3 times.
+        // We can just mock the same response each time.
+        every { response.isSuccessful } returns false
+        every { response.code() } returns 500
+        every { response.errorBody() } returns errorBody
+
+        // Throw exception when trying to read the string
+        every { errorBody.string() } throws RuntimeException("Failed to read body")
+
+        val result = ApiClient.executeWithResult { response }
+
+        assert(result is NetworkResult.Error)
+        val errorResult = result as NetworkResult.Error
+        assertEquals(500, errorResult.code)
+        assertNull(errorResult.message)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `ApiClient.executeWithResult` function has a specific try-catch block to handle errors when reading `response.errorBody()?.string()`. This gap was uncovered where `errorBody` could throw an exception, resulting in a fallback `null` error message, but it lacked dedicated unit testing.

📊 **Coverage:** What scenarios are now tested
Added `ApiClientTest.kt` with a test that covers the path where reading the errorBody string fails using `MockK` and `runTest`. The response is mocked as failing and iterates through retries, eventually triggering the `catch` block by throwing an exception when `errorBody.string()` is invoked.

✨ **Result:** The improvement in test coverage
The code now properly asserts that `NetworkResult.Error` gracefully falls back to a `null` string and returns the proper HTTP code when an underlying reading exception occurs, thereby adding confidence and coverage over the API client's edge cases.

---
*PR created automatically by Jules for task [3425254609954616060](https://jules.google.com/task/3425254609954616060) started by @dogi*