### PR TITLE
sync: smoother upload managing (fixes #14211)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5858
+        versionName = "0.58.58"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -173,7 +173,7 @@ class UploadManager @Inject constructor(
 
                             result.items.forEach { item ->
                                 libMap[item.localId]?.let { library ->
-                                    uploadAttachment(item.remoteId ?: "", item.remoteRev ?: "", library, l)
+                                    uploadAttachment(item.remoteId, item.remoteRev, library, l)
                                 }
                             }
                         }
@@ -189,7 +189,7 @@ class UploadManager @Inject constructor(
 
                             result.succeeded.forEach { item ->
                                 libMap[item.localId]?.let { library ->
-                                    uploadAttachment(item.remoteId ?: "", item.remoteRev ?: "", library, l)
+                                    uploadAttachment(item.remoteId, item.remoteRev, library, l)
                                 }
                             }
                         }


### PR DESCRIPTION
Removes unnecessary Elvis-operator fallbacks (`?: ""`) on `item.remoteId` and `item.remoteRev` in `UploadManager.kt` since both fields are now defined as non-nullable `String` types. This resolves the Kotlin compiler warnings `Elvis operator (?:) always returns the left operand of non-nullable type 'String'`.

---
*PR created automatically by Jules for task [15925572092995705980](https://jules.google.com/task/15925572092995705980) started by @dogi*