### PR TITLE
sync: smoother download service next priority url testing (fixes #13342)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5454
-        versionName = "0.54.54"
+        versionCode = 5471
+        versionName = "0.54.71"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -128,7 +128,7 @@ class DownloadService : Service() {
         }
     }
 
-    internal data class QueuedUrl(val url: String, val isPriority: Boolean)
+    internal data class QueuedUrl(val url: String, val isPriority: Boolean, val priority: Int = 0)
 
     internal fun getNextPriorityUrl(): QueuedUrl? {
         return Companion.getNextUrl(preferences, PRIORITY_DOWNLOADS_KEY, processedUrls, true)
@@ -395,6 +395,11 @@ class DownloadService : Service() {
         const val PENDING_DOWNLOADS_KEY = "pending_downloads_queue"
         const val PRIORITY_DOWNLOADS_KEY = "priority_downloads_queue"
 
+        internal fun getNextPriorityUrl(downloadQueue: List<QueuedUrl>): QueuedUrl? {
+            if (downloadQueue.isEmpty()) return null
+            return downloadQueue.maxByOrNull { it.priority } ?: downloadQueue.first()
+        }
+
         @androidx.annotation.VisibleForTesting
         internal fun getNextUrl(
             preferences: SharedPreferences,
@@ -403,8 +408,10 @@ class DownloadService : Service() {
             isPriority: Boolean
         ): QueuedUrl? {
             val urls = preferences.getStringSet(key, emptySet()) ?: emptySet()
-            val next = urls.sorted().firstOrNull { it !in processedUrls && it.isNotBlank() }
-            return next?.let { QueuedUrl(it, isPriority) }
+            val queue = urls.sorted()
+                .filter { it !in processedUrls && it.isNotBlank() }
+                .map { QueuedUrl(it, isPriority) }
+            return getNextPriorityUrl(queue)
         }
 
         fun startService(context: Context, urlsKey: String, fromSync: Boolean) {

--- a/app/src/test/java/org/ole/planet/myplanet/services/DownloadServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/DownloadServiceTest.kt
@@ -84,4 +84,47 @@ class DownloadServiceTest {
         assertEquals("http://example.com/file1", result?.url)
         assertEquals(false, result?.isPriority)
     }
+
+    // --- Tests for getNextPriorityUrl ---
+
+    @Test
+    fun `test getNextPriorityUrl returns null when queue is empty`() {
+        val result = DownloadService.getNextPriorityUrl(emptyList())
+        assertNull(result)
+    }
+
+    @Test
+    fun `test getNextPriorityUrl returns single item`() {
+        val queue = listOf(DownloadService.QueuedUrl("url1", true, 5))
+        val result = DownloadService.getNextPriorityUrl(queue)
+        assertNotNull(result)
+        assertEquals("url1", result?.url)
+        assertEquals(5, result?.priority)
+    }
+
+    @Test
+    fun `test getNextPriorityUrl returns item with highest priority`() {
+        val queue = listOf(
+            DownloadService.QueuedUrl("url1", true, 5),
+            DownloadService.QueuedUrl("url2", true, 10),
+            DownloadService.QueuedUrl("url3", true, 3)
+        )
+        val result = DownloadService.getNextPriorityUrl(queue)
+        assertNotNull(result)
+        assertEquals("url2", result?.url)
+        assertEquals(10, result?.priority)
+    }
+
+    @Test
+    fun `test getNextPriorityUrl returns first item if multiple have same max priority`() {
+        val queue = listOf(
+            DownloadService.QueuedUrl("url1", true, 10),
+            DownloadService.QueuedUrl("url2", true, 10),
+            DownloadService.QueuedUrl("url3", true, 5)
+        )
+        val result = DownloadService.getNextPriorityUrl(queue)
+        assertNotNull(result)
+        assertEquals("url1", result?.url)
+        assertEquals(10, result?.priority)
+    }
 }


### PR DESCRIPTION
The `getNextPriorityUrl` logic in `DownloadService` was previously integrated with `SharedPreferences` and class state, making it difficult to unit test. This change refactors the core selection algorithm into a pure function within the `Companion` object, allowing for direct verification of the priority selection logic without complex mocking.

Key changes:
- **Model Update:** Added a `priority` field to `QueuedUrl` (default 0) to support priority-based sorting.
- **Logic Extraction:** Moved the selection algorithm to `DownloadService.Companion.getNextPriorityUrl(List<QueuedUrl>)`.
- **Improved Testing:** Added a suite of unit tests in `DownloadServiceTest.kt` covering edge cases like empty queues, single items, and various priority scenarios.
- **Backward Compatibility:** Maintained existing behavior in `getNextUrl` while routing it through the new centralized selection function.

---
*PR created automatically by Jules for task [6496565119324418042](https://jules.google.com/task/6496565119324418042) started by @dogi*