### PR TITLE
sync: less serialization chunk scan upload is more (fixes #13815)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5674
-        versionName = "0.56.74"
+        versionCode = 5676
+        versionName = "0.56.76"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
@@ -134,13 +134,6 @@ class UploadCoordinator @Inject constructor(
             }
 
             val dbId = config.dbIdExtractor?.invoke(copiedItem)
-            val jsonString = serialized.toString()
-            val chunkSize = 3000
-            var offset = 0
-            while (offset < jsonString.length) {
-                val end = minOf(offset + chunkSize, jsonString.length)
-                offset = end
-            }
             PreparedUpload(
                 item = copiedItem,
                 localId = localId,


### PR DESCRIPTION
This PR removes the dead serialization chunk scan logic in `UploadCoordinator.queryItemsToUpload`. The loop iterated over a string length to calculate chunks without utilizing the results or having side effects, causing needless overhead. The removal preserves exactly the same prepared upload payload functionality.

---
*PR created automatically by Jules for task [2687641408719723181](https://jules.google.com/task/2687641408719723181) started by @dogi*