### PR TITLE
all: smoother download service shared preferences handling (fixes #13901)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5681
-        versionName = "0.56.81"
+        versionCode = 5724
+        versionName = "0.57.24"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/SharedPreferencesModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/SharedPreferencesModule.kt
@@ -20,6 +20,10 @@ annotation class AppPreferences
 @Retention(AnnotationRetention.BINARY)
 annotation class DefaultPreferences
 
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DownloadPreferences
+
 @Module
 @InstallIn(SingletonComponent::class)
 object SharedPreferencesModule {
@@ -36,5 +40,12 @@ object SharedPreferencesModule {
     @DefaultPreferences
     fun provideDefaultSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
         return PreferenceManager.getDefaultSharedPreferences(context)
+    }
+
+    @Provides
+    @Singleton
+    @DownloadPreferences
+    fun provideDownloadSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
+        return context.getSharedPreferences(org.ole.planet.myplanet.services.DownloadService.PREFS_NAME, Context.MODE_PRIVATE)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -64,7 +64,11 @@ class DownloadService : Service() {
     private var notificationBuilder: NotificationCompat.Builder? = null
     private var notificationManager: NotificationManager? = null
     private var totalFileSize = 0
-    private lateinit var preferences: SharedPreferences
+
+    @Inject
+    @org.ole.planet.myplanet.di.DownloadPreferences
+    lateinit var preferences: SharedPreferences
+
     private var currentDownloadUrl: String = ""
     private var originalDownloadUrl: String = ""
     private var fromSync = false
@@ -98,7 +102,6 @@ class DownloadService : Service() {
         Log.d(TAG, "onStartCommand: fromSync=$fromSync queueRunning=$isQueueRunning")
 
         downloadScope.launch {
-            preferences = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
             if (!isQueueRunning) {
                 isQueueRunning = true
                 try {

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import okhttp3.ResponseBody
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.di.DownloadPreferences
 import org.ole.planet.myplanet.di.getBroadcastService
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.DownloadResult
@@ -66,7 +67,7 @@ class DownloadService : Service() {
     private var totalFileSize = 0
 
     @Inject
-    @org.ole.planet.myplanet.di.DownloadPreferences
+    @DownloadPreferences
     lateinit var preferences: SharedPreferences
 
     private var currentDownloadUrl: String = ""

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.services
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
@@ -17,6 +18,7 @@ import okio.buffer
 import okio.sink
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.di.DownloadPreferences
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils
@@ -29,7 +31,7 @@ class DownloadWorker @AssistedInject constructor(
     @Assisted private val context: Context, @Assisted workerParams: WorkerParameters,
     private val apiInterface: ApiInterface, private val broadcastService: BroadcastService,
     private val dispatcherProvider: DispatcherProvider,
-    @org.ole.planet.myplanet.di.DownloadPreferences private val preferences: android.content.SharedPreferences
+    @DownloadPreferences private val preferences: SharedPreferences
 ) : CoroutineWorker(context, workerParams) {
 
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
@@ -28,11 +28,11 @@ import org.ole.planet.myplanet.utils.UrlUtils
 class DownloadWorker @AssistedInject constructor(
     @Assisted private val context: Context, @Assisted workerParams: WorkerParameters,
     private val apiInterface: ApiInterface, private val broadcastService: BroadcastService,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    @org.ole.planet.myplanet.di.DownloadPreferences private val preferences: android.content.SharedPreferences
 ) : CoroutineWorker(context, workerParams) {
 
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    private val preferences = context.getSharedPreferences(DownloadService.PREFS_NAME, Context.MODE_PRIVATE)
 
     override suspend fun doWork(): Result = withContext(dispatcherProvider.io) {
         try {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/DownloadUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/DownloadUtils.kt
@@ -140,7 +140,6 @@ object DownloadUtils {
     @RequiresApi(Build.VERSION_CODES.S)
     fun openPriorityDownloadService(context: Context?, urls: ArrayList<String>) {
         context?.let { ctx ->
-            // TODO: Refactor DownloadUtils to support dependency injection for SharedPreferences
             val preferences = ctx.getSharedPreferences(DownloadService.PREFS_NAME, Context.MODE_PRIVATE)
 
             val existingPriority = preferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) ?: emptySet()
@@ -156,7 +155,6 @@ object DownloadUtils {
     @RequiresApi(Build.VERSION_CODES.S)
     fun openDownloadService(context: Context?, urls: ArrayList<String>, fromSync: Boolean) {
         context?.let { ctx ->
-            // TODO: Refactor DownloadUtils to support dependency injection for SharedPreferences
             val preferences = ctx.getSharedPreferences(DownloadService.PREFS_NAME, Context.MODE_PRIVATE)
 
             val existingUrls = preferences.getStringSet(DownloadService.PENDING_DOWNLOADS_KEY, emptySet()) ?: emptySet()

--- a/app/src/main/java/org/ole/planet/myplanet/utils/DownloadUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/DownloadUtils.kt
@@ -140,6 +140,7 @@ object DownloadUtils {
     @RequiresApi(Build.VERSION_CODES.S)
     fun openPriorityDownloadService(context: Context?, urls: ArrayList<String>) {
         context?.let { ctx ->
+            // TODO: Refactor DownloadUtils to support dependency injection for SharedPreferences
             val preferences = ctx.getSharedPreferences(DownloadService.PREFS_NAME, Context.MODE_PRIVATE)
 
             val existingPriority = preferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) ?: emptySet()
@@ -155,6 +156,7 @@ object DownloadUtils {
     @RequiresApi(Build.VERSION_CODES.S)
     fun openDownloadService(context: Context?, urls: ArrayList<String>, fromSync: Boolean) {
         context?.let { ctx ->
+            // TODO: Refactor DownloadUtils to support dependency injection for SharedPreferences
             val preferences = ctx.getSharedPreferences(DownloadService.PREFS_NAME, Context.MODE_PRIVATE)
 
             val existingUrls = preferences.getStringSet(DownloadService.PENDING_DOWNLOADS_KEY, emptySet()) ?: emptySet()


### PR DESCRIPTION
This PR introduces a dedicated `@DownloadPreferences` Hilt qualifier to cleanly provide `DownloadService.PREFS_NAME` specific `SharedPreferences`.

**Changes Made:**
1. Created `@DownloadPreferences` annotation and its corresponding `@Provides` method in `SharedPreferencesModule`.
2. Updated `DownloadService` to inject `SharedPreferences` using `@DownloadPreferences`, replacing the manual setup within its startup coroutine.
3. Updated `DownloadWorker` to accept `@DownloadPreferences` in its `@AssistedInject` constructor, removing the hardcoded property assignment.

This improves testability and follows Hilt dependency injection best practices. All affected test suites have been verified to pass.

---
*PR created automatically by Jules for task [12518739096397459981](https://jules.google.com/task/12518739096397459981) started by @dogi*