### PR TITLE
sync: add resumable heavy-table background  (fixes #13909)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
@@ -24,6 +24,7 @@ import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.retry.RetryQueueWorker
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
+import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.NetworkUtils
@@ -36,7 +37,8 @@ class ServerReachabilityWorker @AssistedInject constructor(
     private val uploadManager: UploadManager,
     private val submissionsRepository: SubmissionsRepository,
     private val serverUrlMapper: ServerUrlMapper,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val syncManager: SyncManager
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -192,6 +194,7 @@ class ServerReachabilityWorker @AssistedInject constructor(
                 }
             }
             uploadExamResultWrapper()
+            syncManager.resumeHeavyTablesIfNeeded()
             if (!MainApplication.isSyncRunning.get()) {
                 RetryQueueWorker.triggerImmediateRetry(applicationContext)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -72,6 +72,7 @@ class SyncManager @Inject constructor(
     private val eventsRepository: org.ole.planet.myplanet.repository.EventsRepository
 ) {
     private val isSyncing = AtomicBoolean(false)
+    private val isHeavySyncing = AtomicBoolean(false)
     private val stringArray = arrayOfNulls<String>(4)
     private var listener: OnSyncListener? = null
     private var backgroundSync: Job? = null
@@ -267,12 +268,18 @@ class SyncManager @Inject constructor(
 
             // Heavy tables start only after main sync fully completes — no overlap with resources/library
             val heavyTables = listOf("ratings", "courses_progress", "submissions", "login_activities", "team_activities")
-            syncScope.launch(dispatcherProvider.io) {
-                heavyTables.forEach { table ->
+            if (isHeavySyncing.compareAndSet(false, true)) {
+                syncScope.launch(dispatcherProvider.io) {
                     try {
-                        transactionSyncManager.syncDb(table)
-                    } catch (e: Exception) {
-                        Log.e("SyncPerf", "Background sync failed for $table: ${e.message}")
+                        heavyTables.forEach { table ->
+                            try {
+                                transactionSyncManager.syncDb(table, useCheckpoint = true)
+                            } catch (e: Exception) {
+                                Log.e("SyncPerf", "Background sync failed for $table: ${e.message}")
+                            }
+                        }
+                    } finally {
+                        isHeavySyncing.set(false)
                     }
                 }
             }
@@ -531,6 +538,29 @@ class SyncManager @Inject constructor(
             }
         }
         create(context, R.mipmap.ic_launcher, "Syncing data", "Please wait...")
+    }
+
+    fun resumeHeavyTablesIfNeeded() {
+        val heavyTables = listOf("ratings", "courses_progress", "submissions", "login_activities", "team_activities")
+        val pendingTables = heavyTables.filter { table ->
+            sharedPrefManager.rawPreferences.getInt("heavy_sync_skip_$table", 0) > 0
+        }
+        if (pendingTables.isEmpty()) return
+        if (isSyncing.get()) return
+        if (!isHeavySyncing.compareAndSet(false, true)) return
+        syncScope.launch(dispatcherProvider.io) {
+            try {
+                pendingTables.forEach { table ->
+                    try {
+                        transactionSyncManager.syncDb(table, useCheckpoint = true)
+                    } catch (e: Exception) {
+                        Log.e("SyncPerf", "Resume failed for $table: ${e.message}")
+                    }
+                }
+            } finally {
+                isHeavySyncing.set(false)
+            }
+        }
     }
 
     fun cancelBackgroundSync() {

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -151,26 +151,32 @@ class TransactionSyncManager @Inject constructor(
         }
     }
 
-    suspend fun syncDb(table: String): Int = withContext(dispatcherProvider.io) {
+    suspend fun syncDb(table: String, useCheckpoint: Boolean = false): Int = withContext(dispatcherProvider.io) {
         val syncStartTime = System.currentTimeMillis()
+        val checkpointKey = "heavy_sync_skip_$table"
         android.util.Log.d("SyncPerf", "  ▶ Starting $table sync")
         try {
-            // Determine pagination size based on table (smaller for slow endpoints)
             val pageSize = when (table) {
-                "ratings" -> 20        // Small batches for slow endpoint
-                "submissions" -> 100   // Medium batches for slow endpoint
-                "courses_progress", "login_activities", "team_activities" -> 200  // Smaller batches when running in background to reduce write-lock hold time
-                else -> 1000           // Large batches for fast endpoints
+                "ratings" -> 20
+                "submissions" -> 100
+                "courses_progress", "login_activities", "team_activities" -> 200
+                else -> 1000
             }
-            var skip = 0
+            var skip = if (useCheckpoint) {
+                val saved = sharedPrefManager.rawPreferences.getInt(checkpointKey, 0)
+                if (saved > 0) android.util.Log.d("SyncPerf", "  ↻ Resuming $table from skip=$saved")
+                saved
+            } else 0
             var totalDocs = 0
-            var batchNumber = 0
+            var batchNumber = if (useCheckpoint) skip / pageSize else 0
+            var syncCompletedFully = false
 
-            // Paginated fetching to avoid long-blocking API calls
             while (true) {
                 batchNumber++
+                if (useCheckpoint) {
+                    sharedPrefManager.rawPreferences.edit().putInt(checkpointKey, skip).apply()
+                }
                 val batchStartTime = System.currentTimeMillis()
-                // Time the batch API call (much faster with pagination)
                 val batchApiStartTime = System.currentTimeMillis()
                 val response = apiInterface.findDocs(
                     UrlUtils.header,
@@ -185,7 +191,8 @@ class TransactionSyncManager @Inject constructor(
                 }
                 val arr = getJsonArray("rows", response.body())
                 if (arr.size() == 0) {
-                    break // No more documents
+                    syncCompletedFully = true
+                    break
                 }
                 org.ole.planet.myplanet.utils.SyncTimeLogger.logApiCall(
                     "${UrlUtils.getUrl()}/$table/_all_docs (batch $batchNumber)",
@@ -287,8 +294,12 @@ class TransactionSyncManager @Inject constructor(
                 }
                 // If we got less than pageSize, we're done
                 if (arr.size() < pageSize) {
+                    syncCompletedFully = true
                     break
                 }
+            }
+            if (useCheckpoint && syncCompletedFully) {
+                sharedPrefManager.rawPreferences.edit().remove(checkpointKey).apply()
             }
             val totalDuration = System.currentTimeMillis() - syncStartTime
             android.util.Log.d("SyncPerf", "  ✓ Completed $table sync: $totalDocs docs in ${totalDuration}ms")


### PR DESCRIPTION
fixes #13909
```
Checkpoint/resume in TransactionSyncManager.syncDb()
Added a useCheckpoint: Boolean = false parameter. When enabled:
- Before the pagination loop starts, the function reads heavy_sync_skip_<table> from SharedPreferences and initialises skip from it. If the value is > 0 it logs that it is
resuming and skips directly to the saved offset.
- At the start of each loop iteration — before the API call — it writes the current skip value to SharedPreferences. Saving before the call (not after) means a crash or network
failure during a batch will re-fetch that batch on resume, which is safe because all Realm writes are upserts (copyToRealmOrUpdate).
- On clean completion (empty page or partial page confirming the last batch), a syncCompletedFully flag is set. The checkpoint key is only removed when that flag is true, so an
HTTP error or network exception mid-sync leaves the checkpoint intact for the next attempt.

Auto-resume on reconnect via SyncManager
Added resumeHeavyTablesIfNeeded() to SyncManager. It reads the five checkpoint keys from SharedPreferences, filters to only those with a non-zero value, and launches a background
coroutine to sync just those tables — skipping tables that either completed or never started.

Two guards prevent concurrent runs:
  - isSyncing.get() — skips if a full sync is currently in progress.
  - isHeavySyncing.compareAndSet(false, true) — skips if the post-full-sync background job is still running (there is a window between destroy() setting isSyncing = false and the background job finishing).
  
Wired into ServerReachabilityWorker
NetworkMonitorWorker already detects the network-disconnected → connected transition and schedules ServerReachabilityWorker with a 30-second stabilisation delay.
ServerReachabilityWorker already confirms the Planet server is reachable before doing anything. resumeHeavyTablesIfNeeded() is called from uploadSubmissions() in that worker,
after server reachability is confirmed, so the resume only fires when there is actually a server to talk to.
```