### PR TITLE
Refactor course membership mutations to use RealmRepository transaction helper

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -167,44 +167,42 @@ class CoursesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markCoursesAdded(courseIds: List<String>, userId: String?): Result<Boolean> {
-        return withContext(databaseService.ioDispatcher) {
-            runCatching {
-                if (courseIds.isEmpty()) {
-                    return@runCatching false
-                }
+        return runCatching {
+            if (courseIds.isEmpty()) {
+                return@runCatching false
+            }
 
-                var courseFound = false
-                executeTransaction { realm ->
-                    val validCourseIds = courseIds.filter { it.isNotBlank() }
-                    if (validCourseIds.isEmpty()) return@executeTransaction
+            var courseFound = false
+            executeTransaction { realm ->
+                val validCourseIds = courseIds.filter { it.isNotBlank() }
+                if (validCourseIds.isEmpty()) return@executeTransaction
 
-                    val chunkSize = 1000
-                    validCourseIds.chunked(chunkSize).forEach { chunk ->
-                        val courses = realm.where(RealmMyCourse::class.java)
-                            .`in`("courseId", chunk.toTypedArray())
-                            .findAll()
+                val chunkSize = 1000
+                validCourseIds.chunked(chunkSize).forEach { chunk ->
+                    val courses = realm.where(RealmMyCourse::class.java)
+                        .`in`("courseId", chunk.toTypedArray())
+                        .findAll()
 
-                        if (courses.isNotEmpty()) {
-                            courses.forEach { course ->
-                                course.setUserId(userId)
-                            }
-
-                            val foundCourseIds = courses.mapNotNull { it.courseId }.toTypedArray()
-                            if (!userId.isNullOrBlank() && foundCourseIds.isNotEmpty()) {
-                                realm.where(RealmRemovedLog::class.java)
-                                    .equalTo("type", "courses")
-                                    .equalTo("userId", userId)
-                                    .`in`("docId", foundCourseIds)
-                                    .findAll()
-                                    .deleteAllFromRealm()
-                            }
-                            courseFound = true
+                    if (courses.isNotEmpty()) {
+                        courses.forEach { course ->
+                            course.setUserId(userId)
                         }
+
+                        val foundCourseIds = courses.mapNotNull { it.courseId }.toTypedArray()
+                        if (!userId.isNullOrBlank() && foundCourseIds.isNotEmpty()) {
+                            realm.where(RealmRemovedLog::class.java)
+                                .equalTo("type", "courses")
+                                .equalTo("userId", userId)
+                                .`in`("docId", foundCourseIds)
+                                .findAll()
+                                .deleteAllFromRealm()
+                        }
+                        courseFound = true
                     }
                 }
-
-                courseFound
             }
+
+            courseFound
         }
     }
 
@@ -342,45 +340,41 @@ class CoursesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun joinCourse(courseId: String, userId: String): Result<Unit> {
-        return withContext(databaseService.ioDispatcher) {
-            runCatching {
-                if (courseId.isBlank() || userId.isBlank()) return@runCatching
+        return runCatching {
+            if (courseId.isBlank() || userId.isBlank()) return@runCatching
 
-                executeTransaction { realm ->
-                    val course = realm.where(RealmMyCourse::class.java)
-                        .equalTo("courseId", courseId)
+            executeTransaction { realm ->
+                val course = realm.where(RealmMyCourse::class.java)
+                    .equalTo("courseId", courseId)
+                    .findFirst()
+
+                course?.let {
+                    if (it.userId?.contains(userId) == false) {
+                        it.setUserId(userId)
+                    }
+
+                    val removedLog = realm.where(RealmRemovedLog::class.java)
+                        .equalTo("type", "courses")
+                        .equalTo("userId", userId)
+                        .equalTo("docId", courseId)
                         .findFirst()
 
-                    course?.let {
-                        if (it.userId?.contains(userId) == false) {
-                            it.setUserId(userId)
-                        }
-
-                        val removedLog = realm.where(RealmRemovedLog::class.java)
-                            .equalTo("type", "courses")
-                            .equalTo("userId", userId)
-                            .equalTo("docId", courseId)
-                            .findFirst()
-
-                        removedLog?.deleteFromRealm()
-                    }
+                    removedLog?.deleteFromRealm()
                 }
             }
         }
     }
 
     override suspend fun leaveCourse(courseId: String, userId: String): Result<Unit> {
-        return withContext(databaseService.ioDispatcher) {
-            runCatching {
-                executeTransaction { realm ->
-                    val course = realm.where(RealmMyCourse::class.java)
-                        .equalTo("courseId", courseId)
-                        .findFirst()
-                    course?.removeUserId(userId)
-                    RealmRemovedLog.onRemove(realm, "courses", userId, courseId)
-                }
-                RealtimeSyncManager.getInstance().notifyTableUpdated(TableDataUpdate("courses", 0, 1))
+        return runCatching {
+            executeTransaction { realm ->
+                val course = realm.where(RealmMyCourse::class.java)
+                    .equalTo("courseId", courseId)
+                    .findFirst()
+                course?.removeUserId(userId)
+                RealmRemovedLog.onRemove(realm, "courses", userId, courseId)
             }
+            RealtimeSyncManager.getInstance().notifyTableUpdated(TableDataUpdate("courses", 0, 1))
         }
     }
 

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Testing with context dispatcher"

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "Testing with context dispatcher"


### PR DESCRIPTION
Refactored course membership mutation methods (`markCoursesAdded`, `joinCourse`, `leaveCourse`) to remove redundant coroutine dispatcher wrapping. Delegated the transaction lifecycle execution entirely to the shared `executeTransaction` helper in `RealmRepository`, correctly fulfilling the requirement while preserving all internal logic intact. Also removed the test_script.sh file.

---
*PR created automatically by Jules for task [10257428006885304230](https://jules.google.com/task/10257428006885304230) started by @dogi*