### PR TITLE
🧪 Add test for setLoggedIn and isLoggedIn in SharedPrefManager

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
@@ -170,6 +170,26 @@ class SharedPrefManagerTest {
     }
 
     @Test
+    fun testGetAndSetLoggedIn() {
+        // Test isLoggedIn
+        every { mockSharedPreferences.getBoolean("isLoggedIn", false) } returns true
+        assertTrue(sharedPrefManager.isLoggedIn())
+
+        every { mockSharedPreferences.getBoolean("isLoggedIn", false) } returns false
+        assertEquals(false, sharedPrefManager.isLoggedIn())
+
+        // Test setLoggedIn true
+        sharedPrefManager.setLoggedIn(true)
+        verify { mockEditor.putBoolean("isLoggedIn", true) }
+        verify { mockEditor.apply() }
+
+        // Test setLoggedIn false
+        sharedPrefManager.setLoggedIn(false)
+        verify { mockEditor.putBoolean("isLoggedIn", false) }
+        verify { mockEditor.apply() }
+    }
+
+    @Test
     fun testRawString() {
         every { mockSharedPreferences.getString("test_key", "") } returns "test_val"
         assertEquals("test_val", sharedPrefManager.getRawString("test_key", ""))


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `setLoggedIn` and `isLoggedIn` functions in `SharedPrefManager`.
📊 **Coverage:** The new test `testGetAndSetLoggedIn` covers scenarios for `setLoggedIn(true)`, `setLoggedIn(false)`, and verifying the respective getter values with `isLoggedIn()`.
✨ **Result:** The improvement in test coverage guarantees that setting the login status to SharedPreferences works correctly using proper Editor configurations.

---
*PR created automatically by Jules for task [8587728496456789133](https://jules.google.com/task/8587728496456789133) started by @dogi*