### PR TITLE
resources: smoother search filtering (fixes #12984)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5296
-        versionName = "0.52.96"
+        versionCode = 5318
+        versionName = "0.53.18"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -22,6 +22,8 @@ import fisk.chipcloud.ChipCloud
 import fisk.chipcloud.ChipCloudConfig
 import fisk.chipcloud.ChipDeletedListener
 import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
@@ -69,6 +71,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     private var searchTextWatcher: TextWatcher? = null
     private var isFirstResume = true
     private var allLibraryItems: List<RealmMyLibrary> = emptyList()
+    private var searchJob: Job? = null
 
     @Inject
     lateinit var prefManager: SharedPrefManager
@@ -158,17 +161,12 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
                 loadRatingsAndTags(allResourceIds, model?.id)
 
-                val currentSearchTags = if (::searchTags.isInitialized) searchTags else emptyList()
-
-                val filteredLibraryList = applyFilter(filterLocalLibraryByTag(searchQuery, currentSearchTags))
-
                 if (::adapterLibrary.isInitialized) {
-                    adapterLibrary.setLibraryList(filteredLibraryList.map { it.toResourceItem() })
                     adapterLibrary.setRatingMap(map ?: HashMap())
                     adapterLibrary.setTagsMap(tagsMap.mapValues { entry -> entry.value.map { it.toTagItem() } })
                 }
-                checkList(filteredLibraryList.size)
-                showNoData(tvMessage, filteredLibraryList.size, "resources")
+
+                applyFiltersAndUpdateUI()
 
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -318,19 +316,30 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         searchTextWatcher = object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-                if (!::adapterLibrary.isInitialized) return
-                lifecycleScope.launch {
-                    val filteredList = applyFilter(filterLocalLibraryByTag(etSearch.text.toString().trim(), searchTags))
-                    adapterLibrary.setLibraryList(filteredList.map { it.toResourceItem() }) {
-                        recyclerView.scrollToPosition(0)
-                    }
-                    showNoData(tvMessage, adapterLibrary.itemCount, "resources")
+                searchJob?.cancel()
+                searchJob = viewLifecycleOwner.lifecycleScope.launch {
+                    delay(300)
+                    applyFiltersAndUpdateUI()
                 }
             }
 
             override fun afterTextChanged(s: Editable) {}
         }
         etSearch.addTextChangedListener(searchTextWatcher)
+    }
+
+    private fun applyFiltersAndUpdateUI() {
+        if (!::adapterLibrary.isInitialized || !isAdded || _binding == null) return
+        val searchQuery = etSearch.text?.toString()?.trim().orEmpty()
+        viewLifecycleOwner.lifecycleScope.launch {
+            val currentSearchTags = if (::searchTags.isInitialized) searchTags else emptyList()
+            val filteredList = applyFilter(filterLocalLibraryByTag(searchQuery, currentSearchTags))
+            adapterLibrary.setLibraryList(filteredList.map { it.toResourceItem() }) {
+                recyclerView.scrollToPosition(0)
+            }
+            checkList(filteredList.size)
+            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
+        }
     }
 
     private fun setupCollectionsButton() {
@@ -466,12 +475,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
             mediums.clear()
             subjects.clear()
             languages.clear()
-            viewLifecycleOwner.lifecycleScope.launch {
-                adapterLibrary.setLibraryList(applyFilter(filterLocalLibraryByTag("", searchTags)).map { it.toResourceItem() }) {
-                    recyclerView.scrollToPosition(0)
-                }
-                showNoData(tvMessage, adapterLibrary.itemCount, "resources")
-            }
+            applyFiltersAndUpdateUI()
         }
     }
 
@@ -506,13 +510,8 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         chipCloud.setDeleteListener(this)
         if (!searchTags.any { it.name == tag.name }) searchTags.add(tag)
         chipCloud.addChips(searchTags)
-        viewLifecycleOwner.lifecycleScope.launch {
-            adapterLibrary.setLibraryList(applyFilter(filterLocalLibraryByTag(etSearch.text.toString(), searchTags)).map { it.toResourceItem() }) {
-                recyclerView.scrollToPosition(0)
-            }
-            showTagText(searchTags, tvSelected)
-            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
-        }
+        showTagText(searchTags, tvSelected)
+        applyFiltersAndUpdateUI()
     }
 
     override fun onTagSelected(tag: RealmTag) {
@@ -521,23 +520,13 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         li.add(tag)
         searchTags = li
         tvSelected.text = getString(R.string.tag_selected, tag.name)
-        viewLifecycleOwner.lifecycleScope.launch {
-            adapterLibrary.setLibraryList(applyFilter(filterLocalLibraryByTag(etSearch.text.toString(), li)).map { it.toResourceItem() }) {
-                recyclerView.scrollToPosition(0)
-            }
-            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
-        }
+        applyFiltersAndUpdateUI()
     }
 
     override fun onOkClicked(list: List<RealmTag>?) {
         if (list?.isEmpty() == true) {
             searchTags.clear()
-            viewLifecycleOwner.lifecycleScope.launch {
-                adapterLibrary.setLibraryList(applyFilter(filterLocalLibraryByTag(etSearch.text.toString(), searchTags)).map { it.toResourceItem() }) {
-                    recyclerView.scrollToPosition(0)
-                }
-                showNoData(tvMessage, adapterLibrary.itemCount, "resources")
-            }
+            applyFiltersAndUpdateUI()
         } else {
             for (tag in list ?: emptyList()) {
                 onTagClicked(tag)
@@ -558,12 +547,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     override fun chipDeleted(i: Int, s: String) {
         searchTags.removeAt(i)
-        viewLifecycleOwner.lifecycleScope.launch {
-            adapterLibrary.setLibraryList(applyFilter(filterLocalLibraryByTag(etSearch.text.toString(), searchTags)).map { it.toResourceItem() }) {
-                recyclerView.scrollToPosition(0)
-            }
-            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
-        }
+        applyFiltersAndUpdateUI()
     }
 
     override fun filter(subjects: MutableSet<String>, languages: MutableSet<String>, mediums: MutableSet<String>, levels: MutableSet<String>) {
@@ -571,12 +555,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         this.languages = languages
         this.mediums = mediums
         this.levels = levels
-        viewLifecycleOwner.lifecycleScope.launch {
-            adapterLibrary.setLibraryList(applyFilter(filterLocalLibraryByTag(etSearch.text.toString().trim { it <= ' ' }, searchTags)).map { it.toResourceItem() }) {
-                recyclerView.scrollToPosition(0)
-            }
-            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
-        }
+        applyFiltersAndUpdateUI()
     }
 
     override suspend fun getData(): Map<String, Set<String>> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -166,7 +166,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
                     adapterLibrary.setTagsMap(tagsMap.mapValues { entry -> entry.value.map { it.toTagItem() } })
                 }
 
-                applyFiltersAndUpdateUI()
+                applyFiltersAndUpdateUI(scrollToTop = false)
 
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -319,6 +319,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
                 searchJob?.cancel()
                 searchJob = viewLifecycleOwner.lifecycleScope.launch {
                     delay(300)
+                    if (!::adapterLibrary.isInitialized || !isAdded || _binding == null) return@launch
                     applyFiltersAndUpdateUI()
                 }
             }
@@ -328,18 +329,23 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         etSearch.addTextChangedListener(searchTextWatcher)
     }
 
