### PR TITLE
courses: smoother steps inline resources dispatcher providing (fixes #13889)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5680
-        versionName = "0.56.80"
+        versionCode = 5713
+        versionName = "0.57.13"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -184,7 +184,7 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
         fragmentCourseStepBinding.tvResourcesHeader.visibility = View.VISIBLE
         fragmentCourseStepBinding.rvInlineResources.visibility = View.VISIBLE
 
-        inlineResourceAdapter = InlineResourceAdapter { library ->
+        inlineResourceAdapter = InlineResourceAdapter(dispatcherProvider) { library ->
             openResource(library)
         }
         fragmentCourseStepBinding.rvInlineResources.apply {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -18,7 +18,6 @@ import com.opencsv.CSVReaderBuilder
 import java.io.File
 import java.io.FileReader
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelChildren
@@ -31,9 +30,11 @@ import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.ResourceOpener
 import org.ole.planet.myplanet.utils.UrlUtils
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.Utilities
 
 class InlineResourceAdapter(
+    private val dispatcherProvider: DispatcherProvider,
     private val onResourceClick: (RealmMyLibrary) -> Unit
 ) : ListAdapter<RealmMyLibrary, InlineResourceAdapter.ViewHolder>(
     DiffUtils.itemCallback<RealmMyLibrary>(
@@ -55,8 +56,8 @@ class InlineResourceAdapter(
 
     private var externalFilesDir: java.io.File? = null
 
-    class ViewHolder(val binding: ItemInlineResourceBinding) : RecyclerView.ViewHolder(binding.root) {
-        private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+    class ViewHolder(val binding: ItemInlineResourceBinding, dispatcherProvider: DispatcherProvider) : RecyclerView.ViewHolder(binding.root) {
+        private val scope = CoroutineScope(dispatcherProvider.main + SupervisorJob())
 
         fun cancelPreviousPreviews() {
             scope.coroutineContext.cancelChildren()
@@ -72,7 +73,16 @@ class InlineResourceAdapter(
         val binding = ItemInlineResourceBinding.inflate(
             LayoutInflater.from(parent.context), parent, false
         )
-        return ViewHolder(binding)
+        return ViewHolder(binding, dispatcherProvider)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        super.onDetachedFromRecyclerView(recyclerView)
+        for (i in 0 until recyclerView.childCount) {
+            val child = recyclerView.getChildAt(i)
+            val holder = recyclerView.getChildViewHolder(child) as? ViewHolder
+            holder?.cancelPreviousPreviews()
+        }
     }
 
     override fun onViewRecycled(holder: ViewHolder) {
@@ -189,7 +199,7 @@ class InlineResourceAdapter(
     private fun showPdfPreview(holder: ViewHolder, file: File) {
         if (!file.exists()) return
         holder.launchPreview {
-            val bitmap = withContext(Dispatchers.IO) {
+            val bitmap = withContext(dispatcherProvider.io) {
                 try {
                     ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { fd ->
                         PdfRenderer(fd).use { renderer ->
@@ -218,7 +228,7 @@ class InlineResourceAdapter(
         holder.binding.audioPreviewContainer.visibility = View.VISIBLE
         if (!file.exists()) return
         holder.launchPreview {
-            val durationText = withContext(Dispatchers.IO) {
+            val durationText = withContext(dispatcherProvider.io) {
                 val retriever = MediaMetadataRetriever()
                 try {
                     retriever.setDataSource(file.absolutePath)
@@ -238,7 +248,7 @@ class InlineResourceAdapter(
     private fun showCsvPreview(holder: ViewHolder, file: File) {
         if (!file.exists()) return
         holder.launchPreview {
-            val preview = withContext(Dispatchers.IO) {
+            val preview = withContext(dispatcherProvider.io) {
                 try {
                     val sb = StringBuilder()
                     CSVReaderBuilder(FileReader(file))
@@ -266,7 +276,7 @@ class InlineResourceAdapter(
     private fun showTextPreview(holder: ViewHolder, file: File) {
         if (!file.exists()) return
         holder.launchPreview {
-            val text = withContext(Dispatchers.IO) {
+            val text = withContext(dispatcherProvider.io) {
                 try {
                     file.bufferedReader().useLines { it.take(8).joinToString("\n") }.takeIf { it.isNotEmpty() }
                 } catch (e: Exception) {


### PR DESCRIPTION
- Added `DispatcherProvider` to `InlineResourceAdapter` and its `ViewHolder`.
- Replaced `withContext(Dispatchers.IO)` and `Dispatchers.Main` with corresponding `dispatcherProvider` calls.
- Implemented `onDetachedFromRecyclerView` to cancel previews to prevent memory leaks and detached view crashes.
- Removed unused `Dispatchers` import.

---
*PR created automatically by Jules for task [967001519336609743](https://jules.google.com/task/967001519336609743) started by @dogi*