### PR TITLE
login: smoother activities repository uploading (fixes #13150)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5380
+        versionName = "0.53.80"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
@@ -25,4 +25,5 @@ interface ActivitiesRepository {
     suspend fun getRecentLogin(): RealmOfflineActivity?
     fun serializeLoginActivities(activity: RealmOfflineActivity, context: android.content.Context): JsonObject
     fun bulkInsertLoginActivitiesFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
+    suspend fun uploadActivities()
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -15,6 +15,14 @@ import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmRemovedLog
 import org.ole.planet.myplanet.model.RealmResourceActivity
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.utils.UrlUtils
+import android.util.Log
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.services.UserSessionManager
@@ -25,7 +33,8 @@ class ActivitiesRepositoryImpl @Inject constructor(
     @RealmDispatcher realmDispatcher: CoroutineDispatcher,
     @ApplicationContext private val context: Context,
     private val teamsRepository: Lazy<TeamsRepository>,
-    private val userRepository: Lazy<UserRepository>
+    private val userRepository: Lazy<UserRepository>,
+    private val apiInterface: ApiInterface
 ) : RealmRepository(databaseService, realmDispatcher), ActivitiesRepository {
     override suspend fun getOfflineActivities(userName: String, type: String): List<RealmOfflineActivity> {
         return queryList(RealmOfflineActivity::class.java) {
@@ -303,6 +312,42 @@ class ActivitiesRepositoryImpl @Inject constructor(
             ob.addProperty("_rev", activity._rev)
         }
         return ob
+    }
+
+        override suspend fun uploadActivities() {
+        val activitiesToUpload = getUnuploadedLoginActivities()
+
+        activitiesToUpload.chunked(50).forEach { batch ->
+            val successfulUpdates = mutableMapOf<String, com.google.gson.JsonObject?>()
+
+            val semaphore = Semaphore(6)
+            coroutineScope {
+                val deferreds = batch.map { activityData ->
+                    async {
+                        try {
+                            val `object` = semaphore.withPermit {
+                                apiInterface.postDoc(
+                                    UrlUtils.header, "application/json",
+                                    "${UrlUtils.getUrl()}/login_activities", activityData.serialized
+                                ).body()
+                            }
+                            activityData.id to `object`
+                        } catch (e: java.io.IOException) {
+                            Log.e("ActivitiesRepository", "Exception in UploadManager", e)
+                            null
+                        }
+                    }
+                }
+                deferreds.awaitAll().filterNotNull().forEach { (id, obj) ->
+                    successfulUpdates[id] = obj
+                }
+            }
+
+            if (successfulUpdates.isNotEmpty()) {
+                val idsToUpdate = successfulUpdates.keys.toTypedArray()
+                markActivitiesUploaded(idsToUpdate, successfulUpdates)
+            }
+        }
     }
 
     override fun bulkInsertLoginActivitiesFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray) {

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -456,39 +456,7 @@ class UploadManager @Inject constructor(
         }
 
         try {
-            val activitiesToUpload = activitiesRepository.getUnuploadedLoginActivities()
-
-            activitiesToUpload.chunked(BATCH_SIZE).forEach { batch ->
-                val successfulUpdates = mutableMapOf<String, com.google.gson.JsonObject?>()
-
-                val semaphore = Semaphore(6)
-                coroutineScope {
-                    val deferreds = batch.map { activityData ->
-                        async {
-                            try {
-                                val `object` = semaphore.withPermit {
-                                    apiInterface.postDoc(
-                                        UrlUtils.header, "application/json",
-                                        "${UrlUtils.getUrl()}/login_activities", activityData.serialized
-                                    ).body()
-                                }
-                                activityData.id to `object`
-                            } catch (e: java.io.IOException) {
-                                Log.e(TAG, "Exception in UploadManager", e)
-                                null
-                            }
-                        }
-                    }
-                    deferreds.awaitAll().filterNotNull().forEach { (id, obj) ->
-                        successfulUpdates[id] = obj
-                    }
-                }
-
-                if (successfulUpdates.isNotEmpty()) {
-                    val idsToUpdate = successfulUpdates.keys.toTypedArray()
-                    activitiesRepository.markActivitiesUploaded(idsToUpdate, successfulUpdates)
-                }
-            }
+            activitiesRepository.uploadActivities()
 
             uploadTeamActivities()
 


### PR DESCRIPTION
Refactors the application's login activity sync mechanism to ensure `ActivitiesRepository` fully owns its data lifecycle.

💡 **What**:
- Added `uploadActivities()` method to `ActivitiesRepository`.
- Moved the concurrent `apiInterface.postDoc` upload logic (with semaphore limiting) from `UploadManager.uploadUserActivities` into `ActivitiesRepositoryImpl.uploadActivities()`.
- Added `ApiInterface` to the constructor of `ActivitiesRepositoryImpl`.
- Simplified `UploadManager` to delegate to the new repository method.

🎯 **Why**:
`UploadManager` was acting as a god-class, bypassing the repository to perform direct network calls and coordinating local database updates manually. Encapsulating this behavior within the relevant repository improves modularity and adhering to the Single Responsibility Principle.

---
*PR created automatically by Jules for task [6820148354933584756](https://jules.google.com/task/6820148354933584756) started by @dogi*