### PR TITLE
all: smoother realm model indexing (fixes #13750)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5660
-        versionName = "0.56.60"
+        versionCode = 5664
+        versionName = "0.56.64"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -26,7 +26,7 @@ class DatabaseService(context: Context, private val dispatcherProvider: Dispatch
         if (currentConfig == null || currentConfig.realmDirectory.name == Realm.DEFAULT_REALM_NAME) {
             val config = RealmConfiguration.Builder()
                 .name(Realm.DEFAULT_REALM_NAME)
-                .schemaVersion(10)
+                .schemaVersion(11)
                 .migration(RealmMigrations())
                 .build()
             Realm.setDefaultConfiguration(config)

--- a/app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/RealmMigrations.kt
@@ -72,5 +72,46 @@ class RealmMigrations : RealmMigration {
                 ?.addIndex("subjectLevel")
             version++
         }
+
+        if (version == 10L) {
+            schema.get("RealmOfflineActivity")
+                ?.addIndex("userId")
+                ?.addIndex("type")
+            schema.get("RealmCourseActivity")
+                ?.addIndex("courseId")
+                ?.addIndex("type")
+            schema.get("RealmCourseProgress")
+                ?.addIndex("userId")
+                ?.addIndex("courseId")
+            schema.get("RealmStepExam")
+                ?.addIndex("courseId")
+            schema.get("RealmRating")
+                ?.addIndex("userId")
+            schema.get("RealmHealthExamination")
+                ?.addIndex("userId")
+            schema.get("RealmSubmission")
+                ?.addIndex("type")
+                ?.addIndex("userId")
+            schema.get("RealmMyLife")
+                ?.addIndex("userId")
+            schema.get("RealmNotification")
+                ?.addIndex("userId")
+                ?.addIndex("type")
+            schema.get("RealmRemovedLog")
+                ?.addIndex("userId")
+                ?.addIndex("type")
+            schema.get("RealmTeamLog")
+                ?.addIndex("teamId")
+                ?.addIndex("type")
+            schema.get("RealmTeamTask")
+                ?.addIndex("teamId")
+            schema.get("RealmTeamNotification")
+                ?.addIndex("type")
+            schema.get("RealmResourceActivity")
+                ?.addIndex("type")
+            schema.get("RealmNews")
+                ?.addIndex("userId")
+            version++
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseActivity.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.model
 
 import com.google.gson.JsonObject
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.utils.NetworkUtils
 
@@ -13,8 +14,10 @@ open class RealmCourseActivity : RealmObject() {
     var _rev: String? = null
     var time: Long = 0
     var title: String? = null
+    @Index
     var courseId: String? = null
     var parentCode: String? = null
+    @Index
     var type: String? = null
     var user: String? = null
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseProgress.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseProgress.kt
@@ -16,7 +16,9 @@ open class RealmCourseProgress : RealmObject() {
     var _rev: String? = null
     var stepNum = 0
     var passed = false
+    @Index
     var userId: String? = null
+    @Index
     var courseId: String? = null
     var parentCode: String? = null
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmHealthExamination.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmHealthExamination.kt
@@ -4,6 +4,7 @@ import android.text.TextUtils
 import com.google.gson.JsonObject
 import io.realm.Realm
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.utils.AndroidDecrypter
 import org.ole.planet.myplanet.utils.JsonUtils
@@ -11,6 +12,7 @@ import org.ole.planet.myplanet.utils.JsonUtils
 open class RealmHealthExamination : RealmObject() {
     @PrimaryKey
     var _id: String? = null
+    @Index
     var userId: String? = null
     var isUpdated = false
     var _rev: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLife.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMyLife.kt
@@ -3,12 +3,14 @@ package org.ole.planet.myplanet.model
 import android.content.SharedPreferences
 import io.realm.Realm
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 
 open class RealmMyLife : RealmObject {
     @PrimaryKey
     var _id: String? = null
     var imageId: String? = null
+    @Index
     var userId: String? = null
     var title: String? = null
     var isVisible = false

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmNews.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmNews.kt
@@ -8,6 +8,7 @@ import io.realm.Realm
 import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.annotations.Ignore
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 import java.util.Date
 import java.util.UUID
@@ -18,6 +19,7 @@ open class RealmNews : RealmObject() {
     var id: String? = null
     var _id: String? = null
     var _rev: String? = null
+    @Index
     var userId: String? = null
     var user: String? = null
     var message: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmNotification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmNotification.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.model
 
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 import java.util.Date
 import java.util.UUID
@@ -8,10 +9,12 @@ import java.util.UUID
 open class RealmNotification : RealmObject() {
     @PrimaryKey
     var id: String = UUID.randomUUID().toString()
+    @Index
     var userId: String = ""
     var message: String = ""
     var isRead: Boolean = false
     var createdAt: Date = Date()
+    @Index
     var type: String = ""
     var relatedId: String? = null
     var title: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
@@ -13,7 +13,9 @@ open class RealmOfflineActivity : RealmObject() {
     @Index
     var _rev: String? = null
     var userName: String? = null
+    @Index
     var userId: String? = null
+    @Index
     var type: String? = null
     var description: String? = null
     var createdOn: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmRating.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmRating.kt
@@ -16,6 +16,7 @@ open class RealmRating : RealmObject() {
     var _rev: String? = null
     var time: Long = 0
     var title: String? = null
+    @Index
     var userId: String? = null
     @Index
     var isUpdated = false

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmRemovedLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmRemovedLog.kt
@@ -2,13 +2,16 @@ package org.ole.planet.myplanet.model
 
 import io.realm.Realm
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 import java.util.UUID
 
 open class RealmRemovedLog : RealmObject() {
     @PrimaryKey
     var id: String? = null
+    @Index
     var userId: String? = null
+    @Index
     var type: String? = null
     var docId: String? = null
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmResourceActivity.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.model
 
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 
 open class RealmResourceActivity : RealmObject() {
@@ -13,6 +14,7 @@ open class RealmResourceActivity : RealmObject() {
     var title: String? = null
     var resourceId: String? = null
     var parentCode: String? = null
+    @Index
     var type: String? = null
     var user: String? = null
     var androidId: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
@@ -4,6 +4,7 @@ import android.text.TextUtils
 import com.google.gson.JsonObject
 import io.realm.Realm
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.utils.JsonUtils
 
@@ -20,6 +21,7 @@ open class RealmStepExam : RealmObject() {
     var description: String? = null
     var type: String? = null
     var stepId: String? = null
+    @Index
     var courseId: String? = null
     var sourcePlanet: String? = null
     var passingPercentage: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmission.kt
@@ -14,7 +14,9 @@ open class RealmSubmission : RealmObject() {
     @Index
     var _rev: String? = null
     var parentId: String? = null
+    @Index
     var type: String? = null
+    @Index
     var userId: String? = null
     var user: String? = null
     var startTime: Long = 0

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.model
 
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 
 open class RealmTeamLog : RealmObject() {
@@ -8,8 +9,10 @@ open class RealmTeamLog : RealmObject() {
     var id: String? = null
     var _id: String? = null
     var _rev: String? = null
+    @Index
     var teamId: String? = null
     var user: String? = null
+    @Index
     var type: String? = null
     var teamType: String? = null
     var createdOn: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamNotification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamNotification.kt
@@ -1,11 +1,13 @@
 package org.ole.planet.myplanet.model
 
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 
 open class RealmTeamNotification : RealmObject() {
     @PrimaryKey
     var id: String? = null
+    @Index
     var type: String? = null
     var parentId: String? = null
     var lastCount = 0

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamTask.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamTask.kt
@@ -4,6 +4,7 @@ import android.text.TextUtils
 import com.google.gson.JsonObject
 import io.realm.Realm
 import io.realm.RealmObject
+import io.realm.annotations.Index
 import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.utils.JsonUtils
 
@@ -16,6 +17,7 @@ open class RealmTeamTask : RealmObject() {
     var description: String? = null
     var link: String? = null
     var sync: String? = null
+    @Index
     var teamId: String? = null
     var isUpdated = false
     var assignee: String? = null


### PR DESCRIPTION
fixes #13750
```
improvements after the fix:
- Realm uses the index to jump directly to rows matching userId, then filters type from that smaller set. For a table with 500 submissions belonging to 50 users, that's ~10 rows
  checked instead of 500.
- The benefit scales with data: users who've been using the app for months have larger tables, so they feel the improvement most.
- Queries that are chained (.equalTo("userId").equalTo("type")) benefit from the first indexed field narrowing the result set before the second condition is applied.
  ```
