### PR TITLE
🧪 Add LoginSyncManager Unit Tests

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/LoginSyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/LoginSyncManagerTest.kt
@@ -8,19 +8,24 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.utils.MainDispatcherRule
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LoginSyncManagerTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     @MockK
     private lateinit var context: Context
@@ -30,17 +35,15 @@ class LoginSyncManagerTest {
     private lateinit var userRepository: UserRepository
     @MockK
     private lateinit var apiInterface: ApiInterface
-    @MockK
+    @MockK(relaxed = true)
     private lateinit var listener: OnSyncListener
 
-    private val testDispatcher = UnconfinedTestDispatcher()
     private val testScope = TestScope(testDispatcher)
 
     private lateinit var loginSyncManager: LoginSyncManager
 
     @Before
     fun setup() {
-        Dispatchers.setMain(testDispatcher)
         MockKAnnotations.init(this, relaxed = true)
 
         loginSyncManager = LoginSyncManager(
@@ -52,36 +55,39 @@ class LoginSyncManagerTest {
         )
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
     @Test
-    fun testLogin_emptyUsername_callsOnSyncFailed() = runTest {
+    fun testLogin_emptyUsername_callsOnSyncFailed() = testScope.runTest {
         loginSyncManager.login("", "password", listener)
 
-        verify(timeout = 1000) { listener.onSyncFailed("Username and password are required.") }
+        advanceUntilIdle()
+
+        verify { listener.onSyncFailed("Username and password are required.") }
     }
 
     @Test
-    fun testLogin_nullUsername_callsOnSyncFailed() = runTest {
+    fun testLogin_nullUsername_callsOnSyncFailed() = testScope.runTest {
         loginSyncManager.login(null, "password", listener)
 
-        verify(timeout = 1000) { listener.onSyncFailed("Username and password are required.") }
+        advanceUntilIdle()
+
+        verify { listener.onSyncFailed("Username and password are required.") }
     }
 
     @Test
-    fun testLogin_emptyPassword_callsOnSyncFailed() = runTest {
+    fun testLogin_emptyPassword_callsOnSyncFailed() = testScope.runTest {
         loginSyncManager.login("username", "", listener)
 
-        verify(timeout = 1000) { listener.onSyncFailed("Username and password are required.") }
+        advanceUntilIdle()
+
+        verify { listener.onSyncFailed("Username and password are required.") }
     }
 
     @Test
-    fun testLogin_nullPassword_callsOnSyncFailed() = runTest {
+    fun testLogin_nullPassword_callsOnSyncFailed() = testScope.runTest {
         loginSyncManager.login("username", null, listener)
 
-        verify(timeout = 1000) { listener.onSyncFailed("Username and password are required.") }
+        advanceUntilIdle()
+
+        verify { listener.onSyncFailed("Username and password are required.") }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/LoginSyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/LoginSyncManagerTest.kt
@@ -1,0 +1,87 @@
+package org.ole.planet.myplanet.services.sync
+
+import android.content.Context
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.callback.OnSyncListener
+import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.services.SharedPrefManager
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LoginSyncManagerTest {
+
+    @MockK
+    private lateinit var context: Context
+    @MockK
+    private lateinit var sharedPrefManager: SharedPrefManager
+    @MockK
+    private lateinit var userRepository: UserRepository
+    @MockK
+    private lateinit var apiInterface: ApiInterface
+    @MockK
+    private lateinit var listener: OnSyncListener
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    private lateinit var loginSyncManager: LoginSyncManager
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        MockKAnnotations.init(this, relaxed = true)
+
+        loginSyncManager = LoginSyncManager(
+            context,
+            sharedPrefManager,
+            userRepository,
+            apiInterface,
+            testScope
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun testLogin_emptyUsername_callsOnSyncFailed() = runTest {
+        loginSyncManager.login("", "password", listener)
+
+        verify(timeout = 1000) { listener.onSyncFailed("Username and password are required.") }
+    }
+
+    @Test
+    fun testLogin_nullUsername_callsOnSyncFailed() = runTest {
+        loginSyncManager.login(null, "password", listener)
+
+        verify(timeout = 1000) { listener.onSyncFailed("Username and password are required.") }
+    }
+
+    @Test
+    fun testLogin_emptyPassword_callsOnSyncFailed() = runTest {
+        loginSyncManager.login("username", "", listener)
+
+        verify(timeout = 1000) { listener.onSyncFailed("Username and password are required.") }
+    }
+
+    @Test
+    fun testLogin_nullPassword_callsOnSyncFailed() = runTest {
+        loginSyncManager.login("username", null, listener)
+
+        verify(timeout = 1000) { listener.onSyncFailed("Username and password are required.") }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `app/src/main/java/org/ole/planet/myplanet/services/sync/LoginSyncManager.kt` had missing tests, particularly for the empty/null username/password login validation logic.
📊 **Coverage:** Added tests to verify scenarios where either the username or password (or both) are empty or null, verifying that the `onSyncFailed` listener callback is correctly triggered with the appropriate error message.
✨ **Result:** Test coverage for `LoginSyncManager` validation logic is now improved, making sure incorrect authentication credentials correctly surface the failure.

---
*PR created automatically by Jules for task [14291108514145049322](https://jules.google.com/task/14291108514145049322) started by @dogi*