### PR TITLE
teams: less repository user id is more (fixes #14176)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5826
+        versionName = "0.58.26"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -42,7 +42,6 @@ data class TeamUploadData(
 interface TeamsRepository {
     suspend fun getAllActiveTeams(): List<RealmMyTeam>
     suspend fun getMyTeamsFlow(userId: String): Flow<List<RealmMyTeam>>
-    suspend fun getMyTeamsByUserId(userId: String): List<RealmMyTeam>
     suspend fun getResourceIds(teamId: String): List<String>
     suspend fun getResourceIdsByUser(userId: String?): List<String>
     suspend fun getTeamSummaries(userId: String?): List<TeamSummary>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -1197,20 +1197,6 @@ class TeamsRepositoryImpl @Inject constructor(
         }.mapNotNull { it.resourceId }
     }
 
-    override suspend fun getMyTeamsByUserId(userId: String): List<RealmMyTeam> {
-        val teamIds = queryList(RealmMyTeam::class.java) {
-            equalTo("userId", userId)
-            equalTo("docType", "membership")
-        }.mapNotNull { it.teamId }
-
-        if (teamIds.isEmpty()) return emptyList()
-
-        return queryList(RealmMyTeam::class.java) {
-            `in`("_id", teamIds.toTypedArray())
-            notEqualTo("status", "archived")
-        }
-    }
-
     override suspend fun getTeamType(teamId: String): String? {
         if (teamId.isBlank()) return null
         return findByField(RealmMyTeam::class.java, "_id", teamId)?.type


### PR DESCRIPTION
This commit removes an unused method `getMyTeamsByUserId` from the `TeamsRepository` interface and its implementation class. The unused method was identified as dead code since a search across the `app/src` directory revealed no callers.

Steps taken:
1. Confirmed no callers exist for `getMyTeamsByUserId`.
2. Removed the method declaration from `TeamsRepository.kt`.
3. Removed the method implementation from `TeamsRepositoryImpl.kt`.
4. Verified successful compilation (`compileDefaultDebugKotlin`). Unit testing compilation was skipped due to an external network issue (HTTP 429), but the codebase syntax is correct.

---
*PR created automatically by Jules for task [1415670828415768628](https://jules.google.com/task/1415670828415768628) started by @dogi*