### PR TITLE
sync: smoother upload repository bulk querying (fixes #14212)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5859
+        versionName = "0.58.59"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
@@ -21,7 +21,7 @@ class UploadRepositoryImpl @Inject constructor(
             val query = realm.where(config.modelClass.java)
             val filteredQuery = config.queryBuilder(query)
             val results = filteredQuery.findAll()
-            results.map { realm.copyFromRealm(it) }
+            realm.copyFromRealm(results)
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UploadRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UploadRepositoryImplTest.kt
@@ -1,0 +1,81 @@
+package org.ole.planet.myplanet.repository
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.invoke
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.realm.Realm
+import io.realm.RealmObject
+import io.realm.RealmQuery
+import io.realm.RealmResults
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.services.upload.UploadConfig
+import org.ole.planet.myplanet.services.upload.UploadSerializer
+
+open class DummyModel : RealmObject()
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UploadRepositoryImplTest {
+
+    private lateinit var databaseService: DatabaseService
+    private lateinit var repository: UploadRepositoryImpl
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        databaseService = mockk(relaxed = true)
+        repository = UploadRepositoryImpl(databaseService, testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        io.mockk.unmockkAll()
+    }
+
+    @Test
+    fun `queryPending returns list from copyFromRealm`() = runTest {
+        val realm = mockk<Realm>(relaxed = true)
+        val querySlot = slot<(Realm) -> Any>()
+
+        coEvery { databaseService.withRealmAsync(capture(querySlot)) } answers {
+            querySlot.captured.invoke(realm)
+        }
+
+        val realmQuery = mockk<RealmQuery<DummyModel>>(relaxed = true)
+        val filteredQuery = mockk<RealmQuery<DummyModel>>(relaxed = true)
+        val results = mockk<RealmResults<DummyModel>>(relaxed = true)
+        val expectedList = listOf(DummyModel(), DummyModel())
+
+        every { realm.where(DummyModel::class.java) } returns realmQuery
+
+        val queryBuilder: (RealmQuery<DummyModel>) -> RealmQuery<DummyModel> = { q ->
+            assertEquals(realmQuery, q)
+            filteredQuery
+        }
+
+        val config = UploadConfig(
+            modelClass = DummyModel::class,
+            endpoint = "test",
+            queryBuilder = queryBuilder,
+            serializer = mockk<UploadSerializer<DummyModel>>(),
+            idExtractor = { null }
+        )
+
+        every { filteredQuery.findAll() } returns results
+        every { realm.copyFromRealm(results) } returns expectedList
+
+        val actualList = repository.queryPending(config)
+
+        assertEquals(expectedList, actualList)
+        verify(exactly = 1) { realm.copyFromRealm(results) }
+    }
+}


### PR DESCRIPTION
This PR replaces a row-by-row `map` mapping with Realm's native bulk `copyFromRealm` in the `queryPending` method of `UploadRepositoryImpl.kt`. This improves memory efficiency and execution performance while keeping the `UploadConfig.queryBuilder` semantics fully intact. A new MockK test file `UploadRepositoryImplTest.kt` is introduced to assure the single bulk-copy acts accordingly to configurations.

---
*PR created automatically by Jules for task [12180231521603972305](https://jules.google.com/task/12180231521603972305) started by @dogi*