### PR TITLE
sync: smoother upload repository caching (fixes #14174)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5824
+        versionName = "0.58.24"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.repository
 
 import android.util.Log
+import java.util.concurrent.ConcurrentHashMap
 import io.realm.RealmObject
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -65,25 +66,40 @@ class UploadRepositoryImpl @Inject constructor(
         return failedLocally
     }
 
+    private class FieldCacheEntry(val field: java.lang.reflect.Field?)
+
+    private val fieldCache = ConcurrentHashMap<Pair<Class<*>, String>, FieldCacheEntry>()
+
     private fun setRealmField(obj: RealmObject, fieldName: String, value: Any?) {
         try {
-            var clazz: Class<*>? = obj.javaClass
-            var field: java.lang.reflect.Field? = null
+            val cacheKey = Pair(obj.javaClass, fieldName)
+            var entry = fieldCache[cacheKey]
 
-            while (clazz != null && field == null) {
-                try {
-                    field = clazz.getDeclaredField(fieldName)
-                } catch (e: NoSuchFieldException) {
-                    clazz = clazz.superclass
+            if (entry == null) {
+                var clazz: Class<*>? = obj.javaClass
+                var field: java.lang.reflect.Field? = null
+
+                while (clazz != null && field == null) {
+                    try {
+                        field = clazz.getDeclaredField(fieldName)
+                    } catch (e: NoSuchFieldException) {
+                        clazz = clazz.superclass
+                    }
                 }
-            }
 
-            if (field != null) {
-                field.isAccessible = true
-                field.set(obj, value)
-            } else {
+                if (field != null) {
+                    field.isAccessible = true
+                } else {
+                    Log.w("UploadRepositoryImpl", "Field $fieldName not found in class hierarchy of ${obj.javaClass.simpleName}")
+                }
+
+                entry = FieldCacheEntry(field)
+                fieldCache[cacheKey] = entry
+            } else if (entry.field == null) {
                 Log.w("UploadRepositoryImpl", "Field $fieldName not found in class hierarchy of ${obj.javaClass.simpleName}")
             }
+
+            entry.field?.set(obj, value)
         } catch (e: Exception) {
             Log.w("UploadRepositoryImpl", "Failed to set field $fieldName: ${e.message}")
         }


### PR DESCRIPTION
Added a private cache `ConcurrentHashMap<Pair<Class<*>, String>, FieldCacheEntry>` in `UploadRepositoryImpl.kt` to cache Java reflections of `Field`s for setting `_id` and `_rev` values in `markUploaded`. Retained logging behavior when a field doesn't exist, and improved reflection performance during batch uploads.

---
*PR created automatically by Jules for task [11496727627481294162](https://jules.google.com/task/11496727627481294162) started by @dogi*