### PR TITLE
all: smoother base permission handling (fixes #13337)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5467
+        versionName = "0.54.67"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Process
 import android.provider.Settings
+import android.util.Log
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat

--- a/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
@@ -47,7 +47,7 @@ abstract class BasePermissionActivity : AppCompatActivity() {
             }
             mode = method.invoke(appOps, AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), context.packageName) as Int
         } catch (e: Exception) {
-            e.printStackTrace()
+            android.util.Log.e("BasePermissionActivity", "Error checking usages permission", e)
         }
 
         return if (mode == AppOpsManager.MODE_DEFAULT) {
@@ -114,7 +114,7 @@ abstract class BasePermissionActivity : AppCompatActivity() {
             val packageInfo = packageManager.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS)
             packageInfo.requestedPermissions?.contains(permission) == true
         } catch (e: Exception) {
-            e.printStackTrace()
+            android.util.Log.e("BasePermissionActivity", "Error checking if permission is declared in manifest", e)
             false
         }
     }
@@ -342,7 +342,7 @@ abstract class BasePermissionActivity : AppCompatActivity() {
             startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             startActivity(Intent(Settings.ACTION_SETTINGS))
-            e.printStackTrace()
+            android.util.Log.e("BasePermissionActivity", "ActivityNotFoundException for notification settings", e)
         }
     }
 
@@ -354,7 +354,7 @@ abstract class BasePermissionActivity : AppCompatActivity() {
             startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             startActivity(Intent(Settings.ACTION_SETTINGS))
-            e.printStackTrace()
+            android.util.Log.e("BasePermissionActivity", "ActivityNotFoundException for app settings", e)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
@@ -48,7 +48,7 @@ abstract class BasePermissionActivity : AppCompatActivity() {
             }
             mode = method.invoke(appOps, AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), context.packageName) as Int
         } catch (e: Exception) {
-            android.util.Log.e("BasePermissionActivity", "Error checking usages permission", e)
+            Log.e("BasePermissionActivity", "Error checking usages permission", e)
         }
 
         return if (mode == AppOpsManager.MODE_DEFAULT) {
@@ -115,7 +115,7 @@ abstract class BasePermissionActivity : AppCompatActivity() {
             val packageInfo = packageManager.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS)
             packageInfo.requestedPermissions?.contains(permission) == true
         } catch (e: Exception) {
-            android.util.Log.e("BasePermissionActivity", "Error checking if permission is declared in manifest", e)
+            Log.e("BasePermissionActivity", "Error checking if permission is declared in manifest", e)
             false
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
@@ -343,7 +343,7 @@ abstract class BasePermissionActivity : AppCompatActivity() {
             startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             startActivity(Intent(Settings.ACTION_SETTINGS))
-            android.util.Log.e("BasePermissionActivity", "ActivityNotFoundException for notification settings", e)
+            Log.e("BasePermissionActivity", "ActivityNotFoundException for notification settings", e)
         }
     }
 
@@ -355,7 +355,7 @@ abstract class BasePermissionActivity : AppCompatActivity() {
             startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             startActivity(Intent(Settings.ACTION_SETTINGS))
-            android.util.Log.e("BasePermissionActivity", "ActivityNotFoundException for app settings", e)
+            Log.e("BasePermissionActivity", "ActivityNotFoundException for app settings", e)
         }
     }
 


### PR DESCRIPTION
🎯 **What:** Replaced four instances of `e.printStackTrace()` with `android.util.Log.e` in `BasePermissionActivity.kt`.
💡 **Why:** Swallowing exceptions silently or logging them improperly to standard error without context makes debugging difficult. Using Android's proper logging framework (`Log.e`) ensures exceptions are properly categorized and captured by Logcat along with the preserved stack trace, improving maintainability.
✅ **Verification:** Verified the code changes by compiling locally without errors and running `BasePermissionActivity` unit tests to ensure no regressions were introduced.
✨ **Result:** Enhanced the codebase's error handling and logging capabilities within the core permissions base class.

---
*PR created automatically by Jules for task [748471415169363515](https://jules.google.com/task/748471415169363515) started by @dogi*