### PR TITLE
Align UploadRepositoryImpl with @RealmDispatcher

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -63,9 +63,9 @@ object ServiceModule {
     @Singleton
     fun provideUploadRepository(
         databaseService: DatabaseService,
-        dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider
+        @RealmDispatcher realmDispatcher: kotlinx.coroutines.CoroutineDispatcher
     ): org.ole.planet.myplanet.repository.UploadRepository {
-        return org.ole.planet.myplanet.repository.UploadRepositoryImpl(databaseService, dispatcherProvider)
+        return org.ole.planet.myplanet.repository.UploadRepositoryImpl(databaseService, realmDispatcher)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
@@ -4,16 +4,17 @@ import android.util.Log
 import io.realm.RealmObject
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.services.upload.UploadConfig
 import org.ole.planet.myplanet.services.upload.UploadedItem
-import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @Singleton
 class UploadRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
-    dispatcherProvider: DispatcherProvider
-) : RealmRepository(databaseService, dispatcherProvider.io), UploadRepository {
+    @RealmDispatcher realmDispatcher: CoroutineDispatcher
+) : RealmRepository(databaseService, realmDispatcher), UploadRepository {
 
     override suspend fun <T : RealmObject> queryPending(config: UploadConfig<T>): List<T> {
         return withRealmAsync { realm ->


### PR DESCRIPTION
Aligned `UploadRepositoryImpl` with the `@RealmDispatcher` pattern used by other Realm repositories in the project. This removes the manual wiring of the generic dispatcher provider in the service layer while keeping the repository behavior unchanged and standardizing the threading contract.

---
*PR created automatically by Jules for task [213478965762498747](https://jules.google.com/task/213478965762498747) started by @dogi*