### PR TITLE
all: smoother user repository querying (fixes #14184)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5831
+        versionName = "0.58.31"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -843,8 +843,7 @@ class UserRepositoryImpl @Inject constructor(
                 val mutableObj = mutableMapOf<String, Any>().apply { putAll(objMap) }
                 latestRev?.let { rev -> mutableObj["_rev"] = rev as Any }
 
-                val gson = com.google.gson.Gson()
-                val jsonElement = gson.toJsonTree(mutableObj)
+                val jsonElement = JsonUtils.gson.toJsonTree(mutableObj)
                 val jsonObject = jsonElement.asJsonObject
 
                 val updateResponse = apiInterface.putDoc(header, "application/json", "${replacedUrl(model)}/_users/org.couchdb.user:${model.name}", jsonObject)
@@ -903,8 +902,8 @@ class UserRepositoryImpl @Inject constructor(
         val userMap = if (userIds.isEmpty()) {
             emptyMap()
         } else {
-            val users = realm.where(RealmUser::class.java).`in`("id", userIds.toTypedArray()).findAll()
-            realm.copyFromRealm(users).filter { it.id != null }.associateBy { it.id ?: "" }
+            val users = realm.where(RealmUser::class.java).isNotNull("id").`in`("id", userIds.toTypedArray()).findAll()
+            realm.copyFromRealm(users).associateBy { it.id ?: "" }
         }
         HealthRecord(mhCopy, mm, list, userMap)
     }


### PR DESCRIPTION
- Replaced `com.google.gson.Gson()` and its tree conversion with `JsonUtils.gson.toJsonTree()` in `updateExistingUser`.
- Moved the null check for `id` directly into the realm query using `.isNotNull("id")` and removed the trailing `.filter { it.id != null }` from the returned list in the health-record lookup.

---
*PR created automatically by Jules for task [15196149756424542619](https://jules.google.com/task/15196149756424542619) started by @dogi*