### PR TITLE
all: smoother retry repository testing (fixes #13690)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5600
-        versionName = "0.56.0"
+        versionCode = 5630
+        versionName = "0.56.30"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5627
-        versionName = "0.56.27"
+        versionCode = 5628
+        versionName = "0.56.28"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
@@ -1,18 +1,42 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.coVerify
+import io.realm.Realm
+import io.realm.RealmQuery
+import io.realm.RealmResults
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.RealmUser
+import org.ole.planet.myplanet.utils.AndroidDecrypter
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.JsonUtils
+import org.ole.planet.myplanet.data.applyEqualTo
+import org.ole.planet.myplanet.data.findCopyByField
+import org.ole.planet.myplanet.data.queryList
 
 @ExperimentalCoroutinesApi
 class HealthRepositoryImplTest {
@@ -22,10 +46,49 @@ class HealthRepositoryImplTest {
     private val testDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
     private val databaseService: DatabaseService = mockk(relaxed = true)
+    private val realm: Realm = mockk(relaxed = true)
+    private val healthQuery: RealmQuery<RealmHealthExamination> = mockk(relaxed = true)
+    private val userQuery: RealmQuery<RealmUser> = mockk(relaxed = true)
+    private val healthResults: RealmResults<RealmHealthExamination> = mockk(relaxed = true)
+    private val healthResultsIterable = mutableListOf<RealmHealthExamination>()
 
     @Before
     fun setUp() {
         every { dispatcherProvider.default } returns testDispatcher
+
+        every { databaseService.createManagedRealmInstance() } returns realm
+        coEvery { databaseService.withRealmAsync<Any?>(any()) } answers {
+            val operation = arg<(Realm) -> Any?>(0)
+            operation(realm)
+        }
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val transaction = invocation.args[0] as (Realm) -> Unit
+            transaction(realm)
+        }
+
+        every { realm.where(RealmHealthExamination::class.java) } returns healthQuery
+        every { realm.where(RealmUser::class.java) } returns userQuery
+
+        every { healthQuery.equalTo(any<String>(), any<String>()) } returns healthQuery
+        every { healthQuery.equalTo(any<String>(), any<Boolean>()) } returns healthQuery
+        every { healthQuery.notEqualTo(any<String>(), any<String>()) } returns healthQuery
+        every { healthQuery.`in`(any<String>(), any<Array<String>>()) } returns healthQuery
+        every { healthQuery.findAll() } returns healthResults
+
+        every { userQuery.equalTo(any<String>(), any<String>()) } returns userQuery
+
+        every { healthResults.iterator() } answers { healthResultsIterable.toMutableList().iterator() }
+        every { healthResults.isValid } returns true
+
+        every { realm.copyFromRealm(any<Iterable<RealmHealthExamination>>()) } answers {
+            val list = arg<Iterable<RealmHealthExamination>>(0)
+            list.toList()
+        }
+        every { realm.copyFromRealm(any<RealmHealthExamination>()) } answers { arg<RealmHealthExamination>(0) }
+        every { realm.copyFromRealm(any<RealmUser>()) } answers { arg<RealmUser>(0) }
+
+        mockkStatic("org.ole.planet.myplanet.data.DatabaseServiceKt")
+
         repository = HealthRepositoryImpl(
             databaseService,
             UnconfinedTestDispatcher(),
@@ -33,11 +96,221 @@ class HealthRepositoryImplTest {
         )
     }
 
+    @After
+    fun tearDown() {
+        unmockkObject(AndroidDecrypter)
+        unmockkStatic("org.ole.planet.myplanet.data.DatabaseServiceKt")
+        unmockkStatic(JsonUtils::class)
+        unmockkObject(RealmHealthExamination.Companion)
+    }
+
     @Test
     fun initHealth_uses_dispatcherProvider_default() = testScope.runTest {
+        mockkObject(AndroidDecrypter)
+        every { AndroidDecrypter.generateKey() } returns "test_key"
+
         val result = repository.initHealth()
         advanceUntilIdle()
         assertNotNull(result)
-        io.mockk.verify { dispatcherProvider.default }
+        assertEquals("test_key", result.userKey)
+        assertNotNull(result.profile)
+        verify { dispatcherProvider.default }
+    }
+
+    @Test
+    fun getHealthEntry_returns_user_and_examination() = testScope.runTest {
+        val user = RealmUser()
+        user.id = "user1"
+        val examination = RealmHealthExamination()
+        examination._id = "user1"
+
+        every { realm.findCopyByField(RealmUser::class.java, "id", "user1") } returns user
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "user1") } returns examination
+
+        val result = repository.getHealthEntry("user1")
+        advanceUntilIdle()
+
+        assertEquals(user, result.first)
+        assertEquals(examination, result.second)
+    }
+
+    @Test
+    fun getHealthEntry_fallback_to_userId() = testScope.runTest {
+        val user = RealmUser()
+        user.id = "user1"
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.userId = "user1"
+
+        every { realm.findCopyByField(RealmUser::class.java, "id", "user1") } returns user
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "user1") } returns null
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "userId", "user1") } returns examination
+
+        val result = repository.getHealthEntry("user1")
+        advanceUntilIdle()
+
+        assertEquals(user, result.first)
+        assertEquals(examination, result.second)
+    }
+
+    @Test
+    fun getExaminationById_returns_examination() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+
+        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "exam1") } returns examination
+
+        val result = repository.getExaminationById("exam1")
+        advanceUntilIdle()
+
+        assertEquals(examination, result)
+    }
+
+    @Test
+    fun getUpdatedHealthExaminations_returns_list() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.isUpdated = true
+
+        healthResultsIterable.clear()
+        healthResultsIterable.add(examination)
+
+        val builderSlot = slot<(RealmQuery<RealmHealthExamination>) -> Unit>()
+        every { realm.queryList(RealmHealthExamination::class.java, capture(builderSlot)) } returns healthResultsIterable
+
+        val result = repository.getUpdatedHealthExaminations()
+        builderSlot.captured.invoke(healthQuery)
+        verify { healthQuery.equalTo("isUpdated", true) }
+        verify { healthQuery.notEqualTo("userId", "") }
+        advanceUntilIdle()
+
+        assertEquals(1, result.size)
+        assertEquals(examination, result[0])
+    }
+
+    @Test
+    fun getUpdatedHealthForUser_returns_list() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.isUpdated = true
+        examination.userId = "user1"
+
+        healthResultsIterable.clear()
+        healthResultsIterable.add(examination)
+
+        val builderSlot = slot<(RealmQuery<RealmHealthExamination>) -> Unit>()
+        every { realm.queryList(RealmHealthExamination::class.java, capture(builderSlot)) } returns healthResultsIterable
+
+        val result = repository.getUpdatedHealthForUser("user1")
+        builderSlot.captured.invoke(healthQuery)
+        verify { healthQuery.equalTo("isUpdated", true) }
+        verify { healthQuery.equalTo("userId", "user1") }
+        advanceUntilIdle()
+
+        assertEquals(1, result.size)
+        assertEquals(examination, result[0])
+    }
+
+    @Test
+    fun markHealthExaminationsUploaded_updates_revisions() = testScope.runTest {
+        val idToRevMap = mapOf("exam1" to "rev1", "exam2" to "rev2")
+        val exam1 = RealmHealthExamination()
+        exam1._id = "exam1"
+        val exam2 = RealmHealthExamination()
+        exam2._id = "exam2"
+
+        healthResultsIterable.clear()
+        healthResultsIterable.add(exam1)
+        healthResultsIterable.add(exam2)
+
+        every { healthQuery.`in`("_id", any<Array<String>>()) } returns healthQuery
+
+        repository.markHealthExaminationsUploaded(idToRevMap)
+        advanceUntilIdle()
+
+        verify { healthQuery.`in`(eq("_id"), match<Array<String>> { it.toSet() == setOf("exam1", "exam2") }) }
+        assertEquals("rev1", exam1._rev)
+        assertEquals(false, exam1.isUpdated)
+        assertEquals("rev2", exam2._rev)
+        assertEquals(false, exam2.isUpdated)
+    }
+
+    @Test
+    fun saveExamination_saves_objects_to_realm() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        val pojo = RealmHealthExamination()
+        val user = RealmUser()
+
+        every { realm.copyToRealmOrUpdate(any<RealmHealthExamination>()) } returns examination
+        every { realm.copyToRealmOrUpdate(any<RealmUser>()) } returns user
+
+        repository.saveExamination(examination, pojo, user)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(user) }
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(pojo) }
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(examination) }
+    }
+
+    @Test
+    fun saveExamination_handles_nulls() = testScope.runTest {
+        val examination = RealmHealthExamination()
+
+        every { realm.copyToRealmOrUpdate(any<RealmHealthExamination>()) } returns examination
+
+        repository.saveExamination(examination, null, null)
+        advanceUntilIdle()
+
+        verify(exactly = 0) { realm.copyToRealmOrUpdate(any<RealmUser>()) }
+        verify(exactly = 1) { realm.copyToRealmOrUpdate(examination) }
+    }
+
+    @Test
+    fun updateExaminationUserId_updates_id() = testScope.runTest {
+        val examination = RealmHealthExamination()
+        examination._id = "exam1"
+        examination.userId = "old_user"
+
+        every { healthQuery.applyEqualTo("_id", "exam1") } returns healthQuery
+        every { healthQuery.findFirst() } returns examination
+
+        repository.updateExaminationUserId("exam1", "new_user")
+        advanceUntilIdle()
+
+        assertEquals("new_user", examination.userId)
+    }
+
+    @Test
+    fun bulkInsertFromSync_inserts_items() = testScope.runTest {
+        mockkStatic(JsonUtils::class)
+        mockkObject(RealmHealthExamination.Companion)
+
+        val jsonArray = JsonArray()
+        val doc1 = JsonObject()
+        doc1.addProperty("_id", "exam1")
+        val item1 = JsonObject()
+        item1.add("doc", doc1)
+
+        val doc2 = JsonObject()
+        doc2.addProperty("_id", "_design/doc")
+        val item2 = JsonObject()
+        item2.add("doc", doc2)
+
+        jsonArray.add(item1)
+        jsonArray.add(item2)
+
+        every { JsonUtils.getJsonObject("doc", item1) } returns doc1
+        every { JsonUtils.getString("_id", doc1) } returns "exam1"
+
+        every { JsonUtils.getJsonObject("doc", item2) } returns doc2
+        every { JsonUtils.getString("_id", doc2) } returns "_design/doc"
+
+        every { RealmHealthExamination.insert(realm, doc1) } returns Unit
+
+        repository.bulkInsertFromSync(realm, jsonArray)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { RealmHealthExamination.insert(realm, doc1) }
+        verify(exactly = 0) { RealmHealthExamination.insert(realm, doc2) }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
@@ -350,18 +350,12 @@ class RetryRepositoryImplTest {
         every { realm.where(RealmRetryOperation::class.java) } returns query
         every { query.equalTo("status", RealmRetryOperation.STATUS_PENDING) } returns query
         every { query.findAll() } returns results
-        every { results.iterator() } answers { mutableListOf(operation1).iterator() }
-        every { results.size } returns 1
-        every { results[0] } returns operation1
-        every { results.get(0) } returns operation1
-
-
+        every { results.iterator() } answers { mutableListOf(operation1, operation2).iterator() }
 
         repository.resetAllPending()
 
-        verify { query.findAll() }
-        // Note: We cannot easily verify the inline forEach mutation on the mocked list,
-        // but we verify the query was executed.
+        assert(operation1.nextRetryTime > 0)
+        assert(operation2.nextRetryTime > 0)
     }
 
     @Test
@@ -403,11 +397,6 @@ class RetryRepositoryImplTest {
         every { query.equalTo("status", RealmRetryOperation.STATUS_IN_PROGRESS) } returns query
         every { query.findAll() } returns results
         every { results.iterator() } answers { mutableListOf(operation1).iterator() }
-        every { results.size } returns 1
-        every { results[0] } returns operation1
-        every { results.get(0) } returns operation1
-
-
 
         repository.recoverStuckOperations()
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
@@ -1,0 +1,419 @@
+package org.ole.planet.myplanet.repository
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.invoke
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import io.realm.Realm
+import io.realm.RealmQuery
+import io.realm.RealmResults
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.After
+import org.junit.Before
+import java.util.function.Consumer
+import org.junit.Test
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.services.upload.UploadError
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("UNCHECKED_CAST")
+class RetryRepositoryImplTest {
+
+
+
+
+
+    private lateinit var databaseService: DatabaseService
+    private lateinit var repository: RetryRepositoryImpl
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @org.junit.After
+    fun tearDown() {
+        io.mockk.unmockkAll()
+    }
+
+    @Before
+    fun setUp() {
+        databaseService = mockk(relaxed = true)
+        repository = RetryRepositoryImpl(databaseService, testDispatcher)
+    }
+
+    @Test
+    fun `enqueue invokes transaction and creates operation`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val transactionSlot = slot<(Realm) -> Unit>()
+        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(realm)
+        }
+
+        val uploadError = UploadError("itemId", Exception(), retryable = true, httpCode = 500)
+
+        val op = mockk<RealmRetryOperation>(relaxed = true)
+        every { realm.createObject(RealmRetryOperation::class.java, any<String>()) } returns op
+
+
+
+        repository.enqueue(
+            "testUploadType", uploadError, "testPayload", "testEndpoint",
+            "POST", "testDbId", "TestClass", "testUserId"
+        )
+
+        verify { realm.createObject(RealmRetryOperation::class.java, any<String>()) }
+    }
+
+    @Test
+    fun `updateAttempt updates operation fields`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val operation = RealmRetryOperation().apply {
+            attemptCount = 1
+            maxAttempts = 5
+        }
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = invocation.args[0] as Function1<Realm, Unit>
+            block.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("id", "opId") } returns query
+        every { query.findFirst() } returns operation
+
+        val uploadError = UploadError("itemId", Exception("Test Error"), retryable = true, httpCode = 503)
+
+        repository.updateAttempt("opId", uploadError)
+
+        assertEquals(2, operation.attemptCount)
+        assertEquals("Test Error", operation.errorMessage)
+        assertEquals(503, operation.httpCode)
+        // Check nextRetryTime was calculated properly (we assume calculateNextRetryTime sets a future time)
+        assert(operation.nextRetryTime > 0)
+    }
+
+    @Test
+    fun `updateAttempt changes status to abandoned when max attempts reached`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val operation = RealmRetryOperation().apply {
+            attemptCount = 4
+            maxAttempts = 5
+            status = RealmRetryOperation.STATUS_PENDING
+        }
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = invocation.args[0] as Function1<Realm, Unit>
+            block.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("id", "opId") } returns query
+        every { query.findFirst() } returns operation
+
+        val uploadError = UploadError("itemId", Exception(), retryable = false)
+
+        repository.updateAttempt("opId", uploadError)
+
+        assertEquals(5, operation.attemptCount)
+        assertEquals(RealmRetryOperation.STATUS_ABANDONED, operation.status)
+    }
+
+    @Test
+    fun `markInProgress updates status`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val operation = RealmRetryOperation().apply {
+            status = RealmRetryOperation.STATUS_PENDING
+        }
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = invocation.args[0] as Function1<Realm, Unit>
+            block.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("id", "opId") } returns query
+        every { query.findFirst() } returns operation
+
+        repository.markInProgress("opId")
+
+        assertEquals(RealmRetryOperation.STATUS_IN_PROGRESS, operation.status)
+    }
+
+    @Test
+    fun `markCompleted updates status and timestamp`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val operation = RealmRetryOperation().apply {
+            status = RealmRetryOperation.STATUS_PENDING
+            lastAttemptTime = 0
+        }
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = invocation.args[0] as Function1<Realm, Unit>
+            block.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("id", "opId") } returns query
+        every { query.findFirst() } returns operation
+
+        repository.markCompleted("opId")
+
+        assertEquals(RealmRetryOperation.STATUS_COMPLETED, operation.status)
+        assert(operation.lastAttemptTime > 0)
+    }
+
+    @Test
+    fun `markFailed updates status to pending when attempts remain`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val operation = RealmRetryOperation().apply {
+            attemptCount = 1
+            maxAttempts = 5
+            status = RealmRetryOperation.STATUS_IN_PROGRESS
+        }
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = invocation.args[0] as Function1<Realm, Unit>
+            block.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("id", "opId") } returns query
+        every { query.findFirst() } returns operation
+
+        repository.markFailed("opId", "Fail reason", 404)
+
+        assertEquals(2, operation.attemptCount)
+        assertEquals("Fail reason", operation.errorMessage)
+        assertEquals(404, operation.httpCode)
+        assertEquals(RealmRetryOperation.STATUS_PENDING, operation.status)
+        assert(operation.nextRetryTime > 0)
+    }
+
+    @Test
+    fun `markFailed updates status to abandoned when max attempts reached`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val operation = RealmRetryOperation().apply {
+            attemptCount = 4
+            maxAttempts = 5
+            status = RealmRetryOperation.STATUS_IN_PROGRESS
+        }
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = invocation.args[0] as Function1<Realm, Unit>
+            block.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("id", "opId") } returns query
+        every { query.findFirst() } returns operation
+
+        repository.markFailed("opId", "Fail reason", 500)
+
+        assertEquals(5, operation.attemptCount)
+        assertEquals(RealmRetryOperation.STATUS_ABANDONED, operation.status)
+    }
+
+    @Test
+    fun `getPending returns filtered operations`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val results = mockk<RealmResults<RealmRetryOperation>>()
+
+        val operation1 = RealmRetryOperation().apply { attemptCount = 1; maxAttempts = 5 }
+        val operation2 = RealmRetryOperation().apply { attemptCount = 5; maxAttempts = 5 } // should be filtered out
+
+        val list = listOf(operation1, operation2)
+
+        val transactionSlot = slot<(Realm) -> Any>()
+        coEvery { databaseService.withRealmAsync<Any>(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("status", RealmRetryOperation.STATUS_PENDING) } returns query
+        every { query.lessThanOrEqualTo("nextRetryTime", any<Long>()) } returns query
+        every { query.findAll() } returns results
+        every { results.deleteAllFromRealm() } returns true
+        every { results.iterator() } returns list.toMutableList().iterator()
+        every { realm.copyFromRealm(any<Iterable<RealmRetryOperation>>()) } answers {
+            arg<Iterable<RealmRetryOperation>>(0).toList()
+        }
+
+        val pending = repository.getPending()
+
+        assertEquals(1, pending.size)
+        assertEquals(operation1, pending[0])
+    }
+
+    @Test
+    fun `getPendingCount returns correct total count`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+
+        val transactionSlot = slot<(Realm) -> Any>()
+        coEvery { databaseService.withRealmAsync<Any>(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("status", RealmRetryOperation.STATUS_PENDING) } returns query
+        every { query.or() } returns query
+        every { query.equalTo("status", RealmRetryOperation.STATUS_IN_PROGRESS) } returns query
+        every { query.count() } returns 10L
+
+        val count = repository.getPendingCount()
+
+        assertEquals(10L, count)
+    }
+
+    @Test
+    fun `getExistingOperation finds operation not completed or abandoned`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val operation = RealmRetryOperation()
+
+        val transactionSlot = slot<(Realm) -> Any>()
+        coEvery { databaseService.withRealmAsync<Any>(capture(transactionSlot)) } answers {
+            transactionSlot.captured.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("itemId", "item123") } returns query
+        every { query.equalTo("uploadType", "typeA") } returns query
+        every { query.notEqualTo("status", RealmRetryOperation.STATUS_COMPLETED) } returns query
+        every { query.notEqualTo("status", RealmRetryOperation.STATUS_ABANDONED) } returns query
+        every { query.findFirst() } returns operation
+        every { realm.copyFromRealm(operation) } returns operation
+
+        val result = repository.getExistingOperation("item123", "typeA")
+
+        assertEquals(operation, result)
+    }
+
+    @Test
+    fun `cleanup deletes old completed operations`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val results = mockk<RealmResults<RealmRetryOperation>>()
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = invocation.args[0] as Function1<Realm, Unit>
+            block.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("status", RealmRetryOperation.STATUS_COMPLETED) } returns query
+        every { query.lessThan("lastAttemptTime", any<Long>()) } returns query
+        every { query.findAll() } returns results
+        every { results.deleteAllFromRealm() } returns true
+
+        repository.cleanup()
+
+        verify { results.deleteAllFromRealm() }
+    }
+
+    @Test
+    fun `resetAllPending updates nextRetryTime`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val results = mockk<RealmResults<RealmRetryOperation>>()
+
+        val operation1 = RealmRetryOperation().apply { nextRetryTime = 0 }
+        val operation2 = RealmRetryOperation().apply { nextRetryTime = 0 }
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = invocation.args[0] as Function1<Realm, Unit>
+            block.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("status", RealmRetryOperation.STATUS_PENDING) } returns query
+        every { query.findAll() } returns results
+        every { results.deleteAllFromRealm() } returns true
+        every { results.iterator() } answers { mutableListOf(operation1).iterator() }
+        every { results.size } returns 1
+        every { results[0] } returns operation1
+        every { results.get(0) } returns operation1
+        every { results.forEach(any<java.util.function.Consumer<RealmRetryOperation>>()) } answers {
+            val action = invocation.args[0] as java.util.function.Consumer<RealmRetryOperation>
+            action.accept(operation1)
+        }
+
+
+
+        repository.resetAllPending()
+
+        verify { query.findAll() }
+        // Note: We cannot easily verify the inline forEach mutation on the mocked list,
+        // but we verify the query was executed.
+    }
+
+    @Test
+    fun `deletePendingAndAbandonedOperations deletes matching records`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val results = mockk<RealmResults<RealmRetryOperation>>()
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = invocation.args[0] as Function1<Realm, Unit>
+            block.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("status", RealmRetryOperation.STATUS_PENDING) } returns query
+        every { query.or() } returns query
+        every { query.equalTo("status", RealmRetryOperation.STATUS_ABANDONED) } returns query
+        every { query.findAll() } returns results
+        every { results.deleteAllFromRealm() } returns true
+
+        repository.deletePendingAndAbandonedOperations()
+
+        verify { results.deleteAllFromRealm() }
+    }
+
+    @Test
+    fun `recoverStuckOperations changes status to pending`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmRetryOperation>>()
+        val results = mockk<RealmResults<RealmRetryOperation>>()
+
+        val operation1 = RealmRetryOperation().apply { status = RealmRetryOperation.STATUS_IN_PROGRESS; nextRetryTime = 0 }
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = invocation.args[0] as Function1<Realm, Unit>
+            block.invoke(realm)
+        }
+
+        every { realm.where(RealmRetryOperation::class.java) } returns query
+        every { query.equalTo("status", RealmRetryOperation.STATUS_IN_PROGRESS) } returns query
+        every { query.findAll() } returns results
+        every { results.deleteAllFromRealm() } returns true
+        every { results.iterator() } answers { mutableListOf(operation1).iterator() }
+        every { results.size } returns 1
+        every { results[0] } returns operation1
+        every { results.get(0) } returns operation1
+        every { results.forEach(any<java.util.function.Consumer<RealmRetryOperation>>()) } answers {
+            val action = invocation.args[0] as java.util.function.Consumer<RealmRetryOperation>
+            action.accept(operation1)
+        }
+
+
+
+        repository.recoverStuckOperations()
+
+        assertEquals(RealmRetryOperation.STATUS_PENDING, operation1.status)
+        assert(operation1.nextRetryTime > 0)
+    }
+
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
@@ -54,10 +54,10 @@ class RetryRepositoryImplTest {
             transactionSlot.captured.invoke(realm)
         }
 
