### PR TITLE
Add user-specific sync route and logging

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -161,6 +161,78 @@ class SyncManager @Inject constructor(
         }
     }
 
+    fun startUserSync(listener: OnSyncListener?) {
+        this.listener = listener
+        Log.d("SyncRoute", "[1] startUserSync called — isSyncing=${isSyncing.get()}")
+        if (isSyncing.compareAndSet(false, true)) {
+            Log.d("SyncRoute", "[2] isSyncing lock acquired — proceeding with user sync")
+            _syncStatus.value = SyncStatus.Idle
+            sharedPrefManager.removeKey("concatenated_links")
+            listener?.onSyncStarted()
+            _syncStatus.value = SyncStatus.Syncing
+            createLog("sync_manager_route", "user_specific")
+            backgroundSync = syncScope.launch(Dispatchers.IO) {
+                Log.d("SyncRoute", "[3] authenticating…")
+                val authStart = System.currentTimeMillis()
+                val authenticated = transactionSyncManager.authenticate()
+                Log.d("SyncRoute", "[4] authentication ${if (authenticated) "SUCCESS" else "FAILED"} in ${System.currentTimeMillis() - authStart}ms")
+                if (authenticated) {
+                    startUserDataSync()
+                } else {
+                    handleException(context.getString(R.string.invalid_configuration))
+                    cleanupMainSync()
+                }
+            }
+        } else {
+            Log.d("SyncRoute", "[!] startUserSync SKIPPED — another sync is already in progress")
+        }
+    }
+
+    private suspend fun startUserDataSync() {
+        val logger = SyncTimeLogger
+        logger.startLogging()
+        val startTime = System.currentTimeMillis()
+        Log.d("SyncRoute", "[5] USER SYNC STARTED — ${USER_SYNC_TABLES.size} tables: ${USER_SYNC_TABLES.joinToString()}")
+        Log.d("SyncRoute", "[5] Skipping: submissions, ratings, login_activities, notifications, chat_history, teams, tasks, tablet_users, feedback, courses, resources, exams, tags")
+        try {
+            val initStart = System.currentTimeMillis()
+            initializeSync()
+            Log.d("SyncRoute", "[6] initializeSync done in ${System.currentTimeMillis() - initStart}ms")
+            coroutineScope {
+                val syncJobs = USER_SYNC_TABLES.map { table ->
+                    async {
+                        val t = System.currentTimeMillis()
+                        logger.startProcess("${table}_sync")
+                        transactionSyncManager.syncDb(table)
+                        logger.endProcess("${table}_sync")
+                        Log.d("SyncRoute", "[7] $table synced in ${System.currentTimeMillis() - t}ms")
+                    }
+                }
+                syncJobs.awaitAll()
+            }
+            Log.d("SyncRoute", "[8] all tables done — ${System.currentTimeMillis() - startTime}ms elapsed")
+            val adminStart = System.currentTimeMillis()
+            logger.startProcess("admin_sync")
+            loginSyncManager.syncAdmin()
+            logger.endProcess("admin_sync")
+            Log.d("SyncRoute", "[9] syncAdmin done in ${System.currentTimeMillis() - adminStart}ms")
+            logger.startProcess("notification_reads_upload")
+            transactionSyncManager.syncNotificationReads()
+            logger.endProcess("notification_reads_upload")
+            databaseService.withRealm { realm ->
+                onSynced(realm, sharedPrefManager.rawPreferences)
+            }
+            logger.stopLogging()
+            val elapsed = System.currentTimeMillis() - startTime
+            Log.d("SyncRoute", "[10] USER SYNC COMPLETED in ${elapsed}ms")
+        } catch (err: Exception) {
+            err.printStackTrace()
+            handleException(err.message)
+        } finally {
+            destroy()
+        }
+    }
+
     private suspend fun startSync(type: String, syncTables: List<String>?) {
         val isFastSync = sharedPrefManager.getFastSync()
         if (!isFastSync || type == "upload") {
@@ -172,6 +244,7 @@ class SyncManager @Inject constructor(
 
     private suspend fun startFullSync() {
         val syncStartTime = System.currentTimeMillis()
+        Log.d("SyncRoute", "[F1] FULL SYNC STARTED")
         val logger = SyncTimeLogger
         logger.startLogging()
         Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
@@ -319,6 +392,7 @@ class SyncManager @Inject constructor(
             Log.d("SyncPerf", "FULL SYNC COMPLETED at ${java.text.SimpleDateFormat("HH:mm:ss.SSS").format(java.util.Date())}")
             Log.d("SyncPerf", "TOTAL SYNC TIME: ${minutes}m ${seconds}s (${totalSyncTime}ms)")
             Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+            Log.d("SyncRoute", "[F2] FULL SYNC COMPLETED in ${minutes}m ${seconds}s (${totalSyncTime}ms)")
         } catch (err: Exception) {
             val syncEndTime = System.currentTimeMillis()
             val totalSyncTime = syncEndTime - syncStartTime
@@ -326,6 +400,7 @@ class SyncManager @Inject constructor(
             Log.d("SyncPerf", "SYNC FAILED after ${totalSyncTime}ms")
             Log.d("SyncPerf", "Error: ${err.message}")
             Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+            Log.d("SyncRoute", "[F!] FULL SYNC FAILED after ${totalSyncTime}ms — ${err.message}")
             err.printStackTrace()
             handleException(err.message)
         } finally {
@@ -1039,4 +1114,19 @@ class SyncManager @Inject constructor(
         return ThreadSafeRealmManager.withRealm(databaseService, operation)
     }
 
+    companion object {
+        // Tables that are small enough to sync quickly for a single user session.
+        // Excluded from user sync because they contain ALL users' data and are too large:
+        //   submissions (~644s), ratings (~239s), login_activities (~228s),
+        //   notifications (~51s), chat_history (~40s), teams (~9s), tasks (~9s),
+        //   tablet_users (~14s), feedback (~6s)
+        // Those remain part of the full sync (syncIcon).
+        val USER_SYNC_TABLES = listOf(
+            "achievements",     // ~350ms
+            "certifications",   // ~373ms
+            "health",           // ~1.4s
+            "meetups",          // ~1.7s
+            "courses_progress"  // ~19s  — most important for UX
+        )
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -376,7 +376,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                 }
             }
             R.id.menu_goOnline -> wifiStatusSwitch()
-            R.id.action_sync -> logSyncInSharedPrefs()
+            R.id.action_sync -> logUserSyncInSharedPrefs()
             R.id.action_feedback -> {
                 if (user?.id?.startsWith("guest") == false) {
                     openCallFragment(

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivity.kt
@@ -131,14 +131,23 @@ abstract class DashboardElementActivity : SyncActivity(), FragmentManager.OnBack
             R.id.action_feedback -> {
                 openCallFragment(FeedbackFragment(), getString(R.string.menu_feedback))
             }
-            R.id.action_sync -> {
-                logSyncInSharedPrefs()
-            }
         }
         return super.onOptionsItemSelected(item)
     }
 
+    fun logUserSyncInSharedPrefs() {
+        android.util.Log.d("SyncRoute", "action_sync clicked → user-specific sync (current user only)")
+        isUserSync = true
+        triggerSyncFlow()
+    }
+
     fun logSyncInSharedPrefs() {
+        android.util.Log.d("SyncRoute", "syncIcon clicked → full sync (all users)")
+        isUserSync = false
+        triggerSyncFlow()
+    }
+
+    private fun triggerSyncFlow() {
         val protocol = prefData.getServerProtocol()
         val serverUrl = prefData.getServerUrl()
         val serverPin = prefData.getServerPin()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -217,12 +217,16 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
         customProgressDialog.show()
 
         applicationScope.launch(Dispatchers.IO) {
+            val uploadStartTime = System.currentTimeMillis()
+            android.util.Log.d("SyncRoute", "[U1] UPLOAD STARTED — pushing local changes for current user")
             val asyncOperationsCounter = AtomicInteger(0)
             val totalAsyncOperations = 6
             val activity = this@ProcessUserDataActivity
 
             suspend fun checkAllOperationsComplete() {
                 if (asyncOperationsCounter.incrementAndGet() == totalAsyncOperations) {
+                    val elapsed = System.currentTimeMillis() - uploadStartTime
+                    android.util.Log.d("SyncRoute", "[U2] UPLOAD COMPLETED in ${elapsed}ms")
                     withContext(Dispatchers.Main) {
                         if (!activity.isFinishing && !activity.isDestroyed) {
                             customProgressDialog.dismiss()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -119,6 +119,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
     lateinit var processedUrl: String
     var isSync = false
     var forceSync = false
+    var isUserSync = false
     var syncFailed = false
     lateinit var defaultPref: SharedPreferences
     @Inject
@@ -215,8 +216,15 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
                 }
 
                 override fun onVersionCheckSuccess() {
-                    isSync = false
-                    forceSync = true
+                    if (isUserSync) {
+                        android.util.Log.d("SyncRoute", "onVersionCheckSuccess: isUserSync=true → download path")
+                        isSync = true
+                        forceSync = false
+                    } else {
+                        android.util.Log.d("SyncRoute", "onVersionCheckSuccess: isUserSync=false → upload path")
+                        isSync = false
+                        forceSync = true
+                    }
                     configurationsRepository.checkVersion(this@SyncActivity, prefData)
                 }
 
@@ -409,7 +417,13 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
     }
 
     fun startSync(type: String) {
-        syncManager.start(null, type)
+        if (isUserSync && type == "sync") {
+            android.util.Log.d("SyncRoute", "startSync: routing to user-specific sync (tables: ${SyncManager.USER_SYNC_TABLES.joinToString()})")
+            syncManager.startUserSync(null)
+        } else {
+            android.util.Log.d("SyncRoute", "startSync: routing to full sync (type=$type)")
+            syncManager.start(null, type)
+        }
     }
 
     private fun saveConfigAndContinue(


### PR DESCRIPTION
Introduce a fast, user-only sync flow and verbose route/performance logging.

- Add SyncManager.startUserSync and startUserDataSync to perform a targeted sync of USER_SYNC_TABLES (small, user-specific tables) while skipping large global tables to improve UX.
- Add USER_SYNC_TABLES companion constant with rationale comments for excluded heavy tables.
- Wire UI to trigger user-only sync: DashboardActivity now calls logUserSyncInSharedPrefs; DashboardElementActivity adds logUserSyncInSharedPrefs and a trigger helper, preserving the existing full-sync path.
- Add isUserSync flag to SyncActivity and route startSync to syncManager.startUserSync when a user sync is requested; adjust onVersionCheckSuccess to set isSync/forceSync based on isUserSync.
- Add detailed Log.d traces for sync routes, full sync start/complete/failure, and upload timing to aid diagnostics and performance measurement.

This change enables faster, current-user-only synchronization while keeping the full sync path intact and improving observability.