### PR TITLE
teams: smoother voices repository testing (fixes #13681)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5600
-        versionName = "0.56.0"
+        versionCode = 5626
+        versionName = "0.56.26"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,13 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-<<<<<<< jules-testing-voices-repository-12978417455366046690
-        versionCode = 5626
-        versionName = "0.56.26"
-=======
-        versionCode = 5624
-        versionName = "0.56.24"
->>>>>>> master
+        versionCode = 5625
+        versionName = "0.56.25"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/VoicesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/VoicesRepositoryImplTest.kt
@@ -63,4 +63,223 @@ class VoicesRepositoryImplTest {
         assertNotNull(result)
         io.mockk.verify { dispatcherProvider.default }
     }
+
+
+    @Test
+    fun `getCommunityVisibleNews filters correctly based on viewableBy and viewIn`() = testScope.runTest {
+        val mockRealm = mockk<io.realm.Realm>(relaxed = true)
+        val mockRealmQuery = mockk<io.realm.RealmQuery<RealmNews>>(relaxed = true)
+
+        val realGson = Gson()
+        val repoWithRealGson = spyk(VoicesRepositoryImpl(
+            databaseService,
+            UnconfinedTestDispatcher(),
+            dispatcherProvider,
+            realGson,
+            sharedPrefManager
+        ), recordPrivateCalls = true)
+
+        coEvery { databaseService.withRealmAsync<Any>(any()) } answers {
+            val block = firstArg<(io.realm.Realm) -> Any>()
+            block(mockRealm)
+        }
+
+        val news1 = RealmNews().apply {
+            viewableBy = "community"
+            viewIn = null
+        }
+        val news2 = RealmNews().apply {
+            viewableBy = "other"
+            viewIn = "[{\"_id\":\"user1\"}]"
+        }
+        val news3 = RealmNews().apply {
+            viewableBy = "other"
+            viewIn = "[{\"_id\":\"user2\"}]"
+        }
+
+        every { mockRealm.where(RealmNews::class.java) } returns mockRealmQuery
+        every { mockRealmQuery.isEmpty("replyTo") } returns mockRealmQuery
+        every { mockRealmQuery.equalTo("docType", "message", io.realm.Case.INSENSITIVE) } returns mockRealmQuery
+        every { mockRealmQuery.sort("time", io.realm.Sort.DESCENDING) } returns mockRealmQuery
+
+        val realmResults = mockk<io.realm.RealmResults<RealmNews>>()
+        every { mockRealmQuery.findAll() } returns realmResults
+
+        // Return a mock list from copyFromRealm
+        every { mockRealm.copyFromRealm(realmResults as Iterable<RealmNews>) } returns listOf(news1, news2, news3)
+
+        val result = repoWithRealGson.getCommunityVisibleNews("user1")
+
+        org.junit.Assert.assertEquals(2, result.size)
+        org.junit.Assert.assertEquals("community", result[0].viewableBy)
+        org.junit.Assert.assertEquals("[{\"_id\":\"user1\"}]", result[1].viewIn)
+    }
+
+    @Test
+    fun `getNewsByTeamId filters correctly based on viewableBy and viewIn`() = testScope.runTest {
+        val mockRealm = mockk<io.realm.Realm>(relaxed = true)
+        val mockRealmQuery = mockk<io.realm.RealmQuery<RealmNews>>(relaxed = true)
+
+        val realGson = Gson()
+        val repoWithRealGson = spyk(VoicesRepositoryImpl(
+            databaseService,
+            UnconfinedTestDispatcher(),
+            dispatcherProvider,
+            realGson,
+            sharedPrefManager
+        ), recordPrivateCalls = true)
+
+        coEvery { databaseService.withRealmAsync<Any>(any()) } answers {
+            val block = firstArg<(io.realm.Realm) -> Any>()
+            block(mockRealm)
+        }
+
+        val news1 = RealmNews().apply {
+            viewableBy = "teams"
+            viewableId = "team1"
+        }
+        val news2 = RealmNews().apply {
+            viewableBy = "other"
+            viewIn = "[{\"_id\":\"team1\"}]"
+        }
+        val news3 = RealmNews().apply {
+            viewableBy = "other"
+            viewIn = "[{\"_id\":\"team2\"}]"
+        }
+
+        every { mockRealm.where(RealmNews::class.java) } returns mockRealmQuery
+        every { mockRealmQuery.isEmpty("replyTo") } returns mockRealmQuery
+        every { mockRealmQuery.sort("time", io.realm.Sort.DESCENDING) } returns mockRealmQuery
+
+        val realmResults = mockk<io.realm.RealmResults<RealmNews>>()
+        every { mockRealmQuery.findAll() } returns realmResults
+        every { realmResults.iterator() } returns mutableListOf(news1, news2, news3).iterator()
+        every { mockRealm.copyFromRealm(any<RealmNews>()) } answers { firstArg() }
+
+        val result = repoWithRealGson.getNewsByTeamId("team1")
+
+        org.junit.Assert.assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `getFilteredNews executes correct Realm query`() = testScope.runTest {
+        val mockRealm = mockk<io.realm.Realm>(relaxed = true)
+        val mockRealmQuery = mockk<io.realm.RealmQuery<RealmNews>>(relaxed = true)
+
+        coEvery { databaseService.withRealmAsync<Any>(any()) } answers {
+            val block = firstArg<(io.realm.Realm) -> Any>()
+            block(mockRealm)
+        }
+
+        every { mockRealm.where(RealmNews::class.java) } returns mockRealmQuery
+        every { mockRealmQuery.isEmpty("replyTo") } returns mockRealmQuery
+        every { mockRealmQuery.beginGroup() } returns mockRealmQuery
+        every { mockRealmQuery.equalTo("viewableBy", "teams", io.realm.Case.INSENSITIVE) } returns mockRealmQuery
+        every { mockRealmQuery.equalTo("viewableId", "team1", io.realm.Case.INSENSITIVE) } returns mockRealmQuery
+        every { mockRealmQuery.endGroup() } returns mockRealmQuery
+        every { mockRealmQuery.or() } returns mockRealmQuery
+        every { mockRealmQuery.contains("viewIn", "\"_id\":\"team1\"", io.realm.Case.INSENSITIVE) } returns mockRealmQuery
+        every { mockRealmQuery.sort("time", io.realm.Sort.DESCENDING) } returns mockRealmQuery
+
+        val realmResults = mockk<io.realm.RealmResults<RealmNews>>()
+        every { mockRealmQuery.findAll() } returns realmResults
+
+        val news1 = RealmNews()
+        every { mockRealm.copyFromRealm(realmResults as Iterable<RealmNews>) } returns listOf(news1)
+
+        val result = repository.getFilteredNews("team1")
+
+        org.junit.Assert.assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `deleteNews recursively deletes replies`() = testScope.runTest {
+        val mockRealm = mockk<io.realm.Realm>(relaxed = true)
+
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = firstArg<(io.realm.Realm) -> Unit>()
+            block(mockRealm)
+        }
+
+        val mockQueryLevel1 = mockk<io.realm.RealmQuery<RealmNews>>(relaxed = true)
+        val mockQueryLevel2 = mockk<io.realm.RealmQuery<RealmNews>>(relaxed = true)
+        val mockQueryTarget = mockk<io.realm.RealmQuery<RealmNews>>(relaxed = true)
+
+        val realmResultsTarget = mockk<io.realm.RealmResults<RealmNews>>(relaxed = true)
+        val realmResultsLevel1 = mockk<io.realm.RealmResults<RealmNews>>(relaxed = true)
+        val realmResultsLevel2 = mockk<io.realm.RealmResults<RealmNews>>(relaxed = true)
+
+        val reply1 = mockk<RealmNews>(relaxed = true)
+        every { reply1.id } returns "reply1_id"
+        val reply2 = mockk<RealmNews>(relaxed = true)
+        every { reply2.id } returns "reply2_id"
+
+        every { mockRealm.where(RealmNews::class.java) } returns mockQueryTarget
+        every { mockQueryTarget.equalTo("replyTo", "newsId") } returns mockQueryLevel1
+        every { mockQueryLevel1.findAll() } returns realmResultsLevel1
+        every { realmResultsLevel1.iterator() } returns mutableListOf(reply1).iterator()
+
+        every { mockQueryTarget.equalTo("replyTo", "reply1_id") } returns mockQueryLevel2
+        every { mockQueryLevel2.findAll() } returns realmResultsLevel2
+        every { realmResultsLevel2.iterator() } returns mutableListOf(reply2).iterator()
+
+        every { mockQueryTarget.equalTo("replyTo", "reply2_id") } returns mockk(relaxed = true) {
+            every { findAll() } returns mockk(relaxed = true) {
+                every { iterator() } returns mutableListOf<RealmNews>().iterator()
+            }
+        }
+
+        every { mockQueryTarget.equalTo("id", "newsId") } returns mockQueryTarget
+        every { mockQueryTarget.findAll() } returns realmResultsTarget
+
+        repository.deleteNews("newsId")
+
+        io.mockk.verify(exactly = 1) { reply2.deleteFromRealm() }
+        io.mockk.verify(exactly = 1) { reply1.deleteFromRealm() }
+        io.mockk.verify(exactly = 1) { realmResultsTarget.deleteAllFromRealm() }
+    }
+
+    @Test
+    fun `addLabel modifies realm object correctly`() = testScope.runTest {
+        val mockRealm = mockk<io.realm.Realm>(relaxed = true)
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = firstArg<(io.realm.Realm) -> Unit>()
+            block(mockRealm)
+        }
+
+        val mockQuery = mockk<io.realm.RealmQuery<RealmNews>>(relaxed = true)
+        val mockNews = mockk<RealmNews>(relaxed = true)
+        val mockLabels = mockk<io.realm.RealmList<String>>(relaxed = true)
+
+        every { mockRealm.where(RealmNews::class.java) } returns mockQuery
+        every { mockQuery.equalTo("id", "newsId") } returns mockQuery
+        every { mockQuery.findFirst() } returns mockNews
+        every { mockNews.labels } returns mockLabels
+
+        repository.addLabel("newsId", "testLabel")
+
+        io.mockk.verify(exactly = 1) { mockLabels.add("testLabel") }
+    }
+
+    @Test
+    fun `removeLabel modifies realm object correctly`() = testScope.runTest {
+        val mockRealm = mockk<io.realm.Realm>(relaxed = true)
+        coEvery { databaseService.executeTransactionAsync(any()) } answers {
+            val block = firstArg<(io.realm.Realm) -> Unit>()
+            block(mockRealm)
+        }
+
+        val mockQuery = mockk<io.realm.RealmQuery<RealmNews>>(relaxed = true)
+        val mockNews = mockk<RealmNews>(relaxed = true)
+        val mockLabels = mockk<io.realm.RealmList<String>>(relaxed = true)
+
+        every { mockRealm.where(RealmNews::class.java) } returns mockQuery
+        every { mockQuery.equalTo("id", "newsId") } returns mockQuery
+        every { mockQuery.findFirst() } returns mockNews
+        every { mockNews.labels } returns mockLabels
+
+        repository.removeLabel("newsId", "testLabel")
+
+        io.mockk.verify(exactly = 1) { mockLabels.remove("testLabel") }
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/VoicesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/VoicesRepositoryImplTest.kt
@@ -159,6 +159,8 @@ class VoicesRepositoryImplTest {
         val result = repoWithRealGson.getNewsByTeamId("team1")
 
         org.junit.Assert.assertEquals(2, result.size)
+        org.junit.Assert.assertEquals("teams", result[0].viewableBy)
+        org.junit.Assert.assertEquals("[{\"_id\":\"team1\"}]", result[1].viewIn)
     }
 
     @Test
@@ -190,6 +192,12 @@ class VoicesRepositoryImplTest {
         val result = repository.getFilteredNews("team1")
 
         org.junit.Assert.assertEquals(1, result.size)
+        io.mockk.verify(exactly = 1) { mockRealmQuery.beginGroup() }
+        io.mockk.verify(exactly = 1) { mockRealmQuery.equalTo("viewableBy", "teams", io.realm.Case.INSENSITIVE) }
+        io.mockk.verify(exactly = 1) { mockRealmQuery.equalTo("viewableId", "team1", io.realm.Case.INSENSITIVE) }
+        io.mockk.verify(exactly = 1) { mockRealmQuery.endGroup() }
+        io.mockk.verify(exactly = 1) { mockRealmQuery.or() }
+        io.mockk.verify(exactly = 1) { mockRealmQuery.contains("viewIn", "\"_id\":\"team1\"", io.realm.Case.INSENSITIVE) }
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** Added tests for VoicesRepositoryImpl.
📊 **Coverage:** Covered methods: `getCommunityVisibleNews`, `getNewsByTeamId`, `getFilteredNews`, `deleteNews`, `addLabel`, `removeLabel`. Used mockk for most Realm interactions and a real `Gson` instance combined with `spyk` to properly test the filtering logic that uses JSON parsing for `viewIn`.
✨ **Result:** Improved test coverage for repository data and filtering layers, allowing for confident refactoring.

---
*PR created automatically by Jules for task [12978417455366046690](https://jules.google.com/task/12978417455366046690) started by @dogi*