### PR TITLE
teams: smoother events description item callback diffing (fixes #14191)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5838
+        versionName = "0.58.38"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDescriptionAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDescriptionAdapter.kt
@@ -4,21 +4,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.utils.DiffUtils
 
 class EventsDescriptionAdapter : ListAdapter<EventsDescriptionAdapter.DescriptionItem, EventsDescriptionAdapter.ViewHolder>(
-    object : DiffUtil.ItemCallback<DescriptionItem>() {
-        override fun areItemsTheSame(oldItem: DescriptionItem, newItem: DescriptionItem): Boolean {
-            return oldItem.key == newItem.key
-        }
-
-        override fun areContentsTheSame(oldItem: DescriptionItem, newItem: DescriptionItem): Boolean {
-            return oldItem == newItem
-        }
-    }
+    DiffUtils.itemCallback(
+        areItemsTheSame = { oldItem, newItem -> oldItem.key == newItem.key },
+        areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
+    )
 ) {
 
     data class DescriptionItem(val key: String, val value: String)

--- a/app/src/test/java/org/ole/planet/myplanet/ui/events/EventsDescriptionAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/events/EventsDescriptionAdapterTest.kt
@@ -1,0 +1,70 @@
+package org.ole.planet.myplanet.ui.events
+
+import android.content.Context
+import android.os.Build
+import android.widget.LinearLayout
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], application = android.app.Application::class)
+class EventsDescriptionAdapterTest {
+
+    private lateinit var context: Context
+    private lateinit var adapter: EventsDescriptionAdapter
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        adapter = EventsDescriptionAdapter()
+    }
+
+    @Test
+    fun `test adapter item binding and diff`() {
+        val initialList = listOf(
+            EventsDescriptionAdapter.DescriptionItem("Date", "2023-10-27"),
+            EventsDescriptionAdapter.DescriptionItem("Time", "10:00 AM")
+        )
+
+        val commitCallback = Runnable {}
+        adapter.submitList(initialList, commitCallback)
+        // Ensure UI thread has processed the updates in Robolectric
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+
+        assertEquals(2, adapter.itemCount)
+
+        val parent = LinearLayout(context)
+        val holder = adapter.onCreateViewHolder(parent, 0)
+
+        adapter.onBindViewHolder(holder, 0)
+        assertEquals("Date : ", holder.title.text.toString())
+        assertEquals("2023-10-27", holder.description.text.toString())
+
+        adapter.onBindViewHolder(holder, 1)
+        assertEquals("Time : ", holder.title.text.toString())
+        assertEquals("10:00 AM", holder.description.text.toString())
+
+        val updatedList = listOf(
+            EventsDescriptionAdapter.DescriptionItem("Date", "2023-10-28"),
+            EventsDescriptionAdapter.DescriptionItem("Location", "Online")
+        )
+
+        adapter.submitList(updatedList, commitCallback)
+        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+
+        assertEquals(2, adapter.itemCount)
+
+        adapter.onBindViewHolder(holder, 0)
+        assertEquals("Date : ", holder.title.text.toString())
+        assertEquals("2023-10-28", holder.description.text.toString())
+
+        adapter.onBindViewHolder(holder, 1)
+        assertEquals("Location : ", holder.title.text.toString())
+        assertEquals("Online", holder.description.text.toString())
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/events/EventsDescriptionAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/events/EventsDescriptionAdapterTest.kt
@@ -10,6 +10,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.P], application = android.app.Application::class)
@@ -31,10 +32,14 @@ class EventsDescriptionAdapterTest {
             EventsDescriptionAdapter.DescriptionItem("Time", "10:00 AM")
         )
 
-        val commitCallback = Runnable {}
-        adapter.submitList(initialList, commitCallback)
-        // Ensure UI thread has processed the updates in Robolectric
-        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        var committed = false
+        adapter.submitList(initialList) {
+            committed = true
+        }
+
+        while (!committed) {
+            ShadowLooper.idleMainLooper()
+        }
 
         assertEquals(2, adapter.itemCount)
 
@@ -54,8 +59,14 @@ class EventsDescriptionAdapterTest {
             EventsDescriptionAdapter.DescriptionItem("Location", "Online")
         )
 
-        adapter.submitList(updatedList, commitCallback)
-        org.robolectric.shadows.ShadowLooper.idleMainLooper()
+        var updatedCommitted = false
+        adapter.submitList(updatedList) {
+            updatedCommitted = true
+        }
+
+        while (!updatedCommitted) {
+            ShadowLooper.idleMainLooper()
+        }
 
         assertEquals(2, adapter.itemCount)
 


### PR DESCRIPTION
Refactor EventsDescriptionAdapter to use shared DiffUtils.itemCallback

This commit refactors the `EventsDescriptionAdapter` to use the shared `DiffUtils.itemCallback` utility instead of implementing an anonymous `DiffUtil.ItemCallback`. The redundant `DiffUtil` import has been removed. Identity remains evaluated by the item's key, and content equivalence continues using the data class's default equals. 

Additionally, an `EventsDescriptionAdapterTest` unit test was added to verify Robolectric-based binding and view holder population, preventing future regressions.

---
*PR created automatically by Jules for task [7124069980544762343](https://jules.google.com/task/7124069980544762343) started by @dogi*