### PR TITLE
Refactor: Inject DispatcherProvider into BaseTeamFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseTeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseTeamFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,6 +13,7 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @AndroidEntryPoint
 abstract class BaseTeamFragment : BaseVoicesFragment() {
@@ -28,6 +28,8 @@ abstract class BaseTeamFragment : BaseVoicesFragment() {
     var team: RealmMyTeam? = null
     @Inject
     lateinit var teamsRepository: TeamsRepository
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
     private val _teamFlow = MutableStateFlow<RealmMyTeam?>(null)
     val teamFlow: StateFlow<RealmMyTeam?> = _teamFlow.asStateFlow()
     private val _isMemberFlow = MutableStateFlow(false)
@@ -49,7 +51,7 @@ abstract class BaseTeamFragment : BaseVoicesFragment() {
     private fun loadTeamDetails() {
         val shouldQueryTeam = shouldQueryTeamFromRealm()
         val existingTeam = team
-        lifecycleScope.launch(Dispatchers.IO) {
+        lifecycleScope.launch(dispatcherProvider.io) {
             val teamResult = if (shouldQueryTeam) {
                 try {
                     teamsRepository.getTeamById(teamId)
@@ -67,7 +69,7 @@ abstract class BaseTeamFragment : BaseVoicesFragment() {
 
             val membership = teamsRepository.isMember(user?.id, teamId)
 
-            withContext(Dispatchers.Main) {
+            withContext(dispatcherProvider.main) {
                 teamResult?.let {
                     team = it
                 }


### PR DESCRIPTION
Inject DispatcherProvider into BaseTeamFragment and replace hardcoded Dispatchers. This improves testability and follows the project's dependency injection patterns.

---
*PR created automatically by Jules for task [6367491965284636884](https://jules.google.com/task/6367491965284636884) started by @dogi*