### PR TITLE
all: smoother database module handler thread dispatching (fixes #12994)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5326
-        versionName = "0.53.26"
+        versionCode = 5327
+        versionName = "0.53.27"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
@@ -11,7 +11,6 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.android.asCoroutineDispatcher
-import kotlinx.coroutines.asCoroutineDispatcher
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.utils.DispatcherProvider
@@ -30,10 +29,9 @@ object DatabaseModule {
     @Singleton
     @RealmDispatcher
     fun provideRealmDispatcher(): CoroutineDispatcher {
-        // App-level shutdown hook ownership
-        return java.util.concurrent.Executors.newSingleThreadExecutor { r ->
-            Thread(r, "RealmQueryThread")
-        }.asCoroutineDispatcher()
+        // Realm async queries and change listeners require a thread with a Looper.
+        val handlerThread = HandlerThread("RealmQueryThread").also { it.start() }
+        return Handler(handlerThread.looper).asCoroutineDispatcher()
     }
 
     // Realm initialization is handled in DatabaseService


### PR DESCRIPTION
fixes #12994
Replace the single-thread executor with a HandlerThread-backed CoroutineDispatcher so Realm async queries and change listeners run on a thread with a Looper. Starts a HandlerThread named "RealmQueryThread" and returns Handler(looper).asCoroutineDispatcher(). Removes the unused executor import and obsolete shutdown-hook comment.