### PR TITLE
life: smoother health examination realm model bulk inserting (fixes 14227)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5869
+        versionName = "0.58.69"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmHealthExamination.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmHealthExamination.kt
@@ -51,32 +51,30 @@ open class RealmHealthExamination : RealmObject() {
 
     companion object {
         @JvmStatic
-        fun insert(mRealm: Realm, act: JsonObject?) {
-            var myHealth = mRealm.where(RealmHealthExamination::class.java)
-                .equalTo("_id", JsonUtils.getString("_id", act)).findFirst()
-            if (myHealth == null) {
-                myHealth = mRealm.createObject(RealmHealthExamination::class.java, JsonUtils.getString("_id", act))
-            }
-            myHealth?.data = JsonUtils.getString("data", act)
-            myHealth?.userId = JsonUtils.getString("_id", act)
-            myHealth?._rev = JsonUtils.getString("_rev", act)
-            myHealth?.setTemperature(JsonUtils.getFloat("temperature", act))
-            myHealth?.isUpdated = false
-            myHealth?.pulse = JsonUtils.getInt("pulse", act)
-            myHealth?.height = JsonUtils.getFloat("height", act)
-            myHealth?.setWeight(JsonUtils.getFloat("weight", act))
-            myHealth?.vision = JsonUtils.getString("vision", act)
-            myHealth?.hearing = JsonUtils.getString("hearing", act)
-            myHealth?.bp = JsonUtils.getString("bp", act)
-            myHealth?.isSelfExamination = JsonUtils.getBoolean("selfExamination", act)
-            myHealth?.isHasInfo = JsonUtils.getBoolean("hasInfo", act)
-            myHealth?.date = JsonUtils.getLong("date", act)
-            myHealth?.profileId = JsonUtils.getString("profileId", act)
-            myHealth?.creatorId = JsonUtils.getString("creatorId", act)
-            myHealth?.age = JsonUtils.getInt("age", act)
-            myHealth?.gender = JsonUtils.getString("gender", act)
-            myHealth?.planetCode = JsonUtils.getString("planetCode", act)
-            myHealth?.conditions = JsonUtils.gson.toJson(JsonUtils.getJsonObject("conditions", act))
+        fun fromJson(act: JsonObject?): RealmHealthExamination {
+            val myHealth = RealmHealthExamination()
+            myHealth._id = JsonUtils.getString("_id", act)
+            myHealth.data = JsonUtils.getString("data", act)
+            myHealth.userId = JsonUtils.getString("_id", act)
+            myHealth._rev = JsonUtils.getString("_rev", act)
+            myHealth.setTemperature(JsonUtils.getFloat("temperature", act))
+            myHealth.isUpdated = false
+            myHealth.pulse = JsonUtils.getInt("pulse", act)
+            myHealth.height = JsonUtils.getFloat("height", act)
+            myHealth.setWeight(JsonUtils.getFloat("weight", act))
+            myHealth.vision = JsonUtils.getString("vision", act)
+            myHealth.hearing = JsonUtils.getString("hearing", act)
+            myHealth.bp = JsonUtils.getString("bp", act)
+            myHealth.isSelfExamination = JsonUtils.getBoolean("selfExamination", act)
+            myHealth.isHasInfo = JsonUtils.getBoolean("hasInfo", act)
+            myHealth.date = JsonUtils.getLong("date", act)
+            myHealth.profileId = JsonUtils.getString("profileId", act)
+            myHealth.creatorId = JsonUtils.getString("creatorId", act)
+            myHealth.age = JsonUtils.getInt("age", act)
+            myHealth.gender = JsonUtils.getString("gender", act)
+            myHealth.planetCode = JsonUtils.getString("planetCode", act)
+            myHealth.conditions = JsonUtils.gson.toJson(JsonUtils.getJsonObject("conditions", act))
+            return myHealth
         }
 
         @JvmStatic

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -104,9 +104,10 @@ class HealthRepositoryImpl @Inject constructor(
                 documentList.add(jsonDoc)
             }
         }
-        documentList.forEach { jsonDoc ->
-            org.ole.planet.myplanet.model.RealmHealthExamination.insert(realm, jsonDoc)
+        val examinations = documentList.map { jsonDoc ->
+            RealmHealthExamination.fromJson(jsonDoc)
         }
+        realm.insertOrUpdate(examinations)
     }
 
     override suspend fun uploadHealthData(myHealths: List<RealmHealthExamination>): Map<String, String?> {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
@@ -306,12 +306,15 @@ class HealthRepositoryImplTest {
         every { JsonUtils.getJsonObject("doc", item2) } returns doc2
         every { JsonUtils.getString("_id", doc2) } returns "_design/doc"
 
-        every { RealmHealthExamination.insert(realm, doc1) } returns Unit
+        val detachedExamination = mockk<RealmHealthExamination>()
+        every { RealmHealthExamination.fromJson(doc1) } returns detachedExamination
+        every { realm.insertOrUpdate(any<List<RealmHealthExamination>>()) } returns Unit
 
         repository.bulkInsertFromSync(realm, jsonArray)
         advanceUntilIdle()
 
-        verify(exactly = 1) { RealmHealthExamination.insert(realm, doc1) }
-        verify(exactly = 0) { RealmHealthExamination.insert(realm, doc2) }
+        verify(exactly = 1) { RealmHealthExamination.fromJson(doc1) }
+        verify(exactly = 0) { RealmHealthExamination.fromJson(doc2) }
+        verify(exactly = 1) { realm.insertOrUpdate(listOf(detachedExamination)) }
     }
 }


### PR DESCRIPTION
Refactored the `RealmHealthExamination` to replace the individual `insert` method with a `fromJson` method that builds and returns detached Realm objects. Updated the `bulkInsertFromSync` method in `HealthRepositoryImpl` to accumulate these objects into a list and execute a bulk `realm.insertOrUpdate()` operation, significantly reducing database transaction overhead. Fixed related tests to use the new implementations.

---
*PR created automatically by Jules for task [8659060463268083303](https://jules.google.com/task/8659060463268083303) started by @dogi*