### PR TITLE
Refactor: Remove deprecated UserSessionManager properties

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
@@ -33,14 +33,6 @@ class UserSessionManager @Inject constructor(
         }
     }
 
-    @Deprecated("Use getUserModel() suspend function instead")
-    val userModel: RealmUser? get() = userRepository.getUserModel()
-
-    @Deprecated("Use getUserModel() suspend function instead")
-    fun getUserModelCopy(): RealmUser? {
-        return userRepository.getUserModel()
-    }
-
     suspend fun getUserModel(): RealmUser? {
         return userRepository.getUserModelSuspending()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -137,17 +137,16 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             }
         )
 
-        @Suppress("DEPRECATION")
-        user = userSessionManager.userModel
-        checkUser()
-        updateAppTitle()
-        if (handleGuestAccess()) return
-
-        handleInitialFragment()
-        addBackPressCallback()
-        collectUiState()
-
         lifecycleScope.launch {
+            user = userSessionManager.getUserModel()
+            checkUser()
+            updateAppTitle()
+            if (handleGuestAccess()) return@launch
+
+            handleInitialFragment()
+            addBackPressCallback()
+            collectUiState()
+
             initializeDashboard()
             isReady = true
             binding.root.invalidate()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -142,11 +142,13 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             checkUser()
             updateAppTitle()
             if (handleGuestAccess()) return@launch
+        }
 
-            handleInitialFragment()
-            addBackPressCallback()
-            collectUiState()
+        handleInitialFragment()
+        addBackPressCallback()
+        collectUiState()
 
+        lifecycleScope.launch {
             initializeDashboard()
             isReady = true
             binding.root.invalidate()


### PR DESCRIPTION
Replaced synchronous `userSessionManager.userModel` call site in `DashboardActivity` with the suspend equivalent `getUserModel()` and wrapped it in `lifecycleScope.launch`.

Removed the deprecated `userModel` property and `getUserModelCopy()` function from `UserSessionManager`. Verified by running compilation and test suite.

---
*PR created automatically by Jules for task [5435244142139131440](https://jules.google.com/task/5435244142139131440) started by @dogi*