### PR TITLE
resources: smoother tag repository list inserting (fixes #14218)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5820
-        versionName = "0.58.20"
+        versionCode = 5840
+        versionName = "0.58.40"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
@@ -11,5 +11,5 @@ interface TagsRepository {
     suspend fun getLinkedCourseIds(db: String, tagIds: Array<String>): Set<String>
     suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<RealmTag>>
     fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
-    suspend fun insert(act: com.google.gson.JsonObject)
+    suspend fun insert(documentList: List<com.google.gson.JsonObject>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
@@ -150,15 +150,20 @@ class TagsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun insert(act: com.google.gson.JsonObject) {
+    override suspend fun insert(documentList: List<com.google.gson.JsonObject>) {
+        if (documentList.isEmpty()) return
         executeTransaction { realm ->
-            val id = org.ole.planet.myplanet.utils.JsonUtils.getString("_id", act)
+            val ids = documentList.map { org.ole.planet.myplanet.utils.JsonUtils.getString("_id", it) }.filter { it.isNotEmpty() }
             val tagCache = mutableMapOf<String, RealmTag>()
-            val existingTag = realm.where(RealmTag::class.java).equalTo("_id", id).findFirst()
-            if (existingTag != null) {
-                existingTag._id?.let { tagCache[it] = existingTag }
+            if (ids.isNotEmpty()) {
+                val existingTags = realm.where(RealmTag::class.java).`in`("_id", ids.toTypedArray()).findAll()
+                for (tag in existingTags) {
+                    tag._id?.let { tagCache[it] = tag }
+                }
             }
-            insertIntoRealm(realm, act, tagCache)
+            for (act in documentList) {
+                insertIntoRealm(realm, act, tagCache)
+            }
         }
     }
 


### PR DESCRIPTION
💡 **What:** 
Modified the `TagsRepository` interface and its implementation to change `insert(act: JsonObject)` to `insert(documentList: List<JsonObject>)`. Implemented a `tagCache` prepopulation logic using a bulk `.in()` query on `_id` to avoid N+1 queries during document loops.

🎯 **Why:** 
The issue identified an N+1 query vulnerability when iterating through document lists and processing each `JsonObject` through `insert()`. By extracting the IDs and fetching existing tags with a single `realm.where(RealmTag::class.java).in(...)` call before iterating over insertions, we significantly optimize database operations.

📊 **Measured Improvement:** 
The execution logic now performs 1 query instead of N queries for fetching existing tags across batched inputs. For large sync datasets, this directly reduces disk I/O and synchronous database locking times proportional to the size of the incoming batch. Since this repository method had zero callers outside of testing (the bulk of tag insertion uses `bulkInsertFromSync`), this optimization proactively hardens the `insert` API for future batch insertion usage without risking regressions in the current system.

---
*PR created automatically by Jules for task [8754725149847344155](https://jules.google.com/task/8754725149847344155) started by @dogi*