### PR TITLE
🧹 Refactor MyHealthFragment TextWatcher to use doAfterTextChanged

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -16,6 +16,7 @@ import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.core.content.ContextCompat
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -315,39 +316,34 @@ class MyHealthFragment : Fragment() {
     }
 
     private fun setTextWatcher(etSearch: EditText, btnAddMember: Button, rv: RecyclerView) {
-        textWatcher = object : TextWatcher {
-            override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
-            override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
-            override fun afterTextChanged(editable: Editable) {
-                searchJob?.cancel()
-                searchJob = viewLifecycleOwner.lifecycleScope.launch {
-                    delay(300)
-                    val loadingJob = launch(dispatcherProvider.main) {
-                        delay(100)
-                        alertHealthListBinding?.searchProgress?.visibility = View.VISIBLE
-                        rv.visibility = View.GONE
-                    }
+        textWatcher = etSearch.doAfterTextChanged { editable ->
+            searchJob?.cancel()
+            searchJob = viewLifecycleOwner.lifecycleScope.launch {
+                delay(300)
+                val loadingJob = launch(dispatcherProvider.main) {
+                    delay(100)
+                    alertHealthListBinding?.searchProgress?.visibility = View.VISIBLE
+                    rv.visibility = View.GONE
+                }
 
-                    val userModelList = userRepository.searchUsers(editable.toString(), "joinDate", Sort.DESCENDING)
+                val userModelList = userRepository.searchUsers(editable.toString(), "joinDate", Sort.DESCENDING)
 
-                    loadingJob.cancel()
-                    if (isAdded) {
-                        alertHealthListBinding?.searchProgress?.visibility = View.GONE
-                        rv.visibility = View.VISIBLE
-                        val searchAdapter = HealthUsersAdapter { selected ->
-                            userId = if (selected._id.isNullOrEmpty()) selected.id else selected._id
-                            getHealthRecords(userId)
-                            dialog?.dismiss()
-                        }
-                        searchAdapter.submitList(userModelList)
-                        rv.adapter = searchAdapter
-                        btnAddMember.visibility =
-                            if (userModelList.isEmpty()) View.VISIBLE else View.GONE
+                loadingJob.cancel()
+                if (isAdded) {
+                    alertHealthListBinding?.searchProgress?.visibility = View.GONE
+                    rv.visibility = View.VISIBLE
+                    val searchAdapter = HealthUsersAdapter { selected ->
+                        userId = if (selected._id.isNullOrEmpty()) selected.id else selected._id
+                        getHealthRecords(userId)
+                        dialog?.dismiss()
                     }
+                    searchAdapter.submitList(userModelList)
+                    rv.adapter = searchAdapter
+                    btnAddMember.visibility =
+                        if (userModelList.isEmpty()) View.VISIBLE else View.GONE
                 }
             }
         }
-        etSearch.addTextChangedListener(textWatcher)
     }
 
     override fun onResume() {


### PR DESCRIPTION
🎯 **What:** Replaced the anonymous `TextWatcher` object in `setTextWatcher` with the `doAfterTextChanged` Kotlin extension function in `MyHealthFragment.kt`. Added the required import and removed the explicit `addTextChangedListener` call.

💡 **Why:** The previous `TextWatcher` implementation contained empty `beforeTextChanged` and `onTextChanged` override methods. Using `doAfterTextChanged` eliminates this boilerplate, making the code more idiomatic, readable, and concise.

✅ **Verification:** Verified that the code compiles successfully (`./gradlew compileDefaultDebugKotlin --no-build-cache --offline`) and runs related unit tests (`./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.ui.health.*"`). The `doAfterTextChanged` function handles listener attachment internally, ensuring no logic or functionality is lost.

✨ **Result:** Improved code health by removing empty overrides and leveraging Android KTX extensions without changing behavior.

---
*PR created automatically by Jules for task [17360270472721555005](https://jules.google.com/task/17360270472721555005) started by @dogi*