### PR TITLE
Attempt to improve synce

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
@@ -39,6 +39,14 @@ annotation class StandardHttpClient
 @Retention(AnnotationRetention.BINARY)
 annotation class StandardRetrofit
 
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class SyncHttpClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class SyncApiInterface
+
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
@@ -94,6 +102,25 @@ object NetworkModule {
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
+    }
+
+    @Provides
+    @Singleton
+    @SyncHttpClient
+    fun provideSyncOkHttpClient(broadcastService: BroadcastService): OkHttpClient {
+        return buildOkHttpClient(30, 300, 300, RetryInterceptor(broadcastService))
+    }
+
+    @Provides
+    @Singleton
+    @SyncApiInterface
+    fun provideSyncApiInterface(@SyncHttpClient okHttpClient: OkHttpClient, gson: Gson): ApiInterface {
+        return Retrofit.Builder()
+            .baseUrl("https://vi.media.mit.edu/")
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .build()
+            .create(ApiInterface::class.java)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import io.realm.Realm
 import javax.inject.Inject
 import javax.inject.Singleton
+import java.net.SocketTimeoutException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -170,15 +171,37 @@ class TransactionSyncManager @Inject constructor(
             while (true) {
                 batchNumber++
                 val batchStartTime = System.currentTimeMillis()
-                // Time the batch API call (much faster with pagination)
-                val batchApiStartTime = System.currentTimeMillis()
-                val response = apiInterface.findDocs(
-                    UrlUtils.header,
-                    "application/json",
-                    UrlUtils.getUrl() + "/" + table + "/_all_docs?include_docs=true&limit=$pageSize&skip=$skip",
-                    JsonObject() // Empty body for GET-style query
-                )
-                val batchApiDuration = System.currentTimeMillis() - batchApiStartTime
+
+                // Retry each batch up to 3 times to recover from stale connections
+                // killed by a server-side 60-second connection timeout.
+                val maxBatchRetries = 3
+                var batchResponse: retrofit2.Response<JsonObject>? = null
+                var batchAttempt = 0
+                while (batchAttempt < maxBatchRetries) {
+                    try {
+                        val batchApiStartTime = System.currentTimeMillis()
+                        batchResponse = apiInterface.findDocs(
+                            UrlUtils.header,
+                            "application/json",
+                            UrlUtils.getUrl() + "/" + table + "/_all_docs?include_docs=true&limit=$pageSize&skip=$skip",
+                            JsonObject()
+                        )
+                        val batchApiDuration = System.currentTimeMillis() - batchApiStartTime
+                        org.ole.planet.myplanet.utils.SyncTimeLogger.logApiCall(
+                            "${UrlUtils.getUrl()}/$table/_all_docs (batch $batchNumber)",
+                            batchApiDuration,
+                            batchResponse.isSuccessful,
+                            batchResponse.body()?.let { getJsonArray("rows", it).size() } ?: 0
+                        )
+                        break // success — exit retry loop
+                    } catch (e: SocketTimeoutException) {
+                        batchAttempt++
+                        if (batchAttempt >= maxBatchRetries) throw e
+                        android.util.Log.d("SyncPerf", "  ↺ $table batch $batchNumber timeout (attempt $batchAttempt/$maxBatchRetries), retrying...")
+                    }
+                }
+                val response = batchResponse ?: break
+
                 if (response.body() == null || !response.isSuccessful) {
                     android.util.Log.d("SyncPerf", "  ✗ Failed $table batch $batchNumber: HTTP ${response.code()}")
                     break
@@ -187,12 +210,6 @@ class TransactionSyncManager @Inject constructor(
                 if (arr.size() == 0) {
                     break // No more documents
                 }
-                org.ole.planet.myplanet.utils.SyncTimeLogger.logApiCall(
-                    "${UrlUtils.getUrl()}/$table/_all_docs (batch $batchNumber)",
-                    batchApiDuration,
-                    response.isSuccessful,
-                    arr.size()
-                )
                 if (table == "news") {
                     val insertStartTime = System.currentTimeMillis()
                     val docs = ArrayList<JsonObject>(arr.size())

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -18,6 +18,7 @@ import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.ApplicationScope
+import org.ole.planet.myplanet.di.SyncApiInterface
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.saveConcatenatedLinksToPrefs
 import org.ole.planet.myplanet.model.RealmUser
@@ -36,7 +37,7 @@ import org.ole.planet.myplanet.utils.Utilities
 
 @Singleton
 class TransactionSyncManager @Inject constructor(
-    private val apiInterface: ApiInterface,
+    @SyncApiInterface private val apiInterface: ApiInterface,
     private val databaseService: DatabaseService,
     @param:ApplicationContext private val context: Context,
     private val voicesRepository: org.ole.planet.myplanet.repository.VoicesRepository,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -21,11 +21,9 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TeamNotificationInfo
 import org.ole.planet.myplanet.repository.ActivitiesRepository
@@ -113,16 +111,8 @@ class DashboardViewModel @Inject constructor(
         notificationsRepository.updateResourceNotification(userId, resourceCount)
     }
 
-    suspend fun getSurveySubmissionCount(userId: String?): Int {
-        return surveysRepository.getSurveySubmissionCount(userId)
-    }
-
     suspend fun getUnreadNotificationsSize(userId: String?, isAdmin: Boolean = false): Int {
         return notificationsRepository.getUnreadCount(userId, isAdmin)
-    }
-
-    suspend fun getTeamNotificationInfo(teamId: String, userId: String): TeamNotificationInfo {
-        return notificationsRepository.getTeamNotificationInfo(teamId, userId)
     }
 
     suspend fun getTeamNotifications(teamIds: List<String>, userId: String): Map<String, TeamNotificationInfo> {
@@ -178,10 +168,6 @@ class DashboardViewModel @Inject constructor(
 
     suspend fun getTeamType(teamId: String): String? {
         return teamsRepository.getTeamType(teamId)
-    }
-
-    suspend fun getOfflineActivities(userName: String, type: String): List<RealmOfflineActivity> {
-        return activitiesRepository.getOfflineActivities(userName, type)
     }
 
     suspend fun getLibraryForSelectedUser(userId: String): List<RealmMyLibrary> {


### PR DESCRIPTION
```
═══════════════════════════════════════════════════════════════
SYNC STARTED at 18:37:42.308
═══════════════════════════════════════════════════════════════
═══════════════════════════════════════════════════════════════
FULL SYNC STARTED at 18:37:42.310
═══════════════════════════════════════════════════════════════
  ▶ Starting submissions sync
  ▶ Starting feedback sync
  ▶ Starting achievements sync
  ▶ Starting news sync
  ▶ Starting ratings sync
  ▶ Starting exams sync
  ▶ Starting tags sync
  ▶ Starting courses_progress sync
  ▶ Starting login_activities sync
  ▶ Starting tasks sync
  ▶ Starting health sync
  ▶ Starting certifications sync
  ▶ Starting team_activities sync
  ▶ Starting chat_history sync
  ▶ Starting tablet_users sync
  ▶ Starting teams sync
  ▶ Starting meetups sync
  ▶ Starting courses sync
  ▶ Starting notifications sync
[  0.543s] ✓ API #1: ...3@planet.learning.ole.org:443/db/ratings/_all_docs (batch 1) - 526ms, 20 items
[  0.554s] 💾 DB #1: insert_batch ratings - 7ms, 20 items
    ratings batch 1: 20 docs in 546ms (total: 20)
[  0.563s] ℹ ratings: Progress: 20 documents synced so far...
[  3.704s] ✓ API #2: ...983@planet.learning.ole.org:443/db/tasks/_all_docs (batch 1) - 3.68s, 71 items
[  3.721s] 💾 DB #2: insert_batch tasks - 14ms, 71 items
    tasks batch 1: 71 docs in 3708ms (total: 71)
  ✓ Completed tasks sync: 71 docs in 3708ms
[  3.728s] ✓ tasks_sync completed: 3.71s
[  8.613s] ✓ API #3: ...@planet.learning.ole.org:443/db/feedback/_all_docs (batch 1) - 8.60s, 194 items
[  8.658s] 💾 DB #3: insert_batch feedback - 45ms, 194 items
    feedback batch 1: 194 docs in 8641ms (total: 194)
  ✓ Completed feedback sync: 194 docs in 8641ms
[  8.658s] ✓ feedback_sync completed: 8.64s
[ 12.188s] ✓ API #4: ...learning.ole.org:443/db/courses_progress/_all_docs (batch 1) - 12.17s, 1000 items
[ 12.196s] ✓ API #5: ...1983@planet.learning.ole.org:443/db/tags/_all_docs (batch 1) - 12.18s, 25 items
[ 12.271s] 💾 DB #4: insert_batch courses_progress - 81ms, 1000 items
    courses_progress batch 1: 1000 docs in 12267ms (total: 1000)
[ 12.291s] 💾 DB #5: insert_batch tags - 6ms, 25 items
    tags batch 1: 25 docs in 12281ms (total: 25)
  ✓ Completed tags sync: 25 docs in 12281ms
[ 12.299s] ✓ tags_sync completed: 12.28s
[ 12.732s] ✓ API #6: ...1983@planet.learning.ole.org:443/db/news/_all_docs (batch 1) - 12.72s, 519 items
[ 12.901s] 💾 DB #6: insert_batch news - 169ms, 519 items
    news batch 1: 519 docs in 12884ms (total: 519)
  ✓ Completed news sync: 519 docs in 12884ms
[ 12.901s] ✓ news_sync completed: 12.89s
[ 13.407s] ✓ API #7: ...learning.ole.org:443/db/login_activities/_all_docs (batch 1) - 13.39s, 1000 items
[ 13.601s] ✓ API #8: ...anet.learning.ole.org:443/db/submissions/_all_docs (batch 1) - 13.58s, 100 items
[ 13.628s] ✓ API #9: ...net.learning.ole.org:443/db/achievements/_all_docs (batch 1) - 13.61s, 6 items
[ 13.720s] 💾 DB #7: insert_batch submissions - 114ms, 100 items
    submissions batch 1: 100 docs in 13715ms (total: 100)
[ 13.732s] ℹ submissions: Progress: 100 documents synced so far...
[ 13.740s] 💾 DB #8: insert_batch achievements - 2ms, 6 items
    achievements batch 1: 6 docs in 13728ms (total: 6)
  ✓ Completed achievements sync: 6 docs in 13728ms
[ 13.745s] ✓ achievements_sync completed: 13.73s
[ 14.512s] ✓ API #10: ...83@planet.learning.ole.org:443/db/health/_all_docs (batch 1) - 14.49s, 78 items
[ 14.525s] 💾 DB #9: insert_batch health - 7ms, 78 items
    health batch 1: 78 docs in 14510ms (total: 78)
  ✓ Completed health sync: 78 docs in 14510ms
[ 14.531s] ✓ health_sync completed: 14.51s
[ 15.592s] ✓ API #11: ...983@planet.learning.ole.org:443/db/exams/_all_docs (batch 1) - 15.57s, 184 items
[ 15.706s] 💾 DB #10: insert_batch exams - 110ms, 184 items
    exams batch 1: 184 docs in 15699ms (total: 184)
  ✓ Completed exams sync: 184 docs in 15700ms
[ 15.718s] ✓ exams_sync completed: 15.70s
[ 17.014s] ✓ API #12: ....learning.ole.org:443/db/team_activities/_all_docs (batch 1) - 16.98s, 1000 items
[ 17.079s] 💾 DB #11: insert_batch team_activities - 65ms, 1000 items
    team_activities batch 1: 1000 docs in 17045ms (total: 1000)
[ 18.075s] 💾 DB #12: insert_batch login_activities - 4.67s, 1000 items
    login_activities batch 1: 1000 docs in 18056ms (total: 1000)
[ 18.572s] ✓ API #13: ...t.learning.ole.org:443/db/certifications/_all_docs (batch 1) - 18.53s, 1 items
[ 18.574s] 💾 DB #13: insert_batch certifications - 0ms, 1 items
    certifications batch 1: 1 docs in 18546ms (total: 1)
  ✓ Completed certifications sync: 1 docs in 18550ms
[ 18.584s] ✓ certifications_sync completed: 18.55s
[ 18.908s] ✓ API #14: ...net.learning.ole.org:443/db/tablet_users/_all_docs (batch 1) - 18.87s, 618 items
[ 19.006s] 💾 DB #14: insert_batch tablet_users - 96ms, 618 items
    tablet_users batch 1: 618 docs in 18977ms (total: 618)
  ✓ Completed tablet_users sync: 618 docs in 18978ms
[ 19.017s] ✓ tablet_users_sync completed: 19.00s
[ 23.497s] ✓ API #15: ...3@planet.learning.ole.org:443/db/meetups/_all_docs (batch 1) - 23.45s, 84 items
[ 23.508s] 💾 DB #15: insert_batch meetups - 9ms, 84 items
    meetups batch 1: 84 docs in 23475ms (total: 84)
  ✓ Completed meetups sync: 84 docs in 23475ms
[ 23.518s] ✓ meetups_sync completed: 23.48s
[ 29.356s] ✓ API #16: ...983@planet.learning.ole.org:443/db/teams/_all_docs (batch 1) - 29.31s, 1000 items
[ 29.462s] ✓ API #17: ...3@planet.learning.ole.org:443/db/courses/_all_docs (batch 1) - 29.42s, 21 items
[ 30.253s] ✓ API #18: ...et.learning.ole.org:443/db/notifications/_all_docs (batch 1) - 30.21s, 1000 items
[ 30.606s] 💾 DB #16: insert_batch teams - 1.25s, 1000 items
    teams batch 1: 1000 docs in 30578ms (total: 1000)
    courses insertDuration: 106ms for 21 items
[ 30.726s] 💾 DB #17: insert_batch courses - 106ms, 21 items
    courses batch 1: 21 docs in 30707ms (total: 21)
  ✓ Completed courses sync: 21 docs in 30707ms
[ 30.751s] ✓ courses_sync completed: 30.71s
[ 30.816s] 💾 DB #18: insert_batch notifications - 64ms, 1000 items
    notifications batch 1: 1000 docs in 30777ms (total: 1000)
[ 34.940s] ✓ API #19: ...net.learning.ole.org:443/db/chat_history/_all_docs (batch 1) - 34.91s, 1000 items
[ 35.084s] 💾 DB #19: insert_batch chat_history - 138ms, 1000 items
[ 35.220s] 💾 DB #20: insert_batch chat_history - 279ms, 1000 items
    chat_history batch 1: 1000 docs in 35186ms (total: 1000)
[ 38.265s] ✓ API #20: ....learning.ole.org:443/db/team_activities/_all_docs (batch 2) - 21.19s, 1000 items
[ 38.334s] 💾 DB #21: insert_batch team_activities - 69ms, 1000 items
    team_activities batch 2: 1000 docs in 21255ms (total: 2000)
[ 41.235s] ✓ API #21: ...learning.ole.org:443/db/login_activities/_all_docs (batch 2) - 23.16s, 1000 items
[ 44.023s] ✓ API #22: ...983@planet.learning.ole.org:443/db/teams/_all_docs (batch 2) - 13.40s, 239 items
[ 44.372s] 💾 DB #22: insert_batch teams - 345ms, 239 items
    teams batch 2: 239 docs in 13765ms (total: 1239)
  ✓ Completed teams sync: 1239 docs in 44343ms
[ 44.385s] ✓ teams_sync completed: 44.34s
[ 45.768s] 💾 DB #23: insert_batch login_activities - 4.53s, 1000 items
    login_activities batch 2: 1000 docs in 27692ms (total: 2000)
[ 68.169s] ✓ API #23: ...et.learning.ole.org:443/db/notifications/_all_docs (batch 2) - 37.35s, 1000 items
[ 68.315s] 💾 DB #24: insert_batch notifications - 143ms, 1000 items
    notifications batch 2: 1000 docs in 37504ms (total: 2000)
[ 74.187s] ✓ API #24: ....learning.ole.org:443/db/team_activities/_all_docs (batch 3) - 35.85s, 1000 items
[ 74.269s] 💾 DB #25: insert_batch team_activities - 82ms, 1000 items
    team_activities batch 3: 1000 docs in 35935ms (total: 3000)
[ 83.317s] ✓ API #25: ...learning.ole.org:443/db/login_activities/_all_docs (batch 3) - 37.55s, 1000 items
[ 87.258s] 💾 DB #26: insert_batch login_activities - 3.94s, 1000 items
    login_activities batch 3: 1000 docs in 41490ms (total: 3000)
[ 94.169s] ✓ API #26: ...et.learning.ole.org:443/db/notifications/_all_docs (batch 3) - 25.84s, 503 items
[ 94.200s] 💾 DB #27: insert_batch notifications - 30ms, 503 items
    notifications batch 3: 503 docs in 25885ms (total: 2503)
  ✓ Completed notifications sync: 2503 docs in 94166ms
[ 94.210s] ✓ notifications_sync completed: 1m 34.166s
[127.107s] ✓ API #27: ...learning.ole.org:443/db/courses_progress/_all_docs (batch 2) - 1m 54.821s, 1000 items
[127.160s] 💾 DB #28: insert_batch courses_progress - 50ms, 1000 items
    courses_progress batch 2: 1000 docs in 114887ms (total: 2000)
[131.287s] ✓ API #28: ....learning.ole.org:443/db/team_activities/_all_docs (batch 4) - 57.02s, 1000 items
[131.356s] 💾 DB #29: insert_batch team_activities - 69ms, 1000 items
    team_activities batch 4: 1000 docs in 57088ms (total: 4000)
[134.550s] ✓ API #29: ...learning.ole.org:443/db/login_activities/_all_docs (batch 4) - 47.29s, 1000 items
[136.687s] ✓ API #30: ...learning.ole.org:443/db/courses_progress/_all_docs (batch 3) - 9.52s, 1000 items
[136.730s] 💾 DB #30: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 3: 1000 docs in 9566ms (total: 3000)
[138.250s] ✓ API #31: ....learning.ole.org:443/db/team_activities/_all_docs (batch 5) - 6.89s, 1000 items
[138.324s] 💾 DB #31: insert_batch team_activities - 74ms, 1000 items
    team_activities batch 5: 1000 docs in 6967ms (total: 5000)
[139.124s] 💾 DB #32: insert_batch login_activities - 4.57s, 1000 items
    login_activities batch 4: 1000 docs in 51866ms (total: 4000)
[139.723s] ✓ API #32: ...learning.ole.org:443/db/courses_progress/_all_docs (batch 4) - 2.99s, 1000 items
[139.777s] 💾 DB #33: insert_batch courses_progress - 51ms, 1000 items
    courses_progress batch 4: 1000 docs in 3048ms (total: 4000)
[143.547s] ✓ API #33: ...learning.ole.org:443/db/login_activities/_all_docs (batch 5) - 4.42s, 1000 items
[147.959s] 💾 DB #34: insert_batch login_activities - 4.41s, 1000 items
    login_activities batch 5: 1000 docs in 8835ms (total: 5000)
[161.955s] ✓ API #34: ....learning.ole.org:443/db/team_activities/_all_docs (batch 6) - 23.63s, 1000 items
[162.037s] 💾 DB #35: insert_batch team_activities - 81ms, 1000 items
    team_activities batch 6: 1000 docs in 23713ms (total: 6000)
[165.267s] ✓ API #35: ...learning.ole.org:443/db/login_activities/_all_docs (batch 6) - 17.31s, 1000 items
[165.960s] ✓ API #36: ...net.learning.ole.org:443/db/chat_history/_all_docs (batch 2) - 2m 10.739s, 518 items
[166.014s] 💾 DB #36: insert_batch chat_history - 48ms, 518 items
[166.091s] 💾 DB #37: insert_batch chat_history - 131ms, 518 items
    chat_history batch 2: 518 docs in 130870ms (total: 1518)
  ✓ Completed chat_history sync: 1518 docs in 166056ms
[166.091s] ✓ chat_history_sync completed: 2m 46.57s
[169.809s] 💾 DB #38: insert_batch login_activities - 4.54s, 1000 items
    login_activities batch 6: 1000 docs in 21850ms (total: 6000)
[174.319s] ✓ API #37: ...learning.ole.org:443/db/login_activities/_all_docs (batch 7) - 4.51s, 1000 items
[178.595s] 💾 DB #39: insert_batch login_activities - 4.28s, 1000 items
    login_activities batch 7: 1000 docs in 8786ms (total: 7000)
[192.464s] ✓ API #38: ...learning.ole.org:443/db/login_activities/_all_docs (batch 8) - 13.87s, 1000 items
[196.847s] 💾 DB #40: insert_batch login_activities - 4.38s, 1000 items
    login_activities batch 8: 1000 docs in 18252ms (total: 8000)
[209.974s] ✓ API #39: ...anet.learning.ole.org:443/db/submissions/_all_docs (batch 2) - 3m 16.242s, 100 items
[210.040s] 💾 DB #41: insert_batch submissions - 64ms, 100 items
    submissions batch 2: 100 docs in 196318ms (total: 200)
[210.051s] ℹ submissions: Progress: 200 documents synced so far...
[216.414s] ✓ API #40: ...anet.learning.ole.org:443/db/submissions/_all_docs (batch 3) - 6.36s, 100 items
[216.463s] 💾 DB #42: insert_batch submissions - 47ms, 100 items
    submissions batch 3: 100 docs in 6420ms (total: 300)
[216.471s] ℹ submissions: Progress: 300 documents synced so far...
[222.417s] ✓ API #41: ...anet.learning.ole.org:443/db/submissions/_all_docs (batch 4) - 5.94s, 100 items
[222.489s] 💾 DB #43: insert_batch submissions - 58ms, 100 items
    submissions batch 4: 100 docs in 6039ms (total: 400)
[222.510s] ℹ submissions: Progress: 400 documents synced so far...
[229.677s] ✓ API #42: ...anet.learning.ole.org:443/db/submissions/_all_docs (batch 5) - 7.17s, 100 items
[229.737s] 💾 DB #44: insert_batch submissions - 55ms, 100 items
    submissions batch 5: 100 docs in 7238ms (total: 500)
[229.748s] ℹ submissions: Progress: 500 documents synced so far...
[260.679s] ✓ API #43: ...learning.ole.org:443/db/courses_progress/_all_docs (batch 5) - 2m 0.892s, 1000 items
[260.737s] 💾 DB #45: insert_batch courses_progress - 54ms, 1000 items
    courses_progress batch 5: 1000 docs in 120964ms (total: 5000)
[264.030s] ✓ API #44: ...learning.ole.org:443/db/courses_progress/_all_docs (batch 6) - 3.28s, 1000 items
[264.073s] 💾 DB #46: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 6: 1000 docs in 3335ms (total: 6000)
[269.600s] ✓ API #45: ...learning.ole.org:443/db/courses_progress/_all_docs (batch 7) - 5.51s, 1000 items
[269.642s] 💾 DB #47: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 7: 1000 docs in 5568ms (total: 7000)
[273.711s] ✓ API #46: ...learning.ole.org:443/db/courses_progress/_all_docs (batch 8) - 4.06s, 1000 items
[273.755s] 💾 DB #48: insert_batch courses_progress - 42ms, 1000 items
    courses_progress batch 8: 1000 docs in 4111ms (total: 8000)
[277.404s] ✓ API #47: ...learning.ole.org:443/db/courses_progress/_all_docs (batch 9) - 3.64s, 1000 items
[277.454s] 💾 DB #49: insert_batch courses_progress - 48ms, 1000 items
    courses_progress batch 9: 1000 docs in 3699ms (total: 9000)
[279.402s] ✓ API #48: ....learning.ole.org:443/db/team_activities/_all_docs (batch 7) - 1m 57.364s, 1000 items
[279.487s] 💾 DB #50: insert_batch team_activities - 84ms, 1000 items
    team_activities batch 7: 1000 docs in 117449ms (total: 7000)
[281.451s] ✓ API #49: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 10) - 3.99s, 1000 items
[281.496s] 💾 DB #51: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 10: 1000 docs in 4043ms (total: 10000)
[286.139s] ✓ API #50: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 11) - 4.63s, 1000 items
[286.187s] 💾 DB #52: insert_batch courses_progress - 45ms, 1000 items
    courses_progress batch 11: 1000 docs in 4692ms (total: 11000)
[291.423s] ✓ API #51: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 12) - 5.22s, 1000 items
[291.468s] 💾 DB #53: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 12: 1000 docs in 5282ms (total: 12000)
[296.417s] ✓ API #52: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 13) - 4.94s, 1000 items
[296.462s] 💾 DB #54: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 13: 1000 docs in 4990ms (total: 13000)
[297.575s] ✓ API #53: ...learning.ole.org:443/db/login_activities/_all_docs (batch 9) - 1m 40.728s, 1000 items
[301.108s] ✓ API #54: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 14) - 4.64s, 1000 items
[301.151s] 💾 DB #55: insert_batch courses_progress - 37ms, 1000 items
    courses_progress batch 14: 1000 docs in 4686ms (total: 14000)
[301.904s] 💾 DB #56: insert_batch login_activities - 4.33s, 1000 items
    login_activities batch 9: 1000 docs in 105057ms (total: 9000)
[302.316s] ✓ API #55: ....learning.ole.org:443/db/team_activities/_all_docs (batch 8) - 22.83s, 1000 items
[302.427s] 💾 DB #57: insert_batch team_activities - 110ms, 1000 items
    team_activities batch 8: 1000 docs in 22940ms (total: 8000)
[306.840s] ✓ API #56: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 15) - 5.68s, 1000 items
[306.884s] 💾 DB #58: insert_batch courses_progress - 42ms, 1000 items
    courses_progress batch 15: 1000 docs in 5735ms (total: 15000)
[307.469s] ✓ API #57: ...earning.ole.org:443/db/login_activities/_all_docs (batch 10) - 5.57s, 1000 items
[310.898s] ✓ API #58: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 16) - 4.01s, 1000 items
[310.949s] 💾 DB #59: insert_batch courses_progress - 44ms, 1000 items
    courses_progress batch 16: 1000 docs in 4063ms (total: 16000)
[311.920s] 💾 DB #60: insert_batch login_activities - 4.45s, 1000 items
    login_activities batch 10: 1000 docs in 10016ms (total: 10000)
[316.541s] ✓ API #59: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 17) - 5.58s, 1000 items
[316.594s] 💾 DB #61: insert_batch courses_progress - 50ms, 1000 items
    courses_progress batch 17: 1000 docs in 5660ms (total: 17000)
[317.634s] ✓ API #60: ...earning.ole.org:443/db/login_activities/_all_docs (batch 11) - 5.71s, 1000 items
[322.088s] 💾 DB #62: insert_batch login_activities - 4.45s, 1000 items
    login_activities batch 11: 1000 docs in 10168ms (total: 11000)
[324.250s] ✓ API #61: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 18) - 7.63s, 1000 items
[324.293s] 💾 DB #63: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 18: 1000 docs in 7688ms (total: 18000)
[328.554s] ✓ API #62: ....learning.ole.org:443/db/team_activities/_all_docs (batch 9) - 26.13s, 1000 items
[328.670s] 💾 DB #64: insert_batch team_activities - 116ms, 1000 items
    team_activities batch 9: 1000 docs in 26243ms (total: 9000)
[329.608s] ✓ API #63: ...earning.ole.org:443/db/login_activities/_all_docs (batch 12) - 7.52s, 1000 items
[329.793s] ✓ API #64: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 19) - 5.49s, 1000 items
[329.842s] 💾 DB #65: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 19: 1000 docs in 5546ms (total: 19000)
[334.005s] 💾 DB #66: insert_batch login_activities - 4.40s, 1000 items
    login_activities batch 12: 1000 docs in 11917ms (total: 12000)
[336.186s] ✓ API #65: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 20) - 6.34s, 1000 items
[336.227s] 💾 DB #67: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 20: 1000 docs in 6388ms (total: 20000)
[347.480s] ✓ API #66: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 21) - 11.24s, 1000 items
[347.532s] 💾 DB #68: insert_batch courses_progress - 50ms, 1000 items
    courses_progress batch 21: 1000 docs in 11301ms (total: 21000)
[350.443s] ✓ API #67: ...earning.ole.org:443/db/login_activities/_all_docs (batch 13) - 16.44s, 1000 items
[354.204s] ✓ API #68: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 22) - 6.66s, 1000 items
[354.251s] 💾 DB #69: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 22: 1000 docs in 6718ms (total: 22000)
[355.153s] 💾 DB #70: insert_batch login_activities - 4.71s, 1000 items
    login_activities batch 13: 1000 docs in 21148ms (total: 13000)
[358.512s] ✓ API #69: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 23) - 4.25s, 1000 items
[358.564s] 💾 DB #71: insert_batch courses_progress - 47ms, 1000 items
    courses_progress batch 23: 1000 docs in 4315ms (total: 23000)
[359.208s] ✓ API #70: ...learning.ole.org:443/db/team_activities/_all_docs (batch 10) - 30.54s, 1000 items
[359.234s] ✓ API #71: ...earning.ole.org:443/db/login_activities/_all_docs (batch 14) - 4.08s, 1000 items
[359.313s] 💾 DB #72: insert_batch team_activities - 105ms, 1000 items
    team_activities batch 10: 1000 docs in 30644ms (total: 10000)
[362.980s] ✓ API #72: ...learning.ole.org:443/db/team_activities/_all_docs (batch 11) - 3.67s, 475 items
[363.035s] 💾 DB #73: insert_batch team_activities - 54ms, 475 items
    team_activities batch 11: 475 docs in 3721ms (total: 10475)
  ✓ Completed team_activities sync: 10475 docs in 363001ms
[363.035s] ✓ team_activities_sync completed: 6m 3.1s
[363.274s] ✓ API #73: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 24) - 4.70s, 1000 items
[363.315s] 💾 DB #74: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 24: 1000 docs in 4748ms (total: 24000)
[364.097s] 💾 DB #75: insert_batch login_activities - 4.86s, 1000 items
    login_activities batch 14: 1000 docs in 8944ms (total: 14000)
[369.354s] ✓ API #74: ...earning.ole.org:443/db/login_activities/_all_docs (batch 15) - 5.26s, 1000 items
[370.456s] ✓ API #75: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 25) - 7.13s, 1000 items
[370.494s] 💾 DB #76: insert_batch courses_progress - 35ms, 1000 items
    courses_progress batch 25: 1000 docs in 7178ms (total: 25000)
[373.902s] 💾 DB #77: insert_batch login_activities - 4.55s, 1000 items
    login_activities batch 15: 1000 docs in 9805ms (total: 15000)
[378.397s] ✓ API #76: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 26) - 7.90s, 1000 items
[378.441s] 💾 DB #78: insert_batch courses_progress - 42ms, 1000 items
    courses_progress batch 26: 1000 docs in 7953ms (total: 26000)
[383.788s] ✓ API #77: ...earning.ole.org:443/db/login_activities/_all_docs (batch 16) - 9.89s, 399 items
[385.451s] 💾 DB #79: insert_batch login_activities - 1.66s, 399 items
    login_activities batch 16: 399 docs in 11549ms (total: 15399)
  ✓ Completed login_activities sync: 15399 docs in 385431ms
[385.451s] ✓ login_activities_sync completed: 6m 25.432s
[388.766s] ✓ API #78: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 27) - 10.31s, 1000 items
[388.808s] 💾 DB #80: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 27: 1000 docs in 10369ms (total: 27000)
[394.430s] ✓ API #79: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 28) - 5.61s, 1000 items
[394.470s] 💾 DB #81: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 28: 1000 docs in 5663ms (total: 28000)
[398.892s] ✓ API #80: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 29) - 4.41s, 1000 items
[398.934s] 💾 DB #82: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 29: 1000 docs in 4459ms (total: 29000)
[404.949s] ✓ API #81: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 30) - 6.00s, 1000 items
[404.994s] 💾 DB #83: insert_batch courses_progress - 42ms, 1000 items
    courses_progress batch 30: 1000 docs in 6061ms (total: 30000)
[410.452s] ✓ API #82: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 31) - 5.45s, 1000 items
[410.497s] 💾 DB #84: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 31: 1000 docs in 5500ms (total: 31000)
[418.708s] ✓ API #83: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 32) - 8.20s, 1000 items
[418.752s] 💾 DB #85: insert_batch courses_progress - 42ms, 1000 items
    courses_progress batch 32: 1000 docs in 8252ms (total: 32000)
[429.037s] ✓ API #84: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 33) - 10.28s, 1000 items
[429.084s] 💾 DB #86: insert_batch courses_progress - 44ms, 1000 items
    courses_progress batch 33: 1000 docs in 10332ms (total: 33000)
[437.613s] ✓ API #85: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 34) - 8.52s, 1000 items
[437.656s] 💾 DB #87: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 34: 1000 docs in 8577ms (total: 34000)
[444.172s] ✓ API #86: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 35) - 6.50s, 1000 items
[444.215s] 💾 DB #88: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 35: 1000 docs in 6559ms (total: 35000)
[447.700s] ✓ API #87: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 36) - 3.47s, 1000 items
[447.741s] 💾 DB #89: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 36: 1000 docs in 3522ms (total: 36000)
[451.643s] ✓ API #88: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 37) - 3.89s, 1000 items
[451.693s] 💾 DB #90: insert_batch courses_progress - 47ms, 1000 items
    courses_progress batch 37: 1000 docs in 3963ms (total: 37000)
[456.192s] ✓ API #89: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 38) - 4.48s, 1000 items
[456.238s] 💾 DB #91: insert_batch courses_progress - 44ms, 1000 items
    courses_progress batch 38: 1000 docs in 4537ms (total: 38000)
[463.540s] ✓ API #90: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 39) - 7.29s, 1000 items
[463.588s] 💾 DB #92: insert_batch courses_progress - 45ms, 1000 items
    courses_progress batch 39: 1000 docs in 7350ms (total: 39000)
[472.560s] ✓ API #91: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 40) - 8.96s, 1000 items
[472.605s] 💾 DB #93: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 40: 1000 docs in 9019ms (total: 40000)
[483.234s] ✓ API #92: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 41) - 10.61s, 1000 items
[483.275s] 💾 DB #94: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 41: 1000 docs in 10672ms (total: 41000)
[491.634s] ✓ API #93: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 42) - 8.34s, 1000 items
[491.687s] 💾 DB #95: insert_batch courses_progress - 50ms, 1000 items
    courses_progress batch 42: 1000 docs in 8407ms (total: 42000)
[502.707s] ✓ API #94: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 43) - 11.01s, 1000 items
[502.755s] 💾 DB #96: insert_batch courses_progress - 45ms, 1000 items
    courses_progress batch 43: 1000 docs in 11067ms (total: 43000)
[512.695s] ✓ API #95: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 44) - 9.93s, 1000 items
[512.736s] 💾 DB #97: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 44: 1000 docs in 9982ms (total: 44000)
[532.577s] ✓ API #96: ...anet.learning.ole.org:443/db/submissions/_all_docs (batch 6) - 5m 2.828s, 100 items
[535.014s] 💾 DB #98: insert_batch submissions - 2.43s, 100 items
    submissions batch 6: 100 docs in 305424ms (total: 600)
[535.172s] ℹ submissions: Progress: 600 documents synced so far...
[541.718s] ✓ API #97: ...anet.learning.ole.org:443/db/submissions/_all_docs (batch 7) - 6.55s, 100 items
[541.772s] 💾 DB #99: insert_batch submissions - 51ms, 100 items
    submissions batch 7: 100 docs in 6615ms (total: 700)
[541.787s] ℹ submissions: Progress: 700 documents synced so far...
[608.222s] ✓ API #98: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 45) - 1m 35.471s, 1000 items
[608.511s] 💾 DB #100: insert_batch courses_progress - 266ms, 1000 items
    courses_progress batch 45: 1000 docs in 95773ms (total: 45000)
[615.493s] ✓ API #99: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 46) - 6.97s, 1000 items
[615.556s] 💾 DB #101: insert_batch courses_progress - 52ms, 1000 items
    courses_progress batch 46: 1000 docs in 7047ms (total: 46000)
[623.166s] ✓ API #100: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 47) - 7.60s, 1000 items
[623.213s] 💾 DB #102: insert_batch courses_progress - 44ms, 1000 items
    courses_progress batch 47: 1000 docs in 7652ms (total: 47000)
[625.238s] ✓ API #101: ...3@planet.learning.ole.org:443/db/ratings/_all_docs (batch 2) - 10m 24.675s, 20 items
[625.814s] ✓ API #102: ...anet.learning.ole.org:443/db/submissions/_all_docs (batch 8) - 1m 24.27s, 100 items
[626.765s] 💾 DB #103: insert_batch ratings - 1.53s, 20 items
    ratings batch 2: 20 docs in 626319ms (total: 40)
[626.883s] ℹ ratings: Progress: 40 documents synced so far...
[626.935s] 💾 DB #104: insert_batch submissions - 53ms, 100 items
    submissions batch 8: 100 docs in 85157ms (total: 800)
[626.944s] ℹ submissions: Progress: 800 documents synced so far...
[628.280s] ✓ API #103: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 48) - 5.06s, 1000 items
[628.419s] 💾 DB #105: insert_batch courses_progress - 114ms, 1000 items
    courses_progress batch 48: 1000 docs in 5204ms (total: 48000)
[628.562s] ✓ API #104: ...3@planet.learning.ole.org:443/db/ratings/_all_docs (batch 3) - 1.68s, 20 items
[628.567s] 💾 DB #106: insert_batch ratings - 3ms, 20 items
    ratings batch 3: 20 docs in 1691ms (total: 60)
[628.574s] ℹ ratings: Progress: 60 documents synced so far...
[631.009s] ✓ API #105: ...anet.learning.ole.org:443/db/submissions/_all_docs (batch 9) - 4.06s, 100 items
[631.069s] 💾 DB #107: insert_batch submissions - 57ms, 100 items
    submissions batch 9: 100 docs in 4135ms (total: 900)
[631.080s] ℹ submissions: Progress: 900 documents synced so far...
[631.094s] ✓ API #106: ...3@planet.learning.ole.org:443/db/ratings/_all_docs (batch 4) - 2.52s, 20 items
[631.100s] 💾 DB #108: insert_batch ratings - 2ms, 20 items
    ratings batch 4: 20 docs in 2532ms (total: 80)
[631.106s] ℹ ratings: Progress: 80 documents synced so far...
[633.203s] ✓ API #107: ...3@planet.learning.ole.org:443/db/ratings/_all_docs (batch 5) - 2.10s, 8 items
[633.206s] 💾 DB #109: insert_batch ratings - 1ms, 8 items
    ratings batch 5: 8 docs in 2110ms (total: 88)
[633.216s] ℹ ratings: Progress: 88 documents synced so far...
  ✓ Completed ratings sync: 88 docs in 633200ms
[633.217s] ✓ ratings_sync completed: 10m 33.201s
[637.226s] ✓ API #108: ...net.learning.ole.org:443/db/submissions/_all_docs (batch 10) - 6.15s, 100 items
[637.300s] 💾 DB #110: insert_batch submissions - 70ms, 100 items
    submissions batch 10: 100 docs in 6233ms (total: 1000)
[637.313s] ℹ submissions: Progress: 1000 documents synced so far...
[639.311s] ✓ API #109: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 49) - 10.89s, 1000 items
[639.355s] 💾 DB #111: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 49: 1000 docs in 10938ms (total: 49000)
[640.394s] ✓ API #110: ...net.learning.ole.org:443/db/submissions/_all_docs (batch 11) - 3.08s, 100 items
[640.424s] 💾 DB #112: insert_batch submissions - 28ms, 100 items
    submissions batch 11: 100 docs in 3121ms (total: 1100)
[640.434s] ℹ submissions: Progress: 1100 documents synced so far...
[644.386s] ✓ API #111: ...net.learning.ole.org:443/db/submissions/_all_docs (batch 12) - 3.95s, 100 items
[644.429s] 💾 DB #113: insert_batch submissions - 42ms, 100 items
    submissions batch 12: 100 docs in 4003ms (total: 1200)
[644.440s] ℹ submissions: Progress: 1200 documents synced so far...
[648.429s] ✓ API #112: ...net.learning.ole.org:443/db/submissions/_all_docs (batch 13) - 3.99s, 100 items
[648.471s] 💾 DB #114: insert_batch submissions - 39ms, 100 items
    submissions batch 13: 100 docs in 4042ms (total: 1300)
[648.482s] ℹ submissions: Progress: 1300 documents synced so far...
[648.486s] ✓ API #113: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 50) - 9.12s, 1000 items
[648.544s] 💾 DB #115: insert_batch courses_progress - 56ms, 1000 items
    courses_progress batch 50: 1000 docs in 9190ms (total: 50000)
[651.912s] ✓ API #114: ...net.learning.ole.org:443/db/submissions/_all_docs (batch 14) - 3.43s, 100 items
[651.948s] 💾 DB #116: insert_batch submissions - 34ms, 100 items
    submissions batch 14: 100 docs in 3473ms (total: 1400)
[651.955s] ℹ submissions: Progress: 1400 documents synced so far...
[655.275s] ✓ API #115: ...net.learning.ole.org:443/db/submissions/_all_docs (batch 15) - 3.32s, 100 items
[655.307s] 💾 DB #117: insert_batch submissions - 30ms, 100 items
    submissions batch 15: 100 docs in 3363ms (total: 1500)
[655.318s] ℹ submissions: Progress: 1500 documents synced so far...
  ↺ courses_progress batch 51 timeout (attempt 1/3), retrying...
[659.123s] ✓ API #116: ...net.learning.ole.org:443/db/submissions/_all_docs (batch 16) - 3.81s, 100 items
[659.181s] 💾 DB #118: insert_batch submissions - 54ms, 100 items
    submissions batch 16: 100 docs in 3875ms (total: 1600)
[659.193s] ℹ submissions: Progress: 1600 documents synced so far...
[663.126s] ✓ API #117: ...net.learning.ole.org:443/db/submissions/_all_docs (batch 17) - 3.93s, 100 items
[663.156s] 💾 DB #119: insert_batch submissions - 28ms, 100 items
    submissions batch 17: 100 docs in 3973ms (total: 1700)
[663.166s] ℹ submissions: Progress: 1700 documents synced so far...
[667.107s] ✓ API #118: ...net.learning.ole.org:443/db/submissions/_all_docs (batch 18) - 3.94s, 100 items
[667.150s] 💾 DB #120: insert_batch submissions - 37ms, 100 items
    submissions batch 18: 100 docs in 3991ms (total: 1800)
[667.157s] ℹ submissions: Progress: 1800 documents synced so far...
[668.079s] ✓ API #119: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 51) - 9.28s, 1000 items
[668.121s] 💾 DB #121: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 51: 1000 docs in 19574ms (total: 51000)
[671.900s] ✓ API #120: ...net.learning.ole.org:443/db/submissions/_all_docs (batch 19) - 4.74s, 82 items
[671.958s] 💾 DB #122: insert_batch submissions - 56ms, 82 items
    submissions batch 19: 82 docs in 4811ms (total: 1882)
[671.969s] ℹ submissions: Progress: 1882 documents synced so far...
  ✓ Completed submissions sync: 1882 docs in 671952ms
[671.969s] ✓ submissions_sync completed: 11m 11.953s
[674.560s] ✓ API #121: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 52) - 6.43s, 1000 items
[674.608s] 💾 DB #123: insert_batch courses_progress - 45ms, 1000 items
    courses_progress batch 52: 1000 docs in 6493ms (total: 52000)
[679.949s] ✓ API #122: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 53) - 5.33s, 1000 items
[680.009s] 💾 DB #124: insert_batch courses_progress - 56ms, 1000 items
    courses_progress batch 53: 1000 docs in 5400ms (total: 53000)
[687.951s] ✓ API #123: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 54) - 7.93s, 1000 items
[687.998s] 💾 DB #125: insert_batch courses_progress - 45ms, 1000 items
    courses_progress batch 54: 1000 docs in 7986ms (total: 54000)
[694.462s] ✓ API #124: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 55) - 6.46s, 1000 items
[694.504s] 💾 DB #126: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 55: 1000 docs in 6504ms (total: 55000)
[700.192s] ✓ API #125: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 56) - 5.68s, 1000 items
[700.237s] 💾 DB #127: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 56: 1000 docs in 5736ms (total: 56000)
[705.898s] ✓ API #126: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 57) - 5.65s, 1000 items
[705.945s] 💾 DB #128: insert_batch courses_progress - 45ms, 1000 items
    courses_progress batch 57: 1000 docs in 5708ms (total: 57000)
[711.984s] ✓ API #127: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 58) - 6.03s, 1000 items
[712.025s] 💾 DB #129: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 58: 1000 docs in 6080ms (total: 58000)
[717.913s] ✓ API #128: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 59) - 5.88s, 1000 items
[717.954s] 💾 DB #130: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 59: 1000 docs in 5928ms (total: 59000)
[723.880s] ✓ API #129: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 60) - 5.92s, 1000 items
[723.922s] 💾 DB #131: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 60: 1000 docs in 5966ms (total: 60000)
[730.273s] ✓ API #130: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 61) - 6.34s, 1000 items
[730.316s] 💾 DB #132: insert_batch courses_progress - 42ms, 1000 items
    courses_progress batch 61: 1000 docs in 6395ms (total: 61000)
[736.427s] ✓ API #131: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 62) - 6.10s, 1000 items
[736.469s] 💾 DB #133: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 62: 1000 docs in 6153ms (total: 62000)
[743.454s] ✓ API #132: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 63) - 6.98s, 1000 items
[743.492s] 💾 DB #134: insert_batch courses_progress - 37ms, 1000 items
    courses_progress batch 63: 1000 docs in 7025ms (total: 63000)
[750.551s] ✓ API #133: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 64) - 7.05s, 1000 items
[750.589s] 💾 DB #135: insert_batch courses_progress - 36ms, 1000 items
    courses_progress batch 64: 1000 docs in 7099ms (total: 64000)
[757.258s] ✓ API #134: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 65) - 6.66s, 1000 items
[757.298s] 💾 DB #136: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 65: 1000 docs in 6706ms (total: 65000)
[763.618s] ✓ API #135: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 66) - 6.31s, 1000 items
[763.675s] 💾 DB #137: insert_batch courses_progress - 53ms, 1000 items
    courses_progress batch 66: 1000 docs in 6379ms (total: 66000)
[769.706s] ✓ API #136: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 67) - 6.02s, 1000 items
[769.757s] 💾 DB #138: insert_batch courses_progress - 48ms, 1000 items
    courses_progress batch 67: 1000 docs in 6081ms (total: 67000)
[775.787s] ✓ API #137: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 68) - 6.02s, 1000 items
[775.843s] 💾 DB #139: insert_batch courses_progress - 54ms, 1000 items
    courses_progress batch 68: 1000 docs in 6085ms (total: 68000)
[781.915s] ✓ API #138: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 69) - 6.06s, 1000 items
[781.953s] 💾 DB #140: insert_batch courses_progress - 36ms, 1000 items
    courses_progress batch 69: 1000 docs in 6107ms (total: 69000)
[788.898s] ✓ API #139: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 70) - 6.94s, 1000 items
[788.938s] 💾 DB #141: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 70: 1000 docs in 6988ms (total: 70000)
[797.522s] ✓ API #140: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 71) - 8.57s, 1000 items
[797.561s] 💾 DB #142: insert_batch courses_progress - 37ms, 1000 items
    courses_progress batch 71: 1000 docs in 8623ms (total: 71000)
[806.992s] ✓ API #141: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 72) - 9.42s, 1000 items
[807.031s] 💾 DB #143: insert_batch courses_progress - 36ms, 1000 items
    courses_progress batch 72: 1000 docs in 9467ms (total: 72000)
[817.386s] ✓ API #142: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 73) - 10.35s, 1000 items
[817.430s] 💾 DB #144: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 73: 1000 docs in 10401ms (total: 73000)
[825.700s] ✓ API #143: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 74) - 8.26s, 1000 items
[825.741s] 💾 DB #145: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 74: 1000 docs in 8310ms (total: 74000)
[833.507s] ✓ API #144: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 75) - 7.76s, 1000 items
[833.548s] 💾 DB #146: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 75: 1000 docs in 7808ms (total: 75000)
[841.396s] ✓ API #145: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 76) - 7.84s, 1000 items
[841.459s] 💾 DB #147: insert_batch courses_progress - 55ms, 1000 items
    courses_progress batch 76: 1000 docs in 7922ms (total: 76000)
[849.341s] ✓ API #146: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 77) - 7.86s, 1000 items
[849.386s] 💾 DB #148: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 77: 1000 docs in 7915ms (total: 77000)
[857.151s] ✓ API #147: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 78) - 7.76s, 1000 items
[857.197s] 💾 DB #149: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 78: 1000 docs in 7816ms (total: 78000)
[864.573s] ✓ API #148: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 79) - 7.36s, 1000 items
[864.612s] 💾 DB #150: insert_batch courses_progress - 36ms, 1000 items
    courses_progress batch 79: 1000 docs in 7410ms (total: 79000)
[871.648s] ✓ API #149: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 80) - 7.03s, 1000 items
[871.694s] 💾 DB #151: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 80: 1000 docs in 7087ms (total: 80000)
[878.430s] ✓ API #150: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 81) - 6.72s, 1000 items
[878.490s] 💾 DB #152: insert_batch courses_progress - 58ms, 1000 items
    courses_progress batch 81: 1000 docs in 6813ms (total: 81000)
[885.360s] ✓ API #151: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 82) - 6.84s, 1000 items
[885.409s] 💾 DB #153: insert_batch courses_progress - 45ms, 1000 items
    courses_progress batch 82: 1000 docs in 6900ms (total: 82000)
[893.123s] ✓ API #152: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 83) - 7.70s, 1000 items
[893.172s] 💾 DB #154: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 83: 1000 docs in 7763ms (total: 83000)
[900.886s] ✓ API #153: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 84) - 7.70s, 1000 items
[900.938s] 💾 DB #155: insert_batch courses_progress - 48ms, 1000 items
    courses_progress batch 84: 1000 docs in 7765ms (total: 84000)
[908.882s] ✓ API #154: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 85) - 7.93s, 1000 items
[908.922s] 💾 DB #156: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 85: 1000 docs in 7982ms (total: 85000)
[916.830s] ✓ API #155: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 86) - 7.90s, 1000 items
[916.868s] 💾 DB #157: insert_batch courses_progress - 36ms, 1000 items
    courses_progress batch 86: 1000 docs in 7947ms (total: 86000)
[925.509s] ✓ API #156: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 87) - 8.63s, 1000 items
[925.558s] 💾 DB #158: insert_batch courses_progress - 44ms, 1000 items
    courses_progress batch 87: 1000 docs in 8687ms (total: 87000)
[934.366s] ✓ API #157: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 88) - 8.80s, 1000 items
[934.413s] 💾 DB #159: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 88: 1000 docs in 8855ms (total: 88000)
[942.420s] ✓ API #158: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 89) - 8.00s, 1000 items
[942.458s] 💾 DB #160: insert_batch courses_progress - 36ms, 1000 items
    courses_progress batch 89: 1000 docs in 8045ms (total: 89000)
[950.084s] ✓ API #159: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 90) - 7.62s, 1000 items
[950.130s] 💾 DB #161: insert_batch courses_progress - 44ms, 1000 items
    courses_progress batch 90: 1000 docs in 7674ms (total: 90000)
[957.742s] ✓ API #160: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 91) - 7.60s, 1000 items
[957.778s] 💾 DB #162: insert_batch courses_progress - 34ms, 1000 items
    courses_progress batch 91: 1000 docs in 7645ms (total: 91000)
[965.798s] ✓ API #161: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 92) - 8.01s, 1000 items
[965.834s] 💾 DB #163: insert_batch courses_progress - 33ms, 1000 items
    courses_progress batch 92: 1000 docs in 8052ms (total: 92000)
[973.805s] ✓ API #162: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 93) - 7.97s, 1000 items
[973.847s] 💾 DB #164: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 93: 1000 docs in 8017ms (total: 93000)
[982.185s] ✓ API #163: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 94) - 8.33s, 1000 items
[982.233s] 💾 DB #165: insert_batch courses_progress - 46ms, 1000 items
    courses_progress batch 94: 1000 docs in 8386ms (total: 94000)
[990.473s] ✓ API #164: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 95) - 8.23s, 1000 items
[990.509s] 💾 DB #166: insert_batch courses_progress - 34ms, 1000 items
    courses_progress batch 95: 1000 docs in 8277ms (total: 95000)
[998.584s] ✓ API #165: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 96) - 8.06s, 1000 items
[998.628s] 💾 DB #167: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 96: 1000 docs in 8118ms (total: 96000)
[1006.827s] ✓ API #166: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 97) - 8.19s, 1000 items
[1006.865s] 💾 DB #168: insert_batch courses_progress - 36ms, 1000 items
    courses_progress batch 97: 1000 docs in 8242ms (total: 97000)
[1014.990s] ✓ API #167: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 98) - 8.11s, 1000 items
[1015.033s] 💾 DB #169: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 98: 1000 docs in 8162ms (total: 98000)
[1023.073s] ✓ API #168: ...earning.ole.org:443/db/courses_progress/_all_docs (batch 99) - 8.03s, 1000 items
[1023.120s] 💾 DB #170: insert_batch courses_progress - 45ms, 1000 items
    courses_progress batch 99: 1000 docs in 8084ms (total: 99000)
[1032.385s] ✓ API #169: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 100) - 9.26s, 1000 items
[1032.425s] 💾 DB #171: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 100: 1000 docs in 9309ms (total: 100000)
[1042.021s] ✓ API #170: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 101) - 9.59s, 1000 items
[1042.067s] 💾 DB #172: insert_batch courses_progress - 44ms, 1000 items
    courses_progress batch 101: 1000 docs in 9640ms (total: 101000)
[1051.401s] ✓ API #171: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 102) - 9.33s, 1000 items
[1051.446s] 💾 DB #173: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 102: 1000 docs in 9383ms (total: 102000)
[1060.979s] ✓ API #172: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 103) - 9.52s, 1000 items
[1061.021s] 💾 DB #174: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 103: 1000 docs in 9574ms (total: 103000)
[1070.718s] ✓ API #173: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 104) - 9.69s, 1000 items
[1070.758s] 💾 DB #175: insert_batch courses_progress - 37ms, 1000 items
    courses_progress batch 104: 1000 docs in 9739ms (total: 104000)
[1080.074s] ✓ API #174: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 105) - 9.30s, 1000 items
[1080.120s] 💾 DB #176: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 105: 1000 docs in 9357ms (total: 105000)
[1089.632s] ✓ API #175: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 106) - 9.50s, 1000 items
[1089.682s] 💾 DB #177: insert_batch courses_progress - 44ms, 1000 items
    courses_progress batch 106: 1000 docs in 9565ms (total: 106000)
[1098.998s] ✓ API #176: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 107) - 9.30s, 1000 items
[1099.043s] 💾 DB #178: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 107: 1000 docs in 9360ms (total: 107000)
[1108.149s] ✓ API #177: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 108) - 9.09s, 1000 items
[1108.189s] 💾 DB #179: insert_batch courses_progress - 37ms, 1000 items
    courses_progress batch 108: 1000 docs in 9147ms (total: 108000)
[1117.252s] ✓ API #178: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 109) - 9.05s, 1000 items
[1117.292s] 💾 DB #180: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 109: 1000 docs in 9106ms (total: 109000)
[1127.561s] ✓ API #179: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 110) - 10.25s, 1000 items
[1127.603s] 💾 DB #181: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 110: 1000 docs in 10307ms (total: 110000)
[1137.647s] ✓ API #180: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 111) - 10.03s, 1000 items
[1137.692s] 💾 DB #182: insert_batch courses_progress - 43ms, 1000 items
    courses_progress batch 111: 1000 docs in 10089ms (total: 111000)
[1147.909s] ✓ API #181: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 112) - 10.21s, 1000 items
[1147.955s] 💾 DB #183: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 112: 1000 docs in 10262ms (total: 112000)
[1158.038s] ✓ API #182: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 113) - 10.07s, 1000 items
[1158.096s] 💾 DB #184: insert_batch courses_progress - 51ms, 1000 items
    courses_progress batch 113: 1000 docs in 10139ms (total: 113000)
[1168.992s] ✓ API #183: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 114) - 10.89s, 1000 items
[1169.036s] 💾 DB #185: insert_batch courses_progress - 42ms, 1000 items
    courses_progress batch 114: 1000 docs in 10943ms (total: 114000)
[1179.091s] ✓ API #184: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 115) - 10.04s, 1000 items
[1179.137s] 💾 DB #186: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 115: 1000 docs in 10103ms (total: 115000)
[1190.260s] ✓ API #185: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 116) - 11.11s, 1000 items
[1190.305s] 💾 DB #187: insert_batch courses_progress - 42ms, 1000 items
    courses_progress batch 116: 1000 docs in 11163ms (total: 116000)
[1200.705s] ✓ API #186: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 117) - 10.39s, 1000 items
[1200.748s] 💾 DB #188: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 117: 1000 docs in 10439ms (total: 117000)
[1212.992s] ✓ API #187: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 118) - 12.24s, 1000 items
[1213.029s] 💾 DB #189: insert_batch courses_progress - 35ms, 1000 items
    courses_progress batch 118: 1000 docs in 12282ms (total: 118000)
[1225.391s] ✓ API #188: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 119) - 12.36s, 1000 items
[1225.435s] 💾 DB #190: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 119: 1000 docs in 12412ms (total: 119000)
[1237.682s] ✓ API #189: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 120) - 12.23s, 1000 items
[1237.720s] 💾 DB #191: insert_batch courses_progress - 36ms, 1000 items
    courses_progress batch 120: 1000 docs in 12282ms (total: 120000)
[1249.455s] ✓ API #190: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 121) - 11.73s, 1000 items
[1249.501s] 💾 DB #192: insert_batch courses_progress - 44ms, 1000 items
    courses_progress batch 121: 1000 docs in 11778ms (total: 121000)
[1260.121s] ✓ API #191: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 122) - 10.61s, 1000 items
[1260.157s] 💾 DB #193: insert_batch courses_progress - 35ms, 1000 items
    courses_progress batch 122: 1000 docs in 10663ms (total: 122000)
[1272.518s] ✓ API #192: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 123) - 12.35s, 1000 items
[1272.563s] 💾 DB #194: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 123: 1000 docs in 12400ms (total: 123000)
[1283.191s] ✓ API #193: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 124) - 10.62s, 1000 items
[1283.233s] 💾 DB #195: insert_batch courses_progress - 36ms, 1000 items
    courses_progress batch 124: 1000 docs in 10672ms (total: 124000)
[1293.901s] ✓ API #194: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 125) - 10.66s, 1000 items
[1293.936s] 💾 DB #196: insert_batch courses_progress - 34ms, 1000 items
    courses_progress batch 125: 1000 docs in 10700ms (total: 125000)
[1304.382s] ✓ API #195: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 126) - 10.44s, 1000 items
[1304.428s] 💾 DB #197: insert_batch courses_progress - 44ms, 1000 items
    courses_progress batch 126: 1000 docs in 10498ms (total: 126000)
[1314.904s] ✓ API #196: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 127) - 10.46s, 1000 items
[1314.954s] 💾 DB #198: insert_batch courses_progress - 47ms, 1000 items
    courses_progress batch 127: 1000 docs in 10524ms (total: 127000)
[1325.681s] ✓ API #197: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 128) - 10.71s, 1000 items
[1325.720s] 💾 DB #199: insert_batch courses_progress - 36ms, 1000 items
    courses_progress batch 128: 1000 docs in 10764ms (total: 128000)
[1336.341s] ✓ API #198: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 129) - 10.61s, 1000 items
[1336.384s] 💾 DB #200: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 129: 1000 docs in 10662ms (total: 129000)
[1346.881s] ✓ API #199: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 130) - 10.49s, 1000 items
[1346.921s] 💾 DB #201: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 130: 1000 docs in 10540ms (total: 130000)
[1357.833s] ✓ API #200: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 131) - 10.90s, 1000 items
[1357.875s] 💾 DB #202: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 131: 1000 docs in 10954ms (total: 131000)
[1368.815s] ✓ API #201: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 132) - 10.93s, 1000 items
[1368.851s] 💾 DB #203: insert_batch courses_progress - 34ms, 1000 items
    courses_progress batch 132: 1000 docs in 10978ms (total: 132000)
[1379.799s] ✓ API #202: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 133) - 10.94s, 1000 items
[1379.852s] 💾 DB #204: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 133: 1000 docs in 11000ms (total: 133000)
[1390.664s] ✓ API #203: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 134) - 10.80s, 1000 items
[1390.705s] 💾 DB #205: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 134: 1000 docs in 10855ms (total: 134000)
[1401.276s] ✓ API #204: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 135) - 10.56s, 1000 items
[1401.313s] 💾 DB #206: insert_batch courses_progress - 35ms, 1000 items
    courses_progress batch 135: 1000 docs in 10600ms (total: 135000)
[1412.048s] ✓ API #205: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 136) - 10.73s, 1000 items
[1412.101s] 💾 DB #207: insert_batch courses_progress - 50ms, 1000 items
    courses_progress batch 136: 1000 docs in 10788ms (total: 136000)
[1422.572s] ✓ API #206: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 137) - 10.46s, 1000 items
[1422.619s] 💾 DB #208: insert_batch courses_progress - 45ms, 1000 items
    courses_progress batch 137: 1000 docs in 10533ms (total: 137000)
[1433.410s] ✓ API #207: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 138) - 10.77s, 1000 items
[1433.468s] 💾 DB #209: insert_batch courses_progress - 54ms, 1000 items
    courses_progress batch 138: 1000 docs in 10837ms (total: 138000)
[1444.130s] ✓ API #208: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 139) - 10.65s, 1000 items
[1444.173s] 💾 DB #210: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 139: 1000 docs in 10706ms (total: 139000)
[1455.169s] ✓ API #209: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 140) - 10.99s, 1000 items
[1455.213s] 💾 DB #211: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 140: 1000 docs in 11038ms (total: 140000)
[1466.234s] ✓ API #210: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 141) - 11.01s, 1000 items
[1466.273s] 💾 DB #212: insert_batch courses_progress - 37ms, 1000 items
    courses_progress batch 141: 1000 docs in 11065ms (total: 141000)
[1477.378s] ✓ API #211: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 142) - 11.09s, 1000 items
[1477.423s] 💾 DB #213: insert_batch courses_progress - 42ms, 1000 items
    courses_progress batch 142: 1000 docs in 11147ms (total: 142000)
[1489.623s] ✓ API #212: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 143) - 12.19s, 1000 items
[1489.663s] 💾 DB #214: insert_batch courses_progress - 37ms, 1000 items
    courses_progress batch 143: 1000 docs in 12237ms (total: 143000)
[1506.085s] ✓ API #213: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 144) - 16.41s, 1000 items
[1506.123s] 💾 DB #215: insert_batch courses_progress - 37ms, 1000 items
    courses_progress batch 144: 1000 docs in 16461ms (total: 144000)
[1519.982s] ✓ API #214: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 145) - 13.85s, 1000 items
[1520.036s] 💾 DB #216: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 145: 1000 docs in 13912ms (total: 145000)
  ↺ courses_progress batch 146 timeout (attempt 1/3), retrying...
[1542.328s] ✓ API #215: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 146) - 12.06s, 1000 items
[1542.370s] 💾 DB #217: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 146: 1000 docs in 22339ms (total: 146000)
[1554.577s] ✓ API #216: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 147) - 12.19s, 1000 items
[1554.619s] 💾 DB #218: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 147: 1000 docs in 12251ms (total: 147000)
[1567.360s] ✓ API #217: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 148) - 12.73s, 1000 items
[1567.402s] 💾 DB #219: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 148: 1000 docs in 12779ms (total: 148000)
[1579.997s] ✓ API #218: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 149) - 12.58s, 1000 items
[1580.039s] 💾 DB #220: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 149: 1000 docs in 12637ms (total: 149000)
[1592.225s] ✓ API #219: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 150) - 12.18s, 1000 items
[1592.268s] 💾 DB #221: insert_batch courses_progress - 41ms, 1000 items
    courses_progress batch 150: 1000 docs in 12225ms (total: 150000)
[1603.630s] ✓ API #220: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 151) - 11.36s, 1000 items
[1603.670s] 💾 DB #222: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 151: 1000 docs in 11406ms (total: 151000)
[1614.719s] ✓ API #221: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 152) - 11.04s, 1000 items
[1614.761s] 💾 DB #223: insert_batch courses_progress - 40ms, 1000 items
    courses_progress batch 152: 1000 docs in 11087ms (total: 152000)
[1626.189s] ✓ API #222: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 153) - 11.42s, 1000 items
[1626.230s] 💾 DB #224: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 153: 1000 docs in 11471ms (total: 153000)
[1637.434s] ✓ API #223: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 154) - 11.20s, 1000 items
[1637.476s] 💾 DB #225: insert_batch courses_progress - 38ms, 1000 items
    courses_progress batch 154: 1000 docs in 11248ms (total: 154000)
  ↺ courses_progress batch 155 timeout (attempt 1/3), retrying...
[1658.968s] ✓ API #224: ...arning.ole.org:443/db/courses_progress/_all_docs (batch 155) - 11.27s, 1000 items
[1659.009s] 💾 DB #226: insert_batch courses_progress - 39ms, 1000 items
    courses_progress batch 155: 1000 docs in 21532ms (total: 155000)
  ↺ courses_progress batch 156 timeout (attempt 1/3), retrying...
  ↺ courses_progress batch 156 timeout (attempt 2/3), retrying...
  ✗ Failed courses_progress sync after 1689667ms: timeout
[1689.686s] ✓ courses_progress_sync completed: 28m 9.668s
  ▶ Starting resource sync
[1689.920s] ✓ API #225: unknown_endpoint - 232ms
[1689.920s] ✓ API #226: ...3@planet.learning.ole.org:443/db/resources/_all_docs?limit=0 - 233ms, 392 items
[1689.920s] ✓ resource_get_total_count completed: 233ms
    Resources: Found 392 documents to sync
[1689.920s] ℹ resource_sync: Total resources: 392, batch size: 100
[1690.784s] ✓ API #227: unknown_endpoint - 864ms, 100 items
[1690.784s] ✓ API #228: ...planet.learning.ole.org:443/db/resources/_all_docs (batch 1) - 864ms, 100 items
[1690.884s] 💾 DB #227: insert_chunks resources - 99ms, 100 items
[1691.387s] ✓ API #229: unknown_endpoint - 502ms, 100 items
[1691.387s] ✓ API #230: ...planet.learning.ole.org:443/db/resources/_all_docs (batch 2) - 503ms, 100 items
[1691.443s] 💾 DB #228: insert_chunks resources - 56ms, 100 items
[1692.730s] ✓ API #231: unknown_endpoint - 1.29s, 100 items
[1692.730s] ✓ API #232: ...planet.learning.ole.org:443/db/resources/_all_docs (batch 3) - 1.29s, 100 items
[1692.808s] 💾 DB #229: insert_chunks resources - 77ms, 98 items
[1693.334s] ✓ API #233: unknown_endpoint - 526ms, 92 items
[1693.334s] ✓ API #234: ...planet.learning.ole.org:443/db/resources/_all_docs (batch 4) - 526ms, 92 items
[1693.419s] 💾 DB #230: insert_chunks resources - 84ms, 92 items
[1693.428s] ✓ resource_cleanup completed: 9ms
[1693.428s] ✓ resource_sync_main completed: 3.74s, 390 items
  ✓ Resources sync completed: 0m 3s - 390 items
[1693.428s] ✓ resource_sync completed: 3.74s
  ▶ Starting library sync
[1693.880s] ✓ API #235: unknown_endpoint - 452ms
[1694.800s] ✓ API #236: unknown_endpoint - 916ms, 25 items
[1694.800s] ✓ API #237: unknown_endpoint - 913ms, 25 items
[1694.800s] ✓ API #238: unknown_endpoint - 915ms, 25 items
[1694.800s] ✓ API #239: unknown_endpoint - 917ms, 25 items
[1694.804s] ✓ API #240: unknown_endpoint - 915ms, 25 items
[1695.167s] ✓ API #241: unknown_endpoint - 1.28s, 25 items
[1695.187s] ✓ API #242: unknown_endpoint - 386ms, 25 items
[1695.227s] ✓ API #243: unknown_endpoint - 1.34s, 25 items
[1695.243s] ✓ API #244: unknown_endpoint - 1.36s, 25 items
[1695.270s] ✓ API #245: unknown_endpoint - 469ms, 25 items
[1695.467s] ✓ API #246: unknown_endpoint - 666ms, 25 items
[1695.503s] ✓ API #247: unknown_endpoint - 699ms, 25 items
[1695.570s] ✓ API #248: unknown_endpoint - 764ms, 25 items
[1695.602s] ✓ API #249: unknown_endpoint - 434ms, 25 items
[1695.630s] ✓ API #250: unknown_endpoint - 442ms, 25 items
[1695.701s] ✓ API #251: unknown_endpoint - 473ms, 25 items
[1695.738s] ✓ API #252: unknown_endpoint - 493ms, 25 items
[1695.814s] ✓ API #253: unknown_endpoint - 542ms, 25 items
[1695.843s] ✓ API #254: unknown_endpoint - 375ms, 25 items
[1695.871s] ✓ API #255: unknown_endpoint - 367ms, 25 items
[1695.947s] ✓ API #256: unknown_endpoint - 375ms, 25 items
[1695.997s] ✓ API #257: unknown_endpoint - 392ms, 25 items
[1696.050s] ✓ API #258: unknown_endpoint - 418ms, 20 items
[1696.098s] ✓ API #259: unknown_endpoint - 394ms, 25 items
[1696.130s] ✓ API #260: unknown_endpoint - 391ms, 25 items
[1696.131s] ✓ library_get_shelves completed: 2.70s, 64 items
    Library: Found 64 shelves with data in 2703ms
[1696.356s] ✓ API #261: unknown_endpoint - 221ms
[1696.360s] ✓ API #262: unknown_endpoint - 224ms
[1696.365s] ✓ API #263: unknown_endpoint - 231ms
[1696.366s] ✓ API #264: unknown_endpoint - 230ms
[1696.366s] ✓ API #265: unknown_endpoint - 230ms
[1696.581s] ✓ API #266: unknown_endpoint - 446ms
[1696.589s] ✓ API #267: unknown_endpoint - 231ms, 1 items
[1696.590s] ✓ API #268: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 232ms, 1 items
[1696.604s] 💾 DB #231: shelf_insert courses - 14ms, 1 items
[1696.823s] ✓ API #269: unknown_endpoint - 465ms, 2 items
[1696.823s] ✓ API #270: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 465ms, 2 items
[1696.840s] 💾 DB #232: shelf_insert resources - 17ms, 2 items
[1696.840s] ℹ library_sync: Shelf 2/64 (org.couchdb.user:adham): 3 items in 708ms
[1696.879s] ✓ API #272: unknown_endpoint - 510ms, 1 items
[1696.879s] ✓ API #271: unknown_endpoint - 512ms, 2 items
[1696.880s] ✓ API #274: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 512ms, 2 items
[1696.880s] ✓ API #273: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 510ms, 1 items
[1696.890s] 💾 DB #233: shelf_insert resources - 10ms, 2 items
[1696.896s] 💾 DB #234: shelf_insert courses - 16ms, 1 items
[1696.897s] ℹ library_sync: Shelf 3/64 (org.couchdb.user:adhamelasfar): 3 items in 765ms
[1696.937s] ✓ API #275: unknown_endpoint - 569ms, 3 items
[1696.937s] ✓ API #276: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 569ms, 3 items
[1696.954s] 💾 DB #235: shelf_insert courses - 17ms, 3 items
[1697.122s] ✓ API #277: unknown_endpoint - 761ms, 3 items
[1697.122s] ✓ API #278: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 761ms, 3 items
[1697.148s] ✓ API #279: unknown_endpoint - 779ms, 1 items
[1697.148s] ✓ API #280: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 780ms, 1 items
[1697.152s] ✓ API #281: unknown_endpoint - 782ms, 1 items
[1697.153s] ✓ API #282: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 783ms, 1 items
[1697.154s] 💾 DB #236: shelf_insert courses - 31ms, 3 items
[1697.155s] ℹ library_sync: Shelf 7/64 (org.couchdb.user:azhir): 3 items in 1022ms
[1697.164s] 💾 DB #237: shelf_insert resources - 11ms, 1 items
[1697.165s] ℹ library_sync: Shelf 5/64 (org.couchdb.user:adminokuro): 4 items in 1033ms
[1697.184s] 💾 DB #238: shelf_insert courses - 36ms, 1 items
[1697.185s] ℹ library_sync: Shelf 1/64 (org.couchdb.user:aa): 1 items in 1053ms
[1697.511s] ✓ API #283: unknown_endpoint - 927ms, 12 items
[1697.512s] ✓ API #284: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 928ms, 12 items
[1697.560s] 💾 DB #239: shelf_insert courses - 48ms, 12 items
[1697.614s] ✓ API #285: unknown_endpoint - 1.03s, 50 items
[1697.615s] ✓ API #286: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/2) - 1.03s, 50 items
[1697.619s] ✓ API #287: unknown_endpoint - 779ms
[1697.619s] ✓ API #288: unknown_endpoint - 722ms
[1697.619s] ✓ API #289: unknown_endpoint - 464ms
[1697.637s] 💾 DB #240: shelf_insert resources - 22ms, 38 items
[1697.637s] ℹ shelf_sync: Shelf org.couchdb.user:avinash_codes resources batch 1/2: 1055ms for 38 docs
[1697.747s] ✓ API #290: unknown_endpoint - 582ms
[1697.851s] ✓ API #291: unknown_endpoint - 666ms
[1697.903s] ✓ API #292: unknown_endpoint - 283ms, 1 items
[1697.904s] ✓ API #293: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 283ms, 1 items
[1697.918s] 💾 DB #241: shelf_insert resources - 14ms, 1 items
[1697.919s] ℹ library_sync: Shelf 9/64 (org.couchdb.user:bru): 1 items in 764ms
[1699.178s] ✓ API #294: unknown_endpoint - 1.56s, 1 items
[1699.178s] ✓ API #295: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.56s, 1 items
[1699.190s] 💾 DB #242: shelf_insert courses - 12ms, 1 items
[1699.190s] ℹ shelf_sync: Shelf org.couchdb.user:bhushan_tester courses batch 1/1: 1569ms for 1 docs
[1699.817s] ✓ API #296: unknown_endpoint - 2.20s, 1 items
[1699.818s] ✓ API #297: unknown_endpoint - 2.20s, 2 items
[1699.819s] ✓ API #298: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 2.20s, 2 items
[1699.819s] ✓ API #299: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 2.20s, 1 items
[1699.820s] ✓ API #300: unknown_endpoint - 2.18s, 10 items
[1699.820s] ✓ API #301: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 2/2) - 2.18s, 10 items
[1699.820s] ℹ shelf_sync: Shelf org.couchdb.user:avinash_codes resources batch 2/2: 2183ms for 0 docs
[1699.820s] ℹ library_sync: Shelf 6/64 (org.couchdb.user:avinash_codes): 50 items in 3687ms
[1699.824s] ✓ API #302: unknown_endpoint - 2.08s, 3 items
[1699.825s] ✓ API #303: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 2.08s, 3 items
[1699.832s] 💾 DB #243: shelf_insert courses - 12ms, 1 items
[1699.833s] ℹ shelf_sync: Shelf org.couchdb.user:adhamelasfar99 courses batch 1/1: 2213ms for 1 docs
[1699.834s] ℹ library_sync: Shelf 4/64 (org.couchdb.user:adhamelasfar99): 1 items in 2994ms
[1699.838s] 💾 DB #244: shelf_insert resources - 16ms, 2 items
[1699.839s] ℹ shelf_sync: Shelf org.couchdb.user:bhushan_tester resources batch 1/1: 2218ms for 2 docs
[1699.839s] ✓ API #304: unknown_endpoint - 2.09s, 2 items
[1699.839s] ℹ library_sync: Shelf 8/64 (org.couchdb.user:bhushan_tester): 3 items in 2942ms
[1699.839s] ✓ API #305: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 2.09s, 2 items
[1699.856s] 💾 DB #245: shelf_insert courses - 31ms, 3 items
[1699.856s] ℹ shelf_sync: Shelf org.couchdb.user:cody courses batch 1/1: 2108ms for 3 docs
[1699.867s] 💾 DB #246: shelf_insert resources - 28ms, 2 items
[1699.867s] ℹ shelf_sync: Shelf org.couchdb.user:cody resources batch 1/1: 2119ms for 2 docs
[1699.868s] ℹ library_sync: Shelf 12/64 (org.couchdb.user:cody): 5 items in 2703ms
[1700.043s] ✓ API #306: unknown_endpoint - 2.12s
[1700.051s] ✓ API #307: unknown_endpoint - 231ms
[1700.600s] ✓ API #308: unknown_endpoint - 2.75s, 1 items
[1700.600s] ✓ API #309: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 2.75s, 1 items
[1700.609s] 💾 DB #247: shelf_insert courses - 9ms, 1 items
[1700.609s] ℹ shelf_sync: Shelf org.couchdb.user:bu courses batch 1/1: 2757ms for 1 docs
[1700.610s] ℹ library_sync: Shelf 10/64 (org.couchdb.user:bu): 1 items in 3425ms
[1700.810s] ✓ API #310: unknown_endpoint - 971ms
[1700.811s] ✓ API #311: unknown_endpoint - 977ms
[1700.816s] ✓ API #312: unknown_endpoint - 946ms
[1700.817s] ✓ API #313: unknown_endpoint - 772ms, 2 items
[1700.817s] ✓ API #314: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 772ms, 2 items
[1700.835s] 💾 DB #248: shelf_insert courses - 18ms, 2 items
[1701.022s] ✓ API #315: unknown_endpoint - 976ms, 1 items
[1701.022s] ✓ API #316: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 976ms, 1 items
[1701.030s] 💾 DB #249: shelf_insert resources - 8ms, 1 items
[1701.030s] ℹ library_sync: Shelf 11/64 (org.couchdb.user:cccc): 3 items in 3111ms
[1701.096s] ✓ API #317: unknown_endpoint - 1.04s, 4 items
[1701.096s] ✓ API #318: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.04s, 4 items
[1701.118s] 💾 DB #250: shelf_insert courses - 22ms, 4 items
[1701.118s] ℹ shelf_sync: Shelf org.couchdb.user:gh courses batch 1/1: 1066ms for 4 docs
[1701.118s] ℹ library_sync: Shelf 20/64 (org.couchdb.user:gh): 4 items in 1298ms
[1701.252s] ✓ API #319: unknown_endpoint - 642ms
[1701.300s] ✓ API #320: unknown_endpoint - 488ms, 1 items
[1701.300s] ✓ API #321: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 488ms, 1 items
[1701.319s] 💾 DB #251: shelf_insert resources - 19ms, 1 items
[1701.741s] ✓ API #322: unknown_endpoint - 929ms, 7 items
[1701.741s] ✓ API #323: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 929ms, 7 items
[1701.770s] 💾 DB #252: shelf_insert courses - 29ms, 7 items
[1701.770s] ℹ library_sync: Shelf 21/64 (org.couchdb.user:hu): 8 items in 1936ms
[1701.792s] ✓ API #324: unknown_endpoint - 977ms, 18 items
[1701.792s] ✓ API #325: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 977ms, 18 items
[1701.808s] 💾 DB #253: shelf_insert resources - 16ms, 18 items
[1703.151s] ✓ API #326: unknown_endpoint - 2.34s, 21 items
[1703.152s] ✓ API #327: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 2.34s, 21 items
[1703.168s] ✓ API #328: unknown_endpoint - 2.35s, 1 items
[1703.168s] ✓ API #329: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 2.35s, 1 items
[1703.216s] ✓ API #330: unknown_endpoint - 2.18s
[1703.216s] ✓ API #331: unknown_endpoint - 2.10s
[1703.240s] 💾 DB #254: shelf_insert courses - 88ms, 21 items
[1703.240s] ℹ shelf_sync: Shelf org.couchdb.user:huitk2 courses batch 1/1: 2425ms for 21 docs
[1703.240s] ℹ library_sync: Shelf 22/64 (org.couchdb.user:huitk2): 39 items in 3401ms
[1703.252s] 💾 DB #255: shelf_insert resources - 84ms, 1 items
[1703.252s] ℹ shelf_sync: Shelf org.couchdb.user:igod resources batch 1/1: 2436ms for 1 docs
[1703.252s] ℹ library_sync: Shelf 23/64 (org.couchdb.user:igod): 1 items in 3383ms
[1703.305s] ✓ API #332: unknown_endpoint - 2.05s, 3 items
[1703.306s] ✓ API #333: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 2.05s, 3 items
[1703.320s] 💾 DB #256: shelf_insert courses - 14ms, 3 items
[1703.320s] ℹ shelf_sync: Shelf org.couchdb.user:jessew courses batch 1/1: 2067ms for 3 docs
[1703.381s] ✓ API #334: unknown_endpoint - 2.13s, 1 items
[1703.381s] ✓ API #335: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 2.13s, 1 items
[1703.385s] ✓ API #336: unknown_endpoint - 1.61s
[1703.396s] 💾 DB #257: shelf_insert resources - 15ms, 1 items
[1703.396s] ℹ shelf_sync: Shelf org.couchdb.user:jessew resources batch 1/1: 2142ms for 1 docs
[1703.397s] ℹ library_sync: Shelf 24/64 (org.couchdb.user:jessew): 4 items in 2787ms
[1703.920s] ✓ API #337: unknown_endpoint - 702ms, 7 items
[1703.921s] ✓ API #338: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 703ms, 7 items
[1703.935s] ✓ API #339: unknown_endpoint - 718ms, 10 items
[1703.936s] ✓ API #340: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 718ms, 10 items
[1703.953s] 💾 DB #258: shelf_insert courses - 32ms, 7 items
[1703.968s] 💾 DB #259: shelf_insert resources - 32ms, 10 items
[1703.969s] ℹ library_sync: Shelf 25/64 (org.couchdb.user:jose): 17 items in 2850ms
[1705.115s] ✓ API #341: unknown_endpoint - 1.90s, 17 items
[1705.116s] ✓ API #342: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.90s, 17 items
[1705.206s] 💾 DB #260: shelf_insert courses - 90ms, 17 items
[1705.206s] ℹ shelf_sync: Shelf org.couchdb.user:deepv15 courses batch 1/1: 1990ms for 17 docs
[1705.228s] ✓ API #343: unknown_endpoint - 1.99s
[1705.511s] ✓ API #344: unknown_endpoint - 2.29s, 50 items
[1705.512s] ✓ API #345: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/3) - 2.29s, 50 items
[1705.512s] ✓ API #346: unknown_endpoint - 2.26s
[1705.523s] ✓ API #347: unknown_endpoint - 2.14s, 1 items
[1705.524s] ✓ API #348: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 2.14s, 1 items
[1705.524s] ✓ API #349: unknown_endpoint - 2.13s
[1705.526s] ✓ API #350: unknown_endpoint - 1.56s
[1705.550s] 💾 DB #261: shelf_insert resources - 38ms, 50 items
[1705.550s] ℹ shelf_sync: Shelf org.couchdb.user:deepv15 resources batch 1/3: 2333ms for 50 docs
[1705.555s] 💾 DB #262: shelf_insert resources - 31ms, 1 items
[1705.556s] ℹ shelf_sync: Shelf org.couchdb.user:eeee resources batch 1/1: 2168ms for 1 docs
[1705.556s] ℹ library_sync: Shelf 17/64 (org.couchdb.user:eeee): 1 items in 3785ms
[1705.736s] ✓ API #351: unknown_endpoint - 507ms, 2 items
[1705.736s] ✓ API #352: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 507ms, 2 items
[1705.752s] 💾 DB #263: shelf_insert resources - 16ms, 2 items
[1705.768s] ✓ API #353: unknown_endpoint - 539ms, 1 items
[1705.768s] ✓ API #354: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 539ms, 1 items
[1705.777s] 💾 DB #264: shelf_insert courses - 9ms, 1 items
[1705.777s] ✓ API #355: unknown_endpoint - 264ms, 1 items
[1705.777s] ✓ API #356: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 264ms, 1 items
[1705.777s] ℹ library_sync: Shelf 26/64 (org.couchdb.user:kayleigh): 3 items in 2536ms
[1705.786s] 💾 DB #265: shelf_insert courses - 9ms, 1 items
[1705.790s] ✓ API #357: unknown_endpoint - 277ms, 6 items
[1705.790s] ✓ API #358: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 277ms, 6 items
[1705.802s] 💾 DB #266: shelf_insert resources - 11ms, 6 items
[1705.803s] ℹ library_sync: Shelf 16/64 (org.couchdb.user:dogi): 7 items in 2550ms
[1706.272s] ✓ API #359: unknown_endpoint - 747ms, 9 items
[1706.273s] ✓ API #360: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 748ms, 9 items
[1706.321s] 💾 DB #267: shelf_insert courses - 48ms, 9 items
[1706.423s] ✓ API #361: unknown_endpoint - 897ms, 1 items
[1706.423s] ✓ API #362: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 897ms, 1 items
[1706.435s] 💾 DB #268: shelf_insert courses - 12ms, 1 items
[1706.443s] ✓ API #363: unknown_endpoint - 918ms, 33 items
[1706.443s] ✓ API #364: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 918ms, 33 items
[1706.451s] ✓ API #365: unknown_endpoint - 924ms, 3 items
[1706.451s] ✓ API #366: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 924ms, 3 items
[1706.470s] 💾 DB #269: shelf_insert resources - 27ms, 33 items
[1706.470s] ℹ library_sync: Shelf 18/64 (org.couchdb.user:ewhang5): 42 items in 3073ms
[1706.484s] 💾 DB #270: shelf_insert resources - 33ms, 3 items
[1706.484s] ℹ library_sync: Shelf 29/64 (org.couchdb.user:luffy): 4 items in 2515ms
[1706.508s] ✓ API #367: unknown_endpoint - 957ms, 50 items
[1706.508s] ✓ API #368: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 2/3) - 957ms, 50 items
[1706.513s] ✓ API #369: unknown_endpoint - 957ms
[1706.520s] 💾 DB #271: shelf_insert resources - 12ms, 19 items
[1706.644s] ✓ API #370: unknown_endpoint - 864ms
[1706.659s] ✓ API #371: unknown_endpoint - 856ms
[1706.712s] ✓ API #372: unknown_endpoint - 241ms
[1706.727s] ✓ API #373: unknown_endpoint - 243ms
[1706.855s] ✓ API #374: unknown_endpoint - 341ms, 2 items
[1706.856s] ✓ API #375: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 341ms, 2 items
[1706.872s] ✓ API #376: unknown_endpoint - 352ms, 5 items
[1706.872s] ✓ API #377: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 3/3) - 352ms, 5 items
[1706.872s] 💾 DB #272: shelf_insert courses - 16ms, 2 items
[1706.872s] ℹ library_sync: Shelf 31/64 (org.couchdb.user:marioefc): 2 items in 1316ms
[1706.872s] ℹ library_sync: Shelf 14/64 (org.couchdb.user:deepv15): 86 items in 5842ms
[1706.975s] ✓ API #378: unknown_endpoint - 330ms, 3 items
[1706.975s] ✓ API #379: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 330ms, 3 items
[1706.988s] 💾 DB #273: shelf_insert courses - 13ms, 3 items
[1707.011s] ✓ API #380: unknown_endpoint - 365ms, 16 items
[1707.013s] ✓ API #381: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 367ms, 16 items
[1707.018s] ✓ API #382: unknown_endpoint - 358ms, 7 items
[1707.019s] ✓ API #383: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 358ms, 7 items
[1707.026s] 💾 DB #274: shelf_insert resources - 13ms, 16 items
[1707.026s] ℹ library_sync: Shelf 32/64 (org.couchdb.user:mutugi): 19 items in 1246ms
[1707.036s] 💾 DB #275: shelf_insert resources - 17ms, 5 items
[1707.109s] ✓ API #384: unknown_endpoint - 448ms, 2 items
[1707.109s] ✓ API #385: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 448ms, 2 items
[1707.124s] 💾 DB #276: shelf_insert courses - 15ms, 2 items
[1707.124s] ℹ library_sync: Shelf 33/64 (org.couchdb.user:ocana): 7 items in 1321ms
[1707.615s] ✓ API #386: unknown_endpoint - 901ms, 50 items
[1707.616s] ✓ API #387: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/5) - 902ms, 50 items
[1707.640s] 💾 DB #277: shelf_insert resources - 24ms, 50 items
[1708.603s] ✓ API #388: unknown_endpoint - 1.89s, 23 items
[1708.603s] ✓ API #389: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.89s, 23 items
[1708.610s] ✓ API #390: unknown_endpoint - 1.74s
[1708.685s] ✓ API #391: unknown_endpoint - 1.96s, 1 items
[1708.685s] ✓ API #392: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.96s, 1 items
[1708.686s] ✓ API #393: unknown_endpoint - 1.81s
[1708.688s] ✓ API #394: unknown_endpoint - 1.66s
[1708.702s] 💾 DB #278: shelf_insert courses - 99ms, 22 items
[1708.702s] ℹ shelf_sync: Shelf org.couchdb.user:okuro courses batch 1/1: 1989ms for 22 docs
[1708.709s] 💾 DB #279: shelf_insert courses - 24ms, 1 items
[1708.710s] ℹ shelf_sync: Shelf org.couchdb.user:opensource courses batch 1/1: 1982ms for 1 docs
[1708.710s] ℹ library_sync: Shelf 35/64 (org.couchdb.user:opensource): 1 items in 2226ms
[1708.837s] ✓ API #395: unknown_endpoint - 1.71s
[1709.059s] ✓ API #396: unknown_endpoint - 1.42s, 50 items
[1709.059s] ✓ API #397: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 2/5) - 1.42s, 50 items
[1709.088s] 💾 DB #280: shelf_insert resources - 29ms, 50 items
[1709.088s] ℹ shelf_sync: Shelf org.couchdb.user:okuro resources batch 2/5: 1448ms for 50 docs
[1709.159s] ✓ API #398: unknown_endpoint - 546ms, 39 items
[1709.159s] ✓ API #399: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 547ms, 39 items
[1709.171s] ✓ API #400: unknown_endpoint - 483ms, 1 items
[1709.171s] ✓ API #401: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 483ms, 1 items
[1709.175s] ✓ API #402: unknown_endpoint - 486ms, 2 items
[1709.175s] ✓ API #403: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 486ms, 2 items
[1709.184s] 💾 DB #281: shelf_insert resources - 25ms, 39 items
[1709.185s] ℹ library_sync: Shelf 36/64 (org.couchdb.user:passo): 39 items in 2312ms
[1709.186s] ✓ API #404: unknown_endpoint - 496ms, 1 items
[1709.186s] ✓ API #405: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 497ms, 1 items
[1709.191s] 💾 DB #282: shelf_insert courses - 20ms, 1 items
[1709.199s] 💾 DB #283: shelf_insert resources - 24ms, 2 items
[1709.204s] 💾 DB #284: shelf_insert courses - 18ms, 1 items
[1709.204s] ℹ library_sync: Shelf 30/64 (org.couchdb.user:malvarado): 3 items in 2331ms
[1709.294s] ✓ API #406: unknown_endpoint - 602ms, 1 items
[1709.294s] ✓ API #407: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 602ms, 1 items
[1709.302s] 💾 DB #285: shelf_insert resources - 8ms, 1 items
[1709.303s] ℹ library_sync: Shelf 37/64 (org.couchdb.user:pavi100): 2 items in 2277ms
[1709.389s] ✓ API #408: unknown_endpoint - 676ms
[1709.454s] ✓ API #409: unknown_endpoint - 615ms, 6 items
[1709.454s] ✓ API #410: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 616ms, 6 items
[1709.468s] 💾 DB #286: shelf_insert resources - 14ms, 6 items
[1709.842s] ✓ API #411: unknown_endpoint - 1.00s, 5 items
[1709.843s] ✓ API #412: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.01s, 5 items
[1709.904s] 💾 DB #287: shelf_insert courses - 61ms, 5 items
[1709.905s] ℹ shelf_sync: Shelf org.couchdb.user:learner courses batch 1/1: 1068ms for 5 docs
[1709.905s] ℹ library_sync: Shelf 27/64 (org.couchdb.user:learner): 11 items in 2780ms
[1710.425s] ✓ API #413: unknown_endpoint - 1.34s, 50 items
[1710.425s] ✓ API #414: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 3/5) - 1.34s, 50 items
[1710.438s] ✓ API #415: unknown_endpoint - 1.14s
[1710.439s] ✓ API #416: unknown_endpoint - 1.23s
[1710.441s] ✓ API #417: unknown_endpoint - 1.26s
[1710.533s] 💾 DB #288: shelf_insert resources - 107ms, 50 items
[1710.533s] ℹ shelf_sync: Shelf org.couchdb.user:okuro resources batch 3/5: 1445ms for 50 docs
[1710.573s] ✓ API #418: unknown_endpoint - 1.18s, 8 items
[1710.573s] ✓ API #419: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.18s, 8 items
[1710.653s] 💾 DB #289: shelf_insert courses - 80ms, 8 items
[1710.653s] ℹ shelf_sync: Shelf org.couchdb.user:demo courses batch 1/1: 1263ms for 8 docs
[1710.682s] ✓ API #420: unknown_endpoint - 776ms
[1710.701s] ✓ API #421: unknown_endpoint - 1.31s, 8 items
[1710.701s] ✓ API #422: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 1.31s, 8 items
[1710.716s] 💾 DB #290: shelf_insert resources - 15ms, 8 items
[1710.717s] ℹ shelf_sync: Shelf org.couchdb.user:demo resources batch 1/1: 1327ms for 8 docs
[1710.717s] ℹ library_sync: Shelf 15/64 (org.couchdb.user:demo): 16 items in 2004ms
[1710.736s] ✓ API #423: unknown_endpoint - 287ms, 1 items
[1710.736s] ✓ API #424: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 287ms, 1 items
[1710.764s] 💾 DB #291: shelf_insert courses - 27ms, 1 items
[1710.975s] ✓ API #425: unknown_endpoint - 525ms, 4 items
[1710.975s] ✓ API #426: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 525ms, 4 items
[1710.990s] 💾 DB #292: shelf_insert courses - 15ms, 4 items
[1711.172s] ✓ API #427: unknown_endpoint - 722ms, 6 items
[1711.172s] ✓ API #428: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 722ms, 6 items
[1711.180s] ✓ API #429: unknown_endpoint - 726ms, 2 items
[1711.180s] ✓ API #430: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 726ms, 2 items
[1711.187s] ✓ API #431: unknown_endpoint - 746ms, 2 items
[1711.187s] ✓ API #432: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 746ms, 2 items
[1711.196s] ✓ API #433: unknown_endpoint - 741ms, 3 items
[1711.196s] ✓ API #434: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 741ms, 3 items
[1711.201s] 💾 DB #293: shelf_insert courses - 29ms, 6 items
[1711.207s] 💾 DB #294: shelf_insert resources - 27ms, 2 items
[1711.208s] ℹ library_sync: Shelf 13/64 (org.couchdb.user:cody1): 3 items in 1905ms
[1711.219s] 💾 DB #295: shelf_insert resources - 31ms, 2 items
[1711.219s] ℹ library_sync: Shelf 28/64 (org.couchdb.user:learning): 8 items in 2014ms
[1711.225s] 💾 DB #296: shelf_insert resources - 29ms, 3 items
[1711.226s] ℹ library_sync: Shelf 19/64 (org.couchdb.user:fernandoc): 7 items in 2041ms
[1711.383s] ✓ API #435: unknown_endpoint - 846ms, 50 items
[1711.384s] ✓ API #436: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 4/5) - 847ms, 50 items
[1711.406s] 💾 DB #297: shelf_insert resources - 22ms, 50 items
[1711.409s] ✓ API #437: unknown_endpoint - 725ms, 1 items
[1711.409s] ✓ API #438: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 725ms, 1 items
[1711.410s] ✓ API #439: unknown_endpoint - 692ms
[1711.420s] 💾 DB #298: shelf_insert courses - 11ms, 1 items
[1711.420s] ℹ library_sync: Shelf 38/64 (org.couchdb.user:pavi108): 1 items in 1514ms
[1711.431s] ✓ API #440: unknown_endpoint - 222ms
[1711.439s] ✓ API #441: unknown_endpoint - 220ms
[1711.600s] ✓ API #442: unknown_endpoint - 374ms
[1711.661s] ✓ API #443: unknown_endpoint - 253ms, 11 items
[1711.661s] ✓ API #444: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 5/5) - 253ms, 11 items
[1711.667s] ✓ API #445: unknown_endpoint - 254ms, 3 items
[1711.667s] ✓ API #446: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 255ms, 3 items
[1711.683s] 💾 DB #299: shelf_insert resources - 22ms, 8 items
[1711.683s] ℹ library_sync: Shelf 34/64 (org.couchdb.user:okuro): 230 items in 5212ms
[1711.688s] 💾 DB #300: shelf_insert resources - 21ms, 3 items
[1711.887s] ✓ API #447: unknown_endpoint - 475ms, 4 items
[1711.888s] ✓ API #448: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 475ms, 4 items
[1711.888s] ✓ API #449: unknown_endpoint - 468ms
[1711.897s] ✓ API #450: unknown_endpoint - 465ms, 2 items
[1711.897s] ✓ API #451: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 465ms, 2 items
[1711.907s] 💾 DB #301: shelf_insert courses - 19ms, 4 items
[1711.907s] ℹ library_sync: Shelf 39/64 (org.couchdb.user:pavi228): 7 items in 1190ms
[1711.913s] ✓ API #452: unknown_endpoint - 473ms, 1 items
[1711.913s] ✓ API #453: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 473ms, 1 items
[1711.913s] ✓ API #454: unknown_endpoint - 473ms, 1 items
[1711.913s] ✓ API #455: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 473ms, 1 items
[1711.918s] 💾 DB #302: shelf_insert resources - 21ms, 2 items
[1711.918s] ℹ library_sync: Shelf 40/64 (org.couchdb.user:pavi43): 2 items in 709ms
[1711.929s] 💾 DB #303: shelf_insert resources - 16ms, 1 items
[1711.936s] 💾 DB #304: shelf_insert courses - 22ms, 1 items
[1711.936s] ℹ library_sync: Shelf 43/64 (org.couchdb.user:pavi67): 2 items in 717ms
[1712.133s] ✓ API #456: unknown_endpoint - 531ms, 5 items
[1712.133s] ✓ API #457: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 531ms, 5 items
[1712.142s] ✓ API #458: unknown_endpoint - 458ms
[1712.149s] 💾 DB #305: shelf_insert resources - 16ms, 5 items
[1712.192s] ✓ API #459: unknown_endpoint - 590ms, 4 items
[1712.192s] ✓ API #460: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 590ms, 4 items
[1712.194s] ✓ API #461: unknown_endpoint - 286ms
[1712.217s] 💾 DB #306: shelf_insert courses - 24ms, 4 items
[1712.217s] ℹ library_sync: Shelf 45/64 (org.couchdb.user:regan): 9 items in 991ms
[1712.364s] ✓ API #462: unknown_endpoint - 476ms, 4 items
[1712.364s] ✓ API #463: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 476ms, 4 items
[1712.365s] ✓ API #464: unknown_endpoint - 446ms
[1712.372s] ✓ API #465: unknown_endpoint - 436ms
[1712.383s] 💾 DB #307: shelf_insert courses - 19ms, 4 items
[1712.383s] ℹ library_sync: Shelf 42/64 (org.couchdb.user:pavi58): 4 items in 963ms
[1712.584s] ✓ API #466: unknown_endpoint - 439ms, 6 items
[1712.584s] ✓ API #467: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 439ms, 6 items
[1712.604s] 💾 DB #308: shelf_insert courses - 20ms, 6 items
[1712.884s] ✓ API #468: unknown_endpoint - 739ms, 50 items
[1712.884s] ✓ API #469: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/2) - 739ms, 50 items
[1712.891s] ✓ API #470: unknown_endpoint - 695ms, 1 items
[1712.891s] ✓ API #471: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 695ms, 1 items
[1712.897s] ✓ API #472: unknown_endpoint - 680ms
[1712.903s] ✓ API #473: unknown_endpoint - 537ms, 7 items
[1712.903s] ✓ API #474: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 537ms, 7 items
[1712.918s] 💾 DB #309: shelf_insert resources - 34ms, 50 items
[1712.925s] 💾 DB #310: shelf_insert courses - 33ms, 1 items
[1712.926s] ℹ library_sync: Shelf 44/64 (org.couchdb.user:priya): 1 items in 1018ms
[1712.932s] ✓ API #475: unknown_endpoint - 565ms, 2 items
[1712.932s] ✓ API #476: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 565ms, 2 items
[1712.939s] 💾 DB #311: shelf_insert resources - 36ms, 2 items
[1712.955s] 💾 DB #312: shelf_insert courses - 23ms, 2 items
[1712.956s] ℹ library_sync: Shelf 41/64 (org.couchdb.user:pavi48): 4 items in 1038ms
[1713.122s] ✓ API #477: unknown_endpoint - 738ms
[1713.166s] ✓ API #478: unknown_endpoint - 793ms, 10 items
[1713.166s] ✓ API #479: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 793ms, 10 items
[1713.181s] 💾 DB #313: shelf_insert resources - 15ms, 10 items
[1713.696s] ✓ API #480: unknown_endpoint - 1.32s, 6 items
[1713.697s] ✓ API #481: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.32s, 6 items
[1713.738s] 💾 DB #314: shelf_insert courses - 41ms, 6 items
[1713.738s] ℹ shelf_sync: Shelf org.couchdb.user:rrr courses batch 1/1: 1365ms for 6 docs
[1713.739s] ℹ library_sync: Shelf 47/64 (org.couchdb.user:rrr): 16 items in 1803ms
[1714.286s] ✓ API #482: unknown_endpoint - 1.39s, 7 items
[1714.287s] ✓ API #483: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.39s, 7 items
[1714.291s] ✓ API #484: unknown_endpoint - 1.39s, 24 items
[1714.292s] ✓ API #485: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 1.39s, 24 items
[1714.298s] ✓ API #486: unknown_endpoint - 1.38s, 33 items
[1714.298s] ✓ API #487: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 2/2) - 1.38s, 33 items
[1714.298s] ✓ API #488: unknown_endpoint - 1.37s
[1714.299s] ✓ API #489: unknown_endpoint - 1.34s
[1714.329s] 💾 DB #315: shelf_insert courses - 41ms, 7 items
[1714.330s] ℹ shelf_sync: Shelf org.couchdb.user:saksham2 courses batch 1/1: 1432ms for 7 docs
[1714.342s] 💾 DB #316: shelf_insert resources - 50ms, 23 items
[1714.342s] ℹ shelf_sync: Shelf org.couchdb.user:saksham2 resources batch 1/1: 1444ms for 23 docs
[1714.343s] ℹ library_sync: Shelf 48/64 (org.couchdb.user:saksham2): 30 items in 2126ms
[1714.359s] 💾 DB #317: shelf_insert resources - 61ms, 29 items
[1714.359s] ℹ shelf_sync: Shelf org.couchdb.user:rlam20 resources batch 2/2: 1441ms for 29 docs
[1714.359s] ℹ library_sync: Shelf 46/64 (org.couchdb.user:rlam20): 85 items in 2675ms
[1714.512s] ✓ API #490: unknown_endpoint - 1.39s, 1 items
[1714.513s] ✓ API #491: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 1.39s, 1 items
[1714.520s] ✓ API #492: unknown_endpoint - 781ms
[1714.526s] 💾 DB #318: shelf_insert resources - 13ms, 1 items
[1714.526s] ℹ shelf_sync: Shelf org.couchdb.user:saksham3 resources batch 1/1: 1404ms for 1 docs
[1714.526s] ℹ library_sync: Shelf 49/64 (org.couchdb.user:saksham3): 1 items in 2142ms
[1714.559s] ✓ API #493: unknown_endpoint - 258ms, 1 items
[1714.560s] ✓ API #494: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 259ms, 1 items
[1714.570s] 💾 DB #319: shelf_insert courses - 10ms, 1 items
[1714.591s] ✓ API #495: unknown_endpoint - 291ms, 2 items
[1714.591s] ✓ API #496: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 291ms, 2 items
[1714.602s] 💾 DB #320: shelf_insert resources - 11ms, 2 items
[1714.603s] ℹ library_sync: Shelf 52/64 (org.couchdb.user:saksham6): 3 items in 1646ms
[1714.854s] ✓ API #497: unknown_endpoint - 510ms
[1714.855s] ✓ API #498: unknown_endpoint - 553ms, 4 items
[1714.855s] ✓ API #499: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 555ms, 4 items
[1714.858s] ✓ API #500: unknown_endpoint - 498ms
[1714.882s] 💾 DB #321: shelf_insert courses - 27ms, 4 items
[1714.883s] ℹ library_sync: Shelf 51/64 (org.couchdb.user:saksham5): 4 items in 1956ms
[1714.899s] ✓ API #501: unknown_endpoint - 377ms, 15 items
[1714.899s] ✓ API #502: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 378ms, 15 items
[1714.916s] 💾 DB #322: shelf_insert resources - 16ms, 15 items
[1715.825s] ✓ API #503: unknown_endpoint - 1.30s, 8 items
[1715.825s] ✓ API #504: unknown_endpoint - 1.22s
[1715.826s] ✓ API #505: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.30s, 8 items
[1715.829s] ✓ API #506: unknown_endpoint - 1.30s
[1715.829s] ✓ API #507: unknown_endpoint - 970ms, 12 items
[1715.829s] ✓ API #508: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 970ms, 12 items
[1715.830s] ✓ API #509: unknown_endpoint - 970ms, 2 items
[1715.830s] ✓ API #510: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 970ms, 2 items
[1715.863s] 💾 DB #323: shelf_insert courses - 37ms, 8 items
[1715.863s] ℹ shelf_sync: Shelf org.couchdb.user:strawberrybread courses batch 1/1: 1343ms for 8 docs
[1715.864s] ℹ library_sync: Shelf 53/64 (org.couchdb.user:strawberrybread): 23 items in 2125ms
[1715.876s] 💾 DB #324: shelf_insert courses - 46ms, 2 items
[1715.876s] ℹ shelf_sync: Shelf org.couchdb.user:test1234 courses batch 1/1: 1016ms for 2 docs
[1715.877s] ℹ library_sync: Shelf 55/64 (org.couchdb.user:test1234): 2 items in 1517ms
[1716.047s] ✓ API #511: unknown_endpoint - 1.16s
[1716.053s] ✓ API #512: unknown_endpoint - 224ms
[1716.068s] ✓ API #513: unknown_endpoint - 238ms, 1 items
[1716.068s] ✓ API #514: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 238ms, 1 items
[1716.085s] ✓ API #515: unknown_endpoint - 257ms, 1 items
[1716.086s] ✓ API #516: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 258ms, 1 items
[1716.093s] ✓ API #517: unknown_endpoint - 229ms
[1716.097s] 💾 DB #325: shelf_insert courses - 11ms, 1 items
[1716.097s] ℹ library_sync: Shelf 56/64 (org.couchdb.user:test26031902): 1 items in 1494ms
[1716.378s] ✓ API #518: unknown_endpoint - 330ms, 1 items
[1716.378s] ✓ API #519: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 330ms, 1 items
[1716.390s] 💾 DB #326: shelf_insert courses - 12ms, 1 items
[1716.391s] ℹ library_sync: Shelf 57/64 (org.couchdb.user:testuser): 1 items in 1507ms
[1716.394s] ✓ API #520: unknown_endpoint - 517ms
[1717.653s] ✓ API #521: unknown_endpoint - 1.60s, 8 items
[1717.653s] ✓ API #522: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.60s, 8 items
[1717.661s] ✓ API #523: unknown_endpoint - 1.61s, 1 items
[1717.662s] ✓ API #524: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 1.61s, 1 items
[1717.669s] ✓ API #525: unknown_endpoint - 1.60s
[1717.706s] 💾 DB #327: shelf_insert courses - 53ms, 8 items
[1717.706s] ℹ shelf_sync: Shelf org.couchdb.user:tracy courses batch 1/1: 1653ms for 8 docs
[1717.716s] 💾 DB #328: shelf_insert resources - 54ms, 1 items
[1717.716s] ℹ shelf_sync: Shelf org.couchdb.user:tracy resources batch 1/1: 1663ms for 1 docs
[1717.716s] ℹ library_sync: Shelf 58/64 (org.couchdb.user:tracy): 9 items in 1887ms
[1717.969s] ✓ API #526: unknown_endpoint - 1.88s, 8 items
[1717.969s] ✓ API #527: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 1.88s, 8 items
[1717.985s] 💾 DB #329: shelf_insert resources - 16ms, 8 items
[1717.986s] ℹ shelf_sync: Shelf org.couchdb.user:tugi resources batch 1/1: 1892ms for 8 docs
[1719.209s] ✓ API #528: unknown_endpoint - 3.11s, 11 items
[1719.209s] ✓ API #529: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 3.11s, 11 items
[1719.214s] ✓ API #530: unknown_endpoint - 3.12s
[1719.214s] ✓ API #531: unknown_endpoint - 2.82s
[1719.271s] 💾 DB #330: shelf_insert courses - 62ms, 11 items
[1719.271s] ℹ shelf_sync: Shelf org.couchdb.user:tugi courses batch 1/1: 3177ms for 11 docs
[1719.271s] ℹ library_sync: Shelf 59/64 (org.couchdb.user:tugi): 19 items in 3407ms
[1719.273s] ✓ API #532: unknown_endpoint - 2.88s, 3 items
[1719.273s] ✓ API #533: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 2.88s, 3 items
[1719.284s] 💾 DB #331: shelf_insert courses - 11ms, 3 items
[1719.284s] ℹ shelf_sync: Shelf org.couchdb.user:uuuu courses batch 1/1: 2887ms for 3 docs
[1719.284s] ✓ API #534: unknown_endpoint - 2.89s, 4 items
[1719.284s] ✓ API #535: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 2.89s, 4 items
[1719.290s] 💾 DB #332: shelf_insert resources - 6ms, 3 items
[1719.290s] ℹ shelf_sync: Shelf org.couchdb.user:uuuu resources batch 1/1: 2893ms for 3 docs
[1719.290s] ℹ library_sync: Shelf 61/64 (org.couchdb.user:uuuu): 6 items in 3413ms
[1719.447s] ✓ API #536: unknown_endpoint - 1.78s, 4 items
[1719.448s] ✓ API #537: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 1.78s, 4 items
[1719.450s] ✓ API #538: unknown_endpoint - 1.78s, 5 items
[1719.451s] ✓ API #539: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 1.78s, 5 items
[1719.454s] ✓ API #540: unknown_endpoint - 1.74s
[1719.468s] 💾 DB #333: shelf_insert courses - 20ms, 4 items
[1719.468s] ℹ shelf_sync: Shelf org.couchdb.user:wlopez courses batch 1/1: 1799ms for 4 docs
[1719.480s] 💾 DB #334: shelf_insert resources - 29ms, 4 items
[1719.480s] ℹ shelf_sync: Shelf org.couchdb.user:wlopez resources batch 1/1: 1810ms for 4 docs
[1719.480s] ℹ library_sync: Shelf 62/64 (org.couchdb.user:wlopez): 8 items in 3411ms
[1719.508s] ✓ API #541: unknown_endpoint - 292ms, 2 items
[1719.509s] ✓ API #542: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 292ms, 2 items
[1719.517s] 💾 DB #335: shelf_insert resources - 8ms, 2 items
[1719.736s] ✓ API #543: unknown_endpoint - 522ms, 4 items
[1719.737s] ✓ API #544: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 523ms, 4 items
[1719.737s] ✓ API #545: unknown_endpoint - 519ms, 2 items
[1719.737s] ✓ API #546: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 519ms, 2 items
[1719.754s] 💾 DB #336: shelf_insert courses - 17ms, 4 items
[1719.755s] ℹ library_sync: Shelf 63/64 (org.couchdb.user:xyb994): 6 items in 3657ms
[1719.763s] 💾 DB #337: shelf_insert resources - 26ms, 2 items
[1719.764s] ℹ library_sync: Shelf 60/64 (org.couchdb.user:ujsxn): 2 items in 3373ms
[1719.898s] ✓ API #547: unknown_endpoint - 443ms, 22 items
[1719.898s] ✓ API #548: ...earning.ole.org:443/db/resources/_all_docs (shelf batch 1/1) - 443ms, 22 items
[1719.913s] 💾 DB #338: shelf_insert resources - 15ms, 22 items
[1719.955s] ✓ API #549: unknown_endpoint - 499ms, 3 items
[1719.955s] ✓ API #550: ....learning.ole.org:443/db/courses/_all_docs (shelf batch 1/1) - 500ms, 3 items
[1719.975s] 💾 DB #339: shelf_insert courses - 20ms, 3 items
[1719.975s] ℹ library_sync: Shelf 64/64 (org.couchdb.user:yyyy): 25 items in 2259ms
[1719.975s] ✓ library_process_shelves completed: 23.84s, 913 items
[1719.977s] ✓ library_sync_main completed: 26.55s, 913 items
  ✓ Library sync completed: 26550ms - 913 items from 64 shelves
[1719.978s] ✓ library_sync completed: 26.55s
[1719.979s] ✓ admin_sync completed: 1ms
[1719.981s] ✓ notification_reads_upload completed: 2ms
[1719.981s] ✓ on_synced completed: 0ms
═══════════════════════════════════════════════════════════════
SYNC COMPLETED at 19:06:22.289
TOTAL DURATION: 28m 39.981s
═══════════════════════════════════════════════════════════════
═══════════════════════════════════════════════════════════════
FULL SYNC COMPLETED at 19:06:22.298
TOTAL SYNC TIME: 28m 39s (1719990ms)
═══════════════════════════════════════════════════════════════
```