### PR TITLE
courses: smoother submissions repository transacting (fixes #13568)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5548
-        versionName = "0.55.48"
+        versionCode = 5565
+        versionName = "0.55.65"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -354,7 +354,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
     }
 
     override suspend fun deleteExamSubmissions(examId: String, courseId: String?, userId: String?) {
-        databaseService.executeTransactionAsync { realm ->
+        executeTransaction { realm ->
             val parentIdToSearch = if (!courseId.isNullOrEmpty()) {
                 "${examId}@${courseId}"
             } else {
@@ -511,7 +511,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         val submissionId = submission?.id
         val questionId = question.id
 
-        databaseService.executeTransactionAsync { r ->
+        executeTransaction { r ->
             val realmSubmission = if (submissionId != null) {
                 r.where(RealmSubmission::class.java).equalTo("id", submissionId).findFirst()
             } else {
@@ -647,14 +647,10 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
     }
 
     override suspend fun markPhotoUploaded(photoId: String?, rev: String, id: String) {
-        executeTransaction { transactionRealm ->
-            transactionRealm.where(RealmSubmitPhotos::class.java)
-                .equalTo("id", photoId)
-                .findFirst()?.let { sub ->
-                    sub.uploaded = true
-                    sub._rev = rev
-                    sub._id = id
-                }
+        update(RealmSubmitPhotos::class.java, "id", photoId ?: "") { sub ->
+            sub.uploaded = true
+            sub._rev = rev
+            sub._id = id
         }
     }
 


### PR DESCRIPTION
Replaced manual database transactions with RealmRepository base class transaction helpers in `SubmissionsRepositoryImpl` to standardize behavior and ensure correct threading.

---
*PR created automatically by Jules for task [7879376557847079433](https://jules.google.com/task/7879376557847079433) started by @dogi*