### PR TITLE
all: smoother realm model indexing (fixes #13609)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5591
-        versionName = "0.55.91"
+        versionCode = 5599
+        versionName = "0.55.99"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -26,7 +26,7 @@ class DatabaseService(context: Context, private val dispatcherProvider: Dispatch
         if (currentConfig == null || currentConfig.realmDirectory.name == Realm.DEFAULT_REALM_NAME) {
             val config = RealmConfiguration.Builder()
                 .name(Realm.DEFAULT_REALM_NAME)
-                .schemaVersion(9)
+                .schemaVersion(10)
                 .migration(RealmMigrations())
                 .build()
             Realm.setDefaultConfiguration(config)

--- a/app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt
@@ -58,5 +58,19 @@ class RealmMigrations : RealmMigration {
                 ?.addField("isDeletePending", Boolean::class.java)
             version++
         }
+
+        if (version == 9L) {
+            schema.get("RealmTag")
+                ?.addIndex("name")
+                ?.addIndex("tagId")
+                ?.addIndex("db")
+            schema.get("RealmRating")
+                ?.addIndex("item")
+                ?.addIndex("type")
+            schema.get("RealmMyCourse")
+                ?.addIndex("gradeLevel")
+                ?.addIndex("subjectLevel")
+            version++
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyCourse.kt
@@ -24,7 +24,9 @@ open class RealmMyCourse : RealmObject() {
     var memberLimit: Int? = null
     var description: String? = null
     var method: String? = null
+    @Index
     var gradeLevel: String? = null
+    @Index
     var subjectLevel: String? = null
     var createdDate: Long = 0
     private var numberOfSteps: Int? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmRating.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmRating.kt
@@ -21,10 +21,12 @@ open class RealmRating : RealmObject() {
     var isUpdated = false
     var rate = 0
     var _id: String? = null
+    @Index
     var item: String? = null
     var comment: String? = null
     var parentCode: String? = null
     var planetCode: String? = null
+    @Index
     var type: String? = null
     var user: String? = null
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTag.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTag.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.model
 import com.google.gson.JsonArray
 import io.realm.RealmList
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.utils.JsonUtils
 
@@ -11,11 +12,14 @@ open class RealmTag : RealmObject() {
     var id: String? = null
     var _id: String? = null
     var _rev: String? = null
+    @Index
     var name: String? = null
     var linkId: String? = null
+    @Index
     var tagId: String? = null
     var attachedTo: RealmList<String>? = null
     var docType: String? = null
+    @Index
     var db: String? = null
     var isAttached = false
     private fun setAttachedTo(attachedTo: JsonArray) {


### PR DESCRIPTION
fixes #13609
The most user-visible speedup will be ratings (type + item): every course list and resource list load calls getCourseRatings() which previously scanned the entire RealmRating table