### PR TITLE
all: smoother feedback list sync manager view modelling (fixes #13160)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5389
+        versionName = "0.53.89"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -20,14 +20,12 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.OnBaseRealtimeSyncListener
 import org.ole.planet.myplanet.callback.OnFeedbackSubmittedListener
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.databinding.FragmentFeedbackListBinding
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.collectWhenStarted
 import org.ole.planet.myplanet.utils.DispatcherProvider
@@ -43,9 +41,6 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     lateinit var sharedPrefManager: SharedPrefManager
     @Inject
     lateinit var serverUrlMapper: ServerUrlMapper
-
-    @Inject
-    lateinit var syncManager: SyncManager
 
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
@@ -112,46 +107,9 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
         lifecycleScope.launch(dispatcherProvider.io) {
             updateServerIfNecessary(mapping)
             withContext(dispatcherProvider.main) {
-                startSyncManager()
+                viewModel.startFeedbackSync()
             }
         }
-    }
-
-    private fun startSyncManager() {
-        syncManager.start(object : OnSyncListener {
-            override fun onSyncStarted() {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded && !requireActivity().isFinishing) {
-                        customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-                        customProgressDialog?.setText(getString(R.string.syncing_feedback))
-                        customProgressDialog?.show()
-                    }
-                }
-            }
-
-            override fun onSyncComplete() {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-                        refreshFeedbackListData()
-                        sharedPrefManager.setSynced(SharedPrefManager.SyncKey.FEEDBACK, true)
-                    }
-                }
-            }
-
-            override fun onSyncFailed(msg: String?) {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-
-                        Snackbar.make(binding.root, "Sync failed: ${msg ?: "Unknown error"}", Snackbar.LENGTH_LONG)
-                            .setAction("Retry") { startFeedbackSync() }.show()
-                    }
-                }
-            }
-        }, "full", listOf("feedback"))
     }
 
     private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
