### PR TITLE
all: smoother voices health repositories dispatcher providing (fixes #13153)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5383
+        versionName = "0.53.83"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -3,7 +3,6 @@ package org.ole.planet.myplanet.repository
 import java.util.Date
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.di.RealmDispatcher
@@ -11,10 +10,12 @@ import org.ole.planet.myplanet.model.RealmHealthExamination
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.AndroidDecrypter
+import org.ole.planet.myplanet.utils.DispatcherProvider
 
 class HealthRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
-    @RealmDispatcher realmDispatcher: CoroutineDispatcher
+    @RealmDispatcher realmDispatcher: CoroutineDispatcher,
+    private val dispatcherProvider: DispatcherProvider
 ) : RealmRepository(databaseService, realmDispatcher), HealthRepository {
     override suspend fun getHealthEntry(userId: String): Pair<RealmUser?, RealmHealthExamination?> {
         val userCopy = findByField(RealmUser::class.java, "id", userId)
@@ -29,7 +30,7 @@ class HealthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun initHealth(): RealmMyHealth {
-        return withContext(Dispatchers.Default) {
+        return withContext(dispatcherProvider.default) {
             val health = RealmMyHealth()
             val profile = RealmMyHealth.RealmMyHealthProfile()
             health.lastExamination = Date().time

--- a/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepositoryImpl.kt
@@ -12,7 +12,6 @@ import java.util.HashMap
 import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -24,6 +23,7 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNews.Companion.createNews
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils.extractLinks
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.UrlUtils
@@ -31,6 +31,7 @@ import org.ole.planet.myplanet.utils.UrlUtils
 class VoicesRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
     @RealmDispatcher realmDispatcher: CoroutineDispatcher,
+    private val dispatcherProvider: DispatcherProvider,
     private val gson: Gson,
     private val sharedPrefManager: SharedPrefManager
 ) : RealmRepository(databaseService, realmDispatcher), VoicesRepository {
@@ -214,7 +215,7 @@ class VoicesRepositoryImpl @Inject constructor(
                 news.sortDate = news.calculateSortDate()
                 news
             }
-        }.flowOn(Dispatchers.Default)
+        }.flowOn(dispatcherProvider.default)
     }
 
     override suspend fun getDiscussionsByTeamIdFlow(teamId: String): Flow<List<RealmNews>> {
@@ -243,7 +244,7 @@ class VoicesRepositoryImpl @Inject constructor(
 
                 viewableByTeams || viewInTeam
             }
-        }.flowOn(Dispatchers.Default)
+        }.flowOn(dispatcherProvider.default)
     }
 
     override suspend fun shareNewsToCommunity(newsId: String, userId: String, planetCode: String, parentCode: String, teamName: String): Result<Unit> {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
@@ -1,0 +1,43 @@
+package org.ole.planet.myplanet.repository
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.utils.DispatcherProvider
+
+@ExperimentalCoroutinesApi
+class HealthRepositoryImplTest {
+
+    private lateinit var repository: HealthRepositoryImpl
+    private val dispatcherProvider: DispatcherProvider = mockk(relaxed = true)
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+    private val databaseService: DatabaseService = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        every { dispatcherProvider.default } returns testDispatcher
+        repository = HealthRepositoryImpl(
+            databaseService,
+            UnconfinedTestDispatcher(),
+            dispatcherProvider
+        )
+    }
+
+    @Test
+    fun initHealth_uses_dispatcherProvider_default() = testScope.runTest {
+        val result = repository.initHealth()
+        advanceUntilIdle()
+        assertNotNull(result)
+        io.mockk.verify { dispatcherProvider.default }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/VoicesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/VoicesRepositoryImplTest.kt
@@ -1,0 +1,66 @@
+package org.ole.planet.myplanet.repository
+
+import com.google.gson.Gson
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.utils.DispatcherProvider
+
+@ExperimentalCoroutinesApi
+class VoicesRepositoryImplTest {
+
+    private lateinit var repository: VoicesRepositoryImpl
+    private val dispatcherProvider: DispatcherProvider = mockk(relaxed = true)
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+    private val databaseService: DatabaseService = mockk(relaxed = true)
+    private val gson: Gson = mockk(relaxed = true)
+    private val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        every { dispatcherProvider.default } returns testDispatcher
+        repository = spyk(VoicesRepositoryImpl(
+            databaseService,
+            UnconfinedTestDispatcher(),
+            dispatcherProvider,
+            gson,
+            sharedPrefManager
+        ), recordPrivateCalls = true)
+    }
+
+    @Test
+    fun getCommunityNews_uses_dispatcherProvider_default() = testScope.runTest {
+        coEvery { repository["queryListFlow"](RealmNews::class.java, any<Function1<*, *>>()) } returns kotlinx.coroutines.flow.flowOf(emptyList<RealmNews>())
+
+        val flow = repository.getCommunityNews("testUser")
+        val result = flow.toList()
+
+        assertNotNull(result)
+        io.mockk.verify { dispatcherProvider.default }
+    }
+
+    @Test
+    fun getDiscussionsByTeamIdFlow_uses_dispatcherProvider_default() = testScope.runTest {
+        coEvery { repository["queryListFlow"](RealmNews::class.java, any<Function1<*, *>>()) } returns kotlinx.coroutines.flow.flowOf(emptyList<RealmNews>())
+
+        val flow = repository.getDiscussionsByTeamIdFlow("testTeam")
+        val result = flow.toList()
+
+        assertNotNull(result)
+        io.mockk.verify { dispatcherProvider.default }
+    }
+}


### PR DESCRIPTION
🎯 What:
Replaced hardcoded `Dispatchers.Default` with `dispatcherProvider.default` in `HealthRepositoryImpl` and `VoicesRepositoryImpl`.

💡 Why:
Using hardcoded dispatchers prevents testing code deterministically because tests run on separate threads. Injecting `DispatcherProvider` allows replacing them with `StandardTestDispatcher` in unit tests, ensuring code runs synchronously without threading issues.

✅ Verification:
Added `HealthRepositoryImplTest` and `VoicesRepositoryImplTest` with deterministic unit tests. Run `./gradlew testDefaultDebugUnitTest` to verify.

✨ Result:
Improved testability and code structure by relying on Dependency Injection for all Coroutine execution contexts.

---
*PR created automatically by Jules for task [3194691875128437135](https://jules.google.com/task/3194691875128437135) started by @dogi*