### PR TITLE
Refactor observeCommunityNews to use NewsViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
@@ -8,13 +8,17 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
+import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class NewsViewModel @Inject constructor(
     private val resourcesRepository: ResourcesRepository,
+    private val voicesRepository: VoicesRepository,
     private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
 
@@ -28,5 +32,9 @@ class NewsViewModel @Inject constructor(
             }
             _privateImageUrls.emit(urls)
         }
+    }
+
+    suspend fun observeCommunityNews(userIdentifier: String): Flow<List<RealmNews>> {
+        return voicesRepository.getCommunityNews(userIdentifier)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
@@ -12,6 +12,7 @@ import android.widget.EditText
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import com.google.gson.JsonArray
@@ -52,6 +53,7 @@ class VoicesFragment : BaseVoicesFragment() {
     lateinit var userSessionManager: UserSessionManager
     @Inject
     lateinit var voicesRepository: VoicesRepository
+    private val viewModel: NewsViewModel by viewModels()
     private var filteredNewsList: List<RealmNews?> = listOf()
     private var searchFilteredList: List<RealmNews?> = listOf()
     private var labelFilteredList: List<RealmNews?> = listOf()
@@ -100,7 +102,7 @@ class VoicesFragment : BaseVoicesFragment() {
             }
 
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                voicesRepository.getCommunityNews(getUserIdentifier()).collect { news ->
+                viewModel.observeCommunityNews(getUserIdentifier()).collect { news ->
                     val filtered = news.map { it as RealmNews? }
                     val labels = collectAllLabels(filtered)
                     val labelFiltered = applyLabelFilter(filtered)

--- a/app/src/test/java/org/ole/planet/myplanet/ui/voices/NewsViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/voices/NewsViewModelTest.kt
@@ -13,7 +13,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.MainDispatcherRule
+import kotlinx.coroutines.flow.flowOf
+import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -23,6 +26,7 @@ class NewsViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private lateinit var resourcesRepository: ResourcesRepository
+    private lateinit var voicesRepository: VoicesRepository
     private lateinit var viewModel: NewsViewModel
 
     private val testDispatcherProvider = object : DispatcherProvider {
@@ -35,7 +39,8 @@ class NewsViewModelTest {
     @Before
     fun setup() {
         resourcesRepository = mockk()
-        viewModel = NewsViewModel(resourcesRepository, testDispatcherProvider)
+        voicesRepository = mockk()
+        viewModel = NewsViewModel(resourcesRepository, voicesRepository, testDispatcherProvider)
     }
 
     @Test
@@ -56,6 +61,27 @@ class NewsViewModelTest {
         advanceUntilIdle()
 
         assertEquals(expectedUrls, capturedResult)
+    }
+
+    @Test
+    fun `observeCommunityNews returns flow from repository`() = runTest {
+        val userIdentifier = "user123"
+        val expectedNews = listOf(RealmNews())
+        val expectedFlow = flowOf(expectedNews)
+        coEvery { voicesRepository.getCommunityNews(userIdentifier) } returns expectedFlow
+
+        val resultFlow = viewModel.observeCommunityNews(userIdentifier)
+
+        var capturedResult: List<RealmNews>? = null
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            resultFlow.collect { news ->
+                capturedResult = news
+            }
+        }
+
+        advanceUntilIdle()
+
+        assertEquals(expectedNews, capturedResult)
     }
 
     @Test


### PR DESCRIPTION
In `VoicesFragment`, replace the direct call to `voicesRepository.getCommunityNews()` with `viewModel.observeCommunityNews()` to abide by separation of concerns. `NewsViewModel` now handles exposing the flow using `VoicesRepository`. Test file for `NewsViewModel` updated to reflect and cover this flow delegation.

---
*PR created automatically by Jules for task [11820182276551564305](https://jules.google.com/task/11820182276551564305) started by @dogi*