### PR TITLE
Refactor UserRepository into focused Health and Achievement interfaces

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -45,6 +45,7 @@ import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.TeamsRepositoryImpl
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.UserRepositoryImpl
+import org.ole.planet.myplanet.repository.AchievementsRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.repository.VoicesRepositoryImpl
 
@@ -131,6 +132,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindAchievementsRepository(impl: UserRepositoryImpl): AchievementsRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/org/ole/planet/myplanet/repository/AchievementsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/AchievementsRepository.kt
@@ -1,0 +1,19 @@
+package org.ole.planet.myplanet.repository
+
+import com.google.gson.JsonArray
+import org.ole.planet.myplanet.model.AchievementData
+import org.ole.planet.myplanet.model.RealmAchievement
+
+interface AchievementsRepository {
+    suspend fun initializeAchievement(achievementId: String): RealmAchievement?
+    suspend fun updateAchievement(
+        achievementId: String,
+        header: String,
+        goals: String,
+        purpose: String,
+        sendToNation: String,
+        achievements: JsonArray,
+        references: JsonArray
+    )
+    suspend fun getAchievementData(userId: String, planetCode: String): AchievementData
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.repository
 
+import org.ole.planet.myplanet.model.HealthRecord
 import org.ole.planet.myplanet.model.RealmHealthExamination
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
@@ -9,4 +10,11 @@ interface HealthRepository {
     suspend fun getExaminationById(id: String): RealmHealthExamination?
     suspend fun initHealth(): RealmMyHealth
     suspend fun saveExamination(examination: RealmHealthExamination?, pojo: RealmHealthExamination?, user: RealmUser?)
+
+    suspend fun getHealthProfile(userId: String): RealmMyHealth?
+    suspend fun updateUserHealthProfile(userId: String, userData: Map<String, Any?>)
+    suspend fun getHealthRecordsAndAssociatedUsers(
+        userId: String,
+        currentUser: RealmUser
+    ): HealthRecord?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -5,13 +5,15 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.HealthRecord
 import org.ole.planet.myplanet.model.RealmHealthExamination
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.AndroidDecrypter
 
 class HealthRepositoryImpl @Inject constructor(
-    databaseService: DatabaseService
+    databaseService: DatabaseService,
+    private val userRepositoryImpl: UserRepositoryImpl
 ) : RealmRepository(databaseService), HealthRepository {
     override suspend fun getHealthEntry(userId: String): Pair<RealmUser?, RealmHealthExamination?> {
         val userCopy = findByField(RealmUser::class.java, "id", userId)
@@ -42,5 +44,20 @@ class HealthRepositoryImpl @Inject constructor(
             pojo?.let { realm.copyToRealmOrUpdate(it) }
             examination?.let { realm.copyToRealmOrUpdate(it) }
         }
+    }
+
+    override suspend fun getHealthProfile(userId: String): RealmMyHealth? {
+        return userRepositoryImpl.getHealthProfile(userId)
+    }
+
+    override suspend fun updateUserHealthProfile(userId: String, userData: Map<String, Any?>) {
+        userRepositoryImpl.updateUserHealthProfile(userId, userData)
+    }
+
+    override suspend fun getHealthRecordsAndAssociatedUsers(
+        userId: String,
+        currentUser: RealmUser
+    ): HealthRecord? {
+        return userRepositoryImpl.getHealthRecordsAndAssociatedUsers(userId, currentUser)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -4,15 +4,9 @@ import android.content.SharedPreferences
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import io.realm.Sort
-import org.ole.planet.myplanet.model.AchievementData
-import org.ole.planet.myplanet.model.HealthRecord
-import org.ole.planet.myplanet.model.RealmAchievement
-import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
 
 interface UserRepository {
-    suspend fun getHealthProfile(userId: String): RealmMyHealth?
-    suspend fun updateUserHealthProfile(userId: String, userData: Map<String, Any?>)
 
     suspend fun getUserById(userId: String): RealmUser?
     suspend fun getUserByAnyId(id: String): RealmUser?
@@ -67,10 +61,6 @@ interface UserRepository {
     suspend fun becomeMember(obj: JsonObject): Pair<Boolean, String>
 
     suspend fun searchUsers(query: String, sortField: String, sortOrder: Sort): List<RealmUser>
-    suspend fun getHealthRecordsAndAssociatedUsers(
-        userId: String,
-        currentUser: RealmUser
-    ): HealthRecord?
 
     @Deprecated("Use getUserModelSuspending() instead")
     fun getUserModel(): RealmUser?
@@ -83,15 +73,4 @@ interface UserRepository {
     fun authenticateUser(username: String?, password: String?, isManagerMode: Boolean): RealmUser?
     fun hasAtLeastOneUser(): Boolean
     suspend fun hasUserSyncAction(userId: String?): Boolean
-    suspend fun initializeAchievement(achievementId: String): RealmAchievement?
-    suspend fun updateAchievement(
-        achievementId: String,
-        header: String,
-        goals: String,
-        purpose: String,
-        sendToNation: String,
-        achievements: JsonArray,
-        references: JsonArray
-    )
-    suspend fun getAchievementData(userId: String, planetCode: String): AchievementData
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -50,7 +50,7 @@ class UserRepositoryImpl @Inject constructor(
     private val configurationsRepository: ConfigurationsRepository,
     @ApplicationScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider
-) : RealmRepository(databaseService), UserRepository {
+) : RealmRepository(databaseService), UserRepository, AchievementsRepository {
     override suspend fun getUserById(userId: String): RealmUser? {
         return withRealm { realm ->
             realm.where(RealmUser::class.java)
@@ -418,7 +418,7 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun getActiveUserIdSuspending(): String {
         return getUserModelSuspending()?.id ?: ""
     }
-    override suspend fun getHealthRecordsAndAssociatedUsers(
+    suspend fun getHealthRecordsAndAssociatedUsers(
         userId: String,
         currentUser: RealmUser
     ): HealthRecord? = withRealm { realm ->
@@ -464,7 +464,7 @@ class UserRepositoryImpl @Inject constructor(
         HealthRecord(mhCopy, mm, list, userMap)
     }
 
-    override suspend fun getHealthProfile(userId: String): RealmMyHealth? {
+    suspend fun getHealthProfile(userId: String): RealmMyHealth? {
         return withRealm { realm ->
             val userModel = realm.where(RealmUser::class.java).equalTo("id", userId).findFirst()
             val healthPojo = realm.where(RealmHealthExamination::class.java).equalTo("_id", userId).findFirst()
@@ -482,7 +482,7 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateUserHealthProfile(userId: String, userData: Map<String, Any?>) {
+    suspend fun updateUserHealthProfile(userId: String, userData: Map<String, Any?>) {
         executeTransaction { transactionRealm ->
             val userModel = transactionRealm.where(RealmUser::class.java).equalTo("id", userId).findFirst()
             val healthPojo = transactionRealm.where(RealmHealthExamination::class.java).equalTo("_id", userId).findFirst()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/AddHealthActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/AddHealthActivity.kt
@@ -18,6 +18,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ActivityAddHealthBinding
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.repository.HealthRepository
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities
@@ -27,6 +28,8 @@ class AddHealthActivity : AppCompatActivity() {
     private lateinit var binding: ActivityAddHealthBinding
     @Inject
     lateinit var userRepository: UserRepository
+    @Inject
+    lateinit var healthRepository: HealthRepository
     var userId: String? = null
     private var myHealth: RealmMyHealth? = null
 
@@ -91,7 +94,7 @@ class AddHealthActivity : AppCompatActivity() {
         )
 
         lifecycleScope.launch {
-            userId?.let { userRepository.updateUserHealthProfile(it, userData) }
+            userId?.let { healthRepository.updateUserHealthProfile(it, userData) }
             finish()
         }
     }
@@ -106,7 +109,7 @@ class AddHealthActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             val userModel = userId?.let { userRepository.getUserById(it) }
-            val decodedHealth = userId?.let { userRepository.getHealthProfile(it) }
+            val decodedHealth = userId?.let { healthRepository.getHealthProfile(it) }
 
             val healthData = HealthData(
                 decodedHealth,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -42,6 +42,7 @@ import org.ole.planet.myplanet.databinding.FragmentVitalSignBinding
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.repository.HealthRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
@@ -62,6 +63,8 @@ class MyHealthFragment : Fragment() {
     lateinit var syncManager: SyncManager
     @Inject
     lateinit var userRepository: UserRepository
+    @Inject
+    lateinit var healthRepository: HealthRepository
     private val syncManagerInstance = RealtimeSyncManager.getInstance()
     private lateinit var onRealtimeSyncListener: OnBaseRealtimeSyncListener
     private var _binding: FragmentVitalSignBinding? = null
@@ -380,7 +383,7 @@ class MyHealthFragment : Fragment() {
             binding.txtLanguage.text = Utilities.checkNA(currentUser.language)
             binding.txtDob.text = TimeUtils.formatDateToDDMMYYYY(currentUser.dob).ifEmpty { getString(R.string.empty_text) }
 
-            val healthRecord = userRepository.getHealthRecordsAndAssociatedUsers(userId!!, currentUser)
+            val healthRecord = healthRepository.getHealthRecordsAndAssociatedUsers(userId!!, currentUser)
 
             if (healthRecord != null) {
                 val (mh, mm, list, userMap) = healthRecord

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/AchievementFragment.kt
@@ -31,6 +31,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.repository.AchievementsRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
@@ -42,6 +43,8 @@ import org.ole.planet.myplanet.utils.JsonUtils.getString
 
 @AndroidEntryPoint
 class AchievementFragment : BaseContainerFragment() {
+    @Inject
+    lateinit var achievementsRepository: AchievementsRepository
     private var _binding: FragmentAchievementBinding? = null
     private val binding get() = _binding!!
     var user: RealmUser? = null
@@ -161,7 +164,7 @@ class AchievementFragment : BaseContainerFragment() {
     private suspend fun loadAchievementDataAsync(): AchievementData {
         val uId = user?.id ?: return AchievementData()
         val pCode = user?.planetCode ?: return AchievementData()
-        return userRepository.getAchievementData(uId, pCode)
+        return achievementsRepository.getAchievementData(uId, pCode)
     }
 
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
@@ -43,6 +43,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.repository.AchievementsRepository
 import org.ole.planet.myplanet.ui.components.CheckboxListView
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.utils.DialogUtils.getDialog
@@ -52,6 +53,9 @@ import org.ole.planet.myplanet.utils.Utilities
 
 @AndroidEntryPoint
 class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDateSetListener {
+    @Inject
+    lateinit var achievementsRepository: AchievementsRepository
+
     private lateinit var fragmentEditAchievementBinding: FragmentEditAchievementBinding
     private lateinit var editAttachmentBinding: EditAttachementBinding
     private lateinit var editOtherInfoBinding: EditOtherInfoBinding
@@ -95,7 +99,7 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
             Utilities.toast(activity, getString(R.string.saving))
 
             lifecycleScope.launch {
-                userRepository.updateAchievement(
+                achievementsRepository.updateAchievement(
                     achievementId = achievementId,
                     header = header,
                     goals = goals,
@@ -299,7 +303,7 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
     private fun initializeData() {
         val achievementId = user?.id + "@" + user?.planetCode
         lifecycleScope.launch {
-            achievement = userRepository.initializeAchievement(achievementId)
+            achievement = achievementsRepository.initializeAchievement(achievementId)
             if (isAdded) {
                 populateAchievementData()
             }


### PR DESCRIPTION
Creates focused interfaces for user-core vs health/achievement operations.

1. **UserRepository:** Now contains only user identity/profile/auth operations.
2. **HealthRepository:** Contains health methods (`getHealthProfile`, `updateUserHealthProfile`, `getHealthRecordsAndAssociatedUsers`).
3. **AchievementsRepository:** Contains achievement methods (`initializeAchievement`, `updateAchievement`, `getAchievementData`).
4. **Implementation:** Defers implementation-file split to follow-up PRs as requested. `HealthRepositoryImpl` delegates to `UserRepositoryImpl`, and `UserRepositoryImpl` directly implements `AchievementsRepository`.
5. **Call Sites Updated:** `AddHealthActivity`, `MyHealthFragment`, `AchievementFragment`, and `EditAchievementFragment` now inject and use the focused repositories instead of `UserRepository`.

---
*PR created automatically by Jules for task [6085572769391456771](https://jules.google.com/task/6085572769391456771) started by @dogi*