### PR TITLE
🧪 Add missing error path test for ApiClient catch block

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/data/api/ApiClientTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/api/ApiClientTest.kt
@@ -1,0 +1,31 @@
+package org.ole.planet.myplanet.data.api
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.ole.planet.myplanet.data.NetworkResult
+import retrofit2.Response
+
+class ApiClientTest {
+
+    @Test
+    fun testExecuteWithResult_errorBodyStringThrowsException() = runTest {
+        val mockResponse = mockk<Response<Any>>()
+        val mockErrorBody = mockk<ResponseBody>()
+
+        every { mockResponse.isSuccessful } returns false
+        every { mockResponse.errorBody() } returns mockErrorBody
+        every { mockResponse.code() } returns 500
+        every { mockErrorBody.string() } throws RuntimeException("Mock exception")
+
+        val result = ApiClient.executeWithResult { mockResponse }
+
+        assertTrue(result is NetworkResult.Error)
+        assertEquals(500, (result as NetworkResult.Error).code)
+        assertEquals(null, result.message)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing error path test coverage in `app/src/main/java/org/ole/planet/myplanet/data/api/ApiClient.kt:96` where `errorBody()?.string()` throws an exception and gets caught by the `catch (_: Exception)` block.

📊 **Coverage:** What scenarios are now tested
Added `testExecuteWithResult_errorBodyStringThrowsException` in a newly created `ApiClientTest.kt`. The test mocks a failed Retrofit response where the error body string conversion forces an exception, simulating scenarios like an I/O read error or a malformed buffer during response parsing.

✨ **Result:** The improvement in test coverage
The exception path handling logic in `ApiClient.executeWithResult` is now verified, ensuring it robustly falls back to a `NetworkResult.Error` containing the correct HTTP code and a `null` error body instead of propagating a crash up the call stack.

---
*PR created automatically by Jules for task [150917929925821636](https://jules.google.com/task/150917929925821636) started by @dogi*