### PR TITLE
🧪 Add error path test for ApiClient.extractEndpointFromStackTrace()

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/api/ApiClient.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/api/ApiClient.kt
@@ -56,10 +56,14 @@ object ApiClient {
         return result
     }
 
+    internal fun getStackTrace(): Array<StackTraceElement> {
+        return Thread.currentThread().stackTrace
+    }
+
     private fun extractEndpointFromStackTrace(): String {
         // Try to extract endpoint from stack trace for logging
         return try {
-            val stackTrace = Thread.currentThread().stackTrace
+            val stackTrace = getStackTrace()
             stackTrace.find { it.className.contains("SyncManager") || it.className.contains("TransactionSyncManager") }
                 ?.let { "${it.className.substringAfterLast(".")}.${it.methodName}" }
                 ?: "unknown_endpoint"

--- a/app/src/test/java/org/ole/planet/myplanet/data/api/ApiClientTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/api/ApiClientTest.kt
@@ -1,0 +1,31 @@
+package org.ole.planet.myplanet.data.api
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.lang.reflect.Method
+
+class ApiClientTest {
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun testExtractEndpointFromStackTrace_Exception() {
+        mockkObject(ApiClient)
+
+        // Mock getStackTrace to throw an exception to test the catch block
+        every { ApiClient.getStackTrace() } throws RuntimeException("Mocked exception for testing")
+
+        val method = ApiClient::class.java.getDeclaredMethod("extractEndpointFromStackTrace")
+        method.isAccessible = true
+
+        val result = method.invoke(ApiClient) as String
+        assertEquals("unknown_endpoint", result)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `extractEndpointFromStackTrace` method in `ApiClient.kt` contained an untested catch block. Attempting to mock `Thread.currentThread().stackTrace` directly causes `StackOverflowError` exceptions due to how MockK intercepts JVM standard library elements.
📊 **Coverage:** Extracted the standard Java Thread lookup into an internal wrapper method (`getStackTrace()`), which is easily mockable without interfering with JVM thread operations. Created a targeted unit test (`ApiClientTest.kt`) to mock `getStackTrace()` to throw a generic exception and ensure the default `"unknown_endpoint"` is correctly returned.
✨ **Result:** 100% test coverage for the error path and exception handling in the stack trace endpoint extraction step.

---
*PR created automatically by Jules for task [13211265623315730505](https://jules.google.com/task/13211265623315730505) started by @dogi*