### PR TITLE
login: smoother settings storage breakdown dispatcher providing (fixes #13555)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5548
-        versionName = "0.55.48"
+        versionCode = 5556
+        versionName = "0.55.56"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
@@ -15,13 +15,13 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentStorageBreakdownBinding
 import org.ole.planet.myplanet.databinding.ItemStorageCategoryBinding
 import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.FileUtils
 
 @AndroidEntryPoint
@@ -32,6 +32,9 @@ class StorageBreakdownFragment : BottomSheetDialogFragment() {
 
     @Inject
     lateinit var resourcesRepository: ResourcesRepository
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
 
     internal data class CategoryData(
         @StringRes val nameRes: Int,
@@ -86,7 +89,7 @@ class StorageBreakdownFragment : BottomSheetDialogFragment() {
         binding.emptyText.visibility = View.GONE
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val totalBytes = withContext(Dispatchers.IO) { scanStorage() }
+            val totalBytes = withContext(dispatcherProvider.io) { scanStorage() }
 
             binding.progressBar.visibility = View.GONE
 


### PR DESCRIPTION
Refactors `StorageBreakdownFragment` to use an injected `DispatcherProvider` instead of the hardcoded `Dispatchers.IO` to improve code modularity and testability. Compilation has been verified with `./gradlew compileDefaultDebugKotlin`.

---
*PR created automatically by Jules for task [17647353556378880723](https://jules.google.com/task/17647353556378880723) started by @dogi*