### PR TITLE
Refactor SyncManager by extracting team sync logic into TeamSyncHandler

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -52,9 +52,10 @@ object ServiceModule {
         @ApplicationScope scope: CoroutineScope,
         activitiesRepository: org.ole.planet.myplanet.repository.ActivitiesRepository,
         dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider,
-        teamsRepository: org.ole.planet.myplanet.repository.TeamsRepository
+        teamsRepository: org.ole.planet.myplanet.repository.TeamsRepository,
+        teamSyncHandler: org.ole.planet.myplanet.services.sync.TeamSyncHandler
     ): SyncManager {
-        return SyncManager(context, databaseService, sharedPrefManager, apiInterface, improvedSyncManager, transactionSyncManager, resourcesRepository, loginSyncManager, scope, activitiesRepository, dispatcherProvider, teamsRepository)
+        return SyncManager(context, databaseService, sharedPrefManager, apiInterface, improvedSyncManager, transactionSyncManager, resourcesRepository, loginSyncManager, scope, activitiesRepository, dispatcherProvider, teamsRepository, teamSyncHandler)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -72,7 +72,8 @@ class SyncManager @Inject constructor(
     @param:ApplicationScope private val syncScope: CoroutineScope,
     private val activitiesRepository: ActivitiesRepository,
     private val dispatcherProvider: DispatcherProvider,
-    private val teamsRepository: org.ole.planet.myplanet.repository.TeamsRepository
+    private val teamsRepository: org.ole.planet.myplanet.repository.TeamsRepository,
+    private val teamSyncHandler: TeamSyncHandler
 ) {
     private val isSyncing = AtomicBoolean(false)
     private val stringArray = arrayOfNulls<String>(4)
@@ -255,11 +256,6 @@ class SyncManager @Inject constructor(
                         logger.endProcess("feedback_sync")
                     },
                     async {
-                        logger.startProcess("tasks_sync")
-                        transactionSyncManager.syncDb("tasks")
-                        logger.endProcess("tasks_sync")
-                    },
-                    async {
                         logger.startProcess("login_activities_sync")
                         transactionSyncManager.syncDb("login_activities")
                         logger.endProcess("login_activities_sync")
@@ -275,19 +271,12 @@ class SyncManager @Inject constructor(
                         logger.endProcess("certifications_sync")
                     },
                     async {
-                        logger.startProcess("team_activities_sync")
-                        transactionSyncManager.syncDb("team_activities")
-                        logger.endProcess("team_activities_sync")
-                    },
-                    async {
                         logger.startProcess("chat_history_sync")
                         transactionSyncManager.syncDb("chat_history")
                         logger.endProcess("chat_history_sync")
                     },
                     async {
-                        logger.startProcess("teams_sync")
-                        transactionSyncManager.syncDb("teams")
-                        logger.endProcess("teams_sync")
+                        teamSyncHandler.syncFull()
                     },
                     async {
                         logger.startProcess("meetups_sync")
@@ -387,13 +376,6 @@ class SyncManager @Inject constructor(
 
                     syncJobs.add(
                         async {
-                            logger.startProcess("teams_sync")
-                            transactionSyncManager.syncDb("teams")
-                            logger.endProcess("teams_sync")
-                        })
-
-                    syncJobs.add(
-                        async {
                             logger.startProcess("news_sync")
                             transactionSyncManager.syncDb("news")
                             logger.endProcess("news_sync")
@@ -453,15 +435,6 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("tasks") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("tasks_sync")
-                            transactionSyncManager.syncDb("tasks")
-                            logger.endProcess("tasks_sync")
-                        })
-                }
-
                 if (syncTables?.contains("meetups") == true) {
                     syncJobs.add(
                         async {
@@ -471,14 +444,12 @@ class SyncManager @Inject constructor(
                         })
                 }
 
-                if (syncTables?.contains("team_activities") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("team_activities_sync")
-                            transactionSyncManager.syncDb("team_activities")
-                            logger.endProcess("team_activities_sync")
-                        })
-                }
+                syncJobs.add(
+                    async {
+                        teamSyncHandler.syncFast(syncTables)
+                        Unit
+                    }
+                )
 
                 if (syncTables?.contains("chat_history") == true) {
                     syncJobs.add(

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TableGroupSyncHandler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TableGroupSyncHandler.kt
@@ -1,0 +1,12 @@
+package org.ole.planet.myplanet.services.sync
+
+data class GroupSyncResult(
+    val itemsSynced: Int,
+    val success: Boolean,
+    val results: Map<String, Int> = emptyMap()
+)
+
+interface TableGroupSyncHandler {
+    suspend fun syncFull(): GroupSyncResult
+    suspend fun syncFast(syncTables: List<String>?): GroupSyncResult
+}

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TeamSyncHandler.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TeamSyncHandler.kt
@@ -1,0 +1,81 @@
+package org.ole.planet.myplanet.services.sync
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import org.ole.planet.myplanet.utils.SyncTimeLogger
+
+@Singleton
+class TeamSyncHandler @Inject constructor(
+    private val transactionSyncManager: TransactionSyncManager
+) : TableGroupSyncHandler {
+
+    override suspend fun syncFull(): GroupSyncResult = coroutineScope {
+        val logger = SyncTimeLogger
+        val jobs = listOf(
+            "teams" to async {
+                logger.startProcess("teams_sync")
+                val count = transactionSyncManager.syncDb("teams")
+                logger.endProcess("teams_sync")
+                count
+            },
+            "tasks" to async {
+                logger.startProcess("tasks_sync")
+                val count = transactionSyncManager.syncDb("tasks")
+                logger.endProcess("tasks_sync")
+                count
+            },
+            "team_activities" to async {
+                logger.startProcess("team_activities_sync")
+                val count = transactionSyncManager.syncDb("team_activities")
+                logger.endProcess("team_activities_sync")
+                count
+            }
+        )
+
+        val results = jobs.associate { it.first to it.second.await() }
+        val total = results.values.sum()
+
+        GroupSyncResult(itemsSynced = total, success = true, results = results)
+    }
+
+    override suspend fun syncFast(syncTables: List<String>?): GroupSyncResult = coroutineScope {
+        val logger = SyncTimeLogger
+        val jobs = mutableListOf<Pair<String, Deferred<Int>>>()
+
+        if (syncTables?.contains("tablet_users") != false) {
+            jobs.add("teams" to async {
+                logger.startProcess("teams_sync")
+                val count = transactionSyncManager.syncDb("teams")
+                logger.endProcess("teams_sync")
+                count
+            })
+        }
+
+        if (syncTables?.contains("tasks") == true) {
+            jobs.add("tasks" to async {
+                logger.startProcess("tasks_sync")
+                val count = transactionSyncManager.syncDb("tasks")
+                logger.endProcess("tasks_sync")
+                count
+            })
+        }
+
+        if (syncTables?.contains("team_activities") == true) {
+            jobs.add("team_activities" to async {
+                logger.startProcess("team_activities_sync")
+                val count = transactionSyncManager.syncDb("team_activities")
+                logger.endProcess("team_activities_sync")
+                count
+            })
+        }
+
+        val results = jobs.associate { it.first to it.second.await() }
+        val total = results.values.sum()
+
+        GroupSyncResult(itemsSynced = total, success = true, results = results)
+    }
+}


### PR DESCRIPTION
Refactored `SyncManager` by extracting the team-related table synchronization logic (teams, tasks, team_activities) into a new, dedicated `TeamSyncHandler`. This adheres to the single responsibility principle and simplifies `SyncManager`, which acts more as a router/scheduler now. `TeamSyncHandler` implements the newly created `TableGroupSyncHandler` interface, introducing an infrastructure for future group sync extractions that report uniform results.

- Introduced `TableGroupSyncHandler` interface with full/fast sync operations reporting a `GroupSyncResult`
- Created `TeamSyncHandler` implementing this interface for the team group
- Injected `TeamSyncHandler` via Hilt into `SyncManager`
- Updated DI module manually (`ServiceModule.kt`) to resolve dependency graph

---
*PR created automatically by Jules for task [14364333853336293954](https://jules.google.com/task/14364333853336293954) started by @dogi*