### PR TITLE
chat: less detail api service injection is more (fixes #13161)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5390
+        versionName = "0.53.90"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.data.api.ChatApiService
 import org.ole.planet.myplanet.databinding.FragmentChatDetailBinding
 import org.ole.planet.myplanet.model.AiProvider
 import org.ole.planet.myplanet.model.ChatMessage
@@ -74,8 +73,6 @@ class ChatDetailFragment : Fragment() {
     lateinit var customProgressDialog: DialogUtils.CustomProgressDialog
     @Inject
     lateinit var chatRepository: ChatRepository
-    @Inject
-    lateinit var chatApiService: ChatApiService
     @Inject
     lateinit var userRepository: UserRepository
     @Inject

--- a/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragmentInjectionTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragmentInjectionTest.kt
@@ -1,0 +1,13 @@
+package org.ole.planet.myplanet.ui.chat
+
+import org.junit.Test
+import kotlin.test.assertFalse
+
+class ChatDetailFragmentInjectionTest {
+    @Test
+    fun verifyNoDirectApiServiceDependency() {
+        val fields = ChatDetailFragment::class.java.declaredFields
+        val hasApiService = fields.any { it.type.simpleName == "ChatApiService" }
+        assertFalse(hasApiService, "ChatDetailFragment should not directly depend on ChatApiService. Use ChatRepository instead.")
+    }
+}


### PR DESCRIPTION
- Removed unused `ChatApiService` injection and its corresponding import from `ChatDetailFragment`. 
- Added a reflection-based unit test (`ChatDetailFragmentInjectionTest`) that programmatically verifies `ChatDetailFragment` does not depend on `ChatApiService` to prevent regressions. All chat functionality continues routing through `ChatRepository`.

---
*PR created automatically by Jules for task [16436992619418637927](https://jules.google.com/task/16436992619418637927) started by @dogi*