### PR TITLE
Refactor ChatHistoryFragment boundary to use ChatViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
@@ -251,7 +251,7 @@ class ChatHistoryFragment : Fragment() {
             val currentUser = cachedUser ?: loadCurrentUser(sharedPrefManager.getUserId())
             val newsMessages = voicesRepository.getPlanetNewsMessages(currentUser?.planetCode)
             val chatHistory = chatRepository.getChatHistoryForUser(currentUser?.name)
-            val targets = cachedTargets ?: loadShareTargets(
+            val targets = cachedTargets ?: sharedViewModel.loadShareTargets(
                 sharedPrefManager.getParentCode(),
                 sharedPrefManager.getCommunityName(),
                 currentUser?._id
@@ -278,18 +278,20 @@ class ChatHistoryFragment : Fragment() {
                         val currentUser = user
                         val chatId = chat._id ?: ""
                         val viewInId = map["viewInId"] ?: ""
-                        if (chatId.isNotEmpty() && viewInId.isNotEmpty() &&
-                            voicesRepository.isAlreadyShared(chatId, viewInId)) {
-                            Snackbar.make(binding.root, getString(R.string.chat_already_shared_to_destination), Snackbar.LENGTH_SHORT).show()
-                            return@launch
-                        }
-                        val createdNews = voicesRepository.createNews(map, currentUser, null)
-                        if (currentUser?.planetCode != null) {
-                            sharedNewsMessages = sharedNewsMessages + createdNews
-                        }
-                        (binding.recyclerView.adapter as? ChatHistoryAdapter)?.let { adapter ->
-                            adapter.updateCachedData(currentUser, sharedNewsMessages)
-                            adapter.notifyChatShared(chat._id)
+                        val result = sharedViewModel.shareChatToVoices(chatId, viewInId, map, currentUser)
+                        if (result.isSuccess) {
+                            val createdNews = result.getOrNull()
+                            if (createdNews == null) {
+                                Snackbar.make(binding.root, getString(R.string.chat_already_shared_to_destination), Snackbar.LENGTH_SHORT).show()
+                                return@launch
+                            }
+                            if (currentUser?.planetCode != null) {
+                                sharedNewsMessages = sharedNewsMessages + createdNews
+                            }
+                            (binding.recyclerView.adapter as? ChatHistoryAdapter)?.let { adapter ->
+                                adapter.updateCachedData(currentUser, sharedNewsMessages)
+                                adapter.notifyChatShared(chat._id)
+                            }
                         }
                     }
                 }
@@ -324,32 +326,6 @@ class ChatHistoryFragment : Fragment() {
             return null
         }
         return userRepository.getUserById(userId)
-    }
-
-    private suspend fun loadShareTargets(parentCode: String?, communityName: String?, userId: String?): ChatShareTargets {
-        val teams = teamsRepository.getTeamSummaries(userId)
-        val enterprises = teamsRepository.getShareableEnterpriseSummaries(userId)
-        val communityId = if (!communityName.isNullOrBlank() && !parentCode.isNullOrBlank()) {
-            "$communityName@$parentCode"
-        } else {
-            null
-        }
-        val community = communityId?.let { id ->
-            teamsRepository.getTeamSummaryById(id) ?: TeamSummary(
-                _id = id,
-                name = communityName ?: "",
-                teamType = null,
-                teamPlanetCode = null,
-                createdDate = null,
-                type = null,
-                status = null,
-                teamId = null,
-                description = null,
-                services = null,
-                rules = null
-            )
-        }
-        return ChatShareTargets(community, teams, enterprises)
     }
 
     private fun checkAiProvidersIfNeeded() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
@@ -13,14 +13,22 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.model.ChatMessage
+import org.ole.planet.myplanet.model.ChatShareTargets
 import org.ole.planet.myplanet.model.RealmConversation
+import org.ole.planet.myplanet.model.RealmNews
+import org.ole.planet.myplanet.model.RealmUser
+import org.ole.planet.myplanet.model.TeamSummary
 import org.ole.planet.myplanet.repository.ChatRepository
+import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.JsonUtils
 
 @HiltViewModel
 class ChatViewModel @Inject constructor(
     private val chatRepository: ChatRepository,
+    private val teamsRepository: TeamsRepository,
+    private val voicesRepository: VoicesRepository,
     private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
     private val _selectedChatHistory = MutableStateFlow<List<RealmConversation>?>(null)
@@ -116,5 +124,39 @@ class ChatViewModel @Inject constructor(
 
     fun shouldFetchAiProviders(): Boolean {
         return _aiProviders.value == null && !_aiProvidersLoading.value
+    }
+
+    suspend fun loadShareTargets(parentCode: String?, communityName: String?, userId: String?): ChatShareTargets {
+        val teams = teamsRepository.getTeamSummaries(userId)
+        val enterprises = teamsRepository.getShareableEnterpriseSummaries(userId)
+        val communityId = if (!communityName.isNullOrBlank() && !parentCode.isNullOrBlank()) {
+            "$communityName@$parentCode"
+        } else {
+            null
+        }
+        val community = communityId?.let { id ->
+            teamsRepository.getTeamSummaryById(id) ?: TeamSummary(
+                _id = id,
+                name = communityName ?: "",
+                teamType = null,
+                teamPlanetCode = null,
+                createdDate = null,
+                type = null,
+                status = null,
+                teamId = null,
+                description = null,
+                services = null,
+                rules = null
+            )
+        }
+        return ChatShareTargets(community, teams, enterprises)
+    }
+
+    suspend fun shareChatToVoices(chatId: String, viewInId: String, map: HashMap<String?, String>, currentUser: RealmUser?): Result<RealmNews?> {
+        if (chatId.isNotEmpty() && viewInId.isNotEmpty() && voicesRepository.isAlreadyShared(chatId, viewInId)) {
+            return Result.success(null)
+        }
+        val createdNews = voicesRepository.createNews(map, currentUser, null)
+        return Result.success(createdNews)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatViewModelTest.kt
@@ -20,6 +20,8 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.model.RealmConversation
 import org.ole.planet.myplanet.repository.ChatRepository
+import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -27,6 +29,8 @@ class ChatViewModelTest {
 
     private lateinit var viewModel: ChatViewModel
     private lateinit var chatRepository: ChatRepository
+    private lateinit var teamsRepository: TeamsRepository
+    private lateinit var voicesRepository: VoicesRepository
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var dispatcherProvider: TestDispatcherProvider
 
@@ -34,8 +38,10 @@ class ChatViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         chatRepository = mockk(relaxed = true)
+        teamsRepository = mockk(relaxed = true)
+        voicesRepository = mockk(relaxed = true)
         dispatcherProvider = TestDispatcherProvider(testDispatcher)
-        viewModel = ChatViewModel(chatRepository, dispatcherProvider)
+        viewModel = ChatViewModel(chatRepository, teamsRepository, voicesRepository, dispatcherProvider)
     }
 
     @After


### PR DESCRIPTION
Moved share-target assembly and share-to-voices creation logic from `ChatHistoryFragment` into `ChatViewModel` to reduce fragment's direct dependency on `VoicesRepository` and `TeamsRepository`, keeping the fragment focused on adapter wiring and UI.

---
*PR created automatically by Jules for task [14507320729814065123](https://jules.google.com/task/14507320729814065123) started by @dogi*