### PR TITLE
resources: smoother base progress dialog testing (fixes #13346)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5475
+        versionName = "0.54.75"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/base/BaseResourceFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/base/BaseResourceFragmentTest.kt
@@ -24,7 +24,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import androidx.fragment.app.FragmentActivity
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.model.Download

--- a/app/src/test/java/org/ole/planet/myplanet/base/BaseResourceFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/base/BaseResourceFragmentTest.kt
@@ -1,6 +1,11 @@
 package org.ole.planet.myplanet.base
 
 import android.text.TextUtils
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -9,22 +14,53 @@ import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.utils.DialogUtils
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class BaseResourceFragmentTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     private lateinit var fragment: BaseResourceFragment
     private lateinit var mockPrgDialog: DialogUtils.CustomProgressDialog
+    private lateinit var mockLifecycleOwner: LifecycleOwner
+    private lateinit var mockActivity: FragmentActivity
+    private val testDispatcher = StandardTestDispatcher()
 
     @Before
     fun setup() {
+        Dispatchers.setMain(testDispatcher)
         fragment = spyk(object : BaseResourceFragment() {})
         mockPrgDialog = mockk(relaxed = true)
         fragment.prgDialog = mockPrgDialog
+
+        mockLifecycleOwner = mockk(relaxed = true)
+        val lifecycleRegistry = LifecycleRegistry(mockLifecycleOwner)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        every { mockLifecycleOwner.lifecycle } returns lifecycleRegistry
+
+        every { fragment.viewLifecycleOwner } returns mockLifecycleOwner
+
+        mockActivity = mockk(relaxed = true)
+
+        every { fragment.activity } returns mockActivity
+        every { fragment.requireActivity() } returns mockActivity
+        every { fragment.isAdded } returns true
+        every { mockActivity.isFinishing } returns false
+        every { mockActivity.isDestroyed } returns false
+
         mockkStatic(TextUtils::class)
         every { TextUtils.isEmpty(any()) } answers {
             val str = it.invocation.args[0] as? CharSequence
@@ -34,7 +70,40 @@ class BaseResourceFragmentTest {
 
     @After
     fun teardown() {
+        Dispatchers.resetMain()
         unmockkAll()
+    }
+
+    @Test
+    fun `showProgressDialog shows dialog when fragment is active`() = runTest {
+        fragment.showProgressDialog()
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        verify { mockPrgDialog.setIndeterminateMode(true) }
+        verify { mockPrgDialog.show() }
+    }
+
+    @Test
+    fun `showProgressDialog does not show dialog when fragment is not added`() = runTest {
+        every { fragment.isAdded } returns false
+
+        fragment.showProgressDialog()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(exactly = 0) { mockPrgDialog.setIndeterminateMode(any()) }
+        verify(exactly = 0) { mockPrgDialog.show() }
+    }
+
+    @Test
+    fun `showProgressDialog does not show dialog when activity is finishing`() = runTest {
+        every { mockActivity.isFinishing } returns true
+
+        fragment.showProgressDialog()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(exactly = 0) { mockPrgDialog.setIndeterminateMode(any()) }
+        verify(exactly = 0) { mockPrgDialog.show() }
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/base/BaseResourceFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/base/BaseResourceFragmentTest.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.base
 
 import android.text.TextUtils
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -21,12 +22,16 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.utils.DialogUtils
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BaseResourceFragmentTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     private lateinit var fragment: BaseResourceFragment
     private lateinit var mockPrgDialog: DialogUtils.CustomProgressDialog

--- a/app/src/test/java/org/ole/planet/myplanet/base/BaseResourceFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/base/BaseResourceFragmentTest.kt
@@ -1,7 +1,6 @@
 package org.ole.planet.myplanet.base
 
 import android.text.TextUtils
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -16,13 +15,12 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.utils.DialogUtils
@@ -30,14 +28,11 @@ import org.ole.planet.myplanet.utils.DialogUtils
 @OptIn(ExperimentalCoroutinesApi::class)
 class BaseResourceFragmentTest {
 
-    @get:Rule
-    val instantTaskExecutorRule = InstantTaskExecutorRule()
-
     private lateinit var fragment: BaseResourceFragment
     private lateinit var mockPrgDialog: DialogUtils.CustomProgressDialog
     private lateinit var mockLifecycleOwner: LifecycleOwner
     private lateinit var mockActivity: FragmentActivity
-    private val testDispatcher = StandardTestDispatcher()
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     @Before
     fun setup() {
@@ -78,10 +73,8 @@ class BaseResourceFragmentTest {
     fun `showProgressDialog shows dialog when fragment is active`() = runTest {
         fragment.showProgressDialog()
 
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        verify { mockPrgDialog.setIndeterminateMode(true) }
-        verify { mockPrgDialog.show() }
+        verify(exactly = 1) { mockPrgDialog.setIndeterminateMode(true) }
+        verify(exactly = 1) { mockPrgDialog.show() }
     }
 
     @Test
@@ -89,7 +82,6 @@ class BaseResourceFragmentTest {
         every { fragment.isAdded } returns false
 
         fragment.showProgressDialog()
-        testDispatcher.scheduler.advanceUntilIdle()
 
         verify(exactly = 0) { mockPrgDialog.setIndeterminateMode(any()) }
         verify(exactly = 0) { mockPrgDialog.show() }
@@ -100,7 +92,26 @@ class BaseResourceFragmentTest {
         every { mockActivity.isFinishing } returns true
 
         fragment.showProgressDialog()
-        testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(exactly = 0) { mockPrgDialog.setIndeterminateMode(any()) }
+        verify(exactly = 0) { mockPrgDialog.show() }
+    }
+
+    @Test
+    fun `showProgressDialog does not show dialog when activity is destroyed`() = runTest {
+        every { mockActivity.isDestroyed } returns true
+
+        fragment.showProgressDialog()
+
+        verify(exactly = 0) { mockPrgDialog.setIndeterminateMode(any()) }
+        verify(exactly = 0) { mockPrgDialog.show() }
+    }
+
+    @Test
+    fun `showProgressDialog does not show dialog when activity is null`() = runTest {
+        every { fragment.activity } returns null
+
+        fragment.showProgressDialog()
 
         verify(exactly = 0) { mockPrgDialog.setIndeterminateMode(any()) }
         verify(exactly = 0) { mockPrgDialog.show() }


### PR DESCRIPTION
🎯 **What:** The `showProgressDialog` method in `BaseResourceFragment` lacked unit testing coverage, leaving the progress dialog generation process prone to silent failures.
📊 **Coverage:** The test suite now covers fragment lifecycle behavior correctly (asserting the dialog is generated if the fragment is active and asserting dialog initialization is skipped if not active or if finishing).
✨ **Result:** Improved test coverage and reliability around Android Dialog generation within active coroutines.

---
*PR created automatically by Jules for task [17795506794126285041](https://jules.google.com/task/17795506794126285041) started by @dogi*