### PR TITLE
sync: smoother user repository achievements bulk inserting (fixes #14202)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5849
+        versionName = "0.58.49"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -1242,7 +1242,7 @@ class UserRepositoryImpl @Inject constructor(
             achievement?.purpose = org.ole.planet.myplanet.utils.JsonUtils.getString("purpose", act)
             achievement?.goals = org.ole.planet.myplanet.utils.JsonUtils.getString("goals", act)
             achievement?.achievementsHeader = org.ole.planet.myplanet.utils.JsonUtils.getString("achievementsHeader", act)
-            achievement?.sendToNation = act?.get("sendToNation")?.asString ?: "false"
+            achievement?.sendToNation = act.get("sendToNation")?.asString ?: "false"
             achievement?.dateSortOrder = org.ole.planet.myplanet.utils.JsonUtils.getString("dateSortOrder", act)
             achievement?.createdOn = org.ole.planet.myplanet.utils.JsonUtils.getString("createdOn", act)
             achievement?.username = org.ole.planet.myplanet.utils.JsonUtils.getString("username", act)


### PR DESCRIPTION
Removed the redundant `?.` safe call on the `act` variable when getting
"sendToNation" inside `UserRepositoryImpl.kt`, as `act` is known to be
non-null in this context, effectively resolving the compiler warning.

---
*PR created automatically by Jules for task [15206216828482238357](https://jules.google.com/task/15206216828482238357) started by @dogi*