### PR TITLE
teams: less calendar day click listener is more (fixes #13662)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5600
-        versionName = "0.56.0"
+        versionCode = 5605
+        versionName = "0.56.5"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/calendar/CalendarFragment.kt
@@ -6,8 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.applandeo.materialcalendarview.CalendarDay
-import com.applandeo.materialcalendarview.listeners.OnCalendarDayClickListener
 import java.util.Calendar
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentCalendarBinding
@@ -24,10 +22,6 @@ class CalendarFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentCalendarBinding.inflate(inflater, container, false)
-        binding.calendarView.setOnCalendarDayClickListener(object : OnCalendarDayClickListener {
-            override fun onClick(calendarDay: CalendarDay) {
-            }
-        })
         val calendar = Calendar.getInstance()
         binding.calendarView.setDate(calendar.time)
         return binding.root


### PR DESCRIPTION
🎯 **What:** Removed the empty `OnCalendarDayClickListener` override in `app/src/main/java/org/ole/planet/myplanet/ui/calendar/CalendarFragment.kt` and its corresponding unused imports.
💡 **Why:** Empty override methods typically indicate missing implementation or unnecessary overrides. Since the application doesn't do anything upon click within `CalendarFragment`, the listener was essentially dead code and added needless verbosity. This improves the codebase's maintainability by removing obsolete code.
✅ **Verification:** Ran successful `./gradlew compileDefaultDebugKotlin --no-build-cache` and verified correctness through unit tests and automated code review validation.
✨ **Result:** Cleaned up code and improved readability.

---
*PR created automatically by Jules for task [781984530392247782](https://jules.google.com/task/781984530392247782) started by @dogi*