### PR TITLE
resources: smoother tags repository inserting (fixes #13151)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5381
+        versionName = "0.53.81"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTag.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTag.kt
@@ -41,30 +41,6 @@ open class RealmTag : RealmObject() {
 
     companion object {
         @JvmStatic
-        fun insert(mRealm: Realm, act: JsonObject) {
-            var tag = mRealm.where(RealmTag::class.java).equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
-            if (tag == null) {
-                tag = mRealm.createObject(RealmTag::class.java, JsonUtils.getString("_id", act))
-            }
-            if (tag != null) {
-                tag._rev = JsonUtils.getString("_rev", act)
-                tag._id = JsonUtils.getString("_id", act)
-                tag.name = JsonUtils.getString("name", act)
-                tag.db = JsonUtils.getString("db", act)
-                tag.docType = JsonUtils.getString("docType", act)
-                tag.tagId = JsonUtils.getString("tagId", act)
-                tag.linkId = JsonUtils.getString("linkId", act)
-                val el = act["attachedTo"]
-                if (el != null && el.isJsonArray) {
-                    tag.setAttachedTo(JsonUtils.getJsonArray("attachedTo", act))
-                } else {
-                    tag.attachedTo?.add(JsonUtils.getString("attachedTo", act))
-                }
-                tag.isAttached = (tag.attachedTo?.size ?: 0) > 0
-            }
-        }
-
-        @JvmStatic
         fun getTagsArray(list: List<RealmTag>): JsonArray {
             val array = JsonArray()
             for (t in list) {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
@@ -11,4 +11,5 @@ interface TagsRepository {
     suspend fun getLinkedCourseIds(db: String, tagIds: Array<String>): Set<String>
     suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<RealmTag>>
     fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
+    suspend fun insert(act: com.google.gson.JsonObject)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
@@ -134,7 +134,40 @@ class TagsRepositoryImpl @Inject constructor(
             }
         }
         documentList.forEach { jsonDoc ->
-            org.ole.planet.myplanet.model.RealmTag.insert(realm, jsonDoc)
+            insertIntoRealm(realm, jsonDoc)
+        }
+    }
+
+    override suspend fun insert(act: com.google.gson.JsonObject) {
+        executeTransaction { realm ->
+            insertIntoRealm(realm, act)
+        }
+    }
+
+    private fun insertIntoRealm(mRealm: io.realm.Realm, act: com.google.gson.JsonObject) {
+        var tag = mRealm.where(RealmTag::class.java).equalTo("_id", org.ole.planet.myplanet.utils.JsonUtils.getString("_id", act)).findFirst()
+        if (tag == null) {
+            tag = mRealm.createObject(RealmTag::class.java, org.ole.planet.myplanet.utils.JsonUtils.getString("_id", act))
+        }
+        if (tag != null) {
+            tag._rev = org.ole.planet.myplanet.utils.JsonUtils.getString("_rev", act)
+            tag._id = org.ole.planet.myplanet.utils.JsonUtils.getString("_id", act)
+            tag.name = org.ole.planet.myplanet.utils.JsonUtils.getString("name", act)
+            tag.db = org.ole.planet.myplanet.utils.JsonUtils.getString("db", act)
+            tag.docType = org.ole.planet.myplanet.utils.JsonUtils.getString("docType", act)
+            tag.tagId = org.ole.planet.myplanet.utils.JsonUtils.getString("tagId", act)
+            tag.linkId = org.ole.planet.myplanet.utils.JsonUtils.getString("linkId", act)
+            val el = act["attachedTo"]
+            if (el != null && el.isJsonArray) {
+                val attachedTo = org.ole.planet.myplanet.utils.JsonUtils.getJsonArray("attachedTo", act)
+                tag.attachedTo = io.realm.RealmList()
+                for (i in 0 until attachedTo.size()) {
+                    tag.attachedTo?.add(org.ole.planet.myplanet.utils.JsonUtils.getString(attachedTo, i))
+                }
+            } else {
+                tag.attachedTo?.add(org.ole.planet.myplanet.utils.JsonUtils.getString("attachedTo", act))
+            }
+            tag.isAttached = (tag.attachedTo?.size ?: 0) > 0
         }
     }
 }


### PR DESCRIPTION
🎯 What
Migrated the `insert` method from `RealmTag.kt`'s companion object into the newly established `TagsRepository`, adapting to use `executeTransaction`.

💡 Why
Realm models should purely act as data structures. Decoupling the data access methods out of `RealmObject` companion objects and placing them in dedicated repositories aligns with clean architecture.

✅ Verification
- Compiles via `./gradlew compileDefaultDebugKotlin compileDefaultDebugUnitTestKotlin` successfully.
- Tests passed via `./gradlew testDefaultDebugUnitTest --tests org.ole.planet.myplanet.repository.TagsRepositoryImplTest`.
- Manual review of usages confirms `TagsRepositoryImpl` securely manages its insertion.

✨ Result
A cleaner codebase with centralized dependency management.

---
*PR created automatically by Jules for task [17211808414903333615](https://jules.google.com/task/17211808414903333615) started by @dogi*