### PR TITLE
resources: smoother audio recorder force stop testing (fixes #13350)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5479
+        versionName = "0.54.79"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/AudioRecorderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/AudioRecorderTest.kt
@@ -52,6 +52,27 @@ class AudioRecorderTest {
     }
 
     @Test
+    fun testForceStopWhenRecording() {
+        val mockMediaRecorder = mockk<MediaRecorder>(relaxed = true)
+
+        val field = AudioRecorder::class.java.getDeclaredField("myAudioRecorder")
+        field.isAccessible = true
+        field.set(audioRecorder, mockMediaRecorder)
+
+        audioRecorder.setAudioRecordListener(mockListener)
+        audioRecorder.forceStop()
+
+        verify { mockMediaRecorder.stop() }
+        verify { mockMediaRecorder.release() }
+        val fieldAfter = AudioRecorder::class.java.getDeclaredField("myAudioRecorder")
+        fieldAfter.isAccessible = true
+        val myAudioRecorder = fieldAfter.get(audioRecorder)
+        assertTrue(myAudioRecorder == null)
+        assertFalse(audioRecorder.isRecording())
+        verify { mockListener.onError("Recording stopped") }
+    }
+
+    @Test
     fun testForceStopWhenNotRecording() {
         audioRecorder.setAudioRecordListener(mockListener)
         audioRecorder.forceStop()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of coverage for the `forceStop` method in `AudioRecorder.kt` when the audio recorder is in a recording state.
📊 **Coverage:** The test covers the scenario when `forceStop` is called while the recorder is recording. It verifies that `stop()` and `release()` are called on the `MediaRecorder`, the `myAudioRecorder` field is set to null, and the `audioRecordListener.onError` method is invoked.
✨ **Result:** The testing improvement increases the test coverage of the `AudioRecorder` class, ensuring that resource releases and side-effects are properly tested.

---
*PR created automatically by Jules for task [17100473157301426532](https://jules.google.com/task/17100473157301426532) started by @dogi*