### PR TITLE
courses: smoother submissions latest collecting (fixes #14242)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5879
+        versionName = "0.58.79"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsAdapter.kt
@@ -160,8 +160,8 @@ class SubmissionsAdapter(
     }
 
     companion object {
-        private const val PAYLOAD_EXAM_UPDATE = "payload_exam_update"
-        private const val PAYLOAD_SUBMISSION_COUNT_UPDATE = "payload_submission_count_update"
+        const val PAYLOAD_EXAM_UPDATE = "payload_exam_update"
+        const val PAYLOAD_SUBMISSION_COUNT_UPDATE = "payload_submission_count_update"
         @JvmStatic
         fun openSurvey(listener: OnHomeItemClickListener?, id: String?, isMySurvey: Boolean, isTeam: Boolean, teamId: String?) {
             if (listener != null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import org.ole.planet.myplanet.databinding.FragmentMySubmissionBinding
 import org.ole.planet.myplanet.services.UserSessionManager
 
@@ -57,19 +58,19 @@ class SubmissionsFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
 
         viewModel.setFilter(type ?: "", "")
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            combine(
-                viewModel.submissions,
-                viewModel.exams,
-                viewModel.submissionCounts
-            ) { submissions, exams, counts ->
-                Triple(submissions, exams, counts)
-            }.collectLatest { (submissions, exams, counts) ->
-                adapter.setExams(exams)
-                adapter.setSubmissionCounts(counts)
-                adapter.submitList(submissions)
-                updateEmptyState(submissions.size)
-            }
+        collectLatestWhenStarted(viewModel.submissions) { submissions ->
+            adapter.submitList(submissions)
+            updateEmptyState(submissions.size)
+        }
+
+        collectLatestWhenStarted(viewModel.exams) { exams ->
+            adapter.setExams(exams)
+            adapter.notifyItemRangeChanged(0, adapter.itemCount, SubmissionsAdapter.PAYLOAD_EXAM_UPDATE)
+        }
+
+        collectLatestWhenStarted(viewModel.submissionCounts) { counts ->
+            adapter.setSubmissionCounts(counts)
+            adapter.notifyItemRangeChanged(0, adapter.itemCount, SubmissionsAdapter.PAYLOAD_SUBMISSION_COUNT_UPDATE)
         }
 
         textWatcher = object : TextWatcher {


### PR DESCRIPTION
Optimize Submissions UI updates by splitting list submission from metadata refresh

- Exposed `PAYLOAD_EXAM_UPDATE` and `PAYLOAD_SUBMISSION_COUNT_UPDATE` in `SubmissionsAdapter.kt`.
- Refactored `SubmissionsFragment.kt` to observe `submissions`, `exams`, and `submissionCounts` independently.
- Avoided full `submitList()` trigger when merely updating exam titles or submission counts.
- Metadata changes now trigger isolated partial rebinds via `adapter.notifyItemRangeChanged()` and adapter setter methods.

---
*PR created automatically by Jules for task [15323554522273428125](https://jules.google.com/task/15323554522273428125) started by @dogi*