### PR TITLE
teams: smoother voices native list adapting (fixes #13007)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5329
-        versionName = "0.53.29"
+        versionCode = 5332
+        versionName = "0.53.32"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseVoicesFragment.kt
@@ -69,13 +69,13 @@ abstract class BaseVoicesFragment : BaseContainerFragment(), OnNewsItemClickList
             if (result.resultCode == Activity.RESULT_OK) {
                 val newsId = result.data?.getStringExtra("newsId")
                 newsId.let { adapterNews?.updateReplyBadge(it) }
-                adapterNews?.refreshCurrentItems()
+                adapterNews?.notifyDataSetChanged()
             }
         }
     }
 
     override fun onDataChanged() {
-        adapterNews?.refreshCurrentItems()
+        adapterNews?.notifyDataSetChanged()
     }
 
     override fun onReplyPosted(newsId: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseVoicesFragment.kt
@@ -69,13 +69,13 @@ abstract class BaseVoicesFragment : BaseContainerFragment(), OnNewsItemClickList
             if (result.resultCode == Activity.RESULT_OK) {
                 val newsId = result.data?.getStringExtra("newsId")
                 newsId.let { adapterNews?.updateReplyBadge(it) }
-                adapterNews?.notifyDataSetChanged()
+                adapterNews?.submitList(adapterNews?.currentList?.toList())
             }
         }
     }
 
     override fun onDataChanged() {
-        adapterNews?.notifyDataSetChanged()
+        adapterNews?.submitList(adapterNews?.currentList?.toList())
     }
 
     override fun onReplyPosted(newsId: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
@@ -240,7 +240,7 @@ class TeamsVoicesFragment : BaseTeamFragment() {
             adapterNews?.sharedPrefManager = sharedPrefManager
             adapterNews?.setListener(this)
             if (!isMemberFlow.value) adapterNews?.setNonTeamMember(true)
-            realmNewsList?.let { adapterNews?.updateList(it) }
+            realmNewsList?.let { adapterNews?.submitList(it) }
             binding.rvDiscussion.adapter = adapterNews
             adapterNews?.let {
                 showNoData(binding.tvNodata, it.itemCount, "discussions")
@@ -248,7 +248,7 @@ class TeamsVoicesFragment : BaseTeamFragment() {
         } else {
             (existingAdapter as? VoicesAdapter)?.let { adapter ->
                 realmNewsList?.let {
-                    adapter.updateList(it)
+                    adapter.submitList(it)
                     showNoData(binding.tvNodata, adapter.itemCount, "discussions")
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
@@ -165,7 +165,7 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
             } else {
                 newsAdapter.updateParentNews(news)
             }
-            newsAdapter.updateList(list)
+            newsAdapter.submitList(list)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -136,17 +136,6 @@ class VoicesAdapter(
         this.imageList = imageList
     }
 
-    fun addItem(news: RealmNews?) {
-        val currentList = currentList.toMutableList()
-        currentList.add(0, news)
-        submitListSafely(currentList) {
-            recyclerView?.post {
-                recyclerView?.scrollToPosition(0)
-                recyclerView?.smoothScrollToPosition(0)
-            }
-        }
-    }
-
     fun setFromLogin(fromLogin: Boolean) {
         this.fromLogin = fromLogin
     }
@@ -327,7 +316,7 @@ class VoicesAdapter(
                             newsToDelete?.id?.let { id ->
                                 deletePostFn(id) {
                                     val newList = snapshotList.toMutableList().apply { removeAt(adjustedPos) }
-                                    submitListSafely(newList)
+                                    submitList(newList)
                                     parentNews?.id?.let { pid ->
                                         val current = replyCountCache[pid]
                                         replyCountCache[pid] = if (current != null) maxOf(0, current - 1) else 0
@@ -426,23 +415,11 @@ class VoicesAdapter(
         return null
     }
 
-    fun updateList(newList: List<RealmNews?>) {
-        submitListSafely(newList)
-    }
-
     fun updateParentNews(news: RealmNews?) {
         val contentChanged = parentNews?.message != news?.message ||
             parentNews?.isEdited != news?.isEdited
         parentNews = news
         if (contentChanged) notifyItemChanged(0)
-    }
-
-    fun refreshCurrentItems() {
-        submitListSafely(currentList.toList())
-    }
-
-    private fun submitListSafely(list: List<RealmNews?>, commitCallback: Runnable? = null) {
-        submitList(list, commitCallback)
     }
 
     private fun setMemberClickListeners(holder: VoicesViewHolder, userModel: RealmUser?, currentLeader: RealmUser?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
@@ -267,10 +267,10 @@ class VoicesFragment : BaseVoicesFragment() {
             adapterNews?.setFromLogin(requireArguments().getBoolean("fromLogin"))
             adapterNews?.setListener(this)
             adapterNews?.registerAdapterDataObserver(observer)
-            adapterNews?.updateList(sortedList)
+            adapterNews?.submitList(sortedList)
             binding.rvNews.adapter = adapterNews
         } else {
-            (binding.rvNews.adapter as? VoicesAdapter)?.updateList(list)
+            (binding.rvNews.adapter as? VoicesAdapter)?.submitList(list)
         }
         adapterNews?.let { showNoData(binding.tvMessage, it.itemCount, currentEmptyStateSource) }
     }


### PR DESCRIPTION
The `VoicesAdapter` class was previously updated to inherit from `ListAdapter`, but retained redundant custom list management methods (`updateList`, `addItem`, `refreshCurrentItems`, `submitListSafely`). This pull request fully migrates the adapter by removing these leftover wrappers and updating all call-sites (`ReplyActivity`, `VoicesFragment`, `TeamsVoicesFragment`) to interact natively with `submitList()`. This correctly lets `ListAdapter` handle diffs.

---
*PR created automatically by Jules for task [2559200356537418385](https://jules.google.com/task/2559200356537418385) started by @dogi*