### PR TITLE
Offload blocking I/O and add socket tagging

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -12,22 +12,14 @@ import android.os.StrictMode.VmPolicy
 import android.provider.Settings
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.hilt.work.HiltWorkerFactory
-import androidx.work.Configuration as WorkManagerConfiguration
+import androidx.preference.PreferenceManager
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.HiltAndroidApp
-import java.net.HttpURLConnection
-import java.net.URL
-import java.util.Date
-import java.util.UUID
-import java.util.concurrent.TimeUnit
-import javax.inject.Inject
-import javax.inject.Provider
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -52,6 +44,7 @@ import org.ole.planet.myplanet.services.TaskNotificationWorker
 import org.ole.planet.myplanet.services.ThemeManager
 import org.ole.planet.myplanet.services.retry.RetryQueueWorker
 import org.ole.planet.myplanet.utils.ANRWatchdog
+import org.ole.planet.myplanet.utils.Constants.PREFS_NAME
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils.downloadAllFiles
 import org.ole.planet.myplanet.utils.LocaleUtils
@@ -60,6 +53,14 @@ import org.ole.planet.myplanet.utils.NetworkUtils.startListenNetworkState
 import org.ole.planet.myplanet.utils.NetworkUtils.stopListenNetworkState
 import org.ole.planet.myplanet.utils.ThemeMode
 import org.ole.planet.myplanet.utils.VersionUtils.getVersionName
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Date
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Provider
+import androidx.work.Configuration as WorkManagerConfiguration
 
 @HiltAndroidApp
 class MainApplication : Application(), Application.ActivityLifecycleCallbacks, WorkManagerConfiguration.Provider {
@@ -211,6 +212,8 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
         super.onCreate()
         context = this
         setupCriticalProperties()
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        PreferenceManager.getDefaultSharedPreferences(this)
         performDeferredInitialization()
         setupStrictMode()
         registerExceptionHandler()

--- a/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.di
 
+import android.net.TrafficStats
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import dagger.Module
@@ -7,9 +8,12 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import java.lang.reflect.Modifier
+import java.net.InetAddress
+import java.net.Socket
 import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import javax.net.SocketFactory
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.data.api.ApiClient
 import org.ole.planet.myplanet.data.api.ApiInterface
@@ -25,6 +29,20 @@ annotation class StandardHttpClient
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class StandardRetrofit
+
+private class TaggedSocketFactory : SocketFactory() {
+    private val delegate = getDefault()
+
+    private fun tag() {
+        if (TrafficStats.getThreadStatsTag() == 0) TrafficStats.setThreadStatsTag(0x1000)
+    }
+
+    override fun createSocket(): Socket { tag(); return delegate.createSocket() }
+    override fun createSocket(host: String, port: Int): Socket { tag(); return delegate.createSocket(host, port) }
+    override fun createSocket(host: String, port: Int, localHost: InetAddress, localPort: Int): Socket { tag(); return delegate.createSocket(host, port, localHost, localPort) }
+    override fun createSocket(host: InetAddress, port: Int): Socket { tag(); return delegate.createSocket(host, port) }
+    override fun createSocket(address: InetAddress, port: Int, localAddress: InetAddress, localPort: Int): Socket { tag(); return delegate.createSocket(address, port, localAddress, localPort) }
+}
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -44,6 +62,7 @@ object NetworkModule {
             .connectTimeout(connect, TimeUnit.SECONDS)
             .readTimeout(read, TimeUnit.SECONDS)
             .writeTimeout(write, TimeUnit.SECONDS)
+            .socketFactory(TaggedSocketFactory())
 
         if (retryInterceptor != null) {
             builder.addInterceptor(retryInterceptor)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/onboarding/OnboardingActivity.kt
@@ -7,9 +7,13 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.viewpager.widget.ViewPager
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ActivityOnboardingBinding
 import org.ole.planet.myplanet.model.OnboardingItem
@@ -38,25 +42,36 @@ class OnboardingActivity : AppCompatActivity() {
         EdgeToEdgeUtils.setupEdgeToEdge(this, binding.root)
 
         copyAssets(this)
-        val savedUser = SecurePrefs.getUserName(this, prefData.rawPreferences)
-        val savedPass = SecurePrefs.getPassword(this, prefData.rawPreferences)
-        if (!savedUser.isNullOrEmpty() && !savedPass.isNullOrEmpty() && !prefData.isLoggedIn()) {
-            prefData.setLoggedIn(true)
-        }
-        if (prefData.isLoggedIn() && !Constants.autoSynFeature(Constants.KEY_AUTOSYNC_, applicationContext)) {
-            val dashboard = Intent(applicationContext, DashboardActivity::class.java)
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                .putExtra("from_login", true)
-            startActivity(dashboard)
-            finish()
-            return
-        }
 
-        if (prefData.getFirstLaunch()) {
-            startActivity(Intent(this, LoginActivity::class.java))
-            finish()
-        }
+        lifecycleScope.launch {
+            val savedUser: String?
+            val savedPass: String?
+            withContext(Dispatchers.IO) {
+                savedUser = SecurePrefs.getUserName(this@OnboardingActivity, prefData.rawPreferences)
+                savedPass = SecurePrefs.getPassword(this@OnboardingActivity, prefData.rawPreferences)
+            }
+            if (!savedUser.isNullOrEmpty() && !savedPass.isNullOrEmpty() && !prefData.isLoggedIn()) {
+                prefData.setLoggedIn(true)
+            }
+            if (prefData.isLoggedIn() && !Constants.autoSynFeature(Constants.KEY_AUTOSYNC_, applicationContext)) {
+                startActivity(Intent(applicationContext, DashboardActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    .putExtra("from_login", true))
+                finish()
+                return@launch
+            }
 
+            if (prefData.getFirstLaunch()) {
+                startActivity(Intent(this@OnboardingActivity, LoginActivity::class.java))
+                finish()
+                return@launch
+            }
+
+            setupOnboarding()
+        }
+    }
+
+    private fun setupOnboarding() {
         loadData()
         mAdapter = OnboardingAdapter(this, onBoardItems)
         binding.pagerIntroduction.adapter = mAdapter
@@ -82,7 +97,7 @@ class OnboardingActivity : AppCompatActivity() {
             override fun onPageScrollStateChanged(state: Int) {}
         })
 
-        binding.skip.setOnClickListener{
+        binding.skip.setOnClickListener {
             finishTutorial()
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -94,10 +94,15 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
         inputName = binding.inputName
         inputPassword = binding.inputPassword
 
-        binding.tvAvailableSpace.text = buildString {
-            append(getString(R.string.available_space_colon))
-            append(" ")
-            append(FileUtils.availableOverTotalMemoryFormattedString(this@LoginActivity))
+        lifecycleScope.launch {
+            val storageInfo = withContext(Dispatchers.IO) {
+                FileUtils.availableOverTotalMemoryFormattedString(this@LoginActivity)
+            }
+            binding.tvAvailableSpace.text = buildString {
+                append(getString(R.string.available_space_colon))
+                append(" ")
+                append(storageInfo)
+            }
         }
         changeLogoColor()
         declareElements()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -7,6 +7,7 @@ import android.content.SharedPreferences
 import android.graphics.drawable.AnimationDrawable
 import android.os.Build
 import android.os.Bundle
+import android.os.StrictMode
 import android.text.TextUtils
 import android.util.Log
 import android.view.ContextThemeWrapper
@@ -184,9 +185,12 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
                 }
             }
         }
+        
+        val oldPolicy = StrictMode.allowThreadDiskReads()
         settings = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-        requestAllPermissions()
         defaultPref = PreferenceManager.getDefaultSharedPreferences(this)
+        StrictMode.setThreadPolicy(oldPolicy)
+        requestAllPermissions()
         processedUrl = UrlUtils.getUrl()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/utils/LocaleUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/LocaleUtils.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.utils
 import android.content.Context
 import android.content.res.Configuration
 import android.os.LocaleList
+import android.os.StrictMode
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import java.util.Locale
@@ -11,8 +12,13 @@ object LocaleUtils {
     private const val SELECTED_LANGUAGE = "Locale.Helper.Selected.Language"
 
     fun onAttach(context: Context): Context {
-        val lang = getPersistedData(context, Locale.getDefault().language)
-        return setLocale(context, lang)
+        val oldPolicy = StrictMode.allowThreadDiskReads()
+        return try {
+            val lang = getPersistedData(context, Locale.getDefault().language)
+            setLocale(context, lang)
+        } finally {
+            StrictMode.setThreadPolicy(oldPolicy)
+        }
     }
 
     fun getLanguage(context: Context): String {


### PR DESCRIPTION
Move potentially blocking disk/network work off the main thread and add network socket tagging.

- Initialize app SharedPreferences early in MainApplication to ensure prefs are created on startup.
- Add TaggedSocketFactory (TrafficStats tagging) and set it on OkHttpClient to tag network traffic for metrics.
- Use lifecycleScope + Dispatchers.IO in OnboardingActivity and LoginActivity to read secure prefs and storage info off the UI thread; extracted onboarding setup into setupOnboarding().
- Temporarily allow disk reads when reading SharedPreferences in SyncActivity and LocaleUtils using StrictMode.allowThreadDiskReads() to avoid StrictMode violations.
- Minor import reordering and cleanup.

These changes reduce main-thread blocking, avoid StrictMode crashes, and enable network traffic tagging for diagnostics.