### PR TITLE
⚡ Tighten realtime adapter refresh micro-optimizations

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
@@ -53,7 +53,6 @@ class RealtimeSyncHelper(private val fragment: Fragment, private val mixin: Real
             when (adapter) {
                 is OnDiffRefreshListener -> adapter.refreshWithDiff()
                 is ListAdapter<*, *> -> {
-                    if (update.newItemsCount == 0 && update.updatedItemsCount == 0) return@launch
                     @Suppress("UNCHECKED_CAST")
                     (adapter as ListAdapter<Any, *>).let { listAdapter ->
                         listAdapter.submitList(listAdapter.currentList.toList())

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
@@ -26,10 +26,11 @@ class RealtimeSyncHelper(private val fragment: Fragment, private val mixin: Real
 
     @OptIn(kotlinx.coroutines.FlowPreview::class)
     fun setupRealtimeSync() {
+        val watchedTablesSet = mixin.getWatchedTables().toSet()
         fragment.lifecycleScope.launch {
             fragment.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 syncManagerInstance.dataUpdateFlow
-                    .filter { update -> mixin.getWatchedTables().contains(update.table) }
+                    .filter { update -> watchedTablesSet.contains(update.table) }
                     .distinctUntilChanged { old, new ->
                         old.table == new.table &&
                         old.newItemsCount == new.newItemsCount &&
@@ -39,19 +40,20 @@ class RealtimeSyncHelper(private val fragment: Fragment, private val mixin: Real
                     .collect { update ->
                         mixin.onDataUpdated(update.table, update)
                         if (mixin.shouldAutoRefresh(update.table)) {
-                            refreshRecyclerView()
+                            refreshRecyclerView(update)
                         }
                     }
             }
         }
     }
 
-    private fun refreshRecyclerView() {
+    private fun refreshRecyclerView(update: TableDataUpdate) {
         fragment.viewLifecycleOwner.lifecycleScope.launch {
             val adapter = mixin.getSyncRecyclerView()?.adapter ?: return@launch
             when (adapter) {
                 is OnDiffRefreshListener -> adapter.refreshWithDiff()
                 is ListAdapter<*, *> -> {
+                    if (update.newItemsCount == 0 && update.updatedItemsCount == 0) return@launch
                     @Suppress("UNCHECKED_CAST")
                     (adapter as ListAdapter<Any, *>).let { listAdapter ->
                         listAdapter.submitList(listAdapter.currentList.toList())


### PR DESCRIPTION
What: Precomputes the watched tables set for O(1) lookups during the realtime sync filter flow. Adds a fast-exit guard in `refreshRecyclerView` to prevent unnecessary allocations when `ListAdapter`s receive updates with zero modified or new items.
Why: Reduces the overhead of re-evaluating the table list on every database emission. The `submitList` guard prevents creating redundant snapshot copies of the adapter's backing list when it hasn't actually mutated.
Measured Improvement: O(1) rather than O(N) lookup. Avoids O(N) allocation in `submitList` on redundant database pings.

---
*PR created automatically by Jules for task [5692128923169815084](https://jules.google.com/task/5692128923169815084) started by @dogi*