### PR TITLE
courses: less repository methods is more (fixes #14171)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5821
+        versionName = "0.58.21"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
@@ -12,10 +12,6 @@ import org.ole.planet.myplanet.model.RealmTag
 
 interface CoursesRepository {
     suspend fun getAllCourses(): List<RealmMyCourse>
-    suspend fun getAllCourses(orderBy: String, sort: io.realm.Sort): List<RealmMyCourse>
-    fun getAllCourses(userId: String?, libs: List<RealmMyCourse>): List<RealmMyCourse>
-    fun getMyCourseByUserId(userId: String?, libs: List<RealmMyCourse>?): List<RealmMyCourse>
-    fun getOurCourse(userId: String?, libs: List<RealmMyCourse>): List<RealmMyCourse>
     fun getMyCourses(userId: String?, courses: List<RealmMyCourse>): List<RealmMyCourse>
     suspend fun getMyCourses(userId: String): List<RealmMyCourse>
     suspend fun getMyCoursesFlow(userId: String): Flow<List<RealmMyCourse>>
@@ -29,7 +25,6 @@ interface CoursesRepository {
     suspend fun getCourseExamCount(courseId: String?): Int
     suspend fun getCourseSteps(courseId: String): List<RealmCourseStep>
     suspend fun getCourseStepIds(courseId: String): List<String?>
-    suspend fun markCourseAdded(courseId: String, userId: String?): Result<Boolean>
     suspend fun batchInsertMyCourses(shelfId: String?, documents: List<JsonObject>): Int
     suspend fun markCoursesAdded(courseIds: List<String>, userId: String?): Result<Boolean>
     suspend fun joinCourse(courseId: String, userId: String): Result<Unit>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -55,28 +55,6 @@ class CoursesRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getAllCourses(orderBy: String, sort: io.realm.Sort): List<RealmMyCourse> {
-        return withRealm { realm ->
-            val results = realm.where(RealmMyCourse::class.java)
-                .isNotEmpty("courseTitle")
-                .sort(orderBy, sort)
-                .findAll()
-            realm.copyFromRealm(results)
-        }
-    }
-
-    override fun getAllCourses(userId: String?, libs: List<RealmMyCourse>): List<RealmMyCourse> {
-        return libs.onEach { it.isMyCourse = it.userId?.contains(userId) == true }
-    }
-
-    override fun getMyCourseByUserId(userId: String?, libs: List<RealmMyCourse>?): List<RealmMyCourse> {
-        return libs?.filter { it.userId?.contains(userId) == true } ?: emptyList()
-    }
-
-    override fun getOurCourse(userId: String?, libs: List<RealmMyCourse>): List<RealmMyCourse> {
-        return libs.filter { it.userId?.contains(userId) != true }
-    }
-
     override fun getMyCourses(userId: String?, courses: List<RealmMyCourse>): List<RealmMyCourse> {
         if (userId == null) return emptyList()
         return courses.filter { it.userId?.contains(userId) == true }
@@ -173,13 +151,6 @@ class CoursesRepositoryImpl @Inject constructor(
             val course = realm.where(RealmMyCourse::class.java).equalTo("courseId", courseId).findFirst()
             course?.courseSteps?.map { it.id } ?: emptyList()
         }
-    }
-
-    override suspend fun markCourseAdded(courseId: String, userId: String?): Result<Boolean> {
-        if (courseId.isBlank()) {
-            return Result.success(false)
-        }
-        return markCoursesAdded(listOf(courseId), userId)
     }
 
     override suspend fun markCoursesAdded(courseIds: List<String>, userId: String?): Result<Boolean> {


### PR DESCRIPTION
Removes unused `CoursesRepository` methods to prevent potential Realm leaks.

The following unused methods were identified and removed from both `CoursesRepository.kt` and `CoursesRepositoryImpl.kt`:
* `getAllCourses(orderBy: String, sort: io.realm.Sort)`
* `getAllCourses(userId: String?, libs: List<RealmMyCourse>)`
* `getMyCourseByUserId(userId: String?, libs: List<RealmMyCourse>?)`
* `getOurCourse(userId: String?, libs: List<RealmMyCourse>)`
* `markCourseAdded(courseId: String, userId: String?)`

Verified via grep that there are no active callers for any of these methods. The code was successfully reviewed as correct.

---
*PR created automatically by Jules for task [18219601708065844824](https://jules.google.com/task/18219601708065844824) started by @dogi*