### PR TITLE
resources: smoother repository shelfing (fixes #13570)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5548
-        versionName = "0.55.48"
+        versionCode = 5567
+        versionName = "0.55.67"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -412,30 +412,28 @@ class ResourcesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun addResourcesToUserLibrary(resourceIds: List<String>, userId: String): Result<Unit> {
-        return withContext(databaseService.ioDispatcher) {
-            runCatching {
-                if (resourceIds.isEmpty() || userId.isBlank()) return@runCatching
+        return runCatching {
+            if (resourceIds.isEmpty() || userId.isBlank()) return@runCatching
 
-                executeTransaction { realm ->
-                    val chunkSize = 1000
-                    resourceIds.chunked(chunkSize).forEach { chunk ->
-                        val libraryItems = realm.where(RealmMyLibrary::class.java)
-                            .`in`("resourceId", chunk.toTypedArray())
-                            .not().equalTo("userId", userId)
-                            .findAll()
+            executeTransaction { realm ->
+                val chunkSize = 1000
+                resourceIds.chunked(chunkSize).forEach { chunk ->
+                    val libraryItems = realm.where(RealmMyLibrary::class.java)
+                        .`in`("resourceId", chunk.toTypedArray())
+                        .not().equalTo("userId", userId)
+                        .findAll()
 
-                        libraryItems.forEach { libraryItem ->
-                            libraryItem.setUserId(userId)
-                        }
-
-                        val removedLogs = realm.where(org.ole.planet.myplanet.model.RealmRemovedLog::class.java)
-                            .equalTo("type", "resources")
-                            .equalTo("userId", userId)
-                            .`in`("docId", chunk.toTypedArray())
-                            .findAll()
-
-                        removedLogs.deleteAllFromRealm()
+                    libraryItems.forEach { libraryItem ->
+                        libraryItem.setUserId(userId)
                     }
+
+                    val removedLogs = realm.where(org.ole.planet.myplanet.model.RealmRemovedLog::class.java)
+                        .equalTo("type", "resources")
+                        .equalTo("userId", userId)
+                        .`in`("docId", chunk.toTypedArray())
+                        .findAll()
+
+                    removedLogs.deleteAllFromRealm()
                 }
             }
         }


### PR DESCRIPTION
Removed the extra `withContext(databaseService.ioDispatcher)` wrapper in `addResourcesToUserLibrary` to rely on the transaction helper. Preserved exact inner logic and cleanup steps. Tested and compiled successfully.

---
*PR created automatically by Jules for task [18356400692693281817](https://jules.google.com/task/18356400692693281817) started by @dogi*