### PR TITLE
enterprises: smoother reporting (fixes #14200)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5847
+        versionName = "0.58.47"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsFragment.kt
@@ -131,9 +131,7 @@ class EnterprisesReportsFragment : BaseTeamFragment() {
                                 // archived successfully
                             }
                             is ReportEvent.Error -> {
-                                view?.let {
-                                    Snackbar.make(it, event.message, Snackbar.LENGTH_LONG).show()
-                                } ?: Utilities.toast(requireContext(), event.message)
+                                Snackbar.make(view, event.message, Snackbar.LENGTH_LONG).show()
                             }
                         }
                     }


### PR DESCRIPTION
Replaces `view?.let { Snackbar... } ?: Utilities.toast(...)` with `Snackbar.make(view, ...).show()` in EnterprisesReportsFragment. This addresses the unnecessary safe call compiler warning and removes the dead fallback code since `view` is already guaranteed to be non-null in this scope.

---
*PR created automatically by Jules for task [13413264875449330862](https://jules.google.com/task/13413264875449330862) started by @dogi*