### PR TITLE
teams: smoother voices label selecting (fixes #14193)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5840
+        versionName = "0.58.40"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesLabelAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesLabelAdapter.kt
@@ -45,7 +45,13 @@ class VoicesLabelAdapter(
     }
 
     fun setSelectedLabel(label: String) {
+        val oldSelectedLabel = selectedLabel
         selectedLabel = label
-        notifyDataSetChanged()
+
+        val oldPosition = currentList.indexOf(oldSelectedLabel)
+        val newPosition = currentList.indexOf(selectedLabel)
+
+        if (oldPosition != -1) notifyItemChanged(oldPosition)
+        if (newPosition != -1) notifyItemChanged(newPosition)
     }
 }


### PR DESCRIPTION
Target VoicesLabelAdapter selection refreshes

1. Track the previous selected label before assigning the new selected label.
2. Use currentList.indexOf for old and new labels and call notifyItemChanged only for valid changed positions.
3. Leave DiffUtils.itemCallback and submitList behavior untouched.

---
*PR created automatically by Jules for task [17356247815182704038](https://jules.google.com/task/17356247815182704038) started by @dogi*