### PR TITLE
resources: smoother repository filter libraries update testing (fixes #13351)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5480
+        versionName = "0.54.80"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,13 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-<<<<<<< testing-improvement-resources-repository-3052598280764427815
-        versionCode = 5480
-        versionName = "0.54.80"
-=======
-        versionCode = 5478
-        versionName = "0.54.78"
->>>>>>> master
+        versionCode = 5479
+        versionName = "0.54.79"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -1,0 +1,72 @@
+package org.ole.planet.myplanet.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.Lazy
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.services.SharedPrefManager
+import java.lang.reflect.Method
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ResourcesRepositoryImplTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val databaseService: DatabaseService = mockk(relaxed = true)
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val activitiesRepository: ActivitiesRepository = mockk(relaxed = true)
+    private val settings: SharedPreferences = mockk(relaxed = true)
+    private val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
+    private val ratingsRepository: RatingsRepository = mockk(relaxed = true)
+    private val tagsRepository: TagsRepository = mockk(relaxed = true)
+    private val teamsRepositoryLazy: Lazy<TeamsRepository> = mockk(relaxed = true)
+
+    private val repository = ResourcesRepositoryImpl(
+        context,
+        databaseService,
+        testDispatcher,
+        activitiesRepository,
+        settings,
+        sharedPrefManager,
+        ratingsRepository,
+        tagsRepository,
+        teamsRepositoryLazy
+    )
+
+    @Test
+    fun testFilterLibrariesNeedingUpdate() {
+        val method: Method = ResourcesRepositoryImpl::class.java.getDeclaredMethod(
+            "filterLibrariesNeedingUpdate",
+            Collection::class.java
+        )
+        method.isAccessible = true
+
+        val lib1 = mockk<RealmMyLibrary>()
+        every { lib1.needToUpdate() } returns true
+
+        val lib2 = mockk<RealmMyLibrary>()
+        every { lib2.needToUpdate() } returns false
+
+        val lib3 = mockk<RealmMyLibrary>()
+        every { lib3.needToUpdate() } returns true
+
+        val lib4 = mockk<RealmMyLibrary>()
+        every { lib4.needToUpdate() } returns false
+
+        val input = listOf(lib1, lib2, lib3, lib4)
+
+        @Suppress("UNCHECKED_CAST")
+        val result = method.invoke(repository, input) as List<RealmMyLibrary>
+
+        assertEquals(2, result.size)
+        assertTrue(result.contains(lib1))
+        assertTrue(result.contains(lib3))
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a unit test to cover the `filterLibrariesNeedingUpdate` private method in `ResourcesRepositoryImpl.kt` by using Kotlin reflection.
📊 **Coverage:** Tests that the filtering logic correctly returns only `RealmMyLibrary` items where `needToUpdate()` is true.
✨ **Result:** Improved test coverage and ensured reliability of the library update filtering logic.

---
*PR created automatically by Jules for task [3052598280764427815](https://jules.google.com/task/3052598280764427815) started by @dogi*