### PR TITLE
resources: smoother bind view holding (fixes #13005)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5296
-        versionName = "0.52.96"
+        versionCode = 5330
+        versionName = "0.53.30"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -194,6 +194,10 @@ class ResourcesAdapter(
                 }
                 handled = true
             }
+            if (payloads.contains(TAGS_PAYLOAD)) {
+                displayTagCloud(holder, position)
+                handled = true
+            }
             if (!handled) {
                 super.onBindViewHolder(holder, position, payloads)
             }


### PR DESCRIPTION
Explicitly handles `TAGS_PAYLOAD` in `ResourcesAdapter.onBindViewHolder` to efficiently update the tag-cloud using `displayTagCloud` without triggering a full row rebind. Reduces overhead when only tags are modified.

---
*PR created automatically by Jules for task [463065976215282100](https://jules.google.com/task/463065976215282100) started by @dogi*