### PR TITLE
chat: smoother repository history list bulk inserting (fixes #13663)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,13 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-<<<<<<< perf-batch-insert-chat-history-10303884226472882223
         versionCode = 5606
         versionName = "0.56.6"
-=======
-        versionCode = 5605
-        versionName = "0.56.5"
->>>>>>> master
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5600
-        versionName = "0.56.0"
+        versionCode = 5606
+        versionName = "0.56.6"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -117,13 +117,29 @@ class ChatRepositoryImpl @Inject constructor(
                 docs.add(jsonDoc)
             }
         }
-        docs.forEach { insertChatHistory(realm, it) }
+
+        val ids = docs.map { JsonUtils.getString("_id", it) }.toTypedArray()
+        if (ids.isNotEmpty()) {
+            realm.where(RealmChatHistory::class.java)
+                .`in`("_id", ids)
+                .findAll()
+                .deleteAllFromRealm()
+        }
+
+        docs.forEach { json ->
+            val chatHistoryId = JsonUtils.getString("_id", json)
+            createAndPopulateChatHistory(realm, chatHistoryId, json)
+        }
     }
 
     private fun insertChatHistory(realm: io.realm.Realm, json: JsonObject) {
         val chatHistoryId = JsonUtils.getString("_id", json)
         val existingChatHistory = realm.where(RealmChatHistory::class.java).equalTo("_id", chatHistoryId).findFirst()
         existingChatHistory?.deleteFromRealm()
+        createAndPopulateChatHistory(realm, chatHistoryId, json)
+    }
+
+    private fun createAndPopulateChatHistory(realm: io.realm.Realm, chatHistoryId: String, json: JsonObject) {
         val chatHistory = realm.createObject(RealmChatHistory::class.java, chatHistoryId)
         chatHistory._rev = JsonUtils.getString("_rev", json)
         chatHistory._id = JsonUtils.getString("_id", json)


### PR DESCRIPTION
💡 **What:** Refactored `bulkInsertFromSync` in `ChatRepositoryImpl` to use batch operations. It extracts all the valid document IDs and performs a single `realm.where().in("_id", ids).findAll().deleteAllFromRealm()` query instead of iterating through the JSON array and invoking an individual query-and-delete transaction for every document.

🎯 **Why:** The previous implementation suffered from an N+1 query issue during bulk document insertion because it processed `insertChatHistory` recursively for each item inside the array. By shifting the read/delete steps outside the individual loop and creating a single batch deletion before looping for direct creation/population, we greatly reduce database round-trips and memory overhead caused by repeated transactions, queries, and locks.

📊 **Measured Improvement:** 
Due to environment limitations and the lack of native Realm binary support in the test sandbox environment (which utilizes Robolectric), calculating the exact performance benchmark locally using mock frameworks throws `MissingLibraryException` errors. However, the logical analysis confirms an optimization from O(N) database reads and O(N) database deletions to O(1) read/deletion and O(N) insertions. The batch implementation is an established standard approach for mitigating N+1 query issues during array syncing loops.

---
*PR created automatically by Jules for task [10303884226472882223](https://jules.google.com/task/10303884226472882223) started by @dogi*