### PR TITLE
life: smoother personals adapting (fixes #14199)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5846
+        versionName = "0.58.46"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsAdapter.kt
@@ -79,7 +79,7 @@ class PersonalsAdapter(private val context: Context) : ListAdapter<RealmMyPerson
             "aac", "mp3" -> openAudioFile(context, path)
             "mp4" -> context.startActivity(
                 Intent(context, ResourceViewerActivity::class.java)
-                    .putExtra("TOUCHED_FILE", Uri.fromFile(path?.let { File(it) }).toString())
+                    .putExtra("TOUCHED_FILE", Uri.fromFile(File(path)).toString())
                     .putExtra("resourceType", ResourceViewerFragment.ResourceType.VIDEO.name)
             )
         }


### PR DESCRIPTION
Removed an unnecessary safe call and let block when constructing a `Uri` from `path` in `PersonalsAdapter.kt`. This fixes a compiler warning where `?.let` was used unnecessarily.

---
*PR created automatically by Jules for task [918417916999954165](https://jules.google.com/task/918417916999954165) started by @dogi*