### PR TITLE
build: replace kapt with ksp for hilt

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.application)
-    alias(libs.plugins.legacy.kapt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.dagger.hilt.android)
     alias(libs.plugins.realm.android)
@@ -149,8 +148,8 @@ android {
 realm {
     syncEnabled = true
 }
-kapt {
-    correctErrorTypes = true
+ksp {
+    arg("dagger.hilt.android.internal.disableAndroidSuperclassValidation", "true")
 }
 kotlin {
     compilerOptions {


### PR DESCRIPTION
Replaced KAPT with KSP for Hilt and removed the kapt plugin in app/build.gradle. Verified build and ran testDefaultDebugUnitTest.

---
*PR created automatically by Jules for task [16178913665254768995](https://jules.google.com/task/16178913665254768995) started by @dogi*