### PR TITLE
sync: smoother download service destroying (fixes #13331)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5466
+        versionName = "0.54.66"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -377,7 +377,8 @@ class DownloadService : Service() {
     override fun onDestroy() {
         try {
             stopForeground(Service.STOP_FOREGROUND_REMOVE)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping foreground service", e)
         }
         downloadJob.cancel()
         notificationManager?.cancel(ONGOING_NOTIFICATION_ID)


### PR DESCRIPTION
🎯 **What:** Modified the `onDestroy` function in `DownloadService.kt` to catch and log the exception when stopping the foreground service, instead of silently swallowing it.

💡 **Why:** Silently swallowing exceptions in empty catch blocks hides potential issues and makes debugging difficult. Logging the exception improves maintainability and debuggability while ensuring the service still shuts down properly.

✅ **Verification:** Verified the code compiles successfully (`./gradlew compileDefaultDebugKotlin --no-build-cache`).

✨ **Result:** The code health issue is resolved. The exception is now properly logged, improving readability and maintainability without changing any existing application behavior.

---
*PR created automatically by Jules for task [95131597227479656](https://jules.google.com/task/95131597227479656) started by @dogi*