### PR TITLE
all: smoother checkbox item callback diffing (fixes #12959)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5296
-        versionName = "0.52.96"
+        versionCode = 5300
+        versionName = "0.53.0"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/components/CheckboxAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/components/CheckboxAdapter.kt
@@ -3,15 +3,15 @@ package org.ole.planet.myplanet.ui.components
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.CheckedTextView
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.utils.DiffUtils
 
 class CheckboxAdapter(
     private val initialSelectedItems: List<Int> = emptyList(),
     private val checkChangeListener: CheckChangeListener? = null
-) : ListAdapter<String, CheckboxAdapter.ViewHolder>(CheckboxDiffCallback()) {
+) : ListAdapter<String, CheckboxAdapter.ViewHolder>(DiffUtils.itemCallback<String>({ old, new -> old == new }, { old, new -> old == new })) {
 
     val selectedItemsList = ArrayList<Int>()
 
@@ -52,14 +52,4 @@ class CheckboxAdapter(
     }
 
     class ViewHolder(val checkedTextView: CheckedTextView) : RecyclerView.ViewHolder(checkedTextView)
-
-    class CheckboxDiffCallback : DiffUtil.ItemCallback<String>() {
-        override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
-            return oldItem == newItem
-        }
-
-        override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
-            return oldItem == newItem
-        }
-    }
 }


### PR DESCRIPTION
The `CheckboxAdapter` was updated to utilize the codebase's existing `DiffUtils.itemCallback` instead of using its own handwritten nested `CheckboxDiffCallback` class.

1. Removed `CheckboxDiffCallback`.
2. Changed the `ListAdapter` initialization to use `DiffUtils.itemCallback<String>({ old, new -> old == new }, { old, new -> old == new })`.
3. Updated imports appropriately (removed `androidx.recyclerview.widget.DiffUtil`, added `org.ole.planet.myplanet.utils.DiffUtils`).
4. Rebuilt successfully to ensure no regressions.

---
*PR created automatically by Jules for task [10793987451464310546](https://jules.google.com/task/10793987451464310546) started by @dogi*