### PR TITLE
Refactor ConfigurationsRepository checkVersion to use a suspend result model

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
@@ -5,17 +5,16 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 
 interface ConfigurationsRepository {
     suspend fun checkHealth(): String
-    fun checkVersion(callback: CheckVersionCallback, spm: SharedPrefManager)
+    suspend fun checkVersion(): VersionCheckResult
     suspend fun checkServerAvailability(): Boolean
     suspend fun checkServerAvailability(url: String): Boolean
     suspend fun checkCheckSum(path: String): Boolean
     suspend fun clearAllData()
     suspend fun getMinApk(url: String, pin: String): ConfigurationResult
 
-    interface CheckVersionCallback {
-        fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean)
-        fun onCheckingVersion() {}
-        fun onError(msg: String, blockSync: Boolean)
+    sealed class VersionCheckResult {
+        data class UpdateAvailable(val info: MyPlanet?, val cancelable: Boolean) : VersionCheckResult()
+        data class Error(val msg: String, val blockSync: Boolean) : VersionCheckResult()
     }
 
     sealed class ConfigurationResult {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -86,15 +86,12 @@ class ConfigurationsRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun checkVersion(callback: ConfigurationsRepository.CheckVersionCallback, spm: SharedPrefManager) {
-        val baseUrl = UrlUtils.baseUrl(spm)
-        if (baseUrl.isEmpty()) {
-            callback.onError(context.getString(R.string.server_url_not_configured), true)
-            return
-        }
-
-        serviceScope.launch(dispatcherProvider.io) {
-            callback.onCheckingVersion()
+    override suspend fun checkVersion(): ConfigurationsRepository.VersionCheckResult {
+        return withContext(dispatcherProvider.io) {
+            val baseUrl = UrlUtils.baseUrl(sharedPrefManager)
+            if (baseUrl.isEmpty()) {
+                return@withContext ConfigurationsRepository.VersionCheckResult.Error(context.getString(R.string.server_url_not_configured), true)
+            }
 
             val lastCheckTime = sharedPrefManager.rawPreferences.getLong("last_version_check_timestamp", 0)
             val currentTime = System.currentTimeMillis()
@@ -107,8 +104,7 @@ class ConfigurationsRepositoryImpl @Inject constructor(
                 if (cachedVersionDetail != null && cachedApkVersion != -1) {
                     try {
                         val cachedInfo = JsonUtils.gson.fromJson(cachedVersionDetail, MyPlanet::class.java)
-                        handleVersionEvaluation(cachedInfo, cachedApkVersion, callback)
-                        return@launch
+                        return@withContext handleVersionEvaluation(cachedInfo, cachedApkVersion)
                     } catch (e: Exception) {
                         e.printStackTrace()
                     }
@@ -116,10 +112,9 @@ class ConfigurationsRepositoryImpl @Inject constructor(
             }
 
             try {
-                val planetInfo = fetchVersionInfo(spm)
+                val planetInfo = fetchVersionInfo(sharedPrefManager)
                 if (planetInfo == null) {
-                    callback.onError(context.getString(R.string.version_not_found), true)
-                    return@launch
+                    return@withContext ConfigurationsRepository.VersionCheckResult.Error(context.getString(R.string.version_not_found), true)
                 }
 
                 sharedPrefManager.rawPreferences.edit {
@@ -128,32 +123,26 @@ class ConfigurationsRepositoryImpl @Inject constructor(
                 sharedPrefManager.setLastWifiId(NetworkUtils.getCurrentNetworkId(context))
                 sharedPrefManager.setVersionDetail(JsonUtils.gson.toJson(planetInfo))
 
-                val rawApkVersion = fetchApkVersionString(spm)
+                val rawApkVersion = fetchApkVersionString(sharedPrefManager)
                 val versionStr = JsonUtils.gson.fromJson(rawApkVersion, String::class.java)
                 if (versionStr.isNullOrEmpty()) {
-                    callback.onError(context.getString(R.string.planet_is_up_to_date), false)
-                    return@launch
+                    return@withContext ConfigurationsRepository.VersionCheckResult.Error(context.getString(R.string.planet_is_up_to_date), false)
                 }
 
                 val apkVersion = VersionUtils.parseApkVersionString(versionStr)
-                    ?: run {
-                        callback.onError(
-                            context.getString(R.string.new_apk_version_required_but_not_found_on_server),
-                            false
-                        )
-                        return@launch
-                    }
+                    ?: return@withContext ConfigurationsRepository.VersionCheckResult.Error(
+                        context.getString(R.string.new_apk_version_required_but_not_found_on_server),
+                        false
+                    )
 
                 sharedPrefManager.rawPreferences.edit {
                     putInt("cachedApkVersion", apkVersion)
                 }
 
-                handleVersionEvaluation(planetInfo, apkVersion, callback)
+                return@withContext handleVersionEvaluation(planetInfo, apkVersion)
             } catch (e: Exception) {
                 e.printStackTrace()
-                withContext(dispatcherProvider.main) {
-                    callback.onError(context.getString(R.string.connection_failed), true)
-                }
+                return@withContext ConfigurationsRepository.VersionCheckResult.Error(context.getString(R.string.connection_failed), true)
             }
         }
     }
@@ -424,17 +413,17 @@ class ConfigurationsRepositoryImpl @Inject constructor(
             }
         }
 
-    private fun handleVersionEvaluation(info: MyPlanet, apkVersion: Int, callback: ConfigurationsRepository.CheckVersionCallback) {
-        val currentVersion = VersionUtils.getVersionCode(context)
-        serviceScope.launch(dispatcherProvider.main) {
+    private suspend fun handleVersionEvaluation(info: MyPlanet, apkVersion: Int): ConfigurationsRepository.VersionCheckResult {
+        return withContext(dispatcherProvider.main) {
+            val currentVersion = VersionUtils.getVersionCode(context)
             if (Constants.showBetaFeature(Constants.KEY_UPGRADE_MAX, context) && info.latestapkcode > currentVersion) {
-                callback.onUpdateAvailable(info, false)
+                ConfigurationsRepository.VersionCheckResult.UpdateAvailable(info, false)
             } else if (apkVersion > currentVersion) {
-                callback.onUpdateAvailable(info, currentVersion >= info.minapkcode)
+                ConfigurationsRepository.VersionCheckResult.UpdateAvailable(info, currentVersion >= info.minapkcode)
             } else if (currentVersion < info.minapkcode && apkVersion < info.minapkcode) {
-                callback.onUpdateAvailable(info, true)
+                ConfigurationsRepository.VersionCheckResult.UpdateAvailable(info, true)
             } else {
-                callback.onError(context.getString(R.string.planet_is_up_to_date), false)
+                ConfigurationsRepository.VersionCheckResult.Error(context.getString(R.string.planet_is_up_to_date), false)
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/AutoSyncWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/AutoSyncWorker.kt
@@ -23,7 +23,6 @@ import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.repository.ConfigurationsRepository
-import org.ole.planet.myplanet.repository.ConfigurationsRepository.CheckVersionCallback
 import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.ui.sync.LoginActivity
 import org.ole.planet.myplanet.utils.DialogUtils.startDownloadUpdate
@@ -41,7 +40,7 @@ class AutoSyncWorker @AssistedInject constructor(
     private val uploadToShelfService: UploadToShelfService,
     private val configurationsRepository: ConfigurationsRepository,
     private val dispatcherProvider: DispatcherProvider
-) : CoroutineWorker(context, workerParams), OnSyncListener, CheckVersionCallback, OnSuccessListener {
+) : CoroutineWorker(context, workerParams), OnSyncListener, OnSuccessListener {
 
     private lateinit var workerScope: CoroutineScope
     private var syncContinuation: CancellableContinuation<Unit>? = null
@@ -63,9 +62,14 @@ class AutoSyncWorker @AssistedInject constructor(
                     Utilities.toast(context, "Syncing started...")
                 }
             }
-            suspendCancellableCoroutine { continuation ->
-                syncContinuation = continuation
-                configurationsRepository.checkVersion(this@AutoSyncWorker, sharedPrefManager)
+            val result = configurationsRepository.checkVersion()
+            when (result) {
+                is ConfigurationsRepository.VersionCheckResult.UpdateAvailable -> {
+                    onUpdateAvailable(result.info, result.cancelable)
+                }
+                is ConfigurationsRepository.VersionCheckResult.Error -> {
+                    onError(result.msg, result.blockSync)
+                }
             }
         }
         return@coroutineScope Result.success()
@@ -87,7 +91,7 @@ class AutoSyncWorker @AssistedInject constructor(
         }
     }
 
-    override fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean) {
+    private fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean) {
         workerScope.launch(dispatcherProvider.main) {
             startDownloadUpdate(context, UrlUtils.getApkUpdateUrl(info?.localapkpath), null, workerScope, configurationsRepository)
         }
@@ -95,7 +99,7 @@ class AutoSyncWorker @AssistedInject constructor(
         syncContinuation = null
     }
 
-    override fun onError(msg: String, blockSync: Boolean) {
+    private fun onError(msg: String, blockSync: Boolean) {
         if (blockSync) {
             syncContinuation?.takeIf { it.isActive }?.resume(Unit)
             syncContinuation = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -35,6 +35,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnUserProfileClickListener
 import org.ole.planet.myplanet.databinding.ActivityLoginBinding
 import org.ole.planet.myplanet.databinding.DialogServerUrlBinding
+import org.ole.planet.myplanet.repository.ConfigurationsRepository
 import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmUser
@@ -152,10 +153,17 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
 
         if (versionInfo != null) {
             onUpdateAvailable(versionInfo, intent.getBooleanExtra("cancelable", false))
+            forceSyncTrigger()
         } else {
-            configurationsRepository.checkVersion(this, prefData)
+            lifecycleScope.launch {
+                val result = configurationsRepository.checkVersion()
+                when (result) {
+                    is ConfigurationsRepository.VersionCheckResult.UpdateAvailable -> onUpdateAvailable(result.info, result.cancelable)
+                    is ConfigurationsRepository.VersionCheckResult.Error -> onError(result.msg, result.blockSync)
+                }
+                forceSyncTrigger()
+            }
         }
-        forceSyncTrigger()
     }
 
     private fun setupAdditionalListeners() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -78,7 +78,7 @@ import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepository.CheckVersionCallback {
+abstract class SyncActivity : ProcessUserDataActivity() {
     private var serverDialogBinding: DialogServerUrlBinding? = null
     private lateinit var syncDate: TextView
     lateinit var lblLastSyncDate: TextView
@@ -222,7 +222,13 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
                 override fun onVersionCheckSuccess() {
                     isSync = false
                     forceSync = true
-                    configurationsRepository.checkVersion(this@SyncActivity, prefData)
+                    lifecycleScope.launch {
+                        val result = configurationsRepository.checkVersion()
+                        when (result) {
+                            is ConfigurationsRepository.VersionCheckResult.UpdateAvailable -> onUpdateAvailable(result.info, result.cancelable)
+                            is ConfigurationsRepository.VersionCheckResult.Error -> onError(result.msg, result.blockSync)
+                        }
+                    }
                 }
 
                 override fun onContinueSync(dialog: MaterialDialog, url: String, isAlternativeUrl: Boolean, defaultUrl: String) {
@@ -758,7 +764,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         syncFailed = false
     }
 
-    override fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean) {
+    protected fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean) {
         lifecycleScope.launch {
             val builder = getUpdateDialog(this@SyncActivity, info, customProgressDialog, lifecycleScope, configurationsRepository)
             if (cancelable || getCustomDeviceName(this@SyncActivity).endsWith("###")) {
@@ -783,7 +789,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         }
     }
 
-    override fun onError(msg: String, blockSync: Boolean) {
+    protected fun onError(msg: String, blockSync: Boolean) {
         lifecycleScope.launch {
             Utilities.toast(this@SyncActivity, msg)
             if (msg.startsWith("Config")) {


### PR DESCRIPTION
Replaced callback-based version checks with a suspend result model, removing callback and caller-owned SharedPrefManager parameters from the repository contract. Updated dependent callers to await the repository result and handle behavior locally.

---
*PR created automatically by Jules for task [8247215252275833460](https://jules.google.com/task/8247215252275833460) started by @dogi*