### PR TITLE
teams: smoother events repository batch transacting (fixes #13577)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5548
-        versionName = "0.55.48"
+        versionCode = 5573
+        versionName = "0.55.73"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepositoryImpl.kt
@@ -67,15 +67,13 @@ class EventsRepositoryImpl @Inject constructor(
     override suspend fun batchInsertMeetups(documents: List<JsonObject>): Int {
         var processedCount = 0
         try {
-            withRealm { realm ->
-                realm.executeTransaction { realmTx ->
-                    documents.forEach { doc ->
-                        try {
-                            RealmMeetup.insert(realmTx, doc)
-                            processedCount++
-                        } catch (e: Exception) {
-                            e.printStackTrace()
-                        }
+            executeTransaction { realm ->
+                documents.forEach { doc ->
+                    try {
+                        RealmMeetup.insert(realm, doc)
+                        processedCount++
+                    } catch (e: Exception) {
+                        e.printStackTrace()
                     }
                 }
             }


### PR DESCRIPTION
This PR simplifies the `batchInsertMeetups` implementation by removing an unnecessary nested `withRealm` block. It directly utilizes the `executeTransaction` helper inherited from `RealmRepository`, cleaning up the transaction logic while maintaining the required transaction semantics.

---
*PR created automatically by Jules for task [12038200492844653024](https://jules.google.com/task/12038200492844653024) started by @dogi*