### PR TITLE
teams: smoother events item callback diffing (fixes #13885)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5680
-        versionName = "0.56.80"
+        versionCode = 5710
+        versionName = "0.57.10"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsAdapter.kt
@@ -10,12 +10,7 @@ import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 
-class EventsAdapter : ListAdapter<RealmMeetup, EventsAdapter.EventsViewHolder>(
-    DiffUtils.itemCallback<RealmMeetup>(
-        areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id },
-        areContentsTheSame = { oldItem, newItem -> oldItem.id == newItem.id && oldItem.title == newItem.title && oldItem.description == newItem.description && oldItem.startDate == newItem.startDate && oldItem.endDate == newItem.endDate && oldItem.startTime == newItem.startTime && oldItem.endTime == newItem.endTime && oldItem.meetupLocation == newItem.meetupLocation && oldItem.meetupLink == newItem.meetupLink && oldItem.recurring == newItem.recurring && oldItem.creator == newItem.creator }
-    )
-) {
+class EventsAdapter : ListAdapter<RealmMeetup, EventsAdapter.EventsViewHolder>(DIFF_CALLBACK) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): EventsViewHolder {
         val binding = ItemMeetupBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return EventsViewHolder(binding)
@@ -38,4 +33,21 @@ class EventsAdapter : ListAdapter<RealmMeetup, EventsAdapter.EventsViewHolder>(
 
     class EventsViewHolder(val binding: ItemMeetupBinding) : RecyclerView.ViewHolder(binding.root)
 
+    companion object {
+        private val DIFF_CALLBACK = DiffUtils.itemCallback<RealmMeetup>(
+            areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id },
+            areContentsTheSame = { oldItem, newItem ->
+                oldItem.title == newItem.title &&
+                        oldItem.description == newItem.description &&
+                        oldItem.startDate == newItem.startDate &&
+                        oldItem.endDate == newItem.endDate &&
+                        oldItem.startTime == newItem.startTime &&
+                        oldItem.endTime == newItem.endTime &&
+                        oldItem.meetupLocation == newItem.meetupLocation &&
+                        oldItem.meetupLink == newItem.meetupLink &&
+                        oldItem.recurring == newItem.recurring &&
+                        oldItem.creator == newItem.creator
+            }
+        )
+    }
 }


### PR DESCRIPTION
Refactored `EventsAdapter.kt` to define `DiffUtils.itemCallback` inside a `companion object`. Cleaned up the callback by formatting it multi-line and removing the redundant `id` comparison in `areContentsTheSame`. Verified by running `testDefaultDebugUnitTest`.

---
*PR created automatically by Jules for task [8242859402838805357](https://jules.google.com/task/8242859402838805357) started by @dogi*