### PR TITLE
all: smoother shared preference manager remove key testing (fixes #13348)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5477
+        versionName = "0.54.77"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
@@ -178,4 +178,11 @@ class SharedPrefManagerTest {
         verify { mockEditor.putString("test_key", "new_val") }
         verify { mockEditor.apply() }
     }
+
+    @Test
+    fun testRemoveKey() {
+        sharedPrefManager.removeKey("some_key")
+        verify { mockEditor.remove("some_key") }
+        verify { mockEditor.apply() }
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `removeKey` method in `SharedPrefManager` was previously untested, leaving a gap in coverage for removing entries from shared preferences.

📊 **Coverage:** What scenarios are now tested
The new `testRemoveKey` covers the happy path, ensuring that calling `removeKey` successfully delegates to the SharedPreferences editor to remove the specified key and applies the changes.

✨ **Result:** The improvement in test coverage
Increased test coverage for `SharedPrefManager`, ensuring the `removeKey` functionality behaves as expected and is protected against future regressions.

---
*PR created automatically by Jules for task [11370905010035579966](https://jules.google.com/task/11370905010035579966) started by @dogi*