### PR TITLE
Refactor Health Examination Upload Queries

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -86,9 +86,10 @@ object ServiceModule {
         coursesRepository: org.ole.planet.myplanet.repository.CoursesRepository,
         userRepository: org.ole.planet.myplanet.repository.UserRepository,
         @ApplicationScope appScope: CoroutineScope,
-        dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider
+        dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider,
+        healthRepository: org.ole.planet.myplanet.repository.HealthRepository
     ): UploadToShelfService {
-        return UploadToShelfService(context, databaseService, preferences, sharedPrefManager, resourcesRepository, coursesRepository, userRepository, appScope, dispatcherProvider)
+        return UploadToShelfService(context, databaseService, preferences, sharedPrefManager, resourcesRepository, coursesRepository, userRepository, appScope, dispatcherProvider, healthRepository)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
@@ -9,4 +9,6 @@ interface HealthRepository {
     suspend fun getExaminationById(id: String): RealmHealthExamination?
     suspend fun initHealth(): RealmMyHealth
     suspend fun saveExamination(examination: RealmHealthExamination?, pojo: RealmHealthExamination?, user: RealmUser?)
+    suspend fun getUnuploadedExaminations(userId: String? = null): List<RealmHealthExamination>
+    suspend fun markExaminationsUploaded(revMap: Map<String, String?>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -43,4 +43,28 @@ class HealthRepositoryImpl @Inject constructor(
             examination?.let { realm.copyToRealmOrUpdate(it) }
         }
     }
+
+    override suspend fun getUnuploadedExaminations(userId: String?): List<RealmHealthExamination> {
+        return queryList(RealmHealthExamination::class.java, true) {
+            equalTo("isUpdated", true)
+            if (userId.isNullOrEmpty()) {
+                notEqualTo("userId", "")
+            } else {
+                equalTo("userId", userId)
+            }
+        }
+    }
+
+    override suspend fun markExaminationsUploaded(revMap: Map<String, String?>) {
+        if (revMap.isEmpty()) return
+        executeTransaction { realm ->
+            revMap.keys.chunked(999).forEach { chunk ->
+                val managedPojos = realm.where(RealmHealthExamination::class.java).`in`("_id", chunk.toTypedArray()).findAll()
+                managedPojos.forEach { managedPojo ->
+                    managedPojo._rev = revMap[managedPojo._id]
+                    managedPojo.isUpdated = false
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
@@ -50,7 +50,8 @@ class UploadToShelfService @Inject constructor(
     private val coursesRepository: CoursesRepository,
     private val userRepository: UserRepository,
     @ApplicationScope private val appScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val healthRepository: org.ole.planet.myplanet.repository.HealthRepository
 ) {
     lateinit var mRealm: Realm
 
@@ -287,13 +288,7 @@ class UploadToShelfService @Inject constructor(
     fun uploadHealth() {
         val apiInterface = client.create(ApiInterface::class.java)
         appScope.launch(dispatcherProvider.io) {
-            val myHealths = dbService.withRealm { realm ->
-                realm.where(RealmHealthExamination::class.java)
-                    .equalTo("isUpdated", true)
-                    .notEqualTo("userId", "")
-                    .findAll()
-                    .map { realm.copyFromRealm(it) }
-            }
+            val myHealths = healthRepository.getUnuploadedExaminations()
 
             val uploadedHealths = mutableMapOf<String, String?>()
             myHealths.forEach { pojo ->
@@ -312,15 +307,7 @@ class UploadToShelfService @Inject constructor(
             }
 
             if (uploadedHealths.isNotEmpty()) {
-                dbService.executeTransactionAsync { realm ->
-                    uploadedHealths.keys.chunked(999).forEach { chunk ->
-                        val managedPojos = realm.where(RealmHealthExamination::class.java).`in`("_id", chunk.toTypedArray()).findAll()
-                        managedPojos.forEach { managedPojo ->
-                            managedPojo._rev = uploadedHealths[managedPojo._id]
-                            managedPojo.isUpdated = false
-                        }
-                    }
-                }
+                healthRepository.markExaminationsUploaded(uploadedHealths)
             }
         }
     }
@@ -331,13 +318,7 @@ class UploadToShelfService @Inject constructor(
             try {
                 if (userId.isNullOrEmpty()) return@launch
 
-                val myHealths = dbService.withRealm { realm ->
-                    realm.where(RealmHealthExamination::class.java)
-                        .equalTo("isUpdated", true)
-                        .equalTo("userId", userId)
-                        .findAll()
-                        .map { realm.copyFromRealm(it) }
-                }
+                val myHealths = healthRepository.getUnuploadedExaminations(userId)
 
                 val uploadedHealths = mutableMapOf<String, String?>()
                 myHealths.forEach { pojo ->
@@ -361,15 +342,7 @@ class UploadToShelfService @Inject constructor(
                 }
 
                 if (uploadedHealths.isNotEmpty()) {
-                    dbService.executeTransactionAsync { realm ->
-                        uploadedHealths.keys.chunked(999).forEach { chunk ->
-                            val managedPojos = realm.where(RealmHealthExamination::class.java).`in`("_id", chunk.toTypedArray()).findAll()
-                            managedPojos.forEach { managedPojo ->
-                                managedPojo._rev = uploadedHealths[managedPojo._id]
-                                managedPojo.isUpdated = false
-                            }
-                        }
-                    }
+                    healthRepository.markExaminationsUploaded(uploadedHealths)
                 }
 
                 withContext(dispatcherProvider.main) {


### PR DESCRIPTION
Refactored RealmHealthExamination upload queries from UploadToShelfService into HealthRepository to improve clean architecture and separation of concerns.

- Added `getUnuploadedExaminations` and `markExaminationsUploaded` to `HealthRepository`.
- Implemented the methods in `HealthRepositoryImpl`.
- Injected `HealthRepository` into `UploadToShelfService` via `ServiceModule`.
- Replaced direct `dbService.withRealm` and `dbService.executeTransactionAsync` calls in `uploadHealth` and `uploadSingleUserHealth` with calls to the new repository methods.

---
*PR created automatically by Jules for task [2564846526312523540](https://jules.google.com/task/2564846526312523540) started by @dogi*