### PR TITLE
🧹 [Code Health] Remove empty ActivityLifecycleCallbacks methods in MainApplication

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet
 
+import org.ole.planet.myplanet.utils.EmptyActivityLifecycleCallbacks
 import android.app.Activity
 import android.app.Application
 import android.content.Context
@@ -65,7 +66,7 @@ import org.ole.planet.myplanet.utils.ThemeMode
 import org.ole.planet.myplanet.utils.VersionUtils.getVersionName
 
 @HiltAndroidApp
-class MainApplication : Application(), Application.ActivityLifecycleCallbacks, WorkManagerConfiguration.Provider {
+class MainApplication : Application(), Application.ActivityLifecycleCallbacks by EmptyActivityLifecycleCallbacks(), WorkManagerConfiguration.Provider {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
@@ -444,8 +445,6 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
         return ThemeManager.getCurrentThemeMode(context)
     }
 
-    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
-
     override fun onActivityStarted(activity: Activity) {
         if (++activityReferences == 1 && !isActivityChangingConfigurations) {
             onAppForegrounded()
@@ -458,16 +457,10 @@ class MainApplication : Application(), Application.ActivityLifecycleCallbacks, W
         }
     }
 
-    override fun onActivityPaused(activity: Activity) {}
-
     override fun onActivityStopped(activity: Activity) {
         isActivityChangingConfigurations = activity.isChangingConfigurations
         --activityReferences
     }
-
-    override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {}
-
-    override fun onActivityDestroyed(activity: Activity) {}
 
     private fun onAppForegrounded() {
         if (isFirstLaunch) {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/EmptyActivityLifecycleCallbacks.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/EmptyActivityLifecycleCallbacks.kt
@@ -1,0 +1,15 @@
+package org.ole.planet.myplanet.utils
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+
+open class EmptyActivityLifecycleCallbacks : Application.ActivityLifecycleCallbacks {
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
+    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityResumed(activity: Activity) {}
+    override fun onActivityPaused(activity: Activity) {}
+    override fun onActivityStopped(activity: Activity) {}
+    override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {}
+    override fun onActivityDestroyed(activity: Activity) {}
+}


### PR DESCRIPTION
🎯 What: Extracted empty interface methods for ActivityLifecycleCallbacks into an EmptyActivityLifecycleCallbacks base class and used Kotlin interface delegation in MainApplication.
💡 Why: Improves readability and maintainability by removing empty interface override clutter from the main application class.
✅ Verification: Ran `compileDefaultDebugKotlin` and `testDefaultDebugUnitTest` to ensure compilation and all relevant tests pass.
✨ Result: `MainApplication.kt` is cleaner and more concise.

---
*PR created automatically by Jules for task [7787856264988903532](https://jules.google.com/task/7787856264988903532) started by @dogi*