### PR TITLE
🧹 Replace e.printStackTrace() with proper logging in MainApplication.kt and fix tests

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.os.StrictMode
 import android.os.StrictMode.VmPolicy
 import android.provider.Settings
+import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration as WorkManagerConfiguration
@@ -93,6 +94,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
             .build()
 
     companion object {
+        private const val TAG = "MainApplication"
         private const val AUTO_SYNC_WORK_TAG = "autoSyncWork"
         private const val TASK_NOTIFICATION_WORK_TAG = "taskNotificationWork"
         lateinit var context: Context
@@ -105,7 +107,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
             try {
                 return Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             } catch (e: Exception) {
-                e.printStackTrace()
+                Log.e(TAG, "Failed to get ANDROID_ID", e)
             }
             return "0"
         }
@@ -137,7 +139,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
                         }
                     }
                 } catch (e: Exception) {
-                    e.printStackTrace()
+                    Log.e(TAG, "Failed to create log", e)
                 }
             }
         }
@@ -184,13 +186,13 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
                 }
                 responseCode in 200..299
             } catch (e: Exception) {
-                e.printStackTrace()
+                Log.e(TAG, "Server reachability check failed", e)
                 false
             }
         }
 
         fun handleUncaughtException(e: Throwable) {
-            e.printStackTrace()
+            Log.e(TAG, "Uncaught exception", e)
             createLog(RealmApkLog.ERROR_TYPE_CRASH, e.stackTraceToString())
 
             val homeIntent = Intent(Intent.ACTION_MAIN).apply {
@@ -310,7 +312,7 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
                 )
                 entryPoint.retryQueue().recoverStuckOperations()
             } catch (e: Exception) {
-                e.printStackTrace()
+                Log.e(TAG, "Failed to recover stuck operations", e)
             }
         }
         RetryQueueWorker.schedule(this)

--- a/app/src/test/java/org/ole/planet/myplanet/MainApplicationTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/MainApplicationTest.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet
 
 import android.content.Context
+import android.util.Log
 import dagger.hilt.android.EntryPointAccessors
 import io.mockk.every
 import io.mockk.mockk
@@ -29,6 +30,9 @@ class MainApplicationTest {
     fun setup() {
         mockContext = mockk(relaxed = true)
         MainApplication.context = mockContext
+
+        mockkStatic(Log::class)
+        every { Log.e(any(), any(), any()) } returns 0
 
         mockEntryPoint = mockk(relaxed = true)
         mockServerUrlMapper = mockk(relaxed = true)


### PR DESCRIPTION
🎯 **What:** Replaced all instances of `e.printStackTrace()` in `MainApplication.kt` with `Log.e(TAG, message, e)`. Also updated `MainApplicationTest.kt` to mock the `Log` class.
💡 **Why:** `e.printStackTrace()` is discouraged in Android development. Using `android.util.Log` ensures errors are correctly recorded in logcat. Mocking `Log` in tests is necessary because the unit test environment does not provide a real implementation of Android's `Log` class.
✅ **Verification:** Verified the code changes in `MainApplication.kt` and `MainApplicationTest.kt`. The addition of `mockkStatic(Log::class)` in the test setup addresses the `RuntimeException` observed in the CI run.
✨ **Result:** Improved maintainability, better error visibility, and fixed test failures related to the new logging calls.

---
*PR created automatically by Jules for task [7727737791297957168](https://jules.google.com/task/7727737791297957168) started by @dogi*