### PR TITLE
courses: smoother progress repository completion realm modelling (fixes #13146)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5376
+        versionName = "0.53.76"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/CourseCompletion.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/CourseCompletion.kt
@@ -1,0 +1,3 @@
+package org.ole.planet.myplanet.model
+
+data class CourseCompletion(val courseId: String?, val courseTitle: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepository.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import org.ole.planet.myplanet.model.CourseCompletion
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
 
@@ -10,6 +11,7 @@ interface ProgressRepository {
     suspend fun getCurrentProgress(steps: List<RealmCourseStep?>?, userId: String?, courseId: String?): Int
     suspend fun fetchCourseData(userId: String?): JsonArray
     suspend fun getProgressRecords(userId: String?): List<RealmCourseProgress>
+    suspend fun getCompletedCourses(userId: String): List<CourseCompletion>
     suspend fun saveCourseProgress(
         userId: String?,
         planetCode: String?,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.di.RealmDispatcher
+import org.ole.planet.myplanet.model.CourseCompletion
 import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
@@ -24,7 +25,8 @@ import org.ole.planet.myplanet.utils.JsonUtils
 class ProgressRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
     @RealmDispatcher realmDispatcher: CoroutineDispatcher,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val coursesRepositoryLazy: dagger.Lazy<CoursesRepository>
 ) : RealmRepository(databaseService, realmDispatcher), ProgressRepository {
     override suspend fun getCourseProgress(userId: String?): HashMap<String?, JsonObject> = withContext(dispatcherProvider.io) {
         val mycourses = queryList(RealmMyCourse::class.java) {
@@ -169,6 +171,37 @@ class ProgressRepositoryImpl @Inject constructor(
         queryList(RealmCourseProgress::class.java) {
             equalTo("userId", userId)
         }
+    }
+
+    override suspend fun getCompletedCourses(userId: String): List<CourseCompletion> = withContext(dispatcherProvider.io) {
+        val myCourses = coursesRepositoryLazy.get().getMyCourses(userId)
+        val allProgressRecords = getProgressRecords(userId)
+
+        val completedCourses = mutableListOf<CourseCompletion>()
+        myCourses.forEachIndexed { index, course ->
+            val hasValidId = !course.courseId.isNullOrBlank()
+            val hasValidTitle = !course.courseTitle.isNullOrBlank()
+
+            // Get progress records for this specific course
+            val courseProgressRecords = allProgressRecords.filter { it.courseId == course.courseId }
+
+            // Count UNIQUE steps that are passed (matches web: step.passed === true)
+            val passedStepNumbers = courseProgressRecords
+                .filter { it.passed }
+                .map { it.stepNum }
+                .toSet()
+            val passedSteps = passedStepNumbers.size
+            val totalSteps = course.courseSteps?.size ?: 0
+
+            // Web logic: ALL steps must be passed AND course must have at least one step
+            val allStepsPassed = passedSteps == totalSteps && totalSteps > 0
+
+            // Match web behavior: Show badge if ALL steps are passed AND course has steps
+            if (allStepsPassed && hasValidId && hasValidTitle) {
+                completedCourses.add(CourseCompletion(course.courseId, course.courseTitle))
+            }
+        }
+        completedCourses
     }
 
     override suspend fun saveCourseProgress(

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseDashboardFragment
 import org.ole.planet.myplanet.databinding.FragmentHomeBellBinding
+import org.ole.planet.myplanet.model.CourseCompletion
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardViewModel.kt
@@ -10,18 +10,15 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
-import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.model.CourseCompletion
 import org.ole.planet.myplanet.repository.ProgressRepository
 import org.ole.planet.myplanet.repository.TeamsRepository
-import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.NetworkUtils.isNetworkConnectedFlow
 
 @HiltViewModel
 class BellDashboardViewModel @Inject constructor(
     private val progressRepository: ProgressRepository,
-    private val coursesRepository: CoursesRepository,
-    private val teamsRepository: TeamsRepository,
-    private val dispatcherProvider: DispatcherProvider
+    private val teamsRepository: TeamsRepository
 ) : ViewModel() {
     private val _networkStatus = MutableStateFlow<NetworkStatus>(NetworkStatus.Disconnected)
     val networkStatus: StateFlow<NetworkStatus> = _networkStatus.asStateFlow()
@@ -43,40 +40,7 @@ class BellDashboardViewModel @Inject constructor(
 
     fun loadCompletedCourses(userId: String) {
         viewModelScope.launch {
-            val completedCourses = withContext(dispatcherProvider.io) {
-                val myCourses = coursesRepository.getMyCourses(userId)
-
-                // Get all progress records for this user
-                val allProgressRecords = progressRepository.getProgressRecords(userId)
-
-                val completedCourses = mutableListOf<CourseCompletion>()
-                myCourses.forEachIndexed { index, course ->
-                    val hasValidId = !course.courseId.isNullOrBlank()
-                    val hasValidTitle = !course.courseTitle.isNullOrBlank()
-
-                    // Get progress records for this specific course
-                    val courseProgressRecords = allProgressRecords.filter { it.courseId == course.courseId }
-
-                    // Count UNIQUE steps that are passed (matches web: step.passed === true)
-                    val passedStepNumbers = courseProgressRecords
-                        .filter { it.passed }
-                        .map { it.stepNum }
-                        .toSet()
-                    val passedSteps = passedStepNumbers.size
-                    val totalSteps = course.courseSteps?.size ?: 0
-
-                    // Web logic: ALL steps must be passed AND course must have at least one step
-                    val allStepsPassed = passedSteps == totalSteps && totalSteps > 0
-
-                    // Match web behavior: Show badge if ALL steps are passed AND course has steps
-                    if (allStepsPassed && hasValidId && hasValidTitle) {
-                        completedCourses.add(CourseCompletion(course.courseId, course.courseTitle))
-                    }
-                }
-                completedCourses
-            }
-
-            _completedCourses.value = completedCourses
+            _completedCourses.value = progressRepository.getCompletedCourses(userId)
         }
     }
 
@@ -92,8 +56,6 @@ class BellDashboardViewModel @Inject constructor(
 
     suspend fun getTeamById(teamId: String) = teamsRepository.getTeamById(teamId)
 }
-
-data class CourseCompletion(val courseId: String?, val courseTitle: String?)
 
 sealed class NetworkStatus {
     object Disconnected : NetworkStatus()

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
@@ -40,10 +40,12 @@ class ProgressRepositoryImplTest {
     @Before
     fun setUp() {
         every { dispatcherProvider.io } returns testDispatcher
+        val mockCoursesRepository = mockk<CoursesRepository>()
         repository = spyk(ProgressRepositoryImpl(
             databaseService,
             UnconfinedTestDispatcher(),
-            dispatcherProvider
+            dispatcherProvider,
+            { mockCoursesRepository }
         ), recordPrivateCalls = true)
         coEvery { repository["queryList"](RealmMyCourse::class.java, any<Function1<*, *>>()) } returns emptyList<RealmMyCourse>()
     }


### PR DESCRIPTION
🎯 What
Decouples course completion logic from the UI (BellDashboardViewModel) by shifting it to `ProgressRepository`. The `CourseCompletion` data class has also been relocated to the `model` package for wider reusability.

💡 Why
It cleans up the ViewModel by separating the core business logic, adhering to the Single Responsibility Principle. Moving logic to the repository enables proper reuse in other layers.

✅ Verification
Compiled successfully, cyclic dependencies handled via `dagger.Lazy`, and all existing unit tests pass via `./gradlew testDefaultDebugUnitTest`.

✨ Result
A leaner ViewModel with fewer dependencies and encapsulated repository logic for course completion checks.

---
*PR created automatically by Jules for task [11972560009570769908](https://jules.google.com/task/11972560009570769908) started by @dogi*