### PR TITLE
all: smoother camera utils dispatcher providing (fixes #14187)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5834
+        versionName = "0.58.34"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -292,7 +292,7 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
                 b.putInt("stepNum", stepNumber)
                 takeExam.arguments = b
                 homeItemClickListener?.openCallFragment(takeExam)
-                capturePhoto(viewLifecycleOwner.lifecycleScope, this)
+                capturePhoto(viewLifecycleOwner.lifecycleScope, this, dispatcherProvider)
             }
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
@@ -636,7 +636,7 @@ class ExamTakingFragment : BaseExamFragment(), View.OnClickListener, CompoundBut
     private fun capturePhoto() {
         try {
             if (isCertified && !isMySurvey) {
-                capturePhoto(viewLifecycleOwner.lifecycleScope, this)
+                capturePhoto(viewLifecycleOwner.lifecycleScope, this, dispatcherProvider)
             }
         } catch (e: Exception) {
             e.printStackTrace()

--- a/app/src/main/java/org/ole/planet/myplanet/utils/CameraUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/CameraUtils.kt
@@ -25,7 +25,6 @@ import java.io.FileOutputStream
 import java.util.Date
 import java.util.concurrent.Executor
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication.Companion.context
@@ -70,7 +69,7 @@ object CameraUtils {
     }
 
     @JvmStatic
-    fun capturePhoto(scope: CoroutineScope, callback: ImageCaptureCallback) {
+    fun capturePhoto(scope: CoroutineScope, callback: ImageCaptureCallback, dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider()) {
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
             return
         }
@@ -85,7 +84,7 @@ object CameraUtils {
                 buffer.get(bytes)
                 image.close()
                 scope.launch {
-                    savePicture(bytes, callback)
+                    savePicture(bytes, callback, dispatcherProvider)
                 }
             }
         }, backgroundHandler)
@@ -124,8 +123,8 @@ object CameraUtils {
         imageReader = null
     }
 
-    private suspend fun savePicture(data: ByteArray, callback: ImageCaptureCallback) {
-        withContext(Dispatchers.IO) {
+    private suspend fun savePicture(data: ByteArray, callback: ImageCaptureCallback, dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider()) {
+        withContext(dispatcherProvider.io) {
             val pictureFileDir = File("${FileUtils.getOlePath(context)}/userimages")
             if (!pictureFileDir.exists() && !pictureFileDir.mkdirs()) {
                 pictureFileDir.mkdirs()
@@ -137,7 +136,7 @@ object CameraUtils {
                 FileOutputStream(mainPicture).use { fos ->
                     fos.write(data)
                 }
-                withContext(Dispatchers.Main) {
+                withContext(dispatcherProvider.main) {
                     callback.onImageCapture(mainPicture.absolutePath)
                 }
             } catch (error: Exception) {


### PR DESCRIPTION
Replaces hardcoded `Dispatchers.IO` and `Dispatchers.Main` inside `CameraUtils.kt` with a `DispatcherProvider` pattern, passed in through Fragment callers.

---
*PR created automatically by Jules for task [10064135728474269113](https://jules.google.com/task/10064135728474269113) started by @dogi*