### PR TITLE
🧪 Add tests for AuthUtils.validateUsername

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/utils/AuthUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/AuthUtilsTest.kt
@@ -1,0 +1,37 @@
+package org.ole.planet.myplanet.utils
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.ole.planet.myplanet.repository.UserRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthUtilsTest {
+
+    private val userRepository = mockk<UserRepository>()
+
+    @Test
+    fun validateUsername_returnsValidString_whenUserRepositoryReturnsString() = runTest {
+        val username = "valid_user"
+        val expectedResult = "validated_string"
+        coEvery { userRepository.validateUsername(username) } returns expectedResult
+
+        val result = AuthUtils.validateUsername(username, userRepository)
+
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun validateUsername_returnsNull_whenUserRepositoryReturnsNull() = runTest {
+        val username = "invalid_user"
+        coEvery { userRepository.validateUsername(username) } returns null
+
+        val result = AuthUtils.validateUsername(username, userRepository)
+
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of test coverage for the suspend function `validateUsername` in `AuthUtils.kt`. 

📊 **Coverage:** What scenarios are now tested
The new tests cover both the happy path (when the `UserRepository` successfully validates and returns a valid string) and the failure/edge case (when the repository returns `null`). The tests mock the dependency cleanly using MockK and utilize `runTest` to correctly handle the coroutines context.

✨ **Result:** The improvement in test coverage
The logic inside `AuthUtils.validateUsername` is now completely covered, offering protection against accidental changes or regressions in how this utility interacts with the repository layer.

---
*PR created automatically by Jules for task [6782694134298183469](https://jules.google.com/task/6782694134298183469) started by @dogi*