### PR TITLE
teams: smoother repository member login caching (fixes #14201)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5848
+        versionName = "0.58.48"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -114,7 +114,7 @@ interface TeamsRepository {
     suspend fun respondToMemberRequest(teamId: String, userId: String, accept: Boolean): Result<Unit>
     suspend fun getTeamType(teamId: String): String?
     suspend fun getJoinedMembers(teamId: String): List<RealmUser>
-    suspend fun getJoinedMembersAndSave(teamId: String): List<RealmUser>
+    suspend fun refreshJoinedMembersForLogin(teamId: String): List<RealmUser>
     suspend fun getJoinedMembersWithVisitInfo(teamId: String): List<JoinedMemberData>
     suspend fun getJoinedMemberCount(teamId: String): Int
     suspend fun getAssignee(userId: String): RealmUser?

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -1216,7 +1216,7 @@ class TeamsRepositoryImpl @Inject constructor(
         return findByField(RealmMyTeam::class.java, "_id", teamId)?.type
     }
 
-    override suspend fun getJoinedMembersAndSave(teamId: String): List<RealmUser> = withContext(dispatcherProvider.io) {
+    override suspend fun refreshJoinedMembersForLogin(teamId: String): List<RealmUser> = withContext(dispatcherProvider.io) {
         val teamMembers = getJoinedMembers(teamId)
         val userList = teamMembers.map {
             User(it.name ?: "", it.name ?: "", "", it.userImage ?: "", "team")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -549,7 +549,7 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
             selectedTeamId = prefData.getSelectedTeamId().toString()
             val teamId = selectedTeamId
             if (!teamId.isNullOrEmpty()) {
-                users = teamsRepository.getJoinedMembersAndSave(teamId)
+                users = teamsRepository.refreshJoinedMembersForLogin(teamId)
             }
             setupAndPopulateRecyclerView()
         }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
@@ -83,6 +83,35 @@ class TeamsRepositoryImplTest {
     }
 
     @Test
+    fun `test refreshJoinedMembersForLogin uses getJoinedMembers and saves users`() = runTest(testDispatcher) {
+        val teamId = "test_team_id"
+        val mockUser = org.ole.planet.myplanet.model.RealmUser().apply {
+            name = "Test User"
+            userImage = "http://example.com/image.png"
+        }
+        val mockTeamMembers = listOf(mockUser)
+
+        val spyRepository = io.mockk.spyk(teamsRepository)
+        coEvery { spyRepository.getJoinedMembers(teamId) } returns mockTeamMembers
+
+        val existingSavedUsers = emptyList<org.ole.planet.myplanet.model.User>()
+        every { sharedPrefManager.getSavedUsers() } returns existingSavedUsers
+
+        every { sharedPrefManager.setSavedUsers(any()) } returns Unit
+
+        val result = spyRepository.refreshJoinedMembersForLogin(teamId)
+
+        org.junit.Assert.assertEquals(mockTeamMembers, result)
+
+        io.mockk.verify {
+            sharedPrefManager.getSavedUsers()
+            sharedPrefManager.setSavedUsers(match { list ->
+                list.size == 1 && list[0].name == "Test User" && list[0].image == "http://example.com/image.png" && list[0].source == "team"
+            })
+        }
+    }
+
+    @Test
     fun `test syncTeamActivities uses dispatcherProvider io`() = runTest(testDispatcher) {
         // We will mock MainApplication object to avoid real network call
         io.mockk.mockkObject(org.ole.planet.myplanet.MainApplication.Companion)


### PR DESCRIPTION
1. Renamed `getJoinedMembersAndSave` to `refreshJoinedMembersForLogin` to make its intent and specific use case explicit.
2. Updated `LoginActivity` to call `refreshJoinedMembersForLogin` to keep behavior consistent.
3. Added a new unit test in `TeamsRepositoryImplTest` to cover `refreshJoinedMembersForLogin` saving the mock user list to `sharedPrefManager`.

---
*PR created automatically by Jules for task [17260960369245688052](https://jules.google.com/task/17260960369245688052) started by @dogi*