### PR TITLE
courses: smoother submissions latest collecting (fixes #14239)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5878
+        versionName = "0.58.78"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5874
-        versionName = "0.58.74"
+        versionCode = 5880
+        versionName = "0.58.80"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
@@ -9,17 +9,15 @@ import android.view.ViewGroup
 import android.widget.CompoundButton
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.databinding.FragmentMySubmissionBinding
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class SubmissionsFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
@@ -57,19 +55,18 @@ class SubmissionsFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
 
         viewModel.setFilter(type ?: "", "")
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            combine(
-                viewModel.submissions,
-                viewModel.exams,
-                viewModel.submissionCounts
-            ) { submissions, exams, counts ->
-                Triple(submissions, exams, counts)
-            }.collectLatest { (submissions, exams, counts) ->
-                adapter.setExams(exams)
-                adapter.setSubmissionCounts(counts)
-                adapter.submitList(submissions)
-                updateEmptyState(submissions.size)
-            }
+        val combinedFlow = combine(
+            viewModel.submissions,
+            viewModel.exams,
+            viewModel.submissionCounts
+        ) { submissions, exams, counts ->
+            Triple(submissions, exams, counts)
+        }
+        collectLatestWhenStarted(combinedFlow) { (submissions, exams, counts) ->
+            adapter.setExams(exams)
+            adapter.setSubmissionCounts(counts)
+            adapter.submitList(submissions)
+            updateEmptyState(submissions.size)
         }
 
         textWatcher = object : TextWatcher {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.widget.CompoundButton
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint


### PR DESCRIPTION
This commit replaces the manual `viewLifecycleOwner.lifecycleScope.launch { flow.collectLatest { ... } }` setup in `SubmissionsFragment` with the custom project utility `collectLatestWhenStarted()`. 

It also ensures the imports are updated cleanly.

---
*PR created automatically by Jules for task [9083387142672140374](https://jules.google.com/task/9083387142672140374) started by @dogi*