### PR TITLE
teams: smoother voices view modelling (fixes #14261)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5888
-        versionName = "0.58.88"
+        versionCode = 5893
+        versionName = "0.58.93"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5893
-        versionName = "0.58.93"
+        versionCode = 5895
+        versionName = "0.58.95"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
@@ -16,7 +16,7 @@ import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -92,7 +92,6 @@ class VoicesFragment : BaseVoicesFragment() {
                 binding.btnNewVoice.visibility = View.GONE
             }
 
-            setupLabelFilter()
             voicesViewModel.observeCommunityNews(getUserIdentifier())
 
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -114,8 +113,14 @@ class VoicesFragment : BaseVoicesFragment() {
                     voicesViewModel.createNewsSuccess.collectLatest { n ->
                         binding.btnSubmit.isEnabled = true
                         if (n != null) {
-                            n.sortDate = n.calculateSortDate()
+                            binding.etMessage.setText(R.string.empty_text)
+                            binding.llAddNews.visibility = View.GONE
+                            binding.btnNewVoice.text = getString(R.string.new_voice)
+                            imageList.clear()
+                            llImage?.removeAllViews()
                             scrollToTop()
+                        } else {
+                            org.ole.planet.myplanet.utils.Utilities.toast(requireContext(), getString(R.string.error, "Failed to create news"))
                         }
                     }
                 }
@@ -127,7 +132,6 @@ class VoicesFragment : BaseVoicesFragment() {
                 binding.tlMessage.error = getString(R.string.please_enter_message)
                 return@setOnClickListener
             }
-            binding.etMessage.setText(R.string.empty_text)
             val map = HashMap<String?, String>()
             map["message"] = message
             map["viewInId"] = "${user?.planetCode ?: ""}@${user?.parentCode ?: ""}"
@@ -135,14 +139,9 @@ class VoicesFragment : BaseVoicesFragment() {
             map["messageType"] = "sync"
             map["messagePlanetCode"] = user?.planetCode ?: ""
 
-            binding.llAddNews.visibility = View.GONE
-            binding.btnNewVoice.text = getString(R.string.new_voice)
             binding.btnSubmit.isEnabled = false
 
             user?.let { it1 -> voicesViewModel.createNews(map, it1, imageList.toList()) }
-            imageList.clear()
-            llImage?.removeAllViews()
-            // The button will be re-enabled when createNewsSuccess emits
         }
 
         binding.addNewsImage.setOnClickListener {
@@ -322,7 +321,7 @@ class VoicesFragment : BaseVoicesFragment() {
         }
     }
 
-    @OptIn(kotlinx.coroutines.FlowPreview::class)
+    @OptIn(FlowPreview::class)
     private fun setupSearchTextListener() {
         etSearch.textChanges()
             .debounce(300)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
@@ -13,11 +13,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
-import com.google.gson.JsonArray
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlin.OptIn
-import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -32,10 +31,7 @@ import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.VoicesLabelManager
 import org.ole.planet.myplanet.ui.chat.ChatDetailFragment
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
-import org.ole.planet.myplanet.ui.voices.VoicesViewModel
-import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.FileUtils
-import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.JsonUtils.getString
 import org.ole.planet.myplanet.utils.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utils.textChanges
@@ -53,12 +49,7 @@ class VoicesFragment : BaseVoicesFragment() {
     lateinit var voicesRepository: VoicesRepository
     @Inject
     lateinit var dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider
-    private var filteredNewsList: List<RealmNews?> = listOf()
-    private var searchFilteredList: List<RealmNews?> = listOf()
-    private var labelFilteredList: List<RealmNews?> = listOf()
     private lateinit var etSearch: EditText
-    private var selectedLabel: String = "All"
-    private val labelDisplayToValue = mutableMapOf<String, String>()
     private var labelAdapter: VoicesLabelAdapter? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -101,19 +92,31 @@ class VoicesFragment : BaseVoicesFragment() {
                 binding.btnNewVoice.visibility = View.GONE
             }
 
+            setupLabelFilter()
+            voicesViewModel.observeCommunityNews(getUserIdentifier())
+
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                voicesRepository.getCommunityNews(getUserIdentifier()).collect { news ->
-                    val filtered = news.map { it as RealmNews? }
-                    val labels = voicesViewModel.collectLabels(filtered)
-                    val labelFiltered = voicesViewModel.filterByLabel(filtered, selectedLabel)
-                    val searchFiltered =
-                        applySearchFilter(labelFiltered, etSearch.text.toString().trim())
-                    if (_binding != null) {
-                        filteredNewsList = filtered
-                        labelFilteredList = labelFiltered
-                        searchFilteredList = searchFiltered
-                        setupLabelFilter(labels)
-                        setData(searchFilteredList)
+                launch {
+                    voicesViewModel.filteredNews.collectLatest { searchFiltered ->
+                        if (_binding != null) {
+                            setData(searchFiltered)
+                        }
+                    }
+                }
+                launch {
+                    voicesViewModel.labels.collectLatest { labels ->
+                        if (_binding != null) {
+                            updateLabelSpinner(labels)
+                        }
+                    }
+                }
+                launch {
+                    voicesViewModel.createNewsSuccess.collectLatest { n ->
+                        binding.btnSubmit.isEnabled = true
+                        if (n != null) {
+                            n.sortDate = n.calculateSortDate()
+                            scrollToTop()
+                        }
                     }
                 }
             }
@@ -135,23 +138,11 @@ class VoicesFragment : BaseVoicesFragment() {
             binding.llAddNews.visibility = View.GONE
             binding.btnNewVoice.text = getString(R.string.new_voice)
             binding.btnSubmit.isEnabled = false
-            viewLifecycleOwner.lifecycleScope.launch {
-                try {
-                    val n = user?.let { it1 -> voicesRepository.createNews(map, it1, imageList) }
-                    imageList.clear()
-                    llImage?.removeAllViews()
-                    if (n != null) {
-                        n.sortDate = n.calculateSortDate()
-                        filteredNewsList = listOf(n) + filteredNewsList
-                        labelFilteredList = voicesViewModel.filterByLabel(filteredNewsList, selectedLabel)
-                        searchFilteredList = applySearchFilter(labelFilteredList)
-                        setData(searchFilteredList)
-                    }
-                    scrollToTop()
-                } finally {
-                    binding.btnSubmit.isEnabled = true
-                }
-            }
+
+            user?.let { it1 -> voicesViewModel.createNews(map, it1, imageList.toList()) }
+            imageList.clear()
+            llImage?.removeAllViews()
+            // The button will be re-enabled when createNewsSuccess emits
         }
 
         binding.addNewsImage.setOnClickListener {
@@ -172,7 +163,7 @@ class VoicesFragment : BaseVoicesFragment() {
     }
 
     private val currentEmptyStateSource: String
-        get() = if (etSearch.text.isNotEmpty() || selectedLabel != "All") "news_filtered" else "news"
+        get() = if (etSearch.text.isNotEmpty() || voicesViewModel.selectedLabel.value != "All") "news_filtered" else "news"
 
     override fun setData(list: List<RealmNews?>?) {
         if (!isAdded || list == null) return
@@ -183,7 +174,7 @@ class VoicesFragment : BaseVoicesFragment() {
             val sortedList = sortNews(list)
             setupVoicesAdapter(sortedList.filterNotNull())
         } else {
-            (binding.rvNews.adapter as? VoicesAdapter)?.submitList(list?.filterNotNull())
+            (binding.rvNews.adapter as? VoicesAdapter)?.submitList(list.filterNotNull())
         }
         showNoData(binding.tvMessage, list.filterNotNull().size, currentEmptyStateSource)
     }
@@ -331,137 +322,41 @@ class VoicesFragment : BaseVoicesFragment() {
         }
     }
 
-    @OptIn(FlowPreview::class)
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
     private fun setupSearchTextListener() {
         etSearch.textChanges()
             .debounce(300)
             .onEach { text ->
                 val searchQuery = text.toString().trim()
-                searchFilteredList = applySearchFilter(labelFilteredList, searchQuery)
-                setData(searchFilteredList)
+                voicesViewModel.updateSearchQuery(searchQuery)
                 scrollToTop()
             }
             .launchIn(viewLifecycleOwner.lifecycleScope)
     }
     
-    private fun applySearchFilter(list: List<RealmNews?>, queryParam: String? = null): List<RealmNews?> {
-        val query = queryParam ?: etSearch.text.toString().trim()
-        if (query.isEmpty()) return list
-        return list.filter { news ->
-            news?.message?.contains(query, ignoreCase = true) == true ||
-            news?.userName?.contains(query, ignoreCase = true) == true ||
-            news?.newsTitle?.contains(query, ignoreCase = true) == true
-        }
-    }
-    
-    private fun setupLabelFilter(precomputedLabels: List<String>? = null) {
+    private fun setupLabelFilter() {
         val binding = _binding ?: return
         if (labelAdapter == null) {
             labelAdapter = VoicesLabelAdapter(
-                selectedLabel = selectedLabel,
+                selectedLabel = voicesViewModel.selectedLabel.value,
                 onItemClick = { label ->
-                    selectedLabel = label
+                    voicesViewModel.updateSelectedLabel(label)
                     labelAdapter?.setSelectedLabel(label)
-                    labelFilteredList = applyLabelFilter(filteredNewsList)
-                    searchFilteredList = applySearchFilter(labelFilteredList)
-                    setData(searchFilteredList)
                     scrollToTop()
                 }
             )
             binding.filterByLabel.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(requireContext(), androidx.recyclerview.widget.LinearLayoutManager.HORIZONTAL, false)
             binding.filterByLabel.adapter = labelAdapter
         }
-        updateLabelSpinner(precomputedLabels)
     }
 
-    private fun updateLabelSpinner(precomputedLabels: List<String>? = null) {
-        val labels = precomputedLabels ?: collectAllLabels(filteredNewsList)
+    private fun updateLabelSpinner(labels: List<String>) {
         labelAdapter?.submitList(labels)
 
-        val position = labels.indexOf(selectedLabel)
+        val position = labels.indexOf(voicesViewModel.selectedLabel.value)
         if (position >= 0) {
             _binding?.filterByLabel?.scrollToPosition(position)
         }
-    }
-
-    private fun collectAllLabels(list: List<RealmNews?>): List<String> {
-        labelDisplayToValue.clear()
-
-        val allLabels = mutableSetOf<String>()
-        allLabels.add("All")
-
-        Constants.LABELS.forEach { (labelName, labelValue) ->
-            allLabels.add(labelName)
-            labelDisplayToValue[labelName] = labelValue
-        }
-
-        allLabels.add("Shared Chat")
-
-        list.forEach { news ->
-            if (!news?.viewIn.isNullOrEmpty()) {
-                try {
-                    val ar = JsonUtils.gson.fromJson(news.viewIn, JsonArray::class.java)
-                    if (ar.size() > 1) {
-                        val ob = ar[0].asJsonObject
-                        if (ob.has("name") && !ob.get("name").isJsonNull) {
-                            val sharedTeamName = ob.get("name").asString
-                            if (sharedTeamName.isNotEmpty()) {
-                                allLabels.add(sharedTeamName)
-                            }
-                        }
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
-
-            news?.labels?.forEach { label ->
-                val labelName = Constants.LABELS.entries.find { it.value == label }?.key
-                    ?: VoicesLabelManager.formatLabelValue(label)
-                allLabels.add(labelName)
-                labelDisplayToValue.putIfAbsent(labelName, label)
-            }
-        }
-
-        return allLabels.sorted()
-    }
-
-    private fun applyLabelFilter(list: List<RealmNews?>): List<RealmNews?> {
-        if (selectedLabel == "All") {
-            return list
-        }
-
-        return list.filter { news ->
-            when {
-                selectedLabel == "Shared Chat" -> {
-                    news?.chat == true || news?.viewableBy.equals("community", ignoreCase = true)
-                }
-                labelDisplayToValue.containsKey(selectedLabel) -> {
-                    val labelValue = labelDisplayToValue[selectedLabel]
-                    news?.labels?.contains(labelValue) == true
-                }
-                else -> {
-                    extractSharedTeamName(news) == selectedLabel
-                }
-            }
-        }
-    }
-
-    private fun extractSharedTeamName(news: RealmNews?): String {
-        if (!news?.viewIn.isNullOrEmpty()) {
-            try {
-                val ar = JsonUtils.gson.fromJson(news.viewIn, JsonArray::class.java)
-                if (ar.size() > 1) {
-                    val ob = ar[0].asJsonObject
-                    if (ob.has("name") && !ob.get("name").isJsonNull) {
-                        return ob.get("name").asString
-                    }
-                }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-        return ""
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesViewModel.kt
@@ -4,6 +4,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.model.RealmMyLibrary
@@ -24,6 +33,69 @@ class VoicesViewModel @Inject constructor(
     private val teamsRepository: TeamsRepository,
     private val dispatcherProvider: DispatcherProvider
 ) : ViewModel(), LabelManipulator by DefaultLabelManipulator(voicesRepository, dispatcherProvider) {
+
+    private val _searchQuery = MutableStateFlow("")
+
+    private val _selectedLabel = MutableStateFlow("All")
+    val selectedLabel: StateFlow<String> = _selectedLabel.asStateFlow()
+
+    private val _baseNewsList = MutableStateFlow<List<RealmNews?>>(emptyList())
+
+    private val _labels = MutableStateFlow<List<String>>(emptyList())
+    val labels: StateFlow<List<String>> = _labels.asStateFlow()
+
+    private val _createNewsSuccess = Channel<RealmNews?>(Channel.BUFFERED)
+    val createNewsSuccess: Flow<RealmNews?> = _createNewsSuccess.receiveAsFlow()
+
+    private var observeJob: kotlinx.coroutines.Job? = null
+
+    val filteredNews: StateFlow<List<RealmNews?>> = combine(
+        _baseNewsList,
+        _searchQuery,
+        _selectedLabel
+    ) { news, query, label ->
+        val labelFiltered = filterByLabel(news, label)
+        applySearchFilter(labelFiltered, query)
+    }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    fun observeCommunityNews(userIdentifier: String) {
+        observeJob?.cancel()
+        observeJob = viewModelScope.launch(dispatcherProvider.io) {
+            voicesRepository.getCommunityNews(userIdentifier).collect { newsList ->
+                val filtered = newsList.map { it as RealmNews? }
+                _baseNewsList.value = filtered
+                _labels.value = collectLabels(filtered)
+            }
+        }
+    }
+
+    fun updateSearchQuery(query: String) {
+        _searchQuery.value = query
+    }
+
+    fun updateSelectedLabel(label: String) {
+        _selectedLabel.value = label
+    }
+
+    fun createNews(map: HashMap<String?, String>, user: RealmUser, imageList: List<String>) {
+        viewModelScope.launch(dispatcherProvider.io) {
+            try {
+                val news = voicesRepository.createNews(map, user, imageList)
+                _createNewsSuccess.send(news)
+            } catch (e: Exception) {
+                _createNewsSuccess.send(null)
+            }
+        }
+    }
+
+    private fun applySearchFilter(list: List<RealmNews?>, query: String): List<RealmNews?> {
+        if (query.isEmpty()) return list
+        return list.filter { news ->
+            news?.message?.contains(query, ignoreCase = true) == true ||
+            news?.userName?.contains(query, ignoreCase = true) == true ||
+            news?.newsTitle?.contains(query, ignoreCase = true) == true
+        }
+    }
 
     fun deletePost(newsId: String, teamName: String, onComplete: () -> Unit) {
         viewModelScope.launch {


### PR DESCRIPTION
Moves local UI state, search query application, label extraction, and label filtering out of VoicesFragment and into VoicesViewModel. Uses StateFlow and combine to create a reactive, single source of truth for the filtered news list, keeping the fragment purely focused on rendering and view clicks. Also wires the news creation path to use a Channel/Flow for completion handling.

---
*PR created automatically by Jules for task [16335038173558488207](https://jules.google.com/task/16335038173558488207) started by @dogi*