-    private fun applyFiltersAndUpdateUI() {
+    private suspend fun applyFiltersAndUpdateUI(scrollToTop: Boolean = true) {
         if (!::adapterLibrary.isInitialized || !isAdded || _binding == null) return
         val searchQuery = etSearch.text?.toString()?.trim().orEmpty()
-        viewLifecycleOwner.lifecycleScope.launch {
-            val currentSearchTags = if (::searchTags.isInitialized) searchTags else emptyList()
-            val filteredList = applyFilter(filterLocalLibraryByTag(searchQuery, currentSearchTags))
+
+        val currentSearchTags = if (::searchTags.isInitialized) searchTags else emptyList()
+        val filteredList = applyFilter(filterLocalLibraryByTag(searchQuery, currentSearchTags))
+
+        if (scrollToTop) {
             adapterLibrary.setLibraryList(filteredList.map { it.toResourceItem() }) {
                 recyclerView.scrollToPosition(0)
             }
-            checkList(filteredList.size)
-            showNoData(tvMessage, adapterLibrary.itemCount, "resources")
+        } else {
+            adapterLibrary.setLibraryList(filteredList.map { it.toResourceItem() })
         }
+
+        checkList(filteredList.size)
+        showNoData(tvMessage, adapterLibrary.itemCount, "resources")
     }
 
     private fun setupCollectionsButton() {
@@ -475,7 +481,9 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
             mediums.clear()
             subjects.clear()
             languages.clear()
-            applyFiltersAndUpdateUI()
+            viewLifecycleOwner.lifecycleScope.launch {
+                applyFiltersAndUpdateUI()
+            }
         }
     }
 
@@ -511,7 +519,9 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         if (!searchTags.any { it.name == tag.name }) searchTags.add(tag)
         chipCloud.addChips(searchTags)
         showTagText(searchTags, tvSelected)
-        applyFiltersAndUpdateUI()
+        viewLifecycleOwner.lifecycleScope.launch {
+            applyFiltersAndUpdateUI()
+        }
     }
 
     override fun onTagSelected(tag: RealmTag) {
@@ -520,13 +530,17 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         li.add(tag)
         searchTags = li
         tvSelected.text = getString(R.string.tag_selected, tag.name)
-        applyFiltersAndUpdateUI()
+        viewLifecycleOwner.lifecycleScope.launch {
+            applyFiltersAndUpdateUI()
+        }
     }
 
     override fun onOkClicked(list: List<RealmTag>?) {
         if (list?.isEmpty() == true) {
             searchTags.clear()
-            applyFiltersAndUpdateUI()
+            viewLifecycleOwner.lifecycleScope.launch {
+                applyFiltersAndUpdateUI()
+            }
         } else {
             for (tag in list ?: emptyList()) {
                 onTagClicked(tag)
@@ -547,7 +561,9 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     override fun chipDeleted(i: Int, s: String) {
         searchTags.removeAt(i)
-        applyFiltersAndUpdateUI()
+        viewLifecycleOwner.lifecycleScope.launch {
+            applyFiltersAndUpdateUI()
+        }
     }
 
     override fun filter(subjects: MutableSet<String>, languages: MutableSet<String>, mediums: MutableSet<String>, levels: MutableSet<String>) {
@@ -555,7 +571,9 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         this.languages = languages
         this.mediums = mediums
         this.levels = levels
-        applyFiltersAndUpdateUI()
+        viewLifecycleOwner.lifecycleScope.launch {
+            applyFiltersAndUpdateUI()
+        }
     }
 
     override suspend fun getData(): Map<String, Set<String>> {


### PR DESCRIPTION
This PR optimizes the filter pipeline inside `ResourcesFragment`.
- **Search debounce:** The search box now debounces input by 300ms, preventing the full library filter logic from executing on every single keystroke.
- **Consolidation:** The repetitive code for filtering library tags, applying filters, updating the adapter, and hiding/showing the UI has been grouped into a single, cohesive `applyFiltersAndUpdateUI()` method to ensure consistency and easier maintainability going forward.

---
*PR created automatically by Jules for task [17786404545618448534](https://jules.google.com/task/17786404545618448534) started by @dogi*