### PR TITLE
life: smoother personals repository testing (fixes #13686)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5600
-        versionName = "0.56.0"
+        versionCode = 5630
+        versionName = "0.56.30"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5627
-        versionName = "0.56.27"
+        versionCode = 5628
+        versionName = "0.56.28"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
@@ -1,18 +1,42 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.coVerify
+import io.realm.Realm
+import io.realm.RealmQuery
+import io.realm.RealmResults
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.RealmUser
+import org.ole.planet.myplanet.utils.AndroidDecrypter
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.JsonUtils
+import org.ole.planet.myplanet.data.applyEqualTo
+import org.ole.planet.myplanet.data.findCopyByField
+import org.ole.planet.myplanet.data.queryList
 
 @ExperimentalCoroutinesApi
 class HealthRepositoryImplTest {
@@ -22,10 +46,49 @@ class HealthRepositoryImplTest {
     private val testDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
     private val databaseService: DatabaseService = mockk(relaxed = true)
+    private val realm: Realm = mockk(relaxed = true)
+    private val healthQuery: RealmQuery<RealmHealthExamination> = mockk(relaxed = true)
+    private val userQuery: RealmQuery<RealmUser> = mockk(relaxed = true)
+    private val healthResults: RealmResults<RealmHealthExamination> = mockk(relaxed = true)
+    private val healthResultsIterable = mutableListOf<RealmHealthExamination>()
 
     @Before
     fun setUp() {
         every { dispatcherProvider.default } returns testDispatcher
+
+        every { databaseService.createManagedRealmInstance() } returns realm
+        coEvery { databaseService.withRealmAsync<Any?>(any()) } answers {
+            val operation = arg<(Realm) -> Any?>(0)
+            operation(realm)
+        }
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val transaction = invocation.args[0] as (Realm) -> Unit
+            transaction(realm)
+        }
+
+        every { realm.where(RealmHealthExamination::class.java) } returns healthQuery
+        every { realm.where(RealmUser::class.java) } returns userQuery
+
+        every { healthQuery.equalTo(any<String>(), any<String>()) } returns healthQuery
+        every { healthQuery.equalTo(any<String>(), any<Boolean>()) } returns healthQuery
+        every { healthQuery.notEqualTo(any<String>(), any<String>()) } returns healthQuery
+        every { healthQuery.`in`(any<String>(), any<Array<String>>()) } returns healthQuery
+        every { healthQuery.findAll() } returns healthResults
+
+        every { userQuery.equalTo(any<String>(), any<String>()) } returns userQuery
+
+        every { healthResults.iterator() } answers { healthResultsIterable.toMutableList().iterator() }
+        every { healthResults.isValid } returns true
+
+        every { realm.copyFromRealm(any<Iterable<RealmHealthExamination>>()) } answers {
+            val list = arg<Iterable<RealmHealthExamination>>(0)
+            list.toList()
+        }
+        every { realm.copyFromRealm(any<RealmHealthExamination>()) } answers { arg<RealmHealthExamination>(0) }
+        every { realm.copyFromRealm(any<RealmUser>()) } answers { arg<RealmUser>(0) }
+
+        mockkStatic("org.ole.planet.myplanet.data.DatabaseServiceKt")
+
         repository = HealthRepositoryImpl(
             databaseService,
             UnconfinedTestDispatcher(),
@@ -33,11 +96,221 @@ class HealthRepositoryImplTest {
         )
     }
 
+    @After
+    fun tearDown() {
+        unmockkObject(AndroidDecrypter)
+        unmockkStatic("org.ole.planet.myplanet.data.DatabaseServiceKt")
+        unmockkStatic(JsonUtils::class)
+        unmockkObject(RealmHealthExamination.Companion)
+    }
+
     @Test
     fun initHealth_uses_dispatcherProvider_default() = testScope.runTest {
+        mockkObject(AndroidDecrypter)
+        every { AndroidDecrypter.generateKey() } returns "test_key"
+
         val result = repository.initHealth()
         advanceUntilIdle()
         assertNotNull(result)
-        io.mockk.verify { dispatcherProvider.default }
+        assertEquals("test_key", result.userKey)
+        assertNotNull(result.profile)
+        verify { dispatcherProvider.default }
+    }
+
+    @Test
+    fun getHealthEntry_returns_user_and_examination() = testScope.runTest {
+        val user = RealmUser()
+        user.id = "user1"
+        val examination = RealmHealthExamination()
+        examination._id = "user1"
+
+        every { realm.findCopyByField(RealmUser::class.java, "id", "user1") } returns user
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "user1") } returns examination
+
+        val result = repository.getHealthEntry("user1")
+        advanceUntilIdle()
+
+        assertEquals(user, result.first)
+        assertEquals(examination, result.second)
+    }
+
+    @Test
+    fun getHealthEntry_fallback_to_userId() = testScope.runTest {
+        val user = RealmUser()
+        user.id = "user1"
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.userId = "user1"
+
+        every { realm.findCopyByField(RealmUser::class.java, "id", "user1") } returns user
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "user1") } returns null
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "userId", "user1") } returns examination
+
+        val result = repository.getHealthEntry("user1")
+        advanceUntilIdle()
+
+        assertEquals(user, result.first)
+        assertEquals(examination, result.second)
+    }
+
+    @Test
+    fun getExaminationById_returns_examination() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "exam1") } returns examination
+
+        val result = repository.getExaminationById("exam1")
+        advanceUntilIdle()
+
+        assertEquals(examination, result)
+    }
+
+    @Test
+    fun getUpdatedHealthExaminations_returns_list() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.isUpdated = true
+
+        healthResultsIterable.clear()
+        healthResultsIterable.add(examination)
+
+        val builderSlot = slot<(RealmQuery<RealmHealthExamination>) -> Unit>()
+        every { realm.queryList(RealmHealthExamination::class.java, capture(builderSlot)) } returns healthResultsIterable
+
+        val result = repository.getUpdatedHealthExaminations()
+        builderSlot.captured.invoke(healthQuery)
+        verify { healthQuery.equalTo("isUpdated", true) }
+        verify { healthQuery.notEqualTo("userId", "") }
+        advanceUntilIdle()
+
+        assertEquals(1, result.size)
+        assertEquals(examination, result[0])
+    }
+
+    @Test
+    fun getUpdatedHealthForUser_returns_list() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.isUpdated = true
+        examination.userId = "user1"
+
+        healthResultsIterable.clear()
+        healthResultsIterable.add(examination)
+
+        val builderSlot = slot<(RealmQuery<RealmHealthExamination>) -> Unit>()
+        every { realm.queryList(RealmHealthExamination::class.java, capture(builderSlot)) } returns healthResultsIterable
+
+        val result = repository.getUpdatedHealthForUser("user1")
+        builderSlot.captured.invoke(healthQuery)
+        verify { healthQuery.equalTo("isUpdated", true) }
+        verify { healthQuery.equalTo("userId", "user1") }
+        advanceUntilIdle()
+
+        assertEquals(1, result.size)
+        assertEquals(examination, result[0])
+    }
+
+    @Test
+    fun markHealthExaminationsUploaded_updates_revisions() = testScope.runTest {
+        val idToRevMap = mapOf("exam1" to "rev1", "exam2" to "rev2")
+        val exam1 = RealmHealthExamination()
+        exam1._id = "exam1"
+        val exam2 = RealmHealthExamination()
+        exam2._id = "exam2"
+
+        healthResultsIterable.clear()
+        healthResultsIterable.add(exam1)
+        healthResultsIterable.add(exam2)
+
+        every { healthQuery.`in`("_id", any<Array<String>>()) } returns healthQuery
+
+        repository.markHealthExaminationsUploaded(idToRevMap)
+        advanceUntilIdle()
+
+        verify { healthQuery.`in`(eq("_id"), match<Array<String>> { it.toSet() == setOf("exam1", "exam2") }) }
+        assertEquals("rev1", exam1._rev)
+        assertEquals(false, exam1.isUpdated)
+        assertEquals("rev2", exam2._rev)
+        assertEquals(false, exam2.isUpdated)
+    }
+
+    @Test
+    fun saveExamination_saves_objects_to_realm() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        val pojo = RealmHealthExamination()
+        val user = RealmUser()
+
+        every { realm.copyToRealmOrUpdate(any<RealmHealthExamination>()) } returns examination
+        every { realm.copyToRealmOrUpdate(any<RealmUser>()) } returns user
+
+        repository.saveExamination(examination, pojo, user)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(user) }
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(pojo) }
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(examination) }
+    }
+
+    @Test
+    fun saveExamination_handles_nulls() = testScope.runTest {
+        val examination = RealmHealthExamination()
+
+        every { realm.copyToRealmOrUpdate(any<RealmHealthExamination>()) } returns examination
+
+        repository.saveExamination(examination, null, null)
+        advanceUntilIdle()
+
+        verify(exactly = 0) { realm.copyToRealmOrUpdate(any<RealmUser>()) }
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(examination) }
+    }
+
+    @Test
+    fun updateExaminationUserId_updates_id() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.userId = "old_user"
+
+        every { healthQuery.applyEqualTo("_id", "exam1") } returns healthQuery
+        every { healthQuery.findFirst() } returns examination
+
+        repository.updateExaminationUserId("exam1", "new_user")
+        advanceUntilIdle()
+
+        assertEquals("new_user", examination.userId)
+    }
+
+    @Test
+    fun bulkInsertFromSync_inserts_items() = testScope.runTest {
+        mockkStatic(JsonUtils::class)
+        mockkObject(RealmHealthExamination.Companion)
+
+        val jsonArray = JsonArray()
+        val doc1 = JsonObject()
+        doc1.addProperty("_id", "exam1")
+        val item1 = JsonObject()
+        item1.add("doc", doc1)
+
+        val doc2 = JsonObject()
+        doc2.addProperty("_id", "_design/doc")
+        val item2 = JsonObject()
+        item2.add("doc", doc2)
+
+        jsonArray.add(item1)
+        jsonArray.add(item2)
+
+        every { JsonUtils.getJsonObject("doc", item1) } returns doc1
+        every { JsonUtils.getString("_id", doc1) } returns "exam1"
+
+        every { JsonUtils.getJsonObject("doc", item2) } returns doc2
+        every { JsonUtils.getString("_id", doc2) } returns "_design/doc"
+
+        every { RealmHealthExamination.insert(realm, doc1) } returns Unit
+
+        repository.bulkInsertFromSync(realm, jsonArray)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { RealmHealthExamination.insert(realm, doc1) }
+        verify(exactly = 0) { RealmHealthExamination.insert(realm, doc2) }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
@@ -1,0 +1,211 @@
+package org.ole.planet.myplanet.repository
+
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.slot
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.realm.Realm
+import io.realm.RealmQuery
+import io.realm.RealmResults
+import java.util.logging.Level
+import java.util.logging.Logger
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.utils.NetworkUtils
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PersonalsRepositoryImplTest {
+
+    private lateinit var databaseService: DatabaseService
+    private lateinit var mockRealm: Realm
+    private lateinit var repository: PersonalsRepositoryImpl
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setup() {
+        Logger.getLogger("io.mockk").level = Level.OFF
+        mockkStatic(io.realm.log.RealmLog::class)
+        every { io.realm.log.RealmLog.error(any<Throwable>(), any<String>(), *anyVararg()) } just Runs
+        every { io.realm.log.RealmLog.error(any<String>(), *anyVararg()) } just Runs
+
+        databaseService = mockk(relaxed = true)
+        mockRealm = mockk(relaxed = true)
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val transaction = firstArg<(Realm) -> Unit>()
+            transaction(mockRealm)
+        }
+
+        coEvery { databaseService.withRealmAsync<Any>(any()) } answers {
+            val operation = firstArg<(Realm) -> Any>()
+            operation(mockRealm)
+        }
+
+        every { databaseService.createManagedRealmInstance() } returns mockRealm
+        every { databaseService.ioDispatcher } returns testDispatcher
+
+        repository = PersonalsRepositoryImpl(databaseService, testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun mockQueryResults(vararg results: List<RealmMyPersonal>): RealmQuery<RealmMyPersonal> {
+        val mockQuery = mockk<RealmQuery<RealmMyPersonal>>(relaxed = true)
+        val mockResults = mockk<RealmResults<RealmMyPersonal>>(relaxed = true)
+
+        every { mockRealm.where(RealmMyPersonal::class.java) } returns mockQuery
+
+        // Setup fluent return
+        every { mockQuery.equalTo(any<String>(), any<String>()) } returns mockQuery
+        every { mockQuery.equalTo(any<String>(), any<String>(), any()) } returns mockQuery
+        every { mockQuery.equalTo(any<String>(), any<Boolean>()) } returns mockQuery
+        every { mockQuery.findAll() } returns mockResults
+        every { mockQuery.count() } returns (results.firstOrNull()?.size?.toLong() ?: 0L)
+
+        // Map sequential calls to copyFromRealm to different results
+        if (results.size == 1) {
+             every { mockRealm.copyFromRealm(mockResults) } returns results[0]
+        } else if (results.isNotEmpty()) {
+             every { mockRealm.copyFromRealm(mockResults) } returnsMany results.toList()
+        }
+
+        return mockQuery
+    }
+
+    @Test
+    fun `personalTitleExists returns true when title and user match`() = runTest {
+        val mockQuery = mockQueryResults(listOf(RealmMyPersonal()))
+        val result = repository.personalTitleExists("My Title", "user1")
+        assertTrue(result)
+        verify {
+            mockQuery.equalTo("title", "My Title", io.realm.Case.INSENSITIVE)
+            mockQuery.equalTo("userId", "user1")
+        }
+    }
+
+    @Test
+    fun `personalTitleExists returns false when title does not exist`() = runTest {
+        val mockQuery = mockQueryResults(emptyList())
+        val result = repository.personalTitleExists("Missing", null)
+        assertFalse(result)
+        verify {
+            mockQuery.equalTo("title", "Missing", io.realm.Case.INSENSITIVE)
+        }
+        verify(exactly = 0) {
+             mockQuery.equalTo("userId", any<String>())
+        }
+    }
+
+    @Test
+    fun `savePersonalResource sets id and properties before saving`() = runTest {
+        val savedObjectSlot = slot<RealmMyPersonal>()
+        every { mockRealm.copyToRealmOrUpdate(capture(savedObjectSlot)) } returns mockk()
+
+        repository.savePersonalResource(
+            title = "Test Title",
+            userId = "user1",
+            userName = "Test User",
+            path = "/path/to/file",
+            description = "Test Desc"
+        )
+
+        verify { mockRealm.copyToRealmOrUpdate(any<RealmMyPersonal>()) }
+
+        val captured = savedObjectSlot.captured
+        assertEquals("Test Title", captured.title)
+        assertEquals("user1", captured.userId)
+        assertEquals("Test User", captured.userName)
+        assertEquals("/path/to/file", captured.path)
+        assertEquals("Test Desc", captured.description)
+        assertTrue(captured.id != null)
+        assertEquals(captured.id, captured._id)
+    }
+
+    @Test
+    fun `getPersonalResources returns empty flow for null or blank userId`() = runTest {
+        val resultNull = repository.getPersonalResources(null).first()
+        assertTrue(resultNull.isEmpty())
+
+        val resultBlank = repository.getPersonalResources("   ").first()
+        assertTrue(resultBlank.isEmpty())
+    }
+
+    @Test
+    fun `deletePersonalResource deletes both _id and id`() = runTest {
+        val mockQuery = mockQueryResults(listOf(RealmMyPersonal()))
+        val mockPersonal = mockk<RealmMyPersonal>(relaxed = true)
+        every { mockQuery.findFirst() } returns mockPersonal
+
+        repository.deletePersonalResource("test-id")
+
+        verify {
+            mockQuery.equalTo("_id", "test-id")
+            mockQuery.equalTo("id", "test-id")
+            mockPersonal.deleteFromRealm()
+        }
+    }
+
+    @Test
+    fun `updatePersonalResource calls updater on matched _id and id`() = runTest {
+        val mockQuery = mockQueryResults()
+        val mockPersonalId = RealmMyPersonal().apply { title = "Old" }
+        val mockPersonal_Id = RealmMyPersonal().apply { title = "Old" }
+
+        // Setting up mock behavior to return different objects for _id and id calls
+        every { mockQuery.equalTo("_id", "test-id").findFirst() } returns mockPersonal_Id
+        every { mockQuery.equalTo("id", "test-id").findFirst() } returns mockPersonalId
+
+        var updateCount = 0
+        repository.updatePersonalResource("test-id") { personal ->
+            personal.title = "New Title"
+            updateCount++
+        }
+
+        assertEquals(2, updateCount)
+        assertEquals("New Title", mockPersonalId.title)
+        assertEquals("New Title", mockPersonal_Id.title)
+    }
+
+    @Test
+    fun `getPendingPersonalUploads queries correctly`() = runTest {
+        val mockQuery = mockQueryResults(listOf(RealmMyPersonal(), RealmMyPersonal()))
+        val results = repository.getPendingPersonalUploads("user1")
+
+        assertEquals(2, results.size)
+        verify {
+            mockQuery.equalTo("userId", "user1")
+            mockQuery.equalTo("isUploaded", false)
+        }
+    }
+
+    @Test
+    fun `updatePersonalAfterSync updates fields properly`() = runTest {
+        val mockQuery = mockQueryResults()
+        val mockPersonal = RealmMyPersonal()
+        every { mockQuery.equalTo("id", "test-id").findFirst() } returns mockPersonal
+
+        repository.updatePersonalAfterSync("test-id", "new-id", "rev-1")
+
+        assertTrue(mockPersonal.isUploaded)
+        assertEquals("new-id", mockPersonal._id)
+        assertEquals("rev-1", mockPersonal._rev)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
@@ -26,7 +26,6 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.model.RealmMyPersonal
-import org.ole.planet.myplanet.utils.NetworkUtils
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PersonalsRepositoryImplTest {
@@ -149,6 +148,30 @@ class PersonalsRepositoryImplTest {
     }
 
     @Test
+    fun `getPersonalResources returns flow of personals for valid userId`() = runTest {
+        val mockQuery = mockk<RealmQuery<RealmMyPersonal>>(relaxed = true)
+        val initialResults = mockk<RealmResults<RealmMyPersonal>>(relaxed = true)
+        val frozenInitial = mockk<RealmResults<RealmMyPersonal>>(relaxed = true)
+        val frozenRealmInitial = mockk<Realm>(relaxed = true)
+        val expectedList = listOf(RealmMyPersonal())
+
+        every { mockRealm.where(RealmMyPersonal::class.java) } returns mockQuery
+        every { mockQuery.equalTo("userId", "user1") } returns mockQuery
+        every { mockQuery.findAll() } returns initialResults
+
+        every { initialResults.isValid } returns true
+        every { initialResults.isLoaded } returns true
+        every { initialResults.freeze() } returns frozenInitial
+        every { frozenInitial.realm } returns frozenRealmInitial
+        every { frozenRealmInitial.copyFromRealm(frozenInitial) } returns expectedList
+
+        val result = repository.getPersonalResources("user1").first()
+        assertEquals(expectedList, result)
+
+        verify { mockQuery.equalTo("userId", "user1") }
+    }
+
+    @Test
     fun `deletePersonalResource deletes both _id and id`() = runTest {
         val mockQuery = mockQueryResults(listOf(RealmMyPersonal()))
         val mockPersonal = mockk<RealmMyPersonal>(relaxed = true)
@@ -166,12 +189,10 @@ class PersonalsRepositoryImplTest {
     @Test
     fun `updatePersonalResource calls updater on matched _id and id`() = runTest {
         val mockQuery = mockQueryResults()
-        val mockPersonalId = RealmMyPersonal().apply { title = "Old" }
         val mockPersonal_Id = RealmMyPersonal().apply { title = "Old" }
+        val mockPersonalId = RealmMyPersonal().apply { title = "Old" }
 
-        // Setting up mock behavior to return different objects for _id and id calls
-        every { mockQuery.equalTo("_id", "test-id").findFirst() } returns mockPersonal_Id
-        every { mockQuery.equalTo("id", "test-id").findFirst() } returns mockPersonalId
+        every { mockQuery.findFirst() } returnsMany listOf(mockPersonal_Id, mockPersonalId)
 
         var updateCount = 0
         repository.updatePersonalResource("test-id") { personal ->


### PR DESCRIPTION
🎯 **What:** Created a new test file for `PersonalsRepositoryImpl` to address the gap in unit testing coverage.

📊 **Coverage:** The test suite extensively covers expected scenarios:
- `personalTitleExists` (correct and empty user IDs, case-insensitivity)
- `savePersonalResource` (creation and properties assignment)
- `getPersonalResources` (generating proper lists/empty collections depending on user ID validitity)
- `deletePersonalResource` (deleting matches by multiple identifier structures)
- `updatePersonalResource` (updating values matched via multiple identifier structures)
- `getPendingPersonalUploads` (filtering pending status efficiently)
- `updatePersonalAfterSync` (updating flag logic upon completed upload)

✨ **Result:** Enhanced the reliability of `PersonalsRepositoryImpl` ensuring refactors won't cause unexpected regressions around Realm transactions and query generation logic.

---
*PR created automatically by Jules for task [2061724357201662167](https://jules.google.com/task/2061724357201662167) started by @dogi*