### PR TITLE
Refactor user ID resolution in RatingsViewModel via Repository

### DIFF
--- a/README_agent_learning.md
+++ b/README_agent_learning.md
@@ -1,5 +1,0 @@
-# Learning from RatingsViewModel Refactor
-
-- **Goal:** Filter direct data references in `RatingsViewModel` via Repository.
-- **Pattern Used:** Move logic that extracts or determines data fields from entities into the repository layer. Specifically, we removed direct access to `RealmUser.id` and `RealmUser._id` within the `RatingsViewModel` by introducing a `getValidUserId(user, fallback)` method in the `UserRepository`. This ensures the ViewModel doesn't need to know the internal data structure or fallback mechanisms for user IDs.
-- **Why:** To adhere to proper MVVM and repository patterns, ensuring that the ViewModel only coordinates UI state and delegates data resolution to the Repository.

--- a/README_agent_learning.md
+++ b/README_agent_learning.md
@@ -1,0 +1,5 @@
+# Learning from RatingsViewModel Refactor
+
+- **Goal:** Filter direct data references in `RatingsViewModel` via Repository.
+- **Pattern Used:** Move logic that extracts or determines data fields from entities into the repository layer. Specifically, we removed direct access to `RealmUser.id` and `RealmUser._id` within the `RatingsViewModel` by introducing a `getValidUserId(user, fallback)` method in the `UserRepository`. This ensures the ViewModel doesn't need to know the internal data structure or fallback mechanisms for user IDs.
+- **Why:** To adhere to proper MVVM and repository patterns, ensuring that the ViewModel only coordinates UI state and delegates data resolution to the Repository.

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -82,6 +82,7 @@ interface UserRepository {
     suspend fun getUserProfile(): RealmUser?
     suspend fun getUserImageUrl(): String?
     suspend fun getActiveUserIdSuspending(): String
+    fun getValidUserId(user: RealmUser, fallbackId: String): String
     suspend fun validateUsername(username: String): String?
     suspend fun cleanupDuplicateUsers()
     suspend fun authenticateUser(username: String?, password: String?, isManagerMode: Boolean): RealmUser?

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -451,6 +451,10 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun getActiveUserIdSuspending(): String {
         return getUserModelSuspending()?.id ?: ""
     }
+
+    override fun getValidUserId(user: RealmUser, fallbackId: String): String {
+        return user.id?.takeIf { it.isNotBlank() } ?: user._id ?: fallbackId
+    }
     override suspend fun getHealthRecordsAndAssociatedUsers(
         userId: String,
         currentUser: RealmUser

--- a/app/src/main/java/org/ole/planet/myplanet/ui/ratings/RatingsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/ratings/RatingsViewModel.kt
@@ -90,7 +90,7 @@ class RatingsViewModel @Inject constructor(
                     type = type,
                     itemId = itemId,
                     title = title,
-                    userId = user.id?.takeIf { it.isNotBlank() } ?: user._id ?: userId,
+                    userId = userRepository.getValidUserId(user, userId),
                     rating = rating,
                     comment = comment
                 )

--- a/app/src/test/java/org/ole/planet/myplanet/ui/ratings/RatingsViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/ratings/RatingsViewModelTest.kt
@@ -113,4 +113,32 @@ class RatingsViewModelTest {
 
         assertEquals(mockUser, viewModel.userState.value)
     }
+
+    @Test
+    fun `submitRating success path`() = runTest {
+        val type = "course"
+        val itemId = "item-1"
+        val title = "Title"
+        val userId = "user-1"
+        val rating = 4.5f
+        val comment = "Great"
+
+        val mockUser = RealmUser().apply { id = userId }
+        val mockSummary = RatingSummary(
+            existingRating = RatingEntry("r-1", "Good", 5),
+            averageRating = 4.5f,
+            totalRatings = 10,
+            userRating = 5
+        )
+
+        coEvery { userRepository.getUserById(userId) } returns mockUser
+        coEvery { userRepository.getValidUserId(mockUser, userId) } returns userId
+        coEvery { ratingsRepository.submitRating(type, itemId, title, userId, rating, comment) } returns mockSummary
+
+        viewModel.submitRating(type, itemId, title, userId, rating, comment)
+        advanceUntilIdle()
+
+        val state = viewModel.submitState.value
+        assertTrue(state is RatingsViewModel.SubmitState.Success)
+    }
 }


### PR DESCRIPTION
Encapsulate user ID resolution logic within the UserRepository to properly implement the repository pattern, removing direct data references from RatingsViewModel.

---
*PR created automatically by Jules for task [10969827942392157936](https://jules.google.com/task/10969827942392157936) started by @dogi*