### PR TITLE
teams: smoother voices repository transacting (fixes #13582)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5548
-        versionName = "0.55.48"
+        versionCode = 5578
+        versionName = "0.55.78"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepositoryImpl.kt
@@ -55,7 +55,7 @@ class VoicesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markNewsUploaded(updates: List<NewsUpdateData>) {
-        databaseService.executeTransactionAsync { realm ->
+        executeTransaction { realm ->
             val ids = updates.mapNotNull { it.id }
             val managedNewsMap = mutableMapOf<String, RealmNews>()
 
@@ -136,7 +136,7 @@ class VoicesRepositoryImpl @Inject constructor(
     override suspend fun createTeamNews(newsData: HashMap<String?, String>, user: RealmUser, imageList: List<String>?): Boolean {
         val realmImageList = imageList?.let { io.realm.RealmList<String>().apply { addAll(it) } }
         return try {
-            databaseService.executeTransactionAsync { realm ->
+            executeTransaction { realm ->
                 RealmNews.createNews(newsData, realm, user, realmImageList)
             }
             true
@@ -249,7 +249,7 @@ class VoicesRepositoryImpl @Inject constructor(
 
     override suspend fun shareNewsToCommunity(newsId: String, userId: String, planetCode: String, parentCode: String, teamName: String): Result<Unit> {
         return try {
-            databaseService.executeTransactionAsync { realm ->
+            executeTransaction { realm ->
                 val news = realm.where(RealmNews::class.java).equalTo("id", newsId).findFirst()
                 if (news != null) {
                     val array = gson.fromJson(news.viewIn, JsonArray::class.java)
@@ -280,47 +280,43 @@ class VoicesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateTeamNotification(teamId: String, count: Int) {
-        withRealm { realm ->
-            realm.executeTransaction {
-                var notification = it.where(org.ole.planet.myplanet.model.RealmTeamNotification::class.java)
-                    .equalTo("type", "chat")
-                    .equalTo("parentId", teamId)
-                    .findFirst()
+        executeTransaction { it ->
+            var notification = it.where(org.ole.planet.myplanet.model.RealmTeamNotification::class.java)
+                .equalTo("type", "chat")
+                .equalTo("parentId", teamId)
+                .findFirst()
 
-                if (notification == null) {
-                    notification = it.createObject(org.ole.planet.myplanet.model.RealmTeamNotification::class.java, UUID.randomUUID().toString())
-                    notification.parentId = teamId
-                    notification.type = "chat"
-                }
-                notification.lastCount = count
+            if (notification == null) {
+                notification = it.createObject(org.ole.planet.myplanet.model.RealmTeamNotification::class.java, UUID.randomUUID().toString())
+                notification.parentId = teamId
+                notification.type = "chat"
             }
+            notification.lastCount = count
         }
     }
 
     override suspend fun deletePost(newsId: String, teamName: String) {
-        withRealm { realm ->
-            realm.executeTransaction { transactionRealm ->
-                val news = transactionRealm.where(RealmNews::class.java).equalTo("id", newsId).findFirst()
-                if (news != null) {
-                    val ar = try {
-                        gson.fromJson(news.viewIn, JsonArray::class.java)
-                    } catch (e: Exception) {
-                        null
-                    }
+        executeTransaction { transactionRealm ->
+            val news = transactionRealm.where(RealmNews::class.java).equalTo("id", newsId).findFirst()
+            if (news != null) {
+                val ar = try {
+                    gson.fromJson(news.viewIn, JsonArray::class.java)
+                } catch (e: Exception) {
+                    null
+                }
 
-                    if (teamName.isNotEmpty() || ar == null || ar.size() < 2) {
-                        news.id?.let { id -> deleteRepliesOf(id, transactionRealm) }
-                        news.deleteFromRealm()
-                    } else {
-                        val filtered = JsonArray().apply {
-                            ar.forEach { elem ->
-                                if (elem.isJsonObject && !elem.asJsonObject.has("sharedDate")) {
-                                    add(elem)
-                                }
+                if (teamName.isNotEmpty() || ar == null || ar.size() < 2) {
+                    news.id?.let { id -> deleteRepliesOf(id, transactionRealm) }
+                    news.deleteFromRealm()
+                } else {
+                    val filtered = JsonArray().apply {
+                        ar.forEach { elem ->
+                            if (elem.isJsonObject && !elem.asJsonObject.has("sharedDate")) {
+                                add(elem)
                             }
                         }
-                        news.viewIn = gson.toJson(filtered)
                     }
+                    news.viewIn = gson.toJson(filtered)
                 }
             }
         }
@@ -362,11 +358,9 @@ class VoicesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteNews(newsId: String) {
-        withRealm { realm ->
-            realm.executeTransaction {
-                deleteRepliesOf(newsId, it)
-                it.where(RealmNews::class.java).equalTo("id", newsId).findAll().deleteAllFromRealm()
-            }
+        executeTransaction {
+            deleteRepliesOf(newsId, it)
+            it.where(RealmNews::class.java).equalTo("id", newsId).findAll().deleteAllFromRealm()
         }
     }
 
@@ -380,20 +374,16 @@ class VoicesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun addLabel(newsId: String, label: String) {
-        withRealm { realm ->
-            realm.executeTransaction {
-                val news = it.where(RealmNews::class.java).equalTo("id", newsId).findFirst()
-                news?.labels?.add(label)
-            }
+        executeTransaction {
+            val news = it.where(RealmNews::class.java).equalTo("id", newsId).findFirst()
+            news?.labels?.add(label)
         }
     }
 
     override suspend fun removeLabel(newsId: String, label: String) {
-        withRealm { realm ->
-            realm.executeTransaction {
-                val news = it.where(RealmNews::class.java).equalTo("id", newsId).findFirst()
-                news?.labels?.remove(label)
-            }
+        executeTransaction {
+            val news = it.where(RealmNews::class.java).equalTo("id", newsId).findFirst()
+            news?.labels?.remove(label)
         }
     }
 


### PR DESCRIPTION
Refactored `VoicesRepositoryImpl` to use the `executeTransaction` helper method from its base class `RealmRepository`, cleaning up database transactions and removing nested scoping.

---
*PR created automatically by Jules for task [14544256216159263220](https://jules.google.com/task/14544256216159263220) started by @dogi*