### PR TITLE
teams: smoother submissions repository transacting (fixes #13576)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5548
-        versionName = "0.55.48"
+        versionCode = 5572
+        versionName = "0.55.72"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -354,7 +354,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
     }
 
     override suspend fun deleteExamSubmissions(examId: String, courseId: String?, userId: String?) {
-        databaseService.executeTransactionAsync { realm ->
+        executeTransaction { realm ->
             val parentIdToSearch = if (!courseId.isNullOrEmpty()) {
                 "${examId}@${courseId}"
             } else {
@@ -511,7 +511,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         val submissionId = submission?.id
         val questionId = question.id
 
-        databaseService.executeTransactionAsync { r ->
+        executeTransaction { r ->
             val realmSubmission = if (submissionId != null) {
                 r.where(RealmSubmission::class.java).equalTo("id", submissionId).findFirst()
             } else {


### PR DESCRIPTION
This refactoring brings `SubmissionsRepositoryImpl` in line with the standard write-path patterns of repositories extending `RealmRepository`. Direct calls to `databaseService.executeTransactionAsync` have been replaced with the provided helper function `executeTransaction`. The underlying Realm transaction blocks and business logic inside them are entirely unmodified to ensure no behavioral changes.

---
*PR created automatically by Jules for task [9828833920644933560](https://jules.google.com/task/9828833920644933560) started by @dogi*