### PR TITLE
Refactor ResourcesAdapter diff util and O(1) selection state

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -21,26 +21,23 @@ import org.ole.planet.myplanet.callback.OnLibraryItemSelectedListener
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.databinding.RowLibraryBinding
 import org.ole.planet.myplanet.model.ResourceListModel
+import org.ole.planet.myplanet.model.ResourceItem
 import org.ole.planet.myplanet.model.TagItem
 import org.ole.planet.myplanet.utils.CourseRatingUtils
+import org.ole.planet.myplanet.utils.DiffUtils
 
 class ResourcesAdapter(
     private val context: Context,
     private val isGuest: Boolean,
     private var openedResourceIds: Set<String>
 ) : ListAdapter<ResourceListModel, RecyclerView.ViewHolder>(
-    object : DiffUtil.ItemCallback<ResourceListModel>() {
-        override fun areItemsTheSame(oldItem: ResourceListModel, newItem: ResourceListModel): Boolean {
-            return oldItem.item.id == newItem.item.id
-        }
-
-        override fun areContentsTheSame(oldItem: ResourceListModel, newItem: ResourceListModel): Boolean {
-            return oldItem == newItem
-        }
-    }
+    DiffUtils.itemCallback(
+        areItemsTheSame = { oldItem, newItem -> oldItem.item.id == newItem.item.id },
+        areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
+    )
 ) {
 
-    private val selectedItems: MutableList<ResourceListModel> = ArrayList()
+    private val selectedItems: MutableMap<String, ResourceItem> = HashMap()
     private var listener: OnLibraryItemSelectedListener? = null
     private var homeItemClickListener: OnHomeItemClickListener? = null
     private var ratingChangeListener: OnRatingChangeListener? = null
@@ -84,7 +81,7 @@ class ResourcesAdapter(
             holder.rowLibraryBinding.title.text = library.title
             holder.rowLibraryBinding.description.text = library.description
             holder.rowLibraryBinding.timesRated.text = context.getString(R.string.rating_count_format, library.timesRated)
-            holder.rowLibraryBinding.checkbox.isChecked = selectedItems.contains(model)
+            holder.rowLibraryBinding.checkbox.isChecked = selectedItems.containsKey(library.id)
             holder.rowLibraryBinding.rating.text = if (TextUtils.isEmpty(library.averageRating)) "0.0" else String.format(Locale.getDefault(), "%.1f", library.averageRating?.toDoubleOrNull() ?: 0.0)
             holder.rowLibraryBinding.tvDate.text = org.ole.planet.myplanet.utils.TimeUtils.formatDate(library.createdDate)
 
@@ -112,13 +109,15 @@ class ResourcesAdapter(
                         context.getString(R.string.select_res_course, library.title ?: "")
                     val isChecked = (view as CheckBox).isChecked
                     if (isChecked) {
-                        if (!selectedItems.contains(model)) {
-                            selectedItems.add(model)
+                        library.id?.let { id ->
+                            selectedItems[id] = library
                         }
                     } else {
-                        selectedItems.remove(model)
+                        library.id?.let { id ->
+                            selectedItems.remove(id)
+                        }
                     }
-                    if (listener != null) listener?.onSelectedListChange(selectedItems.map { it.item })
+                    if (listener != null) listener?.onSelectedListChange(selectedItems.values.toList())
                 }
             } else {
                 holder.rowLibraryBinding.checkbox.visibility = View.GONE
@@ -133,7 +132,11 @@ class ResourcesAdapter(
     fun selectAllItems(selectAll: Boolean) {
         if (selectAll) {
             selectedItems.clear()
-            selectedItems.addAll(currentList)
+            currentList.forEach { model ->
+                model.item.id?.let { id ->
+                    selectedItems[id] = model.item
+                }
+            }
         } else {
             selectedItems.clear()
         }
@@ -141,7 +144,7 @@ class ResourcesAdapter(
         notifyItemRangeChanged(0, currentList.size, SELECTION_PAYLOAD)
 
         if (listener != null) {
-            listener?.onSelectedListChange(selectedItems.map { it.item })
+            listener?.onSelectedListChange(selectedItems.values.toList())
         }
     }
 
@@ -163,7 +166,7 @@ class ResourcesAdapter(
                 handled = true
             }
             if (payloads.contains(SELECTION_PAYLOAD)) {
-                holder.rowLibraryBinding.checkbox.isChecked = selectedItems.contains(model)
+                holder.rowLibraryBinding.checkbox.isChecked = selectedItems.containsKey(library.id)
                 handled = true
             }
             if (payloads.contains(OPENED_RESOURCE_PAYLOAD)) {


### PR DESCRIPTION
This commit addresses the issue to "Adopt shared diff utilities and O(1) selection tracking in ResourcesAdapter":

1.  **Replaced the inline adapter diff callback with `DiffUtils.itemCallback`.**
2.  **Stored selection state by stable resource identifier** rather than scanning a mutable list on every bind (`MutableMap<String, ResourceItem>`).
3.  **Kept the existing payload-based partial refresh behavior** for `SELECTION_PAYLOAD`, `RATING_PAYLOAD`, `OPENED_RESOURCE_PAYLOAD`, and `TAGS_PAYLOAD`.

Verified these changes compile and pass `DiffUtilsTest.kt`. Code review was successfully requested, and learnings have been recorded in memory.

---
*PR created automatically by Jules for task [5479811352457008240](https://jules.google.com/task/5479811352457008240) started by @dogi*