-        val uploadError = UploadError("itemId", Exception(), retryable = true, httpCode = 500)
+        val uploadError = UploadError("itemId", Exception("test error"), retryable = true, httpCode = 500)
 
         val op = mockk<RealmRetryOperation>(relaxed = true)
-        every { realm.createObject(RealmRetryOperation::class.java, any<String>()) } returns op
+        every { realm.createObject(RealmRetryOperation::class.java, any()) } returns op
 
 
 
@@ -66,7 +66,19 @@ class RetryRepositoryImplTest {
             "POST", "testDbId", "TestClass", "testUserId"
         )
 
-        verify { realm.createObject(RealmRetryOperation::class.java, any<String>()) }
+        verify { realm.createObject(RealmRetryOperation::class.java, any()) }
+        verify {
+            op.uploadType = "testUploadType"
+            op.serializedPayload = "testPayload"
+            op.endpoint = "testEndpoint"
+            op.httpMethod = "POST"
+            op.dbId = "testDbId"
+            op.modelClassName = "TestClass"
+            op.userId = "testUserId"
+            op.status = RealmRetryOperation.STATUS_PENDING
+            op.attemptCount = 1
+            op.httpCode = 500
+        }
     }
 
     @Test
@@ -79,7 +91,7 @@ class RetryRepositoryImplTest {
         }
 
         coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val block = invocation.args[0] as Function1<Realm, Unit>
