### PR TITLE
resources: smoother inline coroutine scoping (fixes #14205)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5852
+        versionName = "0.58.52"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -184,7 +184,7 @@ class CourseStepFragment : BaseContainerFragment(), ImageCaptureCallback {
         fragmentCourseStepBinding.tvResourcesHeader.visibility = View.VISIBLE
         fragmentCourseStepBinding.rvInlineResources.visibility = View.VISIBLE
 
-        inlineResourceAdapter = InlineResourceAdapter(dispatcherProvider) { library ->
+        inlineResourceAdapter = InlineResourceAdapter(viewLifecycleOwner.lifecycleScope, dispatcherProvider) { library ->
             openResource(library)
         }
         fragmentCourseStepBinding.rvInlineResources.apply {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -34,6 +34,7 @@ import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
 
 class InlineResourceAdapter(
+    private val parentScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val onResourceClick: (RealmMyLibrary) -> Unit
 ) : ListAdapter<RealmMyLibrary, InlineResourceAdapter.ViewHolder>(
@@ -56,15 +57,19 @@ class InlineResourceAdapter(
 
     private var externalFilesDir: java.io.File? = null
 
-    class ViewHolder(val binding: ItemInlineResourceBinding, dispatcherProvider: DispatcherProvider) : RecyclerView.ViewHolder(binding.root) {
-        private val scope = CoroutineScope(dispatcherProvider.main + SupervisorJob())
+    class ViewHolder(val binding: ItemInlineResourceBinding, private val parentScope: CoroutineScope, private val dispatcherProvider: DispatcherProvider) : RecyclerView.ViewHolder(binding.root) {
+        private var previewJob: Job? = null
 
         fun cancelPreviousPreviews() {
-            scope.coroutineContext.cancelChildren()
+            previewJob?.cancel()
+            previewJob = null
         }
 
         fun launchPreview(block: suspend CoroutineScope.() -> Unit): Job {
-            return scope.launch(block = block)
+            cancelPreviousPreviews()
+            val job = parentScope.launch(dispatcherProvider.main, block = block)
+            previewJob = job
+            return job
         }
     }
 
@@ -73,7 +78,7 @@ class InlineResourceAdapter(
         val binding = ItemInlineResourceBinding.inflate(
             LayoutInflater.from(parent.context), parent, false
         )
-        return ViewHolder(binding, dispatcherProvider)
+        return ViewHolder(binding, parentScope, dispatcherProvider)
     }
 
     override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {


### PR DESCRIPTION
Refactor CoroutineScope in InlineResourceAdapter

Modifies InlineResourceAdapter to accept a CoroutineScope from the parent Fragment (CourseStepFragment using viewLifecycleOwner.lifecycleScope). Removes the inline CoroutineScope instantiation in ViewHolder and updates ViewHolder.launchPreview to launch on the passed scope while explicitly tracking the Job via a previewJob variable to ensure clean cancellation upon view recycling.

---
*PR created automatically by Jules for task [3158162957326182948](https://jules.google.com/task/3158162957326182948) started by @dogi*