### PR TITLE
Refactor insertFeedbackToRealm to manage its own Realm transaction

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -3,7 +3,6 @@ package org.ole.planet.myplanet.repository
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import io.realm.Realm
 import io.realm.Sort
 import java.util.Date
 import java.util.UUID
@@ -96,39 +95,37 @@ class FeedbackRepositoryImpl @Inject constructor(
     }
 
     override suspend fun insertFromJson(jsonObject: JsonObject) {
-        executeTransaction { realm ->
-            insertFeedbackToRealm(realm, jsonObject)
-        }
+        insertFeedbackToRealm(jsonObject)
     }
 
     override suspend fun insertFeedbackList(jsonObjects: List<JsonObject>) {
-        executeTransaction { realm ->
-            jsonObjects.forEach { jsonObject ->
-                insertFeedbackToRealm(realm, jsonObject)
-            }
+        jsonObjects.forEach { jsonObject ->
+            insertFeedbackToRealm(jsonObject)
         }
     }
 
-    private fun insertFeedbackToRealm(mRealm: Realm, act: JsonObject) {
-        var feedback = mRealm.where(RealmFeedback::class.java)
-            .equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
-        if (feedback == null) {
-            feedback = mRealm.createObject(RealmFeedback::class.java, JsonUtils.getString("_id", act))
+    private suspend fun insertFeedbackToRealm(act: JsonObject) {
+        executeTransaction { realm ->
+            var feedback = realm.where(RealmFeedback::class.java)
+                .equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
+            if (feedback == null) {
+                feedback = realm.createObject(RealmFeedback::class.java, JsonUtils.getString("_id", act))
+            }
+            feedback?._id = JsonUtils.getString("_id", act)
+            feedback?.title = JsonUtils.getString("title", act)
+            feedback?.source = JsonUtils.getString("source", act)
+            feedback?.status = JsonUtils.getString("status", act)
+            feedback?.priority = JsonUtils.getString("priority", act)
+            feedback?.owner = JsonUtils.getString("owner", act)
+            feedback?.openTime = JsonUtils.getLong("openTime", act)
+            feedback?.type = JsonUtils.getString("type", act)
+            feedback?.url = JsonUtils.getString("url", act)
+            feedback?.parentCode = JsonUtils.getString("parentCode", act)
+            feedback?.setMessages(JsonUtils.gson.toJson(JsonUtils.getJsonArray("messages", act)))
+            feedback?.isUploaded = true
+            feedback?.item = JsonUtils.getString("item", act)
+            feedback?.state = JsonUtils.getString("state", act)
+            feedback?._rev = JsonUtils.getString("_rev", act)
         }
-        feedback?._id = JsonUtils.getString("_id", act)
-        feedback?.title = JsonUtils.getString("title", act)
-        feedback?.source = JsonUtils.getString("source", act)
-        feedback?.status = JsonUtils.getString("status", act)
-        feedback?.priority = JsonUtils.getString("priority", act)
-        feedback?.owner = JsonUtils.getString("owner", act)
-        feedback?.openTime = JsonUtils.getLong("openTime", act)
-        feedback?.type = JsonUtils.getString("type", act)
-        feedback?.url = JsonUtils.getString("url", act)
-        feedback?.parentCode = JsonUtils.getString("parentCode", act)
-        feedback?.setMessages(JsonUtils.gson.toJson(JsonUtils.getJsonArray("messages", act)))
-        feedback?.isUploaded = true
-        feedback?.item = JsonUtils.getString("item", act)
-        feedback?.state = JsonUtils.getString("state", act)
-        feedback?._rev = JsonUtils.getString("_rev", act)
     }
 }


### PR DESCRIPTION
This PR addresses the request to refactor the `insertFeedbackToRealm` method inside `FeedbackRepositoryImpl`. It has been converted to a suspend function that handles its own Realm transaction natively using the inherited `executeTransaction` wrapper. Callers `insertFromJson` and `insertFeedbackList` have been simplified to call this directly. Additionally, an unused import was removed. Tests were run to ensure these changes do not introduce regressions.

---
*PR created automatically by Jules for task [15478369987957603690](https://jules.google.com/task/15478369987957603690) started by @dogi*