### PR TITLE
teams: smoother resources user extracting (fixes #12442)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyTeam.kt
@@ -209,30 +209,22 @@ open class RealmMyTeam : RealmObject() {
 
         @JvmStatic
         fun getResourceIdsByUser(userId: String?, realm: Realm): MutableList<String> {
-            val list = realm.where(RealmMyTeam::class.java)
+            val teamIds = realm.where(RealmMyTeam::class.java)
                 .equalTo("userId", userId)
                 .equalTo("docType", "membership")
                 .findAll()
-            val teamIds = mutableListOf<String>()
-            for (team in list) {
-                if (!team.teamId.isNullOrBlank()) {
-                    teamIds.add(team.teamId!!)
-                }
-            }
+                .mapNotNull { it.teamId?.takeIf { id -> id.isNotBlank() } }
+
             if (teamIds.isEmpty()) {
                 return mutableListOf()
             }
-            val l2 = realm.where(RealmMyTeam::class.java)
+
+            return realm.where(RealmMyTeam::class.java)
                 .`in`("teamId", teamIds.toTypedArray())
                 .equalTo("docType", "resourceLink")
                 .findAll()
-            val ids = mutableListOf<String>()
-            for (team in l2) {
-                if (!team.resourceId.isNullOrBlank()) {
-                    ids.add(team.resourceId!!)
-                }
-            }
-            return ids
+                .mapNotNull { it.resourceId?.takeIf { id -> id.isNotBlank() } }
+                .toMutableList()
         }
 
         @JvmStatic


### PR DESCRIPTION
💡 **What:** The optimization implemented is replacing manual loops and null/blank checks with Kotlin's mapNotNull and takeIf idioms for extracting teamId and resourceId from Realm results.

🎯 **Why:** The current implementation uses manual list management and explicit loops, which is less idiomatic and potentially less efficient than using high-order collection functions. In Realm Java, this also reduces JNI overhead by minimizing property accesses.

📊 **Measured Improvement:** While environmental constraints made direct benchmarking impractical, this change improves code readability and leverages Kotlin's optimized collection processing. It specifically reduces the number of JNI calls required to extract properties from Realm proxy objects.

---
*PR created automatically by Jules for task [15103226941584158450](https://jules.google.com/task/15103226941584158450) started by @dogi*