### PR TITLE
life: smoother health text watching (fixes #13672)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5600
-        versionName = "0.56.0"
+        versionCode = 5617
+        versionName = "0.56.17"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -16,6 +16,7 @@ import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.core.content.ContextCompat
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -315,39 +316,34 @@ class MyHealthFragment : Fragment() {
     }
 
     private fun setTextWatcher(etSearch: EditText, btnAddMember: Button, rv: RecyclerView) {
-        textWatcher = object : TextWatcher {
-            override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
-            override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
-            override fun afterTextChanged(editable: Editable) {
-                searchJob?.cancel()
-                searchJob = viewLifecycleOwner.lifecycleScope.launch {
-                    delay(300)
-                    val loadingJob = launch(dispatcherProvider.main) {
-                        delay(100)
-                        alertHealthListBinding?.searchProgress?.visibility = View.VISIBLE
-                        rv.visibility = View.GONE
-                    }
+        textWatcher = etSearch.doAfterTextChanged { editable ->
+            searchJob?.cancel()
+            searchJob = viewLifecycleOwner.lifecycleScope.launch {
+                delay(300)
+                val loadingJob = launch(dispatcherProvider.main) {
+                    delay(100)
+                    alertHealthListBinding?.searchProgress?.visibility = View.VISIBLE
+                    rv.visibility = View.GONE
+                }
 
-                    val userModelList = userRepository.searchUsers(editable.toString(), "joinDate", Sort.DESCENDING)
+                val userModelList = userRepository.searchUsers(editable?.toString() ?: "", "joinDate", Sort.DESCENDING)
 
-                    loadingJob.cancel()
-                    if (isAdded) {
-                        alertHealthListBinding?.searchProgress?.visibility = View.GONE
-                        rv.visibility = View.VISIBLE
-                        val searchAdapter = HealthUsersAdapter { selected ->
-                            userId = if (selected._id.isNullOrEmpty()) selected.id else selected._id
-                            getHealthRecords(userId)
-                            dialog?.dismiss()
-                        }
-                        searchAdapter.submitList(userModelList)
-                        rv.adapter = searchAdapter
-                        btnAddMember.visibility =
-                            if (userModelList.isEmpty()) View.VISIBLE else View.GONE
+                loadingJob.cancel()
+                if (isAdded) {
+                    alertHealthListBinding?.searchProgress?.visibility = View.GONE
+                    rv.visibility = View.VISIBLE
+                    val searchAdapter = HealthUsersAdapter { selected ->
+                        userId = if (selected._id.isNullOrEmpty()) selected.id else selected._id
+                        getHealthRecords(userId)
+                        dialog?.dismiss()
                     }
+                    searchAdapter.submitList(userModelList)
+                    rv.adapter = searchAdapter
+                    btnAddMember.visibility =
+                        if (userModelList.isEmpty()) View.VISIBLE else View.GONE
                 }
             }
         }
-        etSearch.addTextChangedListener(textWatcher)
     }
 
     override fun onResume() {


### PR DESCRIPTION
🎯 **What:** Replaced the anonymous `TextWatcher` object in `setTextWatcher` with the `doAfterTextChanged` extension function from Android KTX.

💡 **Why:** This removes the empty boilerplate override methods (`beforeTextChanged` and `onTextChanged`) which makes the code cleaner and easier to read.

✅ **Verification:** Verified by compiling the app successfully with `./gradlew compileDefaultDebugKotlin --no-build-cache` and ensuring the unit tests run. The changes were also code-reviewed successfully.

✨ **Result:** Improved code health by removing unnecessary boilerplate while preserving the exact intended behavior of triggering the action after the text changes.

---
*PR created automatically by Jules for task [5437477169829426329](https://jules.google.com/task/5437477169829426329) started by @dogi*