### PR TITLE
sync: smoother personals repository documents uploading (fixes #14210)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5857
+        versionName = "0.58.57"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepository.kt
@@ -23,4 +23,6 @@ interface PersonalsRepository {
     suspend fun getPendingPersonalUploads(userId: String): List<RealmMyPersonal>
 
     suspend fun updatePersonalAfterSync(id: String, newId: String, rev: String)
+
+    suspend fun uploadPersonalDocument(personal: RealmMyPersonal): Pair<String, String>?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package org.ole.planet.myplanet.repository
 
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
@@ -7,12 +9,17 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.utils.JsonUtils.getString
+import org.ole.planet.myplanet.utils.UrlUtils
 
 class PersonalsRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
-    @RealmDispatcher realmDispatcher: CoroutineDispatcher
+    @RealmDispatcher realmDispatcher: CoroutineDispatcher,
+    private val apiInterface: ApiInterface,
+    @ApplicationContext private val context: Context
 ) : RealmRepository(databaseService, realmDispatcher), PersonalsRepository {
 
     override suspend fun personalTitleExists(title: String, userId: String?): Boolean {
@@ -75,5 +82,25 @@ class PersonalsRepositoryImpl @Inject constructor(
             personal._id = newId
             personal._rev = rev
         }
+    }
+
+    override suspend fun uploadPersonalDocument(personal: RealmMyPersonal): Pair<String, String>? {
+        val response = apiInterface.postDoc(
+            UrlUtils.header, "application/json",
+            "${UrlUtils.getUrl()}/resources", RealmMyPersonal.serialize(personal, context)
+        )
+
+        val `object` = response.body()
+        if (`object` != null) {
+            val rev = getString("rev", `object`)
+            val id = getString("id", `object`)
+
+            personal.id?.let { personalId ->
+                updatePersonalAfterSync(personalId, id, rev)
+            }
+
+            return Pair(id, rev)
+        }
+        return null
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -213,20 +213,9 @@ class UploadManager @Inject constructor(
         if (!personal.isUploaded) {
             return withContext(dispatcherProvider.io) {
                 try {
-                    val response = apiInterface.postDoc(
-                        UrlUtils.header, "application/json",
-                        "${UrlUtils.getUrl()}/resources", RealmMyPersonal.serialize(personal, context)
-                    )
-
-                    val `object` = response.body()
-                    if (`object` != null) {
-                        val rev = getString("rev", `object`)
-                        val id = getString("id", `object`)
-
-                        personal.id?.let { personalId ->
-                            personalsRepository.updatePersonalAfterSync(personalId, id, rev)
-                        }
-
+                    val result = personalsRepository.uploadPersonalDocument(personal)
+                    if (result != null) {
+                        val (id, rev) = result
                         uploadAttachment(id, rev, personal) { }
                         "Personal resource uploaded successfully"
                     } else {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
@@ -24,22 +24,13 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import android.content.Context
-import com.google.gson.JsonObject
-import okhttp3.ResponseBody.Companion.toResponseBody
-import org.junit.Assert.assertNull
 import org.ole.planet.myplanet.data.DatabaseService
-import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.model.RealmMyPersonal
-import org.ole.planet.myplanet.utils.UrlUtils
-import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PersonalsRepositoryImplTest {
 
     private lateinit var databaseService: DatabaseService
-    private lateinit var apiInterface: ApiInterface
-    private lateinit var context: Context
     private lateinit var mockRealm: Realm
     private lateinit var repository: PersonalsRepositoryImpl
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -67,9 +58,8 @@ class PersonalsRepositoryImplTest {
         every { databaseService.createManagedRealmInstance() } returns mockRealm
         every { databaseService.ioDispatcher } returns testDispatcher
 
-        apiInterface = mockk(relaxed = true)
-        context = mockk(relaxed = true)
-
+        val apiInterface = mockk<org.ole.planet.myplanet.data.api.ApiInterface>(relaxed = true)
+        val context = mockk<android.content.Context>(relaxed = true)
         repository = PersonalsRepositoryImpl(databaseService, testDispatcher, apiInterface, context)
     }
 
@@ -240,47 +230,5 @@ class PersonalsRepositoryImplTest {
         assertTrue(mockPersonal.isUploaded)
         assertEquals("new-id", mockPersonal._id)
         assertEquals("rev-1", mockPersonal._rev)
-    }
-
-    @Test
-    fun `uploadPersonalDocument returns id and rev on success`() = runTest {
-        val personal = RealmMyPersonal().apply { id = "test-id" }
-        val mockQuery = mockQueryResults()
-        val mockPersonal = RealmMyPersonal()
-        every { mockQuery.equalTo("id", "test-id").findFirst() } returns mockPersonal
-
-        val jsonObject = JsonObject().apply {
-            addProperty("id", "remote-id")
-            addProperty("rev", "remote-rev")
-        }
-        val response = Response.success(jsonObject)
-
-        coEvery {
-            apiInterface.postDoc(any(), any(), any(), any())
-        } returns response
-
-        val result = repository.uploadPersonalDocument(personal)
-
-        assertEquals("remote-id", result?.first)
-        assertEquals("remote-rev", result?.second)
-
-        assertTrue(mockPersonal.isUploaded)
-        assertEquals("remote-id", mockPersonal._id)
-        assertEquals("remote-rev", mockPersonal._rev)
-    }
-
-    @Test
-    fun `uploadPersonalDocument returns null when response body is null`() = runTest {
-        val personal = RealmMyPersonal()
-
-        val response = Response.success<JsonObject>(null)
-
-        coEvery {
-            apiInterface.postDoc(any(), any(), any(), any())
-        } returns response
-
-        val result = repository.uploadPersonalDocument(personal)
-
-        assertNull(result)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
@@ -24,13 +24,22 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import android.content.Context
+import com.google.gson.JsonObject
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertNull
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.utils.UrlUtils
+import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PersonalsRepositoryImplTest {
 
     private lateinit var databaseService: DatabaseService
+    private lateinit var apiInterface: ApiInterface
+    private lateinit var context: Context
     private lateinit var mockRealm: Realm
     private lateinit var repository: PersonalsRepositoryImpl
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -58,7 +67,10 @@ class PersonalsRepositoryImplTest {
         every { databaseService.createManagedRealmInstance() } returns mockRealm
         every { databaseService.ioDispatcher } returns testDispatcher
 
-        repository = PersonalsRepositoryImpl(databaseService, testDispatcher)
+        apiInterface = mockk(relaxed = true)
+        context = mockk(relaxed = true)
+
+        repository = PersonalsRepositoryImpl(databaseService, testDispatcher, apiInterface, context)
     }
 
     @After
@@ -228,5 +240,47 @@ class PersonalsRepositoryImplTest {
         assertTrue(mockPersonal.isUploaded)
         assertEquals("new-id", mockPersonal._id)
         assertEquals("rev-1", mockPersonal._rev)
+    }
+
+    @Test
+    fun `uploadPersonalDocument returns id and rev on success`() = runTest {
+        val personal = RealmMyPersonal().apply { id = "test-id" }
+        val mockQuery = mockQueryResults()
+        val mockPersonal = RealmMyPersonal()
+        every { mockQuery.equalTo("id", "test-id").findFirst() } returns mockPersonal
+
+        val jsonObject = JsonObject().apply {
+            addProperty("id", "remote-id")
+            addProperty("rev", "remote-rev")
+        }
+        val response = Response.success(jsonObject)
+
+        coEvery {
+            apiInterface.postDoc(any(), any(), any(), any())
+        } returns response
+
+        val result = repository.uploadPersonalDocument(personal)
+
+        assertEquals("remote-id", result?.first)
+        assertEquals("remote-rev", result?.second)
+
+        assertTrue(mockPersonal.isUploaded)
+        assertEquals("remote-id", mockPersonal._id)
+        assertEquals("remote-rev", mockPersonal._rev)
+    }
+
+    @Test
+    fun `uploadPersonalDocument returns null when response body is null`() = runTest {
+        val personal = RealmMyPersonal()
+
+        val response = Response.success<JsonObject>(null)
+
+        coEvery {
+            apiInterface.postDoc(any(), any(), any(), any())
+        } returns response
+
+        val result = repository.uploadPersonalDocument(personal)
+
+        assertNull(result)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -270,4 +270,43 @@ class UploadManagerTest {
 
         coVerify { listener.onSuccess("Resource upload failed: $errorMessage") }
     }
+
+    @Test
+    fun `uploadMyPersonal delegates to personalsRepository and calls uploadAttachment`() = testScope.runTest {
+        val mockPersonal = mockk<org.ole.planet.myplanet.model.RealmMyPersonal>(relaxed = true)
+        every { mockPersonal.isUploaded } returns false
+
+        coEvery { personalsRepository.uploadPersonalDocument(mockPersonal) } returns Pair("remote-id", "remote-rev")
+
+        val result = uploadManager.uploadMyPersonal(mockPersonal)
+        advanceUntilIdle()
+
+        coVerify { personalsRepository.uploadPersonalDocument(mockPersonal) }
+        assert(result == "Personal resource uploaded successfully")
+    }
+
+    @Test
+    fun `uploadMyPersonal returns failure message when response is null`() = testScope.runTest {
+        val mockPersonal = mockk<org.ole.planet.myplanet.model.RealmMyPersonal>(relaxed = true)
+        every { mockPersonal.isUploaded } returns false
+
+        coEvery { personalsRepository.uploadPersonalDocument(mockPersonal) } returns null
+
+        val result = uploadManager.uploadMyPersonal(mockPersonal)
+        advanceUntilIdle()
+
+        coVerify { personalsRepository.uploadPersonalDocument(mockPersonal) }
+        assert(result == "Failed to upload personal resource: No response")
+    }
+
+    @Test
+    fun `uploadMyPersonal returns already uploaded message`() = testScope.runTest {
+        val mockPersonal = mockk<org.ole.planet.myplanet.model.RealmMyPersonal>(relaxed = true)
+        every { mockPersonal.isUploaded } returns true
+
+        val result = uploadManager.uploadMyPersonal(mockPersonal)
+        advanceUntilIdle()
+
+        assert(result == "Resource already uploaded")
+    }
 }


### PR DESCRIPTION
Moves the `uploadMyPersonal` logic for document sync out of `UploadManager` into `PersonalsRepository` to create a repository-led sync path while maintaining the attachment upload flow.

---
*PR created automatically by Jules for task [4934553294996912482](https://jules.google.com/task/4934553294996912482) started by @dogi*