### PR TITLE
teams: smoother voices label selecting (fixes #14193)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5841
+        versionName = "0.58.41"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesLabelAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesLabelAdapter.kt
@@ -45,7 +45,14 @@ class VoicesLabelAdapter(
     }
 
     fun setSelectedLabel(label: String) {
+        val oldIndex = currentList.indexOf(selectedLabel)
+        val newIndex = currentList.indexOf(label)
         selectedLabel = label
-        notifyDataSetChanged()
+        if (oldIndex != RecyclerView.NO_POSITION) {
+            notifyItemChanged(oldIndex)
+        }
+        if (newIndex != RecyclerView.NO_POSITION) {
+            notifyItemChanged(newIndex)
+        }
     }
 }


### PR DESCRIPTION
Replaced `notifyDataSetChanged()` with targeted updates using `notifyItemChanged()` for the previously selected and newly selected items in `VoicesLabelAdapter` by finding their respective indices. This optimizes the layout rendering passes when the user selects a voice label filter.

---
*PR created automatically by Jules for task [8275534549240924363](https://jules.google.com/task/8275534549240924363) started by @dogi*