### PR TITLE
sync: smoother download repository working (fixes #14172)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5822
+        versionName = "0.58.22"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
@@ -17,9 +17,10 @@ import okio.Buffer
 import okio.buffer
 import okio.sink
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.DownloadPreferences
 import org.ole.planet.myplanet.model.Download
+import org.ole.planet.myplanet.model.DownloadResult
+import org.ole.planet.myplanet.repository.DownloadRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils
@@ -29,7 +30,7 @@ import org.ole.planet.myplanet.utils.UrlUtils
 @HiltWorker
 class DownloadWorker @AssistedInject constructor(
     @Assisted private val context: Context, @Assisted workerParams: WorkerParameters,
-    private val apiInterface: ApiInterface, private val broadcastService: BroadcastService,
+    private val downloadRepository: DownloadRepository, private val broadcastService: BroadcastService,
     private val dispatcherProvider: DispatcherProvider,
     @DownloadPreferences private val preferences: SharedPreferences
 ) : CoroutineWorker(context, workerParams) {
@@ -83,14 +84,15 @@ class DownloadWorker @AssistedInject constructor(
             return true
         }
         return try {
-            val response = apiInterface.downloadFile(UrlUtils.header, url)
-            if (response.isSuccessful) {
-                response.body()?.let {
-                    downloadFileBody(it, url, index, total)
+            val response = downloadRepository.downloadFileResponse(url, UrlUtils.header)
+            when (response) {
+                is DownloadResult.Success -> {
+                    downloadFileBody(response.body, url, index, total)
                     true
-                } ?: false
-            } else {
-                false
+                }
+                is DownloadResult.Error -> {
+                    false
+                }
             }
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
Inject `DownloadRepository` into `DownloadWorker` instead of `ApiInterface` to decouple transport behavior. Keep response-to-file writing inside the worker.

---
*PR created automatically by Jules for task [8624554355840517183](https://jules.google.com/task/8624554355840517183) started by @dogi*