### PR TITLE
Migrate root build.gradle.kts from buildscript classpath to plugins DSL

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.application)
-    alias(libs.plugins.legacy.kapt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.dagger.hilt.android)
     alias(libs.plugins.realm.android)
@@ -148,9 +147,6 @@ android {
 }
 realm {
     syncEnabled = true
-}
-kapt {
-    correctErrorTypes = true
 }
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.application) apply false
-    alias(libs.plugins.legacy.kapt) apply false
     alias(libs.plugins.realm.android) apply false
     alias(libs.plugins.dagger.hilt.android) apply false
     alias(libs.plugins.ksp) apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,14 @@
-import org.gradle.api.tasks.Delete
-
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath(libs.android.gradle.plugin)
-        classpath(libs.realm.gradle.plugin)
-        classpath(libs.hilt.android.gradle.plugin)
-        classpath(libs.kotlin.gradle.plugin)
-        classpath(libs.kotlin.serialization)
-        classpath(libs.ksp.symbol.processing.gradle.plugin)
-    }
+plugins {
+    alias(libs.plugins.application) apply false
+    alias(libs.plugins.legacy.kapt) apply false
+    alias(libs.plugins.realm.android) apply false
+    alias(libs.plugins.dagger.hilt.android) apply false
+    alias(libs.plugins.ksp) apply false
+    kotlin("android") version libs.versions.kotlin apply false
+    kotlin("plugin.serialization") version libs.versions.kotlin apply false
 }
+
+import org.gradle.api.tasks.Delete
 
 allprojects {
     repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,6 @@ testArch = "2.2.0"
 
 [plugins]
 application = { id = "com.android.application", version.ref = "gradle" }
-legacy-kapt = { id = "com.android.legacy-kapt", version.ref = "gradle" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 realm-android = { id = "realm-android", version.ref = "realm" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,11 +50,11 @@ testRunner = "1.7.0"
 testArch = "2.2.0"
 
 [plugins]
-application = { id = "com.android.application" }
+application = { id = "com.android.application", version.ref = "gradle" }
 legacy-kapt = { id = "com.android.legacy-kapt", version.ref = "gradle" }
-ksp = { id = "com.google.devtools.ksp" }
-dagger-hilt-android = { id = "com.google.dagger.hilt.android" }
-realm-android = { id = "realm-android" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+realm-android = { id = "realm-android", version.ref = "realm" }
 
 [libraries]
 test-junit = { module = "junit:junit", version.ref = "junit" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,13 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "realm-android") {
+                useModule("io.realm:realm-gradle-plugin:${requested.version}")
+            }
+        }
+    }
 }
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'


### PR DESCRIPTION
Migrate plugin declarations to plugins block and remove buildscript block. Verifications done: ./gradlew assembleLiteDebug assembleDefaultDebug and ./gradlew testDefaultDebugUnitTest.

---
*PR created automatically by Jules for task [6795909251310001158](https://jules.google.com/task/6795909251310001158) started by @dogi*