### PR TITLE
resources: smoother repository list searching (fixes #12975)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5296
-        versionName = "0.52.96"
+        versionCode = 5312
+        versionName = "0.53.12"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -123,11 +123,17 @@ class ResourcesRepositoryImpl @Inject constructor(
         return withRealm { realm ->
             val queryObj = realm.where(RealmMyLibrary::class.java).equalTo("isPrivate", false)
 
-            val data = if (isMyCourseLib) {
-                queryObj.findAll().filter { it.userId?.contains(userId) == true }
-            } else {
-                queryObj.findAll().filter { it.userId?.contains(userId) == false }
+            if (userId != null) {
+                if (isMyCourseLib) {
+                    queryObj.equalTo("userId", userId)
+                } else {
+                    queryObj.not().equalTo("userId", userId)
+                }
+            } else if (isMyCourseLib) {
+                return@withRealm emptyList()
             }
+
+            val data = queryObj.findAll()
 
             if (query.isEmpty()) {
                 return@withRealm realm.copyFromRealm(data)
@@ -179,9 +185,9 @@ class ResourcesRepositoryImpl @Inject constructor(
 
         val results = queryList(RealmMyLibrary::class.java) {
             equalTo("isPrivate", false)
+            equalTo("userId", userId)
         }
         return filterLibrariesNeedingUpdate(results)
-            .filter { it.userId?.contains(userId) == true }
     }
 
     override suspend fun getLibraryForSelectedUser(userId: String): List<RealmMyLibrary> {
@@ -217,9 +223,9 @@ class ResourcesRepositoryImpl @Inject constructor(
 
         val results = queryList(RealmMyLibrary::class.java) {
             equalTo("isPrivate", false)
+            equalTo("userId", userId)
         }
-        return filterLibrariesNeedingUpdate(results)
-            .count { it.userId?.contains(userId) == true }
+        return filterLibrariesNeedingUpdate(results).size
     }
 
     override suspend fun resourceTitleExists(title: String): Boolean {
@@ -408,12 +414,11 @@ class ResourcesRepositoryImpl @Inject constructor(
                     resourceIds.chunked(chunkSize).forEach { chunk ->
                         val libraryItems = realm.where(RealmMyLibrary::class.java)
                             .`in`("resourceId", chunk.toTypedArray())
+                            .not().equalTo("userId", userId)
                             .findAll()
 
                         libraryItems.forEach { libraryItem ->
-                            if (libraryItem.userId?.contains(userId) == false) {
-                                libraryItem.setUserId(userId)
-                            }
+                            libraryItem.setUserId(userId)
                         }
 
                         val removedLogs = realm.where(org.ole.planet.myplanet.model.RealmRemovedLog::class.java)
@@ -456,19 +461,22 @@ class ResourcesRepositoryImpl @Inject constructor(
 
     override suspend fun getDownloadSuggestionList(userId: String?): List<RealmMyLibrary> {
         val targetUserId = userId ?: sharedPrefManager.getUserId().ifEmpty { null }
-        val results = queryList(RealmMyLibrary::class.java) {
-            equalTo("isPrivate", false)
-        }
-        val allNeedingUpdate = filterLibrariesNeedingUpdate(results)
 
         if (!targetUserId.isNullOrBlank()) {
-            val userLibraries = allNeedingUpdate.filter { it.userId?.contains(targetUserId) == true }
-            if (userLibraries.isNotEmpty()) {
-                return userLibraries
+            val userLibraries = queryList(RealmMyLibrary::class.java) {
+                equalTo("isPrivate", false)
+                equalTo("userId", targetUserId)
+            }
+            val userLibrariesNeedingUpdate = filterLibrariesNeedingUpdate(userLibraries)
+            if (userLibrariesNeedingUpdate.isNotEmpty()) {
+                return userLibrariesNeedingUpdate
             }
         }
 
-        return allNeedingUpdate
+        val results = queryList(RealmMyLibrary::class.java) {
+            equalTo("isPrivate", false)
+        }
+        return filterLibrariesNeedingUpdate(results)
     }
 
     override suspend fun getLibraryByUserId(userId: String): List<RealmMyLibrary> {


### PR DESCRIPTION
What:
Pushed ownership filtering logic down to the Realm query layer across `ResourcesRepositoryImpl` methods (`search`, `getDownloadSuggestionList`, `getLibraryListForUser`, `countLibrariesNeedingUpdate`, `addResourcesToUserLibrary`).

Why:
These methods previously fetched massive amounts of `RealmMyLibrary` items into memory and then used `.filter { it.userId?.contains(userId) }`. Querying directly via Realm improves execution time, avoids copying unneeded lists into memory, and prevents garbage collector strain during app initialization and resource searches.

Measured Improvement:
Replaces O(N) memory allocations (where N is the number of all library items) with O(K) where K is the much smaller list of items explicitly matching or not matching the criteria at the database level. Reduces latency on search and sync updates.

---
*PR created automatically by Jules for task [18108383629589508418](https://jules.google.com/task/18108383629589508418) started by @dogi*