### PR TITLE
security: disable app backups in AndroidManifest (fixes #14028)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
         android:required="false" />
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_project_name"
         android:largeHeap="true"


### PR DESCRIPTION
fixes #14028
Change android:allowBackup from true to false in the application element to prevent app data from being included in device backups. This reduces risk of sensitive data being stored in cloud backups or transferred during device migrations.