### PR TITLE
Optimize ResourceAdapter Diff Updates

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -153,13 +153,22 @@ class ResourcesAdapter(
     }
 
     fun selectAllItems(selectAll: Boolean) {
+        val oldSelectedIds = selectedItems.mapNotNull { it.id }.toSet()
         if (selectAll) {
             selectedItems.clear()
             selectedItems.addAll(currentList)
         } else {
             selectedItems.clear()
         }
-        notifyItemRangeChanged(0, currentList.size, SELECTION_PAYLOAD)
+        val newSelectedIds = selectedItems.mapNotNull { it.id }.toSet()
+
+        currentList.forEachIndexed { index, library ->
+            val wasSelected = oldSelectedIds.contains(library.id)
+            val isSelected = newSelectedIds.contains(library.id)
+            if (wasSelected != isSelected) {
+                notifyItemChanged(index, SELECTION_PAYLOAD)
+            }
+        }
         if (listener != null) {
             listener?.onSelectedListChange(selectedItems)
         }
@@ -203,8 +212,19 @@ class ResourcesAdapter(
     }
 
     fun setTagsMap(tagsMap: Map<String, List<TagItem>>) {
+        val oldTagsMap = this.tagsMap
         this.tagsMap = tagsMap
-        notifyItemRangeChanged(0, currentList.size, TAGS_PAYLOAD)
+
+        currentList.forEachIndexed { index, library ->
+            val resourceId = library.id
+            if (resourceId != null) {
+                val oldTags = oldTagsMap[resourceId].orEmpty()
+                val newTags = tagsMap[resourceId].orEmpty()
+                if (oldTags != newTags) {
+                    notifyItemChanged(index, TAGS_PAYLOAD)
+                }
+            }
+        }
     }
 
     fun setOpenedResourceIds(openedResourceIds: Set<String>) {


### PR DESCRIPTION
Fixes a performance issue in `ResourcesAdapter` by introducing fine-grained diff logic for item selections and tag map updates. Previously, operations like `selectAllItems` and `setTagsMap` would broadly trigger `notifyItemRangeChanged` for the entire list, causing unnecessary UI rebinding.

Changes:
1. `selectAllItems`: Computes the `oldSelectedIds` and `newSelectedIds` sets, iterating over `currentList` to strictly call `notifyItemChanged(index, SELECTION_PAYLOAD)` on rows where the state flipped.
2. `setTagsMap`: Retains the previous `tagsMap`, comparing the old and new tag lists for each `resourceId`, dispatching `TAGS_PAYLOAD` only when a delta is detected.
3. Payload handling logic within `onBindViewHolder` remains unmodified to ensure zero behavioral regressions.

---
*PR created automatically by Jules for task [5790781113832838258](https://jules.google.com/task/5790781113832838258) started by @dogi*