### PR TITLE
all: smoother notification action receiver testing (fixes #13004)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5296
-        versionName = "0.52.96"
+        versionCode = 5329
+        versionName = "0.53.29"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/NotificationActionReceiverTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/NotificationActionReceiverTest.kt
@@ -5,13 +5,11 @@ import android.content.Intent
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
 import android.content.BroadcastReceiver
 import io.mockk.unmockkAll
-import io.mockk.unmockkConstructor
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -26,17 +24,24 @@ import org.ole.planet.myplanet.di.getBroadcastService
 import org.ole.planet.myplanet.repository.NotificationsRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.NotificationUtils
-import dagger.hilt.internal.GeneratedComponentManager
+import android.provider.Settings
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import androidx.test.core.app.ApplicationProvider
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class NotificationActionReceiverTest {
 
     private lateinit var receiver: NotificationActionReceiver
     private lateinit var mockContext: Context
-    private lateinit var mockNotificationsRepository: NotificationsRepository
     private lateinit var testDispatcher: CoroutineDispatcher
-    private lateinit var mockDispatcherProvider: DispatcherProvider
     private lateinit var testScope: TestScope
+
+    private val mockNotificationsRepository: NotificationsRepository = mockk(relaxed = true)
+    private var mockDispatcherProvider: DispatcherProvider = mockk(relaxed = true)
     private lateinit var mockNotificationUtils: NotificationUtils.NotificationManager
 
     @Before
@@ -46,32 +51,13 @@ class NotificationActionReceiverTest {
 
         MainApplication.applicationScope = testScope
 
-        mockContext = mockk<Context>(relaxed = true)
+        mockContext = spyk(ApplicationProvider.getApplicationContext<Context>())
+        every { mockContext.startActivity(any()) } returns Unit
 
-        abstract class MockAppContext : android.app.Application(), dagger.hilt.internal.GeneratedComponentManager<Any>
-        val mockApplication = mockk<MockAppContext>(relaxed = true)
-        every { mockContext.applicationContext } returns mockApplication
-        every { mockApplication.generatedComponent() } returns mockk<NotificationActionReceiver_GeneratedInjector>(relaxed = true)
-
-
-
-        mockNotificationsRepository = mockk(relaxed = true)
-
-        mockDispatcherProvider = object : DispatcherProvider {
-            override val main: CoroutineDispatcher = testDispatcher
-            override val io: CoroutineDispatcher = testDispatcher
-            override val default: CoroutineDispatcher = testDispatcher
-            override val unconfined: CoroutineDispatcher = testDispatcher
-        }
-
-        mockkConstructor(Intent::class)
-        every { anyConstructed<Intent>().setPackage(any()) } answers { call.invocation.self as Intent }
-        every { anyConstructed<Intent>().putExtra(any<String>(), any<String>()) } answers { call.invocation.self as Intent }
-        every { anyConstructed<Intent>().putExtra(any<String>(), any<Boolean>()) } answers { call.invocation.self as Intent }
-        every { anyConstructed<Intent>().setFlags(any()) } answers { call.invocation.self as Intent }
-        every { anyConstructed<Intent>().setAction(any()) } answers { call.invocation.self as Intent }
-        // Property setters in mockk
-        // No need to mock property setters if we mock the underlying methods
+        every { mockDispatcherProvider.main } returns testDispatcher
+        every { mockDispatcherProvider.io } returns testDispatcher
+        every { mockDispatcherProvider.default } returns testDispatcher
+        every { mockDispatcherProvider.unconfined } returns testDispatcher
 
         mockNotificationUtils = mockk(relaxed = true)
         mockkStatic(NotificationUtils::class)
@@ -80,18 +66,22 @@ class NotificationActionReceiverTest {
         mockkStatic("org.ole.planet.myplanet.di.ServiceDependenciesEntryPointKt")
         every { getBroadcastService(any()) } returns mockk(relaxed = true)
 
-
         receiver = spyk(NotificationActionReceiver().apply {
             notificationsRepository = mockNotificationsRepository
             dispatcherProvider = mockDispatcherProvider
         })
-        every { receiver.goAsync() } returns mockk<BroadcastReceiver.PendingResult>(relaxed = true)
+        try {
+            val injectedField = org.ole.planet.myplanet.services.Hilt_NotificationActionReceiver::class.java.getDeclaredField("injected")
+            injectedField.isAccessible = true
+            injectedField.set(receiver, true)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     @After
     fun tearDown() {
         unmockkAll()
-        unmockkConstructor(Intent::class)
     }
 
     @Test
@@ -108,9 +98,8 @@ class NotificationActionReceiverTest {
     @Test
     fun `test onReceive ACTION_MARK_AS_READ`() = testScope.runTest {
         val notificationId = "test_id"
-        val mockIntent = mockk<Intent>(relaxed = true)
-        every { mockIntent.action } returns NotificationUtils.ACTION_MARK_AS_READ
-        every { mockIntent.getStringExtra(NotificationUtils.EXTRA_NOTIFICATION_ID) } returns notificationId
+        val mockIntent = Intent(NotificationUtils.ACTION_MARK_AS_READ)
+        mockIntent.putExtra(NotificationUtils.EXTRA_NOTIFICATION_ID, notificationId)
 
         val pendingResult = mockk<BroadcastReceiver.PendingResult>(relaxed = true)
         every { receiver.goAsync() } returns pendingResult
@@ -126,9 +115,8 @@ class NotificationActionReceiverTest {
     @Test
     fun `test onReceive ACTION_STORAGE_SETTINGS`() = testScope.runTest {
         val notificationId = "test_id"
-        val mockIntent = mockk<Intent>(relaxed = true)
-        every { mockIntent.action } returns NotificationUtils.ACTION_STORAGE_SETTINGS
-        every { mockIntent.getStringExtra(NotificationUtils.EXTRA_NOTIFICATION_ID) } returns notificationId
+        val mockIntent = Intent(NotificationUtils.ACTION_STORAGE_SETTINGS)
+        mockIntent.putExtra(NotificationUtils.EXTRA_NOTIFICATION_ID, notificationId)
 
         val pendingResult = mockk<BroadcastReceiver.PendingResult>(relaxed = true)
         every { receiver.goAsync() } returns pendingResult
@@ -137,7 +125,9 @@ class NotificationActionReceiverTest {
         advanceUntilIdle()
 
         coVerify { mockNotificationsRepository.markNotificationsAsRead(setOf(notificationId)) }
-        verify { mockContext.startActivity(any()) }
+        val intentList = mutableListOf<Intent>()
+        verify { mockContext.startActivity(capture(intentList)) }
+        assert(intentList.any { it.action == Settings.ACTION_INTERNAL_STORAGE_SETTINGS })
         verify { mockNotificationUtils.clearNotification(notificationId) }
         verify { pendingResult.finish() }
     }
@@ -148,11 +138,10 @@ class NotificationActionReceiverTest {
         val notificationType = "type"
         val relatedId = "related_id"
 
-        val mockIntent = mockk<Intent>(relaxed = true)
-        every { mockIntent.action } returns NotificationUtils.ACTION_OPEN_NOTIFICATION
-        every { mockIntent.getStringExtra(NotificationUtils.EXTRA_NOTIFICATION_ID) } returns notificationId
-        every { mockIntent.getStringExtra(NotificationUtils.EXTRA_NOTIFICATION_TYPE) } returns notificationType
-        every { mockIntent.getStringExtra(NotificationUtils.EXTRA_RELATED_ID) } returns relatedId
+        val mockIntent = Intent(NotificationUtils.ACTION_OPEN_NOTIFICATION)
+        mockIntent.putExtra(NotificationUtils.EXTRA_NOTIFICATION_ID, notificationId)
+        mockIntent.putExtra(NotificationUtils.EXTRA_NOTIFICATION_TYPE, notificationType)
+        mockIntent.putExtra(NotificationUtils.EXTRA_RELATED_ID, relatedId)
 
         val pendingResult = mockk<BroadcastReceiver.PendingResult>(relaxed = true)
         every { receiver.goAsync() } returns pendingResult
@@ -161,7 +150,14 @@ class NotificationActionReceiverTest {
         advanceUntilIdle()
 
         coVerify { mockNotificationsRepository.markNotificationsAsRead(setOf(notificationId)) }
-        verify { mockContext.startActivity(any()) }
+        val intentList = mutableListOf<Intent>()
+        verify { mockContext.startActivity(capture(intentList)) }
+        val targetIntent = intentList.find { it.getStringExtra("notification_type") == notificationType }
+        assert(targetIntent != null)
+        assert(targetIntent?.getStringExtra("notification_type") == notificationType)
+        assert(targetIntent?.getStringExtra("notification_id") == notificationId)
+        assert(targetIntent?.getStringExtra("related_id") == relatedId)
+
         verify { mockNotificationUtils.clearNotification(notificationId) }
         verify { pendingResult.finish() }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/NotificationActionReceiverTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/NotificationActionReceiverTest.kt
@@ -7,6 +7,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.verify
+import android.content.BroadcastReceiver
 import io.mockk.unmockkAll
 import io.mockk.unmockkConstructor
 import kotlinx.coroutines.CoroutineDispatcher
@@ -23,6 +26,7 @@ import org.ole.planet.myplanet.di.getBroadcastService
 import org.ole.planet.myplanet.repository.NotificationsRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.NotificationUtils
+import dagger.hilt.internal.GeneratedComponentManager
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NotificationActionReceiverTest {
@@ -43,6 +47,14 @@ class NotificationActionReceiverTest {
         MainApplication.applicationScope = testScope
 
         mockContext = mockk<Context>(relaxed = true)
+
+        abstract class MockAppContext : android.app.Application(), dagger.hilt.internal.GeneratedComponentManager<Any>
+        val mockApplication = mockk<MockAppContext>(relaxed = true)
+        every { mockContext.applicationContext } returns mockApplication
+        every { mockApplication.generatedComponent() } returns mockk<NotificationActionReceiver_GeneratedInjector>(relaxed = true)
+
+
+
         mockNotificationsRepository = mockk(relaxed = true)
 
         mockDispatcherProvider = object : DispatcherProvider {
@@ -53,11 +65,13 @@ class NotificationActionReceiverTest {
         }
 
         mockkConstructor(Intent::class)
-        every { anyConstructed<Intent>().setPackage(any()) } answers { mockk() }
-        every { anyConstructed<Intent>().putExtra(any<String>(), any<String>()) } answers { mockk() }
-        every { anyConstructed<Intent>().putExtra(any<String>(), any<Boolean>()) } answers { mockk() }
-        every { anyConstructed<Intent>().flags = any() } returns Unit
-        every { anyConstructed<Intent>().action = any() } returns Unit
+        every { anyConstructed<Intent>().setPackage(any()) } answers { call.invocation.self as Intent }
+        every { anyConstructed<Intent>().putExtra(any<String>(), any<String>()) } answers { call.invocation.self as Intent }
+        every { anyConstructed<Intent>().putExtra(any<String>(), any<Boolean>()) } answers { call.invocation.self as Intent }
+        every { anyConstructed<Intent>().setFlags(any()) } answers { call.invocation.self as Intent }
+        every { anyConstructed<Intent>().setAction(any()) } answers { call.invocation.self as Intent }
+        // Property setters in mockk
+        // No need to mock property setters if we mock the underlying methods
 
         mockNotificationUtils = mockk(relaxed = true)
         mockkStatic(NotificationUtils::class)
@@ -67,10 +81,11 @@ class NotificationActionReceiverTest {
         every { getBroadcastService(any()) } returns mockk(relaxed = true)
 
 
-        receiver = NotificationActionReceiver().apply {
+        receiver = spyk(NotificationActionReceiver().apply {
             notificationsRepository = mockNotificationsRepository
             dispatcherProvider = mockDispatcherProvider
-        }
+        })
+        every { receiver.goAsync() } returns mockk<BroadcastReceiver.PendingResult>(relaxed = true)
     }
 
     @After
@@ -88,5 +103,66 @@ class NotificationActionReceiverTest {
         advanceUntilIdle()
 
         coVerify { mockNotificationsRepository.markNotificationsAsRead(setOf(notificationId)) }
+    }
+
+    @Test
+    fun `test onReceive ACTION_MARK_AS_READ`() = testScope.runTest {
+        val notificationId = "test_id"
+        val mockIntent = mockk<Intent>(relaxed = true)
+        every { mockIntent.action } returns NotificationUtils.ACTION_MARK_AS_READ
+        every { mockIntent.getStringExtra(NotificationUtils.EXTRA_NOTIFICATION_ID) } returns notificationId
+
+        val pendingResult = mockk<BroadcastReceiver.PendingResult>(relaxed = true)
+        every { receiver.goAsync() } returns pendingResult
+
+        receiver.onReceive(mockContext, mockIntent)
+        advanceUntilIdle()
+
+        coVerify { mockNotificationsRepository.markNotificationsAsRead(setOf(notificationId)) }
+        verify { mockNotificationUtils.clearNotification(notificationId) }
+        verify { pendingResult.finish() }
+    }
+
+    @Test
+    fun `test onReceive ACTION_STORAGE_SETTINGS`() = testScope.runTest {
+        val notificationId = "test_id"
+        val mockIntent = mockk<Intent>(relaxed = true)
+        every { mockIntent.action } returns NotificationUtils.ACTION_STORAGE_SETTINGS
+        every { mockIntent.getStringExtra(NotificationUtils.EXTRA_NOTIFICATION_ID) } returns notificationId
+
+        val pendingResult = mockk<BroadcastReceiver.PendingResult>(relaxed = true)
+        every { receiver.goAsync() } returns pendingResult
+
+        receiver.onReceive(mockContext, mockIntent)
+        advanceUntilIdle()
+
+        coVerify { mockNotificationsRepository.markNotificationsAsRead(setOf(notificationId)) }
+        verify { mockContext.startActivity(any()) }
+        verify { mockNotificationUtils.clearNotification(notificationId) }
+        verify { pendingResult.finish() }
+    }
+
+    @Test
+    fun `test onReceive ACTION_OPEN_NOTIFICATION`() = testScope.runTest {
+        val notificationId = "test_id"
+        val notificationType = "type"
+        val relatedId = "related_id"
+
+        val mockIntent = mockk<Intent>(relaxed = true)
+        every { mockIntent.action } returns NotificationUtils.ACTION_OPEN_NOTIFICATION
+        every { mockIntent.getStringExtra(NotificationUtils.EXTRA_NOTIFICATION_ID) } returns notificationId
+        every { mockIntent.getStringExtra(NotificationUtils.EXTRA_NOTIFICATION_TYPE) } returns notificationType
+        every { mockIntent.getStringExtra(NotificationUtils.EXTRA_RELATED_ID) } returns relatedId
+
+        val pendingResult = mockk<BroadcastReceiver.PendingResult>(relaxed = true)
+        every { receiver.goAsync() } returns pendingResult
+
+        receiver.onReceive(mockContext, mockIntent)
+        advanceUntilIdle()
+
+        coVerify { mockNotificationsRepository.markNotificationsAsRead(setOf(notificationId)) }
+        verify { mockContext.startActivity(any()) }
+        verify { mockNotificationUtils.clearNotification(notificationId) }
+        verify { pendingResult.finish() }
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap in `NotificationActionReceiver.kt` regarding its `onReceive` method has been addressed. The previous tests only validated `markNotificationAsRead` but left `onReceive` and its handling of different intent actions (`ACTION_MARK_AS_READ`, `ACTION_STORAGE_SETTINGS`, `ACTION_OPEN_NOTIFICATION`) completely untested.
📊 **Coverage:** New unit tests were added for:
*   Receiving `ACTION_MARK_AS_READ` intent, confirming `markNotificationAsRead`, `clearNotification`, and `finish()` on `PendingResult` are executed.
*   Receiving `ACTION_STORAGE_SETTINGS` intent, confirming it also starts the device storage settings activity.
*   Receiving `ACTION_OPEN_NOTIFICATION` intent, confirming it opens the `DashboardActivity` and passes the required notification intent extras correctly.
✨ **Result:** The `NotificationActionReceiver` now has reliable unit test coverage over its broadcast event processing lifecycle, preventing silent regressions on push notification handling.

---
*PR created automatically by Jules for task [5053400633281185945](https://jules.google.com/task/5053400633281185945) started by @dogi*