### PR TITLE
all: less create action async challenge is more (fixes #13814)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5674
-        versionName = "0.56.74"
+        versionCode = 5675
+        versionName = "0.56.75"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmUserChallengeActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmUserChallengeActions.kt
@@ -3,7 +3,6 @@ package org.ole.planet.myplanet.model
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 import java.util.UUID
-import org.ole.planet.myplanet.data.DatabaseService
 
 open class RealmUserChallengeActions : RealmObject() {
     @PrimaryKey
@@ -12,24 +11,4 @@ open class RealmUserChallengeActions : RealmObject() {
     var actionType: String? = null
     var resourceId: String? = null
     var time: Long = 0
-
-    companion object {
-        suspend fun createActionAsync(
-            databaseService: DatabaseService,
-            userId: String,
-            resourceId: String?,
-            actionType: String
-        ) {
-            databaseService.executeTransactionAsync { bgRealm ->
-                val action = bgRealm.createObject(
-                    RealmUserChallengeActions::class.java,
-                    UUID.randomUUID().toString()
-                )
-                action.userId = userId
-                action.actionType = actionType
-                action.resourceId = resourceId
-                action.time = System.currentTimeMillis()
-            }
-        }
-    }
 }


### PR DESCRIPTION
Deleted the unused `createActionAsync` companion object method and the corresponding unused `DatabaseService` import from `RealmUserChallengeActions.kt` as it has no callers in the project.

---
*PR created automatically by Jules for task [1705488768705987123](https://jules.google.com/task/1705488768705987123) started by @dogi*