### PR TITLE
Refactor: Move course cascade deletion logic to repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -209,11 +209,15 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     open suspend fun deleteSelected(deleteProgress: Boolean) {
         selectedItems?.forEachIndexed { _, item ->
             try {
+                val `object` = item as RealmObject
+                if (deleteProgress && `object` is RealmMyCourse) {
+                    `object`.courseId?.let { courseId ->
+                        coursesRepository.deleteCourseProgressCascade(courseId)
+                    }
+                }
                 if (!mRealm.isInTransaction) {
                     mRealm.beginTransaction()
                 }
-                val `object` = item as RealmObject
-                deleteCourseProgress(deleteProgress, `object`)
                 removeFromShelf(`object`)
                 if (mRealm.isInTransaction) {
                     mRealm.commitTransaction()
@@ -230,22 +234,6 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
 
     fun countSelected(): Int {
         return selectedItems?.size ?: 0
-    }
-
-    private fun deleteCourseProgress(deleteProgress: Boolean, `object`: RealmObject) {
-        if (deleteProgress && `object` is RealmMyCourse) {
-            mRealm.where(RealmCourseProgress::class.java).equalTo("courseId", `object`.courseId).findAll().deleteAllFromRealm()
-            val examList: List<RealmStepExam> = mRealm.where(RealmStepExam::class.java).equalTo("courseId", `object`.courseId).findAll()
-            val examIds = examList.mapNotNull { it.id }.toTypedArray()
-            if (examIds.isNotEmpty()) {
-                mRealm.where(RealmSubmission::class.java)
-                    .`in`("parentId", examIds)
-                    .notEqualTo("type", "survey")
-                    .equalTo("uploaded", false)
-                    .findAll()
-                    .deleteAllFromRealm()
-            }
-        }
     }
 
     private fun <LI : RealmModel> getData(s: String, c: Class<LI>): List<LI> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
@@ -27,6 +27,7 @@ interface CoursesRepository {
     suspend fun joinCourse(courseId: String, userId: String): Result<Unit>
     suspend fun leaveCourse(courseId: String, userId: String): Result<Unit>
     suspend fun isMyCourse(userId: String?, courseId: String?): Boolean
+    suspend fun deleteCourseProgressCascade(courseId: String)
     suspend fun filterCourses(
         searchText: String,
         gradeLevel: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -476,6 +476,22 @@ class CoursesRepositoryImpl @Inject constructor(
         leaveCourse(courseId, userId)
     }
 
+    override suspend fun deleteCourseProgressCascade(courseId: String) {
+        executeTransaction { realm ->
+            realm.where(RealmCourseProgress::class.java).equalTo("courseId", courseId).findAll().deleteAllFromRealm()
+            val examList: List<RealmStepExam> = realm.where(RealmStepExam::class.java).equalTo("courseId", courseId).findAll()
+            val examIds = examList.mapNotNull { it.id }.toTypedArray()
+            if (examIds.isNotEmpty()) {
+                realm.where(RealmSubmission::class.java)
+                    .`in`("parentId", examIds)
+                    .notEqualTo("type", "survey")
+                    .equalTo("uploaded", false)
+                    .findAll()
+                    .deleteAllFromRealm()
+            }
+        }
+    }
+
     override suspend fun logCourseVisit(courseId: String, title: String, userId: String) {
         activitiesRepository.logCourseVisit(courseId, title, userId)
     }


### PR DESCRIPTION
The course cascade deletion logic that removes progress, exams, and submissions associated with a deleted course has been decoupled from the UI layer (`BaseRecyclerFragment`) and encapsulated into `CoursesRepository` as a suspend function. `BaseRecyclerFragment` now correctly delegates this responsibility to the repository while retaining a scoped manual Realm transaction only around its remaining synchronous deletions.

---
*PR created automatically by Jules for task [8945946196068604767](https://jules.google.com/task/8945946196068604767) started by @dogi*