### PR TITLE
🧪 [Test] Add error path test for ApiClient logging catch block

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/data/api/ApiClientTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/api/ApiClientTest.kt
@@ -1,0 +1,66 @@
+package org.ole.planet.myplanet.data.api
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.utils.SyncTimeLogger
+import retrofit2.Response
+
+class ApiClientTest {
+
+    @Before
+    fun setup() {
+        mockkObject(SyncTimeLogger)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `executeWithRetryAndWrap returns result even when logging throws exception`() = runTest {
+        // Arrange
+        val expectedResponse = Response.success("Test Data")
+
+        // Force logApiCall to throw an exception to test the catch block
+        every {
+            SyncTimeLogger.logApiCall(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } throws RuntimeException("Forced logging error")
+
+        // Act
+        val actualResponse = ApiClient.executeWithRetryAndWrap {
+            expectedResponse
+        }
+
+        // Assert
+        // The method should catch the exception and return the expected response normally
+        assertNotNull(actualResponse)
+        assertTrue(actualResponse!!.isSuccessful)
+        assertEquals("Test Data", actualResponse.body())
+
+        // Verify the logger was actually called and threw the exception
+        verify(exactly = 1) {
+            SyncTimeLogger.logApiCall(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `try...catch` block in `ApiClient.kt:executeWithRetryAndWrap` handles exceptions during `SyncTimeLogger.logApiCall` specifically so that logging errors do not crash or alter the result of the API call itself. However, this fallback path was completely untested.

📊 **Coverage:** What scenarios are now tested
- Validates the happy-path resolution of the API network lambda.
- Explicitly tests the error edge-case where `SyncTimeLogger.logApiCall` throws an exception (e.g. `RuntimeException`).
- Asserts that the API method still successfully returns the raw network `Response` unhindered.

✨ **Result:** The improvement in test coverage
We now have reliable test coverage over the catch block in `ApiClient.kt`, ensuring any future refactoring of the internal logging mechanism won't accidentally break core API functionality.

---
*PR created automatically by Jules for task [13415907288038503133](https://jules.google.com/task/13415907288038503133) started by @dogi*