### PR TITLE
teams: smoother voices caching (fixes #13581)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 5577
-        versionName = "0.55."77
+        versionName = "0.55.77"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5548
-        versionName = "0.55.48"
+        versionCode = 5577
+        versionName = "0.55."77
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -138,7 +138,7 @@ class VoicesAdapter(
     private var nonTeamMember = false
     private var recyclerView: RecyclerView? = null
     private val profileDbHandler = userSessionManager
-    private val userCache = mutableMapOf<String, RealmUser?>()
+    private val userCache = object : LinkedHashMap<String, RealmUser?>(64, 0.75f, true) { override fun removeEldestEntry(e: Map.Entry<String, RealmUser?>) = size > 128 }
     private val fetchingUserIds = mutableSetOf<String>()
     private val replyCountCache = mutableMapOf<String, Int>()
     private val leadersList: List<RealmUser> by lazy {
@@ -686,6 +686,8 @@ class VoicesAdapter(
     override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
         super.onDetachedFromRecyclerView(recyclerView)
         this.recyclerView = null
+        userCache.clear()
+        fetchingUserIds.clear()
     }
 
     override fun onViewRecycled(holder: RecyclerView.ViewHolder) {


### PR DESCRIPTION
Replaced `userCache` in `VoicesAdapter` with an LRU-like bounded `LinkedHashMap` that automatically evicts entries above size 128 to reduce unbounded memory usage.
Also implemented `onDetachedFromRecyclerView()` to explicitly clear `userCache` and `fetchingUserIds` sets when the adapter is detached, preventing potential memory leaks while navigating between fragments. No public API calls or logic related to cache lookup/write have been altered.

---
*PR created automatically by Jules for task [8928176388570276780](https://jules.google.com/task/8928176388570276780) started by @dogi*