### PR TITLE
all: smoother adapter item callback diffing (fixes #13157)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5387
+        versionName = "0.53.87"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -87,9 +87,30 @@ class CoursesAdapter(
         this.ratingChangeListener = ratingChangeListener
     }
 
-    fun setTagsMap(tagsMap: Map<String, List<Tag>>) {
-        this.tagsMap = tagsMap
-        notifyItemRangeChanged(0, itemCount, TAG_PAYLOAD)
+    fun setTagsMap(newTagsMap: Map<String, List<Tag>>) {
+        val updatedCourseIds = mutableSetOf<String?>()
+
+        newTagsMap.forEach { (courseId, newTags) ->
+            if (tagsMap[courseId] != newTags) {
+                updatedCourseIds.add(courseId)
+            }
+        }
+
+        tagsMap.keys.filterNot { newTagsMap.containsKey(it) }.forEach { removedKey ->
+            updatedCourseIds.add(removedKey)
+        }
+
+        tagsMap = newTagsMap
+
+        updatedCourseIds.forEach { courseId ->
+            if (courseId.isNullOrEmpty()) {
+                return@forEach
+            }
+            val index = currentList.indexOfFirst { it.courseId == courseId }
+            if (index != -1) {
+                notifyItemChanged(index, TAG_PAYLOAD)
+            }
+        }
     }
 
     fun removeCourses(courseIds: List<String>) {
@@ -109,14 +130,43 @@ class CoursesAdapter(
         newMap: HashMap<String?, JsonObject>,
         newProgressMap: HashMap<String?, JsonObject>?
     ) {
+        val updatedCourseIds = mutableSetOf<String?>()
+
+        newMap.forEach { (courseId, newRating) ->
+            if (this.map[courseId] != newRating) {
+                updatedCourseIds.add(courseId)
+            }
+        }
+        this.map.keys.filterNot { newMap.containsKey(it) }.forEach { removedKey ->
+            updatedCourseIds.add(removedKey)
+        }
+
+        newProgressMap?.forEach { (courseId, newProgress) ->
+            if (this.progressMap?.get(courseId) != newProgress) {
+                updatedCourseIds.add(courseId)
+            }
+        }
+        this.progressMap?.keys?.filterNot { newProgressMap?.containsKey(it) == true }?.forEach { removedKey ->
+            updatedCourseIds.add(removedKey)
+        }
+
         this.map.clear()
         this.map.putAll(newMap)
         this.progressMap = newProgressMap
+
         submitList(newCourseList) {
             val bundle = Bundle()
             bundle.putBoolean(RATING_PAYLOAD, true)
             bundle.putBoolean(PROGRESS_PAYLOAD, true)
-            notifyItemRangeChanged(0, itemCount, bundle)
+            updatedCourseIds.forEach { courseId ->
+                if (courseId.isNullOrEmpty()) {
+                    return@forEach
+                }
+                val index = currentList.indexOfFirst { it.courseId == courseId }
+                if (index != -1) {
+                    notifyItemChanged(index, bundle)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -26,6 +26,7 @@ import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.MarkdownUtils.setMarkdownText
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.callback.OnDiffRefreshListener
 
 class ResourcesAdapter(
     private val context: Context,
@@ -38,7 +39,12 @@ class ResourcesAdapter(
         { oldItem, newItem -> oldItem.id == newItem.id },
         { oldItem, newItem -> oldItem._rev == newItem._rev && oldItem.uploadDate == newItem.uploadDate }
     )
-) {
+), OnDiffRefreshListener {
+
+    override fun refreshWithDiff() {
+        submitList(currentList.toList())
+    }
+
 
     private val selectedItems: MutableList<ResourceItem> = ArrayList()
     private var listener: OnLibraryItemSelectedListener? = null
@@ -159,7 +165,9 @@ class ResourcesAdapter(
         } else {
             selectedItems.clear()
         }
+
         notifyItemRangeChanged(0, currentList.size, SELECTION_PAYLOAD)
+
         if (listener != null) {
             listener?.onSelectedListChange(selectedItems)
         }
@@ -206,9 +214,30 @@ class ResourcesAdapter(
         }
     }
 
-    fun setTagsMap(tagsMap: Map<String, List<TagItem>>) {
-        this.tagsMap = tagsMap
-        notifyItemRangeChanged(0, currentList.size, TAGS_PAYLOAD)
+    fun setTagsMap(newTagsMap: Map<String, List<TagItem>>) {
+        val updatedResourceIds = mutableSetOf<String?>()
+
+        newTagsMap.forEach { (resourceId, newTags) ->
+            if (tagsMap[resourceId] != newTags) {
+                updatedResourceIds.add(resourceId)
+            }
+        }
+
+        tagsMap.keys.filterNot { newTagsMap.containsKey(it) }.forEach { removedKey ->
+            updatedResourceIds.add(removedKey)
+        }
+
+        tagsMap = newTagsMap
+
+        updatedResourceIds.forEach { resourceId ->
+            if (resourceId.isNullOrEmpty()) {
+                return@forEach
+            }
+            val index = currentList.indexOfFirst { it.id == resourceId }
+            if (index != -1) {
+                notifyItemChanged(index, TAGS_PAYLOAD)
+            }
+        }
     }
 
     fun setOpenedResourceIds(openedResourceIds: Set<String>) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysAdapter.kt
@@ -15,6 +15,7 @@ import org.ole.planet.myplanet.model.SurveyFormState
 import org.ole.planet.myplanet.model.SurveyInfo
 import org.ole.planet.myplanet.ui.submissions.SubmissionsAdapter
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.callback.OnDiffRefreshListener
 
 class SurveysAdapter(
     private val context: Context,
@@ -27,7 +28,11 @@ class SurveysAdapter(
 ) : ListAdapter<RealmStepExam, SurveysAdapter.SurveysViewHolder>(DiffUtils.itemCallback(
     { oldItem, newItem -> oldItem.id == newItem.id },
     { oldItem, newItem -> oldItem == newItem }
-)) {
+)), OnDiffRefreshListener {
+    override fun refreshWithDiff() {
+        submitList(currentList.toList())
+    }
+
     private var listener: OnHomeItemClickListener? = null
     private var isTitleAscending = true
     private var sortStrategy: (List<RealmStepExam>) -> List<RealmStepExam> = { list ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
@@ -47,14 +47,8 @@ class RealtimeSyncHelper(private val fragment: Fragment, private val mixin: Real
     private fun refreshRecyclerView() {
         fragment.viewLifecycleOwner.lifecycleScope.launch {
             val adapter = mixin.getSyncRecyclerView()?.adapter ?: return@launch
-            when (adapter) {
-                is OnDiffRefreshListener -> adapter.refreshWithDiff()
-                is ListAdapter<*, *> -> {
-                    @Suppress("UNCHECKED_CAST")
-                    (adapter as ListAdapter<Any, *>).let { listAdapter ->
-                        listAdapter.submitList(listAdapter.currentList.toList())
-                    }
-                }
+            if (adapter is OnDiffRefreshListener) {
+                adapter.refreshWithDiff()
             }
         }
     }


### PR DESCRIPTION
Normalize list adapter refresh mechanisms by explicitly requiring `OnDiffRefreshListener` for realtime updates instead of blindly resubmitting `ListAdapter` items, and replacing inefficient, broad `notifyItemRangeChanged` calls with targeted, diff-based updates.

---
*PR created automatically by Jules for task [8726172645162216510](https://jules.google.com/task/8726172645162216510) started by @dogi*