### PR TITLE
sync: less check version callback is more (fixes #13668)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5600
-        versionName = "0.56.0"
+        versionCode = 5613
+        versionName = "0.56.13"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
@@ -14,7 +14,7 @@ interface ConfigurationsRepository {
 
     interface CheckVersionCallback {
         fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean)
-        fun onCheckingVersion()
+        fun onCheckingVersion() {}
         fun onError(msg: String, blockSync: Boolean)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/AutoSyncWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/AutoSyncWorker.kt
@@ -95,8 +95,6 @@ class AutoSyncWorker @AssistedInject constructor(
         syncContinuation = null
     }
 
-    override fun onCheckingVersion() {}
-
     override fun onError(msg: String, blockSync: Boolean) {
         if (blockSync) {
             syncContinuation?.takeIf { it.isActive }?.resume(Unit)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -780,8 +780,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         }
     }
 
-    override fun onCheckingVersion() {}
-
     fun registerReceiver() {
         collectWhenStarted(broadcastService.events) { intent ->
             if (intent.action == DashboardActivity.MESSAGE_PROGRESS) {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was "Empty Override Method" for `onCheckingVersion()` in `AutoSyncWorker`.
💡 **Why:** Adding a default empty implementation `{}` directly to the interface (`ConfigurationsRepository.CheckVersionCallback`) allows classes that do not need to handle this callback method to omit the empty override, improving code clarity and removing unnecessary boilerplate. 
✅ **Verification:** Ran `./gradlew compileDefaultDebugKotlin --no-build-cache` and the full unit test suite `./gradlew testDefaultDebugUnitTest` to verify the refactoring was safe and no regressions were introduced.
✨ **Result:** Cleaned up empty methods across the project (`AutoSyncWorker`, `SyncActivity`), enhancing maintainability while preserving exact existing functionality.

---
*PR created automatically by Jules for task [17345806772078468715](https://jules.google.com/task/17345806772078468715) started by @dogi*