### PR TITLE
all: smoother coroutines delaying (fixes #14098)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,13 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-<<<<<<< 14098-raw-handlerpostdelayed-calls
         versionCode = 5818
         versionName = "0.58.18"
-=======
-        versionCode = 5817
-        versionName = "0.58.17"
->>>>>>> master
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5811
-        versionName = "0.58.11"
+        versionCode = 5817
+        versionName = "0.58.17"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5817
-        versionName = "0.58.17"
+        versionCode = 5818
+        versionName = "0.58.18"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -19,6 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentTakeCourseBinding
@@ -217,10 +218,11 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
 
                 pendingJoinDialog = true
                 maybeShowJoinDialog()
-                binding.viewPager2.postDelayed({
+                viewLifecycleOwner.lifecycleScope.launch {
+                    delay(JOIN_DIALOG_FALLBACK_MS)
                     courseDetailContentReady = true
                     maybeShowJoinDialog()
-                }, JOIN_DIALOG_FALLBACK_MS)
+                }
             } else {
                 binding.btnRemove.visibility = View.GONE
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
@@ -13,6 +13,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
@@ -383,9 +384,10 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
             selectPage(targetPageId)
             MainApplication.showDownload = false
 
-            val delay = if (isAlreadyOnTargetPage) 50L else 300L
+            val delayMs = if (isAlreadyOnTargetPage) 50L else 300L
 
-            binding.root.postDelayed({
+            viewLifecycleOwner.lifecycleScope.launch {
+                delay(delayMs)
                 val pageListener = childFragmentManager.fragments.firstOrNull {
                     it is OnTeamPageListener && it.arguments?.getString("fragmentType") == targetPageId
                 } as? OnTeamPageListener
@@ -405,7 +407,7 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
                         }
                     }
                 }
-            }, delay)
+            }
         }
     }
 


### PR DESCRIPTION
fixes #14098
```
Replaced both postDelayed calls with viewLifecycleOwner.lifecycleScope.launch { delay(...); ... }. 
The coroutine is automatically cancelled when the view lifecycle is destroyed, so the deferred work 
can no longer run against a torn-down view. This matches the existing coroutine idiom already used 
throughout both fragments.
```
