### PR TITLE
dashboard: smoother upload shelf coroutines concurring (fixes #13141)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5366
-        versionName = "0.53.66"
+        versionCode = 5369
+        versionName = "0.53.69"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
@@ -13,7 +13,12 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.data.DatabaseService
@@ -274,18 +279,29 @@ class UploadToShelfService @Inject constructor(
             val myHealths = healthRepository.getUpdatedHealthExaminations()
 
             val uploadedHealths = mutableMapOf<String, String?>()
-            myHealths.forEach { pojo ->
-                try {
-                    val res = apiInterface.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/health", serialize(pojo))
+            val semaphore = Semaphore(5)
+            supervisorScope {
+                myHealths.map { pojo ->
+                    async {
+                        semaphore.withPermit {
+                            try {
+                                val res = apiInterface.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/health", serialize(pojo))
 
-                    if (res.body() != null && res.body()?.has("id") == true) {
-                        val rev = res.body()?.get("rev")?.asString
-                        pojo._id?.let { id ->
-                            uploadedHealths[id] = rev
+                                if (res.body() != null && res.body()?.has("id") == true) {
+                                    val rev = res.body()?.get("rev")?.asString
+                                    val id = pojo._id
+                                    if (id != null) {
+                                        return@async id to rev
+                                    }
+                                }
+                            } catch (e: Throwable) {
+                                e.printStackTrace()
+                            }
+                            null
                         }
                     }
-                } catch (e: Exception) {
-                    e.printStackTrace()
+                }.awaitAll().filterNotNull().forEach { (id, rev) ->
+                    uploadedHealths[id] = rev
                 }
             }
 
@@ -301,23 +317,34 @@ class UploadToShelfService @Inject constructor(
                 val myHealths = healthRepository.getUpdatedHealthForUser(userId)
 
                 val uploadedHealths = mutableMapOf<String, String?>()
-                myHealths.forEach { pojo ->
-                    try {
-                        val res = apiInterface.postDoc(
-                            UrlUtils.header,
-                            "application/json",
-                            "${UrlUtils.getUrl()}/health",
-                            serialize(pojo)
-                        )
+                val semaphore = Semaphore(5)
+                supervisorScope {
+                    myHealths.map { pojo ->
+                        async {
+                            semaphore.withPermit {
+                                try {
+                                    val res = apiInterface.postDoc(
+                                        UrlUtils.header,
+                                        "application/json",
+                                        "${UrlUtils.getUrl()}/health",
+                                        serialize(pojo)
+                                    )
 
-                        if (res.body() != null && res.body()?.has("id") == true) {
-                            val rev = res.body()?.get("rev")?.asString
-                            pojo._id?.let { id ->
-                                uploadedHealths[id] = rev
+                                    if (res.body() != null && res.body()?.has("id") == true) {
+                                        val rev = res.body()?.get("rev")?.asString
+                                        val id = pojo._id
+                                        if (id != null) {
+                                            return@async id to rev
+                                        }
+                                    }
+                                } catch (e: Throwable) {
+                                    e.printStackTrace()
+                                }
+                                null
                             }
                         }
-                    } catch (e: Exception) {
-                        e.printStackTrace()
+                    }.awaitAll().filterNotNull().forEach { (id, rev) ->
+                        uploadedHealths[id] = rev
                     }
                 }
 
@@ -326,7 +353,7 @@ class UploadToShelfService @Inject constructor(
                 withContext(dispatcherProvider.main) {
                     listener?.onSuccess("Health data for user $userId uploaded successfully")
                 }
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 withContext(dispatcherProvider.main) {
                     listener?.onSuccess("Error uploading health data for user $userId: ${e.localizedMessage}")
                 }
@@ -346,22 +373,29 @@ class UploadToShelfService @Inject constructor(
             }
 
             try {
-                unmanagedUsers.forEach { model ->
-                    try {
-                        val jsonDoc = apiInterface.getJsonObject(UrlUtils.header, "${UrlUtils.getUrl()}/shelf/${model._id}").body()
-                        val myLibs = resourcesRepository.getMyLibIds(model.id ?: "")
-                        val myCourseIds = coursesRepository.getMyCourseIds(model.id ?: "")
-                        val shelfData = userRepository.getShelfData(model.id, jsonDoc, myLibs, myCourseIds)
-                        shelfData.addProperty("_rev", getString("_rev", jsonDoc))
-                        apiInterface.putDoc(
-                            UrlUtils.header,
-                            "application/json",
-                            "${UrlUtils.getUrl()}/shelf/${sharedPrefManager.getUserId()}",
-                            shelfData
-                        )
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                    }
+                val semaphore = Semaphore(5)
+                supervisorScope {
+                    unmanagedUsers.map { model ->
+                        async {
+                            semaphore.withPermit {
+                                try {
+                                    val jsonDoc = apiInterface.getJsonObject(UrlUtils.header, "${UrlUtils.getUrl()}/shelf/${model._id}").body()
+                                    val myLibs = resourcesRepository.getMyLibIds(model.id ?: "")
+                                    val myCourseIds = coursesRepository.getMyCourseIds(model.id ?: "")
+                                    val shelfData = userRepository.getShelfData(model.id, jsonDoc, myLibs, myCourseIds)
+                                    shelfData.addProperty("_rev", getString("_rev", jsonDoc))
+                                    apiInterface.putDoc(
+                                        UrlUtils.header,
+                                        "application/json",
+                                        "${UrlUtils.getUrl()}/shelf/${model._id}",
+                                        shelfData
+                                    )
+                                } catch (e: Throwable) {
+                                    e.printStackTrace()
+                                }
+                            }
+                        }
+                    }.awaitAll()
                 }
                 withContext(dispatcherProvider.main) {
                     listener.onSuccess("Sync with server completed successfully")
@@ -388,7 +422,7 @@ class UploadToShelfService @Inject constructor(
                     val shelfObject = userRepository.getShelfData(model.id, jsonDoc, myLibs, myCourseIds)
                     shelfObject.addProperty("_rev", getString("_rev", jsonDoc))
 
-                    val targetUrl = "${UrlUtils.getUrl()}/shelf/${sharedPrefManager.getUserId()}"
+                    val targetUrl = "${UrlUtils.getUrl()}/shelf/${model._id}"
                     apiInterface.putDoc(UrlUtils.header, "application/json", targetUrl, shelfObject)
                 }
                 withContext(dispatcherProvider.main) {


### PR DESCRIPTION
Combines logic from PR 13024 and PR 13036 into a single set of operations for `UploadToShelfService`, employing safer Coroutine parallelization with semaphores.

---
*PR created automatically by Jules for task [14137975709141564006](https://jules.google.com/task/14137975709141564006) started by @dogi*