### PR TITLE
all: smoother utilities toasting (fixes #14190)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5837
+        versionName = "0.58.37"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Utilities.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.SharedPreferences
+import android.os.Looper
 import android.util.Patterns
 import android.webkit.MimeTypeMap
 import android.widget.Toast
@@ -39,19 +40,27 @@ object Utilities {
     @JvmStatic
     fun toast(context: Context?, message: CharSequence?, duration: Int = Toast.LENGTH_LONG) {
         context ?: return
-        MainApplication.applicationScope.launch(Dispatchers.Main) {
-            if (!isAppInForeground()) {
-                return@launch
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            showToastIfValid(context, message, duration)
+        } else {
+            MainApplication.applicationScope.launch(Dispatchers.Main) {
+                showToastIfValid(context, message, duration)
             }
+        }
+    }
 
-            val visualContext = getActivityFromContext(context)
+    private fun showToastIfValid(context: Context, message: CharSequence?, duration: Int) {
+        if (!isAppInForeground()) {
+            return
+        }
 
-            if (visualContext != null && !visualContext.isFinishing && !visualContext.isDestroyed) {
-                try {
-                    Toast.makeText(visualContext, message, duration).show()
-                } catch (e: IllegalAccessException) {
-                    e.printStackTrace()
-                }
+        val visualContext = getActivityFromContext(context)
+
+        if (visualContext != null && !visualContext.isFinishing && !visualContext.isDestroyed) {
+            try {
+                Toast.makeText(visualContext, message, duration).show()
+            } catch (e: IllegalAccessException) {
+                e.printStackTrace()
             }
         }
     }


### PR DESCRIPTION
This commit extracts the `Toast` logic from `Utilities.toast` into a private `showToastIfValid` method. It updates `toast` to check if `Looper.myLooper() == Looper.getMainLooper()`. If it is the main thread, `showToastIfValid` is invoked synchronously, avoiding a coroutine context switch. Otherwise, it dispatches to the main thread via `MainApplication.applicationScope.launch(Dispatchers.Main)` as before. This optimizes the fast-path for Toasts triggered from the main thread while preserving all original logic, validation, defaults, and call sites.

---
*PR created automatically by Jules for task [11772527368466193997](https://jules.google.com/task/11772527368466193997) started by @dogi*