### PR TITLE
Refactor CheckboxAdapter to use ListAdapter and DiffUtil

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -297,9 +297,9 @@ abstract class BaseResourceFragment : Fragment() {
     fun createListView(dbMyLibrary: List<RealmMyLibrary?>, alertDialog: AlertDialog) {
         lv = convertView?.findViewById(R.id.alertDialog_listView)
         val names = dbMyLibrary.map { it?.title ?: "" }
-        val adapter = CheckboxAdapter(names) {
+        val adapter = CheckboxAdapter(checkChangeListener = {
             alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = ((lv?.adapter as? CheckboxAdapter)?.selectedItemsList?.size ?: 0) > 0
-        }
+        }).apply { submitList(names) }
         lv?.layoutManager = LinearLayoutManager(requireActivity().baseContext)
         lv?.adapter = adapter
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -299,9 +299,10 @@ abstract class BaseResourceFragment : Fragment() {
         val names = dbMyLibrary.map { it?.title ?: "" }
         val adapter = CheckboxAdapter(checkChangeListener = {
             alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = ((lv?.adapter as? CheckboxAdapter)?.selectedItemsList?.size ?: 0) > 0
-        }).apply { submitList(names) }
+        })
         lv?.layoutManager = LinearLayoutManager(requireActivity().baseContext)
         lv?.adapter = adapter
+        adapter.submitList(names)
     }
 
     private fun registerReceiver() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/components/CheckboxAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/components/CheckboxAdapter.kt
