### PR TITLE
Fix FileUtilsTest cache directory mismatch

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/utils/FileUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/FileUtilsTest.kt
@@ -63,7 +63,8 @@ class FileUtilsTest {
 
     @Test
     fun checkFileExist_returnsTrueWhenFileExists() {
-        val testFile = File(context.getExternalFilesDir(null), "ole/123/test_file.txt")
+        FileUtils.warmUp(context)
+        val testFile = File(FileUtils.getExternalFilesDir(context), "ole/123/test_file.txt")
         testFile.parentFile?.mkdirs()
         testFile.createNewFile()
 


### PR DESCRIPTION
Fix file caching in FileUtilsTest checkFileExist

- Updated FileUtilsTest to use FileUtils.getExternalFilesDir
- Added FileUtils.warmUp call to properly cache directory in tests
- Resolves failing FileUtilsTest.checkFileExist_returnsTrueWhenFileExists

---
*PR created automatically by Jules for task [12026281395751449197](https://jules.google.com/task/12026281395751449197) started by @dogi*