### PR TITLE
community: smoother repository realm handling (fixes #13152)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5382
+        versionName = "0.53.82"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CommunityRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CommunityRepositoryImpl.kt
@@ -40,11 +40,8 @@ class CommunityRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getAllSorted(): List<RealmCommunity> {
-        return withRealm { realm ->
-            realm.where(RealmCommunity::class.java)
-                .sort("weight", Sort.ASCENDING)
-                .findAll()
-                .let { realm.copyFromRealm(it) }
+        return queryList(RealmCommunity::class.java) {
+            sort("weight", Sort.ASCENDING)
         }
     }
 


### PR DESCRIPTION
Migrated the `withRealm` query in `CommunityRepositoryImpl.getAllSorted` to utilize the base `queryList` method inherited from `RealmRepository`. The `sort` method was successfully preserved via the lambda builder.

---
*PR created automatically by Jules for task [14809616700659274168](https://jules.google.com/task/14809616700659274168) started by @dogi*