### PR TITLE
sync: smoother improved manager coroutine scoping (fixes #14188)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,13 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-<<<<<<< fix-sync-manager-cancellation-17370151503995738763
         versionCode = 5835
         versionName = "0.58.35"
-=======
-        versionCode = 5834
-        versionName = "0.58.34"
->>>>>>> master
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5835
+        versionName = "0.58.35"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt
@@ -11,10 +11,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication.Companion.createLog
 import org.ole.planet.myplanet.callback.OnSyncListener
@@ -23,7 +22,6 @@ import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.NotificationUtils
 import org.ole.planet.myplanet.utils.SyncTimeLogger
-
 @Singleton
 class ImprovedSyncManager @Inject constructor(
     @param:ApplicationContext private val context: Context,
@@ -75,9 +73,6 @@ class ImprovedSyncManager @Inject constructor(
     ) {
         this.listener = listener
         if (isSyncing.compareAndSet(false, true)) {
-            if (!syncScope.isActive) {
-                syncScope = CoroutineScope(dispatcherProvider.io + SupervisorJob())
-            }
             isCanceled.set(false)
             sharedPrefManager.removeKey("concatenated_links")
             listener?.onSyncStarted()
@@ -192,7 +187,7 @@ class ImprovedSyncManager @Inject constructor(
 
     fun cancel() {
         isCanceled.set(true)
-        syncScope.cancel()
+        syncScope.coroutineContext.cancelChildren()
     }
 
     private fun SyncMode.describe(): String {


### PR DESCRIPTION
Refactor CoroutineScope cancellation in ImprovedSyncManager

- Changed `syncScope.cancel()` to `syncScope.coroutineContext.cancelChildren()` to cleanly cancel active operations while preserving the original coroutine scope.
- Removed the conditional `syncScope` recreation logic in `start()` since the scope remains active and usable for subsequent launches.
- Removed unnecessary imports.

---
*PR created automatically by Jules for task [17370151503995738763](https://jules.google.com/task/17370151503995738763) started by @dogi*