### PR TITLE
Enable R8 minification and resource shrinking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,8 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled = false
+            minifyEnabled = true
+            shrinkResources = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         debug {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -45,14 +45,11 @@
 
 # Realm Keep Rules
 -keep class io.realm.** { *; }
--keep class * extends io.realm.RealmObject
--keep class * extends io.realm.RealmModel
--keep @io.realm.annotations.RealmClass class *
-
-# Hilt Keep Rules
--keep class dagger.hilt.** { *; }
--keep @dagger.hilt.android.AndroidEntryPoint class *
--keep @dagger.hilt.android.lifecycle.HiltViewModel class *
+-keep class * extends io.realm.RealmObject { *; }
+-keep class * extends io.realm.RealmModel { *; }
 
 # Retrofit / Gson Keep Rules
 -keep class org.ole.planet.myplanet.model.** { *; }
+-keepclasseswithmembers class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -42,3 +42,17 @@
 # Markwon missing optional dependencies
 -dontwarn com.caverock.androidsvg.**
 -dontwarn org.commonmark.ext.gfm.strikethrough.**
+
+# Realm Keep Rules
+-keep class io.realm.** { *; }
+-keep class * extends io.realm.RealmObject
+-keep class * extends io.realm.RealmModel
+-keep @io.realm.annotations.RealmClass class *
+
+# Hilt Keep Rules
+-keep class dagger.hilt.** { *; }
+-keep @dagger.hilt.android.AndroidEntryPoint class *
+-keep @dagger.hilt.android.lifecycle.HiltViewModel class *
+
+# Retrofit / Gson Keep Rules
+-keep class org.ole.planet.myplanet.model.** { *; }


### PR DESCRIPTION
Enables R8 minification and resource shrinking for release builds. Includes ProGuard keep rules for Realm, Gson, Retrofit, and Hilt.

---
*PR created automatically by Jules for task [7694756373237464046](https://jules.google.com/task/7694756373237464046) started by @dogi*