+            val block = invocation.args[0] as ((Realm) -> Unit)
             block.invoke(realm)
         }
 
@@ -109,7 +121,7 @@ class RetryRepositoryImplTest {
         }
 
         coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val block = invocation.args[0] as Function1<Realm, Unit>
+            val block = invocation.args[0] as ((Realm) -> Unit)
             block.invoke(realm)
         }
 
@@ -134,7 +146,7 @@ class RetryRepositoryImplTest {
         }
 
         coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val block = invocation.args[0] as Function1<Realm, Unit>
+            val block = invocation.args[0] as ((Realm) -> Unit)
             block.invoke(realm)
         }
 
@@ -157,7 +169,7 @@ class RetryRepositoryImplTest {
         }
 
         coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val block = invocation.args[0] as Function1<Realm, Unit>
+            val block = invocation.args[0] as ((Realm) -> Unit)
             block.invoke(realm)
         }
 
@@ -182,7 +194,7 @@ class RetryRepositoryImplTest {
         }
 
         coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val block = invocation.args[0] as Function1<Realm, Unit>
+            val block = invocation.args[0] as ((Realm) -> Unit)
             block.invoke(realm)
         }
 
@@ -210,7 +222,7 @@ class RetryRepositoryImplTest {
         }
 
         coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val block = invocation.args[0] as Function1<Realm, Unit>
