### PR TITLE
Optimize VoicesLabelAdapter selection updates

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesLabelAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesLabelAdapter.kt
@@ -45,7 +45,15 @@ class VoicesLabelAdapter(
     }
 
     fun setSelectedLabel(label: String) {
+        if (selectedLabel == label) return
+        val oldIndex = currentList.indexOf(selectedLabel)
+        val newIndex = currentList.indexOf(label)
         selectedLabel = label
-        notifyDataSetChanged()
+        if (oldIndex != -1) {
+            notifyItemChanged(oldIndex)
+        }
+        if (newIndex != -1) {
+            notifyItemChanged(newIndex)
+        }
     }
 }


### PR DESCRIPTION
Replaced `notifyDataSetChanged()` with targeted `notifyItemChanged()` calls in `setSelectedLabel()` to optimize `VoicesLabelAdapter` and only update the previously and newly selected items instead of re-binding the entire list. Also added a no-op check to ensure chip highlighting still works efficiently for the default All state and repeated taps.

---
*PR created automatically by Jules for task [17378673349777331344](https://jules.google.com/task/17378673349777331344) started by @dogi*