### PR TITLE
sync: smoother upload manager logging (fixes #12957)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5296
-        versionName = "0.52.96"
+        versionCode = 5298
+        versionName = "0.52.98"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -46,6 +46,7 @@ private inline fun <T> Iterable<T>.processInBatches(action: (T) -> Unit) {
             action(item)
         }
     }
+
 }
 
 @Singleton
@@ -122,7 +123,7 @@ class UploadManager @Inject constructor(
                 )
                 notifyListener(listener, "My planet activities uploaded successfully")
             } catch (e: Exception) {
-                e.printStackTrace()
+                Log.e(TAG, "Exception in UploadManager", e)
                 notifyListener(listener, "Failed to upload activities: ${e.message}")
             }
         }
@@ -143,7 +144,7 @@ class UploadManager @Inject constructor(
                 uploadCourseProgress()
                 notifyListener(listener, message)
             } catch (e: Exception) {
-                e.printStackTrace()
+                Log.e(TAG, "Exception in UploadManager", e)
                 notifyListener(listener, "Error during result sync: ${e.message}")
             }
         }
@@ -181,7 +182,7 @@ class UploadManager @Inject constructor(
                         userRepository.markAchievementUploaded(id, rev)
                     }
                 } catch (e: Exception) {
-                    e.printStackTrace()
+                    Log.e(TAG, "Exception in UploadManager", e)
                 }
             }
         }
@@ -232,7 +233,7 @@ class UploadManager @Inject constructor(
                             }
                         }
                     } catch (e: Exception) {
-                        e.printStackTrace()
+                        Log.e(TAG, "Exception in UploadManager", e)
                     }
                 }
 
@@ -277,7 +278,7 @@ class UploadManager @Inject constructor(
                                 successfulUpdates.add(Pair(resourceData, `object`))
                             }
                         } catch (e: Exception) {
-                            e.printStackTrace()
+                            Log.e(TAG, "Exception in UploadManager", e)
                         }
                     }
 
@@ -312,7 +313,7 @@ class UploadManager @Inject constructor(
                             // We catch it here to prevent crashing the batch loop and prevent
                             // `isTransactionSuccessful` from being set to true, so we don't upload
                             // attachments for failed DB writes.
-                            e.printStackTrace()
+                            Log.e(TAG, "Exception in UploadManager", e)
                         }
 
                         if (isTransactionSuccessful) {
@@ -370,7 +371,7 @@ class UploadManager @Inject constructor(
                         "Failed to upload personal resource: No response"
                     }
                 } catch (e: Exception) {
-                    e.printStackTrace()
+                    Log.e(TAG, "Exception in UploadManager", e)
                     "Unable to upload resource: ${e.message}"
                 }
             }
@@ -431,7 +432,7 @@ class UploadManager @Inject constructor(
                             teamsRepository.get().markTeamUploaded(teamData.teamId, rev)
                         }
                     } catch (e: IOException) {
-                        e.printStackTrace()
+                        Log.e(TAG, "Exception in UploadManager", e)
                     }
                 }
             }
@@ -464,7 +465,7 @@ class UploadManager @Inject constructor(
 
                         successfulUpdates[activityData.id] = `object`
                     } catch (e: java.io.IOException) {
-                        e.printStackTrace()
+                        Log.e(TAG, "Exception in UploadManager", e)
                     }
                 }
 
@@ -478,7 +479,7 @@ class UploadManager @Inject constructor(
 
             notifyListener(listener, "User activities sync completed successfully")
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.e(TAG, "Exception in UploadManager", e)
             notifyListener(listener, "Failed to upload user activities: ${e.message}")
         }
     }
@@ -578,7 +579,7 @@ class UploadManager @Inject constructor(
                             ))
                         }
                     } catch (e: Exception) {
-                        e.printStackTrace()
+                        Log.e(TAG, "Exception in UploadManager", e)
                     }
                 }
 
@@ -617,5 +618,9 @@ class UploadManager @Inject constructor(
 
     suspend fun uploadAdoptedSurveys() {
         uploadCoordinator.upload(uploadConfigs.AdoptedSurveys)
+    }
+
+    companion object {
+        private const val TAG = "UploadManager"
     }
 }


### PR DESCRIPTION
🎯 **What:** Replaced swallowed exceptions logged with `e.printStackTrace()` with `Log.e(TAG, "Exception in UploadManager", e)` in `UploadManager.kt`. Added a `companion object` to define the `TAG` constant.
💡 **Why:** `e.printStackTrace()` prints to the standard error stream and is difficult to track or filter in log management tools. Replacing it with proper logging using `Log.e()` improves code maintainability, debugging capabilities, and standardizes error logging within the application.
✅ **Verification:** Replaced the method calls, verified by running `./gradlew testDefaultDebugUnitTest --tests "*UploadManagerTest"`, and ensured all instances of `e.printStackTrace()` were properly addressed.
✨ **Result:** Improved and standardized error logging in `UploadManager.kt`.

---
*PR created automatically by Jules for task [15775368997268202347](https://jules.google.com/task/15775368997268202347) started by @dogi*