### PR TITLE
all: smoother retry queue worker testing (fixes #13345)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5474
+        versionName = "0.54.74"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueWorkerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueWorkerTest.kt
@@ -1,0 +1,82 @@
+package org.ole.planet.myplanet.services.retry
+
+import android.content.Context
+import android.util.Log
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
+import androidx.work.WorkManager
+import androidx.work.Operation
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.MainApplication
+
+class RetryQueueWorkerTest {
+
+    @MockK(relaxed = true)
+    lateinit var workManagerImpl: androidx.work.impl.WorkManagerImpl
+
+    @MockK(relaxed = true)
+    lateinit var context: MainApplication
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        mockkStatic(Log::class)
+        every { Log.d(any<String>(), any<String>()) } returns 0
+        every { Log.i(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any<String>(), any<String>(), any<Throwable>()) } returns 0
+
+        every { context.applicationContext } returns context
+
+        // Mock WorkManagerImpl.getInstance since WorkManager$Companion.getInstance calls it
+        mockkStatic(androidx.work.impl.WorkManagerImpl::class)
+        every { androidx.work.impl.WorkManagerImpl.getInstance(any()) } returns workManagerImpl
+
+        mockkStatic(WorkManager::class)
+        every { WorkManager.getInstance(any()) } returns workManagerImpl
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+        unmockkStatic(WorkManager::class)
+        unmockkStatic(androidx.work.impl.WorkManagerImpl::class)
+    }
+
+    @Test
+    fun schedule_enqueuesUniquePeriodicWork() {
+        every { workManagerImpl.enqueueUniquePeriodicWork(any(), any(), any<PeriodicWorkRequest>()) } returns mockk<Operation>(relaxed = true)
+
+        RetryQueueWorker.schedule(context)
+
+        verify(exactly = 1) {
+            workManagerImpl.enqueueUniquePeriodicWork(
+                "retryQueueWork",
+                ExistingPeriodicWorkPolicy.KEEP,
+                any<PeriodicWorkRequest>()
+            )
+        }
+    }
+
+    @Test
+    fun triggerImmediateRetry_enqueuesOneTimeWork() {
+        every { workManagerImpl.enqueue(any<OneTimeWorkRequest>()) } returns mockk<Operation>(relaxed = true)
+
+        RetryQueueWorker.triggerImmediateRetry(context)
+
+        verify(exactly = 1) {
+            workManagerImpl.enqueue(any<OneTimeWorkRequest>())
+        }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueWorkerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueWorkerTest.kt
@@ -3,22 +3,34 @@ package org.ole.planet.myplanet.services.retry
 import android.content.Context
 import android.util.Log
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ListenableWorker.Result
 import androidx.work.OneTimeWorkRequest
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import androidx.work.Operation
+import androidx.work.WorkerParameters
 import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.MainApplication
+import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.model.RealmRetryOperation
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class RetryQueueWorkerTest {
 
     @MockK(relaxed = true)
@@ -27,9 +39,20 @@ class RetryQueueWorkerTest {
     @MockK(relaxed = true)
     lateinit var context: MainApplication
 
+    @MockK
+    lateinit var workerParams: WorkerParameters
+
+    @MockK
+    lateinit var retryQueue: RetryQueue
+
+    @MockK
+    lateinit var apiInterface: ApiInterface
+
+    private lateinit var worker: RetryQueueWorker
+
     @Before
     fun setUp() {
-        MockKAnnotations.init(this)
+        MockKAnnotations.init(this, relaxed = true)
 
         mockkStatic(Log::class)
         every { Log.d(any<String>(), any<String>()) } returns 0
@@ -39,19 +62,20 @@ class RetryQueueWorkerTest {
 
         every { context.applicationContext } returns context
 
-        // Mock WorkManagerImpl.getInstance since WorkManager$Companion.getInstance calls it
         mockkStatic(androidx.work.impl.WorkManagerImpl::class)
         every { androidx.work.impl.WorkManagerImpl.getInstance(any()) } returns workManagerImpl
 
         mockkStatic(WorkManager::class)
         every { WorkManager.getInstance(any()) } returns workManagerImpl
+
+        worker = RetryQueueWorker(context, workerParams, retryQueue, apiInterface)
+
+        mockkObject(MainApplication)
     }
 
     @After
     fun tearDown() {
-        unmockkStatic(Log::class)
-        unmockkStatic(WorkManager::class)
-        unmockkStatic(androidx.work.impl.WorkManagerImpl::class)
+        unmockkAll()
     }
 
     @Test
@@ -78,5 +102,54 @@ class RetryQueueWorkerTest {
         verify(exactly = 1) {
             workManagerImpl.enqueue(any<OneTimeWorkRequest>())
         }
+    }
+
+    @Test
+    fun doWork_returnsSuccessImmediately_whenSyncIsRunning() = runTest {
+        MainApplication.isSyncRunning = true
+
+        val result = worker.doWork()
+
+        assertEquals(Result.success(), result)
+        coVerify(exactly = 0) { retryQueue.isCurrentlyProcessing() }
+    }
+
+    @Test
+    fun doWork_returnsSuccessImmediately_whenQueueIsProcessing() = runTest {
+        MainApplication.isSyncRunning = false
+        coEvery { retryQueue.isCurrentlyProcessing() } returns true
+
+        val result = worker.doWork()
+
+        assertEquals(Result.success(), result)
+        coVerify(exactly = 0) { retryQueue.getPendingOperations() }
+    }
+
+    @Test
+    fun doWork_callsCleanup_afterProcessingNonEmptyQueue() = runTest {
+        MainApplication.isSyncRunning = false
+        coEvery { retryQueue.isCurrentlyProcessing() } returns false
+        coEvery { retryQueue.setProcessing(any()) } returns Unit
+        coEvery { retryQueue.cleanup() } returns Unit
+
+        val operation = RealmRetryOperation().apply { id = "testId" }
+        coEvery { retryQueue.getPendingOperations() } returns listOf(operation)
+
+        val result = worker.doWork()
+
+        assertEquals(Result.success(), result)
+        coVerify(exactly = 1) { retryQueue.cleanup() }
+    }
+
+    @Test
+    fun doWork_returnsRetry_onUnexpectedException() = runTest {
+        MainApplication.isSyncRunning = false
+        val e = Exception("Unexpected error")
+        coEvery { retryQueue.isCurrentlyProcessing() } returns false
+        coEvery { retryQueue.getPendingOperations() } throws e
+
+        val result = worker.doWork()
+
+        assertEquals(Result.retry(), result)
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the static schedule and trigger operations in RetryQueueWorker, resolving the lack of automated checks for work manager interactions.
📊 **Coverage:** Covered `schedule` (verifying enqueueUniquePeriodicWork with ExistingPeriodicWorkPolicy.KEEP) and `triggerImmediateRetry` (verifying enqueueing a OneTimeWorkRequest).
✨ **Result:** Enhanced test suite and validation confidence that `RetryQueueWorker` correctly interfaces with `WorkManager`.

---
*PR created automatically by Jules for task [5524209042563050731](https://jules.google.com/task/5524209042563050731) started by @dogi*