### PR TITLE
🧹 Refactor deprecated userModel property to use suspending getUserModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
@@ -35,14 +35,6 @@ class UserSessionManager @Inject constructor(
         }
     }
 
-    @Deprecated("Use getUserModel() suspend function instead")
-    val userModel: RealmUser? get() = userRepository.getUserModel()
-
-    @Deprecated("Use getUserModel() suspend function instead")
-    fun getUserModelCopy(): RealmUser? {
-        return userRepository.getUserModel()
-    }
-
     suspend fun getUserModel(): RealmUser? {
         return userRepository.getUserModelSuspending()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -137,17 +137,16 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             }
         )
 
-        @Suppress("DEPRECATION")
-        user = userSessionManager.userModel
-        checkUser()
-        updateAppTitle()
-        if (handleGuestAccess()) return
-
-        handleInitialFragment()
-        addBackPressCallback()
-        collectUiState()
-
         lifecycleScope.launch {
+            user = userSessionManager.getUserModel()
+            checkUser()
+            updateAppTitle()
+            if (handleGuestAccess()) return@launch
+
+            handleInitialFragment()
+            addBackPressCallback()
+            collectUiState()
+
             initializeDashboard()
             isReady = true
             binding.root.invalidate()


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the deprecated `userModel` property and the `getUserModelCopy()` method from `UserSessionManager.kt`. Refactored the sole remaining caller in `DashboardActivity.kt` to instead use the asynchronous suspending method `getUserModel()` within a `lifecycleScope.launch` block.

💡 **Why:** How this improves maintainability
The old property and method were executing synchronous, blocking Realm database read operations on the main UI thread during activity initialization. By migrating callers to the suspending `getUserModel()`, we eliminate the risk of UI thread blockage and "Application Not Responding" (ANR) errors, thereby improving application performance and ensuring a smoother user experience, particularly on slower devices or under heavy database loads.

✅ **Verification:** How you confirmed the change is safe
Ran the full unit test suite (`./gradlew testDefaultDebugUnitTest`) successfully. The code review confirmed that integrating the synchronous dependent logic sequentially inside the `lifecycleScope.launch` block safely ensures all initialization logic correctly waits for the asynchronous database lookup to finish before proceeding, avoiding race conditions or regressions.

✨ **Result:** The improvement achieved
A cleaner `UserSessionManager` API strictly enforcing asynchronous data access, and a more responsive, performant main activity startup.

---
*PR created automatically by Jules for task [10948196413765407841](https://jules.google.com/task/10948196413765407841) started by @dogi*