### PR TITLE
fix: Sync translated localized strings.xml files

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1228,5 +1228,6 @@
     <string name="no_achievement_added">ملخص الإنجازات</string>
     <string name="no_references_added">لم تتم إضافة مراجع</string>
     <string name="chat_already_shared_to_destination">تمت مشاركة هذه الدردشة بالفعل إلى هذه الوجهة</string>
+    <string name="already_shared">تمت المشاركة بالفعل</string>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1215,5 +1215,6 @@
     <string name="no_achievement_added">Resumen de logros</string>
     <string name="no_references_added">No se agregaron referencias</string>
     <string name="chat_already_shared_to_destination">Este chat ya ha sido compartido a este destino</string>
+    <string name="already_shared">Ya compartido</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1216,5 +1216,6 @@
     <string name="no_achievement_added">Résumé des réalisations</string>
     <string name="no_references_added">Aucune référence ajoutée</string>
     <string name="chat_already_shared_to_destination">Cette discussion a déjà été partagée vers cette destination</string>
+    <string name="already_shared">Déjà partagé</string>
 
 </resources>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -1212,5 +1212,6 @@
     <string name="no_achievement_added">उपलब्धिहरूको सारांश</string>
     <string name="no_references_added">कुनै सन्दर्भ थपिएको छैन</string>
     <string name="chat_already_shared_to_destination">यो च्याट पहिले नै यस गन्तव्यमा साझेदारी गरिएको छ</string>
+    <string name="already_shared">पहिले नै साझा गरिएको</string>
 
 </resources>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -1212,5 +1212,6 @@
     <string name="no_achievement_added">Soo koobidda guulaha</string>
     <string name="no_references_added">Tixraac lama darin</string>
     <string name="chat_already_shared_to_destination">Wadahadalkan hore ayaa loogu wadaagay goobtan</string>
+    <string name="already_shared">Hore loo wadaagay</string>
 
 </resources>


### PR DESCRIPTION
Add translated `already_shared` strings to localized files with specific line spacing.

---
*PR created automatically by Jules for task [2961876846491548051](https://jules.google.com/task/2961876846491548051) started by @dogi*