### PR TITLE
Improve download handling (fixes #13464)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.base
 
 import android.content.BroadcastReceiver
+import android.util.Log
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
@@ -88,10 +89,14 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     internal fun showProgressDialog() {
+        Log.d("DL_TIMER", "showProgressDialog called pendingUrls=${pendingDownloadUrls.size} t=${System.currentTimeMillis()}")
         viewLifecycleOwner.lifecycleScope.launch {
-            if (isFragmentActive()) {
+            val active = isFragmentActive()
+            Log.d("DL_TIMER", "showProgressDialog isFragmentActive=$active t=${System.currentTimeMillis()}")
+            if (active) {
                 prgDialog.setIndeterminateMode(true)
                 prgDialog.show()
+                Log.d("DL_TIMER", "showProgressDialog prgDialog.show() called t=${System.currentTimeMillis()}")
             }
         }
     }
@@ -117,10 +122,16 @@ abstract class BaseResourceFragment : Fragment() {
         }
     }
     private val pendingDownloadUrls = mutableSetOf<String>()
+    private val pendingLibraryResourceIds = mutableListOf<String>()
 
     protected fun trackDownloadUrls(urls: Collection<String>) {
         pendingDownloadUrls.clear()
         pendingDownloadUrls.addAll(urls)
+        if (pendingDownloadUrls.isEmpty()) {
+            Log.w("DL_TIMER", "trackDownloadUrls: pendingDownloadUrls is EMPTY — dialog will never auto-dismiss t=${System.currentTimeMillis()}")
+        } else {
+            Log.d("DL_TIMER", "trackDownloadUrls: tracking ${pendingDownloadUrls.size} url(s) t=${System.currentTimeMillis()}")
+        }
     }
 
     private val broadcastReceiver: BroadcastReceiver = object : BroadcastReceiver() {
@@ -136,6 +147,7 @@ abstract class BaseResourceFragment : Fragment() {
                     if (pendingDownloadUrls.isNotEmpty()) {
                         val fileUrl = download.fileUrl
                         if (!fileUrl.isNullOrEmpty() && fileUrl in pendingDownloadUrls) {
+                            Log.d("DL_TIMER", "broadcastReceiver: progress=${download.progress} completeAll will=${pendingDownloadUrls.size - (if (download.progress == 100) 1 else 0) == 0} file=${fileUrl.substringAfterLast('/')} t=${System.currentTimeMillis()}")
                             if (download.progress == 100) {
                                 pendingDownloadUrls.remove(fileUrl)
                             }
@@ -143,7 +155,9 @@ abstract class BaseResourceFragment : Fragment() {
                         }
                     }
                 } else {
+                    Log.d("DL_TIMER", "broadcastReceiver: download failed msg=${download?.message}, dismissing dialog t=${System.currentTimeMillis()}")
                     pendingDownloadUrls.clear()
+                    pendingLibraryResourceIds.clear()
                     prgDialog.dismiss()
                     download?.message?.let { showError(prgDialog, it) }
                 }
@@ -156,6 +170,7 @@ abstract class BaseResourceFragment : Fragment() {
         if (dbMyLibrary.isEmpty()) {
             return
         }
+        Log.d("DL_TIMER", "showDownloadDialog count=${dbMyLibrary.size} t=${System.currentTimeMillis()}")
 
         activity?.let { fragmentActivity ->
             val inflater = fragmentActivity.layoutInflater
@@ -168,28 +183,35 @@ abstract class BaseResourceFragment : Fragment() {
                 setPadding(48, 40, 48, 0)
                 textSize = 18f
                 maxLines = 5
-                setSingleLine(false)
+                isSingleLine = false
                 setTextColor(androidx.core.content.ContextCompat.getColor(requireContext(), R.color.daynight_textColor))
             }
             alertDialogBuilder.setView(convertView)
                 .setCustomTitle(titleView)
-
-
                 .setPositiveButton(R.string.download_selected) { _: DialogInterface?, _: Int ->
+                    val t0 = System.currentTimeMillis()
+                    Log.d("DL_TIMER", "positiveButton clicked t=$t0")
                     lifecycleScope.launch {
+                        Log.d("DL_TIMER", "serverCheck start dt=${System.currentTimeMillis()-t0}ms")
                         val serverAvailable = serverCheckDeferred?.await()
                             ?: configurationsRepository.checkServerAvailability()
-                        if (serverAvailable) {
+                        val serviceRunning = DownloadService.isRunning
+                        val canProceed = serverAvailable || serviceRunning
+                        Log.d("DL_TIMER", "serverCheck done available=$serverAvailable serviceRunning=$serviceRunning canProceed=$canProceed dt=${System.currentTimeMillis()-t0}ms")
+                        if (canProceed) {
                             val selectedItemsList = (lv?.adapter as? CheckboxAdapter)?.selectedItemsList
                             selectedItemsList?.let {
-                                addToLibrary(dbMyLibrary, ArrayList(it))
                                 val selectedLibraries = it.mapNotNull { index ->
-                                    dbMyLibrary.getOrNull(
-                                        index
-                                    ) }
+                                    dbMyLibrary.getOrNull(index)
+                                }
+                                pendingLibraryResourceIds.clear()
+                                pendingLibraryResourceIds.addAll(selectedLibraries.mapNotNull { lib -> lib.resourceId })
                                 if (resourcesRepository.downloadResources(selectedLibraries)) {
-                                    trackDownloadUrls(selectedLibraries.mapNotNull { lib -> lib?.resourceRemoteAddress })
-                                    showProgressDialog()
+                                    Log.d("DL_TIMER", "downloadResources returned true count=${selectedLibraries.size} dt=${System.currentTimeMillis()-t0}ms")
+                                    trackDownloadUrls(selectedLibraries.mapNotNull { lib -> lib.resourceRemoteAddress })
+                                    if (pendingDownloadUrls.isNotEmpty()) {
+                                        showProgressDialog()
+                                    }
                                 }
                             }
                         } else {
@@ -198,12 +220,16 @@ abstract class BaseResourceFragment : Fragment() {
                     }
                 }.setNeutralButton(R.string.download_all) { _: DialogInterface?, _: Int ->
                     lifecycleScope.launch {
-                        if (serverCheckDeferred?.await() ?: configurationsRepository.checkServerAvailability()) {
-                            addAllToLibrary(dbMyLibrary)
+                        val available = serverCheckDeferred?.await() ?: configurationsRepository.checkServerAvailability()
+                        if (available || DownloadService.isRunning) {
                             val filtered = dbMyLibrary.filterNotNull()
+                            pendingLibraryResourceIds.clear()
+                            pendingLibraryResourceIds.addAll(filtered.mapNotNull { it.resourceId })
                             if (resourcesRepository.downloadResources(filtered)) {
-                                trackDownloadUrls(filtered.mapNotNull { lib -> lib?.resourceRemoteAddress })
-                                showProgressDialog()
+                                trackDownloadUrls(filtered.mapNotNull { lib -> lib.resourceRemoteAddress })
+                                if (pendingDownloadUrls.isNotEmpty()) {
+                                    showProgressDialog()
+                                }
                             }
                         } else {
                             showNotConnectedToast()
@@ -220,8 +246,7 @@ abstract class BaseResourceFragment : Fragment() {
                     serverCheckDeferred = null
                 }
                 dialog.show()
-                dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = ((lv?.adapter as? CheckboxAdapter)?.selectedItemsList?.size
-                    ?: 0) > 0
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = ((lv?.adapter as? CheckboxAdapter)?.selectedItemsList?.size ?: 0) > 0
             }
         }
     }
@@ -269,6 +294,7 @@ abstract class BaseResourceFragment : Fragment() {
     private fun showResourceNotFoundDialog() {
         if (isAdded) {
             if (prgDialog.isShowing()) {
+                Log.d("DL_TIMER", "showResourceNotFoundDialog: dismissing prgDialog t=${System.currentTimeMillis()}")
                 prgDialog.dismiss()
             }
 
@@ -292,6 +318,7 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     fun setProgress(download: Download) {
+        Log.d("DL_TIMER", "fragment setProgress progress=${download.progress} completeAll=${download.completeAll} file=${download.fileName} t=${System.currentTimeMillis()}")
         prgDialog.setProgress(download.progress)
         if (!TextUtils.isEmpty(download.fileName)) {
             prgDialog.setTitle(download.fileName)
@@ -302,7 +329,19 @@ abstract class BaseResourceFragment : Fragment() {
     }
 
     open fun onDownloadComplete() {
+        Log.d("DL_TIMER", "fragment onDownloadComplete t=${System.currentTimeMillis()}")
         prgDialog.dismiss()
+
+        val resourceIds = pendingLibraryResourceIds.toList()
+        pendingLibraryResourceIds.clear()
+        if (resourceIds.isNotEmpty()) {
+            lifecycleScope.launch {
+                val userId = profileDbHandler.getUserModel()?.id ?: return@launch
+                resourcesRepository.addResourcesToUserLibrary(resourceIds, userId)
+                    .onSuccess { Utilities.toast(activity, getString(R.string.added_to_my_library)) }
+                    .onFailure { Utilities.toast(activity, getString(R.string.error, it.message)) }
+            }
+        }
 
         if (sharedPrefManager.isAlternativeUrl()) {
             sharedPrefManager.setAlternativeUrl("")
@@ -382,36 +421,6 @@ abstract class BaseResourceFragment : Fragment() {
         tvSelected?.text = selected
     }
 
-    fun addToLibrary(libraryItems: List<RealmMyLibrary?>, selectedItems: ArrayList<Int>) {
-        lifecycleScope.launch {
-            val userId = profileDbHandler.getUserModel()?.id ?: return@launch
-            val resourceIds = selectedItems.mapNotNull { index ->
-                libraryItems.getOrNull(index)?.resourceId
-            }
-            resourcesRepository.addResourcesToUserLibrary(resourceIds, userId)
-                .onSuccess {
-                    Utilities.toast(activity, getString(R.string.added_to_my_library))
-                }
-                .onFailure {
-                    Utilities.toast(activity, getString(R.string.error, it.message))
-                }
-        }
-    }
-
-    fun addAllToLibrary(libraryItems: List<RealmMyLibrary?>) {
-        lifecycleScope.launch {
-            val user = profileDbHandler.getUserModel()
-            val userId = user?.id ?: return@launch
-            val validLibraryItems = libraryItems.filterNotNull()
-            resourcesRepository.addAllResourcesToUserLibrary(validLibraryItems, userId)
-                .onSuccess {
-                    Utilities.toast(activity, getString(R.string.added_to_my_library))
-                }
-                .onFailure {
-                    Utilities.toast(activity, getString(R.string.error, it.message))
-                }
-        }
-    }
 
     override fun onDestroyView() {
         downloadSuggestionDialog?.dismiss()

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLibrary.kt
@@ -176,7 +176,8 @@ open class RealmMyLibrary : RealmObject() {
     }
 
     fun needToUpdate(): Boolean {
-        return !resourceOffline || resourceLocalAddress != null && _rev != downloadedRev
+        if (resourceLocalAddress == null) return false
+        return !resourceOffline || _rev != downloadedRev
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -29,6 +29,7 @@ import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.TeamsRepository
+import android.util.Log
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.UrlUtils
@@ -383,9 +384,17 @@ class ResourcesRepositoryImpl @Inject constructor(
 
     override suspend fun downloadResources(resources: List<RealmMyLibrary>): Boolean {
         return try {
-            val urls = resources.filter { !it.isResourceOffline() }.mapNotNull { it.resourceRemoteAddress }
+            Log.d("DL_TIMER", "downloadResources entry count=${resources.size} t=${System.currentTimeMillis()}")
+            resources.forEach { lib ->
+                if (lib.resourceRemoteAddress == null) {
+                    Log.w("DL_TIMER", "downloadResources: NO remoteAddress — id=${lib.resourceId} title=${lib.title} type=${lib.resourceType} mediaType=${lib.mediaType} localAddress=${lib.resourceLocalAddress} resourceOffline=${lib.resourceOffline}")
+                }
+            }
+            val urls = resources.mapNotNull { it.resourceRemoteAddress }
+            Log.d("DL_TIMER", "downloadResources urls=${urls.size} t=${System.currentTimeMillis()}")
             if (urls.isNotEmpty()) {
                 DownloadUtils.openPriorityDownloadService(context, ArrayList(urls))
+                Log.d("DL_TIMER", "downloadResources openPriorityDownloadService done t=${System.currentTimeMillis()}")
             }
             true
         } catch (e: Exception) {
@@ -395,7 +404,7 @@ class ResourcesRepositoryImpl @Inject constructor(
 
     override suspend fun downloadResourcesPriority(resources: List<RealmMyLibrary>): Boolean {
         return try {
-            val urls = resources.filter { !it.isResourceOffline() }.mapNotNull { it.resourceRemoteAddress }
+            val urls = resources.mapNotNull { it.resourceRemoteAddress }
             if (urls.isNotEmpty()) {
                 DownloadUtils.openPriorityDownloadService(context, ArrayList(urls))
             }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -66,6 +66,7 @@ class DownloadService : Service() {
     private var sessionCompletedCount = 0
     private var isCurrentDownloadPriority = false
     private var isQueueRunning = false
+    @Volatile private var interruptCurrentDownload = false
 
     private val downloadJob = SupervisorJob()
     private lateinit var downloadScope: CoroutineScope
@@ -74,10 +75,12 @@ class DownloadService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        isRunning = true
         downloadScope = CoroutineScope(downloadJob + dispatcherProvider.io)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d("DL_TIMER", "DownloadService onStartCommand t=${System.currentTimeMillis()}")
         notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
 
         DownloadUtils.createChannels(this)
@@ -86,6 +89,7 @@ class DownloadService : Service() {
         startForeground(ONGOING_NOTIFICATION_ID, initialNotification)
 
         fromSync = intent?.getBooleanExtra("fromSync", false) == true
+        val urlsKey = intent?.getStringExtra("urls_key") ?: PENDING_DOWNLOADS_KEY
 
         downloadScope.launch {
             preferences = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
@@ -96,6 +100,9 @@ class DownloadService : Service() {
                 } finally {
                     isQueueRunning = false
                 }
+            } else if (urlsKey == PRIORITY_DOWNLOADS_KEY && !isCurrentDownloadPriority) {
+                Log.d("DL_TIMER", "priority url arrived mid-background-download, interrupting")
+                interruptCurrentDownload = true
             }
         }
 
@@ -103,10 +110,12 @@ class DownloadService : Service() {
     }
 
     private suspend fun processDownloadQueue() {
+        Log.d("DL_TIMER", "processDownloadQueue started t=${System.currentTimeMillis()}")
         while (true) {
             val nextUrl = getNextPriorityUrl() ?: getNextPendingUrl()
 
             if (nextUrl == null) {
+                Log.d("DL_TIMER", "processDownloadQueue no more urls, stopping t=${System.currentTimeMillis()}")
                 if (sessionCompletedCount > 0) {
                     showCompletionNotification(false)
                 }
@@ -114,14 +123,25 @@ class DownloadService : Service() {
                 return
             }
 
+            Log.d("DL_TIMER", "processDownloadQueue dequeued file=${nextUrl.url.substringAfterLast('/')} t=${System.currentTimeMillis()}")
             processedUrls.add(nextUrl.url)
             sessionTotalCount++
 
             isCurrentDownloadPriority = nextUrl.isPriority
+            interruptCurrentDownload = false
             updateNotificationForBatchDownload()
             initDownload(nextUrl.url, fromSync)
 
-            sessionCompletedCount++
+            if (interruptCurrentDownload) {
+                Log.d("DL_TIMER", "download interrupted, re-queuing file=${nextUrl.url.substringAfterLast('/')}")
+                interruptCurrentDownload = false
+                processedUrls.remove(nextUrl.url)
+                val pending = preferences.getStringSet(PENDING_DOWNLOADS_KEY, emptySet())?.toMutableSet() ?: mutableSetOf()
+                pending.add(nextUrl.url)
+                preferences.edit { putStringSet(PENDING_DOWNLOADS_KEY, pending) }
+            } else {
+                sessionCompletedCount++
+            }
 
             cleanupProcessedUrls()
         }
@@ -171,6 +191,8 @@ class DownloadService : Service() {
     }
 
     private suspend fun initDownload(url: String, fromSync: Boolean) {
+        val t0 = System.currentTimeMillis()
+        Log.d("DL_TIMER", "initDownload start file=${url.substringAfterLast('/')} t=$t0")
         currentDownloadUrl = url
         try {
             if (url.isBlank()) {
@@ -179,6 +201,7 @@ class DownloadService : Service() {
             }
 
             if (FileUtils.checkFileExist(this, url)) {
+                Log.d("DL_TIMER", "initDownload already cached dt=${System.currentTimeMillis()-t0}ms")
                 DownloadUtils.updateResourceOfflineStatus(url)
                 onDownloadComplete(url)
                 return
@@ -190,8 +213,10 @@ class DownloadService : Service() {
                 return
             }
 
+            Log.d("DL_TIMER", "initDownload HTTP request sent dt=${System.currentTimeMillis()-t0}ms")
             when (val result = downloadRepository.downloadFileResponse(url, authHeader)) {
                 is DownloadResult.Success -> {
+                    Log.d("DL_TIMER", "initDownload HTTP response received dt=${System.currentTimeMillis()-t0}ms")
                     try {
                         val contentLength = result.body.contentLength()
                         if (contentLength > 0 && !checkStorage(contentLength)) {
@@ -206,6 +231,7 @@ class DownloadService : Service() {
                     }
                 }
                 is DownloadResult.Error -> {
+                    Log.d("DL_TIMER", "initDownload HTTP error=${result.message} dt=${System.currentTimeMillis()-t0}ms")
                     downloadFailed(result.message, fromSync)
                 }
             }
@@ -232,23 +258,27 @@ class DownloadService : Service() {
         if (!fromSync) {
             if (message == "File Not Found") {
                 val intent = Intent(RESOURCE_NOT_FOUND_ACTION)
-                downloadScope.launch {
-                    val broadcastService = getBroadcastService(this@DownloadService)
-                    broadcastService.sendBroadcast(intent)
-                }
+                getBroadcastService(this).trySendBroadcast(intent)
             }
         }
     }
 
     @Throws(IOException::class)
     private fun downloadFile(body: ResponseBody, url: String) {
+        val t0 = System.currentTimeMillis()
+        Log.d("DL_TIMER", "downloadFile start file=${url.substringAfterLast('/')} t=$t0")
         val fileSize = body.contentLength()
         outputFile = FileUtils.getSDPathFromUrl(this@DownloadService, url)
         var total: Long = 0
+        var interrupted = false
 
         BufferedInputStream(body.byteStream(), 1024 * 8).use { bis ->
             FileOutputStream(outputFile).use { output ->
                 while (true) {
+                    if (interruptCurrentDownload) {
+                        interrupted = true
+                        break
+                    }
                     val readCount = bis.read(data)
                     if (readCount == -1) break
 
@@ -283,6 +313,11 @@ class DownloadService : Service() {
                     }
                 }
             }
+        }
+        if (interrupted) {
+            outputFile?.delete()
+            outputFile = null
+            return
         }
         onDownloadComplete(url)
     }
@@ -337,13 +372,11 @@ class DownloadService : Service() {
             putExtra("download", download)
             putExtra("fromSync", fromSync)
         }
-        downloadScope.launch {
-            val broadcastService = getBroadcastService(this@DownloadService)
-            broadcastService.sendBroadcast(intent)
-        }
+        getBroadcastService(this).trySendBroadcast(intent)
     }
 
     private fun onDownloadComplete(url: String) {
+        Log.d("DL_TIMER", "service onDownloadComplete file=${url.substringAfterLast('/')} t=${System.currentTimeMillis()}")
         if ((outputFile?.length() ?: 0) > 0) {
             DownloadUtils.updateResourceOfflineStatus(url)
         }
@@ -380,6 +413,7 @@ class DownloadService : Service() {
     }
 
     override fun onDestroy() {
+        isRunning = false
         try {
             stopForeground(Service.STOP_FOREGROUND_REMOVE)
         } catch (e: Exception) {
@@ -419,6 +453,8 @@ class DownloadService : Service() {
                 .map { QueuedUrl(it, isPriority) }
             return getNextPriorityUrl(queue)
         }
+
+        @Volatile var isRunning = false
 
         fun startService(context: Context, urlsKey: String, fromSync: Boolean) {
             val intent = Intent(context, DownloadService::class.java).apply {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/DialogUtils.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.utils
 
 import android.app.Activity
+import android.util.Log
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
@@ -30,6 +31,7 @@ object DialogUtils {
         prgDialog.setTitle(context.getString(R.string.downloading_file))
         prgDialog.setMax(100)
         prgDialog.setNegativeButton(context.getString(R.string.stop_download), isVisible = true) {
+            Log.d("DL_TIMER", "stopDownload button tapped, dismissing dialog t=${System.currentTimeMillis()}")
             context.stopService(Intent(context, DownloadService::class.java))
             prgDialog.dismiss()
         }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/DownloadUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/DownloadUtils.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.utils
 
 import android.app.ActivityManager
+import android.util.Log
 import android.app.AlarmManager
 import android.app.Notification
 import android.app.NotificationChannel
@@ -140,6 +141,7 @@ object DownloadUtils {
     @RequiresApi(Build.VERSION_CODES.S)
     fun openPriorityDownloadService(context: Context?, urls: ArrayList<String>) {
         context?.let { ctx ->
+            Log.d("DL_TIMER", "openPriorityDownloadService urls=${urls.size} t=${System.currentTimeMillis()}")
             val preferences = ctx.getSharedPreferences(DownloadService.PREFS_NAME, Context.MODE_PRIVATE)
 
             val existingPriority = preferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) ?: emptySet()
@@ -148,7 +150,9 @@ object DownloadUtils {
             preferences.edit {
                 putStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, mergedPriority)
             }
+            Log.d("DL_TIMER", "openPriorityDownloadService prefs written, starting service t=${System.currentTimeMillis()}")
             startDownloadServiceSafely(ctx, DownloadService.PRIORITY_DOWNLOADS_KEY, false)
+            Log.d("DL_TIMER", "openPriorityDownloadService startService returned t=${System.currentTimeMillis()}")
         }
     }
 


### PR DESCRIPTION
fixes #13464
Add extensive DL_TIMER logging across download flow and utils; track pending download URLs and library resource IDs in BaseResourceFragment and only show/dismiss progress dialog when appropriate. Add automatic add-to-user-library after downloads complete. Implement priority-download interrupt in DownloadService with an interruptCurrentDownload flag, re-queue interrupted items, and log lifecycle events; use trySendBroadcast for broadcast sending and maintain service isRunning state. Fix RealmMyLibrary.needToUpdate logic and adjust ResourcesRepositoryImpl to log missing remote addresses and not filter out nulls before queuing. Small UI/behavior tweaks (singleLine property, removed duplicate addToLibrary/addAllToLibrary helpers) and minor dialog/service start logging.