### PR TITLE
resources: smoother repository local api saving (fixes #14173)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5823
+        versionName = "0.58.23"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -29,6 +29,27 @@ data class UploadedResourceInfo(
     val title: String?
 )
 
+data class LocalResourceRequest(
+    val title: String?,
+    val addedBy: String?,
+    val author: String?,
+    val year: String?,
+    val description: String?,
+    val publisher: String?,
+    val linkToLicense: String?,
+    val openWith: String?,
+    val language: String?,
+    val mediaType: String?,
+    val resourceType: String?,
+    val subjects: io.realm.RealmList<String>?,
+    val levels: io.realm.RealmList<String>?,
+    val resourceFor: io.realm.RealmList<String>?,
+    val resourceUrl: String?,
+    val userId: String?,
+    val isPrivateTeamResource: Boolean,
+    val teamId: String?
+)
+
 interface ResourcesRepository {
     suspend fun getAllLibraries(): List<RealmMyLibrary>
     suspend fun getAllLibraryItems(): List<RealmMyLibrary>
@@ -48,7 +69,7 @@ interface ResourcesRepository {
     suspend fun countLibrariesNeedingUpdate(userId: String?): Int
     suspend fun resourceTitleExists(title: String): Boolean
     suspend fun saveLibraryItem(item: RealmMyLibrary)
-    suspend fun saveLocalResource(resource: RealmMyLibrary, userId: String?, isPrivateTeamResource: Boolean, teamId: String?): Result<Unit>
+    suspend fun saveLocalResource(request: LocalResourceRequest): Result<Unit>
     suspend fun markResourceAdded(userId: String?, resourceId: String)
     suspend fun updateUserLibrary(resourceId: String, userId: String, isAdd: Boolean): RealmMyLibrary?
     suspend fun updateLibraryItem(id: String, updater: (RealmMyLibrary) -> Unit)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -193,24 +193,52 @@ class ResourcesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun saveLocalResource(
-        resource: RealmMyLibrary,
-        userId: String?,
-        isPrivateTeamResource: Boolean,
-        teamId: String?
+        request: LocalResourceRequest
     ): Result<Unit> {
-        val title = resource.title ?: return Result.failure(Exception("Title is missing"))
+        val title = request.title ?: return Result.failure(Exception("Title is missing"))
 
         if (resourceTitleExists(title)) {
             return Result.failure(Exception("Resource title already exists"))
         }
 
-        saveLibraryItem(resource)
+        val id = UUID.randomUUID().toString()
+        val resource = RealmMyLibrary().apply {
+            this.id = id
+            this.title = title
+            this.addedBy = request.addedBy
+            this.author = request.author
+            this.resourceId = id
+            this.year = request.year
+            this.description = request.description
+            this.publisher = request.publisher
+            this.linkToLicense = request.linkToLicense
+            this.openWith = request.openWith
+            this.language = request.language
+            this.mediaType = request.mediaType
+            this.resourceType = request.resourceType
+            this.subject = request.subjects
+            this.setUserId(io.realm.RealmList())
+            this.level = request.levels
+            this.createdDate = Calendar.getInstance().timeInMillis
+            this.resourceFor = request.resourceFor
+            this.resourceLocalAddress = request.resourceUrl
+            this.resourceOffline = true
+            this.filename = request.resourceUrl?.let { it.substring(it.lastIndexOf("/")) }
+            this.isPrivate = request.isPrivateTeamResource
+            this.privateFor = if (request.isPrivateTeamResource) request.teamId else null
 
-        if (!isPrivateTeamResource) {
-            markResourceAdded(userId, resource.id ?: "")
+            if (!request.isPrivateTeamResource) {
+                setUserId(request.userId)
+            }
         }
 
-        if (teamId != null) {
+        saveLibraryItem(resource)
+
+        if (!request.isPrivateTeamResource) {
+            markResourceAdded(request.userId, resource.id ?: "")
+        }
+
+        if (request.teamId != null) {
             teamsSyncRepositoryLazy.get().syncTeamActivities()
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.databinding.ActivityAddResourceBinding
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.repository.LocalResourceRequest
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.ui.components.CheckboxAdapter
@@ -143,25 +144,31 @@ class AddResourceActivity : AppCompatActivity() {
     private fun saveResource() {
         val title = binding.etTitle.text.toString().trim { it <= ' ' }
         if (!validate(title)) return
-        val id = UUID.randomUUID().toString()
         val isPrivateTeamResource = binding.cbPrivateResource.isChecked && teamId != null
 
-        val resource = RealmMyLibrary().apply {
-            this.id = id
-            this.title = title
-            createResource(this, id)
-            if (!isPrivateTeamResource) {
-                setUserId(userModel?.id)
-            }
-        }
+        val request = LocalResourceRequest(
+            title = title,
+            addedBy = binding.tvAddedBy.text.toString().trim { it <= ' ' },
+            author = binding.etAuthor.text.toString().trim { it <= ' ' },
+            year = binding.etYear.text.toString().trim { it <= ' ' },
+            description = binding.etDescription.text.toString().trim { it <= ' ' },
+            publisher = binding.etPublisher.text.toString().trim { it <= ' ' },
+            linkToLicense = binding.etLinkToLicense.text.toString().trim { it <= ' ' },
+            openWith = if (binding.spnOpenWith.selectedItemPosition > 0) binding.spnOpenWith.selectedItem.toString() else "",
+            language = if (binding.spnLang.selectedItemPosition > 0) binding.spnLang.selectedItem.toString() else "",
+            mediaType = if (binding.spnMedia.selectedItemPosition > 0) binding.spnMedia.selectedItem.toString() else "",
+            resourceType = if (binding.spnResourceType.selectedItemPosition > 0) binding.spnResourceType.selectedItem.toString() else "",
+            subjects = subjects,
+            levels = levels,
+            resourceFor = resourceFor,
+            resourceUrl = resourceUrl,
+            userId = userModel?.id,
+            isPrivateTeamResource = isPrivateTeamResource,
+            teamId = teamId
+        )
         binding.btnSubmit.isEnabled = false
         lifecycleScope.launch {
-            val result = resourcesRepository.saveLocalResource(
-                resource,
-                userModel?.id,
-                isPrivateTeamResource,
-                teamId
-            )
+            val result = resourcesRepository.saveLocalResource(request)
 
             if (result.isSuccess) {
                 val message = if (isPrivateTeamResource) {
@@ -176,30 +183,6 @@ class AddResourceActivity : AppCompatActivity() {
                 binding.btnSubmit.isEnabled = true
             }
         }
-    }
-
-    private fun createResource(resource: RealmMyLibrary, id: String) {
-        resource.addedBy = binding.tvAddedBy.text.toString().trim { it <= ' ' }
-        resource.author = binding.etAuthor.text.toString().trim { it <= ' ' }
-        resource.resourceId = id
-        resource.year = binding.etYear.text.toString().trim { it <= ' ' }
-        resource.description = binding.etDescription.text.toString().trim { it <= ' ' }
-        resource.publisher = binding.etPublisher.text.toString().trim { it <= ' ' }
-        resource.linkToLicense = binding.etLinkToLicense.text.toString().trim { it <= ' ' }
-        resource.openWith = if (binding.spnOpenWith.selectedItemPosition > 0) binding.spnOpenWith.selectedItem.toString() else ""
-        resource.language = if (binding.spnLang.selectedItemPosition > 0) binding.spnLang.selectedItem.toString() else ""
-        resource.mediaType = if (binding.spnMedia.selectedItemPosition > 0) binding.spnMedia.selectedItem.toString() else ""
-        resource.resourceType = if (binding.spnResourceType.selectedItemPosition > 0) binding.spnResourceType.selectedItem.toString() else ""
-        resource.subject = subjects
-        resource.setUserId(RealmList())
-        resource.level = levels
-        resource.createdDate = Calendar.getInstance().timeInMillis
-        resource.resourceFor = resourceFor
-        resource.resourceLocalAddress = resourceUrl
-        resource.resourceOffline = true
-        resource.filename = resourceUrl?.let { it.substring(it.lastIndexOf("/")) }
-        resource.isPrivate = binding.cbPrivateResource.isChecked && teamId != null
-        resource.privateFor = if (binding.cbPrivateResource.isChecked && teamId != null) teamId else null
     }
 
     private fun validate(title: String): Boolean {


### PR DESCRIPTION
Decoupled UI components from directly instantiating the Realm database model by introducing `LocalResourceRequest`. `ResourcesRepository` and its implementation now handle the construction, UUID generation, and assignment logic locally.

---
*PR created automatically by Jules for task [941227495284189035](https://jules.google.com/task/941227495284189035) started by @dogi*