### PR TITLE
teams: smoother events repository testing (fixes #13682)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5627
-        versionName = "0.56.27"
+        versionCode = 5628
+        versionName = "0.56.28"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5600
-        versionName = "0.56.0"
+        versionCode = 5626
+        versionName = "0.56.26"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
@@ -1,0 +1,189 @@
+package org.ole.planet.myplanet.repository
+
+import com.google.gson.JsonObject
+import io.mockk.*
+import io.realm.Realm
+import io.realm.RealmQuery
+import io.realm.RealmResults
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.RealmUser
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventsRepositoryImplTest {
+
+    private lateinit var databaseService: DatabaseService
+    private lateinit var repository: EventsRepositoryImpl
+    private lateinit var mockRealm: Realm
+
+    @Before
+    fun setup() {
+        mockRealm = mockk(relaxed = true)
+        databaseService = mockk(relaxed = true)
+
+        coEvery { databaseService.withRealmAsync<Any>(any()) } answers {
+            val operation = firstArg<(Realm) -> Any>()
+            operation(mockRealm)
+        }
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val operation = firstArg<(Realm) -> Unit>()
+            operation(mockRealm)
+        }
+
+        repository = EventsRepositoryImpl(databaseService, UnconfinedTestDispatcher())
+    }
+
+    @Test
+    fun getMeetupsForTeam() = runTest {
+        val mockResults = mockk<RealmResults<RealmMeetup>>(relaxed = true)
+        val mockQuery = mockk<RealmQuery<RealmMeetup>>(relaxed = true)
+        every { mockRealm.where(RealmMeetup::class.java) } returns mockQuery
+        every { mockQuery.equalTo("teamId", "team1") } returns mockQuery
+        every { mockQuery.findAll() } returns mockResults
+        every { mockRealm.copyFromRealm(mockResults) } returns listOf(RealmMeetup().apply { id = "1" })
+
+        val result = repository.getMeetupsForTeam("team1")
+
+        assertEquals(1, result.size)
+        assertEquals("1", result[0].id)
+    }
+
+    @Test
+    fun getMeetupById() = runTest {
+        val mockQuery = mockk<RealmQuery<RealmMeetup>>(relaxed = true)
+        val mockMeetup = RealmMeetup().apply { meetupId = "meetup1" }
+        every { mockRealm.where(RealmMeetup::class.java) } returns mockQuery
+        every { mockQuery.equalTo("meetupId", "meetup1") } returns mockQuery
+        every { mockQuery.findFirst() } returns mockMeetup
+        every { mockRealm.copyFromRealm(mockMeetup) } returns mockMeetup
+
+        val result = repository.getMeetupById("meetup1")
+        assertNotNull(result)
+        assertEquals("meetup1", result?.meetupId)
+
+        val emptyResult = repository.getMeetupById("")
+        assertNull(emptyResult)
+    }
+
+    @Test
+    fun getJoinedMembers() = runTest {
+        val mockResults = mockk<RealmResults<RealmMeetup>>(relaxed = true)
+        val mockQuery = mockk<RealmQuery<RealmMeetup>>(relaxed = true)
+        val mockUserResults = mockk<RealmResults<RealmUser>>(relaxed = true)
+        val mockUserQuery = mockk<RealmQuery<RealmUser>>(relaxed = true)
+
+        val meetupMember1 = mockk<RealmMeetup>(relaxed = true)
+        every { meetupMember1.userId } returns "user1"
+        val meetupMember2 = mockk<RealmMeetup>(relaxed = true)
+        every { meetupMember2.userId } returns "user2"
+        val meetupMember3 = mockk<RealmMeetup>(relaxed = true)
+        every { meetupMember3.userId } returns "user1" // duplicate
+
+        every { mockRealm.where(RealmMeetup::class.java) } returns mockQuery
+        every { mockQuery.equalTo("meetupId", "meetup1") } returns mockQuery
+        every { mockQuery.isNotEmpty("userId") } returns mockQuery
+        every { mockQuery.findAll() } returns mockResults
+        every { mockRealm.copyFromRealm(mockResults) } returns listOf(meetupMember1, meetupMember2, meetupMember3)
+
+        every { mockRealm.where(RealmUser::class.java) } returns mockUserQuery
+        every { mockUserQuery.`in`("id", arrayOf("user1", "user2")) } returns mockUserQuery
+        every { mockUserQuery.findAll() } returns mockUserResults
+        every { mockRealm.copyFromRealm(mockUserResults) } returns listOf(RealmUser().apply { id = "user1" }, RealmUser().apply { id = "user2" })
+
+        val result = repository.getJoinedMembers("meetup1")
+
+        assertEquals(2, result.size)
+        assertEquals("user1", result[0].id)
+        assertEquals("user2", result[1].id)
+
+        val emptyResult = repository.getJoinedMembers("")
+        assertTrue(emptyResult.isEmpty())
+    }
+
+    @Test
+    fun toggleAttendance() = runTest {
+        val mockQuery = mockk<RealmQuery<RealmMeetup>>(relaxed = true)
+        val mockMeetup = mockk<RealmMeetup>(relaxed = true)
+        val mockMeetupQueryFirst = mockk<RealmMeetup>(relaxed = true)
+
+        // Setup for update
+        every { mockRealm.where(RealmMeetup::class.java) } returns mockQuery
+        every { mockQuery.equalTo("meetupId", "meetup1") } returns mockQuery
+        every { mockQuery.findFirst() } returns mockMeetupQueryFirst
+        every { mockRealm.copyFromRealm(mockMeetupQueryFirst) } returns mockMeetupQueryFirst
+
+        // Setup for getMeetupById
+        every { mockRealm.copyFromRealm(mockMeetup) } returns mockMeetup
+
+        // Test joining
+        every { mockMeetupQueryFirst.userId } returns ""
+        val joinResult = repository.toggleAttendance("meetup1", "user1")
+        verify { mockMeetupQueryFirst.userId = "user1" }
+        assertNotNull(joinResult)
+
+        // Test leaving
+        every { mockMeetupQueryFirst.userId } returns "user1"
+        val leaveResult = repository.toggleAttendance("meetup1", "user1")
+        verify { mockMeetupQueryFirst.userId = "" }
+        assertNotNull(leaveResult)
+
+        // Test empty id
+        val emptyResult = repository.toggleAttendance("", "user1")
+        assertNull(emptyResult)
+    }
+
+    @Test
+    fun batchInsertMeetups() = runTest {
+        mockkObject(RealmMeetup.Companion)
+        val docs = listOf(JsonObject(), JsonObject())
+
+        every { RealmMeetup.insert(any(), any()) } just Runs
+
+        val count = repository.batchInsertMeetups(docs)
+        assertEquals(2, count)
+
+        verify(exactly = 2) { RealmMeetup.insert(mockRealm, any()) }
+        unmockkObject(RealmMeetup.Companion)
+    }
+
+    @Test
+    fun batchInsertMeetupsException() = runTest {
+        mockkObject(RealmMeetup.Companion)
+        val docs = listOf(JsonObject(), JsonObject())
+
+        every { RealmMeetup.insert(any(), any()) } throws Exception("Test Exception")
+
+        val count = repository.batchInsertMeetups(docs)
+        assertEquals(0, count)
+
+        verify(exactly = 2) { RealmMeetup.insert(mockRealm, any()) }
+        unmockkObject(RealmMeetup.Companion)
+    }
+
+    @Test
+    fun createMeetup() = runTest {
+        val meetup = RealmMeetup()
+        every { mockRealm.copyToRealmOrUpdate(meetup) } returns meetup
+
+        val result = repository.createMeetup(meetup)
+        assertTrue(result)
+        verify { mockRealm.copyToRealmOrUpdate(meetup) }
+    }
+
+    @Test
+    fun createMeetupException() = runTest {
+        val meetup = RealmMeetup()
+        every { mockRealm.copyToRealmOrUpdate(meetup) } throws Exception("Test Exception")
+
+        val result = repository.createMeetup(meetup)
+        assertFalse(result)
+        verify { mockRealm.copyToRealmOrUpdate(meetup) }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
@@ -22,6 +22,13 @@ class EventsRepositoryImplTest {
     private lateinit var repository: EventsRepositoryImpl
     private lateinit var mockRealm: Realm
 
+    // A silent exception to avoid cluttering test logs with stack traces
+    class SilentException(message: String) : Exception(message) {
+        override fun printStackTrace() {
+            // Do nothing
+        }
+    }
+
     @Before
     fun setup() {
         mockRealm = mockk(relaxed = true)
@@ -158,7 +165,7 @@ class EventsRepositoryImplTest {
         mockkObject(RealmMeetup.Companion)
         val docs = listOf(JsonObject(), JsonObject())
 
-        every { RealmMeetup.insert(any(), any()) } throws Exception("Test Exception")
+        every { RealmMeetup.insert(any(), any()) } throws SilentException("Test Exception")
 
         val count = repository.batchInsertMeetups(docs)
         assertEquals(0, count)
@@ -180,7 +187,7 @@ class EventsRepositoryImplTest {
     @Test
     fun createMeetupException() = runTest {
         val meetup = RealmMeetup()
-        every { mockRealm.copyToRealmOrUpdate(meetup) } throws Exception("Test Exception")
+        every { mockRealm.copyToRealmOrUpdate(meetup) } throws SilentException("Test Exception")
 
         val result = repository.createMeetup(meetup)
         assertFalse(result)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
@@ -171,38 +171,33 @@ class EventsRepositoryImplTest {
         coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
             transactionSlot.captured.invoke(mockRealm)
         }
-        every { RealmMeetup.insert(any(), any()) } just Runs
+        every { RealmMeetup.insertList(any(), any(), any()) } just Runs
 
         val count = repository.batchInsertMeetups(docs)
         assertEquals(2, count)
 
-        verify(exactly = 2) { RealmMeetup.insert(mockRealm, any()) }
+        verify(exactly = 1) { RealmMeetup.insertList(mockRealm, "", docs) }
         unmockkObject(RealmMeetup.Companion)
     }
 
     @Test
-    fun batchInsertMeetupsPartialException() = runTest {
+    fun batchInsertMeetupsInnerException() = runTest {
         val mockRealm = mockk<Realm>(relaxed = true)
         mockkObject(RealmMeetup.Companion)
-
-        val doc1 = JsonObject().apply { addProperty("id", "1") }
-        val doc2 = JsonObject().apply { addProperty("id", "2") }
-        val docs = listOf(doc1, doc2)
+        val docs = listOf(JsonObject(), JsonObject())
 
         val transactionSlot = slot<Function1<Realm, Unit>>()
         coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
             transactionSlot.captured.invoke(mockRealm)
         }
 
-        // Fail on second doc
-        every { RealmMeetup.insert(mockRealm, doc1) } just Runs
-        every { RealmMeetup.insert(mockRealm, doc2) } throws SilentException("Test Exception")
+        // Fail during insertList
+        every { RealmMeetup.insertList(mockRealm, "", docs) } throws SilentException("Inner Exception")
 
         val count = repository.batchInsertMeetups(docs)
-        assertEquals(1, count)
+        assertEquals(0, count)
 
-        verify(exactly = 1) { RealmMeetup.insert(mockRealm, doc1) }
-        verify(exactly = 1) { RealmMeetup.insert(mockRealm, doc2) }
+        verify(exactly = 1) { RealmMeetup.insertList(mockRealm, "", docs) }
         unmockkObject(RealmMeetup.Companion)
     }
 
@@ -218,7 +213,7 @@ class EventsRepositoryImplTest {
         val count = repository.batchInsertMeetups(docs)
         assertEquals(0, count)
 
-        verify(exactly = 0) { RealmMeetup.insert(mockRealm, any()) }
+        verify(exactly = 0) { RealmMeetup.insertList(any(), any(), any()) }
         unmockkObject(RealmMeetup.Companion)
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
@@ -20,7 +20,6 @@ class EventsRepositoryImplTest {
 
     private lateinit var databaseService: DatabaseService
     private lateinit var repository: EventsRepositoryImpl
-    private lateinit var mockRealm: Realm
 
     // A silent exception to avoid cluttering test logs with stack traces
     class SilentException(message: String) : Exception(message) {
@@ -31,30 +30,24 @@ class EventsRepositoryImplTest {
 
     @Before
     fun setup() {
-        mockRealm = mockk(relaxed = true)
         databaseService = mockk(relaxed = true)
-
-        coEvery { databaseService.withRealmAsync<Any>(any()) } answers {
-            val operation = firstArg<(Realm) -> Any>()
-            operation(mockRealm)
-        }
-
-        coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val operation = firstArg<(Realm) -> Unit>()
-            operation(mockRealm)
-        }
-
         repository = EventsRepositoryImpl(databaseService, UnconfinedTestDispatcher())
     }
 
     @Test
     fun getMeetupsForTeam() = runTest {
+        val mockRealm = mockk<Realm>(relaxed = true)
         val mockResults = mockk<RealmResults<RealmMeetup>>(relaxed = true)
         val mockQuery = mockk<RealmQuery<RealmMeetup>>(relaxed = true)
         every { mockRealm.where(RealmMeetup::class.java) } returns mockQuery
         every { mockQuery.equalTo("teamId", "team1") } returns mockQuery
         every { mockQuery.findAll() } returns mockResults
         every { mockRealm.copyFromRealm(mockResults) } returns listOf(RealmMeetup().apply { id = "1" })
+
+        val operationSlot = slot<Function1<Realm, List<RealmMeetup>>>()
+        coEvery { databaseService.withRealmAsync(capture(operationSlot)) } answers {
+            operationSlot.captured.invoke(mockRealm)
+        }
 
         val result = repository.getMeetupsForTeam("team1")
 
@@ -64,12 +57,18 @@ class EventsRepositoryImplTest {
 
     @Test
     fun getMeetupById() = runTest {
+        val mockRealm = mockk<Realm>(relaxed = true)
         val mockQuery = mockk<RealmQuery<RealmMeetup>>(relaxed = true)
         val mockMeetup = RealmMeetup().apply { meetupId = "meetup1" }
         every { mockRealm.where(RealmMeetup::class.java) } returns mockQuery
         every { mockQuery.equalTo("meetupId", "meetup1") } returns mockQuery
         every { mockQuery.findFirst() } returns mockMeetup
         every { mockRealm.copyFromRealm(mockMeetup) } returns mockMeetup
+
+        val operationSlot = slot<Function1<Realm, RealmMeetup?>>()
+        coEvery { databaseService.withRealmAsync(capture(operationSlot)) } answers {
+            operationSlot.captured.invoke(mockRealm)
+        }
 
         val result = repository.getMeetupById("meetup1")
         assertNotNull(result)
@@ -81,6 +80,7 @@ class EventsRepositoryImplTest {
 
     @Test
     fun getJoinedMembers() = runTest {
+        val mockRealm = mockk<Realm>(relaxed = true)
         val mockResults = mockk<RealmResults<RealmMeetup>>(relaxed = true)
         val mockQuery = mockk<RealmQuery<RealmMeetup>>(relaxed = true)
         val mockUserResults = mockk<RealmResults<RealmUser>>(relaxed = true)
@@ -104,6 +104,11 @@ class EventsRepositoryImplTest {
         every { mockUserQuery.findAll() } returns mockUserResults
         every { mockRealm.copyFromRealm(mockUserResults) } returns listOf(RealmUser().apply { id = "user1" }, RealmUser().apply { id = "user2" })
 
+        val operationSlot = slot<Function1<Realm, List<RealmUser>>>()
+        coEvery { databaseService.withRealmAsync(capture(operationSlot)) } answers {
+            operationSlot.captured.invoke(mockRealm)
+        }
+
         val result = repository.getJoinedMembers("meetup1")
 
         assertEquals(2, result.size)
@@ -116,6 +121,7 @@ class EventsRepositoryImplTest {
 
     @Test
     fun toggleAttendance() = runTest {
+        val mockRealm = mockk<Realm>(relaxed = true)
         val mockQuery = mockk<RealmQuery<RealmMeetup>>(relaxed = true)
         val mockMeetup = mockk<RealmMeetup>(relaxed = true)
         val mockMeetupQueryFirst = mockk<RealmMeetup>(relaxed = true)
@@ -128,6 +134,15 @@ class EventsRepositoryImplTest {
 
         // Setup for getMeetupById
         every { mockRealm.copyFromRealm(mockMeetup) } returns mockMeetup
+
+        val transactionSlot = slot<Function1<Realm, Unit>>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(mockRealm)
+        }
+        val operationSlot = slot<Function1<Realm, RealmMeetup?>>()
+        coEvery { databaseService.withRealmAsync(capture(operationSlot)) } answers {
+            operationSlot.captured.invoke(mockRealm)
+        }
 
         // Test joining
         every { mockMeetupQueryFirst.userId } returns ""
@@ -148,9 +163,14 @@ class EventsRepositoryImplTest {
 
     @Test
     fun batchInsertMeetups() = runTest {
+        val mockRealm = mockk<Realm>(relaxed = true)
         mockkObject(RealmMeetup.Companion)
         val docs = listOf(JsonObject(), JsonObject())
 
+        val transactionSlot = slot<Function1<Realm, Unit>>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(mockRealm)
+        }
         every { RealmMeetup.insert(any(), any()) } just Runs
 
         val count = repository.batchInsertMeetups(docs)
@@ -161,21 +181,55 @@ class EventsRepositoryImplTest {
     }
 
     @Test
+    fun batchInsertMeetupsPartialException() = runTest {
+        val mockRealm = mockk<Realm>(relaxed = true)
+        mockkObject(RealmMeetup.Companion)
+
+        val doc1 = JsonObject().apply { addProperty("id", "1") }
+        val doc2 = JsonObject().apply { addProperty("id", "2") }
+        val docs = listOf(doc1, doc2)
+
+        val transactionSlot = slot<Function1<Realm, Unit>>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(mockRealm)
+        }
+
+        // Fail on second doc
+        every { RealmMeetup.insert(mockRealm, doc1) } just Runs
+        every { RealmMeetup.insert(mockRealm, doc2) } throws SilentException("Test Exception")
+
+        val count = repository.batchInsertMeetups(docs)
+        assertEquals(1, count)
+
+        verify(exactly = 1) { RealmMeetup.insert(mockRealm, doc1) }
+        verify(exactly = 1) { RealmMeetup.insert(mockRealm, doc2) }
+        unmockkObject(RealmMeetup.Companion)
+    }
+
+    @Test
     fun batchInsertMeetupsException() = runTest {
+        val mockRealm = mockk<Realm>(relaxed = true)
         mockkObject(RealmMeetup.Companion)
         val docs = listOf(JsonObject(), JsonObject())
 
-        every { RealmMeetup.insert(any(), any()) } throws SilentException("Test Exception")
+        val transactionSlot = slot<Function1<Realm, Unit>>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } throws SilentException("Outer Exception")
 
         val count = repository.batchInsertMeetups(docs)
         assertEquals(0, count)
 
-        verify(exactly = 2) { RealmMeetup.insert(mockRealm, any()) }
+        verify(exactly = 0) { RealmMeetup.insert(mockRealm, any()) }
         unmockkObject(RealmMeetup.Companion)
     }
 
     @Test
     fun createMeetup() = runTest {
+        val mockRealm = mockk<Realm>(relaxed = true)
+        val transactionSlot = slot<Function1<Realm, Unit>>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(mockRealm)
+        }
+
         val meetup = RealmMeetup()
         every { mockRealm.copyToRealmOrUpdate(meetup) } returns meetup
 
@@ -186,11 +240,13 @@ class EventsRepositoryImplTest {
 
     @Test
     fun createMeetupException() = runTest {
+        val mockRealm = mockk<Realm>(relaxed = true)
+        val transactionSlot = slot<Function1<Realm, Unit>>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } throws SilentException("Test Exception")
+
         val meetup = RealmMeetup()
-        every { mockRealm.copyToRealmOrUpdate(meetup) } throws SilentException("Test Exception")
 
         val result = repository.createMeetup(meetup)
         assertFalse(result)
-        verify { mockRealm.copyToRealmOrUpdate(meetup) }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
@@ -1,18 +1,42 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.coVerify
+import io.realm.Realm
+import io.realm.RealmQuery
+import io.realm.RealmResults
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.RealmUser
+import org.ole.planet.myplanet.utils.AndroidDecrypter
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.JsonUtils
+import org.ole.planet.myplanet.data.applyEqualTo
+import org.ole.planet.myplanet.data.findCopyByField
+import org.ole.planet.myplanet.data.queryList
 
 @ExperimentalCoroutinesApi
 class HealthRepositoryImplTest {
@@ -22,10 +46,49 @@ class HealthRepositoryImplTest {
     private val testDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
     private val databaseService: DatabaseService = mockk(relaxed = true)
+    private val realm: Realm = mockk(relaxed = true)
+    private val healthQuery: RealmQuery<RealmHealthExamination> = mockk(relaxed = true)
+    private val userQuery: RealmQuery<RealmUser> = mockk(relaxed = true)
+    private val healthResults: RealmResults<RealmHealthExamination> = mockk(relaxed = true)
+    private val healthResultsIterable = mutableListOf<RealmHealthExamination>()
 
     @Before
     fun setUp() {
         every { dispatcherProvider.default } returns testDispatcher
+
+        every { databaseService.createManagedRealmInstance() } returns realm
+        coEvery { databaseService.withRealmAsync<Any?>(any()) } answers {
+            val operation = arg<(Realm) -> Any?>(0)
+            operation(realm)
+        }
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val transaction = invocation.args[0] as (Realm) -> Unit
+            transaction(realm)
+        }
+
+        every { realm.where(RealmHealthExamination::class.java) } returns healthQuery
+        every { realm.where(RealmUser::class.java) } returns userQuery
+
+        every { healthQuery.equalTo(any<String>(), any<String>()) } returns healthQuery
+        every { healthQuery.equalTo(any<String>(), any<Boolean>()) } returns healthQuery
+        every { healthQuery.notEqualTo(any<String>(), any<String>()) } returns healthQuery
+        every { healthQuery.`in`(any<String>(), any<Array<String>>()) } returns healthQuery
+        every { healthQuery.findAll() } returns healthResults
+
+        every { userQuery.equalTo(any<String>(), any<String>()) } returns userQuery
+
+        every { healthResults.iterator() } answers { healthResultsIterable.toMutableList().iterator() }
+        every { healthResults.isValid } returns true
+
+        every { realm.copyFromRealm(any<Iterable<RealmHealthExamination>>()) } answers {
+            val list = arg<Iterable<RealmHealthExamination>>(0)
+            list.toList()
+        }
+        every { realm.copyFromRealm(any<RealmHealthExamination>()) } answers { arg<RealmHealthExamination>(0) }
+        every { realm.copyFromRealm(any<RealmUser>()) } answers { arg<RealmUser>(0) }
+
+        mockkStatic("org.ole.planet.myplanet.data.DatabaseServiceKt")
+
         repository = HealthRepositoryImpl(
             databaseService,
             UnconfinedTestDispatcher(),
@@ -33,11 +96,221 @@ class HealthRepositoryImplTest {
         )
     }
 
+    @After
+    fun tearDown() {
+        unmockkObject(AndroidDecrypter)
+        unmockkStatic("org.ole.planet.myplanet.data.DatabaseServiceKt")
+        unmockkStatic(JsonUtils::class)
+        unmockkObject(RealmHealthExamination.Companion)
+    }
+
     @Test
     fun initHealth_uses_dispatcherProvider_default() = testScope.runTest {
+        mockkObject(AndroidDecrypter)
+        every { AndroidDecrypter.generateKey() } returns "test_key"
+
         val result = repository.initHealth()
         advanceUntilIdle()
         assertNotNull(result)
-        io.mockk.verify { dispatcherProvider.default }
+        assertEquals("test_key", result.userKey)
+        assertNotNull(result.profile)
+        verify { dispatcherProvider.default }
+    }
+
+    @Test
+    fun getHealthEntry_returns_user_and_examination() = testScope.runTest {
+        val user = RealmUser()
+        user.id = "user1"
+        val examination = RealmHealthExamination()
+        examination._id = "user1"
+
+        every { realm.findCopyByField(RealmUser::class.java, "id", "user1") } returns user
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "user1") } returns examination
+
+        val result = repository.getHealthEntry("user1")
+        advanceUntilIdle()
+
+        assertEquals(user, result.first)
+        assertEquals(examination, result.second)
+    }
+
+    @Test
+    fun getHealthEntry_fallback_to_userId() = testScope.runTest {
+        val user = RealmUser()
+        user.id = "user1"
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.userId = "user1"
+
+        every { realm.findCopyByField(RealmUser::class.java, "id", "user1") } returns user
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "user1") } returns null
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "userId", "user1") } returns examination
+
+        val result = repository.getHealthEntry("user1")
+        advanceUntilIdle()
+
+        assertEquals(user, result.first)
+        assertEquals(examination, result.second)
+    }
+
+    @Test
+    fun getExaminationById_returns_examination() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "exam1") } returns examination
+
+        val result = repository.getExaminationById("exam1")
+        advanceUntilIdle()
+
+        assertEquals(examination, result)
+    }
+
+    @Test
+    fun getUpdatedHealthExaminations_returns_list() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.isUpdated = true
+
+        healthResultsIterable.clear()
+        healthResultsIterable.add(examination)
+
+        val builderSlot = slot<(RealmQuery<RealmHealthExamination>) -> Unit>()
+        every { realm.queryList(RealmHealthExamination::class.java, capture(builderSlot)) } returns healthResultsIterable
+
+        val result = repository.getUpdatedHealthExaminations()
+        builderSlot.captured.invoke(healthQuery)
+        verify { healthQuery.equalTo("isUpdated", true) }
+        verify { healthQuery.notEqualTo("userId", "") }
+        advanceUntilIdle()
+
+        assertEquals(1, result.size)
+        assertEquals(examination, result[0])
+    }
+
+    @Test
+    fun getUpdatedHealthForUser_returns_list() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.isUpdated = true
+        examination.userId = "user1"
+
+        healthResultsIterable.clear()
+        healthResultsIterable.add(examination)
+
+        val builderSlot = slot<(RealmQuery<RealmHealthExamination>) -> Unit>()
+        every { realm.queryList(RealmHealthExamination::class.java, capture(builderSlot)) } returns healthResultsIterable
+
+        val result = repository.getUpdatedHealthForUser("user1")
+        builderSlot.captured.invoke(healthQuery)
+        verify { healthQuery.equalTo("isUpdated", true) }
+        verify { healthQuery.equalTo("userId", "user1") }
+        advanceUntilIdle()
+
+        assertEquals(1, result.size)
+        assertEquals(examination, result[0])
+    }
+
+    @Test
+    fun markHealthExaminationsUploaded_updates_revisions() = testScope.runTest {
+        val idToRevMap = mapOf("exam1" to "rev1", "exam2" to "rev2")
+        val exam1 = RealmHealthExamination()
+        exam1._id = "exam1"
+        val exam2 = RealmHealthExamination()
+        exam2._id = "exam2"
+
+        healthResultsIterable.clear()
+        healthResultsIterable.add(exam1)
+        healthResultsIterable.add(exam2)
+
+        every { healthQuery.`in`("_id", any<Array<String>>()) } returns healthQuery
+
+        repository.markHealthExaminationsUploaded(idToRevMap)
+        advanceUntilIdle()
+
+        verify { healthQuery.`in`(eq("_id"), match<Array<String>> { it.toSet() == setOf("exam1", "exam2") }) }
+        assertEquals("rev1", exam1._rev)
+        assertEquals(false, exam1.isUpdated)
+        assertEquals("rev2", exam2._rev)
+        assertEquals(false, exam2.isUpdated)
+    }
+
+    @Test
+    fun saveExamination_saves_objects_to_realm() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        val pojo = RealmHealthExamination()
+        val user = RealmUser()
+
+        every { realm.copyToRealmOrUpdate(any<RealmHealthExamination>()) } returns examination
+        every { realm.copyToRealmOrUpdate(any<RealmUser>()) } returns user
+
+        repository.saveExamination(examination, pojo, user)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(user) }
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(pojo) }
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(examination) }
+    }
+
+    @Test
+    fun saveExamination_handles_nulls() = testScope.runTest {
+        val examination = RealmHealthExamination()
+
+        every { realm.copyToRealmOrUpdate(any<RealmHealthExamination>()) } returns examination
+
+        repository.saveExamination(examination, null, null)
+        advanceUntilIdle()
+
+        verify(exactly = 0) { realm.copyToRealmOrUpdate(any<RealmUser>()) }
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(examination) }
+    }
+
+    @Test
+    fun updateExaminationUserId_updates_id() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.userId = "old_user"
+
+        every { healthQuery.applyEqualTo("_id", "exam1") } returns healthQuery
+        every { healthQuery.findFirst() } returns examination
+
+        repository.updateExaminationUserId("exam1", "new_user")
+        advanceUntilIdle()
+
+        assertEquals("new_user", examination.userId)
+    }
+
+    @Test
+    fun bulkInsertFromSync_inserts_items() = testScope.runTest {
+        mockkStatic(JsonUtils::class)
+        mockkObject(RealmHealthExamination.Companion)
+
+        val jsonArray = JsonArray()
+        val doc1 = JsonObject()
+        doc1.addProperty("_id", "exam1")
+        val item1 = JsonObject()
+        item1.add("doc", doc1)
+
+        val doc2 = JsonObject()
+        doc2.addProperty("_id", "_design/doc")
+        val item2 = JsonObject()
+        item2.add("doc", doc2)
+
+        jsonArray.add(item1)
+        jsonArray.add(item2)
+
+        every { JsonUtils.getJsonObject("doc", item1) } returns doc1
+        every { JsonUtils.getString("_id", doc1) } returns "exam1"
+
+        every { JsonUtils.getJsonObject("doc", item2) } returns doc2
+        every { JsonUtils.getString("_id", doc2) } returns "_design/doc"
+
+        every { RealmHealthExamination.insert(realm, doc1) } returns Unit
+
+        repository.bulkInsertFromSync(realm, jsonArray)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { RealmHealthExamination.insert(realm, doc1) }
+        verify(exactly = 0) { RealmHealthExamination.insert(realm, doc2) }
     }
 }


### PR DESCRIPTION
🎯 **What:** Created a new test file `EventsRepositoryImplTest.kt` to cover `EventsRepositoryImpl`.
📊 **Coverage:** Covered all public methods:
- `getMeetupsForTeam`
- `getMeetupById` (including null cases)
- `getJoinedMembers`
- `toggleAttendance` (join and leave scenarios)
- `batchInsertMeetups` (success and exception scenarios)
- `createMeetup` (success and exception scenarios)
✨ **Result:** Improved unit test coverage for the repository layer by fully testing the Events domain logic, ensuring safe Realm database interactions are maintained.

---
*PR created automatically by Jules for task [12325822086132630631](https://jules.google.com/task/12325822086132630631) started by @dogi*