### PR TITLE
teams: smoother surveys adopt view modelling (fixes #13154)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5384
+        versionName = "0.53.84"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysViewModel.kt
@@ -73,24 +73,20 @@ class SurveysViewModel @Inject constructor(
         _isTeamShareAllowed.value = isTeamShareAllowed
         viewModelScope.launch {
             try {
-                val currentSurveysList = withContext(dispatcherProvider.io) {
-                    when {
-                        isTeam && isTeamShareAllowed -> surveysRepository.getAdoptableTeamSurveys(teamId)
-                        isTeam -> surveysRepository.getTeamOwnedSurveys(teamId)
-                        else -> surveysRepository.getIndividualSurveys()
-                    }
+                val currentSurveysList = when {
+                    isTeam && isTeamShareAllowed -> surveysRepository.getAdoptableTeamSurveys(teamId)
+                    isTeam -> surveysRepository.getTeamOwnedSurveys(teamId)
+                    else -> surveysRepository.getIndividualSurveys()
                 }
 
-                val userModel = withContext(dispatcherProvider.io) { userSessionManager.getUserModel() }
-                val surveyInfos = withContext(dispatcherProvider.io) {
-                    surveysRepository.getSurveyInfos(
-                        isTeam,
-                        teamId,
-                        userModel?.id,
-                        currentSurveysList
-                    )
-                }
-                val bindingData = withContext(dispatcherProvider.io) { surveysRepository.getSurveyFormState(currentSurveysList, teamId) }
+                val userModel = userSessionManager.getUserModel()
+                val surveyInfos = surveysRepository.getSurveyInfos(
+                    isTeam,
+                    teamId,
+                    userModel?.id,
+                    currentSurveysList
+                )
+                val bindingData = surveysRepository.getSurveyFormState(currentSurveysList, teamId)
 
                 _surveyInfos.value = surveyInfos
                 _bindingData.value = bindingData
@@ -217,10 +213,8 @@ class SurveysViewModel @Inject constructor(
     fun adoptSurvey(surveyId: String) {
         viewModelScope.launch {
             try {
-                withContext(dispatcherProvider.io) {
-                    val userModel = userSessionManager.getUserModel()
-                    surveysRepository.adoptSurvey(surveyId, userModel?.id, teamId, isTeam)
-                }
+                val userModel = userSessionManager.getUserModel()
+                surveysRepository.adoptSurvey(surveyId, userModel?.id, teamId, isTeam)
                 _userMessage.value = "Survey adopted successfully"
                 _isTeamShareAllowed.value = false
                 loadSurveys(isTeam, teamId, false)


### PR DESCRIPTION
🧹 [code health improvement description]
🎯 What
Removed redundant `withContext(dispatcherProvider.io)` wrappers from `SurveysViewModel`.

💡 Why
The underlying repository methods and `userSessionManager.getUserModel()` are already suspending functions that internally switch to the appropriate IO context (e.g., via `DatabaseService` or their own coroutine configurations). Therefore, explicitly wrapping them in `withContext(dispatcherProvider.io)` at the ViewModel level is redundant boilerplate that adds unnecessary context switching overhead and harms readability. 

✅ Verification
Ran specific unit tests for `SurveysViewModelTest` which executed successfully. The threading logic within the `viewModelScope.launch` works seamlessly with the underlying suspending calls.

✨ Result
Simplified ViewModel methods (`loadSurveys` and `adoptSurvey`), improved readability, and reduced coroutine context switching overhead.

---
*PR created automatically by Jules for task [2794636371455047306](https://jules.google.com/task/2794636371455047306) started by @dogi*