### PR TITLE
login: smoother view modelling (fixes  #14244)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5877
-        versionName = "0.58.77"
+        versionCode = 5881
+        versionName = "0.58.81"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5881
-        versionName = "0.58.81"
+        versionCode = 5882
+        versionName = "0.58.82"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5882
-        versionName = "0.58.82"
+        versionCode = 5883
+        versionName = "0.58.83"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -690,7 +690,7 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
 
     fun invalidateTeamsCacheAndReload() {
         cachedTeams = null
-        loadTeamsAsync()
+        loginViewModel.loadTeamsAsync(force = true)
     }
 
     private fun resetGuestAsMember(username: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -23,6 +23,9 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.activity.viewModels
+import org.ole.planet.myplanet.ui.sync.viewmodel.LoginViewModel
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import com.afollestad.materialdialogs.MaterialDialog
 import com.bumptech.glide.Glide
 import com.google.android.material.snackbar.Snackbar
@@ -80,11 +83,36 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
     private var teamAdapter: ArrayAdapter<String?>? = null
     private var isUserInteracting = false
     private var cachedTeams: List<RealmMyTeam>? = null
+    private val loginViewModel: LoginViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
         EdgeToEdgeUtils.setupEdgeToEdge(this, binding.root)
+
+        if (mAdapter == null) {
+            mAdapter = UsersAdapter(this@LoginActivity)
+            binding.recyclerView.layoutManager = LinearLayoutManager(this@LoginActivity)
+            binding.recyclerView.adapter = mAdapter
+        }
+
+        collectLatestWhenStarted(loginViewModel.savedUsers) { savedUsers ->
+            mAdapter?.submitList(savedUsers.toMutableList())
+            val hasUsers = savedUsers.isNotEmpty()
+            binding.tvWelcome.setText(if (hasUsers) R.string.welcome_back else R.string.welcome_new)
+            binding.tvSubtitle.setText(if (hasUsers) R.string.sign_in_to_continue else R.string.sign_in_to_get_started)
+        }
+
+        collectLatestWhenStarted(loginViewModel.users) { realmUsers ->
+            users = realmUsers
+        }
+
+        collectLatestWhenStarted(loginViewModel.teams) { teams ->
+            cachedTeams = teams
+            if (teams.isNotEmpty()) {
+                setupTeamDropdown(teams)
+            }
+        }
 
         bindViews()
         setupAvailableSpace()
@@ -419,15 +447,7 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
     }
 
     fun loadTeamsAsync() {
-        if (cachedTeams != null) {
-            setupTeamDropdown(cachedTeams)
-            return
-        }
-        lifecycleScope.launch {
-            val teams = teamsRepository.getAllActiveTeams()
-            cachedTeams = teams
-            setupTeamDropdown(teams)
-        }
+        loginViewModel.loadTeamsAsync()
     }
 
     private fun setupTeamDropdown(teams: List<RealmMyTeam>?) {
@@ -545,30 +565,13 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
     }
 
     fun getTeamMembers() {
-        lifecycleScope.launch {
-            selectedTeamId = prefData.getSelectedTeamId().toString()
-            val teamId = selectedTeamId
-            if (!teamId.isNullOrEmpty()) {
-                users = teamsRepository.getJoinedMembersAndSave(teamId)
-            }
-            setupAndPopulateRecyclerView()
-        }
+        selectedTeamId = prefData.getSelectedTeamId().toString()
+        val teamId = selectedTeamId
+        loginViewModel.getTeamMembers(teamId)
+        setupAndPopulateRecyclerView()
     }
 
-    private suspend fun setupAndPopulateRecyclerView() {
-        if (mAdapter == null) {
-            mAdapter = UsersAdapter(this@LoginActivity)
-            binding.recyclerView.layoutManager = LinearLayoutManager(this@LoginActivity)
-            binding.recyclerView.adapter = mAdapter
-        }
-
-        val savedUsers = withContext(dispatcherProvider.io) { prefData.getSavedUsers().toMutableList() }
-        mAdapter?.submitList(savedUsers)
-
-        val hasUsers = savedUsers.isNotEmpty()
-        binding.tvWelcome.setText(if (hasUsers) R.string.welcome_back else R.string.welcome_new)
-        binding.tvSubtitle.setText(if (hasUsers) R.string.sign_in_to_continue else R.string.sign_in_to_get_started)
-
+    private fun setupAndPopulateRecyclerView() {
         binding.recyclerView.isNestedScrollingEnabled = true
         binding.recyclerView.scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
         binding.recyclerView.isVerticalScrollBarEnabled = true
@@ -658,49 +661,17 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
 
     fun saveUsers(name: String?, password: String?, source: String) {
         lifecycleScope.launch {
-            val encryptedPassword = if (password?.isNotEmpty() == true) {
-                SecurePrefs.encryptString(this@LoginActivity, password)
-            } else {
-                password
-            }
-            val existingUsers: MutableList<User> = ArrayList(prefData.getSavedUsers())
-            if (source == "guest") {
-                val newUser = User("", name, encryptedPassword, "", "guest")
-                var newUserIndex = -1
-                for (i in existingUsers.indices) {
-                    if (existingUsers[i].name == newUser.name?.trim { it <= ' ' }) {
-                        newUserIndex = i
-                        break
-                    }
-                }
-                if (newUserIndex != -1) {
-                    existingUsers[newUserIndex] = newUser
+            val encryptedPassword = withContext(dispatcherProvider.io) {
+                if (password?.isNotEmpty() == true) {
+                    SecurePrefs.encryptString(this@LoginActivity, password)
                 } else {
-                    existingUsers.add(newUser)
+                    password
                 }
-                prefData.setSavedUsers(existingUsers)
-            } else if (source == "member") {
-                val userModel = profileDbHandler.getUserModel()
-                var userProfile = userModel?.userImage
-                val userName: String? = userModel?.name
-                if (userProfile == null) {
-                    userProfile = ""
-                }
-                val newUser = User(userName, name, encryptedPassword, userProfile, "member")
-                var newUserIndex = -1
-                for (i in existingUsers.indices) {
-                    if (existingUsers[i].fullName == newUser.fullName?.trim { it <= ' ' }) {
-                        newUserIndex = i
-                        break
-                    }
-                }
-                if (newUserIndex != -1) {
-                    existingUsers[newUserIndex] = newUser
-                } else {
-                    existingUsers.add(newUser)
-                }
-                prefData.setSavedUsers(existingUsers)
             }
+            val userModel = profileDbHandler.getUserModel()
+            val userProfile = userModel?.userImage ?: ""
+            val userName = userModel?.name
+            loginViewModel.saveUsers(name, encryptedPassword, source, userProfile, userName)
         }
     }
 
@@ -723,24 +694,7 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
     }
 
     private fun resetGuestAsMember(username: String?) {
-        val existingUsers = prefData.getSavedUsers().toMutableList()
-        var newUserExists = false
-        for ((_, name) in existingUsers) {
-            if (name == username) {
-                newUserExists = true
-                break
-            }
-        }
-        if (newUserExists) {
-            val iterator = existingUsers.iterator()
-            while (iterator.hasNext()) {
-                val (_, name) = iterator.next()
-                if (name == username) {
-                    iterator.remove()
-                }
-            }
-            prefData.setSavedUsers(existingUsers)
-        }
+        loginViewModel.resetGuestAsMember(username)
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -24,7 +24,6 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.activity.viewModels
-import org.ole.planet.myplanet.ui.sync.viewmodel.LoginViewModel
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import com.afollestad.materialdialogs.MaterialDialog
 import com.bumptech.glide.Glide

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginViewModel.kt
@@ -1,4 +1,4 @@
-package org.ole.planet.myplanet.ui.sync.viewmodel
+package org.ole.planet.myplanet.ui.sync
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/viewmodel/LoginViewModel.kt
@@ -1,0 +1,128 @@
+package org.ole.planet.myplanet.ui.sync.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.RealmMyTeam
+import org.ole.planet.myplanet.model.RealmUser
+import org.ole.planet.myplanet.model.User
+import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.utils.DispatcherProvider
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val teamsRepository: TeamsRepository,
+    private val sharedPrefManager: SharedPrefManager,
+    private val dispatcherProvider: DispatcherProvider
+) : ViewModel() {
+
+    private val _teams = MutableStateFlow<List<RealmMyTeam>>(emptyList())
+    val teams: StateFlow<List<RealmMyTeam>> = _teams.asStateFlow()
+
+    private val _users = MutableStateFlow<List<RealmUser>>(emptyList())
+    val users: StateFlow<List<RealmUser>> = _users.asStateFlow()
+
+    private val _savedUsers = MutableStateFlow<List<User>>(emptyList())
+    val savedUsers: StateFlow<List<User>> = _savedUsers.asStateFlow()
+
+    init {
+        loadSavedUsers()
+    }
+
+    fun loadTeamsAsync() {
+        if (_teams.value.isNotEmpty()) {
+            return
+        }
+        viewModelScope.launch { // Launch on main to safely emit Realm objects
+            val teamsList = teamsRepository.getAllActiveTeams()
+            _teams.value = teamsList
+        }
+    }
+
+    fun getTeamMembers(teamId: String?) {
+        viewModelScope.launch { // Launch on main to safely emit Realm objects
+            if (!teamId.isNullOrEmpty()) {
+                val teamMembers = teamsRepository.getJoinedMembersAndSave(teamId)
+                _users.value = teamMembers
+            } else {
+                _users.value = emptyList()
+            }
+        }
+    }
+
+    fun loadSavedUsers() {
+        viewModelScope.launch(dispatcherProvider.io) {
+            _savedUsers.value = sharedPrefManager.getSavedUsers()
+        }
+    }
+
+    fun saveUsers(name: String?, encryptedPassword: String?, source: String, userProfile: String?, userName: String?) {
+        viewModelScope.launch(dispatcherProvider.io) {
+            val existingUsers: MutableList<User> = ArrayList(sharedPrefManager.getSavedUsers())
+            if (source == "guest") {
+                val newUser = User("", name, encryptedPassword, "", "guest")
+                var newUserIndex = -1
+                for (i in existingUsers.indices) {
+                    if (existingUsers[i].name == newUser.name?.trim { it <= ' ' }) {
+                        newUserIndex = i
+                        break
+                    }
+                }
+                if (newUserIndex != -1) {
+                    existingUsers[newUserIndex] = newUser
+                } else {
+                    existingUsers.add(newUser)
+                }
+                sharedPrefManager.setSavedUsers(existingUsers)
+            } else if (source == "member") {
+
+                val newUser = User(userName, name, encryptedPassword, userProfile, "member")
+                var newUserIndex = -1
+                for (i in existingUsers.indices) {
+                    if (existingUsers[i].fullName == newUser.fullName?.trim { it <= ' ' }) {
+                        newUserIndex = i
+                        break
+                    }
+                }
+                if (newUserIndex != -1) {
+                    existingUsers[newUserIndex] = newUser
+                } else {
+                    existingUsers.add(newUser)
+                }
+                sharedPrefManager.setSavedUsers(existingUsers)
+            }
+            loadSavedUsers()
+        }
+    }
+
+    fun resetGuestAsMember(username: String?) {
+        viewModelScope.launch(dispatcherProvider.io) {
+            val existingUsers = sharedPrefManager.getSavedUsers().toMutableList()
+            var newUserExists = false
+            for ((_, name) in existingUsers) {
+                if (name == username) {
+                    newUserExists = true
+                    break
+                }
+            }
+            if (newUserExists) {
+                val iterator = existingUsers.iterator()
+                while (iterator.hasNext()) {
+                    val (_, name) = iterator.next()
+                    if (name == username) {
+                        iterator.remove()
+                    }
+                }
+                sharedPrefManager.setSavedUsers(existingUsers)
+                loadSavedUsers()
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/viewmodel/LoginViewModel.kt
@@ -36,8 +36,8 @@ class LoginViewModel @Inject constructor(
         loadSavedUsers()
     }
 
-    fun loadTeamsAsync() {
-        if (_teams.value.isNotEmpty()) {
+    fun loadTeamsAsync(force: Boolean = false) {
+        if (!force && _teams.value.isNotEmpty()) {
             return
         }
         viewModelScope.launch { // Launch on main to safely emit Realm objects
@@ -51,6 +51,7 @@ class LoginViewModel @Inject constructor(
             if (!teamId.isNullOrEmpty()) {
                 val teamMembers = teamsRepository.getJoinedMembersAndSave(teamId)
                 _users.value = teamMembers
+                loadSavedUsers() // Refresh saved users after joining team
             } else {
                 _users.value = emptyList()
             }


### PR DESCRIPTION
This commit refactors `LoginActivity.kt` by moving its data fetching and manipulation logic into a new, dedicated `LoginViewModel.kt`.

* Created `LoginViewModel` with `@HiltViewModel` for dependency injection.
* Migrated `loadTeamsAsync`, `getTeamMembers`, `loadSavedUsers`, `saveUsers`, and `resetGuestAsMember` to the ViewModel.
* Added `StateFlow` variables (`teams`, `users`, `savedUsers`) to reactively publish state to the Activity.
* Updated `LoginActivity.kt` to inject the ViewModel and observe flows securely via `collectLatestWhenStarted`.
* Solved thread-safety constraints by guaranteeing that `profileDbHandler.getUserModel()` runs on the Main thread, and only primitive data (Strings) are passed into the ViewModel.
* Avoided adapter update race conditions by verifying early `mAdapter` instantiation in `onCreate()`.

---
*PR created automatically by Jules for task [5607689539237907707](https://jules.google.com/task/5607689539237907707) started by @dogi*