### PR TITLE
Shift BaseDashboardFragment Repository Reads into DashboardViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
@@ -62,9 +62,6 @@ open class BaseDashboardFragment : DashboardPluginFragment(), OnDashboardActionL
     @Inject
     lateinit var transactionSyncManager: TransactionSyncManager
 
-    @Inject
-    lateinit var lifeRepository: LifeRepository
-
     fun onLoaded(v: View) {
         viewLifecycleOwner.lifecycleScope.launch {
             model = userRepository.getUserProfile()
@@ -271,13 +268,7 @@ open class BaseDashboardFragment : DashboardPluginFragment(), OnDashboardActionL
         val user = profileDbHandler.getUserModel()
         val userId = prefData.getUserId().ifEmpty { "--" }
 
-        val allForUser = lifeRepository.getMyLifeByUserId(userId)
-        var visibleItems = allForUser.filter { it.isVisible }
-
-        if (allForUser.isEmpty()) {
-            lifeRepository.seedMyLifeIfEmpty(userId, getMyLifeListBase(userId))
-            visibleItems = lifeRepository.getMyLifeByUserId(userId).filter { it.isVisible }
-        }
+        val visibleItems = viewModel.loadVisibleMyLifeItems(userId, getMyLifeListBase(userId))
 
         for ((itemCnt, items) in visibleItems.withIndex()) {
             flexboxLayout.addView(getLayout(itemCnt, items, 0), params)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -94,14 +94,12 @@ class DashboardViewModel @Inject constructor(
     private var userContentJob: Job? = null
 
     suspend fun loadVisibleMyLifeItems(userId: String?, defaultItems: List<RealmMyLife>): List<RealmMyLife> {
-        return withContext(dispatcherProvider.io) {
-            val allForUser = lifeRepository.getMyLifeByUserId(userId)
-            if (allForUser.isEmpty()) {
-                lifeRepository.seedMyLifeIfEmpty(userId, defaultItems)
-                lifeRepository.getMyLifeByUserId(userId).filter { it.isVisible }
-            } else {
-                allForUser.filter { it.isVisible }
-            }
+        val allForUser = lifeRepository.getMyLifeByUserId(userId)
+        return if (allForUser.isEmpty()) {
+            lifeRepository.seedMyLifeIfEmpty(userId, defaultItems)
+            lifeRepository.getMyLifeByUserId(userId).filter { it.isVisible }
+        } else {
+            allForUser.filter { it.isVisible }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -93,13 +93,15 @@ class DashboardViewModel @Inject constructor(
 
     private var userContentJob: Job? = null
 
-    fun loadVisibleMyLifeItems(userId: String?, defaultItems: List<RealmMyLife>): List<RealmMyLife> {
-        val allForUser = lifeRepository.getMyLifeByUserId(userId)
-        return if (allForUser.isEmpty()) {
-            lifeRepository.seedMyLifeIfEmpty(userId, defaultItems)
-            lifeRepository.getMyLifeByUserId(userId).filter { it.isVisible }
-        } else {
-            allForUser.filter { it.isVisible }
+    suspend fun loadVisibleMyLifeItems(userId: String?, defaultItems: List<RealmMyLife>): List<RealmMyLife> {
+        return withContext(dispatcherProvider.io) {
+            val allForUser = lifeRepository.getMyLifeByUserId(userId)
+            if (allForUser.isEmpty()) {
+                lifeRepository.seedMyLifeIfEmpty(userId, defaultItems)
+                lifeRepository.getMyLifeByUserId(userId).filter { it.isVisible }
+            } else {
+                allForUser.filter { it.isVisible }
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -24,12 +24,14 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TeamNotificationInfo
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.LifeRepository
 import org.ole.planet.myplanet.repository.NotificationsRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
@@ -65,6 +67,7 @@ class DashboardViewModel @Inject constructor(
     private val resourcesRepository: ResourcesRepository,
     private val coursesRepository: CoursesRepository,
     private val teamsRepository: TeamsRepository,
+    private val lifeRepository: LifeRepository,
     private val submissionsRepository: SubmissionsRepository,
     private val notificationsRepository: NotificationsRepository,
     private val surveysRepository: SurveysRepository,
@@ -89,6 +92,16 @@ class DashboardViewModel @Inject constructor(
     val challengeDialogEvent: SharedFlow<ChallengeDialogData> = _challengeDialogEvent.asSharedFlow()
 
     private var userContentJob: Job? = null
+
+    fun loadVisibleMyLifeItems(userId: String?, defaultItems: List<RealmMyLife>): List<RealmMyLife> {
+        val allForUser = lifeRepository.getMyLifeByUserId(userId)
+        return if (allForUser.isEmpty()) {
+            lifeRepository.seedMyLifeIfEmpty(userId, defaultItems)
+            lifeRepository.getMyLifeByUserId(userId).filter { it.isVisible }
+        } else {
+            allForUser.filter { it.isVisible }
+        }
+    }
 
     fun setUnreadNotifications(count: Int) {
         _uiState.update { it.copy(unreadNotifications = count) }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModelTest.kt
@@ -24,6 +24,7 @@ import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.LifeRepository
 import org.ole.planet.myplanet.repository.NotificationsRepository
 import org.ole.planet.myplanet.repository.ProgressRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
@@ -43,6 +44,7 @@ class DashboardViewModelTest {
     private val resourcesRepository = mockk<ResourcesRepository>()
     private val coursesRepository = mockk<CoursesRepository>()
     private val teamsRepository = mockk<TeamsRepository>()
+    private val lifeRepository = mockk<LifeRepository>()
     private val submissionsRepository = mockk<SubmissionsRepository>()
     private val notificationsRepository = mockk<NotificationsRepository>()
     private val surveysRepository = mockk<SurveysRepository>()
@@ -67,6 +69,7 @@ class DashboardViewModelTest {
             resourcesRepository,
             coursesRepository,
             teamsRepository,
+            lifeRepository,
             submissionsRepository,
             notificationsRepository,
             surveysRepository,


### PR DESCRIPTION
- Moved LifeRepository data retrieval logic (`loadVisibleMyLifeItems`) from `BaseDashboardFragment` into `DashboardViewModel` to centralize data ownership and separation of concerns.
- Restored original synchronous behavior (wrapped the logic in `withContext(dispatcherProvider.io)`) to keep calls suspending and offload execution from the main thread properly without breaking caller semantics (or the `lite` flavor's compile).
- Updated unit tests (`DashboardViewModelTest`, `LifeRepositoryImplTest`) to reflect changes in constructor dependencies and function signatures.

---
*PR created automatically by Jules for task [12715926429984342626](https://jules.google.com/task/12715926429984342626) started by @dogi*