### PR TITLE
🧹 [code health improvement] Remove redundant DispatcherProvider from CoursesViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
@@ -7,7 +7,6 @@ import java.util.HashMap
 import javax.inject.Inject
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,7 +16,6 @@ import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.Tag
 import org.ole.planet.myplanet.repository.CoursesRepository
-import org.ole.planet.myplanet.utils.DispatcherProvider
 
 data class CoursesUiState(
     val courses: List<Course> = emptyList(),
@@ -28,8 +26,7 @@ data class CoursesUiState(
 
 @HiltViewModel
 class CoursesViewModel @Inject constructor(
-    private val coursesRepository: CoursesRepository,
-    private val dispatcherProvider: DispatcherProvider
+    private val coursesRepository: CoursesRepository
 ) : ViewModel() {
 
     private val _coursesState = MutableStateFlow(CoursesUiState())
@@ -58,40 +55,15 @@ class CoursesViewModel @Inject constructor(
 
     fun loadCourses(isMyCourseLib: Boolean, userId: String?) {
         viewModelScope.launch {
-            withContext(dispatcherProvider.io) {
-                try {
-                    val allCourses = coursesRepository.getAllCourses()
-                    val validCourses = allCourses.filter { !it.courseTitle.isNullOrBlank() }
+            try {
+                val allCourses = coursesRepository.getAllCourses()
+                val validCourses = allCourses.filter { !it.courseTitle.isNullOrBlank() }
 
-                    val myCourses = if (isMyCourseLib) {
-                        coursesRepository.getMyCourses(userId, validCourses)
-                    } else {
-                        emptyList()
-                    }
-
-                    val (map, progressMap) = coroutineScope {
-                        val ratingsDeferred = async { coursesRepository.getCourseRatings(userId) }
-                        val progressDeferred = async { coursesRepository.getCourseProgress(userId) }
-                        Pair(ratingsDeferred.await(), progressDeferred.await())
-                    }
-
-                    val allCourseIds = validCourses.mapNotNull { it.courseId }
-                    val tagsMap = coursesRepository.getCourseTagsBulk(allCourseIds)
-                        .mapValues { entry -> entry.value.map { it.toTag() } }
-
-                    processCourses(isMyCourseLib, userId, validCourses, myCourses, map, progressMap, tagsMap)
-                } catch (e: Exception) {
-                    e.printStackTrace()
+                val myCourses = if (isMyCourseLib) {
+                    coursesRepository.getMyCourses(userId, validCourses)
+                } else {
+                    emptyList()
                 }
-            }
-        }
-    }
-
-    fun filterCourses(isMyCourseLib: Boolean, userId: String?, searchText: String, selectedGrade: String, selectedSubject: String, tagNames: List<String>) {
-        viewModelScope.launch {
-            withContext(dispatcherProvider.io) {
-                val filteredCourses = coursesRepository.filterCourses(searchText, selectedGrade, selectedSubject, tagNames)
-                val myCourses = filteredCourses.filter { it.userId?.contains(userId) == true }
 
                 val (map, progressMap) = coroutineScope {
                     val ratingsDeferred = async { coursesRepository.getCourseRatings(userId) }
@@ -99,9 +71,30 @@ class CoursesViewModel @Inject constructor(
                     Pair(ratingsDeferred.await(), progressDeferred.await())
                 }
 
-                val tagsMap = _coursesState.value.tagsMap
-                processCourses(isMyCourseLib, userId, filteredCourses, myCourses, map, progressMap, tagsMap)
+                val allCourseIds = validCourses.mapNotNull { it.courseId }
+                val tagsMap = coursesRepository.getCourseTagsBulk(allCourseIds)
+                    .mapValues { entry -> entry.value.map { it.toTag() } }
+
+                processCourses(isMyCourseLib, userId, validCourses, myCourses, map, progressMap, tagsMap)
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
+        }
+    }
+
+    fun filterCourses(isMyCourseLib: Boolean, userId: String?, searchText: String, selectedGrade: String, selectedSubject: String, tagNames: List<String>) {
+        viewModelScope.launch {
+            val filteredCourses = coursesRepository.filterCourses(searchText, selectedGrade, selectedSubject, tagNames)
+            val myCourses = filteredCourses.filter { it.userId?.contains(userId) == true }
+
+            val (map, progressMap) = coroutineScope {
+                val ratingsDeferred = async { coursesRepository.getCourseRatings(userId) }
+                val progressDeferred = async { coursesRepository.getCourseProgress(userId) }
+                Pair(ratingsDeferred.await(), progressDeferred.await())
+            }
+
+            val tagsMap = _coursesState.value.tagsMap
+            processCourses(isMyCourseLib, userId, filteredCourses, myCourses, map, progressMap, tagsMap)
         }
     }
 


### PR DESCRIPTION
🎯 **What**: Removed redundant `withContext(dispatcherProvider.io)` wrapping and the `dispatcherProvider` dependency from `CoursesViewModel`.
💡 **Why**: `CoursesRepositoryImpl` natively executes its queries on its own `realmDispatcher` making the explicit IO dispatch at the ViewModel layer redundant noise.
✅ **Verification**: Compiled the project and ran all debug unit tests successfully. Verified that no functional regressions were introduced.
✨ **Result**: Cleaner ViewModels with better separation of concerns (Repositories control their dispatchers).

---
*PR created automatically by Jules for task [6923616145405481511](https://jules.google.com/task/6923616145405481511) started by @dogi*