### PR TITLE
all: smoother notifications repository inserting (fixes #13148)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5378
+        versionName = "0.53.78"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmNotification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmNotification.kt
@@ -22,28 +22,4 @@ open class RealmNotification : RealmObject() {
     var isFromServer: Boolean = false
     var rev: String? = null
     var needsSync: Boolean = false
-
-    companion object {
-        @JvmStatic
-        fun insert(mRealm: Realm, doc: JsonObject) {
-            val id = doc.get("_id")?.asString ?: return
-            val notification = mRealm.where(RealmNotification::class.java)
-                .equalTo("id", id).findFirst()
-                ?: mRealm.createObject(RealmNotification::class.java, id)
-            notification.apply {
-                userId = doc.get("user")?.asString ?: ""
-                message = doc.get("message")?.asString ?: ""
-                type = doc.get("type")?.asString ?: ""
-                link = doc.get("link")?.asString
-                priority = doc.get("priority")?.asInt ?: 0
-                rev = doc.get("_rev")?.asString
-                // Preserve local read state if a change is pending upload
-                if (!needsSync) {
-                    isRead = doc.get("status")?.asString != "unread"
-                }
-                createdAt = doc.get("time")?.let { Date(it.asLong) } ?: Date()
-                isFromServer = true
-            }
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepository.kt
@@ -23,4 +23,5 @@ interface NotificationsRepository {
     suspend fun getPendingSyncNotifications(): List<org.ole.planet.myplanet.model.RealmNotification>
     suspend fun markNotificationsSynced(syncResults: List<Pair<String, String?>>)
     fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
+    suspend fun insert(doc: com.google.gson.JsonObject)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -452,6 +452,33 @@ class NotificationsRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun insert(doc: com.google.gson.JsonObject) {
+        executeTransaction { realm ->
+            internalInsert(realm, doc)
+        }
+    }
+
+    private fun internalInsert(mRealm: io.realm.Realm, doc: com.google.gson.JsonObject) {
+        val id = doc.get("_id")?.asString ?: return
+        val notification = mRealm.where(RealmNotification::class.java)
+            .equalTo("id", id).findFirst()
+            ?: mRealm.createObject(RealmNotification::class.java, id)
+        notification.apply {
+            userId = doc.get("user")?.asString ?: ""
+            message = doc.get("message")?.asString ?: ""
+            type = doc.get("type")?.asString ?: ""
+            link = doc.get("link")?.asString
+            priority = doc.get("priority")?.asInt ?: 0
+            rev = doc.get("_rev")?.asString
+            // Preserve local read state if a change is pending upload
+            if (!needsSync) {
+                isRead = doc.get("status")?.asString != "unread"
+            }
+            createdAt = doc.get("time")?.let { java.util.Date(it.asLong) } ?: java.util.Date()
+            isFromServer = true
+        }
+    }
+
     override fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray) {
         val documentList = ArrayList<com.google.gson.JsonObject>(jsonArray.size())
         for (j in jsonArray) {
@@ -463,7 +490,7 @@ class NotificationsRepositoryImpl @Inject constructor(
             }
         }
         documentList.forEach { jsonDoc ->
-            org.ole.planet.myplanet.model.RealmNotification.insert(realm, jsonDoc)
+            internalInsert(realm, jsonDoc)
         }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
@@ -1,18 +1,40 @@
-package org.ole.planet.myplanet.model
+package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonObject
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.slot
+import io.mockk.invoke
 import io.realm.Realm
 import io.realm.RealmQuery
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmNotification
 
-class RealmNotificationTest {
+@ExperimentalCoroutinesApi
+class NotificationsRepositoryImplTest {
+
+    private lateinit var databaseService: DatabaseService
+    private lateinit var userRepository: dagger.Lazy<UserRepository>
+    private lateinit var repository: NotificationsRepositoryImpl
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        databaseService = mockk(relaxed = true)
+        userRepository = mockk(relaxed = true)
+        repository = NotificationsRepositoryImpl(databaseService, testDispatcher, userRepository)
+    }
 
     @Test
     fun `test default property values`() {
@@ -33,18 +55,23 @@ class RealmNotificationTest {
     }
 
     @Test
-    fun `insert with missing id does nothing`() {
+    fun `insert with missing id does nothing`() = runTest {
         val realm = mockk<Realm>(relaxed = true)
         val jsonObject = JsonObject() // Missing _id
 
-        RealmNotification.insert(realm, jsonObject)
+        val transactionSlot = slot<(Realm) -> Unit>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(realm)
+        }
+
+        repository.insert(jsonObject)
 
         verify(exactly = 0) { realm.where(RealmNotification::class.java) }
         verify(exactly = 0) { realm.createObject(RealmNotification::class.java, any<String>()) }
     }
 
     @Test
-    fun `insert creates new notification when not found`() {
+    fun `insert creates new notification when not found`() = runTest {
         val realm = mockk<Realm>(relaxed = true)
         val query = mockk<RealmQuery<RealmNotification>>()
         val notification = RealmNotification()
@@ -60,12 +87,17 @@ class RealmNotificationTest {
             addProperty("time", 123456789L)
         }
 
+        val transactionSlot = slot<(Realm) -> Unit>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(realm)
+        }
+
         every { realm.where(RealmNotification::class.java) } returns query
         every { query.equalTo("id", "testId") } returns query
         every { query.findFirst() } returns null
         every { realm.createObject(RealmNotification::class.java, "testId") } returns notification
 
-        RealmNotification.insert(realm, jsonObject)
+        repository.insert(jsonObject)
 
         assertEquals("testUser", notification.userId)
         assertEquals("testMessage", notification.message)
@@ -79,7 +111,7 @@ class RealmNotificationTest {
     }
 
     @Test
-    fun `insert updates existing notification`() {
+    fun `insert updates existing notification`() = runTest {
         val realm = mockk<Realm>(relaxed = true)
         val query = mockk<RealmQuery<RealmNotification>>()
         val notification = RealmNotification()
@@ -92,11 +124,16 @@ class RealmNotificationTest {
             addProperty("time", 987654321L)
         }
 
+        val transactionSlot = slot<(Realm) -> Unit>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(realm)
+        }
+
         every { realm.where(RealmNotification::class.java) } returns query
         every { query.equalTo("id", "testId") } returns query
         every { query.findFirst() } returns notification
 
-        RealmNotification.insert(realm, jsonObject)
+        repository.insert(jsonObject)
 
         assertEquals("updatedUser", notification.userId)
         assertEquals("updatedMessage", notification.message)
@@ -109,7 +146,7 @@ class RealmNotificationTest {
     }
 
     @Test
-    fun `insert preserves read status if needsSync is true`() {
+    fun `insert preserves read status if needsSync is true`() = runTest {
         val realm = mockk<Realm>(relaxed = true)
         val query = mockk<RealmQuery<RealmNotification>>()
         val notification = RealmNotification().apply {
@@ -121,11 +158,16 @@ class RealmNotificationTest {
             addProperty("status", "unread")
         }
 
+        val transactionSlot = slot<(Realm) -> Unit>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(realm)
+        }
+
         every { realm.where(RealmNotification::class.java) } returns query
         every { query.equalTo("id", "testId") } returns query
         every { query.findFirst() } returns notification
 
-        RealmNotification.insert(realm, jsonObject)
+        repository.insert(jsonObject)
 
         // isRead should be preserved (true) even though status is "unread", because needsSync is true
         assertTrue(notification.isRead)


### PR DESCRIPTION
**What**: Migrated the `insert` logic from `RealmNotification.kt` to `NotificationsRepository.kt` and `NotificationsRepositoryImpl.kt`, ensuring tests are updated.

**Why**: Consolidating data-access methods to their corresponding repositories simplifies maintenance and improves codebase architecture, avoiding static access patterns inside Realm models.

**Verification**:
- Successfully migrated all related test logic into `NotificationsRepositoryImplTest.kt` and used `coEvery` to mock transaction handling.
- `NotificationsRepositoryImplTest` runs successfully without nested coroutine errors.
- Checked `TransactionSyncManagerTest` and found no regressions.
- Tested and verified there are no other external callers to `RealmNotification.insert`.

---
*PR created automatically by Jules for task [303899506390196401](https://jules.google.com/task/303899506390196401) started by @dogi*