### PR TITLE
Refactor enterprise transaction creation to ViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesFragment.kt
@@ -252,33 +252,31 @@ class EnterprisesFinancesFragment : BaseTeamFragment() {
                 val type = addTransactionBinding.spnType.selectedItem.toString()
                 val note = "${addTransactionBinding.tlNote.editText?.text}".trim { it <= ' ' }
                 val amount = "${addTransactionBinding.tlAmount.editText?.text}".trim { it <= ' ' }
-                if (note.isEmpty()) {
-                    Utilities.toast(activity, getString(R.string.note_is_required))
-                } else if (amount.isEmpty()) {
-                    Utilities.toast(activity, getString(R.string.amount_is_required))
-                } else if (date == null) {
-                    Utilities.toast(activity, getString(R.string.date_is_required))
-                } else {
-                    val amountValue = amount.toIntOrNull()
-                    if (amountValue == null) {
-                        Utilities.toast(activity, getString(R.string.amount_is_required))
-                        return@setPositiveButton
-                    }
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        val capturedDate = date ?: return@launch
-                        val result = teamsRepository.createTransaction(
-                            teamId = teamId,
-                            type = type,
-                            note = note,
-                            amount = amountValue,
-                            date = capturedDate.timeInMillis,
-                            parentCode = user?.parentCode,
-                            planetCode = user?.planetCode,
-                        )
-                        if (result.isSuccess) {
+                viewLifecycleOwner.lifecycleScope.launch {
+                    val result = viewModel.addTransaction(
+                        teamId = teamId,
+                        type = type,
+                        note = note,
+                        amountString = amount,
+                        dateMillis = date?.timeInMillis,
+                        parentCode = user?.parentCode,
+                        planetCode = user?.planetCode
+                    )
+                    when (result) {
+                        is TransactionResult.Success -> {
                             Utilities.toast(activity, getString(R.string.transaction_added))
-                        } else {
-                            val errorMessage = result.exceptionOrNull()?.localizedMessage
+                        }
+                        is TransactionResult.NoteRequired -> {
+                            Utilities.toast(activity, getString(R.string.note_is_required))
+                        }
+                        is TransactionResult.AmountRequired -> {
+                            Utilities.toast(activity, getString(R.string.amount_is_required))
+                        }
+                        is TransactionResult.DateRequired -> {
+                            Utilities.toast(activity, getString(R.string.date_is_required))
+                        }
+                        is TransactionResult.Error -> {
+                            val errorMessage = result.message
                                 ?: getString(R.string.no_data_available_please_check_and_try_again)
                             Utilities.toast(activity, errorMessage)
                         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesViewModel.kt
@@ -41,4 +41,49 @@ class EnterprisesFinancesViewModel @Inject constructor(
             }
         }
     }
+
+    suspend fun addTransaction(
+        teamId: String,
+        type: String,
+        note: String,
+        amountString: String,
+        dateMillis: Long?,
+        parentCode: String?,
+        planetCode: String?
+    ): TransactionResult {
+        if (note.isEmpty()) {
+            return TransactionResult.NoteRequired
+        }
+        if (amountString.isEmpty()) {
+            return TransactionResult.AmountRequired
+        }
+        if (dateMillis == null) {
+            return TransactionResult.DateRequired
+        }
+        val amountValue = amountString.toIntOrNull() ?: return TransactionResult.AmountRequired
+
+        val result = teamsRepository.createTransaction(
+            teamId = teamId,
+            type = type,
+            note = note,
+            amount = amountValue,
+            date = dateMillis,
+            parentCode = parentCode,
+            planetCode = planetCode
+        )
+
+        return if (result.isSuccess) {
+            TransactionResult.Success
+        } else {
+            TransactionResult.Error(result.exceptionOrNull()?.localizedMessage)
+        }
+    }
+}
+
+sealed class TransactionResult {
+    object Success : TransactionResult()
+    object NoteRequired : TransactionResult()
+    object AmountRequired : TransactionResult()
+    object DateRequired : TransactionResult()
+    data class Error(val message: String?) : TransactionResult()
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesViewModelTest.kt
@@ -54,4 +54,113 @@ class EnterprisesFinancesViewModelTest {
         val actualTransactions = viewModel.transactions.first()
         assertEquals(mockTransactions, actualTransactions)
     }
+
+    @Test
+    fun `addTransaction returns NoteRequired when note is empty`() = runTest {
+        val result = viewModel.addTransaction(
+            teamId = "teamId",
+            type = "type",
+            note = "",
+            amountString = "100",
+            dateMillis = 1000L,
+            parentCode = "parent",
+            planetCode = "planet"
+        )
+        assertEquals(TransactionResult.NoteRequired, result)
+    }
+
+    @Test
+    fun `addTransaction returns AmountRequired when amount is empty`() = runTest {
+        val result = viewModel.addTransaction(
+            teamId = "teamId",
+            type = "type",
+            note = "note",
+            amountString = "",
+            dateMillis = 1000L,
+            parentCode = "parent",
+            planetCode = "planet"
+        )
+        assertEquals(TransactionResult.AmountRequired, result)
+    }
+
+    @Test
+    fun `addTransaction returns AmountRequired when amount is invalid`() = runTest {
+        val result = viewModel.addTransaction(
+            teamId = "teamId",
+            type = "type",
+            note = "note",
+            amountString = "abc",
+            dateMillis = 1000L,
+            parentCode = "parent",
+            planetCode = "planet"
+        )
+        assertEquals(TransactionResult.AmountRequired, result)
+    }
+
+    @Test
+    fun `addTransaction returns DateRequired when date is null`() = runTest {
+        val result = viewModel.addTransaction(
+            teamId = "teamId",
+            type = "type",
+            note = "note",
+            amountString = "100",
+            dateMillis = null,
+            parentCode = "parent",
+            planetCode = "planet"
+        )
+        assertEquals(TransactionResult.DateRequired, result)
+    }
+
+    @Test
+    fun `addTransaction returns Success when repository succeeds`() = runTest {
+        coEvery {
+            teamsRepository.createTransaction(
+                teamId = "teamId",
+                type = "type",
+                note = "note",
+                amount = 100,
+                date = 1000L,
+                parentCode = "parent",
+                planetCode = "planet"
+            )
+        } returns Result.success(Unit)
+
+        val result = viewModel.addTransaction(
+            teamId = "teamId",
+            type = "type",
+            note = "note",
+            amountString = "100",
+            dateMillis = 1000L,
+            parentCode = "parent",
+            planetCode = "planet"
+        )
+        assertEquals(TransactionResult.Success, result)
+    }
+
+    @Test
+    fun `addTransaction returns Error when repository fails`() = runTest {
+        val exception = Exception("Repository error")
+        coEvery {
+            teamsRepository.createTransaction(
+                teamId = "teamId",
+                type = "type",
+                note = "note",
+                amount = 100,
+                date = 1000L,
+                parentCode = "parent",
+                planetCode = "planet"
+            )
+        } returns Result.failure(exception)
+
+        val result = viewModel.addTransaction(
+            teamId = "teamId",
+            type = "type",
+            note = "note",
+            amountString = "100",
+            dateMillis = 1000L,
+            parentCode = "parent",
+            planetCode = "planet"
+        )
+        assertEquals(TransactionResult.Error("Repository error"), result)
+    }
 }


### PR DESCRIPTION
Moved transaction validation and creation logic from `EnterprisesFinancesFragment` to `EnterprisesFinancesViewModel` and added corresponding unit tests to align with MVVM architecture.

---
*PR created automatically by Jules for task [8012043522696741792](https://jules.google.com/task/8012043522696741792) started by @dogi*