### PR TITLE
courses: smoother sync manager view modelling (fixes #13159)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5389
+        versionName = "0.53.89"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -85,12 +85,6 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     lateinit var prefManager: SharedPrefManager
 
     @Inject
-    lateinit var serverUrlMapper: ServerUrlMapper
-
-    @Inject
-    lateinit var syncManager: SyncManager
-
-    @Inject
     lateinit var userSessionManager: UserSessionManager
 
     private val serverUrl: String
@@ -100,70 +94,6 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
 
     override fun getLayout(): Int {
         return R.layout.fragment_my_course
-    }
-
-    private fun startCoursesSync() {
-        val isFastSync = prefManager.getFastSync()
-        if (isFastSync && !prefManager.isSynced(SharedPrefManager.SyncKey.COURSES)) {
-            checkServerAndStartSync()
-        }
-    }
-
-    private fun checkServerAndStartSync() {
-        val mapping = serverUrlMapper.processUrl(serverUrl)
-
-        lifecycleScope.launch {
-            withContext(dispatcherProvider.io) {
-                updateServerIfNecessary(mapping)
-            }
-            startSyncManager()
-        }
-    }
-
-    private fun startSyncManager() {
-        syncManager.start(object : OnSyncListener {
-            override fun onSyncStarted() {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded && !requireActivity().isFinishing) {
-                        customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-                        customProgressDialog?.setText(getString(R.string.syncing_courses_data))
-                        customProgressDialog?.show()
-                    }
-                }
-            }
-
-            override fun onSyncComplete() {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded) {
-                        customProgressDialog?.setText(getString(R.string.loading_courses))
-                        delay(3000)
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-                        loadDataAsync()
-                        prefManager.setSynced(SharedPrefManager.SyncKey.COURSES, true)
-                    }
-                }
-            }
-
-            override fun onSyncFailed(msg: String?) {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-
-                        Snackbar.make(requireView(), "Sync failed: ${msg ?: "Unknown error"}", Snackbar.LENGTH_LONG).setAction("Retry") {
-                            startCoursesSync()
-                        }.show()
-                    }
-                }
-            }
-        }, "full", listOf("courses"))
-    }
-
-    private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
-        serverUrlMapper.updateServerIfNecessary(mapping, prefManager.rawPreferences) { url ->
-            isServerReachable(url)
-        }
     }
 
     private fun scrollToTop() {
@@ -247,9 +177,49 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             }
         }
 
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.syncStatus.collectLatest { status ->
+                when (status) {
+                    is SyncStatus.Idle -> { /* Do nothing */ }
+                    is SyncStatus.Syncing -> {
+                        if (isAdded && !requireActivity().isFinishing) {
+                            if (customProgressDialog == null) {
+                                customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
+                            }
+                            customProgressDialog?.setText(getString(R.string.syncing_courses_data))
+                            customProgressDialog?.show()
+                        }
+                    }
+                    is SyncStatus.Success -> {
+                        if (isAdded) {
+                            customProgressDialog?.setText(getString(R.string.loading_courses))
+                            delay(3000)
+                            customProgressDialog?.dismiss()
+                            customProgressDialog = null
+                            loadDataAsync()
+                            prefManager.setSynced(SharedPrefManager.SyncKey.COURSES, true)
+                            viewModel.resetSyncStatus()
+                        }
+                    }
+                    is SyncStatus.Failed -> {
+                        if (isAdded) {
+                            customProgressDialog?.dismiss()
+                            customProgressDialog = null
+                            Snackbar.make(requireView(), "Sync failed: ${status.message ?: "Unknown error"}", Snackbar.LENGTH_LONG)
+                                .setAction("Retry") {
+                                    viewModel.startCoursesSync()
+                                }.show()
+                            viewModel.resetSyncStatus()
+                        }
+                    }
+                }
+            }
+        }
+
         realtimeSyncHelper = RealtimeSyncHelper(this, this)
         realtimeSyncHelper.setupRealtimeSync()
