### PR TITLE
courses: less tags repository linked ids is more (fixes #14183)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5830
+        versionName = "0.58.30"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
@@ -8,7 +8,6 @@ interface TagsRepository {
     suspend fun getTagsForResource(resourceId: String): List<RealmTag>
     suspend fun getTagsForCourse(courseId: String): List<RealmTag>
     suspend fun getTagsForResources(resourceIds: List<String>): Map<String, List<RealmTag>>
-    suspend fun getLinkedCourseIds(db: String, tagIds: Array<String>): Set<String>
     suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<RealmTag>>
     fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
     suspend fun insert(act: com.google.gson.JsonObject)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
@@ -47,14 +47,6 @@ class TagsRepositoryImpl @Inject constructor(
         return getLinkedTagsBulk("resources", resourceIds)
     }
 
-    override suspend fun getLinkedCourseIds(db: String, tagIds: Array<String>): Set<String> {
-        val links = queryList(RealmTag::class.java) {
-            equalTo("db", db)
-            `in`("tagId", tagIds)
-        }
-        return links.mapNotNull { it.linkId }.toSet()
-    }
-
     override suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<RealmTag>> {
         return getLinkedTagsBulk("courses", courseIds)
     }


### PR DESCRIPTION
The `getLinkedCourseIds` method in `TagsRepository` and its implementation in `TagsRepositoryImpl` were found to be completely unused. They have been removed to clean up the codebase.

---
*PR created automatically by Jules for task [7491090334023635683](https://jules.google.com/task/7491090334023635683) started by @dogi*