### PR TITLE
all: smoother shared preferences encrypting (fixes #13779)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5660
-        versionName = "0.56.60"
+        versionCode = 5669
+        versionName = "0.56.69"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/SecurePrefs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/SecurePrefs.kt
@@ -69,26 +69,29 @@ object SecurePrefs {
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
             )
 
-            val plainPrefs = context.getSharedPreferences(PLAIN_PREFS_FILE_NAME, Context.MODE_PRIVATE)
-            if (plainPrefs.all.isNotEmpty()) {
-                encryptedPrefs.edit(commit = true) {
-                    plainPrefs.all.forEach { (key, value) ->
-                        when (value) {
-                            is String -> putString(key, value)
-                            is Boolean -> putBoolean(key, value)
-                            is Int -> putInt(key, value)
-                            is Long -> putLong(key, value)
-                            is Float -> putFloat(key, value)
-                            is Set<*> -> {
-                                @Suppress("UNCHECKED_CAST")
-                                putStringSet(key, value as Set<String>)
+            val plainPrefsFile = java.io.File(context.applicationInfo.dataDir, "shared_prefs/$PLAIN_PREFS_FILE_NAME.xml")
+            if (plainPrefsFile.exists()) {
+                val plainPrefs = context.getSharedPreferences(PLAIN_PREFS_FILE_NAME, Context.MODE_PRIVATE)
+                if (plainPrefs.all.isNotEmpty()) {
+                    encryptedPrefs.edit(commit = true) {
+                        plainPrefs.all.forEach { (key, value) ->
+                            when (value) {
+                                is String -> putString(key, value)
+                                is Boolean -> putBoolean(key, value)
+                                is Int -> putInt(key, value)
+                                is Long -> putLong(key, value)
+                                is Float -> putFloat(key, value)
+                                is Set<*> -> {
+                                    @Suppress("UNCHECKED_CAST")
+                                    putStringSet(key, value as Set<String>)
+                                }
                             }
                         }
                     }
-                }
-                plainPrefs.edit(commit = true) { clear() }
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-                    context.deleteSharedPreferences(PLAIN_PREFS_FILE_NAME)
+                    plainPrefs.edit(commit = true) { clear() }
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                        context.deleteSharedPreferences(PLAIN_PREFS_FILE_NAME)
+                    }
                 }
             }
             encryptedPrefs


### PR DESCRIPTION
🎯 **What:** Preventing the creation of an unencrypted XML file during `SharedPreferences` migration.
⚠️ **Risk:** Temporary exposure of sensitive data at rest during migration.
🛡️ **Solution:** Wrapping `getSharedPreferences` with a `File.exists()` check.

---
*PR created automatically by Jules for task [1062688180252335378](https://jules.google.com/task/1062688180252335378) started by @dogi*