### PR TITLE
all: smoother time utils csv date format testing (fixes #13895)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5681
-        versionName = "0.56.81"
+        versionCode = 5718
+        versionName = "0.57.18"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/TimeUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/TimeUtilsTest.kt
@@ -302,4 +302,15 @@ class TimeUtilsTest {
         assertEquals("", TimeUtils.convertDDMMYYYYToISO(null))
         assertEquals("invalid", TimeUtils.convertDDMMYYYYToISO("invalid"))
     }
+
+    @Test
+    fun testFormatDateForCsv() {
+        val timestamp = 1710115200000L
+        val expected = java.time.format.DateTimeFormatter
+            .ofPattern("EEE MMM dd yyyy HH:mm:ss 'GMT'Z (z)", Locale.US)
+            .withZone(java.time.ZoneId.systemDefault())
+            .format(java.time.Instant.ofEpochMilli(timestamp))
+        val formatted = TimeUtils.formatDateForCsv(timestamp)
+        assertEquals(expected, formatted)
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added a missing unit test `testFormatDateForCsv` for the `formatDateForCsv` function in `TimeUtils.kt`.
📊 **Coverage:** Now validates the formatting path utilizing `csvDateFormatter` to ensure strings are formatted correctly based on a fixed epoch timestamp.
✨ **Result:** Improved test coverage for `TimeUtils.kt` and ensured formatting behavior remains stable. The test avoids flakiness by programmatically generating the expected string using `ZoneId.systemDefault()`.

---
*PR created automatically by Jules for task [11563551094692438497](https://jules.google.com/task/11563551094692438497) started by @dogi*