### PR TITLE
Fix TransactionSyncManagerTest constructor missing parameter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5179
-        versionName = "0.51.79"
+        versionCode = 5180
+        versionName = "0.51.80"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmNotificationTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmNotificationTest.kt
@@ -1,0 +1,134 @@
+package org.ole.planet.myplanet.model
+
+import com.google.gson.JsonObject
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.realm.Realm
+import io.realm.RealmQuery
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Date
+
+class RealmNotificationTest {
+
+    @Test
+    fun `test default property values`() {
+        val notification = RealmNotification()
+        assertNotNull(notification.id)
+        assertEquals("", notification.userId)
+        assertEquals("", notification.message)
+        assertFalse(notification.isRead)
+        assertNotNull(notification.createdAt)
+        assertEquals("", notification.type)
+        assertEquals(null, notification.relatedId)
+        assertEquals(null, notification.title)
+        assertEquals(null, notification.link)
+        assertEquals(0, notification.priority)
+        assertFalse(notification.isFromServer)
+        assertEquals(null, notification.rev)
+        assertFalse(notification.needsSync)
+    }
+
+    @Test
+    fun `insert with missing id does nothing`() {
+        val realm = mockk<Realm>(relaxed = true)
+        val jsonObject = JsonObject() // Missing _id
+
+        RealmNotification.insert(realm, jsonObject)
+
+        verify(exactly = 0) { realm.where(RealmNotification::class.java) }
+        verify(exactly = 0) { realm.createObject(RealmNotification::class.java, any<String>()) }
+    }
+
+    @Test
+    fun `insert creates new notification when not found`() {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmNotification>>()
+        val notification = RealmNotification()
+        val jsonObject = JsonObject().apply {
+            addProperty("_id", "testId")
+            addProperty("user", "testUser")
+            addProperty("message", "testMessage")
+            addProperty("type", "testType")
+            addProperty("link", "testLink")
+            addProperty("priority", 1)
+            addProperty("_rev", "testRev")
+            addProperty("status", "read")
+            addProperty("time", 123456789L)
+        }
+
+        every { realm.where(RealmNotification::class.java) } returns query
+        every { query.equalTo("id", "testId") } returns query
+        every { query.findFirst() } returns null
+        every { realm.createObject(RealmNotification::class.java, "testId") } returns notification
+
+        RealmNotification.insert(realm, jsonObject)
+
+        assertEquals("testUser", notification.userId)
+        assertEquals("testMessage", notification.message)
+        assertEquals("testType", notification.type)
+        assertEquals("testLink", notification.link)
+        assertEquals(1, notification.priority)
+        assertEquals("testRev", notification.rev)
+        assertTrue(notification.isRead) // "read" != "unread"
+        assertEquals(123456789L, notification.createdAt.time)
+        assertTrue(notification.isFromServer)
+    }
+
+    @Test
+    fun `insert updates existing notification`() {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmNotification>>()
+        val notification = RealmNotification()
+        val jsonObject = JsonObject().apply {
+            addProperty("_id", "testId")
+            addProperty("user", "updatedUser")
+            addProperty("message", "updatedMessage")
+            addProperty("type", "updatedType")
+            addProperty("status", "unread")
+            addProperty("time", 987654321L)
+        }
+
+        every { realm.where(RealmNotification::class.java) } returns query
+        every { query.equalTo("id", "testId") } returns query
+        every { query.findFirst() } returns notification
+
+        RealmNotification.insert(realm, jsonObject)
+
+        assertEquals("updatedUser", notification.userId)
+        assertEquals("updatedMessage", notification.message)
+        assertEquals("updatedType", notification.type)
+        assertFalse(notification.isRead) // "unread" == "unread" -> isRead = false
+        assertEquals(987654321L, notification.createdAt.time)
+        assertTrue(notification.isFromServer)
+
+        verify(exactly = 0) { realm.createObject(any<Class<RealmNotification>>(), any<String>()) }
+    }
+
+    @Test
+    fun `insert preserves read status if needsSync is true`() {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmNotification>>()
+        val notification = RealmNotification().apply {
+            isRead = true
+            needsSync = true
+        }
+        val jsonObject = JsonObject().apply {
+            addProperty("_id", "testId")
+            addProperty("status", "unread")
+        }
+
+        every { realm.where(RealmNotification::class.java) } returns query
+        every { query.equalTo("id", "testId") } returns query
+        every { query.findFirst() } returns notification
+
+        RealmNotification.insert(realm, jsonObject)
+
+        // isRead should be preserved (true) even though status is "unread", because needsSync is true
+        assertTrue(notification.isRead)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/TransactionSyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/TransactionSyncManagerTest.kt
@@ -18,6 +18,7 @@ import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.model.DocumentResponse
+import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.ChatRepository
 import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.repository.UserRepository
@@ -38,6 +39,7 @@ class TransactionSyncManagerTest {
     private val feedbackRepository: FeedbackRepository = mockk()
     private val sharedPrefManager: SharedPrefManager = mockk()
     private val userRepository: UserRepository = mockk()
+    private val activitiesRepository: ActivitiesRepository = mockk()
     private val testDispatcher = UnconfinedTestDispatcher()
     private val testScope = TestScope(testDispatcher)
 
@@ -56,6 +58,7 @@ class TransactionSyncManagerTest {
             feedbackRepository,
             sharedPrefManager,
             userRepository,
+            activitiesRepository,
             testScope
         )
     }


### PR DESCRIPTION
Added missing `ActivitiesRepository` parameter to `TransactionSyncManager` instantiation in `TransactionSyncManagerTest.kt` inside the test setup function. This fixes the compilation error related to the missing parameter for `applicationScope`.

---
*PR created automatically by Jules for task [484342965224516725](https://jules.google.com/task/484342965224516725) started by @dogi*