### PR TITLE
🧪 [Test] Add unit tests for ResourceDownloadCoordinator

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/ResourceDownloadCoordinator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/ResourceDownloadCoordinator.kt
@@ -15,6 +15,8 @@ class ResourceDownloadCoordinator @Inject constructor(
     private val configurationsRepository: ConfigurationsRepository,
     @ApplicationContext private val context: Context
 ) {
+
+    // Starts a background download if the server is available
     fun startBackgroundDownload(urls: ArrayList<String>) {
         MainApplication.applicationScope.launch {
             if (configurationsRepository.checkServerAvailability()) {

--- a/app/src/main/java/org/ole/planet/myplanet/services/ResourceDownloadCoordinator.kt.orig
+++ b/app/src/main/java/org/ole/planet/myplanet/services/ResourceDownloadCoordinator.kt.orig
@@ -16,6 +16,7 @@ class ResourceDownloadCoordinator @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
 
+    // Starts a background download if the server is available
     fun startBackgroundDownload(urls: ArrayList<String>) {
         MainApplication.applicationScope.launch {
             if (configurationsRepository.checkServerAvailability()) {

--- a/app/src/test/java/org/ole/planet/myplanet/services/ResourceDownloadCoordinatorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/ResourceDownloadCoordinatorTest.kt
@@ -1,0 +1,87 @@
+package org.ole.planet.myplanet.services
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.TestScope
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.MainApplication
+import org.ole.planet.myplanet.repository.ConfigurationsRepository
+import org.ole.planet.myplanet.utils.DownloadUtils
+import org.robolectric.annotation.Config
+import java.util.ArrayList
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33], manifest = Config.NONE, application = android.app.Application::class)
+class ResourceDownloadCoordinatorTest {
+
+    private lateinit var coordinator: ResourceDownloadCoordinator
+    private lateinit var configurationsRepository: ConfigurationsRepository
+    private lateinit var context: Context
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        context = spyk(ApplicationProvider.getApplicationContext())
+        configurationsRepository = mockk()
+        MainApplication.applicationScope = TestScope(testDispatcher)
+
+        coordinator = ResourceDownloadCoordinator(configurationsRepository, context)
+        mockkObject(DownloadUtils)
+        every { DownloadUtils.openDownloadService(any(), any(), any()) } returns Unit
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `startBackgroundDownload starts service when server available and urls not empty`() = runTest {
+        coEvery { configurationsRepository.checkServerAvailability() } returns true
+        val urls = arrayListOf("url1", "url2")
+
+        coordinator.startBackgroundDownload(urls)
+
+        verify { DownloadUtils.openDownloadService(context, urls, false) }
+    }
+
+    @Test
+    fun `startBackgroundDownload does not start service when server unavailable`() = runTest {
+        coEvery { configurationsRepository.checkServerAvailability() } returns false
+        val urls = arrayListOf("url1", "url2")
+
+        coordinator.startBackgroundDownload(urls)
+
+        verify(exactly = 0) { DownloadUtils.openDownloadService(any(), any(), any()) }
+    }
+
+    @Test
+    fun `startBackgroundDownload does not start service when urls empty`() = runTest {
+        coEvery { configurationsRepository.checkServerAvailability() } returns true
+        val urls = arrayListOf<String>()
+
+        coordinator.startBackgroundDownload(urls)
+
+        verify(exactly = 0) { DownloadUtils.openDownloadService(any(), any(), any()) }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/services/ResourceDownloadCoordinatorTest.kt.orig
+++ b/app/src/test/java/org/ole/planet/myplanet/services/ResourceDownloadCoordinatorTest.kt.orig
@@ -10,7 +10,6 @@ import io.mockk.mockkObject
 import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -52,7 +51,6 @@ class ResourceDownloadCoordinatorTest {
 
     @After
     fun tearDown() {
-        (MainApplication.applicationScope as? TestScope)?.cancel()
         Dispatchers.resetMain()
         unmockkAll()
     }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This pull request adds unit tests for `startBackgroundDownload` in `ResourceDownloadCoordinator`, which previously lacked test coverage. 

📊 **Coverage:** What scenarios are now tested
The unit tests verify the background download initiation logic, including:
- **Happy Path:** When the server is available and URLs are not empty, verify that `DownloadUtils.openDownloadService` is called.
- **Edge Cases:**
  - When the server is unavailable, verify the service is not started.
  - When the URL list is empty, verify the service is not started.

✨ **Result:** The improvement in test coverage
The code logic is now comprehensively covered by tests leveraging MockK for simulating dependencies (`ConfigurationsRepository`, `DownloadUtils`) and `kotlinx-coroutines-test` for testing the suspended launch behavior, ensuring no regressions to future changes.

---
*PR created automatically by Jules for task [6124530464924229193](https://jules.google.com/task/6124530464924229193) started by @dogi*