### PR TITLE
sync: smoother server address payload handling (fixes #13890)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5680
-        versionName = "0.56.80"
+        versionCode = 5713
+        versionName = "0.57.13"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerAddressAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerAddressAdapter.kt
@@ -7,7 +7,6 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.button.MaterialButton
-import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.ServerAddress
 import org.ole.planet.myplanet.utils.DiffUtils
@@ -30,10 +29,10 @@ class ServerAddressAdapter(
         lastSelectedPosition = previous
         selectedPosition = position
         if (previous in currentList.indices) {
-            notifyItemChanged(previous)
+            notifyItemChanged(previous, SELECTION_PAYLOAD)
         }
         if (position in currentList.indices) {
-            notifyItemChanged(position)
+            notifyItemChanged(position, SELECTION_PAYLOAD)
         }
     }
 
@@ -41,10 +40,10 @@ class ServerAddressAdapter(
         val current = selectedPosition
         selectedPosition = lastSelectedPosition
         if (current in currentList.indices) {
-            notifyItemChanged(current)
+            notifyItemChanged(current, SELECTION_PAYLOAD)
         }
         if (selectedPosition in currentList.indices) {
-            notifyItemChanged(selectedPosition)
+            notifyItemChanged(selectedPosition, SELECTION_PAYLOAD)
         }
     }
 
@@ -52,7 +51,7 @@ class ServerAddressAdapter(
         val current = selectedPosition
         selectedPosition = -1
         if (current in currentList.indices) {
-            notifyItemChanged(current)
+            notifyItemChanged(current, SELECTION_PAYLOAD)
         }
     }
 
@@ -60,6 +59,18 @@ class ServerAddressAdapter(
         val view = LayoutInflater.from(parent.context)
             .inflate(R.layout.item_server_address, parent, false)
         return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(
+        holder: ViewHolder,
+        position: Int,
+        payloads: MutableList<Any>
+    ) {
+        if (payloads.contains(SELECTION_PAYLOAD)) {
+            holder.updateSelectionState(position == selectedPosition)
+        } else {
+            super.onBindViewHolder(holder, position, payloads)
+        }
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -82,10 +93,14 @@ class ServerAddressAdapter(
         fun bind(serverAddress: ServerAddress, isSelected: Boolean) {
             button.text = serverAddress.name
             button.contentDescription =
-                context.getString(
+                itemView.context.getString(
                     R.string.server_address_content_description,
                     serverAddress.name,
                 )
+            updateSelectionState(isSelected)
+        }
+
+        fun updateSelectionState(isSelected: Boolean) {
             button.isSelected = isSelected
             if (isSelected) {
                 button.setBackgroundColor(
@@ -100,6 +115,6 @@ class ServerAddressAdapter(
     }
 
     companion object {
-        private val URL_PROTOCOL_REGEX = Regex("^https?://")
+        private const val SELECTION_PAYLOAD = "selection_payload"
     }
 }


### PR DESCRIPTION
This pull request optimizes the UI logic and cleans up dead code inside `ServerAddressAdapter.kt`.

### Changes Made:
- Removed an unused `context` static import.
- Removed unused `URL_PROTOCOL_REGEX` pattern from the companion object.
- Replaced `MainApplication.context.getString` with `itemView.context.getString` inside `ViewHolder.bind` to utilize scoped view context.
- Implemented payload-based selection updates by introducing a `SELECTION_PAYLOAD` constant. `setSelectedPosition`, `revertSelection`, and `clearSelection` now pass `SELECTION_PAYLOAD` during notification updates to prevent full-item re-binding, matching the optimization pattern seen in `ResourcesAdapter`.
- Added the `onBindViewHolder(..., payloads: MutableList<Any>)` override to catch the `SELECTION_PAYLOAD` and securely update just the button state/background.

---
*PR created automatically by Jules for task [9720981049032298549](https://jules.google.com/task/9720981049032298549) started by @dogi*