### PR TITLE
Refactor `checkDownloadResult` to use `lifecycleScope`

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -91,18 +91,16 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
     }
 
     fun checkDownloadResult(download: Download?) {
-        runOnUiThread {
-            if (!isFinishing && !isDestroyed) {
-                customProgressDialog.show()
-                customProgressDialog.setText("${getString(R.string.downloading)} ${download?.progress}% ${getString(R.string.complete)}")
-                customProgressDialog.setProgress(download?.progress ?: 0)
-                if (download?.completeAll == true) {
-                    safelyDismissDialog()
-                    installApk(this, download.fileUrl)
-                } else {
-                    safelyDismissDialog()
-                    showError(customProgressDialog, download?.message)
-                }
+        lifecycleScope.launch(Dispatchers.Main.immediate) {
+            customProgressDialog.show()
+            customProgressDialog.setText("${getString(R.string.downloading)} ${download?.progress}% ${getString(R.string.complete)}")
+            customProgressDialog.setProgress(download?.progress ?: 0)
+            if (download?.completeAll == true) {
+                safelyDismissDialog()
+                installApk(this@ProcessUserDataActivity, download.fileUrl)
+            } else {
+                safelyDismissDialog()
+                showError(customProgressDialog, download?.message)
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -92,6 +92,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
 
     fun checkDownloadResult(download: Download?) {
         lifecycleScope.launch(Dispatchers.Main.immediate) {
+            if (isFinishing || isDestroyed) return@launch
             customProgressDialog.show()
             customProgressDialog.setText("${getString(R.string.downloading)} ${download?.progress}% ${getString(R.string.complete)}")
             customProgressDialog.setProgress(download?.progress ?: 0)


### PR DESCRIPTION
Refactor `checkDownloadResult` to use `lifecycleScope` in `ProcessUserDataActivity.kt`. This standardizes concurrency and reduces boilerplate manual lifecycle checks.

---
*PR created automatically by Jules for task [15115635973499247257](https://jules.google.com/task/15115635973499247257) started by @dogi*