@@ -171,6 +129,38 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
     private fun observeFeedbackList() {
         collectWhenStarted(viewModel.feedbackList) { feedbackList ->
             updatedFeedbackList(feedbackList)
+        }
+
+        collectWhenStarted(viewModel.syncStatus) { status ->
+            when (status) {
+                is FeedbackListViewModel.SyncStatus.Idle -> {
+                    // Do nothing
+                }
+                is FeedbackListViewModel.SyncStatus.Syncing -> {
+                    if (isAdded && !requireActivity().isFinishing) {
+                        customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
+                        customProgressDialog?.setText(getString(R.string.syncing_feedback))
+                        customProgressDialog?.show()
+                    }
+                }
+                is FeedbackListViewModel.SyncStatus.Success -> {
+                    if (isAdded) {
+                        customProgressDialog?.dismiss()
+                        customProgressDialog = null
+                        refreshFeedbackListData()
+                        sharedPrefManager.setSynced(SharedPrefManager.SyncKey.FEEDBACK, true)
+                    }
+                }
+                is FeedbackListViewModel.SyncStatus.Error -> {
+                    if (isAdded) {
+                        customProgressDialog?.dismiss()
+                        customProgressDialog = null
+
+                        Snackbar.make(binding.root, "Sync failed: ${status.message}", Snackbar.LENGTH_LONG)
+                            .setAction("Retry") { startFeedbackSync() }.show()
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModel.kt
@@ -10,20 +10,33 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class FeedbackListViewModel @Inject constructor(
     private val feedbackRepository: FeedbackRepository,
     private val userSessionManager: UserSessionManager,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val syncManager: SyncManager
 ) : ViewModel() {
+
+    sealed class SyncStatus {
+        object Idle : SyncStatus()
+        object Syncing : SyncStatus()
+        object Success : SyncStatus()
+        data class Error(val message: String) : SyncStatus()
+    }
 
     private val _feedbackList = MutableStateFlow<List<RealmFeedback>>(emptyList())
     val feedbackList: StateFlow<List<RealmFeedback>> = _feedbackList.asStateFlow()
+
+    private val _syncStatus = MutableStateFlow<SyncStatus>(SyncStatus.Idle)
+    val syncStatus: StateFlow<SyncStatus> = _syncStatus.asStateFlow()
 
     private var fetchJob: Job? = null
 
@@ -42,5 +55,21 @@ class FeedbackListViewModel @Inject constructor(
     }
     fun refreshFeedback() {
         loadFeedback()
+    }
+
+    fun startFeedbackSync() {
+        syncManager.start(object : OnSyncListener {
+            override fun onSyncStarted() {
+                _syncStatus.value = SyncStatus.Syncing
+            }
+
+            override fun onSyncComplete() {
+                _syncStatus.value = SyncStatus.Success
+            }
+
+            override fun onSyncFailed(msg: String?) {
+                _syncStatus.value = SyncStatus.Error(msg ?: "Unknown error")
+            }
+        }, "full", listOf("feedback"))
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModelTest.kt
@@ -8,14 +8,18 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import io.mockk.every
+import io.mockk.slot
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.utils.MainDispatcherRule
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
 
@@ -30,12 +34,14 @@ class FeedbackListViewModelTest {
     private lateinit var viewModel: FeedbackListViewModel
     private lateinit var feedbackRepository: FeedbackRepository
     private lateinit var userSessionManager: UserSessionManager
+    private lateinit var syncManager: SyncManager
     private val dispatcherProvider = TestDispatcherProvider(testDispatcher)
 
     @Before
     fun setup() {
         feedbackRepository = mockk()
         userSessionManager = mockk()
+        syncManager = mockk()
 
         val user = mockk<RealmUser>()
         coEvery { userSessionManager.getUserModel() } returns user
@@ -44,7 +50,8 @@ class FeedbackListViewModelTest {
         viewModel = FeedbackListViewModel(
             feedbackRepository = feedbackRepository,
             userSessionManager = userSessionManager,
-            dispatcherProvider = dispatcherProvider
+            dispatcherProvider = dispatcherProvider,
+            syncManager = syncManager
         )
     }
 
@@ -68,7 +75,8 @@ class FeedbackListViewModelTest {
         viewModel = FeedbackListViewModel(
             feedbackRepository = feedbackRepository,
             userSessionManager = userSessionManager,
-            dispatcherProvider = dispatcherProvider
+            dispatcherProvider = dispatcherProvider,
+            syncManager = syncManager
         )
 
         advanceUntilIdle()
@@ -92,7 +100,8 @@ class FeedbackListViewModelTest {
         viewModel = FeedbackListViewModel(
             feedbackRepository = feedbackRepository,
             userSessionManager = userSessionManager,
-            dispatcherProvider = dispatcherProvider
+            dispatcherProvider = dispatcherProvider,
+            syncManager = syncManager
         )
         advanceUntilIdle()
         assertEquals(initialFeedback, viewModel.feedbackList.value)
@@ -107,5 +116,26 @@ class FeedbackListViewModelTest {
         assertEquals(updatedFeedback, viewModel.feedbackList.value)
         // Verify it was called twice: once in init, once in refreshFeedback
         coVerify(exactly = 2) { feedbackRepository.getFeedback(user) }
+    }
+
+    @Test
+    fun testStartFeedbackSyncUpdatesSyncStatus() {
+        val listenerSlot = slot<OnSyncListener>()
+        every { syncManager.start(capture(listenerSlot), "full", listOf("feedback")) } answers {
+            // Do nothing, just capture the listener
+        }
+
+        assertEquals(FeedbackListViewModel.SyncStatus.Idle, viewModel.syncStatus.value)
+
+        viewModel.startFeedbackSync()
+
+        listenerSlot.captured.onSyncStarted()
+        assertEquals(FeedbackListViewModel.SyncStatus.Syncing, viewModel.syncStatus.value)
+
+        listenerSlot.captured.onSyncComplete()
+        assertEquals(FeedbackListViewModel.SyncStatus.Success, viewModel.syncStatus.value)
+
+        listenerSlot.captured.onSyncFailed("Error message")
+        assertEquals(FeedbackListViewModel.SyncStatus.Error("Error message"), viewModel.syncStatus.value)
     }
 }

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "Ready"

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Ready"


### PR DESCRIPTION
Refactors the `FeedbackListFragment` to move all `SyncManager` responsibilities into its associated `FeedbackListViewModel`.

**Changes Made:**
1. Added `SyncManager` as a constructor parameter to `FeedbackListViewModel`.
2. Created a `SyncStatus` sealed class and `syncStatus` `StateFlow` within the ViewModel.
3. Created a `startFeedbackSync()` function in the ViewModel to encapsulate the `syncManager.start` call.
4. Removed the injected `SyncManager` field from `FeedbackListFragment`.
5. Updated `FeedbackListFragment` to collect `viewModel.syncStatus` and update the UI (progress dialogs, snackbar, and saving to `SharedPrefManager`).
6. Updated `FeedbackListViewModelTest` by supplying a mocked `SyncManager` and testing the new `startFeedbackSync()` function's state changes.

---
*PR created automatically by Jules for task [6533762978802184617](https://jules.google.com/task/6533762978802184617) started by @dogi*