### PR TITLE
sync: smoother heavy table background resuming (fixes #13909)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5727
-        versionName = "0.57.27"
+        versionCode = 5733
+        versionName = "0.57.33"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/androidTest/java/org/ole/planet/myplanet/model/RealmUserTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/model/RealmUserTest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.ConfigurationsRepository
 import org.ole.planet.myplanet.repository.CoursesRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
@@ -66,6 +67,7 @@ class RealmUserTest {
         val mockConfigurationsRepository = mockk<ConfigurationsRepository>(relaxed = true)
         val mockAppScope = CoroutineScope(Dispatchers.Unconfined)
         val mockDispatcherProvider = mockk<DispatcherProvider>(relaxed = true)
+        val mockActivitiesRepositoryLazy = mockk<Lazy<ActivitiesRepository>>(relaxed = true)
 
         userRepository = UserRepositoryImpl(
             databaseService,
@@ -79,7 +81,8 @@ class RealmUserTest {
             mockContext,
             mockConfigurationsRepository,
             mockAppScope,
-            mockDispatcherProvider
+            mockDispatcherProvider,
+            mockActivitiesRepositoryLazy
         )
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
@@ -23,8 +23,8 @@ import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.retry.RetryQueueWorker
+import org.ole.planet.myplanet.services.sync.HeavyTableSyncWorker
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.NetworkUtils
@@ -37,8 +37,7 @@ class ServerReachabilityWorker @AssistedInject constructor(
     private val uploadManager: UploadManager,
     private val submissionsRepository: SubmissionsRepository,
     private val serverUrlMapper: ServerUrlMapper,
-    private val dispatcherProvider: DispatcherProvider,
-    private val syncManager: SyncManager
+    private val dispatcherProvider: DispatcherProvider
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -194,7 +193,7 @@ class ServerReachabilityWorker @AssistedInject constructor(
                 }
             }
             uploadExamResultWrapper()
-            syncManager.resumeHeavyTablesIfNeeded()
+            HeavyTableSyncWorker.scheduleIfPending(applicationContext, sharedPrefManager)
             if (!MainApplication.isSyncRunning.get()) {
                 RetryQueueWorker.triggerImmediateRetry(applicationContext)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
@@ -24,6 +24,7 @@ import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.retry.RetryQueueWorker
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
+import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.NetworkUtils
@@ -36,7 +37,8 @@ class ServerReachabilityWorker @AssistedInject constructor(
     private val uploadManager: UploadManager,
     private val submissionsRepository: SubmissionsRepository,
     private val serverUrlMapper: ServerUrlMapper,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val syncManager: SyncManager
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -192,6 +194,7 @@ class ServerReachabilityWorker @AssistedInject constructor(
                 }
             }
             uploadExamResultWrapper()
+            syncManager.resumeHeavyTablesIfNeeded()
             if (!MainApplication.isSyncRunning.get()) {
                 RetryQueueWorker.triggerImmediateRetry(applicationContext)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/HeavyTableSyncWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/HeavyTableSyncWorker.kt
@@ -1,0 +1,66 @@
+package org.ole.planet.myplanet.services.sync
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.util.concurrent.TimeUnit
+import org.ole.planet.myplanet.services.SharedPrefManager
+
+@HiltWorker
+class HeavyTableSyncWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val transactionSyncManager: TransactionSyncManager,
+    private val sharedPrefManager: SharedPrefManager,
+    private val syncManager: SyncManager
+) : CoroutineWorker(context, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val table = inputData.getString(KEY_TABLE) ?: return Result.failure()
+        if (syncManager.isMainSyncActive()) return Result.retry()
+        transactionSyncManager.syncDb(table, useCheckpoint = true)
+        val interrupted = sharedPrefManager.rawPreferences.getInt("heavy_sync_skip_$table", 0) > 0
+        return if (interrupted) Result.retry() else Result.success()
+    }
+
+    companion object {
+        const val KEY_TABLE = "table"
+        val ALL_HEAVY_TABLES = listOf(
+            "ratings", "courses_progress", "submissions", "login_activities", "team_activities"
+        )
+
+        fun schedule(context: Context, tables: List<String> = ALL_HEAVY_TABLES) {
+            val wm = WorkManager.getInstance(context)
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+            tables.forEach { table ->
+                val request = OneTimeWorkRequestBuilder<HeavyTableSyncWorker>()
+                    .setConstraints(constraints)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .setBackoffCriteria(BackoffPolicy.LINEAR, 30, TimeUnit.SECONDS)
+                    .setInputData(workDataOf(KEY_TABLE to table))
+                    .build()
+                wm.enqueueUniqueWork("heavy_sync_$table", ExistingWorkPolicy.KEEP, request)
+            }
+        }
+
+        fun scheduleIfPending(context: Context, sharedPrefManager: SharedPrefManager) {
+            val pending = ALL_HEAVY_TABLES.filter { table ->
+                sharedPrefManager.rawPreferences.getInt("heavy_sync_skip_$table", 0) > 0
+            }
+            if (pending.isNotEmpty()) schedule(context, pending)
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt
@@ -110,7 +110,10 @@ class ImprovedSyncManager @Inject constructor(
 
         initializeSync()
 
-        val tablesToSync = syncTables ?: syncOrder
+        val heavyTableSet = HeavyTableSyncWorker.ALL_HEAVY_TABLES.toSet()
+        val requested = syncTables ?: syncOrder
+        val tablesToSync = requested.filter { it !in heavyTableSet }
+        val heavyTablesToSchedule = requested.filter { it in heavyTableSet }
         val strategy = getStrategy(syncMode)
 
         coroutineScope {
@@ -133,6 +136,10 @@ class ImprovedSyncManager @Inject constructor(
         logger.endProcess("on_synced")
 
         logger.stopLogging()
+
+        if (heavyTablesToSchedule.isNotEmpty()) {
+            HeavyTableSyncWorker.schedule(context, heavyTablesToSchedule)
+        }
     }
 
     private suspend fun syncTable(table: String, strategy: SyncStrategy, logger: SyncTimeLogger) {

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -72,6 +72,7 @@ class SyncManager @Inject constructor(
     private val eventsRepository: org.ole.planet.myplanet.repository.EventsRepository
 ) {
     private val isSyncing = AtomicBoolean(false)
+    private val isHeavySyncing = AtomicBoolean(false)
     private val stringArray = arrayOfNulls<String>(4)
     private var listener: OnSyncListener? = null
     private var backgroundSync: Job? = null
@@ -267,12 +268,18 @@ class SyncManager @Inject constructor(
 
             // Heavy tables start only after main sync fully completes — no overlap with resources/library
             val heavyTables = listOf("ratings", "courses_progress", "submissions", "login_activities", "team_activities")
-            syncScope.launch(dispatcherProvider.io) {
-                heavyTables.forEach { table ->
+            if (isHeavySyncing.compareAndSet(false, true)) {
+                syncScope.launch(dispatcherProvider.io) {
                     try {
-                        transactionSyncManager.syncDb(table)
-                    } catch (e: Exception) {
-                        Log.e("SyncPerf", "Background sync failed for $table: ${e.message}")
+                        heavyTables.forEach { table ->
+                            try {
+                                transactionSyncManager.syncDb(table, useCheckpoint = true)
+                            } catch (e: Exception) {
+                                Log.e("SyncPerf", "Background sync failed for $table: ${e.message}")
+                            }
+                        }
+                    } finally {
+                        isHeavySyncing.set(false)
                     }
                 }
             }
@@ -531,6 +538,29 @@ class SyncManager @Inject constructor(
             }
         }
         create(context, R.mipmap.ic_launcher, "Syncing data", "Please wait...")
+    }
+
+    fun resumeHeavyTablesIfNeeded() {
+        val heavyTables = listOf("ratings", "courses_progress", "submissions", "login_activities", "team_activities")
+        val pendingTables = heavyTables.filter { table ->
+            sharedPrefManager.rawPreferences.getInt("heavy_sync_skip_$table", 0) > 0
+        }
+        if (pendingTables.isEmpty()) return
+        if (isSyncing.get()) return
+        if (!isHeavySyncing.compareAndSet(false, true)) return
+        syncScope.launch(dispatcherProvider.io) {
+            try {
+                pendingTables.forEach { table ->
+                    try {
+                        transactionSyncManager.syncDb(table, useCheckpoint = true)
+                    } catch (e: Exception) {
+                        Log.e("SyncPerf", "Resume failed for $table: ${e.message}")
+                    }
+                }
+            } finally {
+                isHeavySyncing.set(false)
+            }
+        }
     }
 
     fun cancelBackgroundSync() {

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -72,7 +72,6 @@ class SyncManager @Inject constructor(
     private val eventsRepository: org.ole.planet.myplanet.repository.EventsRepository
 ) {
     private val isSyncing = AtomicBoolean(false)
-    private val isHeavySyncing = AtomicBoolean(false)
     private val stringArray = arrayOfNulls<String>(4)
     private var listener: OnSyncListener? = null
     private var backgroundSync: Job? = null
@@ -126,6 +125,8 @@ class SyncManager @Inject constructor(
     fun resetSyncStatus() {
         _syncStatus.value = SyncStatus.Idle
     }
+
+    fun isMainSyncActive(): Boolean = isSyncing.get()
 
     private fun initializeAndStartImprovedSync(listener: OnSyncListener?, syncTables: List<String>?) {
         syncScope.launch {
@@ -266,23 +267,7 @@ class SyncManager @Inject constructor(
 
             logger.stopLogging()
 
-            // Heavy tables start only after main sync fully completes — no overlap with resources/library
-            val heavyTables = listOf("ratings", "courses_progress", "submissions", "login_activities", "team_activities")
-            if (isHeavySyncing.compareAndSet(false, true)) {
-                syncScope.launch(dispatcherProvider.io) {
-                    try {
-                        heavyTables.forEach { table ->
-                            try {
-                                transactionSyncManager.syncDb(table, useCheckpoint = true)
-                            } catch (e: Exception) {
-                                Log.e("SyncPerf", "Background sync failed for $table: ${e.message}")
-                            }
-                        }
-                    } finally {
-                        isHeavySyncing.set(false)
-                    }
-                }
-            }
+            HeavyTableSyncWorker.schedule(context)
 
             val syncEndTime = System.currentTimeMillis()
             val totalSyncTime = syncEndTime - syncStartTime
@@ -324,7 +309,7 @@ class SyncManager @Inject constructor(
 
                     syncJobs.add(async {
                         logger.startProcess("login_activities_sync")
-                        transactionSyncManager.syncDb("login_activities")
+                        transactionSyncManager.syncDb("login_activities", useCheckpoint = true)
                         logger.endProcess("login_activities_sync")
                     })
 
@@ -390,13 +375,13 @@ class SyncManager @Inject constructor(
 
                     syncJobs.add(async {
                         logger.startProcess("courses_progress_sync")
-                        transactionSyncManager.syncDb("courses_progress")
+                        transactionSyncManager.syncDb("courses_progress", useCheckpoint = true)
                         logger.endProcess("courses_progress_sync")
                     })
 
                     syncJobs.add(async {
                         logger.startProcess("ratings_sync")
-                        transactionSyncManager.syncDb("ratings")
+                        transactionSyncManager.syncDb("ratings", useCheckpoint = true)
                         logger.endProcess("ratings_sync")
                     })
                 }
@@ -422,7 +407,7 @@ class SyncManager @Inject constructor(
                 if (syncTables?.contains("team_activities") == true) {
                     syncJobs.add(async {
                         logger.startProcess("team_activities_sync")
-                        transactionSyncManager.syncDb("team_activities")
+                        transactionSyncManager.syncDb("team_activities", useCheckpoint = true)
                         logger.endProcess("team_activities_sync")
                     })
                 }
@@ -480,7 +465,7 @@ class SyncManager @Inject constructor(
 
                     syncJobs.add(async {
                         logger.startProcess("submissions_sync")
-                        transactionSyncManager.syncDb("submissions")
+                        transactionSyncManager.syncDb("submissions", useCheckpoint = true)
                         logger.endProcess("submissions_sync")
                     })
                 }
@@ -538,29 +523,6 @@ class SyncManager @Inject constructor(
             }
         }
         create(context, R.mipmap.ic_launcher, "Syncing data", "Please wait...")
-    }
-
-    fun resumeHeavyTablesIfNeeded() {
-        val heavyTables = listOf("ratings", "courses_progress", "submissions", "login_activities", "team_activities")
-        val pendingTables = heavyTables.filter { table ->
-            sharedPrefManager.rawPreferences.getInt("heavy_sync_skip_$table", 0) > 0
-        }
-        if (pendingTables.isEmpty()) return
-        if (isSyncing.get()) return
-        if (!isHeavySyncing.compareAndSet(false, true)) return
-        syncScope.launch(dispatcherProvider.io) {
-            try {
-                pendingTables.forEach { table ->
-                    try {
-                        transactionSyncManager.syncDb(table, useCheckpoint = true)
-                    } catch (e: Exception) {
-                        Log.e("SyncPerf", "Resume failed for $table: ${e.message}")
-                    }
-                }
-            } finally {
-                isHeavySyncing.set(false)
-            }
-        }
     }
 
     fun cancelBackgroundSync() {

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -151,26 +151,32 @@ class TransactionSyncManager @Inject constructor(
         }
     }
 
-    suspend fun syncDb(table: String): Int = withContext(dispatcherProvider.io) {
+    suspend fun syncDb(table: String, useCheckpoint: Boolean = false): Int = withContext(dispatcherProvider.io) {
         val syncStartTime = System.currentTimeMillis()
+        val checkpointKey = "heavy_sync_skip_$table"
         android.util.Log.d("SyncPerf", "  ▶ Starting $table sync")
         try {
-            // Determine pagination size based on table (smaller for slow endpoints)
             val pageSize = when (table) {
-                "ratings" -> 20        // Small batches for slow endpoint
-                "submissions" -> 100   // Medium batches for slow endpoint
-                "courses_progress", "login_activities", "team_activities" -> 200  // Smaller batches when running in background to reduce write-lock hold time
-                else -> 1000           // Large batches for fast endpoints
+                "ratings" -> 20
+                "submissions" -> 100
+                "courses_progress", "login_activities", "team_activities" -> 200
+                else -> 1000
             }
-            var skip = 0
+            var skip = if (useCheckpoint) {
+                val saved = sharedPrefManager.rawPreferences.getInt(checkpointKey, 0)
+                if (saved > 0) android.util.Log.d("SyncPerf", "  ↻ Resuming $table from skip=$saved")
+                saved
+            } else 0
             var totalDocs = 0
-            var batchNumber = 0
+            var batchNumber = if (useCheckpoint) skip / pageSize else 0
+            var syncCompletedFully = false
 
-            // Paginated fetching to avoid long-blocking API calls
             while (true) {
                 batchNumber++
+                if (useCheckpoint) {
+                    sharedPrefManager.rawPreferences.edit().putInt(checkpointKey, skip).apply()
+                }
                 val batchStartTime = System.currentTimeMillis()
-                // Time the batch API call (much faster with pagination)
                 val batchApiStartTime = System.currentTimeMillis()
                 val response = apiInterface.findDocs(
                     UrlUtils.header,
@@ -185,7 +191,8 @@ class TransactionSyncManager @Inject constructor(
                 }
                 val arr = getJsonArray("rows", response.body())
                 if (arr.size() == 0) {
-                    break // No more documents
+                    syncCompletedFully = true
+                    break
                 }
                 org.ole.planet.myplanet.utils.SyncTimeLogger.logApiCall(
                     "${UrlUtils.getUrl()}/$table/_all_docs (batch $batchNumber)",
@@ -287,8 +294,12 @@ class TransactionSyncManager @Inject constructor(
                 }
                 // If we got less than pageSize, we're done
                 if (arr.size() < pageSize) {
+                    syncCompletedFully = true
                     break
                 }
+            }
+            if (useCheckpoint && syncCompletedFully) {
+                sharedPrefManager.rawPreferences.edit().remove(checkpointKey).apply()
             }
             val totalDuration = System.currentTimeMillis() - syncStartTime
             android.util.Log.d("SyncPerf", "  ✓ Completed $table sync: $totalDocs docs in ${totalDuration}ms")

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -61,12 +61,8 @@ class TransactionSyncManager @Inject constructor(
     suspend fun authenticate(): Boolean {
         try {
             val targetUrl = "${UrlUtils.getUrl()}/tablet_users/_all_docs"
-            val response = apiInterface.getDocuments(
-                UrlUtils.header,
-                targetUrl
-            )
-            val code = response.code()
-            return code == 200
+            val response = apiInterface.getDocuments(UrlUtils.header, targetUrl)
+            return response.code() == 200 && response.body() != null
         } catch (e: Exception) {
             e.printStackTrace()
         }
@@ -170,18 +166,20 @@ class TransactionSyncManager @Inject constructor(
             var totalDocs = 0
             var batchNumber = if (useCheckpoint) skip / pageSize else 0
             var syncCompletedFully = false
+            val url = UrlUtils.getUrl()
+            val authHeader = UrlUtils.header
 
             while (true) {
                 batchNumber++
                 if (useCheckpoint) {
-                    sharedPrefManager.rawPreferences.edit().putInt(checkpointKey, skip).apply()
+                    sharedPrefManager.rawPreferences.edit().putInt(checkpointKey, skip).commit()
                 }
                 val batchStartTime = System.currentTimeMillis()
                 val batchApiStartTime = System.currentTimeMillis()
                 val response = apiInterface.findDocs(
-                    UrlUtils.header,
+                    authHeader,
                     "application/json",
-                    UrlUtils.getUrl() + "/" + table + "/_all_docs?include_docs=true&limit=$pageSize&skip=$skip",
+                    "$url/$table/_all_docs?include_docs=true&limit=$pageSize&skip=$skip",
                     JsonObject() // Empty body for GET-style query
                 )
                 val batchApiDuration = System.currentTimeMillis() - batchApiStartTime
@@ -195,7 +193,7 @@ class TransactionSyncManager @Inject constructor(
                     break
                 }
                 org.ole.planet.myplanet.utils.SyncTimeLogger.logApiCall(
-                    "${UrlUtils.getUrl()}/$table/_all_docs (batch $batchNumber)",
+                    "$url/$table/_all_docs (batch $batchNumber)",
                     batchApiDuration,
                     response.isSuccessful,
                     arr.size()
@@ -299,7 +297,7 @@ class TransactionSyncManager @Inject constructor(
                 }
             }
             if (useCheckpoint && syncCompletedFully) {
-                sharedPrefManager.rawPreferences.edit().remove(checkpointKey).apply()
+                sharedPrefManager.rawPreferences.edit().remove(checkpointKey).commit()
             }
             val totalDuration = System.currentTimeMillis() - syncStartTime
             android.util.Log.d("SyncPerf", "  ✓ Completed $table sync: $totalDocs docs in ${totalDuration}ms")

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/TransactionSyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/TransactionSyncManagerTest.kt
@@ -102,6 +102,7 @@ class TransactionSyncManagerTest {
     fun authenticate_success_returnsTrue() = testScope.runTest {
         val mockResponse = mockk<Response<DocumentResponse>>()
         every { mockResponse.code() } returns 200
+        every { mockResponse.body() } returns mockk<DocumentResponse>()
         coEvery { apiInterface.getDocuments(any(), any()) } returns mockResponse
 
         val result = transactionSyncManager.authenticate()


### PR DESCRIPTION
fixes #13909
```
  Problem                                                                                                                                                     

  The five heavy tables — ratings, courses_progress, submissions, login_activities, team_activities — were deferred to a background coroutine after the main sync. That coroutine had
  no memory of how far it had got. Any interruption (process kill, network drop, app backgrounded under memory pressure) restarted each table from zero on the next sync.

  ---
  What was built
  
  Checkpoint/resume in TransactionSyncManager.syncDb()

  Added a useCheckpoint: Boolean parameter. When enabled, the current skip offset is written to SharedPreferences with commit() (synchronous flush) at the start of every batch —
  before the API call — so the position survives a hard process kill. A syncCompletedFully flag distinguishes a clean finish from an HTTP error mid-run: the checkpoint is only
  cleared on genuine completion, preserving the resume point for network failures and server errors alike. The URL and auth header are also snapshotted at the start of the method so
  a server-URL switch mid-run cannot split batches across two different servers.                           
                                                                                                                                                              
  HeavyTableSyncWorker

  One WorkManager CoroutineWorker per table (heavy_sync_<table>), each with:
  - NetworkType.CONNECTED constraint — pauses automatically when connectivity drops, resumes when it returns
  - setExpedited(RUN_AS_NON_EXPEDITED_WORK_REQUEST) — runs as a foreground-service job on API 26–30, a native expedited job on API 31+; resists Doze mode and OEM battery killers
  - ExistingWorkPolicy.KEEP — a second schedule() call while a worker is already queued is a no-op, preventing duplicate work
  - Linear 30-second backoff on Result.retry()
  - After each syncDb() call, the worker reads the checkpoint key: non-zero means interrupted → retry(); zero means done → success()

  Auto-resume on reconnect

  NetworkMonitorWorker already detects the disconnected→connected transition and fires ServerReachabilityWorker after a 30-second stabilisation delay. ServerReachabilityWorker
  already confirms the Planet server is reachable before acting. HeavyTableSyncWorker.scheduleIfPending() is called there: it reads the five checkpoint keys and enqueues workers
  only for tables that were actually interrupted.
  
  ImprovedSyncManager parity                                                                                                                                  

  When the improved-sync flag is on, performSync() previously ran the five heavy tables inline with no checkpointing. Now it filters them from the inline list and calls
  HeavyTableSyncWorker.schedule() after the main sync completes, with the same WorkManager guarantees as the standard path.

  Fast sync checkpoints
                                                                                                                                                              
  The five heavy tables in startFastSync() all now pass useCheckpoint = true, so a targeted user-triggered sync that is interrupted mid-table resumes from the saved position rather
  than starting over.

  authenticate() captive portal guard

  Added && response.body() != null. A captive portal returns HTML; Gson fails to parse it and throws, which the existing catch already turned into false. The body check adds a
  second layer for any valid-JSON portal response, preventing a sync from starting against the wrong server.
```