### PR TITLE
life: smoother dictionary dispatcher providing (fixes #13553)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5548
-        versionName = "0.55.48"
+        versionCode = 5554
+        versionName = "0.55.54"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
@@ -8,7 +8,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Case
 import java.util.UUID
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
@@ -17,6 +16,7 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.databinding.FragmentDictionaryBinding
 import org.ole.planet.myplanet.model.RealmDictionary
 import org.ole.planet.myplanet.utils.Constants
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.FileUtils
@@ -27,6 +27,10 @@ import org.ole.planet.myplanet.utils.Utilities
 class DictionaryActivity : BaseActivity() {
     @Inject
     lateinit var databaseService: DatabaseService
+
+    @Inject
+    override lateinit var dispatcherProvider: DispatcherProvider
+
     private lateinit var fragmentDictionaryBinding: FragmentDictionaryBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -61,7 +65,7 @@ class DictionaryActivity : BaseActivity() {
         if (isEmpty) {
             val context = this@DictionaryActivity
             val json = try {
-                val data = withContext(Dispatchers.IO) {
+                val data = withContext(dispatcherProvider.io) {
                     FileUtils.getStringFromFile(
                         FileUtils.getSDPathFromUrl(context, Constants.DICTIONARY_URL)
                     )


### PR DESCRIPTION
Use injected DispatcherProvider in DictionaryActivity to improve testability and rely on a single source of truth for coroutine dispatchers.

---
*PR created automatically by Jules for task [13157822587830633957](https://jules.google.com/task/13157822587830633957) started by @dogi*