### PR TITLE
dashboard: smoother status bar handling (fixes #13429)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5496
-        versionName = "0.54.96"
+        versionCode = 5501
+        versionName = "0.55.1"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -790,12 +790,9 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
             val paddingVerticalDp = (paddingVerticalPx / density).toInt()
             val paddingHorizontalDp = (paddingHorizontalPx / density).toInt()
-            val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
-            val statusBarHeight = if (resourceId > 0) {
-                resources.getDimensionPixelSize(resourceId)
-            } else {
-                ceil(25 * density).toInt()
-            }
+            val statusBarHeight = ViewCompat.getRootWindowInsets(binding.root)
+                ?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
+                ?: ceil(25 * density).toInt()
 
             val header = AccountHeaderBuilder()
                 .withActivity(this@DashboardActivity)
@@ -823,12 +820,9 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
 
     private fun createDrawer() {
-        val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
-        val statusBarHeight = if (resourceId > 0) {
-            resources.getDimensionPixelSize(resourceId)
-        } else {
-            ceil(25 * resources.displayMetrics.density).toInt()
-        }
+        val statusBarHeight = ViewCompat.getRootWindowInsets(binding.root)
+            ?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
+            ?: ceil(25 * resources.displayMetrics.density).toInt()
 
         val headerHeight = 160 + (statusBarHeight / resources.displayMetrics.density).toInt()
         val dimenHolder = DimenHolder.fromDp(headerHeight)

--- a/app/src/main/java/org/ole/planet/myplanet/utils/EdgeToEdgeUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/EdgeToEdgeUtils.kt
@@ -58,7 +58,7 @@ object EdgeToEdgeUtils {
                 systemBarsInsets.left,
                 systemBarsInsets.top,
                 systemBarsInsets.right,
-                systemBarsInsets.bottom
+                maxOf(systemBarsInsets.bottom, imeInsets.bottom)
             )
             WindowInsetsCompat.CONSUMED
         }

--- a/app/src/main/res/layout/activity_web_view.xml
+++ b/app/src/main/res/layout/activity_web_view.xml
@@ -5,7 +5,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:context=".ui.viewer.WebViewActivity">
 
     <include

--- a/app/src/main/res/layout/fragment_chat_detail.xml
+++ b/app/src/main/res/layout/fragment_chat_detail.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/secondary_bg"
-    android:fitsSystemWindows="true"
     tools:context=".ui.chat.ChatDetailFragment">
 
     <View


### PR DESCRIPTION
fixes #13429
```
- EdgeToEdgeUtils.kt — setupEdgeToEdgeWithKeyboard now uses maxOf(systemBarsInsets.bottom, imeInsets.bottom) so the keyboard actually pushes content up.                           
- activity_web_view.xml — removed fitsSystemWindows="true" that was conflicting with WebViewActivity's programmatic inset handling.                                                
- fragment_chat_detail.xml — removed fitsSystemWindows="true" that was redundant and potentially double-insetting.                                                                 
- DashboardActivity.kt — both drawer header height calculations now use ViewCompat.getRootWindowInsets() to read the live inset value instead of the unreliable resources.getIdentifier("status_bar_height") dimension. 
```