### PR TITLE
all: smoother file uploader header map testing (fixes #12961)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5296
-        versionName = "0.52.96"
+        versionCode = 5302
+        versionName = "0.53.2"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/FileUploaderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/FileUploaderTest.kt
@@ -1,0 +1,51 @@
+package org.ole.planet.myplanet.services
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.utils.UrlUtils
+
+class FileUploaderTest {
+
+    @Before
+    fun setUp() {
+        mockkObject(UrlUtils)
+        every { UrlUtils.header } returns "Basic test_header"
+    }
+
+    @After
+    fun tearDown() {
+        io.mockk.unmockkObject(UrlUtils)
+        unmockkAll()
+    }
+
+    @Test
+    fun testGetHeaderMap() {
+        val mimeType = "image/png"
+        val rev = "1-testrev"
+
+        val headerMap = FileUploader.getHeaderMap(mimeType, rev)
+
+        assertEquals("Basic test_header", headerMap["Authorization"])
+        assertEquals("image/png", headerMap["Content-Type"])
+        assertEquals("1-testrev", headerMap["If-Match"])
+        assertEquals(3, headerMap.size)
+    }
+
+    @Test
+    fun testGetHeaderMap_withEmptyValues() {
+        val mimeType = ""
+        val rev = ""
+
+        val headerMap = FileUploader.getHeaderMap(mimeType, rev)
+
+        assertEquals("Basic test_header", headerMap["Authorization"])
+        assertEquals("", headerMap["Content-Type"])
+        assertEquals("", headerMap["If-Match"])
+        assertEquals(3, headerMap.size)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the previously untested `FileUploader.getHeaderMap` pure function.
📊 **Coverage:** Covered the happy path (valid strings) and edge cases (empty strings). Verified that the returned map contains the correct headers, including `"Authorization"`, `"Content-Type"`, and `"If-Match"`, and that the map size is correct. Used MockK to mock `UrlUtils.header` to ensure the test is isolated.
✨ **Result:** Improved test coverage and reliability by testing the file upload header generation logic.

---
*PR created automatically by Jules for task [14357957412917096794](https://jules.google.com/task/14357957412917096794) started by @dogi*