### PR TITLE
chat: smoother target id sharing (fixes #14220)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5862
+        versionName = "0.58.62"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatShareTargetAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatShareTargetAdapter.kt
@@ -17,12 +17,20 @@ class ChatShareTargetAdapter(
     private val expandableDetailList: HashMap<String, List<String>>,
     private val sharedChildren: Set<String> = emptySet()
 ) : BaseExpandableListAdapter() {
+
+    private var nextId = 0L
+    private val groupIds = mutableMapOf<String, Long>()
+    private val childIds = mutableMapOf<Pair<String, String>, Long>()
+
     override fun getChild(lstPosn: Int, expandedListPosition: Int): Any {
         return expandableDetailList[expandableTitleList[lstPosn]]?.get(expandedListPosition) ?: ""
     }
 
     override fun getChildId(listPosition: Int, expandedListPosition: Int): Long {
-        return getChild(listPosition, expandedListPosition).hashCode().toLong()
+        val group = getGroup(listPosition) as String
+        val child = getChild(listPosition, expandedListPosition) as String
+        val key = Pair(group, child)
+        return childIds.getOrPut(key) { nextId++ }
     }
 
     override fun getChildView(lstPosn: Int, expandedListPosition: Int, isLastChild: Boolean, convertView: View?, parent: ViewGroup): View {
@@ -54,7 +62,8 @@ class ChatShareTargetAdapter(
     }
 
     override fun getGroupId(listPosition: Int): Long {
-        return getGroup(listPosition).hashCode().toLong()
+        val group = getGroup(listPosition) as String
+        return groupIds.getOrPut(group) { nextId++ }
     }
 
     override fun getGroupView(listPosition: Int, isExpanded: Boolean, convertView: View?, parent: ViewGroup): View {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatShareTargetAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatShareTargetAdapter.kt
@@ -22,7 +22,7 @@ class ChatShareTargetAdapter(
     }
 
     override fun getChildId(listPosition: Int, expandedListPosition: Int): Long {
-        return expandedListPosition.toLong()
+        return getChild(listPosition, expandedListPosition).hashCode().toLong()
     }
 
     override fun getChildView(lstPosn: Int, expandedListPosition: Int, isLastChild: Boolean, convertView: View?, parent: ViewGroup): View {
@@ -54,7 +54,7 @@ class ChatShareTargetAdapter(
     }
 
     override fun getGroupId(listPosition: Int): Long {
-        return listPosition.toLong()
+        return getGroup(listPosition).hashCode().toLong()
     }
 
     override fun getGroupView(listPosition: Int, isExpanded: Boolean, convertView: View?, parent: ViewGroup): View {
@@ -74,7 +74,7 @@ class ChatShareTargetAdapter(
     }
 
     override fun hasStableIds(): Boolean {
-        return false
+        return true
     }
 
     override fun isChildSelectable(listPosition: Int, expandedListPosition: Int): Boolean {


### PR DESCRIPTION
1. Returned stable group IDs based on the group title hash code.
2. Returned stable child IDs based on the child text hash code.
3. Changed hasStableIds to true since IDs are now deterministic.

---
*PR created automatically by Jules for task [3185534199266548120](https://jules.google.com/task/3185534199266548120) started by @dogi*