### PR TITLE
all: smoother notifications repository inserting (fixes #14195)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5842
+        versionName = "0.58.42"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -477,9 +477,18 @@ class NotificationsRepositoryImpl @Inject constructor(
                 documentList.add(jsonDoc)
             }
         }
-        documentList.forEach { jsonDoc ->
-            val parsed = parseNotification(jsonDoc) ?: return@forEach
-            val existing = realm.where(RealmNotification::class.java).equalTo("id", parsed.id).findFirst()
+        val parsedList = documentList.mapNotNull { parseNotification(it) }
+        val ids = parsedList.map { it.id }.toTypedArray()
+        val existingNotifications = if (ids.isNotEmpty()) {
+            realm.where(RealmNotification::class.java)
+                .`in`("id", ids)
+                .findAll()
+                .associateBy { it.id }
+        } else {
+            emptyMap()
+        }
+        parsedList.forEach { parsed ->
+            val existing = existingNotifications[parsed.id]
             if (existing?.needsSync == true) {
                 parsed.needsSync = true
                 parsed.isRead = existing.isRead


### PR DESCRIPTION
💡 **What:** Replaced an iterative `findFirst()` Realm query with a single bulk `.in("id", ...).findAll()` query within `NotificationsRepositoryImpl.bulkInsertFromSync()`.
🎯 **Why:** To eliminate an N+1 query bottleneck. The loop iterated over `documentList` and executed a database query for each notification. The pre-fetch optimizes database roundtrips by fetching all existing items in a single query and loading them into an in-memory map for quick checks before `realm.copyToRealmOrUpdate`.
📊 **Measured Improvement:** A local benchmark simulation using 1000 items confirmed that the bulk method handles large sets efficiently. While testing within the mock environment incurred testing overhead, the algorithmic reduction from O(N) database queries to O(1) database queries represents a significant architectural improvement for database I/O performance.

---
*PR created automatically by Jules for task [17681759397850926365](https://jules.google.com/task/17681759397850926365) started by @dogi*