### PR TITLE
teams: smoother voices image loading (fixes #13578)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5548
-        versionName = "0.55.48"
+        versionCode = 5574
+        versionName = "0.55.74"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -741,18 +741,25 @@ class VoicesAdapter(
         }
     }
 
-    private fun loadSingleImage(binding: RowNewsBinding, path: String?) {
-        if (path == null) return
-        val request = Glide.with(binding.imgNews.context)
-        val file = File(path)
-        val target = if (path.lowercase(Locale.getDefault()).endsWith(".gif")) {
+
+    private fun loadGlideImage(file: File, target: ImageView, size: Int) {
+        val request = Glide.with(target.context)
+        val path = file.absolutePath
+        val glideTarget = if (path.lowercase(Locale.getDefault()).endsWith(".gif")) {
             request.asGif().load(file).error(request.asGif().load(path))
         } else {
             request.load(file).error(request.load(path))
         }
-        target.diskCacheStrategy(DiskCacheStrategy.ALL).fitCenter().placeholder(R.drawable.ic_loading)
+        glideTarget.diskCacheStrategy(DiskCacheStrategy.ALL).fitCenter().override(size, size).placeholder(R.drawable.ic_loading)
             .error(R.drawable.ic_loading)
-            .into(binding.imgNews)
+            .into(target)
+    }
+
+    private fun loadSingleImage(binding: RowNewsBinding, path: String?) {
+        if (path == null) return
+        val file = File(path)
+        val size = (120 * binding.imgNews.context.resources.displayMetrics.density).toInt()
+        loadGlideImage(file, binding.imgNews, size)
         binding.imgNews.visibility = View.VISIBLE
         binding.imgNews.setOnClickListener {
             showZoomableImage(it.context, path)
@@ -769,16 +776,8 @@ class VoicesAdapter(
         imageView.layoutParams = params
         imageView.scaleType = ImageView.ScaleType.CENTER_CROP
 
-        val request = Glide.with(context)
         val file = File(path)
-        val target = if (path.lowercase(Locale.getDefault()).endsWith(".gif")) {
-            request.asGif().load(file).error(request.asGif().load(path))
-        } else {
-            request.load(file).error(request.load(path))
-        }
-        target.diskCacheStrategy(DiskCacheStrategy.ALL).fitCenter().placeholder(R.drawable.ic_loading)
-            .error(R.drawable.ic_loading)
-            .into(imageView)
+        loadGlideImage(file, imageView, size)
 
         imageView.setOnClickListener {
             showZoomableImage(context, path)
@@ -793,16 +792,8 @@ class VoicesAdapter(
             val basePath = externalFilesDir
             if (library != null && basePath != null) {
                 val imageFile = File(basePath, "ole/${library.id}/${library.resourceLocalAddress}")
-                val request = Glide.with(binding.imgNews.context)
-                val isGif = library.resourceLocalAddress?.lowercase(Locale.getDefault())?.endsWith(".gif") == true
-                val target = if (isGif) {
-                    request.asGif().load(imageFile)
-                } else {
-                    request.load(imageFile)
-                }
-                target.diskCacheStrategy(DiskCacheStrategy.ALL).fitCenter().placeholder(R.drawable.ic_loading)
-                    .error(R.drawable.ic_loading)
-                    .into(binding.imgNews)
+                val size = (120 * binding.imgNews.context.resources.displayMetrics.density).toInt()
+                loadGlideImage(imageFile, binding.imgNews, size)
                 binding.imgNews.visibility = View.VISIBLE
                 binding.imgNews.setOnClickListener {
                     showZoomableImage(it.context, imageFile.toString())
@@ -825,16 +816,7 @@ class VoicesAdapter(
                 imageView.layoutParams = params
                 imageView.scaleType = ImageView.ScaleType.CENTER_CROP
 
-                val request = Glide.with(context)
-                val isGif = library.resourceLocalAddress?.lowercase(Locale.getDefault())?.endsWith(".gif") == true
-                val target = if (isGif) {
-                    request.asGif().load(imageFile)
-                } else {
-                    request.load(imageFile)
-                }
-                target.diskCacheStrategy(DiskCacheStrategy.ALL).fitCenter().placeholder(R.drawable.ic_loading)
-                    .error(R.drawable.ic_loading)
-                    .into(imageView)
+                loadGlideImage(imageFile, imageView, size)
 
                 imageView.setOnClickListener {
                     showZoomableImage(context, imageFile.toString())


### PR DESCRIPTION
Extracted the Glide loading logic into a single helper method `loadGlideImage` that adds `.override(size, size)`. Updated inline image loaders (`loadSingleImage`, `loadLibraryImage`, `addImageToContainer`, `addLibraryImageToContainer`) to utilize this helper with their respective explicit sizes to optimize performance. Left full-screen dialog requests untouched.

---
*PR created automatically by Jules for task [12683034836515431642](https://jules.google.com/task/12683034836515431642) started by @dogi*