+            val block = invocation.args[0] as ((Realm) -> Unit)
             block.invoke(realm)
         }
 
@@ -244,7 +256,6 @@ class RetryRepositoryImplTest {
         every { query.equalTo("status", RealmRetryOperation.STATUS_PENDING) } returns query
         every { query.lessThanOrEqualTo("nextRetryTime", any<Long>()) } returns query
         every { query.findAll() } returns results
-        every { results.deleteAllFromRealm() } returns true
         every { results.iterator() } returns list.toMutableList().iterator()
         every { realm.copyFromRealm(any<Iterable<RealmRetryOperation>>()) } answers {
             arg<Iterable<RealmRetryOperation>>(0).toList()
@@ -308,7 +319,7 @@ class RetryRepositoryImplTest {
         val results = mockk<RealmResults<RealmRetryOperation>>()
 
         coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val block = invocation.args[0] as Function1<Realm, Unit>
+            val block = invocation.args[0] as ((Realm) -> Unit)
             block.invoke(realm)
         }
 
@@ -317,7 +328,6 @@ class RetryRepositoryImplTest {
         every { query.lessThan("lastAttemptTime", any<Long>()) } returns query
         every { query.findAll() } returns results
         every { results.deleteAllFromRealm() } returns true
-
         repository.cleanup()
 
         verify { results.deleteAllFromRealm() }
@@ -333,22 +343,17 @@ class RetryRepositoryImplTest {
         val operation2 = RealmRetryOperation().apply { nextRetryTime = 0 }
 
         coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val block = invocation.args[0] as Function1<Realm, Unit>
+            val block = invocation.args[0] as ((Realm) -> Unit)
             block.invoke(realm)
         }
 
         every { realm.where(RealmRetryOperation::class.java) } returns query
         every { query.equalTo("status", RealmRetryOperation.STATUS_PENDING) } returns query
         every { query.findAll() } returns results
-        every { results.deleteAllFromRealm() } returns true
         every { results.iterator() } answers { mutableListOf(operation1).iterator() }
         every { results.size } returns 1
         every { results[0] } returns operation1
         every { results.get(0) } returns operation1
-        every { results.forEach(any<java.util.function.Consumer<RealmRetryOperation>>()) } answers {
-            val action = invocation.args[0] as java.util.function.Consumer<RealmRetryOperation>
-            action.accept(operation1)
-        }
 
 
 
@@ -366,7 +371,7 @@ class RetryRepositoryImplTest {
         val results = mockk<RealmResults<RealmRetryOperation>>()
 
         coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val block = invocation.args[0] as Function1<Realm, Unit>
+            val block = invocation.args[0] as ((Realm) -> Unit)
             block.invoke(realm)
         }
 
@@ -376,7 +381,6 @@ class RetryRepositoryImplTest {
         every { query.equalTo("status", RealmRetryOperation.STATUS_ABANDONED) } returns query
         every { query.findAll() } returns results
         every { results.deleteAllFromRealm() } returns true
-
         repository.deletePendingAndAbandonedOperations()
 
         verify { results.deleteAllFromRealm() }
@@ -391,22 +395,17 @@ class RetryRepositoryImplTest {
         val operation1 = RealmRetryOperation().apply { status = RealmRetryOperation.STATUS_IN_PROGRESS; nextRetryTime = 0 }
 
         coEvery { databaseService.executeTransactionAsync(any()) } answers {
-            val block = invocation.args[0] as Function1<Realm, Unit>
+            val block = invocation.args[0] as ((Realm) -> Unit)
             block.invoke(realm)
         }
 
         every { realm.where(RealmRetryOperation::class.java) } returns query
         every { query.equalTo("status", RealmRetryOperation.STATUS_IN_PROGRESS) } returns query
         every { query.findAll() } returns results
-        every { results.deleteAllFromRealm() } returns true
         every { results.iterator() } answers { mutableListOf(operation1).iterator() }
         every { results.size } returns 1
         every { results[0] } returns operation1
         every { results.get(0) } returns operation1
-        every { results.forEach(any<java.util.function.Consumer<RealmRetryOperation>>()) } answers {
-            val action = invocation.args[0] as java.util.function.Consumer<RealmRetryOperation>
-            action.accept(operation1)
-        }
 
 
 


### PR DESCRIPTION
🎯 **What:** Created a new test file `RetryRepositoryImplTest.kt` covering testing gaps for the `RetryRepositoryImpl`.
📊 **Coverage:** Covered scenarios for `enqueue`, `updateAttempt` (and the `STATUS_ABANDONED` max-attempt edge cases), `markInProgress`, `markCompleted`, `markFailed`, query operations like `getPending`, and maintenance mechanisms like `recoverStuckOperations` and `deletePendingAndAbandonedOperations`.
✨ **Result:** Solidified confidence in database operation retry queue mapping and improved overall test reliability using comprehensive and verified coroutine mock extensions.

---
*PR created automatically by Jules for task [5688920476653393040](https://jules.google.com/task/5688920476653393040) started by @dogi*