### PR TITLE
sync: smoother resources json inserting (fixes #12777)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5238
-        versionName = "0.52.38"
+        versionCode = 5239
+        versionName = "0.52.39"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
@@ -309,8 +309,10 @@ open class RealmMyLibrary : RealmObject() {
                 if (!isLocalOnlyPrivate) {
                     isPrivate = JsonUtils.getBoolean("private", doc)
                     if (isPrivate && doc.has("privateFor")) {
-                        val privateForObj = doc.getAsJsonObject("privateFor")
-                        privateFor = privateForObj.get("teams")?.asString
+                        val privateForElement = doc.get("privateFor")
+                        if (privateForElement.isJsonObject) {
+                            privateFor = privateForElement.asJsonObject.get("teams")?.asString
+                        }
                     }
                 }
                 setLanguages(JsonUtils.getJsonArray("languages", doc), this)


### PR DESCRIPTION
fixes #12777
Avoid calling getAsJsonObject() unconditionally on the 'privateFor' element. The change checks that privateFor is a JsonObject before accessing its 'teams' property, preventing crashes when the JSON contains a non-object (e.g. array or primitive) and preserving the previous behavior of setting privateFor only when a teams value is present.