### PR TITLE
all: smoother android decrypting (fixes #14036)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5765
-        versionName = "0.57.65"
+        versionCode = 5791
+        versionName = "0.57.91"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/AndroidDecrypter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/AndroidDecrypter.kt
@@ -1,11 +1,10 @@
 package org.ole.planet.myplanet.utils
 
-import de.rtner.misc.BinTools
 import de.rtner.security.auth.spi.PBKDF2Engine
 import de.rtner.security.auth.spi.PBKDF2Parameters
+import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.security.SecureRandom
-import java.util.Locale
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
@@ -87,10 +86,15 @@ class AndroidDecrypter {
         @JvmStatic
         fun androidDecrypter(usrId: String?, usrRawPwd: String?, dbPwdKeyValue: String?, dbSalt: String?): Boolean {
             try {
+                if (dbPwdKeyValue == null) return false
                 val p = PBKDF2Parameters("HmacSHA1", "utf-8", dbSalt?.toByteArray(), 10)
                 val dk = PBKDF2Engine(p).deriveKey(usrRawPwd, 20)
-                return dbPwdKeyValue.equals(BinTools.bin2hex(dk).lowercase(Locale.ROOT), ignoreCase = true)
-
+                val expected = try {
+                    hexStringToByteArray(dbPwdKeyValue)
+                } catch (e: Exception) {
+                    return false
+                }
+                return MessageDigest.isEqual(dk, expected)
             } catch (e: Exception) {
                 e.printStackTrace()
             }


### PR DESCRIPTION
fixes #14036

Replace the previous BinTools-based hex/string equality check with a byte-level constant-time comparison using MessageDigest.isEqual. Adds a null check for dbPwdKeyValue and guards against hex parse errors (returns false on failure). Removes unused BinTools/Locale imports. This avoids timing side-channels and eliminates reliance on string hex conversion for key verification.