### PR TITLE
all: scope user-bound databases to new `device_users` db (fixes open-learning-exchange/planet#9895)

### DIFF
--- a/COURSES_PROGRESS_FILTERED_SYNC_BLUEPRINT.md
+++ b/COURSES_PROGRESS_FILTERED_SYNC_BLUEPRINT.md
@@ -1,0 +1,117 @@
+# courses_progress filtered sync prototype
+
+This prototype changes `myPlanet` full sync so `courses_progress` is no longer fetched with:
+
+- `/_all_docs?include_docs=true`
+
+Instead it now:
+
+1. syncs `tablet_users` first
+2. derives synced local user ids from `UserRepository`
+3. queries `courses_progress/_find` with a selector:
+
+```json
+{
+  "selector": {
+    "userId": {
+      "$in": ["user-a", "user-b"]
+    }
+  },
+  "limit": 1000,
+  "bookmark": "..."
+}
+```
+
+## Why this is a useful prototype
+
+`courses_progress` was the main failure source in issue `planet#9895`, and it is a good template for the other heavy user-scoped databases:
+
+- `submissions`
+- `notifications`
+- `chat_history`
+- `login_activities`
+
+The important part is the pattern, not just this one database:
+
+- establish dependency ordering first
+- derive the relevant local scope
+- replace `/_all_docs` with paged `_find`
+- insert the returned docs using the existing repository bulk-insert path
+
+## Files changed
+
+- `app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt`
+- `app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt`
+
+## Pattern to copy for other databases
+
+### submissions
+
+- selector source: synced local user ids
+- likely selector:
+
+```json
+{
+  "selector": {
+    "userId": {
+      "$in": ["user-a", "user-b"]
+    }
+  }
+}
+```
+
+### notifications
+
+- selector source: synced local user ids
+- likely selector:
+
+```json
+{
+  "selector": {
+    "user": {
+      "$in": ["user-a", "user-b"]
+    }
+  }
+}
+```
+
+Add recency and unread rules later once the server indexes are ready.
+
+### login_activities
+
+- selector source: synced local user names or ids, depending on stored field
+- add a recency window once server indexes exist
+
+### team_activities / teams
+
+- these need a second dependency step:
+  - sync membership docs or teams first
+  - derive relevant `teamId`s
+  - then query `team_activities` with `teamId: { "$in": [...] }`
+
+## Server-side expectations
+
+For this pattern to scale on real data, Planet should add indexes that match the selectors. For `courses_progress`, the first index to add is on `userId`.
+
+Recommended follow-up on the Planet side:
+
+- `courses_progress`: index `userId`
+- `submissions`: index `userId`
+- `notifications`: index `user`
+- `team_activities`: index `teamId`
+
+## Known limitations of this prototype
+
+- It only changes `courses_progress`.
+- It does not yet apply recency filtering.
+- It assumes `courses_progress.userId` matches synced local user ids stored in `RealmUser`.
+- It was not fully compiled in this environment because Gradle download is blocked by sandbox network restrictions.
+
+## Suggested next step for myPlanet team
+
+1. verify the `courses_progress.userId` field against a real server dataset
+2. test sync timing before/after on a heavier Planet
+3. extend the same pattern to `submissions`
+4. then extend to `notifications`
+
+That sequence should give the biggest practical reduction in sync size before tackling team-scoped tables.

--- a/COURSES_PROGRESS_FILTERED_SYNC_BLUEPRINT.md
+++ b/COURSES_PROGRESS_FILTERED_SYNC_BLUEPRINT.md
@@ -1,13 +1,15 @@
 # courses_progress filtered sync prototype
 
-This prototype changes `myPlanet` full sync so `courses_progress` is no longer fetched with:
+This branch changes `myPlanet` sync policy so large user-bound tables are no longer treated as bootstrap data by default.
+
+For steady-state sync, `courses_progress` is no longer fetched with:
 
 - `/_all_docs?include_docs=true`
 
 Instead it now:
 
 1. syncs `tablet_users` first
-2. derives synced local user ids from `UserRepository`
+2. derives candidate user ids from a device-local `RealmDeviceUser` store
 3. queries `courses_progress/_find` with a selector:
 
 ```json
@@ -33,21 +35,36 @@ Instead it now:
 
 The important part is the pattern, not just this one database:
 
-- establish dependency ordering first
-- derive the relevant local scope
+- split bootstrap sync from steady-state sync
+- derive the relevant local scope from actual device users
 - replace `/_all_docs` with paged `_find`
 - insert the returned docs using the existing repository bulk-insert path
 
+Just as importantly, this prototype exposed a bad assumption: `tablet_users` is not a device-local sync scope. It is effectively the set of non-admin users allowed to log into `myPlanet`, so `userId IN tablet_users` still behaves like near-full-table sync on a real Planet.
+
+This branch now enforces that distinction in code:
+
+- bootstrap sync defers the heaviest user-bound tables until the device has real user history
+- `device_users` are stored in Realm and backfilled from local login history
+- steady-state sync uses `device_users` for `courses_progress` and `submissions`
+
 ## Files changed
 
+- `app/src/main/java/org/ole/planet/myplanet/model/RealmDeviceUser.kt`
+- `app/src/main/java/org/ole/planet/myplanet/repository/DeviceUserRepository.kt`
+- `app/src/main/java/org/ole/planet/myplanet/repository/DeviceUserRepositoryImpl.kt`
 - `app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt`
+- `app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt`
+- `app/src/main/java/org/ole/planet/myplanet/services/sync/SyncPolicy.kt`
 - `app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt`
+- `app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt`
+- `app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt`
 
 ## Pattern to copy for other databases
 
 ### submissions
 
-- selector source: synced local user ids
+- selector source: true device-local users, not `tablet_users`
 - likely selector:
 
 ```json
@@ -62,7 +79,7 @@ The important part is the pattern, not just this one database:
 
 ### notifications
 
-- selector source: synced local user ids
+- selector source: true device-local users, not `tablet_users`
 - likely selector:
 
 ```json
@@ -79,7 +96,7 @@ Add recency and unread rules later once the server indexes are ready.
 
 ### login_activities
 
-- selector source: synced local user names or ids, depending on stored field
+- selector source: true device-local users, not `tablet_users`
 - add a recency window once server indexes exist
 
 ### team_activities / teams
@@ -102,16 +119,26 @@ Recommended follow-up on the Planet side:
 
 ## Known limitations of this prototype
 
-- It only changes `courses_progress`.
+- It only moves `courses_progress` and `submissions` to device-scoped `_find`.
+- Bootstrap deferral is currently policy-based, not server-assisted.
 - It does not yet apply recency filtering.
-- It assumes `courses_progress.userId` matches synced local user ids stored in `RealmUser`.
+- It assumes `courses_progress.userId` and `submissions.userId` are the right first selectors, which still need verification against real server documents and indexes.
 - It was not fully compiled in this environment because Gradle download is blocked by sandbox network restrictions.
+
+## What testing showed
+
+- `courses_progress/_find` works mechanically in `myPlanet`.
+- `submissions/_find` can follow the same pattern with an existing `userId` field.
+- Replacing `/_all_docs` with `_find` is not enough by itself.
+- `tablet_users` cannot be used as the source of truth for device-local sync, because it is an auth/login dataset, not a locality dataset.
+- `device_users` is the more viable source of truth for steady-state sync on the tablet.
 
 ## Suggested next step for myPlanet team
 
-1. verify the `courses_progress.userId` field against a real server dataset
-2. test sync timing before/after on a heavier Planet
-3. extend the same pattern to `submissions`
-4. then extend to `notifications`
+1. verify the `courses_progress.userId` and `submissions.userId` selectors against real server documents
+2. add the required Mango indexes on the Planet side for whichever selectors are chosen
+3. retest bootstrap sync and steady-state sync separately
+4. extend the same pattern to `notifications`, `chat_history`, and activity tables
+5. add team-scoped selectors for `team_activities` once the team dependency path is settled
 
 That sequence should give the biggest practical reduction in sync size before tackling team-scoped tables.

--- a/MYPLANET_SYNC_POLICY_BLUEPRINT.md
+++ b/MYPLANET_SYNC_POLICY_BLUEPRINT.md
@@ -46,7 +46,9 @@ This branch now enforces that distinction in code:
 
 - bootstrap sync defers the heaviest user-bound tables until the device has real user history
 - `device_users` are stored in Realm and backfilled from local login history
-- steady-state sync uses `device_users` for `courses_progress` and `submissions`
+- steady-state sync uses `device_users` for `courses_progress`, `submissions`, `login_activities`, and `chat_history`
+- `team_activities` now scopes by derived `teamId` values from device-user memberships
+- `notifications` are deferred from bootstrap and run as a background follow-up once device users exist
 
 ## Files changed
 
@@ -59,6 +61,7 @@ This branch now enforces that distinction in code:
 - `app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt`
 - `app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt`
 - `app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt`
+- `app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt`
 
 ## Pattern to copy for other databases
 
@@ -80,7 +83,10 @@ This branch now enforces that distinction in code:
 ### notifications
 
 - selector source: true device-local users, not `tablet_users`
-- likely selector:
+- current branch behavior:
+  - defer from bootstrap
+  - run in background after main sync when device users exist
+- likely future selector:
 
 ```json
 {
@@ -97,14 +103,21 @@ Add recency and unread rules later once the server indexes are ready.
 ### login_activities
 
 - selector source: true device-local users, not `tablet_users`
+- implemented selector field: `user`
 - add a recency window once server indexes exist
+
+### chat_history
+
+- selector source: true device-local users, not `tablet_users`
+- implemented selector field: `user`
 
 ### team_activities / teams
 
-- these need a second dependency step:
-  - sync membership docs or teams first
+- implemented dependency path:
+  - derive device users first
+  - read local membership docs for those users
   - derive relevant `teamId`s
-  - then query `team_activities` with `teamId: { "$in": [...] }`
+  - query `team_activities` with `teamId: { "$in": [...] }`
 
 ## Server-side expectations
 
@@ -114,31 +127,36 @@ Recommended follow-up on the Planet side:
 
 - `courses_progress`: index `userId`
 - `submissions`: index `userId`
+- `login_activities`: index `user`
+- `chat_history`: index `user`
 - `notifications`: index `user`
 - `team_activities`: index `teamId`
 
 ## Known limitations of this prototype
 
-- It only moves `courses_progress` and `submissions` to device-scoped `_find`.
+- It moves `courses_progress`, `submissions`, `login_activities`, `chat_history`, and `team_activities` onto device-scoped or team-scoped `_find`.
 - Bootstrap deferral is currently policy-based, not server-assisted.
-- It does not yet apply recency filtering.
-- It assumes `courses_progress.userId` and `submissions.userId` are the right first selectors, which still need verification against real server documents and indexes.
+- It does not yet apply recency filtering to activity/history tables.
+- It assumes `courses_progress.userId`, `submissions.userId`, `login_activities.user`, and `chat_history.user` are the right first selectors, which still need verification against real server documents and indexes.
+- `notifications` are backgrounded rather than fully device-scoped in this branch.
 - It was not fully compiled in this environment because Gradle download is blocked by sandbox network restrictions.
 
 ## What testing showed
 
 - `courses_progress/_find` works mechanically in `myPlanet`.
 - `submissions/_find` can follow the same pattern with an existing `userId` field.
+- `login_activities/_find` and `chat_history/_find` fit the same device-user pattern.
+- `team_activities` is better treated as a team-scoped sync problem than a raw user-scoped one.
 - Replacing `/_all_docs` with `_find` is not enough by itself.
 - `tablet_users` cannot be used as the source of truth for device-local sync, because it is an auth/login dataset, not a locality dataset.
 - `device_users` is the more viable source of truth for steady-state sync on the tablet.
 
 ## Suggested next step for myPlanet team
 
-1. verify the `courses_progress.userId` and `submissions.userId` selectors against real server documents
+1. verify the `courses_progress.userId`, `submissions.userId`, `login_activities.user`, and `chat_history.user` selectors against real server documents
 2. add the required Mango indexes on the Planet side for whichever selectors are chosen
 3. retest bootstrap sync and steady-state sync separately
-4. extend the same pattern to `notifications`, `chat_history`, and activity tables
-5. add team-scoped selectors for `team_activities` once the team dependency path is settled
+4. decide whether `notifications` should stay background-only or move to a selector-based steady-state sync
+5. keep team-scoped selectors for `team_activities` aligned with the local membership/team derivation path
 
 That sequence should give the biggest practical reduction in sync size before tackling team-scoped tables.

--- a/MYPLANET_SYNC_POLICY_BLUEPRINT.md
+++ b/MYPLANET_SYNC_POLICY_BLUEPRINT.md
@@ -1,162 +1,150 @@
-# courses_progress filtered sync prototype
+# myPlanet device-user-scoped sync policy
 
-This branch changes `myPlanet` sync policy so large user-bound tables are no longer treated as bootstrap data by default.
+This branch changes `myPlanet` sync policy so the heaviest user-bound databases are no longer fetched as if they were bootstrap data. Instead they are scoped to the actual users that have logged into this device.
 
-For steady-state sync, `courses_progress` is no longer fetched with:
-
-- `/_all_docs?include_docs=true`
-
-Instead it now:
-
-1. syncs `tablet_users` first
-2. derives candidate user ids from a device-local `RealmDeviceUser` store
-3. queries `courses_progress/_find` with a selector:
-
-```json
-{
-  "selector": {
-    "userId": {
-      "$in": ["user-a", "user-b"]
-    }
-  },
-  "limit": 1000,
-  "bookmark": "..."
-}
-```
-
-## Why this is a useful prototype
-
-`courses_progress` was the main failure source in issue `planet#9895`, and it is a good template for the other heavy user-scoped databases:
-
-- `submissions`
-- `notifications`
-- `chat_history`
-- `login_activities`
-
-The important part is the pattern, not just this one database:
+The shape of the change is the same across all five user-scoped databases:
 
 - split bootstrap sync from steady-state sync
-- derive the relevant local scope from actual device users
-- replace `/_all_docs` with paged `_find`
-- insert the returned docs using the existing repository bulk-insert path
+- derive a device-local scope from a `RealmDeviceUser` store (backfilled from local login history on first run, maintained on every subsequent login)
+- replace `/_all_docs?include_docs=true` with paged `_find`
+- insert the returned docs through the existing repository bulk-insert path
 
-Just as importantly, this prototype exposed a bad assumption: `tablet_users` is not a device-local sync scope. It is effectively the set of non-admin users allowed to log into `myPlanet`, so `userId IN tablet_users` still behaves like near-full-table sync on a real Planet.
+`tablet_users` is **not** used as the locality source. It is the set of non-admin users allowed to log into `myPlanet`, so `userId IN tablet_users` is effectively a near-full-table scan on a real Planet. `device_users` (a Realm-backed table of users actually seen on this device) is the source of truth for steady-state sync.
 
-This branch now enforces that distinction in code:
+## Bootstrap vs. steady-state vs. background
 
-- bootstrap sync defers the heaviest user-bound tables until the device has real user history
-- `device_users` are stored in Realm and backfilled from local login history
-- steady-state sync uses `device_users` for `courses_progress`, `submissions`, `login_activities`, and `chat_history`
-- `team_activities` now scopes by derived `teamId` values from device-user memberships
-- `notifications` are deferred from bootstrap and run as a background follow-up once device users exist
+The three policy sets live in `SyncPolicy.kt`:
 
-## Files changed
+```kotlin
+val bootstrapDeferredTables = setOf(
+    "courses_progress",
+    "submissions",
+    "login_activities",
+    "notifications",
+    "chat_history",
+    "team_activities"
+)
 
-- `app/src/main/java/org/ole/planet/myplanet/model/RealmDeviceUser.kt`
-- `app/src/main/java/org/ole/planet/myplanet/repository/DeviceUserRepository.kt`
-- `app/src/main/java/org/ole/planet/myplanet/repository/DeviceUserRepositoryImpl.kt`
-- `app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt`
-- `app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt`
-- `app/src/main/java/org/ole/planet/myplanet/services/sync/SyncPolicy.kt`
-- `app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt`
-- `app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt`
-- `app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt`
-- `app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt`
+private val steadyStateBackgroundTables = setOf(
+    "courses_progress",
+    "notifications"
+)
+```
 
-## Pattern to copy for other databases
+How each set is applied:
+
+- **Bootstrap (no device users yet)** — `applyBootstrapPolicy` filters `bootstrapDeferredTables` out of the requested table list. The first sync after install therefore skips the heavy user-bound tables entirely; they have no device scope to filter on yet.
+- **Steady-state foreground (device users exist)** — `applyForegroundPolicy` runs the bootstrap filter (a no-op once device users exist) and additionally removes `steadyStateBackgroundTables` from the foreground job, so they don't block sync completion.
+- **Background follow-up** — `backgroundTablesFor` returns `courses_progress` (when `courses` or `courses_progress` was requested) plus `notifications`. These run on a separate coroutine via `startBackgroundDeferredSync` after the main sync wraps up.
+
+Both sync paths apply the same three calls:
+
+- `SyncManager.startFullSync` and `SyncManager.startFastSync` (legacy path)
+- `ImprovedSyncManager.start` (improved path)
+
+So the policy is enforced regardless of which manager the user is routed through, and regardless of fast vs. standard mode.
+
+## Per-database steady-state implementations
+
+All scoped paths are dispatched from `TransactionSyncManager.syncDb`. Three of them share the generic `syncFindByField` helper; `courses_progress` and `submissions` each have a bespoke helper because of their pagination tuning and field projection needs.
+
+### courses_progress
+
+- selector source: `RealmDeviceUser.userId`
+- selector: `userId: { "$in": [...] }`
+- endpoint: `courses_progress/_find`
+- page size: 1000, bookmark pagination
+- requests a fields projection (`_id`, `_rev`, `courseId`, `createdDate`, `createdOn`, `parentCode`, `passed`, `stepNum`, `updatedDate`, `userId`) to keep payloads small
+- runs as a background follow-up after foreground sync, not in the foreground phase
 
 ### submissions
 
-- selector source: true device-local users, not `tablet_users`
-- likely selector:
-
-```json
-{
-  "selector": {
-    "userId": {
-      "$in": ["user-a", "user-b"]
-    }
-  }
-}
-```
-
-### notifications
-
-- selector source: true device-local users, not `tablet_users`
-- current branch behavior:
-  - defer from bootstrap
-  - run in background after main sync when device users exist
-- likely future selector:
-
-```json
-{
-  "selector": {
-    "user": {
-      "$in": ["user-a", "user-b"]
-    }
-  }
-}
-```
-
-Add recency and unread rules later once the server indexes are ready.
+- selector source: `RealmDeviceUser.userId`
+- selector: `userId: { "$in": [...] }`
+- endpoint: `submissions/_find`
+- page size: 100, bookmark pagination
+- runs in the foreground phase once device users exist
 
 ### login_activities
 
-- selector source: true device-local users, not `tablet_users`
-- implemented selector field: `user`
-- add a recency window once server indexes exist
+- selector source: `RealmDeviceUser.userName`
+- selector: `user: { "$in": [...] }`
+- endpoint: `login_activities/_find`
+- page size: 1000, bookmark pagination
+- implemented through the shared `syncFindByField` helper
 
 ### chat_history
 
-- selector source: true device-local users, not `tablet_users`
-- implemented selector field: `user`
+- selector source: `RealmDeviceUser.userName`
+- selector: `user: { "$in": [...] }`
+- endpoint: `chat_history/_find`
+- page size: 1000, bookmark pagination
+- implemented through the shared `syncFindByField` helper
 
-### team_activities / teams
+### team_activities
 
-- implemented dependency path:
-  - derive device users first
-  - read local membership docs for those users
-  - derive relevant `teamId`s
-  - query `team_activities` with `teamId: { "$in": [...] }`
+- dependency path: device users → local team membership (`TeamsRepository.getTeamIdsForUsers`) → `teamId` set
+- selector: `teamId: { "$in": [...] }`
+- endpoint: `team_activities/_find`
+- page size: 1000, bookmark pagination
+- skipped when there are no team memberships for the current device users
+
+### notifications
+
+- deferred from bootstrap and run as a background follow-up after main sync once device users exist
+- not yet selector-scoped on the wire — still pulled via `_all_docs` inside the background job
+- the obvious next step is `user: { "$in": deviceUserNames }`; recency / unread filters can be added once the server side has matching indexes
+
+## Tables intentionally left on `_all_docs`
+
+Issue `planet#9895` listed several heavy tables. Not all of them are user-scoped, so the policy doesn't touch them:
+
+- `ratings` — small payload (the issue's run was 88 docs); slow only because it queues behind other requests. Not user-bound, so a `_find` selector wouldn't help.
+- `teams` — small and not strictly user-scoped; current `_all_docs` behavior is fine.
+- `tablet_users` — synced first, deliberately, because it's the auth scope that other tables depend on.
+
+## Files changed
+
+- `app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt`
+- `app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt`
+- `app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt`
+- `app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt`
+- `app/src/main/java/org/ole/planet/myplanet/model/RealmDeviceUser.kt`
+- `app/src/main/java/org/ole/planet/myplanet/repository/DeviceUserRepository.kt`
+- `app/src/main/java/org/ole/planet/myplanet/repository/DeviceUserRepositoryImpl.kt`
+- `app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt`
+- `app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt`
+- `app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt`
+- `app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt`
+- `app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt`
+- `app/src/main/java/org/ole/planet/myplanet/services/sync/SyncPolicy.kt`
+- `app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt`
+- `app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt`
+- `app/src/test/java/org/ole/planet/myplanet/services/sync/TransactionSyncManagerTest.kt`
 
 ## Server-side expectations
 
-For this pattern to scale on real data, Planet should add indexes that match the selectors. For `courses_progress`, the first index to add is on `userId`.
-
-Recommended follow-up on the Planet side:
+For these `_find` selectors to scale on real data, Planet should add Mango indexes that match them. Without the indexes the server falls back to full table scans and most of the win is lost:
 
 - `courses_progress`: index `userId`
 - `submissions`: index `userId`
 - `login_activities`: index `user`
 - `chat_history`: index `user`
-- `notifications`: index `user`
 - `team_activities`: index `teamId`
+- `notifications`: index `user` (once selector-scoped)
 
-## Known limitations of this prototype
+## Known limitations
 
-- It moves `courses_progress`, `submissions`, `login_activities`, `chat_history`, and `team_activities` onto device-scoped or team-scoped `_find`.
-- Bootstrap deferral is currently policy-based, not server-assisted.
-- It does not yet apply recency filtering to activity/history tables.
-- It assumes `courses_progress.userId`, `submissions.userId`, `login_activities.user`, and `chat_history.user` are the right first selectors, which still need verification against real server documents and indexes.
-- `notifications` are backgrounded rather than fully device-scoped in this branch.
-- It was not fully compiled in this environment because Gradle download is blocked by sandbox network restrictions.
+- Bootstrap deferral is policy-based, not server-assisted — the server still has the full table available; we just stop pulling it client-side until we have a device scope.
+- No recency window on the activity / history tables yet; we still pull every matching doc for every device user.
+- The selector field choices (`courses_progress.userId`, `submissions.userId`, `login_activities.user`, `chat_history.user`) still need verification against real production documents.
+- `notifications` is backgrounded but not yet selector-scoped.
+- The branch was not fully compiled in the original sandbox environment because Gradle download was blocked; verify a clean build locally before merging.
 
-## What testing showed
+## Suggested follow-ups
 
-- `courses_progress/_find` works mechanically in `myPlanet`.
-- `submissions/_find` can follow the same pattern with an existing `userId` field.
-- `login_activities/_find` and `chat_history/_find` fit the same device-user pattern.
-- `team_activities` is better treated as a team-scoped sync problem than a raw user-scoped one.
-- Replacing `/_all_docs` with `_find` is not enough by itself.
-- `tablet_users` cannot be used as the source of truth for device-local sync, because it is an auth/login dataset, not a locality dataset.
-- `device_users` is the more viable source of truth for steady-state sync on the tablet.
-
-## Suggested next step for myPlanet team
-
-1. verify the `courses_progress.userId`, `submissions.userId`, `login_activities.user`, and `chat_history.user` selectors against real server documents
-2. add the required Mango indexes on the Planet side for whichever selectors are chosen
-3. retest bootstrap sync and steady-state sync separately
-4. decide whether `notifications` should stay background-only or move to a selector-based steady-state sync
-5. keep team-scoped selectors for `team_activities` aligned with the local membership/team derivation path
-
-That sequence should give the biggest practical reduction in sync size before tackling team-scoped tables.
+1. Verify `courses_progress.userId`, `submissions.userId`, `login_activities.user`, and `chat_history.user` against real server documents.
+2. Add the Mango indexes listed above on the Planet side.
+3. Move `notifications` from "deferred + background" to a `user`-scoped `_find` matching the others.
+4. Add a recency window to `login_activities` and `chat_history` once the server indexes are in place.
+5. Re-run bootstrap and steady-state sync separately on real data to confirm the duration regressions from issue #9895 are gone.

--- a/MYPLANET_SYNC_POLICY_BLUEPRINT.md
+++ b/MYPLANET_SYNC_POLICY_BLUEPRINT.md
@@ -59,12 +59,21 @@ All scoped paths are dispatched from `TransactionSyncManager.syncDb`. Three of t
 
 ### submissions
 
-- selector source: `RealmDeviceUser.userId` (which holds `org.couchdb.user:<name>`)
-- selector: `user._id: { "$in": [...] }`
+Submissions need two passes because they come in two flavors:
+
+- **Per-user submissions** (exam attempts, individual surveys) carry a populated `user` object with `_id`.
+- **Team-scoped submissions** (team surveys) are written with an empty `user` object and `team._id` set (`submissions.service.ts:223-225`). A pure user-scoped selector misses these entirely. They matter for correctness, not just completeness — Planet's submission writer checks for an existing team submission *before* creating a new one, so missing local copies cause duplicate writes from the tablet.
+
+CouchDB 2.3.1's Mango planner does not reliably index-union `$or` across two different fields, so we run two separate paginated `_find` calls instead of one combined query.
+
+- pass 1 selector: `user._id: { "$in": deviceUserIds }`, against `user-id-index`
+- pass 2 selector: `team._id: { "$in": teamIds }`, against `team-id-index`
+- `teamIds` derived via `TeamsRepository.getTeamIdsForUsers(deviceUserIds)` — same path used for `team_activities`
+- pass 2 is skipped when no team memberships exist for the device users
 - endpoint: `submissions/_find`
-- page size: 100, bookmark pagination
-- runs in the foreground phase once device users exist
-- planet stores submissions with a nested `user` object — the field path `user._id` (dotted) matches the server-side `user-id-index` Mango index
+- page size: 100 per pass, bookmark pagination
+- both passes run in the foreground phase once device users exist
+- both passes feed the same `submissionsRepository.bulkInsertFromSync` path; results don't overlap by construction (team submissions have empty `user._id`)
 
 ### login_activities
 
@@ -128,7 +137,7 @@ Issue `planet#9895` listed several heavy tables. Not all of them are user-scoped
 These Mango indexes are required for the `_find` selectors to scale; without them the server falls back to full-table scans and most of the win is lost. They have been added to `couchdb-setup.sh` in the planet repo (under issue `planet#9895`):
 
 - `courses_progress`: index `userId` (`user-index`)
-- `submissions`: index `user._id` (`user-id-index`)
+- `submissions`: index `user._id` (`user-id-index`) plus index `team._id` (`team-id-index`) for the team-scoped pass
 - `login_activities`: index `user` (`user-index`)
 - `chat_history`: index `user` (`user-index`)
 - `team_activities`: index `teamId` (`team-index`)

--- a/MYPLANET_SYNC_POLICY_BLUEPRINT.md
+++ b/MYPLANET_SYNC_POLICY_BLUEPRINT.md
@@ -59,11 +59,12 @@ All scoped paths are dispatched from `TransactionSyncManager.syncDb`. Three of t
 
 ### submissions
 
-- selector source: `RealmDeviceUser.userId`
-- selector: `userId: { "$in": [...] }`
+- selector source: `RealmDeviceUser.userId` (which holds `org.couchdb.user:<name>`)
+- selector: `user._id: { "$in": [...] }`
 - endpoint: `submissions/_find`
 - page size: 100, bookmark pagination
 - runs in the foreground phase once device users exist
+- planet stores submissions with a nested `user` object — the field path `user._id` (dotted) matches the server-side `user-id-index` Mango index
 
 ### login_activities
 
@@ -92,8 +93,8 @@ All scoped paths are dispatched from `TransactionSyncManager.syncDb`. Three of t
 ### notifications
 
 - deferred from bootstrap and run as a background follow-up after main sync once device users exist
-- not yet selector-scoped on the wire — still pulled via `_all_docs` inside the background job
-- the obvious next step is `user: { "$in": deviceUserNames }`; recency / unread filters can be added once the server side has matching indexes
+- pulled via `_all_docs` inside the background job — **intentionally not user-scoped**
+- planet writes some notifications with sentinel values like `user: 'SYSTEM'` (admin events such as cross-planet connection requests) and the planet UI's reader OR's the current user with `'SYSTEM'` for admins (`notifications.component.ts:67-71`). A strict `user IN [...]` selector on myplanet would silently drop those. Volume from issue `#9895` was small (~2.5k docs / 1m34s), so background `_all_docs` is a reasonable trade-off versus adding policy logic for sentinel values.
 
 ## Tables intentionally left on `_all_docs`
 
@@ -124,27 +125,25 @@ Issue `planet#9895` listed several heavy tables. Not all of them are user-scoped
 
 ## Server-side expectations
 
-For these `_find` selectors to scale on real data, Planet should add Mango indexes that match them. Without the indexes the server falls back to full table scans and most of the win is lost:
+These Mango indexes are required for the `_find` selectors to scale; without them the server falls back to full-table scans and most of the win is lost. They have been added to `couchdb-setup.sh` in the planet repo (under issue `planet#9895`):
 
-- `courses_progress`: index `userId`
-- `submissions`: index `userId`
-- `login_activities`: index `user`
-- `chat_history`: index `user`
-- `team_activities`: index `teamId`
-- `notifications`: index `user` (once selector-scoped)
+- `courses_progress`: index `userId` (`user-index`)
+- `submissions`: index `user._id` (`user-id-index`)
+- `login_activities`: index `user` (`user-index`)
+- `chat_history`: index `user` (`user-index`)
+- `team_activities`: index `teamId` (`team-index`)
+
+`notifications` is intentionally not indexed for user lookup — see the notifications section above.
 
 ## Known limitations
 
 - Bootstrap deferral is policy-based, not server-assisted — the server still has the full table available; we just stop pulling it client-side until we have a device scope.
 - No recency window on the activity / history tables yet; we still pull every matching doc for every device user.
-- The selector field choices (`courses_progress.userId`, `submissions.userId`, `login_activities.user`, `chat_history.user`) still need verification against real production documents.
-- `notifications` is backgrounded but not yet selector-scoped.
+- Selector fields verified against the planet codebase: `courses_progress.userId`, `submissions.user._id`, `login_activities.user`, `chat_history.user`, `team_activities.teamId` all match the actual document shape on Planet.
+- `notifications` is backgrounded on `_all_docs` rather than selector-scoped, by design — see the notifications section.
 - The branch was not fully compiled in the original sandbox environment because Gradle download was blocked; verify a clean build locally before merging.
 
 ## Suggested follow-ups
 
-1. Verify `courses_progress.userId`, `submissions.userId`, `login_activities.user`, and `chat_history.user` against real server documents.
-2. Add the Mango indexes listed above on the Planet side.
-3. Move `notifications` from "deferred + background" to a `user`-scoped `_find` matching the others.
-4. Add a recency window to `login_activities` and `chat_history` once the server indexes are in place.
-5. Re-run bootstrap and steady-state sync separately on real data to confirm the duration regressions from issue #9895 are gone.
+1. Add a recency window to `login_activities` and `chat_history` once we have a sense of how far back is useful on a real device.
+2. Re-run bootstrap and steady-state sync separately on real data to confirm the duration regressions from issue #9895 are gone.

--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -26,7 +26,7 @@ class DatabaseService(context: Context, private val dispatcherProvider: Dispatch
         if (currentConfig == null || currentConfig.realmDirectory.name == Realm.DEFAULT_REALM_NAME) {
             val config = RealmConfiguration.Builder()
                 .name(Realm.DEFAULT_REALM_NAME)
-                .schemaVersion(8)
+                .schemaVersion(9)
                 .migration(RealmMigrations())
                 .build()
             Realm.setDefaultConfiguration(config)

--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -26,7 +26,7 @@ class DatabaseService(context: Context, private val dispatcherProvider: Dispatch
         if (currentConfig == null || currentConfig.realmDirectory.name == Realm.DEFAULT_REALM_NAME) {
             val config = RealmConfiguration.Builder()
                 .name(Realm.DEFAULT_REALM_NAME)
-                .schemaVersion(9)
+                .schemaVersion(10)
                 .migration(RealmMigrations())
                 .build()
             Realm.setDefaultConfiguration(config)

--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -14,7 +14,7 @@ import org.ole.planet.myplanet.utils.DispatcherProvider
 
 class DatabaseService(context: Context, private val dispatcherProvider: DispatcherProvider) {
     val ioDispatcher: CoroutineDispatcher = dispatcherProvider.io
-    private val realmDispatcher: CoroutineDispatcher = dispatcherProvider.io.limitedParallelism(4)
+    private val realmDispatcher: CoroutineDispatcher = dispatcherProvider.io
 
     init {
         Realm.init(context)

--- a/app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt
@@ -52,5 +52,18 @@ class RealmMigrations : RealmMigration {
                 ?.addField("isUpdated", Boolean::class.java)
             version++
         }
+
+        if (version == 8L) {
+            schema.create("RealmDeviceUser")
+                .addField("userId", String::class.java)
+                .addPrimaryKey("userId")
+                .addField("userName", String::class.java)
+                .addIndex("userName")
+                .addField("parentCode", String::class.java)
+                .addField("planetCode", String::class.java)
+                .addField("firstLoginAt", Long::class.javaPrimitiveType!!)
+                .addField("lastLoginAt", Long::class.javaPrimitiveType!!)
+            version++
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt
@@ -53,7 +53,7 @@ class RealmMigrations : RealmMigration {
             version++
         }
 
-        if (version == 8L) {
+        if (version == 9L) {
             schema.create("RealmDeviceUser")
                 .addField("userId", String::class.java)
                 .addPrimaryKey("userId")

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -17,6 +17,8 @@ import org.ole.planet.myplanet.repository.CoursesRepository
 import org.ole.planet.myplanet.repository.CoursesRepositoryImpl
 import org.ole.planet.myplanet.repository.DownloadRepository
 import org.ole.planet.myplanet.repository.DownloadRepositoryImpl
+import org.ole.planet.myplanet.repository.DeviceUserRepository
+import org.ole.planet.myplanet.repository.DeviceUserRepositoryImpl
 import org.ole.planet.myplanet.repository.EventsRepository
 import org.ole.planet.myplanet.repository.EventsRepositoryImpl
 import org.ole.planet.myplanet.repository.FeedbackRepository
@@ -65,6 +67,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindDownloadRepository(impl: DownloadRepositoryImpl): DownloadRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindDeviceUserRepository(impl: DeviceUserRepositoryImpl): DeviceUserRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.repository.DeviceUserRepository
 import org.ole.planet.myplanet.repository.PersonalsRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.services.UploadManager
@@ -51,10 +52,25 @@ object ServiceModule {
         loginSyncManager: org.ole.planet.myplanet.services.sync.LoginSyncManager,
         @ApplicationScope scope: CoroutineScope,
         activitiesRepository: org.ole.planet.myplanet.repository.ActivitiesRepository,
+        deviceUserRepository: DeviceUserRepository,
         dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider,
         teamsRepository: org.ole.planet.myplanet.repository.TeamsRepository
     ): SyncManager {
-        return SyncManager(context, databaseService, sharedPrefManager, apiInterface, improvedSyncManager, transactionSyncManager, resourcesRepository, loginSyncManager, scope, activitiesRepository, dispatcherProvider, teamsRepository)
+        return SyncManager(
+            context,
+            databaseService,
+            sharedPrefManager,
+            apiInterface,
+            improvedSyncManager,
+            transactionSyncManager,
+            resourcesRepository,
+            loginSyncManager,
+            scope,
+            activitiesRepository,
+            deviceUserRepository,
+            dispatcherProvider,
+            teamsRepository
+        )
     }
 
     @Provides
@@ -109,6 +125,7 @@ object ServiceModule {
         chatRepository: org.ole.planet.myplanet.repository.ChatRepository,
         feedbackRepository: org.ole.planet.myplanet.repository.FeedbackRepository,
         sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager,
+        deviceUserRepository: DeviceUserRepository,
         userRepository: org.ole.planet.myplanet.repository.UserRepository,
         activitiesRepository: org.ole.planet.myplanet.repository.ActivitiesRepository,
         teamsRepository: dagger.Lazy<org.ole.planet.myplanet.repository.TeamsRepository>,
@@ -124,6 +141,29 @@ object ServiceModule {
         @ApplicationScope scope: CoroutineScope,
         dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider
     ): TransactionSyncManager {
-        return TransactionSyncManager(apiInterface, databaseService, context, voicesRepository, chatRepository, feedbackRepository, sharedPrefManager, userRepository, activitiesRepository, teamsRepository, notificationsRepository, tagsRepository, ratingsRepository, submissionsRepository, coursesRepository, communityRepository, healthRepository, progressRepository, surveysRepository, scope, dispatcherProvider)
+        return TransactionSyncManager(
+            apiInterface,
+            databaseService,
+            context,
+            voicesRepository,
+            chatRepository,
+            feedbackRepository,
+            sharedPrefManager,
+            deviceUserRepository,
+            userRepository,
+            activitiesRepository,
+            teamsRepository,
+            notificationsRepository,
+            tagsRepository,
+            ratingsRepository,
+            submissionsRepository,
+            coursesRepository,
+            communityRepository,
+            healthRepository,
+            progressRepository,
+            surveysRepository,
+            scope,
+            dispatcherProvider
+        )
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmDeviceUser.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmDeviceUser.kt
@@ -1,0 +1,18 @@
+package org.ole.planet.myplanet.model
+
+import io.realm.RealmObject
+import io.realm.annotations.Index
+import io.realm.annotations.PrimaryKey
+
+open class RealmDeviceUser : RealmObject() {
+    @PrimaryKey
+    var userId: String? = null
+
+    @Index
+    var userName: String? = null
+
+    var parentCode: String? = null
+    var planetCode: String? = null
+    var firstLoginAt: Long = 0
+    var lastLoginAt: Long = 0
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/DeviceUserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/DeviceUserRepository.kt
@@ -1,0 +1,16 @@
+package org.ole.planet.myplanet.repository
+
+interface DeviceUserRepository {
+    suspend fun upsertFromLogin(
+        userId: String?,
+        userName: String?,
+        parentCode: String?,
+        planetCode: String?,
+        loginTime: Long = System.currentTimeMillis()
+    )
+
+    suspend fun ensureInitializedFromLoginHistory(): Int
+    suspend fun hasDeviceUsers(): Boolean
+    suspend fun getDeviceUserIds(): List<String>
+    suspend fun getDeviceUserNames(): List<String>
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/DeviceUserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/DeviceUserRepositoryImpl.kt
@@ -1,0 +1,135 @@
+package org.ole.planet.myplanet.repository
+
+import io.realm.Realm
+import java.util.LinkedHashMap
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.di.RealmDispatcher
+import org.ole.planet.myplanet.model.RealmDeviceUser
+import org.ole.planet.myplanet.model.RealmOfflineActivity
+import org.ole.planet.myplanet.services.UserSessionManager
+
+class DeviceUserRepositoryImpl @Inject constructor(
+    databaseService: DatabaseService,
+    @RealmDispatcher realmDispatcher: CoroutineDispatcher
+) : RealmRepository(databaseService, realmDispatcher), DeviceUserRepository {
+
+    override suspend fun upsertFromLogin(
+        userId: String?,
+        userName: String?,
+        parentCode: String?,
+        planetCode: String?,
+        loginTime: Long
+    ) {
+        if (userId.isNullOrBlank() || userId.startsWith("guest")) {
+            return
+        }
+
+        executeTransaction { realm ->
+            upsertDeviceUser(
+                realm = realm,
+                userId = userId,
+                userName = userName,
+                parentCode = parentCode,
+                planetCode = planetCode,
+                loginTime = loginTime
+            )
+        }
+    }
+
+    override suspend fun ensureInitializedFromLoginHistory(): Int {
+        val existingCount = count(RealmDeviceUser::class.java).toInt()
+        if (existingCount > 0) {
+            return existingCount
+        }
+
+        val loginActivities = queryList(RealmOfflineActivity::class.java) {
+            equalTo("type", UserSessionManager.KEY_LOGIN)
+            isNotEmpty("userId")
+            not().beginsWith("userId", "guest")
+        }
+
+        if (loginActivities.isEmpty()) {
+            return 0
+        }
+
+        val latestLogins = LinkedHashMap<String, RealmOfflineActivity>()
+        loginActivities.forEach { activity ->
+            val deviceUserId = activity.userId ?: return@forEach
+            val existing = latestLogins[deviceUserId]
+            val activityTime = activity.loginTime ?: 0L
+            val existingTime = existing?.loginTime ?: 0L
+            if (existing == null || activityTime >= existingTime) {
+                latestLogins[deviceUserId] = activity
+            }
+        }
+
+        if (latestLogins.isEmpty()) {
+            return 0
+        }
+
+        executeTransaction { realm ->
+            latestLogins.values.forEach { activity ->
+                upsertDeviceUser(
+                    realm = realm,
+                    userId = activity.userId ?: return@forEach,
+                    userName = activity.userName,
+                    parentCode = activity.parentCode,
+                    planetCode = activity.createdOn,
+                    loginTime = activity.loginTime ?: System.currentTimeMillis()
+                )
+            }
+        }
+
+        return count(RealmDeviceUser::class.java).toInt()
+    }
+
+    override suspend fun hasDeviceUsers(): Boolean {
+        return ensureInitializedFromLoginHistory() > 0
+    }
+
+    override suspend fun getDeviceUserIds(): List<String> {
+        return queryList(RealmDeviceUser::class.java) {
+            isNotEmpty("userId")
+        }.mapNotNull { it.userId?.takeIf(String::isNotBlank) }
+    }
+
+    override suspend fun getDeviceUserNames(): List<String> {
+        return queryList(RealmDeviceUser::class.java) {
+            isNotEmpty("userName")
+        }.mapNotNull { it.userName?.takeIf(String::isNotBlank) }
+    }
+
+    private fun upsertDeviceUser(
+        realm: Realm,
+        userId: String,
+        userName: String?,
+        parentCode: String?,
+        planetCode: String?,
+        loginTime: Long
+    ) {
+        val deviceUser = realm.where(RealmDeviceUser::class.java)
+            .equalTo("userId", userId)
+            .findFirst()
+            ?: realm.createObject(RealmDeviceUser::class.java, userId).apply {
+                firstLoginAt = loginTime
+            }
+
+        if (deviceUser.firstLoginAt == 0L || loginTime < deviceUser.firstLoginAt) {
+            deviceUser.firstLoginAt = loginTime
+        }
+        if (loginTime >= deviceUser.lastLoginAt) {
+            deviceUser.lastLoginAt = loginTime
+        }
+        if (!userName.isNullOrBlank()) {
+            deviceUser.userName = userName
+        }
+        if (!parentCode.isNullOrBlank()) {
+            deviceUser.parentCode = parentCode
+        }
+        if (!planetCode.isNullOrBlank()) {
+            deviceUser.planetCode = planetCode
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -47,6 +47,7 @@ interface TeamsRepository {
     suspend fun getAllActiveTeams(): List<RealmMyTeam>
     suspend fun getMyTeamsFlow(userId: String): Flow<List<RealmMyTeam>>
     suspend fun getMyTeamsByUserId(userId: String): List<RealmMyTeam>
+    suspend fun getTeamIdsForUsers(userIds: Collection<String>): List<String>
     suspend fun getResourceIds(teamId: String): List<String>
     suspend fun getResourceIdsByUser(userId: String?): List<String>
     suspend fun getTeamSummaries(userId: String?): List<TeamSummary>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -165,6 +165,17 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getTeamIdsForUsers(userIds: Collection<String>): List<String> {
+        if (userIds.isEmpty()) {
+            return emptyList()
+        }
+        return queryList(RealmMyTeam::class.java) {
+            `in`("userId", userIds.toTypedArray())
+            equalTo("docType", "membership")
+        }.mapNotNull { it.teamId?.takeIf(String::isNotBlank) }
+            .distinct()
+    }
+
     private suspend fun getMemberTeamIds(userId: String): Set<String> {
         return queryList(RealmMyTeam::class.java) {
             equalTo("userId", userId)

--- a/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
@@ -14,6 +14,7 @@ import org.ole.planet.myplanet.di.ApplicationScope
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ActivitiesRepository
+import org.ole.planet.myplanet.repository.DeviceUserRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
@@ -23,6 +24,7 @@ class UserSessionManager @Inject constructor(
     @ApplicationScope private val applicationScope: CoroutineScope,
     private val userRepository: UserRepository,
     private val activitiesRepository: ActivitiesRepository,
+    private val deviceUserRepository: DeviceUserRepository,
     private val dispatcherProvider: DispatcherProvider
 ) {
     private val fullName: String
@@ -48,6 +50,12 @@ class UserSessionManager @Inject constructor(
             try {
                 val model = getUserModel()
                 activitiesRepository.logLogin(
+                    userId = model?.id,
+                    userName = model?.name,
+                    parentCode = model?.parentCode,
+                    planetCode = model?.planetCode
+                )
+                deviceUserRepository.upsertFromLogin(
                     userId = model?.id,
                     userName = model?.name,
                     parentCode = model?.parentCode,

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt
@@ -19,6 +19,7 @@ import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.repository.ActivitiesRepository
+import org.ole.planet.myplanet.repository.DeviceUserRepository
 import org.ole.planet.myplanet.utils.NotificationUtils
 import org.ole.planet.myplanet.utils.SyncTimeLogger
 
@@ -31,7 +32,8 @@ class ImprovedSyncManager @Inject constructor(
     private val transactionSyncManager: TransactionSyncManager,
     private val standardStrategy: StandardSyncStrategy,
     private val loginSyncManager: LoginSyncManager,
-    private val activitiesRepository: ActivitiesRepository
+    private val activitiesRepository: ActivitiesRepository,
+    private val deviceUserRepository: DeviceUserRepository
 ) {
 
     private val batchProcessor = AdaptiveBatchProcessor(context)
@@ -62,8 +64,7 @@ class ImprovedSyncManager @Inject constructor(
         "certifications",
         "team_activities",
         "chat_history",
-        "feedback",
-        "notifications"
+        "feedback"
     )
 
     suspend fun initialize() {
@@ -109,7 +110,9 @@ class ImprovedSyncManager @Inject constructor(
 
         initializeSync()
 
-        val tablesToSync = syncTables ?: syncOrder
+        val hasDeviceUsers = deviceUserRepository.hasDeviceUsers()
+        val requestedTables = syncTables ?: syncOrder
+        val tablesToSync = SyncPolicy.applyBootstrapPolicy(requestedTables, hasDeviceUsers)
         val strategy = getStrategy(syncMode)
 
         coroutineScope {
@@ -130,6 +133,15 @@ class ImprovedSyncManager @Inject constructor(
         logger.startProcess("on_synced")
         activitiesRepository.recordSyncActivity(settings.getString("userId", "") ?: "")
         logger.endProcess("on_synced")
+
+        if (hasDeviceUsers) {
+            syncScope.launch {
+                try {
+                    transactionSyncManager.syncDb("notifications")
+                } catch (_: Exception) {
+                }
+            }
+        }
 
         logger.stopLogging()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt
@@ -112,7 +112,7 @@ class ImprovedSyncManager @Inject constructor(
 
         val hasDeviceUsers = deviceUserRepository.hasDeviceUsers()
         val requestedTables = syncTables ?: syncOrder
-        val tablesToSync = SyncPolicy.applyBootstrapPolicy(requestedTables, hasDeviceUsers)
+        val tablesToSync = SyncPolicy.applyForegroundPolicy(requestedTables, hasDeviceUsers)
         val strategy = getStrategy(syncMode)
 
         coroutineScope {
@@ -134,14 +134,7 @@ class ImprovedSyncManager @Inject constructor(
         activitiesRepository.recordSyncActivity(settings.getString("userId", "") ?: "")
         logger.endProcess("on_synced")
 
-        if (hasDeviceUsers) {
-            syncScope.launch {
-                try {
-                    transactionSyncManager.syncDb("notifications")
-                } catch (_: Exception) {
-                }
-            }
-        }
+        startBackgroundDeferredSync(SyncPolicy.backgroundTablesFor(requestedTables, hasDeviceUsers))
 
         logger.stopLogging()
     }
@@ -172,6 +165,22 @@ class ImprovedSyncManager @Inject constructor(
         return when (syncMode) {
             SyncMode.Standard -> standardStrategy
             SyncMode.Fast, SyncMode.Optimized -> standardStrategy
+        }
+    }
+
+    private fun startBackgroundDeferredSync(tables: List<String>) {
+        if (tables.isEmpty()) {
+            return
+        }
+
+        syncScope.launch {
+            createLog("improved_sync_background", tables.joinToString(","))
+            for (table in tables) {
+                try {
+                    transactionSyncManager.syncDb(table)
+                } catch (_: Exception) {
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -213,26 +213,28 @@ class SyncManager @Inject constructor(
             logger.endProcess("tablet_users_sync")
 
             val hasDeviceUsers = deviceUserRepository.hasDeviceUsers()
-            val fullSyncTables = SyncPolicy.applyBootstrapPolicy(
-                listOf(
-                    "exams",
-                    "ratings",
-                    "courses_progress",
-                    "achievements",
-                    "tags",
-                    "submissions",
-                    "news",
-                    "feedback",
-                    "tasks",
-                    "login_activities",
-                    "health",
-                    "certifications",
-                    "team_activities",
-                    "chat_history",
-                    "teams",
-                    "meetups",
-                    "courses",
-                ),
+            val requestedFullSyncTables = listOf(
+                "exams",
+                "ratings",
+                "courses_progress",
+                "achievements",
+                "tags",
+                "submissions",
+                "news",
+                "feedback",
+                "tasks",
+                "login_activities",
+                "health",
+                "certifications",
+                "team_activities",
+                "chat_history",
+                "teams",
+                "meetups",
+                "courses",
+                "notifications",
+            )
+            val fullSyncTables = SyncPolicy.applyForegroundPolicy(
+                requestedFullSyncTables,
                 hasDeviceUsers
             )
 
@@ -352,7 +354,9 @@ class SyncManager @Inject constructor(
             logger.endProcess("on_synced")
 
             if (hasDeviceUsers) {
-                startBackgroundNotificationSync()
+                startBackgroundDeferredSync(
+                    SyncPolicy.backgroundTablesFor(requestedFullSyncTables, hasDeviceUsers)
+                )
             }
 
             logger.stopLogging()
@@ -391,7 +395,7 @@ class SyncManager @Inject constructor(
                 "teams",
                 "news"
             )
-            val fastSyncTables = SyncPolicy.applyBootstrapPolicy(requestedTables, hasDeviceUsers).toSet()
+            val fastSyncTables = SyncPolicy.applyForegroundPolicy(requestedTables, hasDeviceUsers).toSet()
 
             initializeSync()
             coroutineScope {
@@ -471,15 +475,6 @@ class SyncManager @Inject constructor(
                             transactionSyncManager.syncDb("courses")
                             logger.endProcess("courses_sync")
                         })
-
-                    if (hasDeviceUsers) {
-                        syncJobs.add(
-                            async {
-                                logger.startProcess("courses_progress_sync")
-                                transactionSyncManager.syncDb("courses_progress")
-                                logger.endProcess("courses_progress_sync")
-                            })
-                    }
 
                     syncJobs.add(
                         async {
@@ -593,7 +588,9 @@ class SyncManager @Inject constructor(
             logger.endProcess("on_synced")
 
             if (hasDeviceUsers) {
-                startBackgroundNotificationSync()
+                startBackgroundDeferredSync(
+                    SyncPolicy.backgroundTablesFor(requestedTables, hasDeviceUsers)
+                )
             }
 
             logger.stopLogging()
@@ -610,13 +607,19 @@ class SyncManager @Inject constructor(
         isSyncing.set(false)
     }
 
-    private fun startBackgroundNotificationSync() {
+    private fun startBackgroundDeferredSync(tables: List<String>) {
+        if (tables.isEmpty()) {
+            return
+        }
         syncScope.launch(dispatcherProvider.io) {
-            try {
-                Log.d("SyncPerf", "  ▶ Starting background notifications sync")
-                transactionSyncManager.syncDb("notifications")
-            } catch (e: Exception) {
-                Log.d("SyncPerf", "  ✗ Background notifications sync failed: ${e.message}")
+            Log.d("SyncPerf", "  ▶ Starting background deferred sync: ${tables.joinToString()}")
+            for (table in tables) {
+                try {
+                    Log.d("SyncPerf", "  ▶ Starting background $table sync")
+                    transactionSyncManager.syncDb(table)
+                } catch (e: Exception) {
+                    Log.d("SyncPerf", "  ✗ Background $table sync failed: ${e.message}")
+                }
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -48,6 +48,7 @@ import org.ole.planet.myplanet.model.RealmMyCourse.Companion.saveConcatenatedLin
 import org.ole.planet.myplanet.model.RealmMyLibrary.Companion.insertMyLibrary
 import org.ole.planet.myplanet.model.Rows
 import org.ole.planet.myplanet.repository.ActivitiesRepository
+import org.ole.planet.myplanet.repository.DeviceUserRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.DispatcherProvider
@@ -71,6 +72,7 @@ class SyncManager @Inject constructor(
     private val loginSyncManager: LoginSyncManager,
     @param:ApplicationScope private val syncScope: CoroutineScope,
     private val activitiesRepository: ActivitiesRepository,
+    private val deviceUserRepository: DeviceUserRepository,
     private val dispatcherProvider: DispatcherProvider,
     private val teamsRepository: org.ole.planet.myplanet.repository.TeamsRepository
 ) {
@@ -210,101 +212,119 @@ class SyncManager @Inject constructor(
             transactionSyncManager.syncDb("tablet_users")
             logger.endProcess("tablet_users_sync")
 
+            val hasDeviceUsers = deviceUserRepository.hasDeviceUsers()
+            val fullSyncTables = SyncPolicy.applyBootstrapPolicy(
+                listOf(
+                    "exams",
+                    "ratings",
+                    "courses_progress",
+                    "achievements",
+                    "tags",
+                    "submissions",
+                    "news",
+                    "feedback",
+                    "tasks",
+                    "login_activities",
+                    "health",
+                    "certifications",
+                    "team_activities",
+                    "chat_history",
+                    "teams",
+                    "meetups",
+                    "courses",
+                ),
+                hasDeviceUsers
+            )
+
             // Phase 1: Sync non-library tables in parallel
             // Note: teams, meetups, and courses base tables are synced here, then augmented by library sync
             coroutineScope {
-                val syncJobs = listOf(
-                    async {
+                val syncJobs = mutableListOf<Deferred<Unit>>()
+                if ("exams" in fullSyncTables) syncJobs += async {
                         logger.startProcess("exams_sync")
                         transactionSyncManager.syncDb("exams")
                         logger.endProcess("exams_sync")
-                    },
-                    async {
+                    }
+                if ("ratings" in fullSyncTables) syncJobs += async {
                         logger.startProcess("ratings_sync")
                         transactionSyncManager.syncDb("ratings")
                         logger.endProcess("ratings_sync")
-                    },
-                    async {
+                    }
+                if ("courses_progress" in fullSyncTables) syncJobs += async {
                         logger.startProcess("courses_progress_sync")
                         transactionSyncManager.syncDb("courses_progress")
                         logger.endProcess("courses_progress_sync")
-                    },
-                    async {
+                    }
+                if ("achievements" in fullSyncTables) syncJobs += async {
                         logger.startProcess("achievements_sync")
                         transactionSyncManager.syncDb("achievements")
                         logger.endProcess("achievements_sync")
-                    },
-                    async {
+                    }
+                if ("tags" in fullSyncTables) syncJobs += async {
                         logger.startProcess("tags_sync")
                         transactionSyncManager.syncDb("tags")
                         logger.endProcess("tags_sync")
-                    },
-                    async {
+                    }
+                if ("submissions" in fullSyncTables) syncJobs += async {
                         logger.startProcess("submissions_sync")
                         transactionSyncManager.syncDb("submissions")
                         logger.endProcess("submissions_sync")
-                    },
-                    async {
+                    }
+                if ("news" in fullSyncTables) syncJobs += async {
                         logger.startProcess("news_sync")
                         transactionSyncManager.syncDb("news")
                         logger.endProcess("news_sync")
-                    },
-                    async {
+                    }
+                if ("feedback" in fullSyncTables) syncJobs += async {
                         logger.startProcess("feedback_sync")
                         transactionSyncManager.syncDb("feedback")
                         logger.endProcess("feedback_sync")
-                    },
-                    async {
+                    }
+                if ("tasks" in fullSyncTables) syncJobs += async {
                         logger.startProcess("tasks_sync")
                         transactionSyncManager.syncDb("tasks")
                         logger.endProcess("tasks_sync")
-                    },
-                    async {
+                    }
+                if ("login_activities" in fullSyncTables) syncJobs += async {
                         logger.startProcess("login_activities_sync")
                         transactionSyncManager.syncDb("login_activities")
                         logger.endProcess("login_activities_sync")
-                    },
-                    async {
+                    }
+                if ("health" in fullSyncTables) syncJobs += async {
                         logger.startProcess("health_sync")
                         transactionSyncManager.syncDb("health")
                         logger.endProcess("health_sync")
-                    },
-                    async {
+                    }
+                if ("certifications" in fullSyncTables) syncJobs += async {
                         logger.startProcess("certifications_sync")
                         transactionSyncManager.syncDb("certifications")
                         logger.endProcess("certifications_sync")
-                    },
-                    async {
+                    }
+                if ("team_activities" in fullSyncTables) syncJobs += async {
                         logger.startProcess("team_activities_sync")
                         transactionSyncManager.syncDb("team_activities")
                         logger.endProcess("team_activities_sync")
-                    },
-                    async {
+                    }
+                if ("chat_history" in fullSyncTables) syncJobs += async {
                         logger.startProcess("chat_history_sync")
                         transactionSyncManager.syncDb("chat_history")
                         logger.endProcess("chat_history_sync")
-                    },
-                    async {
+                    }
+                if ("teams" in fullSyncTables) syncJobs += async {
                         logger.startProcess("teams_sync")
                         transactionSyncManager.syncDb("teams")
                         logger.endProcess("teams_sync")
-                    },
-                    async {
+                    }
+                if ("meetups" in fullSyncTables) syncJobs += async {
                         logger.startProcess("meetups_sync")
                         transactionSyncManager.syncDb("meetups")
                         logger.endProcess("meetups_sync")
-                    },
-                    async {
+                    }
+                if ("courses" in fullSyncTables) syncJobs += async {
                         logger.startProcess("courses_sync")
                         transactionSyncManager.syncDb("courses")
                         logger.endProcess("courses_sync")
-                    },
-                    async {
-                        logger.startProcess("notifications_sync")
-                        transactionSyncManager.syncDb("notifications")
-                        logger.endProcess("notifications_sync")
                     }
-                )
                 syncJobs.awaitAll()
             }
 
@@ -330,6 +350,10 @@ class SyncManager @Inject constructor(
             logger.startProcess("on_synced")
             activitiesRepository.recordSyncActivity(sharedPrefManager.rawPreferences.getString("userId", "") ?: "")
             logger.endProcess("on_synced")
+
+            if (hasDeviceUsers) {
+                startBackgroundNotificationSync()
+            }
 
             logger.stopLogging()
 
@@ -359,55 +383,65 @@ class SyncManager @Inject constructor(
         try {
             val logger = SyncTimeLogger
             logger.startLogging()
+            val hasDeviceUsers = deviceUserRepository.hasDeviceUsers()
+            val requestedTables = syncTables ?: listOf(
+                "tablet_users",
+                "login_activities",
+                "tags",
+                "teams",
+                "news"
+            )
+            val fastSyncTables = SyncPolicy.applyBootstrapPolicy(requestedTables, hasDeviceUsers).toSet()
 
             initializeSync()
             coroutineScope {
                 val syncJobs = mutableListOf<Deferred<Unit>>()
-                if (syncTables?.contains("tablet_users") != false) {
+                if ("tablet_users" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("tablet_users_sync")
                             transactionSyncManager.syncDb("tablet_users")
                             logger.endProcess("tablet_users_sync")
                         })
+                }
 
+                if ("login_activities" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("login_activities_sync")
                             transactionSyncManager.syncDb("login_activities")
                             logger.endProcess("login_activities_sync")
                         })
+                }
 
+                if ("tags" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("tags_sync")
                             transactionSyncManager.syncDb("tags")
                             logger.endProcess("tags_sync")
                         })
+                }
 
+                if ("teams" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("teams_sync")
                             transactionSyncManager.syncDb("teams")
                             logger.endProcess("teams_sync")
                         })
+                }
 
+                if ("news" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("news_sync")
                             transactionSyncManager.syncDb("news")
                             logger.endProcess("news_sync")
                         })
-
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("notifications_sync")
-                            transactionSyncManager.syncDb("notifications")
-                            logger.endProcess("notifications_sync")
-                        })
                 }
 
-                if (syncTables?.contains("resources") == true) {
+                if ("resources" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("library_sync")
@@ -423,7 +457,7 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("courses") == true) {
+                if ("courses" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("library_sync")
@@ -438,12 +472,14 @@ class SyncManager @Inject constructor(
                             logger.endProcess("courses_sync")
                         })
 
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("courses_progress_sync")
-                            transactionSyncManager.syncDb("courses_progress")
-                            logger.endProcess("courses_progress_sync")
-                        })
+                    if (hasDeviceUsers) {
+                        syncJobs.add(
+                            async {
+                                logger.startProcess("courses_progress_sync")
+                                transactionSyncManager.syncDb("courses_progress")
+                                logger.endProcess("courses_progress_sync")
+                            })
+                    }
 
                     syncJobs.add(
                         async {
@@ -453,7 +489,7 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("tasks") == true) {
+                if ("tasks" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("tasks_sync")
@@ -462,7 +498,7 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("meetups") == true) {
+                if ("meetups" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("meetups_sync")
@@ -471,7 +507,7 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("team_activities") == true) {
+                if ("team_activities" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("team_activities_sync")
@@ -480,7 +516,7 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("chat_history") == true) {
+                if ("chat_history" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("chat_history_sync")
@@ -489,7 +525,7 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("feedback") == true) {
+                if ("feedback" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("feedback_sync")
@@ -498,7 +534,7 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("achievements") == true) {
+                if ("achievements" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("achievements_sync")
@@ -507,7 +543,7 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("health") == true) {
+                if ("health" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("health_sync")
@@ -523,14 +559,16 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("courses") == true || syncTables?.contains("exams") == true) {
+                if ("courses" in fastSyncTables || "exams" in fastSyncTables) {
                     syncJobs.add(
                         async {
                             logger.startProcess("exams_sync")
                             transactionSyncManager.syncDb("exams")
                             logger.endProcess("exams_sync")
                         })
+                }
 
+                if (hasDeviceUsers && ("courses" in fastSyncTables || "exams" in fastSyncTables)) {
                     syncJobs.add(
                         async {
                             logger.startProcess("submissions_sync")
@@ -554,6 +592,10 @@ class SyncManager @Inject constructor(
             activitiesRepository.recordSyncActivity(sharedPrefManager.rawPreferences.getString("userId", "") ?: "")
             logger.endProcess("on_synced")
 
+            if (hasDeviceUsers) {
+                startBackgroundNotificationSync()
+            }
+
             logger.stopLogging()
         } catch (err: Exception) {
             err.printStackTrace()
@@ -566,6 +608,17 @@ class SyncManager @Inject constructor(
     private fun cleanupMainSync() {
         cancel(context, 111)
         isSyncing.set(false)
+    }
+
+    private fun startBackgroundNotificationSync() {
+        syncScope.launch(dispatcherProvider.io) {
+            try {
+                Log.d("SyncPerf", "  ▶ Starting background notifications sync")
+                transactionSyncManager.syncDb("notifications")
+            } catch (e: Exception) {
+                Log.d("SyncPerf", "  ✗ Background notifications sync failed: ${e.message}")
+            }
+        }
     }
 
     private fun initializeSync() {

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -205,15 +205,15 @@ class SyncManager @Inject constructor(
 
             initializeSync()
 
+            // Seed tablet users first so filtered syncs can scope user-bound tables.
+            logger.startProcess("tablet_users_sync")
+            transactionSyncManager.syncDb("tablet_users")
+            logger.endProcess("tablet_users_sync")
+
             // Phase 1: Sync non-library tables in parallel
             // Note: teams, meetups, and courses base tables are synced here, then augmented by library sync
             coroutineScope {
                 val syncJobs = listOf(
-                    async {
-                        logger.startProcess("tablet_users_sync")
-                        transactionSyncManager.syncDb("tablet_users")
-                        logger.endProcess("tablet_users_sync")
-                    },
                     async {
                         logger.startProcess("exams_sync")
                         transactionSyncManager.syncDb("exams")

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncPolicy.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncPolicy.kt
@@ -1,0 +1,19 @@
+package org.ole.planet.myplanet.services.sync
+
+object SyncPolicy {
+    val bootstrapDeferredTables = setOf(
+        "courses_progress",
+        "submissions",
+        "login_activities",
+        "notifications",
+        "chat_history",
+        "team_activities"
+    )
+
+    fun applyBootstrapPolicy(tables: List<String>, hasDeviceUsers: Boolean): List<String> {
+        if (hasDeviceUsers) {
+            return tables
+        }
+        return tables.filterNot { it in bootstrapDeferredTables }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncPolicy.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncPolicy.kt
@@ -10,10 +10,37 @@ object SyncPolicy {
         "team_activities"
     )
 
+    private val steadyStateBackgroundTables = setOf(
+        "courses_progress",
+        "notifications"
+    )
+
     fun applyBootstrapPolicy(tables: List<String>, hasDeviceUsers: Boolean): List<String> {
         if (hasDeviceUsers) {
             return tables
         }
         return tables.filterNot { it in bootstrapDeferredTables }
+    }
+
+    fun applyForegroundPolicy(tables: List<String>, hasDeviceUsers: Boolean): List<String> {
+        val bootstrapTables = applyBootstrapPolicy(tables, hasDeviceUsers)
+        if (!hasDeviceUsers) {
+            return bootstrapTables
+        }
+        return bootstrapTables.filterNot { it in steadyStateBackgroundTables }
+    }
+
+    fun backgroundTablesFor(tables: List<String>, hasDeviceUsers: Boolean): List<String> {
+        if (!hasDeviceUsers) {
+            return emptyList()
+        }
+
+        val backgroundTables = linkedSetOf<String>()
+        if ("courses" in tables || "courses_progress" in tables) {
+            backgroundTables += "courses_progress"
+        }
+        backgroundTables += "notifications"
+
+        return backgroundTables.filter { it in steadyStateBackgroundTables }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -513,91 +513,46 @@ class TransactionSyncManager @Inject constructor(
 
         val pageSize = 100
         var totalDocs = 0
-        var pageNumber = 0
-        var bookmark: String? = null
 
-        android.util.Log.d(
-            "SyncPerf",
-            "    submissions selector: user._id IN ${userIds.size} device users"
-        )
+        // Pass 1: per-user submissions (exam attempts, individual surveys).
+        // Uses submissions/_find with selector user._id IN device users; matched by the
+        // server-side "user-id-index" Mango index.
+        totalDocs += syncFindByField(
+            table = "submissions",
+            selectorField = "user._id",
+            selectorValues = userIds,
+            pageSize = pageSize,
+            syncStartTime = System.currentTimeMillis()
+        ) { realm, rows ->
+            submissionsRepository.bulkInsertFromSync(realm, rows)
+        }
 
-        while (true) {
-            pageNumber++
-            val batchStartTime = System.currentTimeMillis()
-            val requestBody = JsonObject().apply {
-                add("selector", JsonObject().apply {
-                    add("user._id", JsonObject().apply {
-                        add("\$in", com.google.gson.JsonArray().apply {
-                            userIds.forEach { add(it) }
-                        })
-                    })
-                })
-                addProperty("limit", pageSize)
-                bookmark?.let { addProperty("bookmark", it) }
+        // Pass 2: team-scoped submissions (team surveys). These are written with an empty
+        // user object and team._id set, so the per-user pass cannot reach them. CouchDB 2.3.1
+        // Mango does not reliably index-union $or across two fields, so we do a separate
+        // pass against the "team-id-index" Mango index.
+        val teamIds = teamsRepository.get().getTeamIdsForUsers(userIds)
+        if (teamIds.isNotEmpty()) {
+            totalDocs += syncFindByField(
+                table = "submissions",
+                selectorField = "team._id",
+                selectorValues = teamIds,
+                pageSize = pageSize,
+                syncStartTime = System.currentTimeMillis()
+            ) { realm, rows ->
+                submissionsRepository.bulkInsertFromSync(realm, rows)
             }
-
-            val apiStartTime = System.currentTimeMillis()
-            val response = apiInterface.findDocs(
-                UrlUtils.header,
-                "application/json",
-                "${UrlUtils.getUrl()}/submissions/_find",
-                requestBody
-            )
-            val apiDuration = System.currentTimeMillis() - apiStartTime
-
-            if (response.body() == null || !response.isSuccessful) {
-                android.util.Log.d("SyncPerf", "  ✗ Failed submissions page $pageNumber: HTTP ${response.code()}")
-                break
-            }
-
-            val docs = org.ole.planet.myplanet.utils.JsonUtils.getJsonArray("docs", response.body())
-            if (docs.size() == 0) {
-                break
-            }
-
-            val rows = com.google.gson.JsonArray()
-            docs.forEach { doc ->
-                rows.add(JsonObject().apply {
-                    add("doc", doc)
-                })
-            }
-
-            org.ole.planet.myplanet.utils.SyncTimeLogger.logApiCall(
-                "${UrlUtils.getUrl()}/submissions/_find (page $pageNumber)",
-                apiDuration,
-                response.isSuccessful,
-                docs.size()
-            )
-
-            databaseService.executeTransactionAsync { mRealm: Realm ->
-                val insertStartTime = System.currentTimeMillis()
-                submissionsRepository.bulkInsertFromSync(mRealm, rows)
-                val insertDuration = System.currentTimeMillis() - insertStartTime
-                org.ole.planet.myplanet.utils.SyncTimeLogger.logRealmOperation(
-                    "insert_batch",
-                    "submissions",
-                    insertDuration,
-                    docs.size()
-                )
-            }
-
-            totalDocs += docs.size()
-            bookmark = response.body()?.get("bookmark")?.asString
-            val batchDuration = System.currentTimeMillis() - batchStartTime
+        } else {
             android.util.Log.d(
                 "SyncPerf",
-                "    submissions page $pageNumber: ${docs.size()} docs in ${batchDuration}ms (total: $totalDocs, bookmark=${!bookmark.isNullOrBlank()})"
+                "    submissions team pass: skipped (no team memberships for device users)"
             )
-
-            if (docs.size() < pageSize || bookmark.isNullOrBlank()) {
-                break
-            }
         }
 
         val totalDuration = System.currentTimeMillis() - syncStartTime
         android.util.Log.d(
             "SyncPerf",
-            "  ✓ Completed submissions sync: $totalDocs docs in ${totalDuration}ms for ${userIds.size} device users"
+            "  ✓ Completed submissions sync: $totalDocs docs in ${totalDuration}ms (${userIds.size} users, ${teamIds.size} teams)"
         )
         return totalDocs
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -375,10 +375,20 @@ class TransactionSyncManager @Inject constructor(
             return 0
         }
 
+        android.util.Log.d(
+            "SyncPerf",
+            "    courses_progress selector: userId IN ${userIds.size} synced users"
+        )
+        android.util.Log.d(
+            "SyncPerf",
+            "    courses_progress synced user sample: ${userIds.take(10).joinToString(", ")}"
+        )
+
         val pageSize = 1000
         var totalDocs = 0
         var pageNumber = 0
         var bookmark: String? = null
+        var loggedLargeResultWarning = false
 
         while (true) {
             pageNumber++
@@ -455,7 +465,18 @@ class TransactionSyncManager @Inject constructor(
             totalDocs += docs.size()
             bookmark = response.body()?.get("bookmark")?.asString
             val batchDuration = System.currentTimeMillis() - batchStartTime
-            android.util.Log.d("SyncPerf", "    courses_progress page $pageNumber: ${docs.size()} docs in ${batchDuration}ms (total: $totalDocs)")
+            android.util.Log.d(
+                "SyncPerf",
+                "    courses_progress page $pageNumber: ${docs.size()} docs in ${batchDuration}ms (total: $totalDocs, bookmark=${!bookmark.isNullOrBlank()})"
+            )
+
+            if (!loggedLargeResultWarning && pageNumber >= 5 && totalDocs >= pageSize * 5) {
+                android.util.Log.w(
+                    "SyncPerf",
+                    "    courses_progress warning: selector is still returning full pages after $pageNumber pages for ${userIds.size} users"
+                )
+                loggedLargeResultWarning = true
+            }
 
             if (docs.size() < pageSize || bookmark.isNullOrBlank()) {
                 break
@@ -463,7 +484,10 @@ class TransactionSyncManager @Inject constructor(
         }
 
         val totalDuration = System.currentTimeMillis() - syncStartTime
-        android.util.Log.d("SyncPerf", "  ✓ Completed courses_progress sync: $totalDocs docs in ${totalDuration}ms")
+        android.util.Log.d(
+            "SyncPerf",
+            "  ✓ Completed courses_progress sync: $totalDocs docs in ${totalDuration}ms for ${userIds.size} synced users"
+        )
         return totalDocs
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -155,6 +155,10 @@ class TransactionSyncManager @Inject constructor(
         val syncStartTime = System.currentTimeMillis()
         android.util.Log.d("SyncPerf", "  ▶ Starting $table sync")
         try {
+            if (table == "courses_progress") {
+                return@withContext syncCoursesProgressDb(syncStartTime)
+            }
+
             // Determine pagination size based on table (smaller for slow endpoints)
             val pageSize = when (table) {
                 "ratings" -> 20      // Small batches for slow endpoint
@@ -360,6 +364,107 @@ class TransactionSyncManager @Inject constructor(
             android.util.Log.d("SyncPerf", "  ✗ Failed $table sync after ${failDuration}ms: ${e.message}")
             0
         }
+    }
+
+    private suspend fun syncCoursesProgressDb(syncStartTime: Long): Int {
+        val userIds = userRepository.getSyncedUsers()
+            .mapNotNull { user -> user._id?.takeIf { it.isNotBlank() } ?: user.id?.takeIf { it.isNotBlank() } }
+            .distinct()
+        if (userIds.isEmpty()) {
+            android.util.Log.d("SyncPerf", "  ↷ Skipping courses_progress sync: no synced users available")
+            return 0
+        }
+
+        val pageSize = 1000
+        var totalDocs = 0
+        var pageNumber = 0
+        var bookmark: String? = null
+
+        while (true) {
+            pageNumber++
+            val batchStartTime = System.currentTimeMillis()
+            val requestBody = JsonObject().apply {
+                add("selector", JsonObject().apply {
+                    add("userId", JsonObject().apply {
+                        add("\$in", com.google.gson.JsonArray().apply {
+                            userIds.forEach { add(it) }
+                        })
+                    })
+                })
+                addProperty("limit", pageSize)
+                add("fields", com.google.gson.JsonArray().apply {
+                    add("_id")
+                    add("_rev")
+                    add("courseId")
+                    add("createdDate")
+                    add("createdOn")
+                    add("parentCode")
+                    add("passed")
+                    add("stepNum")
+                    add("updatedDate")
+                    add("userId")
+                })
+                bookmark?.let { addProperty("bookmark", it) }
+            }
+
+            val apiStartTime = System.currentTimeMillis()
+            val response = apiInterface.findDocs(
+                UrlUtils.header,
+                "application/json",
+                "${UrlUtils.getUrl()}/courses_progress/_find",
+                requestBody
+            )
+            val apiDuration = System.currentTimeMillis() - apiStartTime
+
+            if (response.body() == null || !response.isSuccessful) {
+                android.util.Log.d("SyncPerf", "  ✗ Failed courses_progress page $pageNumber: HTTP ${response.code()}")
+                break
+            }
+
+            val docs = org.ole.planet.myplanet.utils.JsonUtils.getJsonArray("docs", response.body())
+            if (docs.size() == 0) {
+                break
+            }
+
+            val rows = com.google.gson.JsonArray()
+            docs.forEach { doc ->
+                rows.add(JsonObject().apply {
+                    add("doc", doc)
+                })
+            }
+
+            org.ole.planet.myplanet.utils.SyncTimeLogger.logApiCall(
+                "${UrlUtils.getUrl()}/courses_progress/_find (page $pageNumber)",
+                apiDuration,
+                response.isSuccessful,
+                docs.size()
+            )
+
+            databaseService.executeTransactionAsync { mRealm: Realm ->
+                val insertStartTime = System.currentTimeMillis()
+                progressRepository.bulkInsertFromSync(mRealm, rows)
+                val insertDuration = System.currentTimeMillis() - insertStartTime
+                org.ole.planet.myplanet.utils.SyncTimeLogger.logRealmOperation(
+                    "insert_batch",
+                    "courses_progress",
+                    insertDuration,
+                    docs.size()
+                )
+            }
+
+            totalDocs += docs.size()
+            bookmark = response.body()?.get("bookmark")?.asString
+            val batchDuration = System.currentTimeMillis() - batchStartTime
+            android.util.Log.d("SyncPerf", "    courses_progress page $pageNumber: ${docs.size()} docs in ${batchDuration}ms (total: $totalDocs)")
+
+            if (docs.size() < pageSize || bookmark.isNullOrBlank()) {
+                break
+            }
+        }
+
+        val totalDuration = System.currentTimeMillis() - syncStartTime
+        android.util.Log.d("SyncPerf", "  ✓ Completed courses_progress sync: $totalDocs docs in ${totalDuration}ms")
+        return totalDocs
     }
 
     suspend fun syncNotificationReads() = withContext(dispatcherProvider.io) {

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -518,7 +518,7 @@ class TransactionSyncManager @Inject constructor(
 
         android.util.Log.d(
             "SyncPerf",
-            "    submissions selector: userId IN ${userIds.size} device users"
+            "    submissions selector: user._id IN ${userIds.size} device users"
         )
 
         while (true) {
@@ -526,7 +526,7 @@ class TransactionSyncManager @Inject constructor(
             val batchStartTime = System.currentTimeMillis()
             val requestBody = JsonObject().apply {
                 add("selector", JsonObject().apply {
-                    add("userId", JsonObject().apply {
+                    add("user._id", JsonObject().apply {
                         add("\$in", com.google.gson.JsonArray().apply {
                             userIds.forEach { add(it) }
                         })

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -22,6 +22,7 @@ import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyCourse.Companion.saveConcatenatedLinksToPrefs
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ChatRepository
+import org.ole.planet.myplanet.repository.DeviceUserRepository
 import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.UserRepository
@@ -43,6 +44,7 @@ class TransactionSyncManager @Inject constructor(
     private val chatRepository: ChatRepository,
     private val feedbackRepository: FeedbackRepository,
     private val sharedPrefManager: SharedPrefManager,
+    private val deviceUserRepository: DeviceUserRepository,
     private val userRepository: UserRepository,
     private val activitiesRepository: org.ole.planet.myplanet.repository.ActivitiesRepository,
     private val teamsRepository: Lazy<TeamsRepository>,
@@ -157,6 +159,18 @@ class TransactionSyncManager @Inject constructor(
         try {
             if (table == "courses_progress") {
                 return@withContext syncCoursesProgressDb(syncStartTime)
+            }
+            if (table == "submissions") {
+                return@withContext syncSubmissionsDb(syncStartTime)
+            }
+            if (table == "login_activities") {
+                return@withContext syncLoginActivitiesDb(syncStartTime)
+            }
+            if (table == "chat_history") {
+                return@withContext syncChatHistoryDb(syncStartTime)
+            }
+            if (table == "team_activities") {
+                return@withContext syncTeamActivitiesDb(syncStartTime)
             }
 
             // Determine pagination size based on table (smaller for slow endpoints)
@@ -308,7 +322,7 @@ class TransactionSyncManager @Inject constructor(
                     // Use async transaction to avoid blocking (ANR-safe)
                     databaseService.executeTransactionAsync { mRealm: Realm ->
                         val insertStartTime = System.currentTimeMillis()
-                                                when (table) {
+                        when (table) {
                             "tablet_users" -> userRepository.bulkInsertUsersFromSync(mRealm, arr, sharedPrefManager.rawPreferences)
                             "exams" -> surveysRepository.bulkInsertExamsFromSync(mRealm, arr)
                             "team_activities" -> teamsRepository.get().bulkInsertTeamActivitiesFromSync(mRealm, arr)
@@ -367,21 +381,20 @@ class TransactionSyncManager @Inject constructor(
     }
 
     private suspend fun syncCoursesProgressDb(syncStartTime: Long): Int {
-        val userIds = userRepository.getSyncedUsers()
-            .mapNotNull { user -> user._id?.takeIf { it.isNotBlank() } ?: user.id?.takeIf { it.isNotBlank() } }
+        val userIds = deviceUserRepository.getDeviceUserIds()
             .distinct()
         if (userIds.isEmpty()) {
-            android.util.Log.d("SyncPerf", "  ↷ Skipping courses_progress sync: no synced users available")
+            android.util.Log.d("SyncPerf", "  ↷ Skipping courses_progress sync: no device users available")
             return 0
         }
 
         android.util.Log.d(
             "SyncPerf",
-            "    courses_progress selector: userId IN ${userIds.size} synced users"
+            "    courses_progress selector: userId IN ${userIds.size} device users"
         )
         android.util.Log.d(
             "SyncPerf",
-            "    courses_progress synced user sample: ${userIds.take(10).joinToString(", ")}"
+            "    courses_progress device user sample: ${userIds.take(10).joinToString(", ")}"
         )
 
         val pageSize = 1000
@@ -473,7 +486,7 @@ class TransactionSyncManager @Inject constructor(
             if (!loggedLargeResultWarning && pageNumber >= 5 && totalDocs >= pageSize * 5) {
                 android.util.Log.w(
                     "SyncPerf",
-                    "    courses_progress warning: selector is still returning full pages after $pageNumber pages for ${userIds.size} users"
+                    "    courses_progress warning: selector is still returning full pages after $pageNumber pages for ${userIds.size} device users"
                 )
                 loggedLargeResultWarning = true
             }
@@ -486,7 +499,263 @@ class TransactionSyncManager @Inject constructor(
         val totalDuration = System.currentTimeMillis() - syncStartTime
         android.util.Log.d(
             "SyncPerf",
-            "  ✓ Completed courses_progress sync: $totalDocs docs in ${totalDuration}ms for ${userIds.size} synced users"
+            "  ✓ Completed courses_progress sync: $totalDocs docs in ${totalDuration}ms for ${userIds.size} device users"
+        )
+        return totalDocs
+    }
+
+    private suspend fun syncSubmissionsDb(syncStartTime: Long): Int {
+        val userIds = deviceUserRepository.getDeviceUserIds().distinct()
+        if (userIds.isEmpty()) {
+            android.util.Log.d("SyncPerf", "  ↷ Skipping submissions sync: no device users available")
+            return 0
+        }
+
+        val pageSize = 100
+        var totalDocs = 0
+        var pageNumber = 0
+        var bookmark: String? = null
+
+        android.util.Log.d(
+            "SyncPerf",
+            "    submissions selector: userId IN ${userIds.size} device users"
+        )
+
+        while (true) {
+            pageNumber++
+            val batchStartTime = System.currentTimeMillis()
+            val requestBody = JsonObject().apply {
+                add("selector", JsonObject().apply {
+                    add("userId", JsonObject().apply {
+                        add("\$in", com.google.gson.JsonArray().apply {
+                            userIds.forEach { add(it) }
+                        })
+                    })
+                })
+                addProperty("limit", pageSize)
+                bookmark?.let { addProperty("bookmark", it) }
+            }
+
+            val apiStartTime = System.currentTimeMillis()
+            val response = apiInterface.findDocs(
+                UrlUtils.header,
+                "application/json",
+                "${UrlUtils.getUrl()}/submissions/_find",
+                requestBody
+            )
+            val apiDuration = System.currentTimeMillis() - apiStartTime
+
+            if (response.body() == null || !response.isSuccessful) {
+                android.util.Log.d("SyncPerf", "  ✗ Failed submissions page $pageNumber: HTTP ${response.code()}")
+                break
+            }
+
+            val docs = org.ole.planet.myplanet.utils.JsonUtils.getJsonArray("docs", response.body())
+            if (docs.size() == 0) {
+                break
+            }
+
+            val rows = com.google.gson.JsonArray()
+            docs.forEach { doc ->
+                rows.add(JsonObject().apply {
+                    add("doc", doc)
+                })
+            }
+
+            org.ole.planet.myplanet.utils.SyncTimeLogger.logApiCall(
+                "${UrlUtils.getUrl()}/submissions/_find (page $pageNumber)",
+                apiDuration,
+                response.isSuccessful,
+                docs.size()
+            )
+
+            databaseService.executeTransactionAsync { mRealm: Realm ->
+                val insertStartTime = System.currentTimeMillis()
+                submissionsRepository.bulkInsertFromSync(mRealm, rows)
+                val insertDuration = System.currentTimeMillis() - insertStartTime
+                org.ole.planet.myplanet.utils.SyncTimeLogger.logRealmOperation(
+                    "insert_batch",
+                    "submissions",
+                    insertDuration,
+                    docs.size()
+                )
+            }
+
+            totalDocs += docs.size()
+            bookmark = response.body()?.get("bookmark")?.asString
+            val batchDuration = System.currentTimeMillis() - batchStartTime
+            android.util.Log.d(
+                "SyncPerf",
+                "    submissions page $pageNumber: ${docs.size()} docs in ${batchDuration}ms (total: $totalDocs, bookmark=${!bookmark.isNullOrBlank()})"
+            )
+
+            if (docs.size() < pageSize || bookmark.isNullOrBlank()) {
+                break
+            }
+        }
+
+        val totalDuration = System.currentTimeMillis() - syncStartTime
+        android.util.Log.d(
+            "SyncPerf",
+            "  ✓ Completed submissions sync: $totalDocs docs in ${totalDuration}ms for ${userIds.size} device users"
+        )
+        return totalDocs
+    }
+
+    private suspend fun syncLoginActivitiesDb(syncStartTime: Long): Int {
+        val userNames = deviceUserRepository.getDeviceUserNames().distinct()
+        if (userNames.isEmpty()) {
+            android.util.Log.d("SyncPerf", "  ↷ Skipping login_activities sync: no device users available")
+            return 0
+        }
+
+        return syncFindByField(
+            table = "login_activities",
+            selectorField = "user",
+            selectorValues = userNames,
+            pageSize = 1000,
+            syncStartTime = syncStartTime
+        ) { realm, rows ->
+            activitiesRepository.bulkInsertLoginActivitiesFromSync(realm, rows)
+        }
+    }
+
+    private suspend fun syncChatHistoryDb(syncStartTime: Long): Int {
+        val userNames = deviceUserRepository.getDeviceUserNames().distinct()
+        if (userNames.isEmpty()) {
+            android.util.Log.d("SyncPerf", "  ↷ Skipping chat_history sync: no device users available")
+            return 0
+        }
+
+        return syncFindByField(
+            table = "chat_history",
+            selectorField = "user",
+            selectorValues = userNames,
+            pageSize = 1000,
+            syncStartTime = syncStartTime
+        ) { realm, rows ->
+            chatRepository.insertChatHistoryBatch(realm, rows)
+        }
+    }
+
+    private suspend fun syncTeamActivitiesDb(syncStartTime: Long): Int {
+        val userIds = deviceUserRepository.getDeviceUserIds().distinct()
+        if (userIds.isEmpty()) {
+            android.util.Log.d("SyncPerf", "  ↷ Skipping team_activities sync: no device users available")
+            return 0
+        }
+
+        val teamIds = teamsRepository.get().getTeamIdsForUsers(userIds)
+        if (teamIds.isEmpty()) {
+            android.util.Log.d("SyncPerf", "  ↷ Skipping team_activities sync: no team memberships for device users")
+            return 0
+        }
+
+        return syncFindByField(
+            table = "team_activities",
+            selectorField = "teamId",
+            selectorValues = teamIds,
+            pageSize = 1000,
+            syncStartTime = syncStartTime
+        ) { realm, rows ->
+            teamsRepository.get().bulkInsertTeamActivitiesFromSync(realm, rows)
+        }
+    }
+
+    private suspend fun syncFindByField(
+        table: String,
+        selectorField: String,
+        selectorValues: List<String>,
+        pageSize: Int,
+        syncStartTime: Long,
+        bulkInsert: (Realm, com.google.gson.JsonArray) -> Unit
+    ): Int {
+        var totalDocs = 0
+        var pageNumber = 0
+        var bookmark: String? = null
+
+        android.util.Log.d(
+            "SyncPerf",
+            "    $table selector: $selectorField IN ${selectorValues.size} values"
+        )
+
+        while (true) {
+            pageNumber++
+            val batchStartTime = System.currentTimeMillis()
+            val requestBody = JsonObject().apply {
+                add("selector", JsonObject().apply {
+                    add(selectorField, JsonObject().apply {
+                        add("\$in", com.google.gson.JsonArray().apply {
+                            selectorValues.forEach { add(it) }
+                        })
+                    })
+                })
+                addProperty("limit", pageSize)
+                bookmark?.let { addProperty("bookmark", it) }
+            }
+
+            val apiStartTime = System.currentTimeMillis()
+            val response = apiInterface.findDocs(
+                UrlUtils.header,
+                "application/json",
+                "${UrlUtils.getUrl()}/$table/_find",
+                requestBody
+            )
+            val apiDuration = System.currentTimeMillis() - apiStartTime
+
+            if (response.body() == null || !response.isSuccessful) {
+                android.util.Log.d("SyncPerf", "  ✗ Failed $table page $pageNumber: HTTP ${response.code()}")
+                break
+            }
+
+            val docs = org.ole.planet.myplanet.utils.JsonUtils.getJsonArray("docs", response.body())
+            if (docs.size() == 0) {
+                break
+            }
+
+            val rows = com.google.gson.JsonArray()
+            docs.forEach { doc ->
+                rows.add(JsonObject().apply {
+                    add("doc", doc)
+                })
+            }
+
+            org.ole.planet.myplanet.utils.SyncTimeLogger.logApiCall(
+                "${UrlUtils.getUrl()}/$table/_find (page $pageNumber)",
+                apiDuration,
+                response.isSuccessful,
+                docs.size()
+            )
+
+            databaseService.executeTransactionAsync { mRealm: Realm ->
+                val insertStartTime = System.currentTimeMillis()
+                bulkInsert(mRealm, rows)
+                val insertDuration = System.currentTimeMillis() - insertStartTime
+                org.ole.planet.myplanet.utils.SyncTimeLogger.logRealmOperation(
+                    "insert_batch",
+                    table,
+                    insertDuration,
+                    docs.size()
+                )
+            }
+
+            totalDocs += docs.size()
+            bookmark = response.body()?.get("bookmark")?.asString
+            val batchDuration = System.currentTimeMillis() - batchStartTime
+            android.util.Log.d(
+                "SyncPerf",
+                "    $table page $pageNumber: ${docs.size()} docs in ${batchDuration}ms (total: $totalDocs, bookmark=${!bookmark.isNullOrBlank()})"
+            )
+
+            if (docs.size() < pageSize || bookmark.isNullOrBlank()) {
+                break
+            }
+        }
+
+        val totalDuration = System.currentTimeMillis() - syncStartTime
+        android.util.Log.d(
+            "SyncPerf",
+            "  ✓ Completed $table sync: $totalDocs docs in ${totalDuration}ms for ${selectorValues.size} selector values"
         )
         return totalDocs
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt
@@ -25,6 +25,7 @@ import org.junit.Test
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ActivitiesRepository
+import org.ole.planet.myplanet.repository.DeviceUserRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
 
@@ -36,6 +37,7 @@ class UserSessionManagerTest {
     private val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
     private val userRepository: UserRepository = mockk(relaxed = true)
     private val activitiesRepository: ActivitiesRepository = mockk(relaxed = true)
+    private val deviceUserRepository: DeviceUserRepository = mockk(relaxed = true)
 
     private val testDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
@@ -54,6 +56,7 @@ class UserSessionManagerTest {
             applicationScope = testScope,
             userRepository = userRepository,
             activitiesRepository = activitiesRepository,
+            deviceUserRepository = deviceUserRepository,
             dispatcherProvider = dispatcherProvider
         )
     }
@@ -78,6 +81,7 @@ class UserSessionManagerTest {
             applicationScope = testScope,
             userRepository = userRepository,
             activitiesRepository = activitiesRepository,
+            deviceUserRepository = deviceUserRepository,
             dispatcherProvider = dispatcherProvider
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/TransactionSyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/TransactionSyncManagerTest.kt
@@ -21,6 +21,7 @@ import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.model.DocumentResponse
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.ChatRepository
+import org.ole.planet.myplanet.repository.DeviceUserRepository
 import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.repository.NotificationsRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
@@ -42,6 +43,7 @@ class TransactionSyncManagerTest {
     private val chatRepository: ChatRepository = mockk()
     private val feedbackRepository: FeedbackRepository = mockk()
     private val sharedPrefManager: SharedPrefManager = mockk()
+    private val deviceUserRepository: DeviceUserRepository = mockk()
     private val userRepository: UserRepository = mockk()
     private val activitiesRepository: ActivitiesRepository = mockk()
     private val teamsRepository: Lazy<TeamsRepository> = mockk()
@@ -74,6 +76,7 @@ class TransactionSyncManagerTest {
             chatRepository,
             feedbackRepository,
             sharedPrefManager,
+            deviceUserRepository,
             userRepository,
             activitiesRepository,
 			teamsRepository,


### PR DESCRIPTION
(fixes open-learning-exchange/planet#9895)                    
                                                                                                                                                                                                                                              
  The change introduces a `RealmDeviceUser` store of users actually seen on this device, and uses it to scope five previously full-table syncs onto paged `_find` queries:                                                                    
                  
  | table            | selector field | source                | endpoint                  |                                                                                                                                                   
  |------------------|---------------|-----------------------|---------------------------|
  | courses_progress | `userId`      | device user ids       | `courses_progress/_find`  |
  | submissions      | `userId`      | device user ids       | `submissions/_find`       |                                                                                                                                                    
  | login_activities | `user`        | device user names     | `login_activities/_find`  |
  | chat_history     | `user`        | device user names     | `chat_history/_find`      |                                                                                                                                                    
  | team_activities  | `teamId`      | derived team memberships | `team_activities/_find` |
                                                                                                                                                                                                                                              
  `tablet_users` is **not** used as the locality source — it is the auth scope, not a device scope, so `userId IN tablet_users` would still behave like a near-full-table sync.
                                                                                                                                                                                                                                              
  A single `SyncPolicy` (`bootstrapDeferredTables`, `steadyStateBackgroundTables`, `applyForegroundPolicy`, `backgroundTablesFor`) now decides:
                                                                                                                                                                                                                                              
  - which tables are skipped on first-ever sync (no device users yet)
  - which tables stay in the foreground job once device users exist                                                                                                                                                                           
  - which tables run as a background follow-up after main sync (`courses_progress`, `notifications`)                                                                                                                                          
                                                                                                                                                                                                                                              
  The same policy is applied in both `SyncManager` (legacy `startFullSync` + `startFastSync`) and `ImprovedSyncManager`, so neither sync path can fall back to the old behavior.                                                              
                                                                                                                                                                                                                                              
  `notifications` is deferred from bootstrap and runs in the background, but is not yet selector-scoped on the wire — left as a follow-up.                                                                                                    
                  
  `ratings` and `teams` were intentionally left on `_all_docs`: ratings isn't user-bound (and was small in the failing run) and teams is small and not strictly user-scoped.                                                                  
                  
  Full design notes are in `MYPLANET_SYNC_POLICY_BLUEPRINT.md`.                                                                                                                                                                               