### PR TITLE
courses: smoother repository filtering (fixes #13884)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5680
-        versionName = "0.56.80"
+        versionCode = 5709
+        versionName = "0.57.9"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -317,11 +317,10 @@ class CoursesRepositoryImpl @Inject constructor(
             courseIdsWithTags?.let {
                 query = query.`in`("courseId", it.toTypedArray())
             }
+            query = query.isNotEmpty("courseTitle")
 
-            val results = query.findAll()
-            val sortedList = results
-                .filter { !it.courseTitle.isNullOrBlank() }
-                .sortedWith(compareBy({ it.isMyCourse }, { it.courseTitle }))
+            val results = query.sort("courseTitle", io.realm.Sort.ASCENDING).findAll()
+            val sortedList = results.sortedBy { it.isMyCourse }
             realm.copyFromRealm(sortedList)
         }
     }


### PR DESCRIPTION
Moved the `courseTitle` blank-title filter and title sort directly into the Realm query in `CoursesRepositoryImpl.filterCourses`. This ensures that blank/empty titles never leave the Realm database and sorts alphabetically within Realm. The secondary stable in-memory sort `sortedBy { it.isMyCourse }` preserves the initial Realm sort. This was implemented by replacing `query.findAll()` with `query.sort("courseTitle", io.realm.Sort.ASCENDING).findAll()`.

---
*PR created automatically by Jules for task [7764069787053839201](https://jules.google.com/task/7764069787053839201) started by @dogi*