### PR TITLE
sync: smoother download resources progress counting (fixes #13314)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5460
+        versionName = "0.54.60"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -59,8 +59,6 @@ class DownloadService : Service() {
     private lateinit var preferences: SharedPreferences
     private var currentDownloadUrl: String = ""
     private var fromSync = false
-    private var totalDownloadsCount = 0
-    private var completedDownloadsCount = 0
     private var lastNotificationUpdateTime = 0L
     private var currentFileProgress = 0
     private val processedUrls = mutableSetOf<String>()
@@ -115,13 +113,11 @@ class DownloadService : Service() {
 
             processedUrls.add(nextUrl.url)
             sessionTotalCount++
-            totalDownloadsCount = getRemainingCount() + 1
 
             isCurrentDownloadPriority = nextUrl.isPriority
             updateNotificationForBatchDownload()
             initDownload(nextUrl.url, fromSync)
 
-            completedDownloadsCount++
             sessionCompletedCount++
 
             cleanupProcessedUrls()
@@ -160,7 +156,7 @@ class DownloadService : Service() {
         DownloadUtils.createChannels(this)
         notificationBuilder = NotificationCompat.Builder(this, "DownloadChannel")
             .setContentTitle(getString(R.string.downloading_files))
-            .setContentText("Starting downloads (0/$totalDownloadsCount)")
+            .setContentText("Starting downloads (0/${getRemainingCount() + 1})")
             .setSmallIcon(R.drawable.ic_download)
             .setProgress(100, 0, true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
@@ -365,8 +361,8 @@ class DownloadService : Service() {
     private fun showCompletionNotification(hadErrors: Boolean) {
         val notification = DownloadUtils.buildCompletionNotification(
             this,
-            completedDownloadsCount,
-            totalDownloadsCount,
+            sessionCompletedCount,
+            sessionTotalCount,
             hadErrors,
             forWorker = false
         )


### PR DESCRIPTION
fixes #13314
Remove global totalDownloadsCount and completedDownloadsCount from DownloadService and rely on sessionTotalCount/sessionCompletedCount instead. Update notification startup text to compute remaining count dynamically and pass session counters to the completion notification. This centralizes per-session progress tracking and avoids stale global counters across service runs.
[Screen_recording_20260504_170009.webm](https://github.com/user-attachments/assets/88cfe00b-4727-4e2b-953e-a18ce27b04d4)
<img width="1410" height="2968" alt="Screenshot_20260504_171243" src="https://github.com/user-attachments/assets/551f0783-4a6a-4243-ab53-facb873745f7" />