### PR TITLE
all: smoother time utils providing (fixes #14247)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5888
-        versionName = "0.58.88"
+        versionCode = 5893
+        versionName = "0.58.93"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.BuildConfig
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.Utilities
 
 abstract class BasePermissionActivity : AppCompatActivity() {
@@ -30,6 +31,8 @@ abstract class BasePermissionActivity : AppCompatActivity() {
     open lateinit var sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager
     @Inject
     open lateinit var dispatcherProvider: DispatcherProvider
+    @Inject
+    open lateinit var timeProvider: TimeProvider
 
     fun checkPermission(strPermission: String?): Boolean {
         val result = strPermission?.let { ContextCompat.checkSelfPermission(this, it) }
@@ -438,7 +441,7 @@ abstract class BasePermissionActivity : AppCompatActivity() {
 
     fun checkNotificationPermissionStatus() {
         lifecycleScope.launch {
-            val currentTime = System.currentTimeMillis()
+            val currentTime = timeProvider.now()
             val lastCheck = withContext(dispatcherProvider.io) {
                 sharedPrefManager.getRawLong("last_notification_check", 0)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -51,12 +51,13 @@ object ServiceModule {
         @ApplicationScope scope: CoroutineScope,
         activitiesRepository: org.ole.planet.myplanet.repository.ActivitiesRepository,
         dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider,
+        timeProvider: org.ole.planet.myplanet.utils.TimeProvider,
         teamsRepository: org.ole.planet.myplanet.repository.TeamsRepository,
         teamsSyncRepository: org.ole.planet.myplanet.repository.TeamsSyncRepository,
         coursesRepository: org.ole.planet.myplanet.repository.CoursesRepository,
         eventsRepository: org.ole.planet.myplanet.repository.EventsRepository
     ): SyncManager {
-        return SyncManager(context, sharedPrefManager, apiInterface, improvedSyncManager, transactionSyncManager, resourcesRepository, loginSyncManager, scope, activitiesRepository, dispatcherProvider, teamsRepository, teamsSyncRepository, coursesRepository, eventsRepository)
+        return SyncManager(context, sharedPrefManager, apiInterface, improvedSyncManager, transactionSyncManager, resourcesRepository, loginSyncManager, scope, activitiesRepository, dispatcherProvider, timeProvider, teamsRepository, teamsSyncRepository, coursesRepository, eventsRepository)
     }
 
     @Provides
@@ -80,9 +81,10 @@ object ServiceModule {
         @ApplicationScope scope: CoroutineScope,
         dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider,
         photoUploader: org.ole.planet.myplanet.services.upload.PhotoUploader,
-        achievementUploader: org.ole.planet.myplanet.services.upload.AchievementUploader
+        achievementUploader: org.ole.planet.myplanet.services.upload.AchievementUploader,
+        timeProvider: org.ole.planet.myplanet.utils.TimeProvider
     ): UploadManager {
-        return UploadManager(context, submissionsRepository, sharedPrefManager, gson, uploadCoordinator, personalsRepository, userRepository, chatRepository, voicesRepository, uploadConfigs, resourcesRepository, teamsRepository, teamsSyncRepository, apiInterface, activitiesRepository, dispatcherProvider, scope, photoUploader, achievementUploader)
+        return UploadManager(context, submissionsRepository, sharedPrefManager, gson, uploadCoordinator, personalsRepository, userRepository, chatRepository, voicesRepository, uploadConfigs, resourcesRepository, teamsRepository, teamsSyncRepository, apiInterface, activitiesRepository, dispatcherProvider, scope, photoUploader, achievementUploader, timeProvider)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/di/TimeModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/TimeModule.kt
@@ -1,0 +1,17 @@
+package org.ole.planet.myplanet.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import org.ole.planet.myplanet.utils.SystemTimeProvider
+import org.ole.planet.myplanet.utils.TimeProvider
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TimeModule {
+    @Provides
+    @Singleton
+    fun provideTimeProvider(): TimeProvider = SystemTimeProvider()
+}

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -27,6 +27,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.NetworkUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 
 class ActivitiesRepositoryImpl @Inject constructor(
@@ -36,7 +37,8 @@ class ActivitiesRepositoryImpl @Inject constructor(
     private val teamsRepository: Lazy<TeamsRepository>,
     private val userRepository: Lazy<UserRepository>,
     private val apiInterface: ApiInterface,
-    private val sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager
+    private val sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager,
+    private val timeProvider: TimeProvider
 ) : RealmRepository(databaseService, realmDispatcher), ActivitiesRepository {
     override suspend fun getOfflineActivities(userName: String, type: String): List<RealmOfflineActivity> {
         return queryList(RealmOfflineActivity::class.java) {
@@ -248,7 +250,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
             action.userId = userId
             action.actionType = "sync"
             action.resourceId = null
-            action.time = System.currentTimeMillis()
+            action.time = timeProvider.now()
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -35,6 +35,7 @@ import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.Sha256Utils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.VersionUtils
 
@@ -47,7 +48,8 @@ class ConfigurationsRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
     private val serverUrlMapper: ServerUrlMapper,
     private val dispatcherProvider: DispatcherProvider,
-    @RealmDispatcher realmDispatcher: CoroutineDispatcher
+    @RealmDispatcher realmDispatcher: CoroutineDispatcher,
+    private val timeProvider: TimeProvider
 ) : RealmRepository(databaseService, realmDispatcher), ConfigurationsRepository {
     private val serverAvailabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
 
@@ -97,7 +99,7 @@ class ConfigurationsRepositoryImpl @Inject constructor(
             callback.onCheckingVersion()
 
             val lastCheckTime = sharedPrefManager.rawPreferences.getLong("last_version_check_timestamp", 0)
-            val currentTime = System.currentTimeMillis()
+            val currentTime = timeProvider.now()
             val twentyFourHoursInMillis = 24 * 60 * 60 * 1000
 
             if (currentTime - lastCheckTime < twentyFourHoursInMillis) {
@@ -123,7 +125,7 @@ class ConfigurationsRepositoryImpl @Inject constructor(
                 }
 
                 sharedPrefManager.rawPreferences.edit {
-                    putLong("last_version_check_timestamp", System.currentTimeMillis())
+                    putLong("last_version_check_timestamp", timeProvider.now())
                 }
                 sharedPrefManager.setLastWifiId(NetworkUtils.getCurrentNetworkId(context))
                 sharedPrefManager.setVersionDetail(JsonUtils.gson.toJson(planetInfo))
@@ -161,7 +163,7 @@ class ConfigurationsRepositoryImpl @Inject constructor(
     override suspend fun checkServerAvailability(): Boolean {
         val updateUrl = sharedPrefManager.getServerUrl()
         serverAvailabilityCache[updateUrl]?.let { (available, timestamp) ->
-            if (System.currentTimeMillis() - timestamp < 30000) {
+            if (timeProvider.now() - timestamp < 30000) {
                 return available
             }
         }
@@ -193,7 +195,7 @@ class ConfigurationsRepositoryImpl @Inject constructor(
             }
         }
 
-        serverAvailabilityCache[updateUrl] = Pair(result, System.currentTimeMillis())
+        serverAvailabilityCache[updateUrl] = Pair(result, timeProvider.now())
         return result
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -14,12 +14,14 @@ import org.ole.planet.myplanet.model.RealmTeamNotification
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.TaskNotificationResult
 import org.ole.planet.myplanet.model.TeamNotificationInfo
+import org.ole.planet.myplanet.utils.TimeProvider
 
 class NotificationsRepositoryImpl @Inject constructor(
         databaseService: DatabaseService,
     @RealmDispatcher realmDispatcher: CoroutineDispatcher,
     private val userRepository: Lazy<UserRepository>,
-    private val teamsRepository: Lazy<TeamsRepository>
+    private val teamsRepository: Lazy<TeamsRepository>,
+    private val timeProvider: TimeProvider
 ) : RealmRepository(databaseService, realmDispatcher), NotificationsRepository {
     override suspend fun refresh() {
         withRealm { it.refresh() }
@@ -314,7 +316,7 @@ class NotificationsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getTeamNotificationInfo(teamId: String, userId: String): TeamNotificationInfo {
-        val current = System.currentTimeMillis()
+        val current = timeProvider.now()
         val tomorrow = Calendar.getInstance()
         tomorrow.add(Calendar.DAY_OF_YEAR, 1)
 
@@ -382,7 +384,7 @@ class NotificationsRepositoryImpl @Inject constructor(
         }
 
         // 3. Fetch all relevant tasks once
-        val current = System.currentTimeMillis()
+        val current = timeProvider.now()
         val tomorrow = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 1) }
         val tasks = queryList(RealmTeamTask::class.java) {
             equalTo("assignee", userId)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepositoryImpl.kt
@@ -7,10 +7,12 @@ import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmRetryOperation
 import org.ole.planet.myplanet.model.RetryFailure
 import org.ole.planet.myplanet.repository.RealmRepository
+import org.ole.planet.myplanet.utils.TimeProvider
 
 class RetryRepositoryImpl @Inject constructor(
     databaseService: DatabaseService,
-    @RealmDispatcher realmDispatcher: CoroutineDispatcher
+    @RealmDispatcher realmDispatcher: CoroutineDispatcher,
+    private val timeProvider: TimeProvider
 ) : RealmRepository(databaseService, realmDispatcher), RetryRepository {
 
     override suspend fun enqueue(
@@ -40,7 +42,7 @@ class RetryRepositoryImpl @Inject constructor(
                 .equalTo("id", operationId)
                 .findFirst()?.let { op ->
                     op.attemptCount += 1
-                    op.lastAttemptTime = System.currentTimeMillis()
+                    op.lastAttemptTime = timeProvider.now()
                     op.nextRetryTime = RealmRetryOperation.calculateNextRetryTime(op.attemptCount)
                     op.errorMessage = failure.message
                     op.httpCode = failure.httpCode
@@ -68,7 +70,7 @@ class RetryRepositoryImpl @Inject constructor(
                 .equalTo("id", operationId)
                 .findFirst()?.let { op ->
                     op.status = RealmRetryOperation.STATUS_COMPLETED
-                    op.lastAttemptTime = System.currentTimeMillis()
+                    op.lastAttemptTime = timeProvider.now()
                 }
         }
     }
@@ -79,7 +81,7 @@ class RetryRepositoryImpl @Inject constructor(
                 .equalTo("id", operationId)
                 .findFirst()?.let { op ->
                     op.attemptCount += 1
-                    op.lastAttemptTime = System.currentTimeMillis()
+                    op.lastAttemptTime = timeProvider.now()
                     op.errorMessage = errorMessage
                     op.httpCode = httpCode
 
@@ -97,7 +99,7 @@ class RetryRepositoryImpl @Inject constructor(
         return withRealmAsync { realm ->
             val results = realm.where(RealmRetryOperation::class.java)
                 .equalTo("status", RealmRetryOperation.STATUS_PENDING)
-                .lessThanOrEqualTo("nextRetryTime", System.currentTimeMillis())
+                .lessThanOrEqualTo("nextRetryTime", timeProvider.now())
                 .findAll()
 
             results.filter { it.attemptCount < it.maxAttempts }
@@ -117,7 +119,7 @@ class RetryRepositoryImpl @Inject constructor(
 
     override suspend fun cleanup() {
         executeTransaction { realm ->
-            val cutoffTime = System.currentTimeMillis() - 24 * 60 * 60 * 1000L
+            val cutoffTime = timeProvider.now() - 24 * 60 * 60 * 1000L
             realm.where(RealmRetryOperation::class.java)
                 .equalTo("status", RealmRetryOperation.STATUS_COMPLETED)
                 .lessThan("lastAttemptTime", cutoffTime)
@@ -132,7 +134,7 @@ class RetryRepositoryImpl @Inject constructor(
                 .equalTo("status", RealmRetryOperation.STATUS_PENDING)
                 .findAll()
                 .forEach { op ->
-                    op.nextRetryTime = System.currentTimeMillis()
+                    op.nextRetryTime = timeProvider.now()
                 }
         }
     }
@@ -167,7 +169,7 @@ class RetryRepositoryImpl @Inject constructor(
                 .findAll()
                 .forEach { op ->
                     op.status = RealmRetryOperation.STATUS_PENDING
-                    op.nextRetryTime = System.currentTimeMillis() + 60_000 // Retry in 1 minute
+                    op.nextRetryTime = timeProvider.now() + 60_000 // Retry in 1 minute
                 }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
@@ -17,11 +17,13 @@ import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmExamQuestion
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils
 
 internal class SubmissionsRepositoryExporter @Inject constructor(
     databaseService: DatabaseService,
-    @RealmDispatcher realmDispatcher: CoroutineDispatcher
+    @RealmDispatcher realmDispatcher: CoroutineDispatcher,
+    private val timeProvider: TimeProvider
 ) : RealmRepository(databaseService, realmDispatcher) {
 
     companion object {
@@ -99,7 +101,7 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
 
                 document.finishPage(page)
 
-                val fileName = "submission_${submission.id}_${System.currentTimeMillis()}.pdf"
+                val fileName = "submission_${submission.id}_${timeProvider.now()}.pdf"
                 val directory = File(context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS), "Submissions")
                 if (!directory.exists()) {
                     directory.mkdirs()
@@ -210,7 +212,7 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
 
                 document.finishPage(page)
 
-                val fileName = "submissions_report_${System.currentTimeMillis()}.pdf"
+                val fileName = "submissions_report_${timeProvider.now()}.pdf"
                 val directory = File(context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS), "Submissions")
                 if (!directory.exists()) {
                     directory.mkdirs()

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
@@ -29,6 +29,7 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.JsonUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 import org.ole.planet.myplanet.utils.TimeUtils.getFormattedDateWithTime
 
@@ -39,6 +40,7 @@ class SurveysRepositoryImpl @Inject constructor(
     private val userSessionManager: UserSessionManager,
     private val sharedPrefManager: SharedPrefManager,
     private val dispatcherProvider: DispatcherProvider,
+    private val timeProvider: TimeProvider,
 ) : RealmRepository(databaseService, realmDispatcher), SurveysRepository {
 
     private val reminderPrefs: SharedPreferences by lazy { context.getSharedPreferences(PREF_SURVEY_REMINDERS, Context.MODE_PRIVATE) }
@@ -186,9 +188,9 @@ class SurveysRepositoryImpl @Inject constructor(
     ) {
         transactionRealm.createObject(RealmStepExam::class.java, newSurveyId).apply {
             this._rev = null
-            this.createdDate = System.currentTimeMillis()
-            this.updatedDate = System.currentTimeMillis()
-            this.adoptionDate = System.currentTimeMillis()
+            this.createdDate = timeProvider.now()
+            this.updatedDate = timeProvider.now()
+            this.adoptionDate = timeProvider.now()
             this.createdBy = userModel?.id
             this.totalMarks = exam.totalMarks
             this.name = "${exam.name} - $teamName"
@@ -228,8 +230,8 @@ class SurveysRepositoryImpl @Inject constructor(
             this.uploaded = false
             this.source = planetCode
             this.parentCode = sParentCode
-            this.startTime = System.currentTimeMillis()
-            this.lastUpdateTime = System.currentTimeMillis()
+            this.startTime = timeProvider.now()
+            this.lastUpdateTime = timeProvider.now()
             this.isUpdated = true
 
             if (isTeam && teamId != null) {
@@ -470,7 +472,7 @@ class SurveysRepositoryImpl @Inject constructor(
 
     override fun dueRemindersFlow(): Flow<List<String>> = flow {
         while (true) {
-            val currentTime = System.currentTimeMillis()
+            val currentTime = timeProvider.now()
             val toShow = mutableListOf<String>()
             val toRemove = mutableListOf<String>()
 
@@ -499,7 +501,7 @@ class SurveysRepositoryImpl @Inject constructor(
     }.flowOn(dispatcherProvider.io)
 
     override suspend fun scheduleSurveyReminder(surveyIds: String, timeUnit: TimeUnit, value: Int) {
-        val currentTime = System.currentTimeMillis()
+        val currentTime = timeProvider.now()
         val reminderTime = currentTime + timeUnit.toMillis(value.toLong())
 
         reminderPrefs.edit {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -44,6 +44,7 @@ import org.ole.planet.myplanet.utils.AndroidDecrypter
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 
 class TeamsRepositoryImpl @Inject constructor(
@@ -59,6 +60,7 @@ class TeamsRepositoryImpl @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val userRepository: UserRepository,
     private val resourcesRepositoryLazy: dagger.Lazy<org.ole.planet.myplanet.repository.ResourcesRepository>,
+    private val timeProvider: TimeProvider,
 ) : RealmRepository(databaseService, realmDispatcher), TeamsRepository, TeamsSyncRepository {
     override fun getTasksFlow(userId: String?): Flow<List<RealmTeamTask>> {
         return queryListFlow(RealmTeamTask::class.java) {
@@ -675,7 +677,7 @@ class TeamsRepositoryImpl @Inject constructor(
             RealmMyTeam.populateReportFields(payload, report)
             report.updated = true
             if (report.updatedDate == 0L) {
-                report.updatedDate = System.currentTimeMillis()
+                report.updatedDate = timeProvider.now()
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/AutoSyncWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/AutoSyncWorker.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.ui.sync.LoginActivity
 import org.ole.planet.myplanet.utils.DialogUtils.startDownloadUpdate
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
 
@@ -40,7 +41,8 @@ class AutoSyncWorker @AssistedInject constructor(
     private val uploadManager: UploadManager,
     private val uploadToShelfService: UploadToShelfService,
     private val configurationsRepository: ConfigurationsRepository,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val timeProvider: TimeProvider
 ) : CoroutineWorker(context, workerParams), OnSyncListener, CheckVersionCallback, OnSuccessListener {
 
     private lateinit var workerScope: CoroutineScope
@@ -50,7 +52,7 @@ class AutoSyncWorker @AssistedInject constructor(
         if (isStopped) return@coroutineScope Result.success()
         workerScope = this
 
-        val currentTime = System.currentTimeMillis()
+        val currentTime = timeProvider.now()
         val lastSync = sharedPrefManager.getLastSync()
         val syncInterval = sharedPrefManager.getAutoSyncInterval()
         if (currentTime - lastSync > syncInterval * 1000) {

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.ActivityManager
 import android.app.NotificationManager
 import android.app.Service
+import android.os.SystemClock
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
@@ -381,7 +382,7 @@ class DownloadService : Service() {
                                 currentFileProgress = progress
                             }
 
-                            val now = System.currentTimeMillis()
+                            val now = SystemClock.elapsedRealtime()
                             if (now - lastNotificationUpdateTime >= NOTIFICATION_UPDATE_INTERVAL_MS) {
                                 download.currentFileSize = current.toInt()
                                 sendNotification(download)

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.services
 
 import android.app.NotificationManager
 import android.content.Context
+import android.os.SystemClock
 import android.content.Intent
 import android.content.SharedPreferences
 import androidx.hilt.work.HiltWorker
@@ -115,7 +116,7 @@ class DownloadWorker @AssistedInject constructor(
                     sink.write(buffer, read)
                     totalBytes += read
 
-                    val now = System.currentTimeMillis()
+                    val now = SystemClock.elapsedRealtime()
                     if (now - lastUpdateTime >= NOTIFICATION_UPDATE_INTERVAL_MS) {
                         val progress = if (fileSize > 0) {
                             (totalBytes * 100 / fileSize).toInt()

--- a/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
@@ -27,6 +27,7 @@ import org.ole.planet.myplanet.services.sync.HeavyTableSyncWorker
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.NetworkUtils
 
 @HiltWorker
@@ -37,7 +38,8 @@ class ServerReachabilityWorker @AssistedInject constructor(
     private val uploadManager: UploadManager,
     private val submissionsRepository: SubmissionsRepository,
     private val serverUrlMapper: ServerUrlMapper,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val timeProvider: TimeProvider
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -72,7 +74,7 @@ class ServerReachabilityWorker @AssistedInject constructor(
 
             if (isReachable && isNetworkReconnection) {
                 val lastNotificationTime = sharedPrefManager.getRawLong(LAST_NOTIFICATION_TIME_KEY)
-                val currentTime = System.currentTimeMillis()
+                val currentTime = timeProvider.now()
                 val timeSinceLastNotification = currentTime - lastNotificationTime
                 if (timeSinceLastNotification > NOTIFICATION_COOLDOWN_MS) {
                     showServerNotification()
@@ -106,7 +108,7 @@ class ServerReachabilityWorker @AssistedInject constructor(
 
                     if (isNetworkReconnection) {
                         val lastNotificationTime = sharedPrefManager.getRawLong(LAST_NOTIFICATION_TIME_KEY)
-                        val currentTime = System.currentTimeMillis()
+                        val currentTime = timeProvider.now()
                         val timeSinceLastNotification = currentTime - lastNotificationTime
                         if (timeSinceLastNotification > NOTIFICATION_COOLDOWN_MS) {
                             showServerNotification()

--- a/app/src/main/java/org/ole/planet/myplanet/services/SharedPrefManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/SharedPrefManager.kt
@@ -12,6 +12,7 @@ import javax.inject.Singleton
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.User
 import org.ole.planet.myplanet.utils.Constants.PREFS_NAME
+import org.ole.planet.myplanet.utils.TimeProvider
 
 data class CachedMyLifeItem(
     var imageId: String?,
@@ -23,7 +24,8 @@ data class CachedMyLifeItem(
 @Singleton
 class SharedPrefManager @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val gson: Gson
+    private val gson: Gson,
+    private val timeProvider: TimeProvider
 ) {
     private var pref: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
@@ -150,7 +152,7 @@ class SharedPrefManager @Inject constructor(
         pref.edit {
             putBoolean(key.key, synced)
             if (synced) {
-                putLong("${key.key}_time", System.currentTimeMillis())
+                putLong("${key.key}_time", timeProvider.now())
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.services
 
 import android.content.Context
+import android.os.SystemClock
 import android.text.TextUtils
 import android.util.Log
 import com.google.gson.Gson
@@ -35,6 +36,7 @@ import org.ole.planet.myplanet.services.upload.UploadResult
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils.getString
 import org.ole.planet.myplanet.utils.NetworkUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 
 private inline fun <T> Iterable<T>.processInBatches(action: (List<T>) -> Unit) {
@@ -61,7 +63,8 @@ class UploadManager @Inject constructor(
     private val dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider,
     @ApplicationScope private val scope: CoroutineScope,
     private val photoUploader: PhotoUploader,
-    private val achievementUploader: org.ole.planet.myplanet.services.upload.AchievementUploader
+    private val achievementUploader: org.ole.planet.myplanet.services.upload.AchievementUploader,
+    private val timeProvider: TimeProvider
 ) : FileUploader(apiInterface, scope) {
 
     private suspend fun uploadNewsActivities() {
@@ -120,7 +123,7 @@ class UploadManager @Inject constructor(
     private fun createImage(user: RealmUser?, imgObject: JsonObject?): JsonObject {
         val `object` = JsonObject()
         `object`.addProperty("title", getString("fileName", imgObject))
-        `object`.addProperty("createdDate", System.currentTimeMillis())
+        `object`.addProperty("createdDate", timeProvider.now())
         `object`.addProperty("filename", getString("fileName", imgObject))
         `object`.addProperty("private", true)
         user?.id?.let { `object`.addProperty("addedBy", it) }
@@ -237,7 +240,7 @@ class UploadManager @Inject constructor(
 
     suspend fun uploadSubmissions(buttonClickTime: Long = 0L) {
         Log.d("UploadManager", "uploadSubmissions called with buttonClickTime: $buttonClickTime")
-        val startTime = if (buttonClickTime > 0) buttonClickTime else System.currentTimeMillis()
+        val startTime = if (buttonClickTime > 0) buttonClickTime else SystemClock.elapsedRealtime()
 
         if (buttonClickTime > 0) {
             Log.d("UploadManager", "Mini survey sync timer started from button click at: $startTime")
@@ -257,7 +260,7 @@ class UploadManager @Inject constructor(
         } catch (e: Exception) {
             Log.e("UploadManager", "Error uploading submissions", e)
         } finally {
-            val endTime = System.currentTimeMillis()
+            val endTime = SystemClock.elapsedRealtime()
             val duration = endTime - startTime
             Log.d("UploadManager", "Mini survey sync completed at: $endTime")
             Log.d("UploadManager", "Total time from button click to sync completion: ${duration}ms (${duration / 1000.0}s)")

--- a/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UserSessionManager.kt
@@ -14,6 +14,7 @@ import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.SecurePrefs
+import org.ole.planet.myplanet.utils.TimeProvider
 
 class UserSessionManager @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -21,7 +22,8 @@ class UserSessionManager @Inject constructor(
     @ApplicationScope private val applicationScope: CoroutineScope,
     private val userRepository: UserRepository,
     private val activitiesRepository: ActivitiesRepository,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val timeProvider: TimeProvider
 ) {
     private val fullName: String
 
@@ -49,7 +51,7 @@ class UserSessionManager @Inject constructor(
             putString("lastName", user?.lastName)
             putString("middleName", user?.middleName)
             user?.userAdmin?.let { putBoolean("isUserAdmin", it) }
-            putLong("lastLogin", System.currentTimeMillis())
+            putLong("lastLogin", timeProvider.now())
             apply()
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/AdaptiveBatchProcessor.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/AdaptiveBatchProcessor.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.services.sync
 
 import android.app.ActivityManager
 import android.content.Context
+import android.os.SystemClock
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
@@ -37,7 +38,7 @@ class AdaptiveBatchProcessor(private val context: Context) {
     }
     
     private fun getSystemCapabilities(): SystemCapabilities {
-        val now = System.currentTimeMillis()
+        val now = SystemClock.elapsedRealtime()
         val cached = cachedCapabilities
         if (cached != null && (now - lastCapabilityCheck) < cacheValidityMs) {
             return cached

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/StandardSyncStrategy.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/StandardSyncStrategy.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.services.sync
 
+import android.os.SystemClock
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -16,13 +17,13 @@ class StandardSyncStrategy @Inject constructor(
         table: String,
         config: SyncConfig
     ): Flow<SyncResult> = flow {
-        val startTime = System.currentTimeMillis()
+        val startTime = SystemClock.elapsedRealtime()
         
         try {
             // Use the existing TransactionSyncManager for standard sync
             val processedItems = transactionSyncManager.syncDb(table)
 
-            val endTime = System.currentTimeMillis()
+            val endTime = SystemClock.elapsedRealtime()
             emit(
                 SyncResult(
                     table = table,
@@ -33,7 +34,7 @@ class StandardSyncStrategy @Inject constructor(
                 )
             )
         } catch (e: Exception) {
-            val endTime = System.currentTimeMillis()
+            val endTime = SystemClock.elapsedRealtime()
             emit(
                 SyncResult(
                     table = table,

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -7,6 +7,7 @@ import android.net.wifi.SupplicantState
 import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
 import android.os.Build
+import android.os.SystemClock
 import android.util.Log
 import androidx.core.content.edit
 import com.google.gson.JsonArray
@@ -46,6 +47,7 @@ import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.JsonUtils.getInt
 import org.ole.planet.myplanet.utils.JsonUtils.getJsonArray
 import org.ole.planet.myplanet.utils.JsonUtils.getJsonObject
@@ -68,6 +70,7 @@ class SyncManager @Inject constructor(
     @param:ApplicationScope private val syncScope: CoroutineScope,
     private val activitiesRepository: ActivitiesRepository,
     private val dispatcherProvider: DispatcherProvider,
+    private val timeProvider: TimeProvider,
     private val teamsRepository: org.ole.planet.myplanet.repository.TeamsRepository,
     private val teamsSyncRepository: org.ole.planet.myplanet.repository.TeamsSyncRepository,
     private val coursesRepository: org.ole.planet.myplanet.repository.CoursesRepository,
@@ -196,7 +199,7 @@ class SyncManager @Inject constructor(
     }
 
     private suspend fun startFullSync() {
-        val syncStartTime = System.currentTimeMillis()
+        val syncStartTime = SystemClock.elapsedRealtime()
         val logger = SyncTimeLogger
         logger.startLogging()
         Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
@@ -264,7 +267,7 @@ class SyncManager @Inject constructor(
 
             HeavyTableSyncWorker.schedule(context)
 
-            val syncEndTime = System.currentTimeMillis()
+            val syncEndTime = SystemClock.elapsedRealtime()
             val totalSyncTime = syncEndTime - syncStartTime
             val minutes = totalSyncTime / 60000
             val seconds = (totalSyncTime % 60000) / 1000
@@ -273,7 +276,7 @@ class SyncManager @Inject constructor(
             Log.d("SyncPerf", "TOTAL SYNC TIME: ${minutes}m ${seconds}s (${totalSyncTime}ms)")
             Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
         } catch (err: Exception) {
-            val syncEndTime = System.currentTimeMillis()
+            val syncEndTime = SystemClock.elapsedRealtime()
             val totalSyncTime = syncEndTime - syncStartTime
             Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
             Log.d("SyncPerf", "SYNC FAILED after ${totalSyncTime}ms")
@@ -527,7 +530,7 @@ class SyncManager @Inject constructor(
     }
 
     private suspend fun resourceTransactionSync() {
-        val resourceSyncStartTime = System.currentTimeMillis()
+        val resourceSyncStartTime = SystemClock.elapsedRealtime()
         Log.d("SyncPerf", "  ▶ Starting resource sync")
 
         val logger = SyncTimeLogger
@@ -540,7 +543,7 @@ class SyncManager @Inject constructor(
 
             // Get total count
             logger.startProcess("resource_get_total_count")
-            val countApiStartTime = System.currentTimeMillis()
+            val countApiStartTime = SystemClock.elapsedRealtime()
             ApiClient.executeWithRetryAndWrap {
                 apiInterface.getJsonObject(UrlUtils.header, "${UrlUtils.getUrl()}/resources/_all_docs?limit=0")
             }?.let { response ->
@@ -548,7 +551,7 @@ class SyncManager @Inject constructor(
                     totalRows = getInt("total_rows", body)
                 }
             }
-            val countApiDuration = System.currentTimeMillis() - countApiStartTime
+            val countApiDuration = SystemClock.elapsedRealtime() - countApiStartTime
             logger.logApiCall("${UrlUtils.getUrl()}/resources/_all_docs?limit=0", countApiDuration, true, totalRows)
             logger.endProcess("resource_get_total_count")
 
@@ -561,18 +564,18 @@ class SyncManager @Inject constructor(
 
             while (skip < totalRows || (totalRows == 0 && skip == 0)) {
                 batchCount++
-                val batchStartTime = System.currentTimeMillis()
+                val batchStartTime = SystemClock.elapsedRealtime()
 
                 try {
                     // Fetch batch of documents
-                    val batchApiStartTime = System.currentTimeMillis()
+                    val batchApiStartTime = SystemClock.elapsedRealtime()
                     var response: JsonObject? = null
                     ApiClient.executeWithRetryAndWrap {
                         apiInterface.getJsonObject(UrlUtils.header, "${UrlUtils.getUrl()}/resources/_all_docs?include_docs=true&limit=$batchSize&skip=$skip")
                     }?.let {
                         response = it.body()
                     }
-                    val batchApiDuration = System.currentTimeMillis() - batchApiStartTime
+                    val batchApiDuration = SystemClock.elapsedRealtime() - batchApiStartTime
 
                     if (response == null) {
                         logger.logApiCall("${UrlUtils.getUrl()}/resources/_all_docs (batch $batchCount)", batchApiDuration, false, 0)
@@ -588,7 +591,7 @@ class SyncManager @Inject constructor(
                     }
 
                     // Parse documents
-                    val parseStartTime = System.currentTimeMillis()
+                    val parseStartTime = SystemClock.elapsedRealtime()
                     val batchDocuments = JsonArray()
                     val validDocuments = mutableListOf<Pair<JsonObject, String>>()
 
@@ -604,7 +607,7 @@ class SyncManager @Inject constructor(
                             }
                         }
                     }
-                    val parseDuration = System.currentTimeMillis() - parseStartTime
+                    val parseDuration = SystemClock.elapsedRealtime() - parseStartTime
                     if (parseDuration > 100) {
                         logger.logDetail("resource_sync", "Batch $batchCount: Parse took ${parseDuration}ms for ${rows.size()} docs")
                     }
@@ -612,9 +615,9 @@ class SyncManager @Inject constructor(
                     if (validDocuments.isNotEmpty()) {
                         val docs = validDocuments.map { it.first }
 
-                        val realmInsertStartTime = System.currentTimeMillis()
+                        val realmInsertStartTime = SystemClock.elapsedRealtime()
                         val savedIds = resourcesRepository.batchInsertResources(docs)
-                        val realmInsertDuration = System.currentTimeMillis() - realmInsertStartTime
+                        val realmInsertDuration = SystemClock.elapsedRealtime() - realmInsertStartTime
                         logger.logRealmOperation("insert_chunks", "resources", realmInsertDuration, validDocuments.size)
 
                         if (savedIds.isNotEmpty()) {
@@ -632,13 +635,13 @@ class SyncManager @Inject constructor(
                         context.getString(R.string.sync_items_of, resourcesDone, totalRows)
                     )
 
-                    val batchEndTime = System.currentTimeMillis()
+                    val batchEndTime = SystemClock.elapsedRealtime()
                     val batchTime = batchEndTime - batchStartTime
                     if (batchCount % 10 == 0) {
                         Log.d("SyncPerf", "    Resources batch $batchCount: ${batchTime}ms - Progress: $skip/$totalRows (${(skip * 100 / totalRows.coerceAtLeast(1))}%)")
                         logger.logDetail("resource_sync", "Batch $batchCount progress: $skip/$totalRows (${(skip * 100 / totalRows.coerceAtLeast(1))}%)")
                         sharedPrefManager.rawPreferences.edit {
-                            putLong("ResourceLastSyncTime", System.currentTimeMillis())
+                            putLong("ResourceLastSyncTime", timeProvider.now())
                             putInt("ResourceSyncPosition", skip)
                         }
                     }
@@ -651,12 +654,12 @@ class SyncManager @Inject constructor(
 
             try {
                 logger.startProcess("resource_cleanup")
-                val cleanupStartTime = System.currentTimeMillis()
+                val cleanupStartTime = SystemClock.elapsedRealtime()
                 val validNewIds = newIds.filter { !it.isNullOrBlank() }
                 if (validNewIds.isNotEmpty() && validNewIds.size == newIds.size) {
                     resourcesRepository.removeDeletedResources(validNewIds)
                 }
-                val cleanupDuration = System.currentTimeMillis() - cleanupStartTime
+                val cleanupDuration = SystemClock.elapsedRealtime() - cleanupStartTime
                 logger.endProcess("resource_cleanup")
                 if (cleanupDuration > 100) {
                     logger.logRealmOperation("delete_cleanup", "resources", cleanupDuration, newIds.size - validNewIds.size)
@@ -667,7 +670,7 @@ class SyncManager @Inject constructor(
             }
             logger.endProcess("resource_sync_main", processedItems)
 
-            val resourceSyncEndTime = System.currentTimeMillis()
+            val resourceSyncEndTime = SystemClock.elapsedRealtime()
             val resourceSyncTime = resourceSyncEndTime - resourceSyncStartTime
             val minutes = resourceSyncTime / 60000
             val seconds = (resourceSyncTime % 60000) / 1000
@@ -675,7 +678,7 @@ class SyncManager @Inject constructor(
         } catch (e: Exception) {
             e.printStackTrace()
             logger.endProcess("resource_sync_main", processedItems)
-            val resourceSyncEndTime = System.currentTimeMillis()
+            val resourceSyncEndTime = SystemClock.elapsedRealtime()
             Log.d("SyncPerf", "  ✗ Resources sync failed after ${resourceSyncEndTime - resourceSyncStartTime}ms: ${e.message}")
         }
     }
@@ -761,7 +764,7 @@ class SyncManager @Inject constructor(
         val cacheValidityHours = 6
 
         val cacheTime = sharedPrefManager.getRawLong(cacheTimeKey, 0)
-        val now = System.currentTimeMillis()
+        val now = timeProvider.now()
 
         if (now - cacheTime < cacheValidityHours * 60 * 60 * 1000) {
             val cachedData = sharedPrefManager.getRawString(cacheKey, "")
@@ -777,12 +780,12 @@ class SyncManager @Inject constructor(
         val cacheTimeKey = "shelves_cache_time"
 
         sharedPrefManager.setRawString(cacheKey, shelves.joinToString(","))
-        sharedPrefManager.setRawLong(cacheTimeKey, System.currentTimeMillis())
+        sharedPrefManager.setRawLong(cacheTimeKey, timeProvider.now())
     }
 
     private suspend fun myLibraryTransactionSync() {
         val logger = SyncTimeLogger
-        val librarySyncStartTime = System.currentTimeMillis()
+        val librarySyncStartTime = SystemClock.elapsedRealtime()
         Log.d("SyncPerf", "  ▶ Starting library sync")
 
         logger.startProcess("library_sync_main")
@@ -790,9 +793,9 @@ class SyncManager @Inject constructor(
 
         try {
             logger.startProcess("library_get_shelves")
-            val shelvesStartTime = System.currentTimeMillis()
+            val shelvesStartTime = SystemClock.elapsedRealtime()
             val shelvesWithData = getShelvesWithDataBatchOptimized()
-            val shelvesDuration = System.currentTimeMillis() - shelvesStartTime
+            val shelvesDuration = SystemClock.elapsedRealtime() - shelvesStartTime
             logger.endProcess("library_get_shelves", shelvesWithData.size)
             Log.d("SyncPerf", "    Library: Found ${shelvesWithData.size} shelves with data in ${shelvesDuration}ms")
 
@@ -810,9 +813,9 @@ class SyncManager @Inject constructor(
                 val shelfJobs = shelvesWithData.mapIndexed { index, shelfId ->
                     async(dispatcherProvider.io) {
                         semaphore.withPermit {
-                            val shelfStartTime = System.currentTimeMillis()
+                            val shelfStartTime = SystemClock.elapsedRealtime()
                             val items = processShelfParallel(shelfId, apiInterface)
-                            val shelfDuration = System.currentTimeMillis() - shelfStartTime
+                            val shelfDuration = SystemClock.elapsedRealtime() - shelfStartTime
                             if (items > 0) {
                                 logger.logDetail("library_sync", "Shelf ${index + 1}/${shelvesWithData.size} ($shelfId): $items items in ${shelfDuration}ms")
                             }
@@ -835,12 +838,12 @@ class SyncManager @Inject constructor(
             saveConcatenatedLinksToPrefs(sharedPrefManager)
             logger.endProcess("library_sync_main", processedItems)
 
-            val totalDuration = System.currentTimeMillis() - librarySyncStartTime
+            val totalDuration = SystemClock.elapsedRealtime() - librarySyncStartTime
             Log.d("SyncPerf", "  ✓ Library sync completed: ${totalDuration}ms - $processedItems items from ${shelvesWithData.size} shelves")
         } catch (e: Exception) {
             e.printStackTrace()
             logger.endProcess("library_sync_main", processedItems)
-            val failDuration = System.currentTimeMillis() - librarySyncStartTime
+            val failDuration = SystemClock.elapsedRealtime() - librarySyncStartTime
             Log.d("SyncPerf", "  ✗ Library sync failed after ${failDuration}ms: ${e.message}")
         }
     }
@@ -912,7 +915,7 @@ class SyncManager @Inject constructor(
 
             for (i in 0 until validIds.size step batchSize) {
                 val batchNum = (i / batchSize) + 1
-                val batchStartTime = System.currentTimeMillis()
+                val batchStartTime = SystemClock.elapsedRealtime()
 
                 val end = minOf(i + batchSize, validIds.size)
                 val batch = validIds.subList(i, end)
@@ -921,14 +924,14 @@ class SyncManager @Inject constructor(
                 keysObject.add("keys", gson.fromJson(gson.toJson(batch), JsonArray::class.java))
 
                 // API call
-                val apiStartTime = System.currentTimeMillis()
+                val apiStartTime = SystemClock.elapsedRealtime()
                 var response: JsonObject? = null
                 ApiClient.executeWithRetryAndWrap {
                     apiInterface.findDocs(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject)
                 }?.let {
                     response = it.body()
                 }
-                val apiDuration = System.currentTimeMillis() - apiStartTime
+                val apiDuration = SystemClock.elapsedRealtime() - apiStartTime
 
                 if (response == null) {
                     logger.logApiCall("${UrlUtils.getUrl()}/${shelfData.type}/_all_docs (shelf batch $batchNum/$totalBatches)", apiDuration, false, 0)
@@ -950,18 +953,18 @@ class SyncManager @Inject constructor(
                 }
 
                 if (documentsToProcess.isNotEmpty()) {
-                    val realmStartTime = System.currentTimeMillis()
+                    val realmStartTime = SystemClock.elapsedRealtime()
                     when (shelfData.type) {
                         "resources" -> processedCount += resourcesRepository.batchInsertMyLibrary(shelfId, documentsToProcess)
                         "courses" -> processedCount += coursesRepository.batchInsertMyCourses(shelfId, documentsToProcess)
                         "meetups" -> processedCount += eventsRepository.batchInsertMeetups(documentsToProcess)
                         "teams" -> processedCount += teamsSyncRepository.batchInsertMyTeams(documentsToProcess)
                     }
-                    val realmDuration = System.currentTimeMillis() - realmStartTime
+                    val realmDuration = SystemClock.elapsedRealtime() - realmStartTime
                     logger.logRealmOperation("shelf_insert", shelfData.type, realmDuration, documentsToProcess.size)
                 }
 
-                val batchDuration = System.currentTimeMillis() - batchStartTime
+                val batchDuration = SystemClock.elapsedRealtime() - batchStartTime
                 if (batchDuration > 1000) {
                     logger.logDetail("shelf_sync", "Shelf $shelfId ${shelfData.type} batch $batchNum/$totalBatches: ${batchDuration}ms for ${documentsToProcess.size} docs")
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.services.sync
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.SystemClock
 import android.util.Base64
 import com.google.gson.JsonObject
 import dagger.Lazy
@@ -149,7 +150,7 @@ class TransactionSyncManager @Inject constructor(
     }
 
     suspend fun syncDb(table: String, useCheckpoint: Boolean = false): Int = withContext(dispatcherProvider.io) {
-        val syncStartTime = System.currentTimeMillis()
+        val syncStartTime = SystemClock.elapsedRealtime()
         val checkpointKey = "heavy_sync_skip_$table"
         android.util.Log.d("SyncPerf", "  ▶ Starting $table sync")
         try {
@@ -175,15 +176,15 @@ class TransactionSyncManager @Inject constructor(
                 if (useCheckpoint) {
                     sharedPrefManager.rawPreferences.edit().putInt(checkpointKey, skip).commit()
                 }
-                val batchStartTime = System.currentTimeMillis()
-                val batchApiStartTime = System.currentTimeMillis()
+                val batchStartTime = SystemClock.elapsedRealtime()
+                val batchApiStartTime = SystemClock.elapsedRealtime()
                 val response = apiInterface.findDocs(
                     authHeader,
                     "application/json",
                     "$url/$table/_all_docs?include_docs=true&limit=$pageSize&skip=$skip",
                     JsonObject() // Empty body for GET-style query
                 )
-                val batchApiDuration = System.currentTimeMillis() - batchApiStartTime
+                val batchApiDuration = SystemClock.elapsedRealtime() - batchApiStartTime
                 if (response.body() == null || !response.isSuccessful) {
                     android.util.Log.d("SyncPerf", "  ✗ Failed $table batch $batchNumber: HTTP ${response.code()}")
                     break
@@ -200,7 +201,7 @@ class TransactionSyncManager @Inject constructor(
                     arr.size()
                 )
                 if (table == "news") {
-                    val insertStartTime = System.currentTimeMillis()
+                    val insertStartTime = SystemClock.elapsedRealtime()
                     val docs = ArrayList<JsonObject>(arr.size())
                     for (j in arr) {
                         var jsonDoc = j.asJsonObject
@@ -211,7 +212,7 @@ class TransactionSyncManager @Inject constructor(
                         }
                     }
                     voicesRepository.insertNewsList(docs)
-                    val insertDuration = System.currentTimeMillis() - insertStartTime
+                    val insertDuration = SystemClock.elapsedRealtime() - insertStartTime
                     org.ole.planet.myplanet.utils.SyncTimeLogger.logRealmOperation(
                         "insert_batch",
                         table,
@@ -219,7 +220,7 @@ class TransactionSyncManager @Inject constructor(
                         arr.size()
                     )
                 } else if (table == "feedback") {
-                    val insertStartTime = System.currentTimeMillis()
+                    val insertStartTime = SystemClock.elapsedRealtime()
                     val docs = ArrayList<JsonObject>(arr.size())
                     for (j in arr) {
                         var jsonDoc = j.asJsonObject
@@ -230,7 +231,7 @@ class TransactionSyncManager @Inject constructor(
                         }
                     }
                     feedbackRepository.insertFeedbackList(docs)
-                    val insertDuration = System.currentTimeMillis() - insertStartTime
+                    val insertDuration = SystemClock.elapsedRealtime() - insertStartTime
                     org.ole.planet.myplanet.utils.SyncTimeLogger.logRealmOperation(
                         "insert_batch",
                         table,
@@ -240,7 +241,7 @@ class TransactionSyncManager @Inject constructor(
                 } else {
                     // Use async transaction to avoid blocking (ANR-safe)
                     databaseService.executeTransactionAsync { mRealm: Realm ->
-                        val insertStartTime = System.currentTimeMillis()
+                        val insertStartTime = SystemClock.elapsedRealtime()
                         when (table) {
                             "tablet_users" -> userSyncRepository.bulkInsertUsersFromSync(mRealm, arr)
                             "exams" -> surveysRepository.bulkInsertExamsFromSync(mRealm, arr)
@@ -264,7 +265,7 @@ class TransactionSyncManager @Inject constructor(
                             "notifications" -> notificationsRepository.bulkInsertFromSync(mRealm, arr)
                             else -> android.util.Log.e("SyncPerf", "Unknown table: $table")
                         }
-                        val insertDuration = System.currentTimeMillis() - insertStartTime
+                        val insertDuration = SystemClock.elapsedRealtime() - insertStartTime
                         if (table == "courses") {
                             android.util.Log.d(
                                 "SyncPerf",
@@ -285,7 +286,7 @@ class TransactionSyncManager @Inject constructor(
                 }
                 totalDocs += arr.size()
                 skip += arr.size()
-                val batchDuration = System.currentTimeMillis() - batchStartTime
+                val batchDuration = SystemClock.elapsedRealtime() - batchStartTime
                 android.util.Log.d("SyncPerf", "    $table batch $batchNumber: ${arr.size()} docs in ${batchDuration}ms (total: $totalDocs)")
                 // Show progress for slow syncs
                 if (table in listOf("ratings", "submissions")) {
@@ -300,12 +301,12 @@ class TransactionSyncManager @Inject constructor(
             if (useCheckpoint && syncCompletedFully) {
                 sharedPrefManager.rawPreferences.edit().remove(checkpointKey).commit()
             }
-            val totalDuration = System.currentTimeMillis() - syncStartTime
+            val totalDuration = SystemClock.elapsedRealtime() - syncStartTime
             android.util.Log.d("SyncPerf", "  ✓ Completed $table sync: $totalDocs docs in ${totalDuration}ms")
             totalDocs
         } catch (e: Exception) {
             e.printStackTrace()
-            val failDuration = System.currentTimeMillis() - syncStartTime
+            val failDuration = SystemClock.elapsedRealtime() - syncStartTime
             android.util.Log.d("SyncPerf", "  ✗ Failed $table sync after ${failDuration}ms: ${e.message}")
             0
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -41,6 +41,7 @@ import org.ole.planet.myplanet.ui.submissions.SubmissionsFragment
 import org.ole.planet.myplanet.ui.teams.TeamDetailFragment
 import org.ole.planet.myplanet.ui.teams.TeamFragment
 import org.ole.planet.myplanet.utils.DialogUtils.guestDialog
+import org.ole.planet.myplanet.utils.TimeProvider
 
 @AndroidEntryPoint
 class BellDashboardFragment : BaseDashboardFragment() {
@@ -53,6 +54,9 @@ class BellDashboardFragment : BaseDashboardFragment() {
 
     @Inject
     lateinit var serverUrlMapper: ServerUrlMapper
+
+    @Inject
+    lateinit var timeProvider: TimeProvider
 
     companion object {
         private val SURVEY_DIALOG_INTERVAL_MS = TimeUnit.HOURS.toMillis(1)
@@ -149,7 +153,7 @@ class BellDashboardFragment : BaseDashboardFragment() {
     private fun checkPendingSurveys() {
         viewLifecycleOwner.lifecycleScope.launch {
             val lastShown = surveysRepository.getLastSurveyDialogShown()
-            if (System.currentTimeMillis() - lastShown < SURVEY_DIALOG_INTERVAL_MS) return@launch
+            if (timeProvider.now() - lastShown < SURVEY_DIALOG_INTERVAL_MS) return@launch
 
             val pendingSurveys = submissionsRepository.getUniquePendingSurveys(user?.id)
             if (pendingSurveys.isNotEmpty()) {
@@ -273,7 +277,7 @@ class BellDashboardFragment : BaseDashboardFragment() {
         recyclerView.layoutManager = LinearLayoutManager(requireActivity())
 
         viewLifecycleOwner.lifecycleScope.launch {
-            surveysRepository.setLastSurveyDialogShown(System.currentTimeMillis())
+            surveysRepository.setLastSurveyDialogShown(timeProvider.now())
         }
 
         surveyListDialog?.dismiss()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.ui.dashboard
 
 import android.app.AlertDialog
 import android.content.BroadcastReceiver
+import android.os.SystemClock
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -579,7 +580,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
     private fun onRealmDataChange() {
         if (notificationsShownThisSession) {
-            val currentTime = System.currentTimeMillis()
+            val currentTime = SystemClock.elapsedRealtime()
             if (currentTime - lastNotificationCheckTime > notificationCheckThrottleMs) {
                 lastNotificationCheckTime = currentTime
                 lifecycleScope.launch { dashboardViewModel.checkAndCreateNewNotifications(user?.id, user?.isManager() == true) }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.utils.TimeProvider
 
 sealed class ReportEvent {
     object ReportAdded : ReportEvent()
@@ -23,7 +24,8 @@ sealed class ReportEvent {
 
 @HiltViewModel
 class EnterprisesViewModel @Inject constructor(
-    private val teamsRepository: TeamsRepository
+    private val teamsRepository: TeamsRepository,
+    private val timeProvider: TimeProvider
 ) : ViewModel() {
 
     private val _reportEvent = MutableSharedFlow<ReportEvent>()
@@ -46,7 +48,7 @@ class EnterprisesViewModel @Inject constructor(
             try {
                 val doc = JsonObject().apply {
                     addProperty("_id", UUID.randomUUID().toString())
-                    addProperty("createdDate", System.currentTimeMillis())
+                    addProperty("createdDate", timeProvider.now())
                     addProperty("description", description)
                     addProperty("beginningBalance", beginningBalance)
                     addProperty("sales", sales)
@@ -55,7 +57,7 @@ class EnterprisesViewModel @Inject constructor(
                     addProperty("otherExpenses", otherExpenses)
                     addProperty("startDate", startDate)
                     addProperty("endDate", endDate)
-                    addProperty("updatedDate", System.currentTimeMillis())
+                    addProperty("updatedDate", timeProvider.now())
                     addProperty("teamId", teamId)
                     addProperty("teamType", teamType)
                     addProperty("teamPlanetCode", teamPlanetCode)
@@ -92,7 +94,7 @@ class EnterprisesViewModel @Inject constructor(
                     addProperty("otherExpenses", otherExpenses)
                     addProperty("startDate", startDate)
                     addProperty("endDate", endDate)
-                    addProperty("updatedDate", System.currentTimeMillis())
+                    addProperty("updatedDate", timeProvider.now())
                     addProperty("updated", true)
                 }
                 teamsRepository.updateReport(reportId, doc)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/UserInformationFragment.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.ui.exam
 import android.app.DatePickerDialog
 import android.content.DialogInterface
 import android.os.Bundle
+import android.os.SystemClock
 import android.text.TextUtils
 import android.util.Log
 import android.view.LayoutInflater
@@ -117,14 +118,14 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
     override fun onClick(view: View) {
         when (view.id) {
             R.id.btn_cancel -> {
-                syncStartTime = System.currentTimeMillis()
+                syncStartTime = SystemClock.elapsedRealtime()
                 Log.d("UserInformationFragment", "Cancel button clicked - Mini survey sync timer started at: $syncStartTime")
                 if (isAdded) {
                     dialog?.dismiss()
                 }
             }
             R.id.btn_submit -> {
-                syncStartTime = System.currentTimeMillis()
+                syncStartTime = SystemClock.elapsedRealtime()
                 Log.d("UserInformationFragment", "Submit button clicked - Mini survey sync timer started at: $syncStartTime")
                 submitForm()
             }
@@ -329,7 +330,7 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
         submissionUploadExecutor.execute {
             Log.d("UserInformationFragment", "ApplicationScope coroutine started, will not be cancelled by fragment lifecycle")
             Log.d("UserInformationFragment", "Starting server reachability checks (15s timeout each)")
-            val checkStartTime = System.currentTimeMillis()
+            val checkStartTime = SystemClock.elapsedRealtime()
 
             val primaryCheck = async {
                 try {
@@ -361,7 +362,7 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
 
             val primaryAvailable = primaryCheck.await()
             val alternativeAvailable = alternativeCheck.await()
-            val checkDuration = System.currentTimeMillis() - checkStartTime
+            val checkDuration = SystemClock.elapsedRealtime() - checkStartTime
             Log.d("UserInformationFragment", "Server checks completed in ${checkDuration}ms. Primary: $primaryAvailable, Alternative: $alternativeAvailable")
 
             if (primaryAvailable || alternativeAvailable) {
@@ -375,7 +376,7 @@ class UserInformationFragment : BaseDialogFragment(), View.OnClickListener {
                 }
                 uploadSubmissionsWithTiming(capturedSyncStartTime)
             } else {
-                Log.w("UserInformationFragment", "No server reachable, upload skipped. Total time since button click: ${System.currentTimeMillis() - capturedSyncStartTime}ms")
+                Log.w("UserInformationFragment", "No server reachable, upload skipped. Total time since button click: ${SystemClock.elapsedRealtime() - capturedSyncStartTime}ms")
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.repository.EventsRepository
+import org.ole.planet.myplanet.utils.TimeProvider
 
 data class MeetupCreationParams(
     val title: String,
@@ -35,7 +36,8 @@ data class MeetupCreationParams(
 @HiltViewModel
 class TeamCalendarViewModel @Inject constructor(
     private val eventsRepository: EventsRepository,
-    private val gson: Gson
+    private val gson: Gson,
+    private val timeProvider: TimeProvider
 ) : ViewModel() {
 
     private val _meetups = MutableStateFlow<List<RealmMeetup>>(emptyList())
@@ -64,7 +66,7 @@ class TeamCalendarViewModel @Inject constructor(
                 endDate = params.endMillis
                 startTime = params.startTime
                 endTime = params.endTime
-                createdDate = System.currentTimeMillis()
+                createdDate = timeProvider.now()
                 sourcePlanet = params.teamPlanetCode
                 val jo = JsonObject()
                 jo.addProperty("type", "local")

--- a/app/src/main/java/org/ole/planet/myplanet/utils/TimeProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/TimeProvider.kt
@@ -1,0 +1,17 @@
+package org.ole.planet.myplanet.utils
+
+/**
+ * Injectable source of wall-clock time so time-of-day / expiry / scheduling decisions are
+ * testable and don't read [System.currentTimeMillis] directly. Mirrors [DispatcherProvider].
+ *
+ * Use [now] for timestamps and time-based decisions persisted across restarts. For measuring
+ * elapsed durations within a single process, use android.os.SystemClock.elapsedRealtime()
+ * directly instead — it is monotonic and immune to wall-clock jumps.
+ */
+interface TimeProvider {
+    fun now(): Long
+}
+
+class SystemTimeProvider : TimeProvider {
+    override fun now(): Long = System.currentTimeMillis()
+}

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
@@ -23,6 +23,7 @@ import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TestTimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 import retrofit2.Response
 
@@ -58,7 +59,8 @@ class ConfigurationsRepositoryImplTest {
             databaseService,
             serverUrlMapper,
             dispatcherProvider,
-            testDispatcher
+            testDispatcher,
+            TestTimeProvider()
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
@@ -20,6 +20,7 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.utils.TestTimeProvider
 
 @ExperimentalCoroutinesApi
 class NotificationsRepositoryImplTest {
@@ -35,7 +36,9 @@ class NotificationsRepositoryImplTest {
         databaseService = mockk(relaxed = true)
         userRepository = mockk(relaxed = true)
         teamsRepository = mockk(relaxed = true)
-        repository = NotificationsRepositoryImpl(databaseService, testDispatcher, userRepository, teamsRepository)
+        repository = NotificationsRepositoryImpl(databaseService, testDispatcher, userRepository, teamsRepository,
+            TestTimeProvider()
+        )
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
@@ -19,15 +19,11 @@ import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.model.RealmRetryOperation
 import org.ole.planet.myplanet.model.RetryFailure
+import org.ole.planet.myplanet.utils.TestTimeProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("UNCHECKED_CAST")
 class RetryRepositoryImplTest {
-
-
-
-
-
     private lateinit var databaseService: DatabaseService
     private lateinit var repository: RetryRepositoryImpl
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -40,7 +36,7 @@ class RetryRepositoryImplTest {
     @Before
     fun setUp() {
         databaseService = mockk(relaxed = true)
-        repository = RetryRepositoryImpl(databaseService, testDispatcher)
+        repository = RetryRepositoryImpl(databaseService, testDispatcher, TestTimeProvider())
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
@@ -27,6 +27,7 @@ class RetryRepositoryImplTest {
     private lateinit var databaseService: DatabaseService
     private lateinit var repository: RetryRepositoryImpl
     private val testDispatcher = UnconfinedTestDispatcher()
+    private val timeProvider = TestTimeProvider(currentTime = 1_700_000_000_000L)
 
     @org.junit.After
     fun tearDown() {
@@ -36,7 +37,7 @@ class RetryRepositoryImplTest {
     @Before
     fun setUp() {
         databaseService = mockk(relaxed = true)
-        repository = RetryRepositoryImpl(databaseService, testDispatcher, TestTimeProvider())
+        repository = RetryRepositoryImpl(databaseService, testDispatcher, timeProvider)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SurveysRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SurveysRepositoryImplTest.kt
@@ -33,6 +33,7 @@ import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TestTimeProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SurveysRepositoryImplTest {
@@ -102,7 +103,8 @@ class SurveysRepositoryImplTest {
             UnconfinedTestDispatcher(),
             userSessionManager,
             sharedPrefManager,
-            dispatcherProvider
+            dispatcherProvider,
+            TestTimeProvider()
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SurveysRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SurveysRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.repository
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -24,20 +25,26 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.model.RealmExamQuestion
+import org.ole.planet.myplanet.model.RealmMembershipDoc
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
+import org.ole.planet.myplanet.model.RealmTeamReference
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.TestTimeProvider
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], application = android.app.Application::class)
 class SurveysRepositoryImplTest {
-
     private lateinit var databaseService: DatabaseService
     private lateinit var repository: SurveysRepositoryImpl
     private lateinit var mockRealm: Realm
@@ -47,6 +54,7 @@ class SurveysRepositoryImplTest {
     private lateinit var dispatcherProvider: DispatcherProvider
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var sharedPreferencesEditor: SharedPreferences.Editor
+    private val timeProvider = TestTimeProvider(currentTime = 1_700_000_000_000L)
 
     @Before
     fun setup() {
@@ -104,7 +112,7 @@ class SurveysRepositoryImplTest {
             userSessionManager,
             sharedPrefManager,
             dispatcherProvider,
-            TestTimeProvider()
+            timeProvider
         )
     }
 
@@ -278,6 +286,8 @@ class SurveysRepositoryImplTest {
 
         every { mockRealm.createObject(RealmStepExam::class.java, any<String>()) } returns newSurvey
         every { mockRealm.createObject(RealmSubmission::class.java, any<String>()) } returns newSubmission
+        every { mockRealm.createObject(RealmTeamReference::class.java) } returns RealmTeamReference()
+        every { mockRealm.createObject(RealmMembershipDoc::class.java) } returns RealmMembershipDoc()
 
         repository.adoptSurvey("exam1", "user1", "team1", true)
 
@@ -392,7 +402,7 @@ class SurveysRepositoryImplTest {
 
     @Test
     fun `dueRemindersFlow emits valid reminders and removes them`() = runTest {
-        val currentTime = System.currentTimeMillis()
+        val currentTime = timeProvider.now()
         val pastTime = currentTime - 1000
 
         // Mock SharedPreferences

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
@@ -24,6 +24,7 @@ import org.ole.planet.myplanet.services.UploadManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TestTimeProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TeamsRepositoryBenchmarkTest {
@@ -68,7 +69,8 @@ class TeamsRepositoryBenchmarkTest {
             serverUrlMapper,
             dispatcherProvider,
             userRepository,
-            resourcesRepositoryLazy
+            resourcesRepositoryLazy,
+            TestTimeProvider()
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
@@ -24,6 +24,7 @@ import org.ole.planet.myplanet.services.UploadManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TestTimeProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TeamsRepositoryImplTest {
@@ -72,7 +73,8 @@ class TeamsRepositoryImplTest {
             serverUrlMapper,
             dispatcherProvider,
             mockUserRepository,
-            mockk()
+            mockk(),
+            TestTimeProvider()
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
@@ -18,6 +18,7 @@ import org.junit.Test
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.User
 import org.ole.planet.myplanet.utils.Constants.PREFS_NAME
+import org.ole.planet.myplanet.utils.TestTimeProvider
 
 class SharedPrefManagerTest {
 
@@ -42,7 +43,7 @@ class SharedPrefManagerTest {
         every { mockEditor.putLong(any(), any()) } returns mockEditor
         every { mockEditor.remove(any()) } returns mockEditor
 
-        sharedPrefManager = SharedPrefManager(mockContext, org.ole.planet.myplanet.di.NetworkModule.provideGson())
+        sharedPrefManager = SharedPrefManager(mockContext, org.ole.planet.myplanet.di.NetworkModule.provideGson(), TestTimeProvider())
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.services
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import com.google.gson.Gson
 import dagger.Lazy
@@ -71,6 +72,8 @@ class UploadManagerTest {
     @Before
     fun setup() {
         mockkStatic(Log::class)
+        mockkStatic(SystemClock::class)
+        every { SystemClock.elapsedRealtime() } returns 0L
         io.mockk.mockkObject(org.ole.planet.myplanet.utils.UrlUtils)
         every { org.ole.planet.myplanet.utils.UrlUtils.header } returns "mockHeader"
         every { org.ole.planet.myplanet.utils.UrlUtils.getUrl() } returns "http://mock.url"
@@ -277,6 +280,7 @@ class UploadManagerTest {
     fun `uploadMyPersonal delegates to personalsRepository and calls uploadAttachment`() = testScope.runTest {
         val mockPersonal = mockk<org.ole.planet.myplanet.model.RealmMyPersonal>(relaxed = true)
         every { mockPersonal.isUploaded } returns false
+        every { mockPersonal.path } returns null
 
         coEvery { personalsRepository.uploadPersonalDocument(mockPersonal) } returns Pair("remote-id", "remote-rev")
 

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -42,6 +42,7 @@ import org.ole.planet.myplanet.services.upload.UploadConfigs
 import org.ole.planet.myplanet.services.upload.UploadCoordinator
 import org.ole.planet.myplanet.services.upload.UploadResult
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
+import org.ole.planet.myplanet.utils.TestTimeProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UploadManagerTest {
@@ -99,7 +100,8 @@ class UploadManagerTest {
                 TestDispatcherProvider(testDispatcher),
                 testScope,
                 photoUploader,
-                achievementUploader
+                achievementUploader,
+                TestTimeProvider()
             )
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UserSessionManagerTest.kt
@@ -23,6 +23,7 @@ import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
+import org.ole.planet.myplanet.utils.TestTimeProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UserSessionManagerTest {
@@ -50,7 +51,8 @@ class UserSessionManagerTest {
             applicationScope = testScope,
             userRepository = userRepository,
             activitiesRepository = activitiesRepository,
-            dispatcherProvider = dispatcherProvider
+            dispatcherProvider = dispatcherProvider,
+            timeProvider = TestTimeProvider()
         )
     }
 
@@ -74,7 +76,8 @@ class UserSessionManagerTest {
             applicationScope = testScope,
             userRepository = userRepository,
             activitiesRepository = activitiesRepository,
-            dispatcherProvider = dispatcherProvider
+            dispatcherProvider = dispatcherProvider,
+            timeProvider = TestTimeProvider()
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/SyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/SyncManagerTest.kt
@@ -29,6 +29,7 @@ import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
+import org.ole.planet.myplanet.utils.TestTimeProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SyncManagerTest {
@@ -71,6 +72,7 @@ class SyncManagerTest {
             testScope,
             activitiesRepository,
             dispatcherProvider,
+            TestTimeProvider(),
             teamsRepository,
             teamsSyncRepository,
             coursesRepository,

--- a/app/src/test/java/org/ole/planet/myplanet/utils/TestTimeProvider.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/TestTimeProvider.kt
@@ -1,0 +1,10 @@
+package org.ole.planet.myplanet.utils
+
+/** Deterministic [TimeProvider] for tests. Advance time via [currentTime] or [advanceBy]. */
+class TestTimeProvider(var currentTime: Long = 0L) : TimeProvider {
+    override fun now(): Long = currentTime
+
+    fun advanceBy(millis: Long) {
+        currentTime += millis
+    }
+}


### PR DESCRIPTION
fixes #14247
```
 Injected into 15 classes (Hilt-clean), covering sync decisions, expiry/throttle windows persisted across restarts, retry scheduling, and record timestamps:                        
  - Repositories: Surveys, Retry, Notifications, Configurations, Activities, Teams, SubmissionsRepositoryExporter                                                                    
  - ViewModels: Enterprises, TeamCalendar                                                                                                                                            
  - Services: SyncManager, UploadManager, UserSessionManager, SharedPrefManager                                                                                                      
  - Workers: AutoSyncWorker, ServerReachabilityWorker (via @AssistedInject)                                                                                                          
  - UI: BellDashboardFragment, BasePermissionActivity                                                                                                                                
```