### PR TITLE
life: smoother adapter view holding (fixes #14221)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5853
+        versionName = "0.58.53"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5853
-        versionName = "0.58.53"
+        versionCode = 5863
+        versionName = "0.58.63"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeAdapter.kt
@@ -41,15 +41,6 @@ class LifeAdapter(
     private val show = 1f
 
     private val drawableCache = mutableMapOf<String, Int>()
-    private val fragmentCache = mapOf<String, () -> Fragment>(
-        "ic_mypersonals" to { PersonalsFragment() },
-        "ic_submissions" to { SubmissionsFragment() },
-        "ic_my_survey" to { newInstance("survey") },
-        "ic_myhealth" to { MyHealthFragment() },
-        "ic_calendar" to { CalendarFragment() },
-        "ic_references" to { ReferencesFragment() },
-        "my_achievement" to { AchievementFragment() }
-    )
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val v = LayoutInflater.from(context).inflate(R.layout.row_life, parent, false)
@@ -70,7 +61,7 @@ class LifeAdapter(
             holder.imageView.contentDescription = context.getString(R.string.icon, myLife.title)
 
             holder.imageView.setOnClickListener { view: View ->
-                val fragment = myLife.imageId?.let { fragmentCache[it]?.invoke() } ?: findFragment(myLife.imageId)
+                val fragment = findFragment(myLife.imageId)
                 if (fragment != null) {
                     transactionFragment(fragment, view)
                 }
@@ -141,18 +132,18 @@ class LifeAdapter(
             areItemsTheSame = { oldItem, newItem -> oldItem._id == newItem._id },
             areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
         )
-        // Kept for backward compatibility if accessed externally, but internally LifeAdapter uses fragmentCache
+        private val fragmentCache = mapOf<String, () -> Fragment>(
+            "ic_mypersonals" to { PersonalsFragment() },
+            "ic_submissions" to { SubmissionsFragment() },
+            "ic_my_survey" to { newInstance("survey") },
+            "ic_myhealth" to { MyHealthFragment() },
+            "ic_calendar" to { CalendarFragment() },
+            "ic_references" to { ReferencesFragment() },
+            "my_achievement" to { AchievementFragment() }
+        )
+
         fun findFragment(frag: String?): Fragment? {
-            when (frag) {
-                "ic_mypersonals" -> return PersonalsFragment()
-                "ic_submissions" -> return SubmissionsFragment()
-                "ic_my_survey" -> return newInstance("survey")
-                "ic_myhealth" -> return MyHealthFragment()
-                "ic_calendar" -> return CalendarFragment()
-                "ic_references" -> return ReferencesFragment()
-                "my_achievement" -> return AchievementFragment()
-            }
-            return null
+            return frag?.let { fragmentCache[it]?.invoke() }
         }
 
         fun transactionFragment(f: Fragment?, view: View) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeAdapter.kt
@@ -39,6 +39,18 @@ class LifeAdapter(
 ) : ListAdapter<RealmMyLife, RecyclerView.ViewHolder>(DIFF_CALLBACK), OnItemMoveListener {
     private val hide = 0.5f
     private val show = 1f
+
+    private val drawableCache = mutableMapOf<String, Int>()
+    private val fragmentCache = mapOf<String, () -> Fragment>(
+        "ic_mypersonals" to { PersonalsFragment() },
+        "ic_submissions" to { SubmissionsFragment() },
+        "ic_my_survey" to { newInstance("survey") },
+        "ic_myhealth" to { MyHealthFragment() },
+        "ic_calendar" to { CalendarFragment() },
+        "ic_references" to { ReferencesFragment() },
+        "my_achievement" to { AchievementFragment() }
+    )
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val v = LayoutInflater.from(context).inflate(R.layout.row_life, parent, false)
         return LifeViewHolder(v)
@@ -49,11 +61,17 @@ class LifeAdapter(
         val myLife = getItem(position)
         if (holder is LifeViewHolder) {
             holder.title.text = myLife.title
-            holder.imageView.setImageResource(context.resources.getIdentifier(myLife.imageId, "drawable", context.packageName))
+            myLife.imageId?.let { imgId ->
+                val resId = drawableCache.getOrPut(imgId) {
+                    context.resources.getIdentifier(imgId, "drawable", context.packageName)
+                }
+                holder.imageView.setImageResource(resId)
+            }
             holder.imageView.contentDescription = context.getString(R.string.icon, myLife.title)
-            val fragment = findFragment(myLife.imageId)
-            if (fragment != null) {
-                holder.imageView.setOnClickListener { view: View ->
+
+            holder.imageView.setOnClickListener { view: View ->
+                val fragment = myLife.imageId?.let { fragmentCache[it]?.invoke() } ?: findFragment(myLife.imageId)
+                if (fragment != null) {
                     transactionFragment(fragment, view)
                 }
             }
@@ -123,6 +141,7 @@ class LifeAdapter(
             areItemsTheSame = { oldItem, newItem -> oldItem._id == newItem._id },
             areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
         )
+        // Kept for backward compatibility if accessed externally, but internally LifeAdapter uses fragmentCache
         fun findFragment(frag: String?): Fragment? {
             when (frag) {
                 "ic_mypersonals" -> return PersonalsFragment()


### PR DESCRIPTION
Optimize LifeAdapter resource and destination lookups

- Precompute and cache drawable resource IDs in `LifeAdapter` using a `drawableCache` (`MutableMap<String, Int>`) to prevent expensive `getIdentifier` calls on every bind.
- Implement lazy initialization of destination fragments inside the `setOnClickListener` block using a `fragmentCache` (`Map<String, () -> Fragment>`) to avoid instantiating unneeded fragments globally during item binds.
- Validated touch and click listener logic remains intact.

---
*PR created automatically by Jules for task [7746851175892075151](https://jules.google.com/task/7746851175892075151) started by @dogi*