### PR TITLE
🧪 Add test file for RealmTeamLog

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmTeamLogTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmTeamLogTest.kt
@@ -1,0 +1,199 @@
+package org.ole.planet.myplanet.model
+
+import android.content.Context
+import android.text.TextUtils
+import com.google.gson.JsonObject
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.realm.Realm
+import io.realm.RealmQuery
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.utils.JsonUtils
+import org.ole.planet.myplanet.utils.NetworkUtils
+
+class RealmTeamLogTest {
+
+    @Before
+    fun setup() {
+        mockkObject(NetworkUtils)
+        mockkStatic(JsonUtils::class)
+        mockkStatic(TextUtils::class)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun testGetLastVisit() {
+        val mockRealm = mockk<Realm>()
+        val mockQuery = mockk<RealmQuery<RealmTeamLog>>()
+
+        every { mockRealm.where(RealmTeamLog::class.java) } returns mockQuery
+        every { mockQuery.equalTo("type", "teamVisit") } returns mockQuery
+        every { mockQuery.equalTo("user", "testUser") } returns mockQuery
+        every { mockQuery.equalTo("teamId", "testTeamId") } returns mockQuery
+        every { mockQuery.max("time") } returns 123456789L
+
+        val result = RealmTeamLog.getLastVisit(mockRealm, "testUser", "testTeamId")
+        assertEquals(123456789L, result)
+    }
+
+    @Test
+    fun testSerializeTeamActivities() {
+        val log = RealmTeamLog().apply {
+            user = "testUser"
+            type = "testType"
+            createdOn = "testDate"
+            parentCode = "testParent"
+            teamType = "testTeamType"
+            time = 12345L
+            teamId = "testTeamId"
+            _rev = "testRev"
+            _id = "testId"
+        }
+        val mockContext = mockk<Context>()
+
+        every { NetworkUtils.getUniqueIdentifier() } returns "testUniqueId"
+        every { NetworkUtils.getDeviceName() } returns "testDevice"
+        every { NetworkUtils.getCustomDeviceName(mockContext) } returns "testCustomDevice"
+        every { TextUtils.isEmpty("testRev") } returns false
+
+        val result = RealmTeamLog.serializeTeamActivities(log, mockContext)
+
+        assertEquals("testUser", result.get("user").asString)
+        assertEquals("testType", result.get("type").asString)
+        assertEquals("testDate", result.get("createdOn").asString)
+        assertEquals("testParent", result.get("parentCode").asString)
+        assertEquals("testTeamType", result.get("teamType").asString)
+        assertEquals(12345L, result.get("time").asLong)
+        assertEquals("testTeamId", result.get("teamId").asString)
+        assertEquals("testUniqueId", result.get("androidId").asString)
+        assertEquals("testDevice", result.get("deviceName").asString)
+        assertEquals("testCustomDevice", result.get("customDeviceName").asString)
+        assertEquals("testRev", result.get("_rev").asString)
+        assertEquals("testId", result.get("_id").asString)
+    }
+
+    @Test
+    fun testSerializeTeamActivities_emptyRev() {
+        val log = RealmTeamLog().apply {
+            user = "testUser"
+            type = "testType"
+            createdOn = "testDate"
+            parentCode = "testParent"
+            teamType = "testTeamType"
+            time = 12345L
+            teamId = "testTeamId"
+            _rev = ""
+            _id = "testId"
+        }
+        val mockContext = mockk<Context>()
+
+        every { NetworkUtils.getUniqueIdentifier() } returns "testUniqueId"
+        every { NetworkUtils.getDeviceName() } returns "testDevice"
+        every { NetworkUtils.getCustomDeviceName(mockContext) } returns "testCustomDevice"
+        every { TextUtils.isEmpty("") } returns true
+
+        val result = RealmTeamLog.serializeTeamActivities(log, mockContext)
+
+        assertEquals(false, result.has("_rev"))
+        assertEquals(false, result.has("_id"))
+    }
+
+    @Test
+    fun testInsert_newObject() {
+        val mockRealm = mockk<Realm>()
+        val mockQuery = mockk<RealmQuery<RealmTeamLog>>()
+        val act = JsonObject().apply {
+            addProperty("_id", "newId")
+            addProperty("_rev", "newRev")
+            addProperty("type", "newType")
+            addProperty("user", "newUser")
+            addProperty("createdOn", "newDate")
+            addProperty("parentCode", "newParent")
+            addProperty("time", 98765L)
+            addProperty("teamId", "newTeamId")
+            addProperty("teamType", "newTeamType")
+        }
+        val newLog = mockk<RealmTeamLog>(relaxed = true)
+
+        every { JsonUtils.getString(any(), act) } answers {
+            val key = firstArg<String>()
+            if (act.has(key)) act.get(key).asString else ""
+        }
+        every { JsonUtils.getLong(any(), act) } answers {
+            val key = firstArg<String>()
+            if (act.has(key)) act.get(key).asLong else 0L
+        }
+
+        every { mockRealm.where(RealmTeamLog::class.java) } returns mockQuery
+        every { mockQuery.equalTo("id", "newId") } returns mockQuery
+        every { mockQuery.findFirst() } returns null
+        every { mockRealm.createObject(RealmTeamLog::class.java, "newId") } returns newLog
+
+        RealmTeamLog.insert(mockRealm, act)
+
+        verify { newLog._rev = "newRev" }
+        verify { newLog._id = "newId" }
+        verify { newLog.type = "newType" }
+        verify { newLog.user = "newUser" }
+        verify { newLog.createdOn = "newDate" }
+        verify { newLog.parentCode = "newParent" }
+        verify { newLog.time = 98765L }
+        verify { newLog.teamId = "newTeamId" }
+        verify { newLog.teamType = "newTeamType" }
+    }
+
+    @Test
+    fun testInsert_existingObject() {
+        val mockRealm = mockk<Realm>()
+        val mockQuery = mockk<RealmQuery<RealmTeamLog>>()
+        val act = JsonObject().apply {
+            addProperty("_id", "existingId")
+            addProperty("_rev", "updatedRev")
+            addProperty("type", "updatedType")
+            addProperty("user", "updatedUser")
+            addProperty("createdOn", "updatedDate")
+            addProperty("parentCode", "updatedParent")
+            addProperty("time", 11111L)
+            addProperty("teamId", "updatedTeamId")
+            addProperty("teamType", "updatedTeamType")
+        }
+        val existingLog = mockk<RealmTeamLog>(relaxed = true)
+
+        every { JsonUtils.getString(any(), act) } answers {
+            val key = firstArg<String>()
+            if (act.has(key)) act.get(key).asString else ""
+        }
+        every { JsonUtils.getLong(any(), act) } answers {
+            val key = firstArg<String>()
+            if (act.has(key)) act.get(key).asLong else 0L
+        }
+
+        every { mockRealm.where(RealmTeamLog::class.java) } returns mockQuery
+        every { mockQuery.equalTo("id", "existingId") } returns mockQuery
+        every { mockQuery.findFirst() } returns existingLog
+
+        RealmTeamLog.insert(mockRealm, act)
+
+        verify(exactly = 0) { mockRealm.createObject(RealmTeamLog::class.java, any<String>()) }
+        verify { existingLog._rev = "updatedRev" }
+        verify { existingLog._id = "existingId" }
+        verify { existingLog.type = "updatedType" }
+        verify { existingLog.user = "updatedUser" }
+        verify { existingLog.createdOn = "updatedDate" }
+        verify { existingLog.parentCode = "updatedParent" }
+        verify { existingLog.time = 11111L }
+        verify { existingLog.teamId = "updatedTeamId" }
+        verify { existingLog.teamType = "updatedTeamType" }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmTeamLogTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmTeamLogTest.kt
@@ -43,7 +43,7 @@ class RealmTeamLogTest {
         every { mockQuery.equalTo("teamId", "testTeamId") } returns mockQuery
         every { mockQuery.max("time") } returns 123456789L
 
-        val result = RealmTeamLog.getLastVisit(mockRealm, "testUser", "testTeamId")
+        val result = RealmTeamLog.Companion.getLastVisit(mockRealm, "testUser", "testTeamId")
         assertEquals(123456789L, result)
 
         verify { mockRealm.where(RealmTeamLog::class.java) }
@@ -73,7 +73,7 @@ class RealmTeamLogTest {
         every { NetworkUtils.getCustomDeviceName(mockContext) } returns "testCustomDevice"
         every { TextUtils.isEmpty("testRev") } returns false
 
-        val result = RealmTeamLog.serializeTeamActivities(log, mockContext)
+        val result = RealmTeamLog.Companion.serializeTeamActivities(log, mockContext)
 
         assertEquals("testUser", result.get("user").asString)
         assertEquals("testType", result.get("type").asString)
@@ -109,7 +109,7 @@ class RealmTeamLogTest {
         every { NetworkUtils.getCustomDeviceName(mockContext) } returns "testCustomDevice"
         every { TextUtils.isEmpty("") } returns true
 
-        val result = RealmTeamLog.serializeTeamActivities(log, mockContext)
+        val result = RealmTeamLog.Companion.serializeTeamActivities(log, mockContext)
 
         assertEquals(false, result.has("_rev"))
         assertEquals(false, result.has("_id"))
@@ -147,7 +147,7 @@ class RealmTeamLogTest {
         every { mockQuery.findFirst() } returns null
         every { mockRealm.createObject(RealmTeamLog::class.java, "newId") } returns newLog
 
-        RealmTeamLog.insert(mockRealm, act)
+        RealmTeamLog.Companion.insert(mockRealm, act)
 
         verify { newLog._rev = "newRev" }
         verify { newLog._id = "newId" }
@@ -191,7 +191,7 @@ class RealmTeamLogTest {
         every { mockQuery.equalTo("id", "existingId") } returns mockQuery
         every { mockQuery.findFirst() } returns existingLog
 
-        RealmTeamLog.insert(mockRealm, act)
+        RealmTeamLog.Companion.insert(mockRealm, act)
 
         verify(exactly = 0) { mockRealm.createObject(RealmTeamLog::class.java, any<String>()) }
         verify { existingLog._rev = "updatedRev" }

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmTeamLogTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmTeamLogTest.kt
@@ -45,6 +45,12 @@ class RealmTeamLogTest {
 
         val result = RealmTeamLog.getLastVisit(mockRealm, "testUser", "testTeamId")
         assertEquals(123456789L, result)
+
+        verify { mockRealm.where(RealmTeamLog::class.java) }
+        verify { mockQuery.equalTo("type", "teamVisit") }
+        verify { mockQuery.equalTo("user", "testUser") }
+        verify { mockQuery.equalTo("teamId", "testTeamId") }
+        verify { mockQuery.max("time") }
     }
 
     @Test
@@ -126,14 +132,15 @@ class RealmTeamLogTest {
         }
         val newLog = mockk<RealmTeamLog>(relaxed = true)
 
-        every { JsonUtils.getString(any(), act) } answers {
-            val key = firstArg<String>()
-            if (act.has(key)) act.get(key).asString else ""
-        }
-        every { JsonUtils.getLong(any(), act) } answers {
-            val key = firstArg<String>()
-            if (act.has(key)) act.get(key).asLong else 0L
-        }
+        every { JsonUtils.getString("_id", act) } returns "newId"
+        every { JsonUtils.getString("_rev", act) } returns "newRev"
+        every { JsonUtils.getString("type", act) } returns "newType"
+        every { JsonUtils.getString("user", act) } returns "newUser"
+        every { JsonUtils.getString("createdOn", act) } returns "newDate"
+        every { JsonUtils.getString("parentCode", act) } returns "newParent"
+        every { JsonUtils.getString("teamId", act) } returns "newTeamId"
+        every { JsonUtils.getString("teamType", act) } returns "newTeamType"
+        every { JsonUtils.getLong("time", act) } returns 98765L
 
         every { mockRealm.where(RealmTeamLog::class.java) } returns mockQuery
         every { mockQuery.equalTo("id", "newId") } returns mockQuery
@@ -170,14 +177,15 @@ class RealmTeamLogTest {
         }
         val existingLog = mockk<RealmTeamLog>(relaxed = true)
 
-        every { JsonUtils.getString(any(), act) } answers {
-            val key = firstArg<String>()
-            if (act.has(key)) act.get(key).asString else ""
-        }
-        every { JsonUtils.getLong(any(), act) } answers {
-            val key = firstArg<String>()
-            if (act.has(key)) act.get(key).asLong else 0L
-        }
+        every { JsonUtils.getString("_id", act) } returns "existingId"
+        every { JsonUtils.getString("_rev", act) } returns "updatedRev"
+        every { JsonUtils.getString("type", act) } returns "updatedType"
+        every { JsonUtils.getString("user", act) } returns "updatedUser"
+        every { JsonUtils.getString("createdOn", act) } returns "updatedDate"
+        every { JsonUtils.getString("parentCode", act) } returns "updatedParent"
+        every { JsonUtils.getString("teamId", act) } returns "updatedTeamId"
+        every { JsonUtils.getString("teamType", act) } returns "updatedTeamType"
+        every { JsonUtils.getLong("time", act) } returns 11111L
 
         every { mockRealm.where(RealmTeamLog::class.java) } returns mockQuery
         every { mockQuery.equalTo("id", "existingId") } returns mockQuery


### PR DESCRIPTION
🎯 **What:** Added a new unit test file for `RealmTeamLog.kt` to address the testing gap for this model's utility methods.
📊 **Coverage:** The new `RealmTeamLogTest.kt` tests the companion object methods: `getLastVisit`, `serializeTeamActivities` (including the empty revision edge case), and `insert` (handling both new object creation and updating existing objects). Dependencies such as `Realm`, `NetworkUtils`, and `JsonUtils` are cleanly mocked via `MockK`.
✨ **Result:** Test coverage for `RealmTeamLog` is now established, providing a safety net against future regressions and making the codebase more reliable.

---
*PR created automatically by Jules for task [8837777795829045208](https://jules.google.com/task/8837777795829045208) started by @dogi*