### PR TITLE
🧹 [code health] Fix compilation errors due to removed sync preference methods in tests

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
@@ -109,15 +109,14 @@ class SharedPrefManagerTest {
 
     @Test
     fun testSetSynced() {
-        // Since setSynced is private, we test it via the public wrapper setChatHistorySynced.
         // Test false synced
-        sharedPrefManager.setChatHistorySynced(false)
+        sharedPrefManager.setSynced(SharedPrefManager.SyncKey.CHAT_HISTORY, false)
         verify { mockEditor.putBoolean("chat_history_synced", false) }
         verify(exactly = 0) { mockEditor.putLong(eq("chat_history_synced_time"), any()) }
         verify { mockEditor.apply() }
 
         // Test true synced
-        sharedPrefManager.setChatHistorySynced(true)
+        sharedPrefManager.setSynced(SharedPrefManager.SyncKey.CHAT_HISTORY, true)
         verify { mockEditor.putBoolean("chat_history_synced", true) }
         verify { mockEditor.putLong(eq("chat_history_synced_time"), any()) }
         verify { mockEditor.apply() }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/surveys/SurveysViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/surveys/SurveysViewModelTest.kt
@@ -195,7 +195,7 @@ class SurveysViewModelTest {
     @Test
     fun `test startExamSync when fastSync is false`() {
         every { sharedPrefManager.getFastSync() } returns false
-        every { sharedPrefManager.isExamsSynced() } returns false
+        every { sharedPrefManager.isSynced(SharedPrefManager.SyncKey.EXAMS) } returns false
 
         viewModel.startExamSync()
 
@@ -205,7 +205,7 @@ class SurveysViewModelTest {
     @Test
     fun `test startExamSync when isExamsSynced is true`() {
         every { sharedPrefManager.getFastSync() } returns true
-        every { sharedPrefManager.isExamsSynced() } returns true
+        every { sharedPrefManager.isSynced(SharedPrefManager.SyncKey.EXAMS) } returns true
 
         viewModel.startExamSync()
 
@@ -215,7 +215,7 @@ class SurveysViewModelTest {
     @Test
     fun `test startExamSync triggers sync and handles error state mapping`() = runTest {
         every { sharedPrefManager.getFastSync() } returns true
-        every { sharedPrefManager.isExamsSynced() } returns false
+        every { sharedPrefManager.isSynced(SharedPrefManager.SyncKey.EXAMS) } returns false
         every { sharedPrefManager.getServerUrl() } returns "http://test.com"
         every { serverUrlMapper.processUrl(any()) } returns mockk()
 
@@ -245,7 +245,7 @@ class SurveysViewModelTest {
 
         // Test onSyncComplete
         listener.onSyncComplete()
-        verify { sharedPrefManager.setExamsSynced(true) }
+        verify { sharedPrefManager.setSynced(SharedPrefManager.SyncKey.EXAMS, true) }
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(false, viewModel.isLoading.value)
     }


### PR DESCRIPTION
🎯 What
Fixed compilation failures in `SharedPrefManagerTest` and `SurveysViewModelTest`.

💡 Why
Methods like `setChatHistorySynced`, `isExamsSynced`, and `setExamsSynced` were recently removed or made private during a refactor. The tests were updated to use the generic `isSynced` and `setSynced` methods with `SharedPrefManager.SyncKey`.

✅ Verification
Ran `./gradlew compileDefaultDebugUnitTestKotlin` and `./gradlew testDefaultDebugUnitTest` locally, and the tests compile and pass successfully.

✨ Result
Broken CI builds should be fixed and the unit tests are synced up with the current generic `SharedPrefManager` implementation.

---
*PR created automatically by Jules for task [8273783357453984837](https://jules.google.com/task/8273783357453984837) started by @dogi*