### PR TITLE
all: smoother retry queue set processing testing (fixes #13347)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5476
+        versionName = "0.54.76"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueTest.kt
@@ -126,6 +126,17 @@ class RetryQueueTest {
     }
 
     @Test
+    fun setProcessing_updatesCurrentlyProcessing() = runTest {
+        assertFalse(retryQueue.isCurrentlyProcessing())
+
+        retryQueue.setProcessing(true)
+        assertTrue(retryQueue.isCurrentlyProcessing())
+
+        retryQueue.setProcessing(false)
+        assertFalse(retryQueue.isCurrentlyProcessing())
+    }
+
+    @Test
     fun safeClearQueue_isProcessing_returnsFalse() = runTest {
         retryQueue.setProcessing(true)
 


### PR DESCRIPTION
🎯 **What:** Added a unit test `setProcessing_updatesCurrentlyProcessing` to `RetryQueueTest.kt` to cover the `setProcessing` method.
📊 **Coverage:** The test covers updating the internal `isProcessing` state to `true` and `false`, verifying the state change using `isCurrentlyProcessing()`.
✨ **Result:** Improved test coverage for `RetryQueue.kt`.

---
*PR created automatically by Jules for task [17471981852167404776](https://jules.google.com/task/17471981852167404776) started by @dogi*