### PR TITLE
Fix syntax error in ChatViewModelTest

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatViewModelTest.kt
@@ -163,6 +163,7 @@ class ChatViewModelTest {
         viewModel.clearPaginationState()
         assertTrue(viewModel.allConversations.isEmpty())
         assertEquals(0, viewModel.loadedCount)
+    }
 
     @Test
     fun `loadChatHistoryScreenData fetches all data correctly when no caches are provided`() = runTest {


### PR DESCRIPTION
Added missing closing brace to `clearPaginationState resets allConversations and loadedCount` test.

---
*PR created automatically by Jules for task [15997788115332281237](https://jules.google.com/task/15997788115332281237) started by @dogi*