### PR TITLE
refactor: move RealmTag logic to TagsRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -97,8 +97,9 @@ object ServiceModule {
         @ApplicationContext context: Context,
         chatRepository: org.ole.planet.myplanet.repository.ChatRepository,
         feedbackRepository: org.ole.planet.myplanet.repository.FeedbackRepository,
-        sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager
+        sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager,
+        tagsRepository: org.ole.planet.myplanet.repository.TagsRepository
     ): TransactionSyncManager {
-        return TransactionSyncManager(apiInterface, databaseService, context, chatRepository, feedbackRepository, sharedPrefManager)
+        return TransactionSyncManager(apiInterface, databaseService, context, chatRepository, feedbackRepository, sharedPrefManager, tagsRepository)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTag.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTag.kt
@@ -20,7 +20,7 @@ open class RealmTag : RealmObject() {
     var docType: String? = null
     var db: String? = null
     var isAttached = false
-    private fun setAttachedTo(attachedTo: JsonArray) {
+    fun setAttachedTo(attachedTo: JsonArray) {
         this.attachedTo = RealmList()
         for (i in 0 until attachedTo.size()) {
             this.attachedTo?.add(JsonUtils.getString(attachedTo, i))
@@ -30,40 +30,5 @@ open class RealmTag : RealmObject() {
 
     override fun toString(): String {
         return name.orEmpty()
-    }
-
-    companion object {
-        @JvmStatic
-        fun insert(mRealm: Realm, act: JsonObject) {
-            var tag = mRealm.where(RealmTag::class.java).equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
-            if (tag == null) {
-                tag = mRealm.createObject(RealmTag::class.java, JsonUtils.getString("_id", act))
-            }
-            if (tag != null) {
-                tag._rev = JsonUtils.getString("_rev", act)
-                tag._id = JsonUtils.getString("_id", act)
-                tag.name = JsonUtils.getString("name", act)
-                tag.db = JsonUtils.getString("db", act)
-                tag.docType = JsonUtils.getString("docType", act)
-                tag.tagId = JsonUtils.getString("tagId", act)
-                tag.linkId = JsonUtils.getString("linkId", act)
-                val el = act["attachedTo"]
-                if (el != null && el.isJsonArray) {
-                    tag.setAttachedTo(JsonUtils.getJsonArray("attachedTo", act))
-                } else {
-                    tag.attachedTo?.add(JsonUtils.getString("attachedTo", act))
-                }
-                tag.isAttached = (tag.attachedTo?.size ?: 0) > 0
-            }
-        }
-
-        @JvmStatic
-        fun getTagsArray(list: List<RealmTag>): JsonArray {
-            val array = JsonArray()
-            for (t in list) {
-                array.add(t._id)
-            }
-            return array
-        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -247,7 +247,7 @@ class CoursesRepositoryImpl @Inject constructor(
             activity.type = "courses"
             val filter = com.google.gson.JsonObject()
 
-            filter.add("tags", RealmTag.getTagsArray(tags))
+            filter.add("tags", tagsRepository.getTagsArray(tags))
             filter.addProperty("doc.gradeLevel", grade)
             filter.addProperty("doc.subjectLevel", subject)
             activity.filter = JsonUtils.gson.toJson(filter)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -233,7 +233,7 @@ class ResourcesRepositoryImpl @Inject constructor(
         mediums: Set<String>
     ) {
         val filter = JsonObject().apply {
-            add("tags", RealmTag.getTagsArray(tags))
+            add("tags", tagsRepository.getTagsArray(tags))
             add("subjects", getJsonArrayFromList(subjects))
             add("language", getJsonArrayFromList(languages))
             add("level", getJsonArrayFromList(levels))

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
@@ -8,4 +8,6 @@ interface TagsRepository {
     suspend fun getTagsForResource(resourceId: String): List<RealmTag>
     suspend fun getTagsForCourse(courseId: String): List<RealmTag>
     suspend fun getTagsForResources(resourceIds: List<String>): Map<String, List<RealmTag>>
+    fun insertFromJson(mRealm: io.realm.Realm, act: com.google.gson.JsonObject)
+    fun getTagsArray(tags: List<RealmTag>): com.google.gson.JsonArray
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
@@ -1,8 +1,11 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import javax.inject.Inject
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.utils.JsonUtils
 
 class TagsRepositoryImpl @Inject constructor(
     databaseService: DatabaseService
@@ -102,5 +105,36 @@ class TagsRepositoryImpl @Inject constructor(
 
         val parentsById = parents.associateBy { it.id }
         return tagIds.mapNotNull { parentsById[it] }
+    }
+
+    override fun insertFromJson(mRealm: io.realm.Realm, act: JsonObject) {
+        var tag = mRealm.where(RealmTag::class.java).equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
+        if (tag == null) {
+            tag = mRealm.createObject(RealmTag::class.java, JsonUtils.getString("_id", act))
+        }
+        if (tag != null) {
+            tag._rev = JsonUtils.getString("_rev", act)
+            tag._id = JsonUtils.getString("_id", act)
+            tag.name = JsonUtils.getString("name", act)
+            tag.db = JsonUtils.getString("db", act)
+            tag.docType = JsonUtils.getString("docType", act)
+            tag.tagId = JsonUtils.getString("tagId", act)
+            tag.linkId = JsonUtils.getString("linkId", act)
+            val el = act["attachedTo"]
+            if (el != null && el.isJsonArray) {
+                tag.setAttachedTo(JsonUtils.getJsonArray("attachedTo", act))
+            } else {
+                tag.attachedTo?.add(JsonUtils.getString("attachedTo", act))
+            }
+            tag.isAttached = (tag.attachedTo?.size ?: 0) > 0
+        }
+    }
+
+    override fun getTagsArray(tags: List<RealmTag>): JsonArray {
+        val array = JsonArray()
+        for (t in tags) {
+            array.add(t._id)
+        }
+        return array
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -52,7 +52,8 @@ class TransactionSyncManager @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val chatRepository: ChatRepository,
     private val feedbackRepository: FeedbackRepository,
-    private val sharedPrefManager: SharedPrefManager
+    private val sharedPrefManager: SharedPrefManager,
+    private val tagsRepository: org.ole.planet.myplanet.repository.TagsRepository
 ) {
     suspend fun authenticate(): Boolean {
         try {
@@ -306,7 +307,7 @@ class TransactionSyncManager @Inject constructor(
         when (table) {
             "exams" -> insertCourseStepsExams("", "", jsonDoc, mRealm)
             "tablet_users" -> populateUsersTable(jsonDoc, mRealm, sharedPrefManager.rawPreferences)
-            "tags" -> RealmTag.insert(mRealm, jsonDoc)
+            "tags" -> tagsRepository.insertFromJson(mRealm, jsonDoc)
             "login_activities" -> RealmOfflineActivity.insert(mRealm, jsonDoc)
             "ratings" -> RealmRating.insert(mRealm, jsonDoc)
             "submissions" -> RealmSubmission.insert(mRealm, jsonDoc)


### PR DESCRIPTION
Moves the `insert` and `getTagsArray` static helpers from `RealmTag` to `TagsRepositoryImpl` to properly separate the database model from data serialization and syncing logic, matching the updated pattern seen across the app. Changes the `setAttachedTo` mutator on `RealmTag` to public to support safer persistence of tag arrays.

---
*PR created automatically by Jules for task [14379877213129383674](https://jules.google.com/task/14379877213129383674) started by @dogi*