### PR TITLE
chat: smoother repository ai providing (fixes #14175)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5825
+        versionName = "0.58.25"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
@@ -12,7 +12,7 @@ sealed class ChatResult {
 interface ChatRepository {
     suspend fun sendNewChatRequest(query: String, user: String?, aiProvider: AiProvider): ChatResult
     suspend fun sendContinueChatRequest(message: String, user: String?, aiProvider: AiProvider, id: String, rev: String): ChatResult
-    suspend fun fetchAiProviders(serverUrl: String, isServerReachable: suspend (String) -> Boolean): Map<String, Boolean>?
+    suspend fun fetchAiProviders(serverUrl: String): Map<String, Boolean>?
     suspend fun getChatHistoryForUser(userName: String?): List<RealmChatHistory>
     suspend fun getLatestRev(id: String): String?
     suspend fun insertChatHistoryList(chats: List<JsonObject>)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -31,6 +31,11 @@ class ChatRepositoryImpl @Inject constructor(
     private val sharedPrefManager: SharedPrefManager
 ) : RealmRepository(databaseService, realmDispatcher), ChatRepository {
 
+    @androidx.annotation.VisibleForTesting
+    internal var reachabilityCheck: suspend (String) -> Boolean = { url ->
+        org.ole.planet.myplanet.MainApplication.isServerReachable(url)
+    }
+
     override suspend fun sendNewChatRequest(
         query: String,
         user: String?,
@@ -100,10 +105,10 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun fetchAiProviders(serverUrl: String, isServerReachable: suspend (String) -> Boolean): Map<String, Boolean>? {
+    override suspend fun fetchAiProviders(serverUrl: String): Map<String, Boolean>? {
         val mapping = serverUrlMapper.processUrl(serverUrl)
         serverUrlMapper.updateServerIfNecessary(mapping, sharedPrefManager.rawPreferences) { url ->
-            isServerReachable(url)
+            reachabilityCheck(url)
         }
         return chatApiService.fetchAiProviders()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -449,7 +449,7 @@ class ChatDetailFragment : Fragment() {
         sharedViewModel.setAiProvidersError(false)
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val providers = chatRepository.fetchAiProviders(serverUrl) { url -> org.ole.planet.myplanet.MainApplication.isServerReachable(url) }
+            val providers = chatRepository.fetchAiProviders(serverUrl)
             sharedViewModel.setAiProvidersLoading(false)
             if (providers == null || providers.values.all { !it }) {
                 val cachedProviders = getCachedProviderAvailability()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
@@ -332,7 +332,7 @@ class ChatHistoryFragment : Fragment() {
         sharedViewModel.setAiProvidersError(false)
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val providers = chatRepository.fetchAiProviders(serverUrl) { url -> org.ole.planet.myplanet.MainApplication.isServerReachable(url) }
+            val providers = chatRepository.fetchAiProviders(serverUrl)
             sharedViewModel.setAiProvidersLoading(false)
             if (providers == null || providers.values.all { !it }) {
                 sharedViewModel.setAiProvidersError(true)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
@@ -64,7 +64,8 @@ class ChatRepositoryImplTest {
         coEvery { serverUrlMapper.updateServerIfNecessary(any(), any(), any()) } answers { }
         coEvery { chatApiService.fetchAiProviders() } returns mockResponse
 
-        val result = chatRepository.fetchAiProviders(serverUrl) { true }
+        chatRepository.reachabilityCheck = { true }
+        val result = chatRepository.fetchAiProviders(serverUrl)
 
         assertEquals(mockResponse, result)
         verify(exactly = 1) { serverUrlMapper.processUrl(serverUrl) }


### PR DESCRIPTION
This refactoring addresses the user's request to "Hide AI provider reachability behind ChatRepository" and narrow the public interface.

Changes made:
1. Removed `isServerReachable: suspend (String) -> Boolean` from `ChatRepository.fetchAiProviders`.
2. Added `@androidx.annotation.VisibleForTesting internal var reachabilityCheck` to `ChatRepositoryImpl`, defaulting to `org.ole.planet.myplanet.MainApplication.isServerReachable`.
3. Updated caller sites (`ChatDetailFragment.kt` and `ChatHistoryFragment.kt`) to drop the lambda block.
4. Updated `ChatRepositoryImplTest.kt` to stub the newly exposed internal property instead of passing a lambda in tests.

---
*PR created automatically by Jules for task [11605281661143168650](https://jules.google.com/task/11605281661143168650) started by @dogi*