### PR TITLE
login: smoother member security data updating (fixes #12966)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5296
-        versionName = "0.52.96"
+        versionCode = 5307
+        versionName = "0.53.7"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
@@ -150,10 +150,8 @@ class BecomeMemberActivity : BaseActivity() {
                     val userName = obj["name"].asString
                     val securityCallback = object : OnSecurityDataListener {
                         override fun onSecurityDataUpdated() {
-                            runOnUiThread {
-                                customProgressDialog.dismiss()
-                                autoLoginNewMember(info.username, info.password)
-                            }
+                            customProgressDialog.dismiss()
+                            autoLoginNewMember(info.username, info.password)
                         }
                     }
                     startUpload("becomeMember", userName, securityCallback)


### PR DESCRIPTION
Removes an unnecessary `runOnUiThread` wrapper inside the `OnSecurityDataListener.onSecurityDataUpdated` callback in `BecomeMemberActivity.kt`. The enclosing coroutine is already executed on `Dispatchers.Main` via `withContext(Dispatchers.Main)`, so the extra context switch was redundant.

---
*PR created automatically by Jules for task [9068063643731586948](https://jules.google.com/task/9068063643731586948) started by @dogi*