### PR TITLE
resources: less repository opened ids is more (fixes #14178)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5828
+        versionName = "0.58.28"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -71,7 +71,6 @@ interface ResourcesRepository {
     suspend fun getAllLibrariesToSync(): List<RealmMyLibrary>
     suspend fun addResourcesToUserLibrary(resourceIds: List<String>, userId: String): Result<Unit>
     suspend fun addAllResourcesToUserLibrary(resources: List<RealmMyLibrary>, userId: String): Result<Unit>
-    suspend fun getOpenedResourceIds(userId: String): Set<String>
     suspend fun observeOpenedResourceIds(userId: String): Flow<Set<String>>
     suspend fun getDownloadSuggestionList(userId: String? = null): List<RealmMyLibrary>
     suspend fun getLibraryByUserId(userId: String): List<RealmMyLibrary>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -399,16 +399,6 @@ class ResourcesRepositoryImpl @Inject constructor(
         return addResourcesToUserLibrary(resourceIds, userId)
     }
 
-    override suspend fun getOpenedResourceIds(userId: String): Set<String> {
-        val user = queryList(RealmUser::class.java) { equalTo("id", userId) }.firstOrNull()
-        val userName = user?.name ?: return emptySet()
-
-        return queryList(RealmResourceActivity::class.java) {
-            equalTo("user", userName)
-            equalTo("type", "resource_opened")
-        }.mapNotNull { it.resourceId }.toSet()
-    }
-
     override suspend fun observeOpenedResourceIds(userId: String): Flow<Set<String>> {
         val user = queryList(RealmUser::class.java) { equalTo("id", userId) }.firstOrNull()
         val userName = user?.name ?: return flowOf(emptySet())


### PR DESCRIPTION
Removed the unused `getOpenedResourceIds` method declaration from the `ResourcesRepository` interface and its corresponding implementation from `ResourcesRepositoryImpl` to clean up dead code. Tests pass successfully.

---
*PR created automatically by Jules for task [16284097399358667484](https://jules.google.com/task/16284097399358667484) started by @dogi*