### PR TITLE
courses: smoother list adapting (fixes #14198)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5845
+        versionName = "0.58.45"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -78,7 +78,7 @@ class CoursesAdapter(
         super.onCurrentListChanged(previousList, currentList)
         courseIdToPosition.clear()
         currentList.forEachIndexed { index, course ->
-            course.courseId?.let { courseIdToPosition[it] = index }
+            courseIdToPosition[course.courseId] = index
         }
     }
 


### PR DESCRIPTION
This commit addresses a Kotlin compiler warning about an unnecessary safe call in `CoursesAdapter.kt`.

* Modified `onCurrentListChanged` to directly use `course.courseId` as the key for `courseIdToPosition` instead of wrapping it in a `?.let` block.
* Verified that the code compiles cleanly and the warning is no longer generated during the assemble process.

---
*PR created automatically by Jules for task [9493097491125957667](https://jules.google.com/task/9493097491125957667) started by @dogi*