### PR TITLE
chat: smoother history utils handling (fixes #14186)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5833
+        versionName = "0.58.33"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/ChatHistoryUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ChatHistoryUtils.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.utils
 
-import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import org.ole.planet.myplanet.model.RealmNews
@@ -15,7 +14,7 @@ object ChatHistoryUtils {
                 else {
                     val ids = newsEntries.flatMap { news ->
                         try {
-                            val array = Gson().fromJson(news.viewIn, JsonArray::class.java)
+                            val array = JsonUtils.gson.fromJson(news.viewIn, JsonArray::class.java)
                             val list = mutableListOf<String>()
                             for (i in 0 until array.size()) {
                                 val elem = array.get(i) as JsonElement


### PR DESCRIPTION
Refactor: Reuse JsonUtils.gson in ChatHistoryUtils

Replaced `Gson().fromJson(...)` with `JsonUtils.gson.fromJson(...)` to avoid unnecessary instantiation of `Gson` objects. Also removed the unused `import com.google.gson.Gson` statement.

---
*PR created automatically by Jules for task [15516779507961791748](https://jules.google.com/task/15516779507961791748) started by @dogi*