### PR TITLE
Refactor UrlUtils to use cached SharedPrefManager

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/UrlUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/UrlUtils.kt
@@ -9,9 +9,20 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.services.SharedPrefManager
 
 object UrlUtils {
-    private val spm: SharedPrefManager by lazy {
-        EntryPointAccessors.fromApplication(context, CoreDependenciesEntryPoint::class.java).sharedPrefManager()
+    private var _spm: SharedPrefManager? = null
+
+    @androidx.annotation.VisibleForTesting
+    fun setSpmForTesting(spm: SharedPrefManager?) {
+        _spm = spm
     }
+
+    private val spm: SharedPrefManager
+        get() {
+            if (_spm == null) {
+                _spm = EntryPointAccessors.fromApplication(context, CoreDependenciesEntryPoint::class.java).sharedPrefManager()
+            }
+            return _spm!!
+        }
 
     val header: String
         get() {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/UrlUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/UrlUtils.kt
@@ -9,19 +9,18 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.services.SharedPrefManager
 
 object UrlUtils {
-    private fun spm(): SharedPrefManager =
+    private val spm: SharedPrefManager by lazy {
         EntryPointAccessors.fromApplication(context, CoreDependenciesEntryPoint::class.java).sharedPrefManager()
+    }
 
     val header: String
         get() {
-            val spm = spm()
             val credentials = "${spm.getUrlUser()}:${spm.getUrlPwd()}".toByteArray()
             return "Basic ${Base64.encodeToString(credentials, Base64.NO_WRAP)}"
         }
 
     val hostUrl: String
         get() {
-            val spm = spm()
             var scheme = spm.getUrlScheme()
             var hostIp = spm.getUrlHost()
             val isAlternativeUrl = spm.isAlternativeUrl()
@@ -89,7 +88,7 @@ object UrlUtils {
     }
 
     fun getUrl(): String {
-        return dbUrl(spm())
+        return dbUrl(spm)
     }
 
     fun getUpdateUrl(spm: SharedPrefManager): String {
@@ -113,7 +112,7 @@ object UrlUtils {
     }
 
     fun getApkUpdateUrl(path: String?): String {
-        val url = baseUrl(spm())
+        val url = baseUrl(spm)
         return "$url$path"
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/UrlUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/UrlUtilsTest.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.utils
 
 import android.content.Context
 import android.net.Uri
-import dagger.hilt.android.EntryPointAccessors
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -13,9 +12,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.any
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -24,19 +21,11 @@ import org.robolectric.annotation.Config
 @Config(sdk = [33], application = android.app.Application::class)
 class UrlUtilsTest {
 
-    private lateinit var mockSpm: SharedPrefManager
-    private lateinit var mockEntryPoint: CoreDependenciesEntryPoint
     private lateinit var sharedPrefManager: SharedPrefManager
 
     @Before
     fun setUp() {
         sharedPrefManager = mockk(relaxed = true)
-        mockSpm = mockk(relaxed = true)
-        mockEntryPoint = mockk()
-        every { mockEntryPoint.sharedPrefManager() } returns mockSpm
-
-        mockkStatic(EntryPointAccessors::class)
-        every { EntryPointAccessors.fromApplication(any(), CoreDependenciesEntryPoint::class.java) } returns mockEntryPoint
 
         mockkObject(MainApplication.Companion)
         val mockContext = mockk<Context>()

--- a/app/src/test/java/org/ole/planet/myplanet/utils/UrlUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/UrlUtilsTest.kt
@@ -30,6 +30,7 @@ class UrlUtilsTest {
 
     @Before
     fun setUp() {
+        sharedPrefManager = mockk(relaxed = true)
         mockSpm = mockk(relaxed = true)
         mockEntryPoint = mockk()
         every { mockEntryPoint.sharedPrefManager() } returns mockSpm
@@ -42,7 +43,7 @@ class UrlUtilsTest {
         every { MainApplication.context } returns mockContext
 
         mockkObject(UrlUtils)
-        sharedPrefManager = mockk(relaxed = true)
+        UrlUtils.setSpmForTesting(sharedPrefManager)
         every { sharedPrefManager.isAlternativeUrl() } returns false
         every { sharedPrefManager.getCouchdbUrl() } returns "http://example.com"
         every { sharedPrefManager.getProcessedAlternativeUrl() } returns "http://alternative.com"
@@ -50,15 +51,17 @@ class UrlUtilsTest {
 
     @After
     fun tearDown() {
+        io.mockk.clearAllMocks()
         unmockkAll()
+        UrlUtils.setSpmForTesting(null) // Reset to prevent bleeding
     }
 
     @Test
     fun `hostUrl fallback behavior when toUri throws Exception`() {
-        every { mockSpm.getUrlScheme() } returns "http"
-        every { mockSpm.getUrlHost() } returns "fallback.org"
-        every { mockSpm.isAlternativeUrl() } returns true
-        every { mockSpm.getProcessedAlternativeUrl() } returns "invalid://url"
+        every { sharedPrefManager.getUrlScheme() } returns "http"
+        every { sharedPrefManager.getUrlHost() } returns "fallback.org"
+        every { sharedPrefManager.isAlternativeUrl() } returns true
+        every { sharedPrefManager.getProcessedAlternativeUrl() } returns "invalid://url"
 
         mockkStatic(Uri::class)
         every { Uri.parse("invalid://url") } throws RuntimeException("Simulated URI Exception")
@@ -70,10 +73,10 @@ class UrlUtilsTest {
 
     @Test
     fun `hostUrl successfully returns alternative URL`() {
-        every { mockSpm.getUrlScheme() } returns "http"
-        every { mockSpm.getUrlHost() } returns "fallback.org"
-        every { mockSpm.isAlternativeUrl() } returns true
-        every { mockSpm.getProcessedAlternativeUrl() } returns "https://newhost.com"
+        every { sharedPrefManager.getUrlScheme() } returns "http"
+        every { sharedPrefManager.getUrlHost() } returns "fallback.org"
+        every { sharedPrefManager.isAlternativeUrl() } returns true
+        every { sharedPrefManager.getProcessedAlternativeUrl() } returns "https://newhost.com"
 
         val result = UrlUtils.hostUrl
 
@@ -82,10 +85,10 @@ class UrlUtilsTest {
 
     @Test
     fun `hostUrl successfully returns standard URL`() {
-        every { mockSpm.getUrlScheme() } returns "http"
-        every { mockSpm.getUrlHost() } returns "standard.org"
-        every { mockSpm.isAlternativeUrl() } returns false
-        every { mockSpm.getProcessedAlternativeUrl() } returns ""
+        every { sharedPrefManager.getUrlScheme() } returns "http"
+        every { sharedPrefManager.getUrlHost() } returns "standard.org"
+        every { sharedPrefManager.isAlternativeUrl() } returns false
+        every { sharedPrefManager.getProcessedAlternativeUrl() } returns ""
 
         val result = UrlUtils.hostUrl
 
@@ -94,10 +97,10 @@ class UrlUtilsTest {
 
     @Test
     fun `hostUrl successfully returns URL when alternativeUrl is true but value is empty`() {
-        every { mockSpm.getUrlScheme() } returns "http"
-        every { mockSpm.getUrlHost() } returns "fallback.org"
-        every { mockSpm.isAlternativeUrl() } returns true
-        every { mockSpm.getProcessedAlternativeUrl() } returns ""
+        every { sharedPrefManager.getUrlScheme() } returns "http"
+        every { sharedPrefManager.getUrlHost() } returns "fallback.org"
+        every { sharedPrefManager.isAlternativeUrl() } returns true
+        every { sharedPrefManager.getProcessedAlternativeUrl() } returns ""
 
         val result = UrlUtils.hostUrl
 


### PR DESCRIPTION
Resolved redundant calls to `EntryPointAccessors.fromApplication` by introducing a safely-scoped cached instance of `SharedPrefManager` in `UrlUtils.kt`. Also addressed unit test isolation issues by utilizing a testing setter and explicit teardowns.

---
*PR created automatically by Jules for task [16411735423716562800](https://jules.google.com/task/16411735423716562800) started by @dogi*