### PR TITLE
teams: smoother notifications repositories looping (fixes #14207)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5854
+        versionName = "0.58.54"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -179,7 +179,7 @@ class NotificationsRepositoryImpl @Inject constructor(
             val linkJson = org.json.JSONObject(task?.link ?: "{}")
             val teamId = linkJson.optString("teams")
             if (teamId.isNotEmpty()) {
-                val teamObject = teamsRepository.get().getTeamById(teamId)
+                val teamObject = teamsRepository.get().getTeamLabelInfo(teamId)
                 TaskNotificationResult(teamId, teamObject?.name, teamObject?.type)
             } else {
                 null
@@ -194,17 +194,16 @@ class NotificationsRepositoryImpl @Inject constructor(
             } else {
                 it
             }
-            teamsRepository.get().getJoinRequestById(actualJoinRequestId)?.teamId
+            teamsRepository.get().getJoinRequestInfo(actualJoinRequestId)?.teamId
         }
     }
 
     override suspend fun getJoinRequestDetails(relatedId: String?): Pair<String, String> {
-        val joinRequest = teamsRepository.get().getJoinRequestById(relatedId)
-        val team = joinRequest?.teamId?.let { tid ->
-            teamsRepository.get().getTeamById(tid)
-        }
+        val joinRequest = teamsRepository.get().getJoinRequestInfo(relatedId)
+        val teamName = joinRequest?.teamId?.let { tid ->
+            teamsRepository.get().getTeamLabelInfo(tid)?.name
+        } ?: "Unknown Team"
         val uid = joinRequest?.userId
-        val teamName = team?.name ?: "Unknown Team"
 
         val requester = uid?.let { userRepository.get().getUserById(it) }
         return Pair(requester?.name ?: "Unknown User", teamName)
@@ -243,18 +242,18 @@ class NotificationsRepositoryImpl @Inject constructor(
     override suspend fun getJoinRequestDetailsBatch(relatedIds: List<String>): Map<String, Pair<String, String>> {
         if (relatedIds.isEmpty()) return emptyMap()
 
-        val joinRequests = relatedIds.mapNotNull { teamsRepository.get().getJoinRequestById(it) }
+        val joinRequests = teamsRepository.get().getJoinRequestsInfo(relatedIds)
 
-        val teamIds = joinRequests.mapNotNull { it.teamId }.distinct()
+        val teamIds = joinRequests.map { it.teamId }.filter { it.isNotEmpty() }.distinct()
 
         val teamMap = teamsRepository.get().getTeamNamesByIds(teamIds)
 
         val intermediateList = mutableListOf<Triple<String, String, String>>()
         joinRequests.forEach { jr ->
-            val id = jr._id
-            if (!id.isNullOrEmpty()) {
-                val tName = teamMap[jr.teamId ?: ""] ?: "Unknown Team"
-                intermediateList.add(Triple(id, jr.userId ?: "", tName))
+            val id = jr.id
+            if (id.isNotEmpty()) {
+                val tName = teamMap[jr.teamId] ?: "Unknown Team"
+                intermediateList.add(Triple(id, jr.userId, tName))
             }
         }
 
@@ -280,8 +279,8 @@ class NotificationsRepositoryImpl @Inject constructor(
 
     override suspend fun getTaskTeamName(taskTitle: String): String? {
         val taskObj = findByField(RealmTeamTask::class.java, "title", taskTitle)
-        val team = taskObj?.teamId?.let { teamsRepository.get().getTeamById(it) }
-        return team?.name
+        val teamInfo = taskObj?.teamId?.let { teamsRepository.get().getTeamLabelInfo(it) }
+        return teamInfo?.name
     }
 
     override suspend fun getTaskTeamNamesByTaskTitles(taskTitles: List<String>): Map<String, String> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -27,6 +27,18 @@ data class TeamMemberStatus(
     val hasPendingRequest: Boolean
 )
 
+data class TeamLabelInfo(
+    val teamId: String,
+    val name: String,
+    val type: String
+)
+
+data class JoinRequestInfo(
+    val id: String,
+    val teamId: String,
+    val userId: String
+)
+
 data class JoinRequestNotification(
     val requesterName: String,
     val teamName: String,
@@ -63,6 +75,10 @@ interface TeamsRepository {
     suspend fun getTaskTeamInfo(taskId: String): Triple<String, String, String>?
     suspend fun getJoinRequestTeamId(requestId: String): String?
     suspend fun getJoinRequestById(id: String?): RealmMyTeam?
+    suspend fun getTeamLabelInfo(teamId: String): TeamLabelInfo?
+    suspend fun getJoinRequestInfo(requestId: String?): JoinRequestInfo?
+    suspend fun getJoinRequestsInfo(requestIds: List<String>): List<JoinRequestInfo>
+
     suspend fun getTeamNamesByIds(ids: List<String>): Map<String, String>
     suspend fun getTaskNotifications(userId: String?): List<Triple<String, String, String>>
     suspend fun getJoinRequestNotifications(userId: String?): List<JoinRequestNotification>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -444,6 +444,45 @@ class TeamsRepositoryImpl @Inject constructor(
     }
 
 
+
+    override suspend fun getTeamLabelInfo(teamId: String): TeamLabelInfo? {
+        val team = findByField(RealmMyTeam::class.java, "_id", teamId) ?: return null
+        return TeamLabelInfo(
+            teamId = team._id ?: "",
+            name = team.name ?: "",
+            type = team.type ?: ""
+        )
+    }
+
+    override suspend fun getJoinRequestInfo(requestId: String?): JoinRequestInfo? {
+        if (requestId.isNullOrEmpty()) return null
+        val req = findByField(RealmMyTeam::class.java, "_id", requestId) ?: return null
+        return JoinRequestInfo(
+            id = req._id ?: "",
+            teamId = req.teamId ?: "",
+            userId = req.userId ?: ""
+        )
+    }
+
+    override suspend fun getJoinRequestsInfo(requestIds: List<String>): List<JoinRequestInfo> {
+        if (requestIds.isEmpty()) return emptyList()
+        val requests = queryList(RealmMyTeam::class.java) {
+            beginGroup()
+            requestIds.forEachIndexed { index, id ->
+                if (index > 0) or()
+                equalTo("_id", id)
+            }
+            endGroup()
+        }
+        return requests.map {
+            JoinRequestInfo(
+                id = it._id ?: "",
+                teamId = it.teamId ?: "",
+                userId = it.userId ?: ""
+            )
+        }
+    }
+
     override suspend fun getJoinRequestById(id: String?): RealmMyTeam? {
         if (id.isNullOrEmpty()) return null
         return findByField(RealmMyTeam::class.java, "_id", id)


### PR DESCRIPTION
This pull request decouples `NotificationsRepositoryImpl` from raw Realm database models when fetching team and join-request information. It introduces new Data Transfer Objects (DTOs) and focused lookup methods in the `TeamsRepository` interface. Batch query capabilities have been explicitly preserved using an `OR` chained `.equalTo()` Realm query to prevent performance regressions during batch lookups of join-request team details.

---
*PR created automatically by Jules for task [8814804557234987533](https://jules.google.com/task/8814804557234987533) started by @dogi*