### PR TITLE
teams: smoother events detail collecting (fixes #14243)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5881
+        versionName = "0.58.81"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDetailFragment.kt
@@ -13,13 +13,11 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Calendar
 import java.util.HashMap
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.AddMeetupBinding
 import org.ole.planet.myplanet.databinding.FragmentEventsDetailBinding
@@ -29,6 +27,7 @@ import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.Constants.showBetaFeature
 import org.ole.planet.myplanet.utils.TimeUtils
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class EventsDetailFragment : Fragment(), View.OnClickListener {
@@ -70,34 +69,26 @@ class EventsDetailFragment : Fragment(), View.OnClickListener {
 
         viewModel.loadData(meetUpId)
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.meetup.collect { meetup ->
-                meetup?.let { setUpData(it) }
-                updateAttendanceButton()
-            }
+        collectWhenStarted(viewModel.meetup) { meetup ->
+            meetup?.let { setUpData(it) }
+            updateAttendanceButton()
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.members.collect { members ->
-                setUserList(members)
-            }
+        collectWhenStarted(viewModel.members) { members ->
+            setUserList(members)
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.user.collect {
-                updateAttendanceButton()
-            }
+        collectWhenStarted(viewModel.user) {
+            updateAttendanceButton()
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.updateSuccess.collect { success ->
-                if (success == true) {
-                    Toast.makeText(requireContext(), getString(R.string.meetup_updated), Toast.LENGTH_SHORT).show()
-                    viewModel.resetUpdateSuccess()
-                } else if (success == false) {
-                    Toast.makeText(requireContext(), getString(R.string.meetup_not_updated), Toast.LENGTH_SHORT).show()
-                    viewModel.resetUpdateSuccess()
-                }
+        collectWhenStarted(viewModel.updateSuccess) { success ->
+            if (success == true) {
+                Toast.makeText(requireContext(), getString(R.string.meetup_updated), Toast.LENGTH_SHORT).show()
+                viewModel.resetUpdateSuccess()
+            } else if (success == false) {
+                Toast.makeText(requireContext(), getString(R.string.meetup_not_updated), Toast.LENGTH_SHORT).show()
+                viewModel.resetUpdateSuccess()
             }
         }
     }


### PR DESCRIPTION
Refactor EventsDetailFragment to use collectWhenStarted

- Replaced `viewLifecycleOwner.lifecycleScope.launch { flow.collect { ... } }` blocks with the custom `collectWhenStarted(flow) { ... }` extension for lifecycle-aware flow collection.
- Updated collections for `viewModel.meetup`, `viewModel.members`, `viewModel.user`, and `viewModel.updateSuccess`.
- Added the necessary import for `org.ole.planet.myplanet.utils.collectWhenStarted`.
- Removed `kotlinx.coroutines.launch` and `androidx.lifecycle.lifecycleScope` imports as they are no longer used in the fragment.

---
*PR created automatically by Jules for task [11203884915355053287](https://jules.google.com/task/11203884915355053287) started by @dogi*