### PR TITLE
sync: smoother network timeout handling (fixes #14228)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5861
-        versionName = "0.58.61"
+        versionCode = 5875
+        versionName = "0.58.75"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
@@ -42,6 +42,9 @@ annotation class StandardRetrofit
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
+    private const val CONNECT_TIMEOUT_SECONDS = 10L
+    private const val READ_TIMEOUT_SECONDS = 60L
+    private const val WRITE_TIMEOUT_SECONDS = 120L
 
     @Provides
     @Singleton
@@ -70,7 +73,12 @@ object NetworkModule {
     @Singleton
     @StandardHttpClient
     fun provideStandardOkHttpClient(broadcastService: BroadcastService): OkHttpClient {
-        return buildOkHttpClient(10, 10, 10, RetryInterceptor(broadcastService))
+        return buildOkHttpClient(
+            CONNECT_TIMEOUT_SECONDS,
+            READ_TIMEOUT_SECONDS,
+            WRITE_TIMEOUT_SECONDS,
+            RetryInterceptor(broadcastService)
+        )
     }
 
     @Provides


### PR DESCRIPTION
fixes #14228
```
- Connect: still 10 seconds. If a server is offline, the app still figures that out fast — no waiting around. (This is what the "is the server reachable?" logic depends on, so I  
didn't touch it.)                                                                                                                                                                  
- Read: now 60 seconds. The app waits longer for the server to send big responses.                                                                                                 
- Write: now 120 seconds. The app waits longer to finish uploading big files.
```