### PR TITLE
teams: smoother submissions repository pdf generating (fixes #13900)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5681
-        versionName = "0.56.81"
+        versionCode = 5723
+        versionName = "0.57.23"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -54,4 +54,6 @@ interface SubmissionsRepository {
     fun insertSubmission(mRealm: io.realm.Realm, submission: com.google.gson.JsonObject)
     suspend fun getExamUploadPayload(submission: org.ole.planet.myplanet.model.RealmSubmission): com.google.gson.JsonObject
     suspend fun serializeSubmission(submission: org.ole.planet.myplanet.model.RealmSubmission, context: android.content.Context, source: String, parentCode: String): com.google.gson.JsonObject
+    suspend fun generateSubmissionPdf(submissionId: String): java.io.File?
+    suspend fun generateMultipleSubmissionsPdf(submissionIds: List<String>, examTitle: String): java.io.File?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
@@ -19,7 +19,7 @@ import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.utils.TimeUtils
 
-class SubmissionsRepositoryExporter @Inject constructor(
+internal class SubmissionsRepositoryExporter @Inject constructor(
     databaseService: DatabaseService,
     @RealmDispatcher realmDispatcher: CoroutineDispatcher
 ) : RealmRepository(databaseService, realmDispatcher) {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -33,8 +33,17 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     private val teamsRepositoryProvider: Provider<TeamsRepository>,
     private val surveysRepositoryProvider: Provider<SurveysRepository>,
     @dagger.hilt.android.qualifiers.ApplicationContext private val context: android.content.Context,
-    private val sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager
+    private val sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager,
+    private val exporter: SubmissionsRepositoryExporter
 ) : RealmRepository(databaseService, realmDispatcher), SubmissionsRepository {
+
+    override suspend fun generateSubmissionPdf(submissionId: String): java.io.File? {
+        return exporter.generateSubmissionPdf(context, submissionId)
+    }
+
+    override suspend fun generateMultipleSubmissionsPdf(submissionIds: List<String>, examTitle: String): java.io.File? {
+        return exporter.generateMultipleSubmissionsPdf(context, submissionIds, examTitle)
+    }
 
     private fun RealmSubmission.examIdFromParentId(): String? {
         return parentId?.substringBefore("@")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionListFragment.kt
@@ -15,7 +15,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentSubmissionListBinding
-import org.ole.planet.myplanet.repository.SubmissionsRepositoryExporter
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
@@ -24,8 +23,6 @@ class SubmissionListFragment : Fragment() {
     private var _binding: FragmentSubmissionListBinding? = null
     private val binding get() = _binding!!
     private val viewModel: SubmissionListViewModel by viewModels()
-    @Inject
-    lateinit var submissionsRepositoryExporter: SubmissionsRepositoryExporter
     private var parentId: String? = null
     private var examTitle: String? = null
     private var userId: String? = null
@@ -53,6 +50,23 @@ class SubmissionListFragment : Fragment() {
         collectWhenStarted(viewModel.submissions) { submissionItems ->
             if (_binding != null) {
                 adapter.submitList(submissionItems)
+            }
+        }
+
+        collectWhenStarted(viewModel.exportProgress) { isExporting ->
+            if (_binding != null) {
+                binding.progressBar.visibility = if (isExporting) View.VISIBLE else View.GONE
+            }
+        }
+
+        collectWhenStarted(viewModel.exportFile) { file ->
+            if (_binding != null) {
+                if (file != null) {
+                    Toast.makeText(requireContext(), "PDF saved to ${file.absolutePath}", Toast.LENGTH_LONG).show()
+                    FileUtils.openPdf(requireContext(), file)
+                } else {
+                    Toast.makeText(requireContext(), "Failed to generate PDF", Toast.LENGTH_SHORT).show()
+                }
             }
         }
 
@@ -87,37 +101,11 @@ class SubmissionListFragment : Fragment() {
     }
 
     private fun generateSubmissionPdf(submissionId: String) {
-        viewLifecycleOwner.lifecycleScope.launch {
-            binding.progressBar.visibility = View.VISIBLE
-            val file = submissionsRepositoryExporter.generateSubmissionPdf(requireContext(), submissionId)
-            binding.progressBar.visibility = View.GONE
-
-            if (file != null) {
-                Toast.makeText(requireContext(), "PDF saved to ${file.absolutePath}", Toast.LENGTH_LONG).show()
-                FileUtils.openPdf(requireContext(), file)
-            } else {
-                Toast.makeText(requireContext(), "Failed to generate PDF", Toast.LENGTH_SHORT).show()
-            }
-        }
+        viewModel.generateSubmissionPdf(submissionId)
     }
 
     private fun generateReport(submissionIds: List<String>) {
-        viewLifecycleOwner.lifecycleScope.launch {
-            binding.progressBar.visibility = View.VISIBLE
-            val file = submissionsRepositoryExporter.generateMultipleSubmissionsPdf(
-                requireContext(),
-                submissionIds,
-                examTitle ?: "Submissions"
-            )
-            binding.progressBar.visibility = View.GONE
-
-            if (file != null) {
-                Toast.makeText(context, "Report saved to ${file.absolutePath}", Toast.LENGTH_LONG).show()
-                FileUtils.openPdf(requireContext(), file)
-            } else {
-                Toast.makeText(context, "Failed to generate report", Toast.LENGTH_SHORT).show()
-            }
-        }
+        viewModel.generateMultipleSubmissionsPdf(submissionIds, examTitle ?: "Submissions")
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionListViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionListViewModel.kt
@@ -3,9 +3,13 @@ package org.ole.planet.myplanet.ui.submissions
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.io.File
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.SubmissionItem
@@ -20,6 +24,30 @@ class SubmissionListViewModel @Inject constructor(
 
     private val _submissions = MutableStateFlow<List<SubmissionItem>>(emptyList())
     val submissions: StateFlow<List<SubmissionItem>> = _submissions.asStateFlow()
+
+    private val _exportProgress = MutableStateFlow(false)
+    val exportProgress: StateFlow<Boolean> = _exportProgress.asStateFlow()
+
+    private val _exportFile = MutableSharedFlow<File?>()
+    val exportFile: SharedFlow<File?> = _exportFile.asSharedFlow()
+
+    fun generateSubmissionPdf(submissionId: String) {
+        viewModelScope.launch(dispatcherProvider.io) {
+            _exportProgress.value = true
+            val file = submissionsRepository.generateSubmissionPdf(submissionId)
+            _exportFile.emit(file)
+            _exportProgress.value = false
+        }
+    }
+
+    fun generateMultipleSubmissionsPdf(submissionIds: List<String>, examTitle: String) {
+        viewModelScope.launch(dispatcherProvider.io) {
+            _exportProgress.value = true
+            val file = submissionsRepository.generateMultipleSubmissionsPdf(submissionIds, examTitle)
+            _exportFile.emit(file)
+            _exportProgress.value = false
+        }
+    }
 
     fun loadSubmissions(parentId: String?, userId: String?) {
         viewModelScope.launch(dispatcherProvider.io) {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -38,6 +38,7 @@ class SubmissionsRepositoryImplTest {
     private lateinit var surveysRepositoryProvider: Provider<SurveysRepository>
     private lateinit var context: Context
     private lateinit var sharedPrefManager: SharedPrefManager
+    private lateinit var exporter: SubmissionsRepositoryExporter
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private lateinit var repository: SubmissionsRepositoryImpl
@@ -51,6 +52,7 @@ class SubmissionsRepositoryImplTest {
         surveysRepositoryProvider = mockk(relaxed = true)
         context = mockk(relaxed = true)
         sharedPrefManager = mockk(relaxed = true)
+        exporter = mockk(relaxed = true)
 
         every { databaseService.ioDispatcher } returns testDispatcher
 
@@ -66,7 +68,8 @@ class SubmissionsRepositoryImplTest {
             teamsRepositoryProvider,
             surveysRepositoryProvider,
             context,
-            sharedPrefManager
+            sharedPrefManager,
+            exporter
         ), recordPrivateCalls = true)
     }
 


### PR DESCRIPTION
This change routes the submission export functionality through the submissions repository boundary instead of directly calling the concrete exporter from the Fragment.

- `SubmissionsRepository.kt`: Added `generateSubmissionPdf` and `generateMultipleSubmissionsPdf`.
- `SubmissionsRepositoryExporter.kt`: Made the class `internal`.
- `SubmissionsRepositoryImpl.kt`: Injected the internal `SubmissionsRepositoryExporter` and delegated the new interface methods to it.
- `SubmissionListViewModel.kt`: Added orchestration logic, tracking progress via `exportProgress` (`StateFlow`) and file results via `exportFile` (`SharedFlow`).
- `SubmissionListFragment.kt`: Removed direct exporter injection, observing the ViewModel's state to handle UI updates cleanly.
- `SubmissionsRepositoryImplTest.kt`: Fixed constructor mock to satisfy the new `SubmissionsRepositoryExporter` dependency.

---
*PR created automatically by Jules for task [5017287927821328619](https://jules.google.com/task/5017287927821328619) started by @dogi*