### PR TITLE
all: smoother settings category detail storing (fixes #14203)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5850
+        versionName = "0.58.50"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -66,11 +65,11 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
             extensions: List<String>,
             allKnownExtensions: List<String>
         ) = StorageCategoryDetailFragment().apply {
-            arguments = bundleOf(
-                ARG_LABEL to label,
-                ARG_EXTENSIONS to ArrayList(extensions),
-                ARG_ALL_KNOWN to ArrayList(allKnownExtensions)
-            )
+            arguments = Bundle().apply {
+                putString(ARG_LABEL, label)
+                putStringArrayList(ARG_EXTENSIONS, ArrayList(extensions))
+                putStringArrayList(ARG_ALL_KNOWN, ArrayList(allKnownExtensions))
+            }
         }
     }
 
@@ -245,7 +244,7 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
             }
 
             // Notify parent to refresh, then dismiss
-            parentFragmentManager.setFragmentResult(RESULT_KEY, bundleOf())
+            parentFragmentManager.setFragmentResult(RESULT_KEY, Bundle())
             dismiss()
         }
     }


### PR DESCRIPTION
Replaced deprecated AndroidX Core `bundleOf` utility with the standard Android `Bundle` platform object in `StorageCategoryDetailFragment.kt` as requested in the issue. Cleaned up the unused import. Verified via `assembleDefaultDebug` (deprecation removed) and full `testDefaultDebugUnitTest` suite (no regressions).

---
*PR created automatically by Jules for task [14273152494726032217](https://jules.google.com/task/14273152494726032217) started by @dogi*