### PR TITLE
🧪 Add test for error path in AuthSessionUpdater catch block

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/data/auth/AuthSessionUpdaterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/auth/AuthSessionUpdaterTest.kt
@@ -1,0 +1,54 @@
+package org.ole.planet.myplanet.data.auth
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.utils.UrlUtils
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthSessionUpdaterTest {
+
+    private lateinit var callback: AuthSessionUpdater.AuthCallback
+    private lateinit var sharedPrefManager: SharedPrefManager
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    @Before
+    fun setup() {
+        callback = mockk(relaxed = true)
+        sharedPrefManager = mockk(relaxed = true)
+        mockkObject(UrlUtils)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `sendPost exception triggers onError callback`() = runTest(testDispatcher) {
+        // Arrange
+        every { UrlUtils.getUrl() } throws RuntimeException("Test Exception")
+
+        // Act
+        val updater = AuthSessionUpdater(callback, sharedPrefManager, this)
+        advanceUntilIdle() // Allow the coroutine to execute
+
+        // Assert
+        verify(atLeast = 1) { callback.onError(any()) }
+
+        // Cleanup
+        updater.stop()
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The code in `AuthSessionUpdater.kt` handles network POST requests for maintaining a session. There was a lack of testing for the `catch` block that catches exceptions during the update and correctly calls `callback.onError()`.

📊 **Coverage:** What scenarios are now tested
- The test mocks `UrlUtils.getUrl()` to intentionally throw a `RuntimeException`. 
- Since `UrlUtils.getUrl()` fails, `getSessionUrl()` returns null.
- `sendPost()` attempts to use the null URL, throwing a NullPointerException which triggers the catch block inside `sendPost`.
- The `onError` callback correctly fires, covering the error logic.

✨ **Result:** The improvement in test coverage
The critical session updater class now has error condition handling covered by unit testing, minimizing regressions and testing the fallback behavior.

---
*PR created automatically by Jules for task [14632669974061381710](https://jules.google.com/task/14632669974061381710) started by @dogi*