### PR TITLE
life: smoother realm model cached items testing (fixes #13364)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5484
-        versionName = "0.54.84"
+        versionCode = 5487
+        versionName = "0.54.87"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -177,5 +178,50 @@ class SharedPrefManagerTest {
         sharedPrefManager.setRawString("test_key", "new_val")
         verify { mockEditor.putString("test_key", "new_val") }
         verify { mockEditor.apply() }
+    }
+
+    @Test
+    fun testGetCachedMyLifeItems_validJson() {
+        val userId = "123"
+        val expectedItems = listOf(
+            CachedMyLifeItem("img1", "Title 1", true, 1),
+            CachedMyLifeItem("img2", "Title 2", false, 2)
+        )
+        val json = Gson().toJson(expectedItems)
+
+        every { mockSharedPreferences.getString("myLifeCache_$userId", null) } returns json
+
+        val result = sharedPrefManager.getCachedMyLifeItems(userId)
+
+        assertEquals(2, result?.size)
+        assertEquals("img1", result?.get(0)?.imageId)
+        assertEquals("Title 1", result?.get(0)?.title)
+        assertEquals(true, result?.get(0)?.isVisible)
+        assertEquals(1, result?.get(0)?.weight)
+
+        assertEquals("img2", result?.get(1)?.imageId)
+        assertEquals("Title 2", result?.get(1)?.title)
+        assertEquals(false, result?.get(1)?.isVisible)
+        assertEquals(2, result?.get(1)?.weight)
+    }
+
+    @Test
+    fun testGetCachedMyLifeItems_nullJson() {
+        val userId = "456"
+        every { mockSharedPreferences.getString("myLifeCache_$userId", null) } returns null
+
+        val result = sharedPrefManager.getCachedMyLifeItems(userId)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun testGetCachedMyLifeItems_invalidJson() {
+        val userId = "789"
+        every { mockSharedPreferences.getString("myLifeCache_$userId", null) } returns "invalid_json"
+
+        val result = sharedPrefManager.getCachedMyLifeItems(userId)
+
+        assertNull(result)
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap for deserializing cached `RealmMyLife` lists from string JSONs was addressed in `SharedPrefManager`.
📊 **Coverage:** The tests now assert `getCachedMyLifeItems` successfully parses standard JSON to objects, handles null pref scenarios properly, and defensively handles Gson `JsonSyntaxException` runtime errors returning `null` when input caches are malformed.
✨ **Result:** Enhanced test coverage providing guardrails against unintentional data parsing refactoring regressions.

---
*PR created automatically by Jules for task [4992733273615374155](https://jules.google.com/task/4992733273615374155) started by @dogi*