### PR TITLE
all: smoother image utils profile loading (fixes #13929)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5730
-        versionName = "0.57.30"
+        versionCode = 5735
+        versionName = "0.57.35"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthUsersAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthUsersAdapter.kt
@@ -5,12 +5,11 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
-import com.bumptech.glide.load.engine.DiskCacheStrategy
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemUserBinding
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.ImageUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 
 class HealthUsersAdapter(private val clickListener: ((RealmUser) -> Unit)? = null) :
@@ -31,13 +30,8 @@ class HealthUsersAdapter(private val clickListener: ((RealmUser) -> Unit)? = nul
             binding.txtJoined.text = binding.root.context.getString(R.string.joined_colon, TimeUtils.formatDate(user.joinDate))
 
             if (!TextUtils.isEmpty(user.userImage)) {
-                Glide.with(binding.ivUser.context)
-                    .load(user.userImage)
-                    .diskCacheStrategy(DiskCacheStrategy.ALL)
-                    .circleCrop()
-                    .placeholder(R.drawable.profile)
-                    .error(R.drawable.profile)
-                    .into(binding.ivUser)
+                val avatarSize = binding.ivUser.context.resources.getDimensionPixelSize(R.dimen._80dp)
+                ImageUtils.loadProfileImage(user.userImage, binding.ivUser, avatarSize)
             } else {
                 binding.ivUser.setImageResource(R.drawable.profile)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersAdapter.kt
@@ -12,8 +12,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
-import com.bumptech.glide.load.engine.DiskCacheStrategy
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -23,6 +21,7 @@ import org.ole.planet.myplanet.databinding.RowJoinedUserBinding
 import org.ole.planet.myplanet.repository.JoinedMemberData
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.ImageUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 
 class MembersAdapter(
@@ -95,14 +94,7 @@ class MembersAdapter(
             lastVisitDate
         )
         val avatarSize = binding.root.context.resources.getDimensionPixelSize(R.dimen._40dp)
-        Glide.with(binding.memberImage.context)
-            .load(member.userImage)
-            .diskCacheStrategy(DiskCacheStrategy.ALL)
-            .override(avatarSize, avatarSize)
-            .circleCrop()
-            .placeholder(R.drawable.profile)
-            .error(R.drawable.profile)
-            .into(binding.memberImage)
+        ImageUtils.loadProfileImage(member.userImage, binding.memberImage, avatarSize)
 
         if (memberData.isLeader) {
             binding.tvIsLeader.visibility = View.VISIBLE

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/UserArrayAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/UserArrayAdapter.kt
@@ -6,12 +6,11 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
-import com.bumptech.glide.load.engine.DiskCacheStrategy
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemUserBinding
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.ImageUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 
 class UserArrayAdapter(
@@ -40,13 +39,8 @@ class UserArrayAdapter(
         holder.binding.txtJoined.text = context.getString(R.string.joined_colon, TimeUtils.formatDate(user.joinDate))
 
         if (!TextUtils.isEmpty(user.userImage)) {
-            Glide.with(context)
-                .load(user.userImage)
-                .diskCacheStrategy(DiskCacheStrategy.ALL)
-                .circleCrop()
-                .placeholder(R.drawable.profile)
-                .error(R.drawable.profile)
-                .into(holder.binding.ivUser)
+            val avatarSize = context.resources.getDimensionPixelSize(R.dimen._80dp)
+            ImageUtils.loadProfileImage(user.userImage, holder.binding.ivUser, avatarSize)
         } else {
             holder.binding.ivUser.setImageResource(R.drawable.profile)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/UsersAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/UsersAdapter.kt
@@ -4,13 +4,12 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
-import com.bumptech.glide.load.engine.DiskCacheStrategy
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnUserProfileClickListener
 import org.ole.planet.myplanet.databinding.UserListItemBinding
 import org.ole.planet.myplanet.model.User
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.ImageUtils
 
 class UsersAdapter(
     private val onItemClickListener: OnUserProfileClickListener
@@ -43,14 +42,7 @@ class UsersAdapter(
                 binding.userNameTextView.text = account.fullName
             }
             val avatarSize = binding.root.context.resources.getDimensionPixelSize(R.dimen._40dp)
-            Glide.with(binding.userProfile.context)
-                .load(account.image)
-                .diskCacheStrategy(DiskCacheStrategy.ALL)
-                .override(avatarSize, avatarSize)
-                .circleCrop()
-                .placeholder(R.drawable.profile)
-                .error(R.drawable.profile)
-                .into(binding.userProfile)
+            ImageUtils.loadProfileImage(account.image, binding.userProfile, avatarSize)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/utils/ImageUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ImageUtils.kt
@@ -6,6 +6,17 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy
 import org.ole.planet.myplanet.R
 
 object ImageUtils {
+    fun loadProfileImage(image: String?, imageView: ImageView, sizePx: Int) {
+        Glide.with(imageView.context)
+            .load(image)
+            .diskCacheStrategy(DiskCacheStrategy.ALL)
+            .override(sizePx, sizePx)
+            .circleCrop()
+            .placeholder(R.drawable.profile)
+            .error(R.drawable.profile)
+            .into(imageView)
+    }
+
     fun loadImage(userImage: String?, imageView: ImageView) {
         if (!userImage.isNullOrEmpty()) {
             Glide.with(imageView.context)


### PR DESCRIPTION
fixes #13929
Replace duplicated Glide usage across user/teams/health adapters with a single ImageUtils.loadProfileImage helper. Adds loadProfileImage(image, imageView, sizePx) to ImageUtils (uses Glide with disk caching, override size, circleCrop, placeholder/error) and updates HealthUsersAdapter, MembersAdapter, UserArrayAdapter, and UsersAdapter to call it and remove direct Glide imports. Simplifies avatar handling and standardizes image loading behavior using resource-based avatar sizes.