### PR TITLE
all: less lifecycle callbacks is more (fixes #13669)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5600
-        versionName = "0.56.0"
+        versionCode = 5614
+        versionName = "0.56.14"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -60,12 +60,15 @@ import org.ole.planet.myplanet.utils.MarkdownUtils
 import org.ole.planet.myplanet.utils.NetworkUtils.isNetworkConnectedFlow
 import org.ole.planet.myplanet.utils.NetworkUtils.startListenNetworkState
 import org.ole.planet.myplanet.utils.NetworkUtils.stopListenNetworkState
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import org.ole.planet.myplanet.utils.SecurePrefs
 import org.ole.planet.myplanet.utils.ThemeMode
 import org.ole.planet.myplanet.utils.VersionUtils.getVersionName
 
 @HiltAndroidApp
-class MainApplication : Application(), Application.ActivityLifecycleCallbacks, WorkManagerConfiguration.Provider {
+class MainApplication : Application(), WorkManagerConfiguration.Provider {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
@@ -218,8 +221,6 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
     }
 
     private var mainThreadRealm: io.realm.Realm? = null
-    private var activityReferences = 0
-    private var isActivityChangingConfigurations = false
     private var isFirstLaunch = true
     private lateinit var anrWatchdog: ANRWatchdog
 
@@ -356,7 +357,11 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
     }
 
     private fun setupLifecycleCallbacks() {
-        registerActivityLifecycleCallbacks(this)
+        ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) {
+                onAppForegrounded()
+            }
+        })
         onAppStarted()
     }
 
@@ -443,31 +448,6 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
     private fun getCurrentThemeMode(): String {
         return ThemeManager.getCurrentThemeMode(context)
     }
-
-    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
-
-    override fun onActivityStarted(activity: Activity) {
-        if (++activityReferences == 1 && !isActivityChangingConfigurations) {
-            onAppForegrounded()
-        }
-    }
-
-    override fun onActivityResumed(activity: Activity) {
-        if (isFirstLaunch) {
-            isFirstLaunch = false
-        }
-    }
-
-    override fun onActivityPaused(activity: Activity) {}
-
-    override fun onActivityStopped(activity: Activity) {
-        isActivityChangingConfigurations = activity.isChangingConfigurations
-        --activityReferences
-    }
-
-    override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {}
-
-    override fun onActivityDestroyed(activity: Activity) {}
 
     private fun onAppForegrounded() {
         if (isFirstLaunch) {


### PR DESCRIPTION
🎯 **What:** The `MainApplication` class contained multiple empty `onActivity*` overrides (such as `onActivityPaused`, `onActivityDestroyed`, etc.) and manually tracked `activityReferences` to detect app foregrounding. This was refactored to use `ProcessLifecycleOwner` and `DefaultLifecycleObserver`.
💡 **Why:** `ProcessLifecycleOwner` is the modern Jetpack standard for determining app-level foreground/background state. This change eliminates the need to implement the cumbersome `Application.ActivityLifecycleCallbacks` directly on the Application class, entirely removing the empty override code smell and simplifying state tracking.
✅ **Verification:** Verified the removal of the empty overrides, ensured the `onAppForegrounded` logic correctly mapped to `onStart` within the `DefaultLifecycleObserver`, and ran `./gradlew compileDefaultDebugKotlin --offline` and `./gradlew testDefaultDebugUnitTest` to confirm the application builds and tests pass successfully.
✨ **Result:** A cleaner, more maintainable `MainApplication` class with fewer empty methods and standard, robust Jetpack lifecycle management.

---
*PR created automatically by Jules for task [2625049672798709364](https://jules.google.com/task/2625049672798709364) started by @dogi*