### PR TITLE
teams: smoother repository logs bulk inserting (fixes #13328)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5464
+        versionName = "0.54.64"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -1464,11 +1464,18 @@ class TeamsRepositoryImpl @Inject constructor(
 
     override suspend fun insertTeamLogs(logs: List<JsonObject>) {
         executeTransaction { realm ->
+            val ids = logs.map { JsonUtils.getString("_id", it) }.toTypedArray()
+            val existingLogs = if (ids.isNotEmpty()) {
+                realm.where(RealmTeamLog::class.java).`in`("_id", ids).findAll().associateBy { it._id }.toMutableMap()
+            } else {
+                mutableMapOf()
+            }
             for (json in logs) {
-                var tag = realm.where(RealmTeamLog::class.java)
-                    .equalTo("_id", JsonUtils.getString("_id", json)).findFirst()
+                val id = JsonUtils.getString("_id", json)
+                var tag = existingLogs[id]
                 if (tag == null) {
-                    tag = realm.createObject(RealmTeamLog::class.java, JsonUtils.getString("_id", json))
+                    tag = realm.createObject(RealmTeamLog::class.java, id)
+                    existingLogs[id] = tag
                 }
                 if (tag != null) {
                     tag._rev = JsonUtils.getString("_rev", json)
@@ -1600,11 +1607,18 @@ class TeamsRepositoryImpl @Inject constructor(
                 documentList.add(jsonDoc)
             }
         }
+        val ids = documentList.map { JsonUtils.getString("_id", it) }.toTypedArray()
+        val existingLogs = if (ids.isNotEmpty()) {
+            realm.where(RealmTeamLog::class.java).`in`("_id", ids).findAll().associateBy { it._id }.toMutableMap()
+        } else {
+            mutableMapOf()
+        }
         for (json in documentList) {
-            var tag = realm.where(RealmTeamLog::class.java)
-                .equalTo("_id", JsonUtils.getString("_id", json)).findFirst()
+            val id = JsonUtils.getString("_id", json)
+            var tag = existingLogs[id]
             if (tag == null) {
-                tag = realm.createObject(RealmTeamLog::class.java, JsonUtils.getString("_id", json))
+                tag = realm.createObject(RealmTeamLog::class.java, id)
+                existingLogs[id] = tag
             }
             if (tag != null) {
                 tag._rev = JsonUtils.getString("_rev", json)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
@@ -1,0 +1,119 @@
+package org.ole.planet.myplanet.repository
+
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import io.mockk.*
+import io.realm.Realm
+import io.realm.RealmQuery
+import io.realm.RealmResults
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmTeamLog
+import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.services.UploadManager
+import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.services.sync.ServerUrlMapper
+import org.ole.planet.myplanet.utils.DispatcherProvider
+import kotlin.system.measureTimeMillis
+import org.junit.Assert.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TeamsRepositoryBenchmarkTest {
+    private lateinit var teamsRepository: TeamsRepositoryImpl
+    private val databaseService: DatabaseService = mockk(relaxed = true)
+    private val userSessionManager: UserSessionManager = mockk(relaxed = true)
+    private val activitiesRepository: ActivitiesRepository = mockk(relaxed = true)
+    private val uploadManager: UploadManager = mockk(relaxed = true)
+    private val gson: Gson = mockk(relaxed = true)
+    private val preferences: SharedPreferences = mockk(relaxed = true)
+    private val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
+    private val serverUrlMapper: ServerUrlMapper = mockk(relaxed = true)
+    private val dispatcherProvider: DispatcherProvider = mockk()
+    private val userRepository: UserRepository = mockk(relaxed = true)
+    private val realm: Realm = mockk(relaxed = true)
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        every { dispatcherProvider.main } returns testDispatcher
+        every { dispatcherProvider.io } returns testDispatcher
+        every { dispatcherProvider.default } returns testDispatcher
+        every { dispatcherProvider.unconfined } returns testDispatcher
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val transaction = firstArg<(Realm) -> Unit>()
+            transaction(realm)
+        }
+
+        teamsRepository = TeamsRepositoryImpl(
+            activitiesRepository,
+            databaseService,
+            testDispatcher,
+            userSessionManager,
+            uploadManager,
+            gson,
+            preferences,
+            sharedPrefManager,
+            serverUrlMapper,
+            dispatcherProvider,
+            userRepository
+        )
+    }
+
+    @Test
+    fun benchmarkInsertTeamLogs() = runTest {
+        val logs = (1..100).map { i ->
+            JsonObject().apply {
+                addProperty("_id", "id_$i")
+                addProperty("_rev", "rev_$i")
+            }
+        }
+
+        val query: RealmQuery<RealmTeamLog> = mockk(relaxed = true)
+        val results: RealmResults<RealmTeamLog> = mockk(relaxed = true)
+
+        every { realm.where(RealmTeamLog::class.java) } returns query
+        every { query.`in`(any<String>(), any<Array<String>>()) } returns query
+        every { query.findAll() } returns results
+        every { results.iterator() } returns emptyList<RealmTeamLog>().iterator()
+
+        every { realm.createObject(RealmTeamLog::class.java, any()) } returns RealmTeamLog()
+
+        teamsRepository.insertTeamLogs(logs)
+
+        verify(exactly = 1) { realm.where(RealmTeamLog::class.java) }
+    }
+
+    @Test
+    fun testInsertTeamLogsWithDuplicatesInBatch() = runTest {
+        val logs = listOf(
+            JsonObject().apply { addProperty("_id", "dup_id"); addProperty("_rev", "rev1") },
+            JsonObject().apply { addProperty("_id", "dup_id"); addProperty("_rev", "rev2") }
+        )
+
+        val query: RealmQuery<RealmTeamLog> = mockk(relaxed = true)
+        val results: RealmResults<RealmTeamLog> = mockk(relaxed = true)
+
+        every { realm.where(RealmTeamLog::class.java) } returns query
+        every { query.`in`(any<String>(), any<Array<String>>()) } returns query
+        every { query.findAll() } returns results
+        every { results.iterator() } returns emptyList<RealmTeamLog>().iterator()
+
+        // Mock createObject to return a new object each time, but we expect it to be called only once
+        every { realm.createObject(RealmTeamLog::class.java, "dup_id") } returns RealmTeamLog().apply { _id = "dup_id" }
+
+        teamsRepository.insertTeamLogs(logs)
+
+        // Should only be called once even with 2 logs with same ID in the same batch
+        verify(exactly = 1) { realm.createObject(RealmTeamLog::class.java, "dup_id") }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
@@ -22,7 +22,6 @@ import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import kotlin.system.measureTimeMillis
-import org.junit.Assert.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TeamsRepositoryBenchmarkTest {
@@ -84,7 +83,7 @@ class TeamsRepositoryBenchmarkTest {
         every { realm.where(RealmTeamLog::class.java) } returns query
         every { query.`in`(any<String>(), any<Array<String>>()) } returns query
         every { query.findAll() } returns results
-        every { results.iterator() } returns emptyList<RealmTeamLog>().iterator()
+        every { results.iterator() } returns mutableListOf<RealmTeamLog>().iterator()
 
         every { realm.createObject(RealmTeamLog::class.java, any()) } returns RealmTeamLog()
 
@@ -106,7 +105,7 @@ class TeamsRepositoryBenchmarkTest {
         every { realm.where(RealmTeamLog::class.java) } returns query
         every { query.`in`(any<String>(), any<Array<String>>()) } returns query
         every { query.findAll() } returns results
-        every { results.iterator() } returns emptyList<RealmTeamLog>().iterator()
+        every { results.iterator() } returns mutableListOf<RealmTeamLog>().iterator()
 
         // Mock createObject to return a new object each time, but we expect it to be called only once
         every { realm.createObject(RealmTeamLog::class.java, "dup_id") } returns RealmTeamLog().apply { _id = "dup_id" }


### PR DESCRIPTION
This PR optimizes the `insertTeamLogs` and `bulkInsertTeamActivitiesFromSync` methods in `TeamsRepositoryImpl` to resolve an N+1 query issue.

### 💡 What:
The optimization replaces individual Realm queries for each log entry with a single batch query using `.in()`. The results are stored in a `MutableMap` for fast lookup. If a log entry is not found, it is created and added to the map to handle potential duplicates within the same batch.

### 🎯 Why:
The original implementation queried the database for every entry, leading to $N$ queries for a batch of $N$ logs. This optimization reduces it to a single query, significantly improving performance for sync operations.

### 📊 Measured Improvement:
- **Query Count:** Reduced from $N$ queries to 1 query per batch.
- **Robustness:** Handles duplicate IDs in the same batch by tracking newly created objects in a local map.
- **Verification:** Added `TeamsRepositoryBenchmarkTest` to verify the single-query behavior and duplicate handling. Fixed a compilation error in the test related to `MutableIterator` mocking.

---
*PR created automatically by Jules for task [6169147131505277198](https://jules.google.com/task/6169147131505277198) started by @dogi*