### PR TITLE
Refactor DatabaseService to inject RealmConfiguration

### DIFF
--- a/app/src/androidTest/java/org/ole/planet/myplanet/data/DatabaseServiceTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/data/DatabaseServiceTest.kt
@@ -34,8 +34,6 @@ class DatabaseServiceTest {
             .allowQueriesOnUiThread(true)
             .schemaVersion(1)
             .build()
-        Realm.setDefaultConfiguration(realmConfiguration)
-
         databaseService = DatabaseService(ApplicationProvider.getApplicationContext(), org.ole.planet.myplanet.utils.DefaultDispatcherProvider(), realmConfiguration)
     }
 

--- a/app/src/androidTest/java/org/ole/planet/myplanet/data/DatabaseServiceTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/data/DatabaseServiceTest.kt
@@ -44,39 +44,31 @@ class DatabaseServiceTest {
 
     @Test
     fun testWithRealmAsync_successPath_closesRealm() = runBlocking {
-        var capturedRealm: Realm? = null
-        val result = databaseService.withRealmAsync { realm ->
-            capturedRealm = realm
+                val result = databaseService.withRealmAsync { realm ->
             assertFalse(realm.isClosed)
             "success"
         }
         assertEquals("success", result)
-        assertNotNull(capturedRealm)
-        assertTrue(capturedRealm!!.isClosed)
+        assertTrue(Realm.getGlobalInstanceCount(realmConfiguration) == 0)
     }
 
     @Test
     fun testWithRealmAsync_exceptionPath_closesRealm() = runBlocking {
-        var capturedRealm: Realm? = null
-        val exception = runCatching {
+                val exception = runCatching {
             databaseService.withRealmAsync { realm ->
-                capturedRealm = realm
-                assertFalse(realm.isClosed)
+                    assertFalse(realm.isClosed)
                 throw RuntimeException("Test exception")
             }
         }.exceptionOrNull()
 
         assertNotNull(exception)
         assertEquals("Test exception", exception?.message)
-        assertNotNull(capturedRealm)
-        assertTrue(capturedRealm!!.isClosed)
+        assertTrue(Realm.getGlobalInstanceCount(realmConfiguration) == 0)
     }
 
     @Test
     fun testExecuteTransactionAsync_commitsData() = runBlocking {
-        var capturedRealm: Realm? = null
-        databaseService.executeTransactionAsync { realm ->
-            capturedRealm = realm
+                databaseService.executeTransactionAsync { realm ->
             val meetup = realm.createObject(RealmMeetup::class.java, "test-id")
             meetup.meetupId = "test-id"
             meetup.title = "Test Meetup"
@@ -87,25 +79,22 @@ class DatabaseServiceTest {
             assertNotNull(meetup)
             assertEquals("Test Meetup", meetup?.title)
             assertNotNull(capturedRealm)
-            assertTrue(capturedRealm!!.isClosed)
+            assertTrue(Realm.getGlobalInstanceCount(realmConfiguration) == 0)
         }
     }
 
     @Test
     fun testExecuteTransactionAsync_exceptionPath_closesRealm() = runBlocking {
-        var capturedRealm: Realm? = null
-        val exception = runCatching {
+                val exception = runCatching {
             databaseService.executeTransactionAsync { realm ->
-                capturedRealm = realm
-                assertFalse(realm.isClosed)
+                    assertFalse(realm.isClosed)
                 throw RuntimeException("Test exception in transaction")
             }
         }.exceptionOrNull()
 
         assertNotNull(exception)
         assertEquals("Test exception in transaction", exception?.message)
-        assertNotNull(capturedRealm)
-        assertTrue(capturedRealm!!.isClosed)
+        assertTrue(Realm.getGlobalInstanceCount(realmConfiguration) == 0)
     }
 
     @Test

--- a/app/src/androidTest/java/org/ole/planet/myplanet/data/DatabaseServiceTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/data/DatabaseServiceTest.kt
@@ -36,7 +36,7 @@ class DatabaseServiceTest {
             .build()
         Realm.setDefaultConfiguration(realmConfiguration)
 
-        databaseService = DatabaseService(ApplicationProvider.getApplicationContext(), org.ole.planet.myplanet.utils.DefaultDispatcherProvider())
+        databaseService = DatabaseService(ApplicationProvider.getApplicationContext(), org.ole.planet.myplanet.utils.DefaultDispatcherProvider(), realmConfiguration)
     }
 
     @After

--- a/app/src/androidTest/java/org/ole/planet/myplanet/model/RealmUserTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/model/RealmUserTest.kt
@@ -46,7 +46,6 @@ class RealmUserTest {
                 .allowQueriesOnUiThread(true)
                 .schemaVersion(1)
                 .build()
-            Realm.setDefaultConfiguration(realmConfiguration)
         }
 
         val testDispatcherProvider = object : DispatcherProvider {

--- a/app/src/androidTest/java/org/ole/planet/myplanet/model/RealmUserTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/model/RealmUserTest.kt
@@ -55,7 +55,7 @@ class RealmUserTest {
             override val default: CoroutineDispatcher = Dispatchers.Unconfined
             override val unconfined: CoroutineDispatcher = Dispatchers.Unconfined
         }
-        databaseService = DatabaseService(ApplicationProvider.getApplicationContext(), testDispatcherProvider)
+        databaseService = DatabaseService(ApplicationProvider.getApplicationContext(), testDispatcherProvider, realmConfiguration)
 
         val mockSettings = mockk<SharedPreferences>(relaxed = true)
         val mockSharedPrefManager = mockk<SharedPrefManager>(relaxed = true)

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -233,6 +233,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
     override fun onCreate() {
         super.onCreate()
         instance = this
+        io.realm.Realm.init(this)
         setupCriticalProperties()
         LocaleUtils.preload(this)
         warmUpMainThreadRealm()

--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -17,7 +17,6 @@ class DatabaseService(context: Context, private val dispatcherProvider: Dispatch
     private val realmDispatcher: CoroutineDispatcher = dispatcherProvider.io.limitedParallelism(4)
 
     init {
-        Realm.init(context)
         val targetLogLevel = if (BuildConfig.DEBUG) LogLevel.DEBUG else LogLevel.ERROR
         if (RealmLog.getLevel() != targetLogLevel) {
             RealmLog.setLevel(targetLogLevel)

--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -22,7 +22,6 @@ class DatabaseService(context: Context, private val dispatcherProvider: Dispatch
         if (RealmLog.getLevel() != targetLogLevel) {
             RealmLog.setLevel(targetLogLevel)
         }
-
     }
 
     fun createManagedRealmInstance(): Realm = Realm.getInstance(realmConfiguration)

--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.BuildConfig
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
-class DatabaseService(context: Context, private val dispatcherProvider: DispatcherProvider) {
+class DatabaseService(context: Context, private val dispatcherProvider: DispatcherProvider, private val realmConfiguration: RealmConfiguration) {
     val ioDispatcher: CoroutineDispatcher = dispatcherProvider.io
     private val realmDispatcher: CoroutineDispatcher = dispatcherProvider.io.limitedParallelism(4)
 
@@ -22,21 +22,13 @@ class DatabaseService(context: Context, private val dispatcherProvider: Dispatch
         if (RealmLog.getLevel() != targetLogLevel) {
             RealmLog.setLevel(targetLogLevel)
         }
-        val currentConfig = Realm.getDefaultConfiguration()
-        if (currentConfig == null || currentConfig.realmDirectory.name == Realm.DEFAULT_REALM_NAME) {
-            val config = RealmConfiguration.Builder()
-                .name(Realm.DEFAULT_REALM_NAME)
-                .schemaVersion(12)
-                .migration(RealmMigrations())
-                .build()
-            Realm.setDefaultConfiguration(config)
-        }
+
     }
 
-    fun createManagedRealmInstance(): Realm = Realm.getDefaultInstance()
+    fun createManagedRealmInstance(): Realm = Realm.getInstance(realmConfiguration)
 
     private inline fun <T> withRealmInstance(block: (Realm) -> T): T {
-        val realm = Realm.getDefaultInstance()
+        val realm = Realm.getInstance(realmConfiguration)
         return try {
             block(realm)
         } finally {
@@ -58,7 +50,7 @@ class DatabaseService(context: Context, private val dispatcherProvider: Dispatch
 
     suspend fun executeTransactionAsync(transaction: (Realm) -> Unit) {
         withContext(realmDispatcher) {
-            val realm = Realm.getDefaultInstance()
+            val realm = Realm.getInstance(realmConfiguration)
             try {
                 realm.executeTransaction { r ->
                     transaction(r)

--- a/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
@@ -6,9 +6,12 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import io.realm.Realm
+import io.realm.RealmConfiguration
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.RealmMigrations
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
@@ -18,17 +21,17 @@ object DatabaseModule {
 
     @Provides
     @Singleton
-    fun provideRealmConfiguration(): io.realm.RealmConfiguration {
-        return io.realm.RealmConfiguration.Builder()
-            .name(io.realm.Realm.DEFAULT_REALM_NAME)
+    fun provideRealmConfiguration(): RealmConfiguration {
+        return RealmConfiguration.Builder()
+            .name(Realm.DEFAULT_REALM_NAME)
             .schemaVersion(12)
-            .migration(org.ole.planet.myplanet.data.RealmMigrations())
+            .migration(RealmMigrations())
             .build()
     }
 
     @Provides
     @Singleton
-    fun provideDatabaseService(@ApplicationContext context: Context, dispatcherProvider: DispatcherProvider, realmConfiguration: io.realm.RealmConfiguration): DatabaseService {
+    fun provideDatabaseService(@ApplicationContext context: Context, dispatcherProvider: DispatcherProvider, realmConfiguration: RealmConfiguration): DatabaseService {
         return DatabaseService(context, dispatcherProvider, realmConfiguration)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
@@ -21,8 +21,7 @@ object DatabaseModule {
 
     @Provides
     @Singleton
-    fun provideRealmConfiguration(@ApplicationContext context: Context): RealmConfiguration {
-        Realm.init(context)
+    fun provideRealmConfiguration(): RealmConfiguration {
         return RealmConfiguration.Builder()
             .name(Realm.DEFAULT_REALM_NAME)
             .schemaVersion(12)

--- a/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
@@ -21,7 +21,8 @@ object DatabaseModule {
 
     @Provides
     @Singleton
-    fun provideRealmConfiguration(): RealmConfiguration {
+    fun provideRealmConfiguration(@ApplicationContext context: Context): RealmConfiguration {
+        Realm.init(context)
         return RealmConfiguration.Builder()
             .name(Realm.DEFAULT_REALM_NAME)
             .schemaVersion(12)

--- a/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/DatabaseModule.kt
@@ -18,8 +18,18 @@ object DatabaseModule {
 
     @Provides
     @Singleton
-    fun provideDatabaseService(@ApplicationContext context: Context, dispatcherProvider: DispatcherProvider): DatabaseService {
-        return DatabaseService(context, dispatcherProvider)
+    fun provideRealmConfiguration(): io.realm.RealmConfiguration {
+        return io.realm.RealmConfiguration.Builder()
+            .name(io.realm.Realm.DEFAULT_REALM_NAME)
+            .schemaVersion(12)
+            .migration(org.ole.planet.myplanet.data.RealmMigrations())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideDatabaseService(@ApplicationContext context: Context, dispatcherProvider: DispatcherProvider, realmConfiguration: io.realm.RealmConfiguration): DatabaseService {
+        return DatabaseService(context, dispatcherProvider, realmConfiguration)
     }
 
     @Provides

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
     }
 }
 plugins {
-
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 dependencyResolutionManagement {
     repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
     }
 }
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+
 }
 dependencyResolutionManagement {
     repositories {


### PR DESCRIPTION
Refactored `DatabaseService` to explicitly rely on an injected `RealmConfiguration` rather than defaulting to the global `Realm.getDefaultInstance()`. This improves decoupling, testability, and avoids implicit state initialization. Included updating `DatabaseModule` and existing tests.

---
*PR created automatically by Jules for task [11898608010819715941](https://jules.google.com/task/11898608010819715941) started by @dogi*