### PR TITLE
teams: smoother meetup realm model bulk upserting (fixes #14225)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5867
+        versionName = "0.58.67"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmMeetup.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmMeetup.kt
@@ -37,35 +37,52 @@ open class RealmMeetup : RealmObject() {
     var updated: Boolean = false
 
     companion object {
+        private fun mapFromJson(meetupDoc: JsonObject, userId: String?, existingMeetup: RealmMeetup?): RealmMeetup {
+            val meetup = RealmMeetup()
+            meetup.id = JsonUtils.getString("_id", meetupDoc)
+            meetup.meetupId = JsonUtils.getString("_id", meetupDoc)
+            meetup.userId = userId
+            meetup.meetupIdRev = JsonUtils.getString("_rev", meetupDoc)
+            meetup.title = JsonUtils.getString("title", meetupDoc)
+            meetup.description = JsonUtils.getString("description", meetupDoc)
+            meetup.startDate = JsonUtils.getLong("startDate", meetupDoc)
+            meetup.endDate = JsonUtils.getLong("endDate", meetupDoc)
+            meetup.recurring = JsonUtils.getString("recurring", meetupDoc)
+            meetup.startTime = JsonUtils.getString("startTime", meetupDoc)
+            meetup.endTime = JsonUtils.getString("endTime", meetupDoc)
+            meetup.category = JsonUtils.getString("category", meetupDoc)
+            meetup.meetupLocation = JsonUtils.getString("meetupLocation", meetupDoc)
+            meetup.meetupLink = JsonUtils.getString("meetupLink", meetupDoc)
+            meetup.creator = JsonUtils.getString("createdBy", meetupDoc)
+            meetup.day = JsonUtils.getJsonArray("day", meetupDoc).toString()
+            meetup.link = JsonUtils.getJsonObject("link", meetupDoc).toString()
+            meetup.teamId = JsonUtils.getString("teams", JsonUtils.getJsonObject("link", meetupDoc))
+
+            if (existingMeetup != null) {
+                meetup.createdDate = existingMeetup.createdDate
+                meetup.recurringNumber = existingMeetup.recurringNumber
+                meetup.sync = existingMeetup.sync
+                meetup.sourcePlanet = existingMeetup.sourcePlanet
+                meetup.updated = existingMeetup.updated
+            }
+
+            return meetup
+        }
+
         @JvmStatic
         fun insert(mRealm: Realm, meetupDoc: JsonObject) {
             insert("", meetupDoc, mRealm)
         }
 
         fun insert(userId: String?, meetupDoc: JsonObject, mRealm: Realm) {
-            var myMeetupsDB = mRealm.where(RealmMeetup::class.java)
-                .equalTo("meetupId", JsonUtils.getString("_id", meetupDoc)).findFirst()
-            if (myMeetupsDB == null) {
-                myMeetupsDB = mRealm.createObject(RealmMeetup::class.java, JsonUtils.getString("_id", meetupDoc))
-            }
+            val meetupId = JsonUtils.getString("_id", meetupDoc)
+            val myMeetupsDB = mRealm.where(RealmMeetup::class.java)
+                .equalTo("meetupId", meetupId).findFirst()
+
             if (myMeetupsDB?.updated == true) return
-            myMeetupsDB?.meetupId = JsonUtils.getString("_id", meetupDoc)
-            myMeetupsDB?.userId = userId
-            myMeetupsDB?.meetupIdRev = JsonUtils.getString("_rev", meetupDoc)
-            myMeetupsDB?.title = JsonUtils.getString("title", meetupDoc)
-            myMeetupsDB?.description = JsonUtils.getString("description", meetupDoc)
-            myMeetupsDB?.startDate = JsonUtils.getLong("startDate", meetupDoc)
-            myMeetupsDB?.endDate = JsonUtils.getLong("endDate", meetupDoc)
-            myMeetupsDB?.recurring = JsonUtils.getString("recurring", meetupDoc)
-            myMeetupsDB?.startTime = JsonUtils.getString("startTime", meetupDoc)
-            myMeetupsDB?.endTime = JsonUtils.getString("endTime", meetupDoc)
-            myMeetupsDB?.category = JsonUtils.getString("category", meetupDoc)
-            myMeetupsDB?.meetupLocation = JsonUtils.getString("meetupLocation", meetupDoc)
-            myMeetupsDB?.meetupLink = JsonUtils.getString("meetupLink", meetupDoc)
-            myMeetupsDB?.creator = JsonUtils.getString("createdBy", meetupDoc)
-            myMeetupsDB?.day = JsonUtils.getJsonArray("day", meetupDoc).toString()
-            myMeetupsDB?.link = JsonUtils.getJsonObject("link", meetupDoc).toString()
-            myMeetupsDB?.teamId = JsonUtils.getString("teams", JsonUtils.getJsonObject("link", meetupDoc))
+
+            val meetup = mapFromJson(meetupDoc, userId, myMeetupsDB)
+            mRealm.insertOrUpdate(meetup)
         }
 
         @JvmStatic
@@ -79,32 +96,19 @@ open class RealmMeetup : RealmObject() {
                 .findAll()
                 .associateByTo(HashMap()) { it.meetupId }
 
+            val meetupsToInsert = mutableListOf<RealmMeetup>()
+
             for (meetupDoc in documents) {
                 val id = JsonUtils.getString("_id", meetupDoc)
-                var myMeetupsDB = existingMeetups[id]
-                if (myMeetupsDB?.updated == true) continue
-                if (myMeetupsDB == null) {
-                    myMeetupsDB = mRealm.createObject(RealmMeetup::class.java, id)
-                    existingMeetups[id] = myMeetupsDB
-                }
+                val myMeetupsDB = existingMeetups[id]
 
-                myMeetupsDB?.meetupId = id
-                myMeetupsDB?.userId = userId
-                myMeetupsDB?.meetupIdRev = JsonUtils.getString("_rev", meetupDoc)
-                myMeetupsDB?.title = JsonUtils.getString("title", meetupDoc)
-                myMeetupsDB?.description = JsonUtils.getString("description", meetupDoc)
-                myMeetupsDB?.startDate = JsonUtils.getLong("startDate", meetupDoc)
-                myMeetupsDB?.endDate = JsonUtils.getLong("endDate", meetupDoc)
-                myMeetupsDB?.recurring = JsonUtils.getString("recurring", meetupDoc)
-                myMeetupsDB?.startTime = JsonUtils.getString("startTime", meetupDoc)
-                myMeetupsDB?.endTime = JsonUtils.getString("endTime", meetupDoc)
-                myMeetupsDB?.category = JsonUtils.getString("category", meetupDoc)
-                myMeetupsDB?.meetupLocation = JsonUtils.getString("meetupLocation", meetupDoc)
-                myMeetupsDB?.meetupLink = JsonUtils.getString("meetupLink", meetupDoc)
-                myMeetupsDB?.creator = JsonUtils.getString("createdBy", meetupDoc)
-                myMeetupsDB?.day = JsonUtils.getJsonArray("day", meetupDoc).toString()
-                myMeetupsDB?.link = JsonUtils.getJsonObject("link", meetupDoc).toString()
-                myMeetupsDB?.teamId = JsonUtils.getString("teams", JsonUtils.getJsonObject("link", meetupDoc))
+                if (myMeetupsDB?.updated == true) continue
+
+                meetupsToInsert.add(mapFromJson(meetupDoc, userId, myMeetupsDB))
+            }
+
+            if (meetupsToInsert.isNotEmpty()) {
+                mRealm.insertOrUpdate(meetupsToInsert)
             }
         }
 

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmMeetupTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmMeetupTest.kt
@@ -69,29 +69,31 @@ class RealmMeetupTest {
         every { mockRealm.where(RealmMeetup::class.java) } returns mockQuery
         every { mockQuery.equalTo("meetupId", "meetup1") } returns mockQuery
         every { mockQuery.findFirst() } returns null
-
-        val newMeetup = mockk<RealmMeetup>(relaxed = true)
-        every { mockRealm.createObject(RealmMeetup::class.java, "meetup1") } returns newMeetup
+        every { mockRealm.insertOrUpdate(any<RealmMeetup>()) } returns Unit
 
         RealmMeetup.insert(userId, meetupDoc, mockRealm)
 
-        verify { newMeetup.meetupId = "meetup1" }
-        verify { newMeetup.userId = userId }
-        verify { newMeetup.meetupIdRev = "rev1" }
-        verify { newMeetup.title = "Test Meetup" }
-        verify { newMeetup.description = "Test Description" }
-        verify { newMeetup.startDate = 1600000000000 }
-        verify { newMeetup.endDate = 1600003600000 }
-        verify { newMeetup.recurring = "weekly" }
-        verify { newMeetup.startTime = "10:00" }
-        verify { newMeetup.endTime = "11:00" }
-        verify { newMeetup.category = "tech" }
-        verify { newMeetup.meetupLocation = "Room 1" }
-        verify { newMeetup.meetupLink = "http://meetup.com" }
-        verify { newMeetup.creator = "creator1" }
-        verify { newMeetup.day = """["Monday"]""" }
-        verify { newMeetup.link = """{"teams":"team1"}""" }
-        verify { newMeetup.teamId = "team1" }
+        verify {
+            mockRealm.insertOrUpdate(withArg<RealmMeetup> {
+                assertEquals("meetup1", it.meetupId)
+                assertEquals(userId, it.userId)
+                assertEquals("rev1", it.meetupIdRev)
+                assertEquals("Test Meetup", it.title)
+                assertEquals("Test Description", it.description)
+                assertEquals(1600000000000, it.startDate)
+                assertEquals(1600003600000, it.endDate)
+                assertEquals("weekly", it.recurring)
+                assertEquals("10:00", it.startTime)
+                assertEquals("11:00", it.endTime)
+                assertEquals("tech", it.category)
+                assertEquals("Room 1", it.meetupLocation)
+                assertEquals("http://meetup.com", it.meetupLink)
+                assertEquals("creator1", it.creator)
+                assertEquals("""["Monday"]""", it.day)
+                assertEquals("""{"teams":"team1"}""", it.link)
+                assertEquals("team1", it.teamId)
+            })
+        }
     }
 
     @Test
@@ -107,16 +109,24 @@ class RealmMeetupTest {
         every { mockRealm.where(RealmMeetup::class.java) } returns mockQuery
         every { mockQuery.equalTo("meetupId", "meetup1") } returns mockQuery
 
-        val existingMeetup = mockk<RealmMeetup>(relaxed = true)
+        val existingMeetup = RealmMeetup()
+        existingMeetup.createdDate = 12345L
+        existingMeetup.sync = "synced"
         every { mockQuery.findFirst() } returns existingMeetup
+        every { mockRealm.insertOrUpdate(any<RealmMeetup>()) } returns Unit
 
         RealmMeetup.insert(userId, meetupDoc, mockRealm)
 
-        verify(exactly = 0) { mockRealm.createObject(RealmMeetup::class.java, "meetup1") }
-        verify { existingMeetup.meetupId = "meetup1" }
-        verify { existingMeetup.userId = userId }
-        verify { existingMeetup.meetupIdRev = "rev2" }
-        verify { existingMeetup.title = "Updated Meetup" }
+        verify {
+            mockRealm.insertOrUpdate(withArg<RealmMeetup> {
+                assertEquals("meetup1", it.meetupId)
+                assertEquals(userId, it.userId)
+                assertEquals("rev2", it.meetupIdRev)
+                assertEquals("Updated Meetup", it.title)
+                assertEquals(12345L, it.createdDate)
+                assertEquals("synced", it.sync)
+            })
+        }
     }
 
     @Test
@@ -129,13 +139,15 @@ class RealmMeetupTest {
         every { mockRealm.where(RealmMeetup::class.java) } returns mockQuery
         every { mockQuery.equalTo("meetupId", "meetup1") } returns mockQuery
         every { mockQuery.findFirst() } returns null
-
-        val newMeetup = mockk<RealmMeetup>(relaxed = true)
-        every { mockRealm.createObject(RealmMeetup::class.java, "meetup1") } returns newMeetup
+        every { mockRealm.insertOrUpdate(any<RealmMeetup>()) } returns Unit
 
         RealmMeetup.insert(mockRealm, meetupDoc)
 
-        verify { newMeetup.userId = "" }
+        verify {
+            mockRealm.insertOrUpdate(withArg<RealmMeetup> {
+                assertEquals("", it.userId)
+            })
+        }
     }
 
     @Test


### PR DESCRIPTION
Refactors `RealmMeetup` insertion logic to be more performant and robust.

- Extracted `mapFromJson` to construct a detached `RealmMeetup` object from JSON data, correctly preserving locally updated fields if the meetup already exists.
- Updated `insert` to utilize this helper and fixed the associated tests (`RealmMeetupTest`) to verify the new `insertOrUpdate` calling pattern.
- Refactored `insertList` to map all provided JSON documents into detached objects, accumulating them into a `List`.
- Performs a single `mRealm.insertOrUpdate` operation for bulk insertions, removing per-iteration database writes.

---
*PR created automatically by Jules for task [18045884029910113067](https://jules.google.com/task/18045884029910113067) started by @dogi*