### PR TITLE
sync: smoother payload processing (fixes #12808)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5238
-        versionName = "0.52.38"
+        versionCode = 5240
+        versionName = "0.52.40"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
@@ -66,7 +66,7 @@ open class RealmMyCourse : RealmObject() {
         private val concatenatedLinks = HashSet<String>()
 
         @JvmStatic
-        fun insertMyCourses(userId: String?, myCoursesDoc: JsonObject?, mRealm: Realm, spm: org.ole.planet.myplanet.services.SharedPrefManager) {
+        fun insertMyCourses(userId: String?, myCoursesDoc: JsonObject?, mRealm: Realm, spm: SharedPrefManager) {
             val id = JsonUtils.getString("_id", myCoursesDoc)
             var myMyCoursesDB = mRealm.where(RealmMyCourse::class.java).equalTo("id", id).findFirst()
             if (myMyCoursesDB == null) {
@@ -160,7 +160,7 @@ open class RealmMyCourse : RealmObject() {
             }
         }
 
-        private fun insertCourseStepsAttachments(myCoursesID: String?, stepId: String?, resources: JsonArray, mRealm: Realm?, spm: org.ole.planet.myplanet.services.SharedPrefManager) {
+        private fun insertCourseStepsAttachments(myCoursesID: String?, stepId: String?, resources: JsonArray, mRealm: Realm?, spm: SharedPrefManager) {
             resources.forEach { resource ->
                 if (mRealm != null) {
                     createStepResource(mRealm, resource.asJsonObject, myCoursesID, stepId, spm)
@@ -176,7 +176,7 @@ open class RealmMyCourse : RealmObject() {
         }
 
         @JvmStatic
-        fun insert(mRealm: Realm, myCoursesDoc: JsonObject?, spm: org.ole.planet.myplanet.services.SharedPrefManager) {
+        fun insert(mRealm: Realm, myCoursesDoc: JsonObject?, spm: SharedPrefManager) {
             val startedTransaction = !mRealm.isInTransaction
             if (startedTransaction) {
                 mRealm.beginTransaction()

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -20,6 +20,7 @@ import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.ApplicationScope
+import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.saveConcatenatedLinksToPrefs
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.insertCourseStepsExams
 import org.ole.planet.myplanet.model.RealmUser
@@ -308,6 +309,9 @@ class TransactionSyncManager @Inject constructor(
             }
             "submissions" -> {
                 submissionsRepository.insertSubmission(mRealm, jsonDoc)
+            }
+            "courses" -> {
+                RealmMyCourse.insert(mRealm, jsonDoc, sharedPrefManager)
             }
             "team_activities" -> {
                 teamsRepository.get().insertTeamLog(mRealm, jsonDoc)


### PR DESCRIPTION
fixes #12808
Call RealmMyCourse.insert when processing 'courses' sync payloads in TransactionSyncManager (adds import and a case that forwards course docs to RealmMyCourse). Also simplify type references in RealmMyCourse by replacing fully-qualified org.ole.planet.myplanet.services.SharedPrefManager usages with the local SharedPrefManager type in method signatures.