### PR TITLE
sync: smoother download service coroutine scoping (fixes #14041)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5744
-        versionName = "0.57.44"
+        versionCode = 5780
+        versionName = "0.57.80"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -27,6 +27,7 @@ import javax.inject.Inject
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import okhttp3.ResponseBody
 import org.ole.planet.myplanet.R
@@ -496,6 +497,7 @@ class DownloadService : Service() {
             Log.e(TAG, "Error stopping foreground service", e)
         }
         downloadJob.cancel()
+        downloadScope.cancel()
         notificationManager?.cancel(ONGOING_NOTIFICATION_ID)
         super.onDestroy()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -82,7 +82,6 @@ class DownloadService : Service() {
     private var isCurrentDownloadPriority = false
     private var isQueueRunning = false
 
-    private val downloadJob = SupervisorJob()
     private lateinit var downloadScope: CoroutineScope
     private lateinit var broadcastService: BroadcastService
 
@@ -90,7 +89,7 @@ class DownloadService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        downloadScope = CoroutineScope(downloadJob + dispatcherProvider.io)
+        downloadScope = CoroutineScope(SupervisorJob() + dispatcherProvider.io)
         broadcastService = getBroadcastService(this)
     }
 
@@ -496,7 +495,6 @@ class DownloadService : Service() {
         } catch (e: Exception) {
             Log.e(TAG, "Error stopping foreground service", e)
         }
-        downloadJob.cancel()
         downloadScope.cancel()
         notificationManager?.cancel(ONGOING_NOTIFICATION_ID)
         super.onDestroy()


### PR DESCRIPTION
Properly manage CoroutineScope in DownloadService by cancelling it in onDestroy() to prevent memory leaks.

---
*PR created automatically by Jules for task [5897660042592137978](https://jules.google.com/task/5897660042592137978) started by @dogi*