-        startCoursesSync()
+        viewModel.startCoursesSync()
     }
 
     private fun setupButtonVisibility() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
@@ -18,6 +18,19 @@ import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.Tag
 import org.ole.planet.myplanet.repository.CoursesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.services.sync.ServerUrlMapper
+import org.ole.planet.myplanet.services.sync.SyncManager
+import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
+import org.ole.planet.myplanet.callback.OnSyncListener
+
+
+sealed class SyncStatus {
+    object Idle : SyncStatus()
+    object Syncing : SyncStatus()
+    object Success : SyncStatus()
+    data class Failed(val message: String?) : SyncStatus()
+}
 
 data class CoursesUiState(
     val courses: List<Course> = emptyList(),
@@ -29,11 +42,62 @@ data class CoursesUiState(
 @HiltViewModel
 class CoursesViewModel @Inject constructor(
     private val coursesRepository: CoursesRepository,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val syncManager: SyncManager,
+    private val serverUrlMapper: ServerUrlMapper,
+    private val prefManager: SharedPrefManager
 ) : ViewModel() {
 
     private val _coursesState = MutableStateFlow(CoursesUiState())
     val coursesState: StateFlow<CoursesUiState> = _coursesState
+
+    private val _syncStatus = MutableStateFlow<SyncStatus>(SyncStatus.Idle)
+    val syncStatus: StateFlow<SyncStatus> = _syncStatus
+
+    fun resetSyncStatus() {
+        _syncStatus.value = SyncStatus.Idle
+    }
+
+    fun startCoursesSync() {
+        val isFastSync = prefManager.getFastSync()
+        if (isFastSync && !prefManager.isSynced(SharedPrefManager.SyncKey.COURSES)) {
+            checkServerAndStartSync()
+        }
+    }
+
+    private fun checkServerAndStartSync() {
+        val serverUrl = prefManager.getServerUrl()
+        val mapping = serverUrlMapper.processUrl(serverUrl)
+
+        viewModelScope.launch {
+            withContext(dispatcherProvider.io) {
+                updateServerIfNecessary(mapping)
+            }
+            startSyncManager()
+        }
+    }
+
+    private fun startSyncManager() {
+        syncManager.start(object : OnSyncListener {
+            override fun onSyncStarted() {
+                _syncStatus.value = SyncStatus.Syncing
+            }
+
+            override fun onSyncComplete() {
+                _syncStatus.value = SyncStatus.Success
+            }
+
+            override fun onSyncFailed(msg: String?) {
+                _syncStatus.value = SyncStatus.Failed(msg)
+            }
+        }, "full", listOf("courses"))
+    }
+
+    private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
+        serverUrlMapper.updateServerIfNecessary(mapping, prefManager.rawPreferences) { url ->
+            isServerReachable(url)
+        }
+    }
 
     private fun processCourses(
         isMyCourseLib: Boolean,


### PR DESCRIPTION
1. **Injected `SyncManager` into `CoursesViewModel.kt`**: Removed constructor injections of `SyncManager` and `ServerUrlMapper` from `CoursesFragment.kt`. Added them to the ViewModel.
2. **Moved sync methods**: Relocated `startCoursesSync()`, `checkServerAndStartSync()`, `startSyncManager()`, and `updateServerIfNecessary()` from the fragment to the ViewModel. 
3. **StateFlow SyncStatus**: Introduced a `SyncStatus` sealed class (`Idle`, `Syncing`, `Success`, `Failed`). The ViewModel now emits these states instead of directly mutating fragment dialogs. 
4. **Fragment observation**: The fragment observes the `syncStatus` flow within a coroutine to display the `CustomProgressDialog`, `Snackbar` errors, and load data upon completion. State is correctly reset to `Idle` after terminal states to handle lifecycle orientation changes.

---
*PR created automatically by Jules for task [15474552031364834195](https://jules.google.com/task/15474552031364834195) started by @dogi*