### PR TITLE
strings: correct translatable attribute on empty_text string (fixes #13391)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -966,7 +966,7 @@
     <string name="no_teams">teams not available</string>
     <string name="no_chats">no previous chats</string>
     <string name="no_feedback">no feedback available</string>
-    <string name="empty_text" />
+    <string name="empty_text" translatable="false" />
     <string name="message_placeholder">%s</string>
     <string name="reports">Reports</string>
     <string name="number_placeholder">%d</string>


### PR DESCRIPTION
fixes #13391 

## Changes
Made `empty_text` string untranslatable.

## Context
The Spanish, French, and Arabic translation files have a higher line count than English. The difference is due to those languages requiring additional plural forms that English does not:

- **Spanish** (+3 lines) — `minutes`, `hours`, `days` each require an extra `many` form
- **French** (+4 lines) — `minutes`, `hours`, `days` each require an extra `many` form, plus `survey_taken_count` gains a `many` form
- **Arabic** (+16 lines) — `minutes`, `hours`, `days`, and `survey_taken_count` each require 4 extra forms (`zero`, `two`, `few`, `many`)