### PR TITLE
all: smoother sync time logger dispatcher providing (fixes #13903)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5681
-        versionName = "0.56.81"
+        versionCode = 5726
+        versionName = "0.57.26"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
@@ -8,6 +8,7 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
+import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
@@ -17,4 +18,5 @@ interface CoreDependenciesEntryPoint {
     fun databaseService(): DatabaseService
     fun userSessionManager(): UserSessionManager
     fun serverUrlMapper(): ServerUrlMapper
+    fun dispatcherProvider(): DispatcherProvider
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
@@ -8,7 +8,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.roundToInt
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
@@ -72,11 +71,13 @@ object SyncTimeLogger {
     }
 
     private fun saveSummaryToRealm(summary: String, uploadManager: UploadManager? = null) {
-        val spm = EntryPointAccessors.fromApplication(MainApplication.context, CoreDependenciesEntryPoint::class.java).sharedPrefManager()
-        MainApplication.applicationScope.launch(Dispatchers.IO) {
+        val entryPoint = EntryPointAccessors.fromApplication(MainApplication.context, CoreDependenciesEntryPoint::class.java)
+        val dispatcherProvider = entryPoint.dispatcherProvider()
+
+        MainApplication.applicationScope.launch(dispatcherProvider.io) {
+            val spm = entryPoint.sharedPrefManager()
             MainApplication.createLog("sync summary", summary)
             val updateUrl = spm.getServerUrl()
-            val entryPoint = EntryPointAccessors.fromApplication(MainApplication.context, CoreDependenciesEntryPoint::class.java)
             val serverUrlMapper = entryPoint.serverUrlMapper()
             val mapping = serverUrlMapper.processUrl(updateUrl)
 


### PR DESCRIPTION
Optimized Hilt dependency resolution and dispatcher usage in `SyncTimeLogger.saveSummaryToRealm`.

---
*PR created automatically by Jules for task [5660437618873148206](https://jules.google.com/task/5660437618873148206) started by @dogi*