### PR TITLE
all: smoother network monitor working (fixes #14209)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5856
+        versionName = "0.58.56"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/NetworkMonitorWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/NetworkMonitorWorker.kt
@@ -11,6 +11,7 @@ import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.first
 import org.ole.planet.myplanet.utils.NetworkUtils
 
 @HiltWorker
@@ -36,13 +37,8 @@ class NetworkMonitorWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         return try {
-            var wasConnected = false
-            NetworkUtils.isNetworkConnectedFlow.collect { isConnected ->
-                if (isConnected && !wasConnected) {
-                    scheduleServerReachabilityCheck()
-                }
-                wasConnected = isConnected
-            }
+            NetworkUtils.isNetworkConnectedFlow.first { it }
+            scheduleServerReachabilityCheck()
 
             Result.success()
         } catch (e: Exception) {


### PR DESCRIPTION
Refactor NetworkMonitorWorker to use flow.first() instead of infinite collect()

Fixes a bug where NetworkMonitorWorker would collect forever on the `isNetworkConnectedFlow`. It now correctly uses `.first { it }` to suspend until a valid network connection is made, schedules the reachability check, and successfully completes.

---
*PR created automatically by Jules for task [9035238382447736446](https://jules.google.com/task/9035238382447736446) started by @dogi*