### PR TITLE
all: smoother retry repository pathing (fixes #12923)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5292
-        versionName = "0.52.92"
+        versionCode = 5293
+        versionName = "0.52.93"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -47,8 +47,8 @@ import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.UserRepositoryImpl
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.repository.VoicesRepositoryImpl
-import org.ole.planet.myplanet.repository.retry.RetryRepository
-import org.ole.planet.myplanet.repository.retry.RetryRepositoryImpl
+import org.ole.planet.myplanet.repository.RetryRepository
+import org.ole.planet.myplanet.repository.RetryRepositoryImpl
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -35,6 +35,8 @@ import org.ole.planet.myplanet.repository.RatingsRepository
 import org.ole.planet.myplanet.repository.RatingsRepositoryImpl
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.ResourcesRepositoryImpl
+import org.ole.planet.myplanet.repository.RetryRepository
+import org.ole.planet.myplanet.repository.RetryRepositoryImpl
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepositoryImpl
 import org.ole.planet.myplanet.repository.SurveysRepository
@@ -47,8 +49,6 @@ import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.UserRepositoryImpl
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.repository.VoicesRepositoryImpl
-import org.ole.planet.myplanet.repository.RetryRepository
-import org.ole.planet.myplanet.repository.RetryRepositoryImpl
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepository.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.repository.retry
+package org.ole.planet.myplanet.repository
 
 import org.ole.planet.myplanet.model.RealmRetryOperation
 import org.ole.planet.myplanet.services.upload.UploadError

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.repository.retry
+package org.ole.planet.myplanet.repository
 
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher

--- a/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueue.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueue.kt
@@ -10,7 +10,7 @@ import javax.inject.Singleton
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.ole.planet.myplanet.model.RealmRetryOperation
-import org.ole.planet.myplanet.repository.retry.RetryRepository
+import org.ole.planet.myplanet.repository.RetryRepository
 import org.ole.planet.myplanet.services.upload.UploadError
 
 @Singleton

--- a/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueTest.kt
@@ -22,7 +22,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.model.RealmRetryOperation
-import org.ole.planet.myplanet.repository.retry.RetryRepository
+import org.ole.planet.myplanet.repository.RetryRepository
 import org.ole.planet.myplanet.services.upload.UploadError
 
 @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
Move RetryRepository and RetryRepositoryImpl out of the `retry` package subfolder to standardise repository structure.

---
*PR created automatically by Jules for task [432605994402385562](https://jules.google.com/task/432605994402385562) started by @dogi*