### PR TITLE
Fix compilation error in BaseResourceFragmentTest

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/base/BaseResourceFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/base/BaseResourceFragmentTest.kt
@@ -24,7 +24,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import androidx.fragment.app.FragmentActivity
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.model.Download


### PR DESCRIPTION
Removed duplicate import of `androidx.fragment.app.FragmentActivity` in `BaseResourceFragmentTest.kt` to resolve compilation error during unit tests.

---
*PR created automatically by Jules for task [7788561774464773061](https://jules.google.com/task/7788561774464773061) started by @dogi*