### PR TITLE
teams: smoother voices repository view modelling (fixes #13147)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5377
+        versionName = "0.53.77"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -51,7 +51,6 @@ interface ResourcesRepository {
     suspend fun updateLibraryItem(id: String, updater: (RealmMyLibrary) -> Unit)
     suspend fun markResourceOfflineByUrl(url: String)
     suspend fun markResourceOfflineByLocalAddress(localAddress: String)
-    suspend fun getPrivateImageUrlsCreatedAfter(timestamp: Long): List<String>
     suspend fun markAllResourcesOffline(isOffline: Boolean)
     suspend fun saveSearchActivity(
         userName: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -294,15 +294,6 @@ class ResourcesRepositoryImpl @Inject constructor(
         return results.filter { it.needToUpdate() }
     }
 
-    override suspend fun getPrivateImageUrlsCreatedAfter(timestamp: Long): List<String> {
-        val imageList = queryList(RealmMyLibrary::class.java) {
-            equalTo("isPrivate", true)
-                .greaterThan("createdDate", timestamp)
-                .equalTo("mediaType", "image")
-        }
-        return imageList.mapNotNull { it.resourceRemoteAddress }
-    }
-
     override fun getRecentResources(userId: String): Flow<List<RealmMyLibrary>> {
         return queryListFlow(RealmMyLibrary::class.java) {
             equalTo("userId", userId)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepository.kt
@@ -51,4 +51,5 @@ interface VoicesRepository {
     suspend fun insertNewsFromJson(doc: com.google.gson.JsonObject)
     suspend fun insertNewsList(docs: List<com.google.gson.JsonObject>)
     fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
+    suspend fun getPrivateImageUrlsCreatedAfter(timestamp: Long): List<String>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepositoryImpl.kt
@@ -645,4 +645,13 @@ class VoicesRepositoryImpl @Inject constructor(
         }
         saveConcatenatedLinksToPrefs()
     }
+
+    override suspend fun getPrivateImageUrlsCreatedAfter(timestamp: Long): List<String> {
+        val imageList = queryList(RealmMyLibrary::class.java) {
+            equalTo("isPrivate", true)
+                .greaterThan("createdDate", timestamp)
+                .equalTo("mediaType", "image")
+        }
+        return imageList.mapNotNull { it.resourceRemoteAddress }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
@@ -9,12 +9,12 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class NewsViewModel @Inject constructor(
-    private val resourcesRepository: ResourcesRepository,
+    private val voicesRepository: VoicesRepository,
     private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
 
@@ -24,7 +24,7 @@ class NewsViewModel @Inject constructor(
     fun getPrivateImageUrlsCreatedAfter(timestamp: Long) {
         viewModelScope.launch {
             val urls = withContext(dispatcherProvider.io) {
-                resourcesRepository.getPrivateImageUrlsCreatedAfter(timestamp)
+                voicesRepository.getPrivateImageUrlsCreatedAfter(timestamp)
             }
             _privateImageUrls.emit(urls)
         }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/voices/NewsViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/voices/NewsViewModelTest.kt
@@ -13,7 +13,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.MainDispatcherRule
-import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -22,7 +22,7 @@ class NewsViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
-    private lateinit var resourcesRepository: ResourcesRepository
+    private lateinit var voicesRepository: VoicesRepository
     private lateinit var viewModel: NewsViewModel
 
     private val testDispatcherProvider = object : DispatcherProvider {
@@ -34,15 +34,15 @@ class NewsViewModelTest {
 
     @Before
     fun setup() {
-        resourcesRepository = mockk()
-        viewModel = NewsViewModel(resourcesRepository, testDispatcherProvider)
+        voicesRepository = mockk()
+        viewModel = NewsViewModel(voicesRepository, testDispatcherProvider)
     }
 
     @Test
     fun `getPrivateImageUrlsCreatedAfter updates flow with list`() = runTest {
         val timestamp = 123456789L
         val expectedUrls = listOf("url1", "url2")
-        coEvery { resourcesRepository.getPrivateImageUrlsCreatedAfter(timestamp) } returns expectedUrls
+        coEvery { voicesRepository.getPrivateImageUrlsCreatedAfter(timestamp) } returns expectedUrls
 
         var capturedResult: List<String>? = null
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -62,7 +62,7 @@ class NewsViewModelTest {
     fun `getPrivateImageUrlsCreatedAfter updates flow with empty list`() = runTest {
         val timestamp = 123456789L
         val expectedUrls = emptyList<String>()
-        coEvery { resourcesRepository.getPrivateImageUrlsCreatedAfter(timestamp) } returns expectedUrls
+        coEvery { voicesRepository.getPrivateImageUrlsCreatedAfter(timestamp) } returns expectedUrls
 
         var capturedResult: List<String>? = null
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {


### PR DESCRIPTION
🎯 **What:** Moved `getPrivateImageUrlsCreatedAfter` from `ResourcesRepository` to `VoicesRepository`.
💡 **Why:** To improve codebase organization and ensure repository responsibilities are correctly aligned, as News features are more closely related to Voices functionality.
✅ **Verification:** Verified compilation and execution of unit tests for `NewsViewModel` where the dependency was changed. No regressions observed.
✨ **Result:** Better aligned repository boundaries.

---
*PR created automatically by Jules for task [13576210338915493783](https://jules.google.com/task/13576210338915493783) started by @dogi*