### PR TITLE
Fix FileUtilsTest.checkFileExist_returnsTrueWhenFileExists

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/utils/FileUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/FileUtilsTest.kt
@@ -66,7 +66,7 @@ class FileUtilsTest {
         FileUtils.warmUp(context)
         val testFile = File(FileUtils.getExternalFilesDir(context), "ole/123/test_file.txt")
         testFile.parentFile?.mkdirs()
-        testFile.createNewFile()
+        testFile.writeText("dummy content")
 
         val url = "http://example.com/resources/123/test_file.txt"
 


### PR DESCRIPTION
Modified `checkFileExist_returnsTrueWhenFileExists` in `FileUtilsTest` to write dummy content instead of just creating an empty 0-byte file, aligning the test file size with `FileUtils.checkFileExist` size requirements (which strictly checks for a non-zero length file). This successfully passed the test assertion previously failing and the remaining tests.

---
*PR created automatically by Jules for task [14384108139189146999](https://jules.google.com/task/14384108139189146999) started by @dogi*