### PR TITLE
Memoize SharedPrefManager in ThemeManager

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/ThemeManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/ThemeManager.kt
@@ -11,8 +11,10 @@ import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
 import org.ole.planet.myplanet.utils.ThemeMode
 
 object ThemeManager {
+    private var spm: SharedPrefManager? = null
+
     private fun getSpm(context: Context): SharedPrefManager =
-        EntryPointAccessors.fromApplication(context.applicationContext, CoreDependenciesEntryPoint::class.java).sharedPrefManager()
+        spm ?: EntryPointAccessors.fromApplication(context.applicationContext, CoreDependenciesEntryPoint::class.java).sharedPrefManager().also { spm = it }
 
     fun showThemeDialog(context: Context) {
         val options = arrayOf(

--- a/app/src/test/java/org/ole/planet/myplanet/services/ThemeManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/ThemeManagerTest.kt
@@ -48,6 +48,11 @@ class ThemeManagerTest {
 
         every { EntryPointAccessors.fromApplication(any(), CoreDependenciesEntryPoint::class.java) } returns mockEntryPoint
         every { mockEntryPoint.sharedPrefManager() } returns mockSpm
+
+        // Reset the object state before each test
+        val spmField = ThemeManager::class.java.getDeclaredField("spm")
+        spmField.isAccessible = true
+        spmField.set(ThemeManager, null)
     }
 
     @After


### PR DESCRIPTION
Memoized SharedPrefManager in ThemeManager to prevent repeated resolution via EntryPointAccessors. Reset the singleton state in tests using reflection to prevent test pollution.

---
*PR created automatically by Jules for task [6403119142173150550](https://jules.google.com/task/6403119142173150550) started by @dogi*