### PR TITLE
all: smoother tts error managing (fixes #13783)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5660
-        versionName = "0.56.60"
+        versionCode = 5673
+        versionName = "0.56.73"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/TTSManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/TTSManager.kt
@@ -37,7 +37,7 @@ class TTSManager @Inject constructor(
                     }
                     @Deprecated("Deprecated in Java")
                     override fun onError(utteranceId: String?) {
-                        _state.value = State.IDLE
+                        onError(utteranceId, TextToSpeech.ERROR)
                     }
                     override fun onError(utteranceId: String?, errorCode: Int) {
                         _state.value = State.IDLE


### PR DESCRIPTION
🎯 **What:** The deprecated `onError(String?)` method in `TTSManager` was refactored to delegate to the non-deprecated version.
💡 **Why:** `UtteranceProgressListener.onError(String)` is deprecated but still abstract up to API 37, so it cannot be removed without breaking compilation. By delegating to the non-deprecated `onError(String?, Int)` method, we eliminate duplicate state updates while keeping the code fully clean and functional.
✅ **Verification:** Verified with `compileDefaultDebugKotlin` and `testDefaultDebugUnitTest`. Also passed code review.
✨ **Result:** Enhanced code maintainability and correctness while complying with Android SDK constraints.

---
*PR created automatically by Jules for task [2599646774007668535](https://jules.google.com/task/2599646774007668535) started by @dogi*