### PR TITLE
teams: smoother activities repository search inserting (fixes #13156)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5385
+        versionName = "0.53.85"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
@@ -38,17 +38,4 @@ open class RealmSearchActivity(
         return obj
     }
 
-    companion object {
-        @JvmStatic
-        fun insert(log: RealmNewsLog): JsonObject {
-            val ob = JsonObject()
-            ob.addProperty("user", log.userId)
-            ob.addProperty("type", log.type)
-            ob.addProperty("time", log.time)
-            ob.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            ob.addProperty("deviceName", NetworkUtils.getDeviceName())
-            ob.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(MainApplication.context))
-            return ob
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
@@ -23,6 +23,7 @@ interface ActivitiesRepository {
     suspend fun recordSyncActivity(userId: String)
     suspend fun insertActivity(json: JsonObject)
     suspend fun getRecentLogin(): RealmOfflineActivity?
+    suspend fun insertSearchActivityFromNewsLog(log: org.ole.planet.myplanet.model.RealmNewsLog)
     fun serializeLoginActivities(activity: RealmOfflineActivity, context: android.content.Context): JsonObject
     fun bulkInsertLoginActivitiesFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -285,6 +285,15 @@ class ActivitiesRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun insertSearchActivityFromNewsLog(log: org.ole.planet.myplanet.model.RealmNewsLog) {
+        executeTransaction { realm ->
+            val activity = realm.createObject(org.ole.planet.myplanet.model.RealmSearchActivity::class.java, UUID.randomUUID().toString())
+            activity.user = log.userId ?: ""
+            activity.type = log.type ?: ""
+            activity.time = log.time ?: 0L
+        }
+    }
+
     override fun serializeLoginActivities(activity: RealmOfflineActivity, context: android.content.Context): com.google.gson.JsonObject {
         val ob = com.google.gson.JsonObject()
         ob.addProperty("user", activity.userName)


### PR DESCRIPTION
🎯 What
Migrated the static `insert` method from `RealmSearchActivity.kt`'s companion object to the `ActivitiesRepository` interface and its implementation `ActivitiesRepositoryImpl.kt`.

💡 Why
The original `insert` method was misleadingly named (it merely returned a `JsonObject` without writing to the database) and was unused. Moving this to the repository layer allows us to use `executeTransaction` and correctly persist the record to Realm, while continuing the broader effort of extracting database manipulation logic from static model classes into injectible repositories.

✅ Verification
- Removed the old method and verified via `grep` that no internal reflective or dynamic calls broke.
- Successfully compiled the Kotlin debug unit tests codebase.
- Code review passed.

✨ Result
Data manipulation for `RealmSearchActivity` is now appropriately scoped and handled by `ActivitiesRepository` via a suspended transactional function, promoting separation of concerns and eliminating misleading logic.

---
*PR created automatically by Jules for task [5697929349397205290](https://jules.google.com/task/5697929349397205290) started by @dogi*