### PR TITLE
Refactor RealmCourseProgress model to decouple persistence logic

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -98,8 +98,9 @@ object ServiceModule {
         @ApplicationContext context: Context,
         chatRepository: org.ole.planet.myplanet.repository.ChatRepository,
         feedbackRepository: org.ole.planet.myplanet.repository.FeedbackRepository,
+        progressRepository: org.ole.planet.myplanet.repository.ProgressRepository,
         sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager
     ): TransactionSyncManager {
-        return TransactionSyncManager(apiInterface, databaseService, context, chatRepository, feedbackRepository, sharedPrefManager)
+        return TransactionSyncManager(apiInterface, databaseService, context, chatRepository, feedbackRepository, progressRepository, sharedPrefManager)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseProgress.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseProgress.kt
@@ -21,39 +21,4 @@ open class RealmCourseProgress : RealmObject() {
     var userId: String? = null
     var courseId: String? = null
     var parentCode: String? = null
-
-    companion object {
-        @JvmStatic
-        fun serializeProgress(progress: RealmCourseProgress): JsonObject {
-            val `object` = JsonObject()
-            `object`.addProperty("userId", progress.userId)
-            `object`.addProperty("parentCode", progress.parentCode)
-            `object`.addProperty("courseId", progress.courseId)
-            `object`.addProperty("passed", progress.passed)
-            `object`.addProperty("stepNum", progress.stepNum)
-            `object`.addProperty("createdOn", progress.createdOn)
-            `object`.addProperty("createdDate", progress.createdDate)
-            `object`.addProperty("updatedDate", progress.updatedDate)
-            return `object`
-        }
-
-
-        @JvmStatic
-        fun insert(mRealm: Realm, act: JsonObject?) {
-            var courseProgress = mRealm.where(RealmCourseProgress::class.java).equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
-            if (courseProgress == null) {
-                courseProgress = mRealm.createObject(RealmCourseProgress::class.java, JsonUtils.getString("_id", act))
-            }
-            courseProgress?._rev = JsonUtils.getString("_rev", act)
-            courseProgress?._id = JsonUtils.getString("_id", act)
-            courseProgress?.passed = JsonUtils.getBoolean("passed", act)
-            courseProgress?.stepNum = JsonUtils.getInt("stepNum", act)
-            courseProgress?.userId = JsonUtils.getString("userId", act)
-            courseProgress?.parentCode = JsonUtils.getString("parentCode", act)
-            courseProgress?.courseId = JsonUtils.getString("courseId", act)
-            courseProgress?.createdOn = JsonUtils.getString("createdOn", act)
-            courseProgress?.createdDate = JsonUtils.getLong("createdDate", act)
-            courseProgress?.updatedDate = JsonUtils.getLong("updatedDate", act)
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepository.kt
@@ -19,4 +19,6 @@ interface ProgressRepository {
         passed: Boolean?
     )
     suspend fun hasUserCompletedSync(userId: String): Boolean
+    suspend fun insertFromJson(act: JsonObject)
+    fun serializeProgress(progress: RealmCourseProgress): JsonObject
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
@@ -169,4 +169,36 @@ class ProgressRepositoryImpl @Inject constructor(databaseService: DatabaseServic
             equalTo("actionType", "sync")
         } > 0
     }
+
+    override suspend fun insertFromJson(act: JsonObject) {
+        executeTransaction { mRealm ->
+            var courseProgress = mRealm.where(RealmCourseProgress::class.java).equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
+            if (courseProgress == null) {
+                courseProgress = mRealm.createObject(RealmCourseProgress::class.java, JsonUtils.getString("_id", act))
+            }
+            courseProgress?._rev = JsonUtils.getString("_rev", act)
+            courseProgress?._id = JsonUtils.getString("_id", act)
+            courseProgress?.passed = JsonUtils.getBoolean("passed", act)
+            courseProgress?.stepNum = JsonUtils.getInt("stepNum", act)
+            courseProgress?.userId = JsonUtils.getString("userId", act)
+            courseProgress?.parentCode = JsonUtils.getString("parentCode", act)
+            courseProgress?.courseId = JsonUtils.getString("courseId", act)
+            courseProgress?.createdOn = JsonUtils.getString("createdOn", act)
+            courseProgress?.createdDate = JsonUtils.getLong("createdDate", act)
+            courseProgress?.updatedDate = JsonUtils.getLong("updatedDate", act)
+        }
+    }
+
+    override fun serializeProgress(progress: RealmCourseProgress): JsonObject {
+        val `object` = JsonObject()
+        `object`.addProperty("userId", progress.userId)
+        `object`.addProperty("parentCode", progress.parentCode)
+        `object`.addProperty("courseId", progress.courseId)
+        `object`.addProperty("passed", progress.passed)
+        `object`.addProperty("stepNum", progress.stepNum)
+        `object`.addProperty("createdOn", progress.createdOn)
+        `object`.addProperty("createdDate", progress.createdDate)
+        `object`.addProperty("updatedDate", progress.updatedDate)
+        return `object`
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -36,6 +36,7 @@ import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.RealmUser.Companion.populateUsersTable
 import org.ole.planet.myplanet.repository.ChatRepository
 import org.ole.planet.myplanet.repository.FeedbackRepository
+import org.ole.planet.myplanet.repository.ProgressRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.JsonUtils.getJsonArray
@@ -52,6 +53,7 @@ class TransactionSyncManager @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val chatRepository: ChatRepository,
     private val feedbackRepository: FeedbackRepository,
+    private val progressRepository: ProgressRepository,
     private val sharedPrefManager: SharedPrefManager
 ) {
     suspend fun authenticate(): Boolean {
@@ -232,6 +234,25 @@ class TransactionSyncManager @Inject constructor(
                         insertDuration,
                         arr.size()
                     )
+                } else if (table == "courses_progress") {
+                    val insertStartTime = System.currentTimeMillis()
+                    val docs = mutableListOf<JsonObject>()
+                    for (j in arr) {
+                        var jsonDoc = j.asJsonObject
+                        jsonDoc = getJsonObject("doc", jsonDoc)
+                        val id = getString("_id", jsonDoc)
+                        if (!id.startsWith("_design")) {
+                            docs.add(jsonDoc)
+                        }
+                    }
+                    docs.forEach { progressRepository.insertFromJson(it) }
+                    val insertDuration = System.currentTimeMillis() - insertStartTime
+                    org.ole.planet.myplanet.utils.SyncTimeLogger.logRealmOperation(
+                        "insert_batch",
+                        table,
+                        insertDuration,
+                        arr.size()
+                    )
                 } else {
                     // Use async transaction to avoid blocking (ANR-safe)
                     databaseService.executeTransactionAsync { mRealm: Realm ->
@@ -318,7 +339,6 @@ class TransactionSyncManager @Inject constructor(
             "health" -> RealmHealthExamination.insert(mRealm, jsonDoc)
             "certifications" -> RealmCertification.insert(mRealm, jsonDoc)
             "team_activities" -> RealmTeamLog.insert(mRealm, jsonDoc)
-            "courses_progress" -> RealmCourseProgress.insert(mRealm, jsonDoc)
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -18,10 +18,12 @@ import org.ole.planet.myplanet.model.RealmSubmitPhotos
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.repository.ChatRepository
+import org.ole.planet.myplanet.repository.ProgressRepository
 
 @Singleton
 class UploadConfigs @Inject constructor(
-    private val chatRepository: ChatRepository
+    private val chatRepository: ChatRepository,
+    private val progressRepository: ProgressRepository
 ) {
     val NewsActivities = UploadConfig(
         modelClass = RealmNewsLog::class,
@@ -39,7 +41,7 @@ class UploadConfigs @Inject constructor(
         queryBuilder = { query -> query.isNull("_id") },
         filterGuests = true,
         guestUserIdExtractor = { it.userId },
-        serializer = UploadSerializer.Simple(RealmCourseProgress::serializeProgress),
+        serializer = UploadSerializer.Simple(progressRepository::serializeProgress),
         idExtractor = { it.id }
     )
 


### PR DESCRIPTION
This commit decouples data persistence and serialization logic from the `RealmCourseProgress` model by migrating it to the repository layer, aligning with the project's refactoring goals.

---
*PR created automatically by Jules for task [16623031369491003288](https://jules.google.com/task/16623031369491003288) started by @dogi*