### PR TITLE
teams: smoother submissions repository survey bulk creating (fixes #14196)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5843
+        versionName = "0.58.43"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -27,6 +27,7 @@ interface SubmissionsRepository {
     suspend fun hasPendingOfflineSubmissions(): Boolean
     suspend fun hasPendingExamResults(): Boolean
     suspend fun createSurveySubmission(examId: String, userId: String?)
+    suspend fun createBulkSurveySubmissions(examId: String, userIds: List<String>)
     suspend fun saveSubmission(submission: RealmSubmission)
     suspend fun markSubmissionComplete(id: String, payload: com.google.gson.JsonObject)
     suspend fun getSubmissionDetail(submissionId: String): SubmissionDetail?

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -229,6 +229,20 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         getOrCreateSubmission(userId, parentId)
     }
 
+    override suspend fun createBulkSurveySubmissions(examId: String, userIds: List<String>) {
+        val parentId = withRealm { realm ->
+            val courseId = realm.where(RealmStepExam::class.java).equalTo("id", examId).findFirst()?.courseId
+            if (!courseId.isNullOrEmpty()) {
+                "$examId@$courseId"
+            } else {
+                examId
+            }
+        }
+        userIds.forEach { userId ->
+            getOrCreateSubmission(userId, parentId)
+        }
+    }
+
     override suspend fun saveSubmission(submission: RealmSubmission) {
         try {
             save(submission)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SendSurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SendSurveyFragment.kt
@@ -50,10 +50,8 @@ class SendSurveyFragment : BaseDialogFragment() {
             viewLifecycleOwner.lifecycleScope.launch {
                 val surveyId = id ?: return@launch
                 val selectedItems = (fragmentSendSurveyBinding.listUsers.adapter as CheckboxAdapter).selectedItemsList
-                for (i in selectedItems) {
-                    val u = users[i]
-                    submissionsRepository.createSurveySubmission(surveyId, u.id)
-                }
+                val selectedUserIds = selectedItems.mapNotNull { users[it].id }
+                submissionsRepository.createBulkSurveySubmissions(surveyId, selectedUserIds)
                 Utilities.toast(activity, getString(R.string.survey_sent_to_users))
                 dismiss()
             }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -157,6 +157,32 @@ class SubmissionsRepositoryImplTest {
     }
 
     @Test
+    fun `createBulkSurveySubmissions calls getOrCreateSubmission for all users`() = runTest {
+        val examId = "examId"
+        val userIds = listOf("user1", "user2")
+        val realm = mockk<Realm>(relaxed = true)
+        val query = mockk<RealmQuery<RealmStepExam>>(relaxed = true)
+        val exam = mockk<RealmStepExam>(relaxed = true)
+
+        every { realm.where(RealmStepExam::class.java) } returns query
+        every { query.equalTo("id", examId) } returns query
+        every { query.findFirst() } returns exam
+        every { exam.courseId } returns "courseId"
+
+        coEvery { repository["withRealm"](any<Boolean>(), any<Function1<Realm, Any>>()) } answers {
+            val action = arg<Function1<Realm, Any>>(1)
+            action.invoke(realm)
+        }
+
+        coEvery { repository.getOrCreateSubmission(any(), any()) } returns mockk()
+
+        repository.createBulkSurveySubmissions(examId, userIds)
+
+        coVerify(exactly = 1) { repository.getOrCreateSubmission("user1", "examId@courseId") }
+        coVerify(exactly = 1) { repository.getOrCreateSubmission("user2", "examId@courseId") }
+    }
+
+    @Test
     fun `saveSubmission performs transaction`() = runTest {
         val sub = mockk<RealmSubmission>(relaxed = true)
 


### PR DESCRIPTION
This PR refactors how `SendSurveyFragment` creates survey submissions. Previously, it iterated over selected user IDs and repeatedly called the `SubmissionsRepository` single `createSurveySubmission` method, resulting in potentially repetitive and expensive `Realm` lookups to resolve the survey's `courseId`.

The update introduces a new bulk operation, `createBulkSurveySubmissions`, which determines the parent ID exactly once and then processes all provided user IDs through `getOrCreateSubmission`. A new unit test verifies the correct behavior for this bulk method.

---
*PR created automatically by Jules for task [6858850679371062952](https://jules.google.com/task/6858850679371062952) started by @dogi*