@@ -3,14 +3,20 @@ package org.ole.planet.myplanet.ui.components
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.CheckedTextView
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.utils.DiffUtils
 
 class CheckboxAdapter(
-    private val items: List<String>,
     private val initialSelectedItems: List<Int> = emptyList(),
     private val checkChangeListener: CheckChangeListener? = null
-) : RecyclerView.Adapter<CheckboxAdapter.ViewHolder>() {
+) : ListAdapter<String, CheckboxAdapter.ViewHolder>(
+    DiffUtils.itemCallback(
+        areItemsTheSame = { a, b -> a == b },
+        areContentsTheSame = { a, b -> a == b }
+    )
+) {
 
     val selectedItemsList = ArrayList<Int>()
 
@@ -29,7 +35,7 @@ class CheckboxAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val isChecked = selectedItemsList.contains(position)
-        holder.checkedTextView.text = items[position]
+        holder.checkedTextView.text = getItem(position)
         holder.checkedTextView.isChecked = isChecked
 
         holder.checkedTextView.setOnClickListener {
@@ -43,8 +49,6 @@ class CheckboxAdapter(
             checkChangeListener?.onCheckChange()
         }
     }
-
-    override fun getItemCount(): Int = items.size
 
     class ViewHolder(val checkedTextView: CheckedTextView) : RecyclerView.ViewHolder(checkedTextView)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/components/CheckboxAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/components/CheckboxAdapter.kt
@@ -24,6 +24,23 @@ class CheckboxAdapter(
         selectedItemsList.addAll(initialSelectedItems)
     }
 
+    override fun onCurrentListChanged(
+        previousList: MutableList<String>,
+        currentList: MutableList<String>
+    ) {
+        super.onCurrentListChanged(previousList, currentList)
+        if (previousList.isNotEmpty()) {
+            val selectedValues = selectedItemsList.mapNotNull { index -> previousList.getOrNull(index) }
+            selectedItemsList.clear()
+            selectedValues.forEach { value ->
+                val newIndex = currentList.indexOf(value)
+                if (newIndex != -1) {
+                    selectedItemsList.add(newIndex)
+                }
+            }
+        }
+    }
+
     fun interface CheckChangeListener {
         fun onCheckChange()
     }
@@ -40,7 +57,7 @@ class CheckboxAdapter(
 
         holder.checkedTextView.setOnClickListener {
             if (selectedItemsList.contains(position)) {
-                selectedItemsList.remove(position)
+                selectedItemsList.remove(Integer.valueOf(position))
                 holder.checkedTextView.isChecked = false
             } else {
                 selectedItemsList.add(position)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -228,8 +228,9 @@ class AddResourceActivity : AppCompatActivity() {
             }
         }
 
-        val adapter = CheckboxAdapter(initialSelectedItems = initialSelectedIndices).apply { submitList(list.toList()) }
+        val adapter = CheckboxAdapter(initialSelectedItems = initialSelectedIndices)
         listView.adapter = adapter
+        adapter.submitList(list.toList())
 
         AlertDialog.Builder(this, R.style.AlertDialogTheme).setView(listView).setPositiveButton(R.string.ok) { _: DialogInterface?, _: Int ->
             val selected = adapter.selectedItemsList

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -228,7 +228,7 @@ class AddResourceActivity : AppCompatActivity() {
             }
         }
 
-        val adapter = CheckboxAdapter(list.toList(), initialSelectedIndices)
+        val adapter = CheckboxAdapter(initialSelectedItems = initialSelectedIndices).apply { submitList(list.toList()) }
         listView.adapter = adapter
 
         AlertDialog.Builder(this, R.style.AlertDialogTheme).setView(listView).setPositiveButton(R.string.ok) { _: DialogInterface?, _: Int ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SendSurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SendSurveyFragment.kt
@@ -61,7 +61,7 @@ class SendSurveyFragment : BaseDialogFragment() {
 
     private fun initListView(users: List<RealmUser>) {
         val names = users.map { it.toString() }
-        val adapter = CheckboxAdapter(names)
+        val adapter = CheckboxAdapter().apply { submitList(names) }
         fragmentSendSurveyBinding.listUsers.layoutManager = LinearLayoutManager(requireActivity())
         fragmentSendSurveyBinding.listUsers.adapter = adapter
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SendSurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SendSurveyFragment.kt
@@ -61,9 +61,10 @@ class SendSurveyFragment : BaseDialogFragment() {
 
     private fun initListView(users: List<RealmUser>) {
         val names = users.map { it.toString() }
-        val adapter = CheckboxAdapter().apply { submitList(names) }
+        val adapter = CheckboxAdapter()
         fragmentSendSurveyBinding.listUsers.layoutManager = LinearLayoutManager(requireActivity())
         fragmentSendSurveyBinding.listUsers.adapter = adapter
+        adapter.submitList(names)
     }
 
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
@@ -126,9 +126,10 @@ class TeamCoursesFragment : BaseTeamFragment(), OnTeamPageListener {
         val names = courses.map { it.courseTitle ?: getString(R.string.untitled_course) }
         val adapter = CheckboxAdapter(checkChangeListener = {
             alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = (lv.adapter as CheckboxAdapter).selectedItemsList.isNotEmpty()
-        }).apply { submitList(names) }
+        })
         lv.layoutManager = LinearLayoutManager(requireActivity())
         lv.adapter = adapter
+        adapter.submitList(names)
         alertDialog.show()
         alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = false
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/courses/TeamCoursesFragment.kt
@@ -124,9 +124,9 @@ class TeamCoursesFragment : BaseTeamFragment(), OnTeamPageListener {
 
     private fun setupCourseListDialog(alertDialog: AlertDialog, courses: List<RealmMyCourse>, lv: RecyclerView) {
         val names = courses.map { it.courseTitle ?: getString(R.string.untitled_course) }
-        val adapter = CheckboxAdapter(names) {
+        val adapter = CheckboxAdapter(checkChangeListener = {
             alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = (lv.adapter as CheckboxAdapter).selectedItemsList.isNotEmpty()
-        }
+        }).apply { submitList(names) }
         lv.layoutManager = LinearLayoutManager(requireActivity())
         lv.adapter = adapter
         alertDialog.show()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
@@ -145,9 +145,10 @@ class TeamResourcesFragment : BaseTeamFragment(), OnTeamPageListener, OnResource
         val names = libraries.map { it.title ?: "" }
         val adapter = CheckboxAdapter(checkChangeListener = {
             alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = (lv.adapter as CheckboxAdapter).selectedItemsList.isNotEmpty()
-        }).apply { submitList(names) }
+        })
         lv.layoutManager = LinearLayoutManager(requireActivity())
         lv.adapter = adapter
+        adapter.submitList(names)
         alertDialog.show()
         alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = (lv.adapter as CheckboxAdapter).selectedItemsList.isNotEmpty()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
@@ -143,9 +143,9 @@ class TeamResourcesFragment : BaseTeamFragment(), OnTeamPageListener, OnResource
 
     private fun listSetting(alertDialog: AlertDialog, libraries: List<RealmMyLibrary>, lv: RecyclerView) {
         val names = libraries.map { it.title ?: "" }
-        val adapter = CheckboxAdapter(names) {
+        val adapter = CheckboxAdapter(checkChangeListener = {
             alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = (lv.adapter as CheckboxAdapter).selectedItemsList.isNotEmpty()
-        }
+        }).apply { submitList(names) }
         lv.layoutManager = LinearLayoutManager(requireActivity())
         lv.adapter = adapter
         alertDialog.show()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
@@ -336,7 +336,7 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
             names.add(list[i].title ?: "")
             if (prevList.contains(list[i].title)) selected.add(i)
         }
-        val adapter = CheckboxAdapter(names, selected)
+        val adapter = CheckboxAdapter(initialSelectedItems = selected).apply { submitList(names) }
         myLibraryAlertdialogBinding.alertDialogListView.layoutManager = LinearLayoutManager(requireActivity())
         myLibraryAlertdialogBinding.alertDialogListView.adapter = adapter
         return myLibraryAlertdialogBinding.alertDialogListView

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
@@ -336,9 +336,10 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
             names.add(list[i].title ?: "")
             if (prevList.contains(list[i].title)) selected.add(i)
         }
-        val adapter = CheckboxAdapter(initialSelectedItems = selected).apply { submitList(names) }
+        val adapter = CheckboxAdapter(initialSelectedItems = selected)
         myLibraryAlertdialogBinding.alertDialogListView.layoutManager = LinearLayoutManager(requireActivity())
         myLibraryAlertdialogBinding.alertDialogListView.adapter = adapter
+        adapter.submitList(names)
         return myLibraryAlertdialogBinding.alertDialogListView
     }
 


### PR DESCRIPTION
The CheckboxAdapter has been migrated from a legacy `RecyclerView.Adapter` structure holding a private `items` list to the modern `ListAdapter` using a custom `DiffUtil` callback. Call sites have been updated to push changes down to the adapter using `submitList()`, paving the way for safer data binding and eventual optimistic UI state management.

---
*PR created automatically by Jules for task [3282965554275701686](https://jules.google.com/task/3282965554275701686) started by @dogi*