### PR TITLE
courses: smoother list latest collecting (fixes #14237)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5877
+        versionName = "0.58.77"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,13 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-<<<<<<< refactor-collect-latest-courses-3903183736294946528
         versionCode = 5877
         versionName = "0.58.77"
-=======
-        versionCode = 5876
-        versionName = "0.58.76"
->>>>>>> master
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -40,6 +40,7 @@ import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
 import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSelectedListener, OnTagClickListener, RealtimeSyncMixin {
@@ -148,9 +149,8 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
             selectionController.clearAll(null)
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.coursesState.collectLatest { state ->
-                if (!::adapterCourses.isInitialized) return@collectLatest
+        collectLatestWhenStarted(viewModel.coursesState) { state ->
+            if (!::adapterCourses.isInitialized) return@collectLatestWhenStarted
 
                 if (isMyCourseLib) {
                     val courseIds = state.courses.mapNotNull { it.courseId }
@@ -174,11 +174,9 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                     }
                 }
             }
-        }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.syncStatus.collectLatest { status ->
-                when (status) {
+        collectLatestWhenStarted(viewModel.syncStatus) { status ->
+            when (status) {
                     is SyncStatus.Idle -> {}
                     is SyncStatus.Syncing -> {
                         if (isAdded && !requireActivity().isFinishing) {
@@ -212,7 +210,6 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                     }
                 }
             }
-        }
 
         realtimeSyncHelper = RealtimeSyncHelper(this, this)
         realtimeSyncHelper.setupRealtimeSync()


### PR DESCRIPTION
Replaces standard `collectLatest` calls within `viewLifecycleOwner.lifecycleScope.launch` with the custom `collectLatestWhenStarted` utility function in `CoursesFragment` for collecting `coursesState` and `syncStatus` flows. Updates the early return label accordingly.

---
*PR created automatically by Jules for task [3903183736294946528](https://jules.google.com/task/3903183736294946528) started by @dogi*