### PR TITLE
all: smoother base recycler list adapting (fixes #13899)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5681
-        versionName = "0.56.81"
+        versionCode = 5722
+        versionName = "0.57.22"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.base
 
 import android.os.Build
+import androidx.recyclerview.widget.ListAdapter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -37,7 +38,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
 
     abstract fun getLayout(): Int
 
-    abstract suspend fun getAdapter(): RecyclerView.Adapter<out RecyclerView.ViewHolder>
+    abstract suspend fun getAdapter(): androidx.recyclerview.widget.ListAdapter<*, *>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.ui.courses
 
 import android.app.AlertDialog
+import androidx.recyclerview.widget.ListAdapter
 import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
@@ -99,7 +100,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         Utilities.toast(activity, getString(R.string.removed_from_mycourse))
     }
 
-    override suspend fun getAdapter(): RecyclerView.Adapter<out RecyclerView.ViewHolder> {
+    override suspend fun getAdapter(): androidx.recyclerview.widget.ListAdapter<*, *> {
         val hostActivity = activity ?: throw CancellationException("Fragment detached")
 
         if (userModel == null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.ui.life
 
 import android.os.Bundle
+import androidx.recyclerview.widget.ListAdapter
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -47,7 +48,7 @@ class LifeFragment : BaseRecyclerFragment<RealmMyLife?>(), OnStartDragListener {
         return view
     }
 
-    override suspend fun getAdapter(): RecyclerView.Adapter<out RecyclerView.ViewHolder> {
+    override suspend fun getAdapter(): androidx.recyclerview.widget.ListAdapter<*, *> {
         lifeAdapter = LifeAdapter(requireContext(), this,
             visibilityCallback = { myLife, isVisible ->
                 myLife._id?.let { id ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.ui.resources
 
 import android.app.AlertDialog
+import androidx.recyclerview.widget.ListAdapter
 import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
@@ -114,7 +115,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         }
     }
 
-    override suspend fun getAdapter(): RecyclerView.Adapter<out RecyclerView.ViewHolder> {
+    override suspend fun getAdapter(): androidx.recyclerview.widget.ListAdapter<*, *> {
         allResourceModels = viewModel.getLibraryListModels(isMyCourseLib, model?.id)
 
         val user = profileDbHandler.getUserModel()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.ui.surveys
 
 import android.os.Bundle
+import androidx.recyclerview.widget.ListAdapter
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
@@ -69,7 +70,7 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), OnSurveyAdoptList
         viewModel.adoptSurvey(surveyId)
     }
 
-    override suspend fun getAdapter(): RecyclerView.Adapter<out RecyclerView.ViewHolder> {
+    override suspend fun getAdapter(): androidx.recyclerview.widget.ListAdapter<*, *> {
         adapterMutex.withLock {
             if (adapter == null) {
                 val userProfileModel = profileDbHandler.getUserModel()

--- a/app/src/test/java/org/ole/planet/myplanet/base/BaseRecyclerFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/base/BaseRecyclerFragmentTest.kt
@@ -19,7 +19,7 @@ class BaseRecyclerFragmentTest {
 
     class TestBaseRecyclerFragment : BaseRecyclerFragment<Any>() {
         override fun getLayout(): Int = 0
-        override suspend fun getAdapter(): androidx.recyclerview.widget.RecyclerView.Adapter<out androidx.recyclerview.widget.RecyclerView.ViewHolder> {
+        override suspend fun getAdapter(): androidx.recyclerview.widget.ListAdapter<*, *> {
             throw NotImplementedError()
         }
     }


### PR DESCRIPTION
This submission updates the abstract `getAdapter()` method in `BaseRecyclerFragment` to enforce the use of `androidx.recyclerview.widget.ListAdapter`. It resolves compilation errors by updating all child classes and test mocks that override `getAdapter()` to adhere to the new ListAdapter return type constraint.

---
*PR created automatically by Jules for task [132438650068966916](https://jules.google.com/task/132438650068966916) started by @dogi*