### PR TITLE
sync: smoother upload coordinator dispatcher providing (fixes #12965)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5296
-        versionName = "0.52.96"
+        versionCode = 5306
+        versionName = "0.53.6"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
@@ -10,12 +10,12 @@ import java.util.concurrent.CancellationException
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.coroutineContext
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.services.retry.RetryQueue
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.JsonUtils.getString
 import org.ole.planet.myplanet.utils.UrlUtils
 
@@ -24,7 +24,8 @@ class UploadCoordinator @Inject constructor(
     private val databaseService: DatabaseService,
     private val apiInterface: ApiInterface,
     @ApplicationContext private val context: Context,
-    private val retryQueue: RetryQueue
+    private val retryQueue: RetryQueue,
+    private val dispatcherProvider: DispatcherProvider
 ) {
 
     companion object {
@@ -33,7 +34,7 @@ class UploadCoordinator @Inject constructor(
 
     suspend fun <T : RealmObject> upload(
         config: UploadConfig<T>
-    ): UploadResult<Int> = withContext(Dispatchers.IO) {
+    ): UploadResult<Int> = withContext(dispatcherProvider.io) {
         try {
             val itemsToUpload = queryItemsToUpload(config)
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -27,7 +27,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
@@ -46,11 +45,15 @@ import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.DialogUtils.showAlert
 import org.ole.planet.myplanet.utils.DialogUtils.showError
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.FileUtils.installApk
 import org.ole.planet.myplanet.utils.SecurePrefs
 
 @AndroidEntryPoint
 abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessListener {
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
     @Inject
     lateinit var prefData: SharedPrefManager
 
@@ -214,7 +217,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
     }
 
     private fun uploadLoginData() {
-        applicationScope.launch(Dispatchers.IO) {
+        applicationScope.launch(dispatcherProvider.io) {
             uploadManager.uploadUserActivities(this@ProcessUserDataActivity)
         }
     }
@@ -223,14 +226,14 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
         customProgressDialog.setText(this.getString(R.string.uploading_data_to_server_please_wait))
         customProgressDialog.show()
 
-        applicationScope.launch(Dispatchers.IO) {
+        applicationScope.launch(dispatcherProvider.io) {
             val asyncOperationsCounter = AtomicInteger(0)
             val totalAsyncOperations = 6
             val activity = this@ProcessUserDataActivity
 
             suspend fun checkAllOperationsComplete() {
                 if (asyncOperationsCounter.incrementAndGet() == totalAsyncOperations) {
-                    withContext(Dispatchers.Main) {
+                    withContext(dispatcherProvider.main) {
                         if (!activity.isFinishing && !activity.isDestroyed) {
                             customProgressDialog.dismiss()
                             Toast.makeText(activity, "upload complete", Toast.LENGTH_SHORT).show()
@@ -274,14 +277,14 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
                 }
             })
 
-            applicationScope.launch(Dispatchers.IO) {
+            applicationScope.launch(dispatcherProvider.io) {
                 val success = uploadManager.uploadFeedback()
                 checkAllOperationsComplete()
             }
 
             uploadManager.uploadResource(object : OnSuccessListener {
                 override fun onSuccess(success: String?) {
-                    applicationScope.launch(Dispatchers.IO) {
+                    applicationScope.launch(dispatcherProvider.io) {
                         uploadManager.uploadTeams()
                         checkAllOperationsComplete()
                     }
@@ -312,7 +315,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
     }
 
     suspend fun saveUserInfoPref(settings: SharedPreferences, password: String?, user: RealmUser?) {
-        withContext(Dispatchers.IO) {
+        withContext(dispatcherProvider.io) {
             SecurePrefs.saveCredentials(this@ProcessUserDataActivity, settings, user?.name, password)
         }
         this.settings = settings
@@ -358,7 +361,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
             } catch (e: Exception) {
                 e.printStackTrace()
             } finally {
-                withContext(Dispatchers.Main) {
+                withContext(dispatcherProvider.main) {
                     securityCallback?.onSecurityDataUpdated()
                 }
             }


### PR DESCRIPTION
Replaced hardcoded Coroutine Dispatchers (`Dispatchers.IO`, `Dispatchers.Main`) with an injected `DispatcherProvider` in `UploadCoordinator` and `ProcessUserDataActivity` to improve testability and decouple the dispatchers.

Tested by verifying compilation passes and running relevant `UploadManagerTest` tests, which passed successfully.

---
*PR created automatically by Jules for task [810448242811666939](https://jules.google.com/task/810448242811666939) started by @dogi*