### PR TITLE
docs: Make UserRepository dual-binding intent explicit in DI

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -135,6 +135,8 @@ abstract class RepositoryModule {
     @Singleton
     abstract fun bindTeamsRepository(impl: TeamsRepositoryImpl): TeamsRepository
 
+    // Dual-binding: UserRepositoryImpl serves both general user data operations (UserRepository)
+    // and sync-specific operations (UserSyncRepository) using a single instance.
     @Binds
     @Singleton
     abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository

--- a/app/src/test/java/org/ole/planet/myplanet/di/RepositoryModuleTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/di/RepositoryModuleTest.kt
@@ -1,0 +1,20 @@
+package org.ole.planet.myplanet.di
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.ole.planet.myplanet.repository.UserRepositoryImpl
+
+class RepositoryModuleTest {
+
+    @Test
+    fun `verify UserRepository dual-binding intent`() {
+        val moduleClass = RepositoryModule::class.java
+
+        val bindUserRepoMethod = moduleClass.getDeclaredMethod("bindUserRepository", UserRepositoryImpl::class.java)
+        val bindUserSyncRepoMethod = moduleClass.getDeclaredMethod("bindUserSyncRepository", UserRepositoryImpl::class.java)
+
+        // Assert both bindings target the same concrete implementation class
+        assertEquals(UserRepositoryImpl::class.java, bindUserRepoMethod.parameterTypes[0])
+        assertEquals(UserRepositoryImpl::class.java, bindUserSyncRepoMethod.parameterTypes[0])
+    }
+}


### PR DESCRIPTION
Resolves PR-10 by making the DI intent for the `UserRepository` and `UserSyncRepository` interfaces explicit. 

Both interfaces bind to the same implementation, `UserRepositoryImpl`. A comment was added to the module, and a lightweight test was added to verify the module's structure via reflection.

---
*PR created automatically by Jules for task [9669253547165821181](https://jules.google.com/task/9669253547165821181) started by @dogi*