### PR TITLE
chat: smoother history view holding (fixes #14234)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5873
+        versionName = "0.58.73"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryAdapter.kt
@@ -42,23 +42,11 @@ class ChatHistoryAdapter(
             oldId != null && newId != null && oldId == newId
         },
         areContentsTheSame = { oldItem, newItem ->
-            oldItem === newItem &&
-                oldItem._rev == newItem._rev &&
+            oldItem._rev == newItem._rev &&
                 oldItem.lastUsed == newItem.lastUsed &&
                 oldItem.title == newItem.title &&
                 oldItem.conversations?.firstOrNull()?.query ==
                 newItem.conversations?.firstOrNull()?.query
-        },
-        getChangePayload = { oldItem, newItem ->
-            if (oldItem._rev == newItem._rev &&
-                oldItem.lastUsed == newItem.lastUsed &&
-                oldItem.title == newItem.title &&
-                oldItem.conversations?.firstOrNull()?.query ==
-                newItem.conversations?.firstOrNull()?.query) {
-                PAYLOAD_CHAT_SHARED
-            } else {
-                null
-            }
         }
     )
 ) {
@@ -85,25 +73,10 @@ class ChatHistoryAdapter(
     }
 
     fun notifyChatShared(chatId: String?) {
-        val newList = currentList.map { item ->
-            if (item._id == chatId) {
-                val copy = RealmChatHistory()
-                copy.id = item.id
-                copy._id = item._id
-                copy._rev = item._rev
-                copy.user = item.user
-                copy.aiProvider = item.aiProvider
-                copy.title = item.title
-                copy.createdDate = item.createdDate
-                copy.updatedDate = item.updatedDate
-                copy.lastUsed = item.lastUsed
-                copy.conversations = item.conversations
-                copy
-            } else {
-                item
-            }
+        val position = currentList.indexOfFirst { it._id == chatId }
+        if (position != -1) {
+            notifyItemChanged(position, PAYLOAD_CHAT_SHARED)
         }
-        submitList(newList)
     }
 
     fun setChatHistoryItemClickListener(listener: OnChatHistoryItemClickListener) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryAdapter.kt
@@ -42,11 +42,23 @@ class ChatHistoryAdapter(
             oldId != null && newId != null && oldId == newId
         },
         areContentsTheSame = { oldItem, newItem ->
-            oldItem._rev == newItem._rev &&
+            oldItem === newItem &&
+                oldItem._rev == newItem._rev &&
                 oldItem.lastUsed == newItem.lastUsed &&
                 oldItem.title == newItem.title &&
                 oldItem.conversations?.firstOrNull()?.query ==
                 newItem.conversations?.firstOrNull()?.query
+        },
+        getChangePayload = { oldItem, newItem ->
+            if (oldItem._rev == newItem._rev &&
+                oldItem.lastUsed == newItem.lastUsed &&
+                oldItem.title == newItem.title &&
+                oldItem.conversations?.firstOrNull()?.query ==
+                newItem.conversations?.firstOrNull()?.query) {
+                PAYLOAD_CHAT_SHARED
+            } else {
+                null
+            }
         }
     )
 ) {
@@ -73,10 +85,25 @@ class ChatHistoryAdapter(
     }
 
     fun notifyChatShared(chatId: String?) {
-        val position = currentList.indexOfFirst { it._id == chatId }
-        if (position != -1) {
-            notifyItemChanged(position)
+        val newList = currentList.map { item ->
+            if (item._id == chatId) {
+                val copy = RealmChatHistory()
+                copy.id = item.id
+                copy._id = item._id
+                copy._rev = item._rev
+                copy.user = item.user
+                copy.aiProvider = item.aiProvider
+                copy.title = item.title
+                copy.createdDate = item.createdDate
+                copy.updatedDate = item.updatedDate
+                copy.lastUsed = item.lastUsed
+                copy.conversations = item.conversations
+                copy
+            } else {
+                item
+            }
         }
+        submitList(newList)
     }
 
     fun setChatHistoryItemClickListener(listener: OnChatHistoryItemClickListener) {
@@ -90,6 +117,14 @@ class ChatHistoryAdapter(
 
     fun updateChatHistory(newChatHistory: List<RealmChatHistory>) {
         submitList(newChatHistory)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolderChat, position: Int, payloads: MutableList<Any>) {
+        if (payloads.contains(PAYLOAD_CHAT_SHARED)) {
+            bindShareChat(holder, getItem(position))
+            return
+        }
+        super.onBindViewHolder(holder, position, payloads)
     }
 
     override fun onBindViewHolder(holder: ViewHolderChat, position: Int) {
@@ -114,6 +149,10 @@ class ChatHistoryAdapter(
             )
         }
 
+        bindShareChat(holder, item)
+    }
+
+    private fun bindShareChat(holder: ViewHolderChat, item: RealmChatHistory) {
         holder.rowChatHistoryBinding.shareChat.setImageResource(R.drawable.baseline_share_24)
 
         holder.rowChatHistoryBinding.shareChat.setOnClickListener {
@@ -247,4 +286,8 @@ class ChatHistoryAdapter(
     }
 
     class ViewHolderChat(val rowChatHistoryBinding: RowChatHistoryBinding) : RecyclerView.ViewHolder(rowChatHistoryBinding.root)
+
+    companion object {
+        const val PAYLOAD_CHAT_SHARED = "PAYLOAD_CHAT_SHARED"
+    }
 }


### PR DESCRIPTION
Refactored `ChatHistoryAdapter` to remove the manual `notifyItemChanged` call and fully rely on `submitList()` with a properly implemented `DiffUtil` payload to trigger partial rebinds.

---
*PR created automatically by Jules for task [3770444760269493108](https://jules.google.com/task/3770444760269493108) started by @dogi*