### PR TITLE
courses: smoother repository tag filtering (fixes #12977)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5296
-        versionName = "0.52.96"
+        versionCode = 5315
+        versionName = "0.53.15"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -56,12 +56,7 @@ class CoursesRepositoryImpl @Inject constructor(
     }
 
     override fun getAllCourses(userId: String?, libs: List<RealmMyCourse>): List<RealmMyCourse> {
-        val libraries: MutableList<RealmMyCourse> = ArrayList()
-        for (item in libs) {
-            item.isMyCourse = item.userId?.contains(userId) == true
-            libraries.add(item)
-        }
-        return libraries
+        return libs.onEach { it.isMyCourse = it.userId?.contains(userId) == true }
     }
 
     override fun getMyCourseByUserId(userId: String?, libs: List<RealmMyCourse>?): List<RealmMyCourse> {
@@ -69,24 +64,12 @@ class CoursesRepositoryImpl @Inject constructor(
     }
 
     override fun getOurCourse(userId: String?, libs: List<RealmMyCourse>): List<RealmMyCourse> {
-        val libraries: MutableList<RealmMyCourse> = ArrayList()
-        for (item in libs) {
-            if (item.userId?.contains(userId) != true) {
-                libraries.add(item)
-            }
-        }
-        return libraries
+        return libs.filter { it.userId?.contains(userId) != true }
     }
 
     override fun getMyCourses(userId: String?, courses: List<RealmMyCourse>): List<RealmMyCourse> {
-        val myCourses: MutableList<RealmMyCourse> = ArrayList()
-        if (userId == null) return myCourses
-        for (course in courses) {
-            if (course.userId?.contains(userId) == true) {
-                myCourses.add(course)
-            }
-        }
-        return myCourses
+        if (userId == null) return emptyList()
+        return courses.filter { it.userId?.contains(userId) == true }
     }
 
     override suspend fun getMyCourses(userId: String): List<RealmMyCourse> {
@@ -628,9 +611,30 @@ class CoursesRepositoryImpl @Inject constructor(
         userId: String?
     ): List<RealmMyCourse> {
         return withRealm { realm ->
-            val data = realm.where(RealmMyCourse::class.java).findAll()
+            var realmQuery = realm.where(RealmMyCourse::class.java)
 
-            var list: List<RealmMyCourse> = if (query.isEmpty()) {
+            if (tags.isNotEmpty()) {
+                val tagIds = tags.mapNotNull { it.id }.toTypedArray()
+                val linkedCourseIds = realm.where(RealmTag::class.java)
+                    .equalTo("db", "courses")
+                    .`in`("tagId", tagIds)
+                    .findAll()
+                    .mapNotNull { it.linkId }
+                    .toTypedArray()
+
+                if (linkedCourseIds.isEmpty()) {
+                    return@withRealm emptyList()
+                }
+                realmQuery = realmQuery.`in`("courseId", linkedCourseIds)
+            }
+
+            if (isMyCourseLib && !userId.isNullOrBlank()) {
+                realmQuery = realmQuery.equalTo("userId", userId)
+            }
+
+            val data = realmQuery.findAll()
+
+            val list: List<RealmMyCourse> = if (query.isEmpty()) {
                 realm.copyFromRealm(data)
             } else {
                 val queryParts = query.split(" ").filterNot { it.isEmpty() }
@@ -652,25 +656,11 @@ class CoursesRepositoryImpl @Inject constructor(
                 realm.copyFromRealm(filteredData)
             }
 
-            list = if (isMyCourseLib) {
-                getMyCourses(userId, list)
-            } else {
-                getAllCourses(userId, list)
+            if (!isMyCourseLib) {
+                list.forEach { it.isMyCourse = it.userId?.contains(userId) == true }
             }
 
-            if (tags.isEmpty()) {
-                return@withRealm list
-            }
-
-            val tagIds = tags.mapNotNull { it.id }.toTypedArray()
-            val linkedCourseIds = realm.where(RealmTag::class.java)
-                .equalTo("db", "courses")
-                .`in`("tagId", tagIds)
-                .findAll()
-                .mapNotNull { it.linkId }
-                .toSet()
-
-            list.filter { linkedCourseIds.contains(it.courseId) }.distinct()
+            list.distinctBy { it.courseId }
         }
     }
 


### PR DESCRIPTION
This PR cleans up memory allocations and full-table scan behavior in `CoursesRepositoryImpl`.

### Changes made
* In course ownership helpers (`getAllCourses`, `getOurCourse`, `getMyCourses`), swapped manual `ArrayList` instantiations and `for` loop population for simpler and more memory-efficient `.onEach { }` and `.filter { }` Kotlin collection operations.
* In `filterCoursesByTag`, previously the code would perform `realm.where(RealmMyCourse::class.java).findAll()`, immediately pulling all records into memory. It now builds a `RealmQuery` and appends `in("courseId", ...)` for matched tags, and `equalTo("userId", ...)` for ownership. This pushes the query resolution down to the Realm core engine, drastically trimming the list size before it runs the subsequent text searching algorithms in Kotlin memory.

### Impact
* Reduces object allocation overhead for list cloning.
* Significantly cuts memory footprint when filtering large libraries by tags since a narrower query runs first.

---
*PR created automatically by Jules for task [11227507646865697827](https://jules.google.com/task/11227507646865697827) started by @dogi*