### PR TITLE
resources: smoother repository local saving (fixes #13149)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5368
-        versionName = "0.53.68"
+        versionCode = 5379
+        versionName = "0.53.79"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -46,6 +46,7 @@ interface ResourcesRepository {
     suspend fun countLibrariesNeedingUpdate(userId: String?): Int
     suspend fun resourceTitleExists(title: String): Boolean
     suspend fun saveLibraryItem(item: RealmMyLibrary)
+    suspend fun saveLocalResource(resource: RealmMyLibrary, userId: String?, isPrivateTeamResource: Boolean, teamId: String?): Result<Unit>
     suspend fun markResourceAdded(userId: String?, resourceId: String)
     suspend fun updateUserLibrary(resourceId: String, userId: String, isAdd: Boolean): RealmMyLibrary?
     suspend fun updateLibraryItem(id: String, updater: (RealmMyLibrary) -> Unit)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -27,6 +27,7 @@ import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUser
+import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.UrlUtils
@@ -39,7 +40,8 @@ class ResourcesRepositoryImpl @Inject constructor(
     @param:AppPreferences private val settings: SharedPreferences,
     private val sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager,
     private val ratingsRepository: RatingsRepository,
-    private val tagsRepository: TagsRepository
+    private val tagsRepository: TagsRepository,
+    private val teamsRepositoryLazy: dagger.Lazy<TeamsRepository>
 ) : RealmRepository(databaseService, realmDispatcher), ResourcesRepository {
 
     override suspend fun getUnuploadedResources(user: RealmUser?): List<ResourceUploadData> {
@@ -236,6 +238,31 @@ class ResourcesRepositoryImpl @Inject constructor(
 
     override suspend fun saveLibraryItem(item: RealmMyLibrary) {
         save(item)
+    }
+
+    override suspend fun saveLocalResource(
+        resource: RealmMyLibrary,
+        userId: String?,
+        isPrivateTeamResource: Boolean,
+        teamId: String?
+    ): Result<Unit> {
+        val title = resource.title ?: return Result.failure(Exception("Title is missing"))
+
+        if (resourceTitleExists(title)) {
+            return Result.failure(Exception("Resource title already exists"))
+        }
+
+        saveLibraryItem(resource)
+
+        if (!isPrivateTeamResource) {
+            markResourceAdded(userId, resource.id ?: "")
+        }
+
+        if (teamId != null) {
+            teamsRepositoryLazy.get().syncTeamActivities()
+        }
+
+        return Result.success(Unit)
     }
 
     override suspend fun markResourceAdded(userId: String?, resourceId: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -156,25 +156,25 @@ class AddResourceActivity : AppCompatActivity() {
         }
         binding.btnSubmit.isEnabled = false
         lifecycleScope.launch {
-            if (resourcesRepository.resourceTitleExists(title)) {
+            val result = resourcesRepository.saveLocalResource(
+                resource,
+                userModel?.id,
+                isPrivateTeamResource,
+                teamId
+            )
+
+            if (result.isSuccess) {
+                val message = if (isPrivateTeamResource) {
+                    getString(R.string.resource_added_to_team)
+                } else {
+                    getString(R.string.added_to_my_library)
+                }
+                toast(this@AddResourceActivity, message)
+                finish()
+            } else {
                 binding.tlTitle.error = getString(R.string.resource_title_already_exists)
                 binding.btnSubmit.isEnabled = true
-                return@launch
             }
-            resourcesRepository.saveLibraryItem(resource)
-            if (!isPrivateTeamResource) {
-                resourcesRepository.markResourceAdded(userModel?.id, id)
-            }
-            if (teamId != null) {
-                teamsRepository.syncTeamActivities()
-            }
-            val message = if (isPrivateTeamResource) {
-                getString(R.string.resource_added_to_team)
-            } else {
-                getString(R.string.added_to_my_library)
-            }
-            toast(this@AddResourceActivity, message)
-            finish()
         }
     }
 


### PR DESCRIPTION
This PR addresses the issue of moving local resource creation into a repository workflow.

💡 **What**
- Added `saveLocalResource` method to `ResourcesRepository`.
- Implemented the workflow in `ResourcesRepositoryImpl` using `dagger.Lazy<TeamsRepository>` to prevent cyclic dependency issues while allowing the repository to sync team activities.
- Refactored `AddResourceActivity` to delegate the save operation entirely to `ResourcesRepository` and handle the returned `Result`.

🎯 **Why**
- To consolidate duplicate-title checking, save routines, and team side-effects in one testable repository API.
- To leave the activity responsible only for UI validation, capture, and rendering.

---
*PR created automatically by Jules for task [11806535864054534291](https://jules.google.com/task/11806535864054534291) started by @dogi*