### PR TITLE
sync: less feedback repository bulk insert is more (fixes #14177)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5827
+        versionName = "0.58.27"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
@@ -21,5 +21,4 @@ interface FeedbackRepository {
     suspend fun saveFeedback(feedback: RealmFeedback)
     suspend fun insertFromJson(jsonObject: JsonObject)
     suspend fun insertFeedbackList(jsonObjects: List<JsonObject>)
-    fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -126,18 +126,4 @@ class FeedbackRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray) {
-        val documentList = ArrayList<com.google.gson.JsonObject>(jsonArray.size())
-        for (j in jsonArray) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = org.ole.planet.myplanet.utils.JsonUtils.getJsonObject("doc", jsonDoc)
-            val id = org.ole.planet.myplanet.utils.JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
-            }
-        }
-        documentList.forEach { jsonDoc ->
-            realm.copyToRealmOrUpdate(mapToRealmFeedback(jsonDoc))
-        }
-    }
 }


### PR DESCRIPTION
Removed the unused `bulkInsertFromSync` method from `FeedbackRepository` and `FeedbackRepositoryImpl` to clean up dead code. Validated absence of usage via `grep`.

---
*PR created automatically by Jules for task [10146888677605844311](https://jules.google.com/task/10146888677605844311) started by @dogi*