### PR TITLE
all: smoother view modelling (fixes #14235)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5874
+        versionName = "0.58.74"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
@@ -87,16 +87,16 @@ class ChatViewModel @Inject constructor(
         communityName: String?
     ) {
         viewModelScope.launch {
-            val data = withContext(dispatcherProvider.io) {
-                val currentUser = cachedUser ?: loadCurrentUser(userId).also { cachedUser = it }
-                val newsMessages = voicesRepository.getPlanetNewsMessages(currentUser?.planetCode)
-                val chatHistory = chatRepository.getChatHistoryForUser(currentUser?.name)
-                val targets = cachedShareTargets ?: loadShareTargets(parentCode, communityName, currentUser?._id).also { cachedShareTargets = it }
+            val currentUser = cachedUser ?: loadCurrentUser(userId).also { cachedUser = it }
+            val newsMessages = voicesRepository.getPlanetNewsMessages(currentUser?.planetCode)
+            val chatHistory = chatRepository.getChatHistoryForUser(currentUser?.name)
+            val targets = cachedShareTargets ?: loadShareTargets(parentCode, communityName, currentUser?._id).also { cachedShareTargets = it }
 
+            withContext(dispatcherProvider.default) {
                 allChats = sortChats(chatHistory)
                 precomputedChats = buildPrecomputedChats(allChats)
-                ChatHistoryScreenData(currentUser, chatHistory, newsMessages, targets)
             }
+            val data = ChatHistoryScreenData(currentUser, chatHistory, newsMessages, targets)
             _screenData.value = data
             _filteredChats.value = allChats
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
@@ -111,20 +111,16 @@ class TeamViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            withContext(dispatcherProvider.io) {
-                teamsRepository.requestToJoin(teamId, userId, userPlanetCode, teamType)
-                teamsSyncRepository.syncTeamActivities()
-            }
+            teamsRepository.requestToJoin(teamId, userId, userPlanetCode, teamType)
+            teamsSyncRepository.syncTeamActivities()
             loadTeams(currentFromDashboard, currentType, currentUserId)
         }
     }
 
     fun leaveTeam(teamId: String, userId: String?) {
         viewModelScope.launch {
-            withContext(dispatcherProvider.io) {
-                teamsRepository.leaveTeam(teamId, userId)
-                teamsSyncRepository.syncTeamActivities()
-            }
+            teamsRepository.leaveTeam(teamId, userId)
+            teamsSyncRepository.syncTeamActivities()
             loadTeams(currentFromDashboard, currentType, currentUserId)
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModel.kt
@@ -38,10 +38,10 @@ class TeamsVoicesViewModel @Inject constructor(
 
     private var observeJob: kotlinx.coroutines.Job? = null
 
-    suspend fun getFilteredNews(teamId: String): List<RealmNews?> = withContext(dispatcherProvider.io) {
+    suspend fun getFilteredNews(teamId: String): List<RealmNews?> {
         val newsList = voicesRepository.getFilteredNews(teamId)
         voicesRepository.updateTeamNotification(teamId, newsList.size)
-        newsList
+        return newsList
     }
 
     fun observeDiscussions(teamId: String) {
@@ -60,16 +60,16 @@ class TeamsVoicesViewModel @Inject constructor(
         }
     }
 
-    suspend fun isTeamLeader(teamId: String, userId: String?): Boolean = withContext(dispatcherProvider.io) {
-        teamsRepository.isTeamLeader(teamId, userId)
+    suspend fun isTeamLeader(teamId: String, userId: String?): Boolean {
+        return teamsRepository.isTeamLeader(teamId, userId)
     }
 
-    suspend fun getUserById(userId: String): RealmUser? = withContext(dispatcherProvider.io) {
-        userRepository.getUserById(userId)
+    suspend fun getUserById(userId: String): RealmUser? {
+        return userRepository.getUserById(userId)
     }
 
-    suspend fun getReplyCount(newsId: String): Int = withContext(dispatcherProvider.io) {
-        voicesRepository.getReplyCount(newsId)
+    suspend fun getReplyCount(newsId: String): Int {
+        return voicesRepository.getReplyCount(newsId)
     }
 
     /**
@@ -78,7 +78,7 @@ class TeamsVoicesViewModel @Inject constructor(
      * and the adapter callback will not fire. This limitation is accepted to keep the adapter
      * interface simple without needing complex Flow correlation for individual items.
      */
-    suspend fun deletePost(newsId: String, teamName: String) = withContext(dispatcherProvider.io) {
+    suspend fun deletePost(newsId: String, teamName: String) {
         voicesRepository.deletePost(newsId, teamName)
     }
 
@@ -88,12 +88,12 @@ class TeamsVoicesViewModel @Inject constructor(
      * and the adapter callback will not fire. This limitation is accepted to keep the adapter
      * interface simple without needing complex Flow correlation for individual items.
      */
-    suspend fun shareNewsToCommunity(newsId: String, userId: String, planetCode: String, parentCode: String, teamName: String): Result<Unit> = withContext(dispatcherProvider.io) {
-        voicesRepository.shareNewsToCommunity(newsId, userId, planetCode, parentCode, teamName)
+    suspend fun shareNewsToCommunity(newsId: String, userId: String, planetCode: String, parentCode: String, teamName: String): Result<Unit> {
+        return voicesRepository.shareNewsToCommunity(newsId, userId, planetCode, parentCode, teamName)
     }
 
-    suspend fun getLibraryResource(resourceId: String): RealmMyLibrary? = withContext(dispatcherProvider.io) {
-        voicesRepository.getLibraryResource(resourceId)
+    suspend fun getLibraryResource(resourceId: String): RealmMyLibrary? {
+        return voicesRepository.getLibraryResource(resourceId)
     }
 
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/LabelManipulator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/LabelManipulator.kt
@@ -14,14 +14,10 @@ class DefaultLabelManipulator(
     private val dispatcherProvider: DispatcherProvider
 ) : LabelManipulator {
     override suspend fun addLabel(newsId: String, label: String) {
-        withContext(dispatcherProvider.io) {
-            voicesRepository.addLabel(newsId, label)
-        }
+        voicesRepository.addLabel(newsId, label)
     }
 
     override suspend fun removeLabel(newsId: String, label: String) {
-        withContext(dispatcherProvider.io) {
-            voicesRepository.removeLabel(newsId, label)
-        }
+        voicesRepository.removeLabel(newsId, label)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
@@ -23,9 +23,7 @@ class NewsViewModel @Inject constructor(
 
     fun getPrivateImageUrlsCreatedAfter(timestamp: Long) {
         viewModelScope.launch {
-            val urls = withContext(dispatcherProvider.io) {
-                voicesRepository.getPrivateImageUrlsCreatedAfter(timestamp)
-            }
+            val urls = voicesRepository.getPrivateImageUrlsCreatedAfter(timestamp)
             _privateImageUrls.emit(urls)
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesViewModel.kt
@@ -27,9 +27,7 @@ class VoicesViewModel @Inject constructor(
 
     fun deletePost(newsId: String, teamName: String, onComplete: () -> Unit) {
         viewModelScope.launch {
-            withContext(dispatcherProvider.io) {
-                voicesRepository.deletePost(newsId, teamName)
-            }
+            voicesRepository.deletePost(newsId, teamName)
             onComplete()
         }
     }
@@ -43,9 +41,7 @@ class VoicesViewModel @Inject constructor(
         onResult: (Result<Unit>) -> Unit
     ) {
         viewModelScope.launch {
-            val result = withContext(dispatcherProvider.io) {
-                voicesRepository.shareNewsToCommunity(newsId, userId, planetCode, parentCode, teamName)
-            }
+            val result = voicesRepository.shareNewsToCommunity(newsId, userId, planetCode, parentCode, teamName)
             onResult(result)
         }
     }
@@ -53,34 +49,26 @@ class VoicesViewModel @Inject constructor(
     // Note: The following are read-only suspend functions designed to be called directly from
     // the UI's lifecycleScope, avoiding intermediate MutableStateFlow caching for point-in-time reads.
     suspend fun getUserById(userId: String): RealmUser? {
-        return withContext(dispatcherProvider.io) {
-            userRepository.getUserById(userId)
-        }
+        return userRepository.getUserById(userId)
     }
 
     suspend fun getReplyCount(newsId: String): Int {
-        return withContext(dispatcherProvider.io) {
-            try {
-                voicesRepository.getReplyCount(newsId)
-            } catch (e: Exception) {
-                0
-            }
+        return try {
+            voicesRepository.getReplyCount(newsId)
+        } catch (e: Exception) {
+            0
         }
     }
 
     suspend fun getLibraryResource(resourceId: String): RealmMyLibrary? {
-        return withContext(dispatcherProvider.io) {
-            voicesRepository.getLibraryResource(resourceId)
-        }
+        return voicesRepository.getLibraryResource(resourceId)
     }
 
     suspend fun isTeamLeader(teamId: String?, userId: String?): Boolean {
-        return withContext(dispatcherProvider.io) {
-            try {
-                if (teamId != null) teamsRepository.isTeamLeader(teamId, userId) else false
-            } catch (e: Exception) {
-                false
-            }
+        return try {
+            if (teamId != null) teamsRepository.isTeamLeader(teamId, userId) else false
+        } catch (e: Exception) {
+            false
         }
     }
 


### PR DESCRIPTION
The goal of this change is to clean up unnecessary coroutine context switches in ViewModels. Many repository methods being called were already `suspend` functions executing their heavy work safely off the main thread (e.g., using `executeTransaction` or `withRealm`), making the outer `withContext(dispatcherProvider.io)` in the ViewModel redundant and slightly inefficient. We preserved context switches specifically for true local blocking work (like JSON parsing) and CPU-bound work (like searching and sorting strings).

---
*PR created automatically by Jules for task [6198679307186853060](https://jules.google.com/task/6198679307186853060) started by @dogi*