### PR TITLE
Refactor TeamFragment updateExistingTeam repository calls to TeamViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
@@ -187,45 +187,37 @@ class TeamFragment : Fragment(), OnTeamEditListener, OnUpdateCompleteListener,
         team: TeamDetails, name: String, description: String, services: String, rules: String,
         userModel: RealmUser, dialog: AlertDialog, failureMessage: String
     ) {
-        val teamTypeForValidation = if (type == "enterprise") "enterprise" else "team"
-        val excludeTeamId = team._id ?: team.teamId
-        val nameExists = teamsRepository.isTeamNameExists(name, teamTypeForValidation, excludeTeamId)
-
-        if (nameExists) {
-            val duplicateMessage = if (type == "enterprise") {
-                getString(R.string.enterprise_name_already_exists)
-            } else {
-                getString(R.string.team_name_already_exists)
-            }
-            Utilities.toast(activity, duplicateMessage)
-            alertCreateTeamBinding.etName.error = duplicateMessage
-            return
-        }
-
         val targetTeamId = team._id ?: team.teamId
-        if (targetTeamId.isNullOrBlank()) {
-            Utilities.toast(activity, failureMessage)
-            return
-        }
-        teamsRepository.updateTeam(
+        val result = viewModel.updateTeam(
             teamId = targetTeamId,
             name = name,
             description = description,
             services = services,
             rules = rules,
-            updatedBy = userModel._id,
-        ).onSuccess { updated ->
-            if (updated) {
+            category = type,
+            userModel = userModel
+        )
+
+        when (result) {
+            is TeamActionResult.NameExists -> {
+                val duplicateMessage = if (type == "enterprise") {
+                    getString(R.string.enterprise_name_already_exists)
+                } else {
+                    getString(R.string.team_name_already_exists)
+                }
+                Utilities.toast(activity, duplicateMessage)
+                alertCreateTeamBinding.etName.error = duplicateMessage
+            }
+            is TeamActionResult.Success -> {
                 binding.etSearch.visibility = View.VISIBLE
                 binding.tableTitle.visibility = View.VISIBLE
                 Utilities.toast(activity, getString(R.string.team_created))
                 viewModel.loadTeams(fromDashboard, type, user?.id)
                 dialog.dismiss()
-            } else {
+            }
+            is TeamActionResult.Failure -> {
                 Utilities.toast(activity, failureMessage)
             }
-        }.onFailure {
-            Utilities.toast(activity, failureMessage)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
@@ -157,4 +157,39 @@ class TeamViewModel @Inject constructor(
                 onFailure = { TeamActionResult.Failure(it.message) }
             )
     }
+
+    suspend fun updateTeam(
+        teamId: String?,
+        name: String,
+        description: String,
+        services: String,
+        rules: String,
+        category: String?,
+        userModel: RealmUser
+    ): TeamActionResult {
+        val teamTypeForValidation = if (category == "enterprise") "enterprise" else "team"
+        if (teamsRepository.isTeamNameExists(name, teamTypeForValidation, teamId)) {
+            return TeamActionResult.NameExists
+        }
+
+        if (teamId.isNullOrBlank()) {
+            return TeamActionResult.Failure(null)
+        }
+
+        return teamsRepository.updateTeam(
+            teamId = teamId,
+            name = name,
+            description = description,
+            services = services,
+            rules = rules,
+            updatedBy = userModel._id
+        ).fold(
+            onSuccess = { updated ->
+                if (updated) TeamActionResult.Success else TeamActionResult.Failure(null)
+            },
+            onFailure = { error ->
+                TeamActionResult.Failure(error.message)
+            }
+        )
+    }
 }


### PR DESCRIPTION
Moves the team update logic and name uniqueness validation from `TeamFragment` into `TeamViewModel`.

Changes:
1. `TeamViewModel` now contains `updateTeam` that performs the collision check and executes the repository update, returning a `TeamActionResult`.
2. `TeamFragment.updateExistingTeam` utilizes the single view model call and handles UI outcomes using the result variants.

---
*PR created automatically by Jules for task [12923722521779912450](https://jules.google.com/task/12923722521779912450) started by @dogi*