### PR TITLE
🧪 [testing improvement] Fix outdated server IPs in ServerConfigUtilsTest

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/utils/ServerConfigUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ServerConfigUtilsTest.kt
@@ -124,8 +124,8 @@ class ServerConfigUtilsTest {
         assertEquals("5932", ServerConfigUtils.getPinForUrl("planet.somalia.ole.org"))
         assertEquals("0660", ServerConfigUtils.getPinForUrl("planet.vi.ole.org"))
         assertEquals("4324", ServerConfigUtils.getPinForUrl("10.82.1.31"))
-        assertEquals("4025", ServerConfigUtils.getPinForUrl("192.168.1.64"))
-        assertEquals("8925", ServerConfigUtils.getPinForUrl("192.168.1.93"))
+        assertEquals("4025", ServerConfigUtils.getPinForUrl("192.168.1.73"))
+        assertEquals("8925", ServerConfigUtils.getPinForUrl("192.168.1.66"))
         assertEquals("0963", ServerConfigUtils.getPinForUrl("192.168.1.148"))
         assertEquals("6407", ServerConfigUtils.getPinForUrl("192.168.68.126"))
     }


### PR DESCRIPTION
🧪 [testing improvement] Fix outdated server IPs in ServerConfigUtilsTest

🎯 What:
The `getPinForUrl_returnsCorrectPinForKnownUrls` test was failing because it asserted against outdated literal IP addresses (`192.168.1.64` and `192.168.1.93`) that no longer matched the `PLANET_` configurations in `gradle.properties`.

📊 Coverage:
Updated the test file to use the current correct IP addresses (`192.168.1.73` and `192.168.1.66`), which restores unit test coverage for the alternative server URL resolution logic.

✨ Result:
The test passes successfully and accurately reflects the current configuration parameters.

---
*PR created automatically by Jules for task [17064872636964510599](https://jules.google.com/task/17064872636964510599) started by @dogi*