### PR TITLE
sync: less beta fast option is more (fixes #14270)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5893
-        versionName = "0.58.93"
+        versionCode = 5898
+        versionName = "0.58.98"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/SyncState.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/SyncState.kt
@@ -1,8 +1,0 @@
-package org.ole.planet.myplanet.model
-
-sealed class SyncState {
-    object Idle : SyncState()
-    object Syncing : SyncState()
-    object Success : SyncState()
-    data class Failed(val message: String?) : SyncState()
-}

--- a/app/src/main/java/org/ole/planet/myplanet/services/SharedPrefManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/SharedPrefManager.kt
@@ -12,7 +12,6 @@ import javax.inject.Singleton
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.User
 import org.ole.planet.myplanet.utils.Constants.PREFS_NAME
-import org.ole.planet.myplanet.utils.TimeProvider
 
 data class CachedMyLifeItem(
     var imageId: String?,
@@ -24,8 +23,7 @@ data class CachedMyLifeItem(
 @Singleton
 class SharedPrefManager @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val gson: Gson,
-    private val timeProvider: TimeProvider
+    private val gson: Gson
 ) {
     private var pref: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
@@ -62,7 +60,6 @@ class SharedPrefManager @Inject constructor(
         private const val USER_NAME = "name"
         private const val COMMUNITY_LEADERS = "communityLeaders"
         private const val AUTO_SYNC = "autoSync"
-        private const val FAST_SYNC = "fastSync"
         private const val USE_IMPROVED_SYNC = "useImprovedSync"
         private const val AUTO_SYNC_INTERVAL = "autoSyncInterval"
         private const val AUTO_SYNC_POSITION = "autoSyncPosition"
@@ -77,17 +74,6 @@ class SharedPrefManager @Inject constructor(
         private const val VERSION_DETAIL = "versionDetail"
         private const val CONCATENATED_LINKS = "concatenated_links"
         private const val MY_LIFE_CACHE_PREFIX = "myLifeCache_"
-    }
-
-    enum class SyncKey(val key: String) {
-        CHAT_HISTORY("chat_history_synced"),
-        TEAMS("teams_synced"),
-        FEEDBACK("feedback_synced"),
-        ACHIEVEMENTS("achievements_synced"),
-        HEALTH("health_synced"),
-        COURSES("courses_synced"),
-        RESOURCES("resources_synced"),
-        EXAMS("exams_synced")
     }
 
     fun getSavedUsers(): List<User> {
@@ -142,23 +128,6 @@ class SharedPrefManager @Inject constructor(
 
     fun setTeamName(teamName: String?) {
         pref.edit { putString(TEAM_NAME, teamName) }
-    }
-
-    fun isSynced(key: SyncKey): Boolean {
-        return pref.getBoolean(key.key, false)
-    }
-
-    fun setSynced(key: SyncKey, synced: Boolean) {
-        pref.edit {
-            putBoolean(key.key, synced)
-            if (synced) {
-                putLong("${key.key}_time", timeProvider.now())
-            }
-        }
-    }
-
-    fun getSyncTime(key: SyncKey): Long {
-        return pref.getLong("${key.key}_time", 0L)
     }
 
     fun getNewLoginUsername(): String? = pref.getString("new_login_username", null)
@@ -241,9 +210,6 @@ class SharedPrefManager @Inject constructor(
 
     fun getAutoSync(): Boolean = pref.getBoolean(AUTO_SYNC, true)
     fun setAutoSync(value: Boolean) = pref.edit { putBoolean(AUTO_SYNC, value) }
-
-    fun getFastSync(): Boolean = pref.getBoolean(FAST_SYNC, false)
-    fun setFastSync(value: Boolean) = pref.edit { putBoolean(FAST_SYNC, value) }
 
     fun getUseImprovedSync(): Boolean = pref.getBoolean(USE_IMPROVED_SYNC, false)
     fun setUseImprovedSync(value: Boolean) = pref.edit { putBoolean(USE_IMPROVED_SYNC, value) }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/ImprovedSyncManager.kt
@@ -164,7 +164,7 @@ class ImprovedSyncManager @Inject constructor(
     private fun getStrategy(syncMode: SyncMode): SyncStrategy {
         return when (syncMode) {
             SyncMode.Standard -> standardStrategy
-            SyncMode.Fast, SyncMode.Optimized -> standardStrategy
+            SyncMode.Optimized -> standardStrategy
         }
     }
 
@@ -194,7 +194,6 @@ class ImprovedSyncManager @Inject constructor(
     private fun SyncMode.describe(): String {
         return when (this) {
             SyncMode.Standard -> "Standard"
-            SyncMode.Fast -> "Fast"
             SyncMode.Optimized -> "Optimized"
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -21,11 +21,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -80,7 +78,6 @@ class SyncManager @Inject constructor(
     private val stringArray = arrayOfNulls<String>(4)
     private var listener: OnSyncListener? = null
     private var backgroundSync: Job? = null
-    private var betaSync = false
     private val _syncStatus = MutableStateFlow<SyncStatus>(SyncStatus.Idle)
     val syncStatus: StateFlow<SyncStatus> = _syncStatus
 
@@ -103,7 +100,7 @@ class SyncManager @Inject constructor(
                 } else if (!useImproved) {
                     createLog("sync_manager_route", "legacy")
                 }
-                authenticateAndSync(type, syncTables)
+                authenticateAndSync()
             }
         }
     }
@@ -132,11 +129,7 @@ class SyncManager @Inject constructor(
         syncScope.launch {
             try {
                 val manager = improvedSyncManager.get()
-                val syncMode = if (sharedPrefManager.getFastSync()) {
-                    SyncMode.Fast
-                } else {
-                    SyncMode.Standard
-                }
+                val syncMode = SyncMode.Standard
                 createLog("sync_manager_route", "improved|mode=${syncMode.javaClass.simpleName}")
                 val wrappedListener = object : OnSyncListener {
                     override fun onSyncStarted() {
@@ -165,9 +158,6 @@ class SyncManager @Inject constructor(
     }
 
     private fun destroy() {
-        if (betaSync) {
-            syncScope.cancel()
-        }
         improvedSyncManager.get().cancel()
         cancelBackgroundSync()
         cancel(context, 111)
@@ -178,23 +168,14 @@ class SyncManager @Inject constructor(
         _syncStatus.value = SyncStatus.Success("Sync completed")
     }
 
-    private fun authenticateAndSync(type: String, syncTables: List<String>?) {
+    private fun authenticateAndSync() {
         backgroundSync = syncScope.launch(dispatcherProvider.io) {
             if (transactionSyncManager.authenticate()) {
-                startSync(type, syncTables)
+                startFullSync()
             } else {
                 handleException(context.getString(R.string.invalid_configuration))
                 cleanupMainSync()
             }
-        }
-    }
-
-    private suspend fun startSync(type: String, syncTables: List<String>?) {
-        val isFastSync = sharedPrefManager.getFastSync()
-        if (!isFastSync || type == "upload") {
-            startFullSync()
-        } else {
-            startFastSync(syncTables)
         }
     }
 
@@ -282,209 +263,6 @@ class SyncManager @Inject constructor(
             Log.d("SyncPerf", "SYNC FAILED after ${totalSyncTime}ms")
             Log.d("SyncPerf", "Error: ${err.message}")
             Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-            err.printStackTrace()
-            handleException(err.message)
-        } finally {
-            destroy()
-        }
-    }
-
-    private suspend fun startFastSync(syncTables: List<String>? = null) {
-        try {
-            val logger = SyncTimeLogger
-            logger.startLogging()
-
-            initializeSync()
-            coroutineScope {
-                val syncJobs = mutableListOf<Deferred<Unit>>()
-                if (syncTables?.contains("tablet_users") != false) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("tablet_users_sync")
-                            transactionSyncManager.syncDb("tablet_users")
-                            logger.endProcess("tablet_users_sync")
-                        })
-
-                    syncJobs.add(async {
-                        logger.startProcess("login_activities_sync")
-                        transactionSyncManager.syncDb("login_activities", useCheckpoint = true)
-                        logger.endProcess("login_activities_sync")
-                    })
-
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("tags_sync")
-                            transactionSyncManager.syncDb("tags")
-                            logger.endProcess("tags_sync")
-                        })
-
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("teams_sync")
-                            transactionSyncManager.syncDb("teams")
-                            logger.endProcess("teams_sync")
-                        })
-
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("news_sync")
-                            transactionSyncManager.syncDb("news")
-                            logger.endProcess("news_sync")
-                        })
-
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("notifications_sync")
-                            transactionSyncManager.syncDb("notifications")
-                            logger.endProcess("notifications_sync")
-                        })
-                }
-
-                if (syncTables?.contains("resources") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("library_sync")
-                            myLibraryTransactionSync()
-                            logger.endProcess("library_sync")
-                        })
-
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("resource_sync")
-                            resourceTransactionSync()
-                            logger.endProcess("resource_sync")
-                        })
-                }
-
-                if (syncTables?.contains("courses") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("library_sync")
-                            myLibraryTransactionSync()
-                            logger.endProcess("library_sync")
-                        })
-
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("courses_sync")
-                            transactionSyncManager.syncDb("courses")
-                            logger.endProcess("courses_sync")
-                        })
-
-                    syncJobs.add(async {
-                        logger.startProcess("courses_progress_sync")
-                        transactionSyncManager.syncDb("courses_progress", useCheckpoint = true)
-                        logger.endProcess("courses_progress_sync")
-                    })
-
-                    syncJobs.add(async {
-                        logger.startProcess("ratings_sync")
-                        transactionSyncManager.syncDb("ratings", useCheckpoint = true)
-                        logger.endProcess("ratings_sync")
-                    })
-                }
-
-                if (syncTables?.contains("tasks") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("tasks_sync")
-                            transactionSyncManager.syncDb("tasks")
-                            logger.endProcess("tasks_sync")
-                        })
-                }
-
-                if (syncTables?.contains("meetups") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("meetups_sync")
-                            transactionSyncManager.syncDb("meetups")
-                            logger.endProcess("meetups_sync")
-                        })
-                }
-
-                if (syncTables?.contains("team_activities") == true) {
-                    syncJobs.add(async {
-                        logger.startProcess("team_activities_sync")
-                        transactionSyncManager.syncDb("team_activities", useCheckpoint = true)
-                        logger.endProcess("team_activities_sync")
-                    })
-                }
-
-                if (syncTables?.contains("chat_history") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("chat_history_sync")
-                            transactionSyncManager.syncDb("chat_history")
-                            logger.endProcess("chat_history_sync")
-                        })
-                }
-
-                if (syncTables?.contains("feedback") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("feedback_sync")
-                            transactionSyncManager.syncDb("feedback")
-                            logger.endProcess("feedback_sync")
-                        })
-                }
-
-                if (syncTables?.contains("achievements") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("achievements_sync")
-                            transactionSyncManager.syncDb("achievements")
-                            logger.endProcess("achievements_sync")
-                        })
-                }
-
-                if (syncTables?.contains("health") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("health_sync")
-                            transactionSyncManager.syncDb("health")
-                            logger.endProcess("health_sync")
-                        })
-
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("certifications_sync")
-                            transactionSyncManager.syncDb("certifications")
-                            logger.endProcess("certifications_sync")
-                        })
-                }
-
-                if (syncTables?.contains("courses") == true || syncTables?.contains("exams") == true) {
-                    syncJobs.add(
-                        async {
-                            logger.startProcess("exams_sync")
-                            transactionSyncManager.syncDb("exams")
-                            logger.endProcess("exams_sync")
-                        })
-
-                    syncJobs.add(async {
-                        logger.startProcess("submissions_sync")
-                        transactionSyncManager.syncDb("submissions", useCheckpoint = true)
-                        logger.endProcess("submissions_sync")
-                    })
-                }
-
-                syncJobs.awaitAll()
-            }
-
-            logger.startProcess("admin_sync")
-            loginSyncManager.syncAdmin()
-            logger.endProcess("admin_sync")
-
-            logger.startProcess("notification_reads_upload")
-            transactionSyncManager.syncNotificationReads()
-            logger.endProcess("notification_reads_upload")
-
-            logger.startProcess("on_synced")
-            activitiesRepository.recordSyncActivity(sharedPrefManager.rawPreferences.getString("userId", "") ?: "")
-            logger.endProcess("on_synced")
-
-            logger.stopLogging()
-        } catch (err: Exception) {
             err.printStackTrace()
             handleException(err.message)
         } finally {

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncStrategy.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncStrategy.kt
@@ -32,6 +32,5 @@ interface SyncStrategy {
 
 sealed class SyncMode {
     object Standard : SyncMode()
-    object Fast : SyncMode()
     object Optimized : SyncMode()
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
@@ -20,12 +20,10 @@ import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.OnBaseRealtimeSyncListener
 import org.ole.planet.myplanet.callback.OnChatHistoryItemClickListener
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.databinding.FragmentChatHistoryBinding
 import org.ole.planet.myplanet.model.ChatShareTargets
 import org.ole.planet.myplanet.model.RealmConversation
@@ -36,10 +34,7 @@ import org.ole.planet.myplanet.repository.ChatRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
-import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 private data class Quartet<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
@@ -53,18 +48,13 @@ class ChatHistoryFragment : Fragment() {
     var user: RealmUser? = null
     private var isFullSearch: Boolean = false
     private var isQuestion: Boolean = false
-    private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
     @Inject
     lateinit var sharedPrefManager: SharedPrefManager
-    @Inject
-    lateinit var serverUrlMapper: ServerUrlMapper
     private var sharedNewsMessages: List<RealmNews> = emptyList()
     private var shareTargets = ChatShareTargets(null, emptyList(), emptyList())
     private var searchBarWatcher: TextWatcher? = null
     private var searchJob: Job? = null
     
-    @Inject
-    lateinit var syncManager: SyncManager
     @Inject
     lateinit var chatRepository: ChatRepository
     @Inject
@@ -76,7 +66,6 @@ class ChatHistoryFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        startChatHistorySync()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -178,72 +167,6 @@ class ChatHistoryFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         refreshChatHistory()
-    }
-
-    private fun startChatHistorySync() {
-        val isFastSync = sharedPrefManager.getFastSync()
-        if (isFastSync && !sharedPrefManager.isSynced(SharedPrefManager.SyncKey.CHAT_HISTORY)) {
-            checkServerAndStartSync()
-        }
-    }
-
-    private fun checkServerAndStartSync() {
-        val mapping = serverUrlMapper.processUrl(serverUrl)
-
-        lifecycleScope.launch {
-            updateServerIfNecessary(mapping)
-            startSyncManager()
-        }
-    }
-
-    private fun startSyncManager() {
-        syncManager.start(object : OnSyncListener {
-            override fun onSyncStarted() {
-                if (view != null && isAdded) {
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        if (isAdded && !requireActivity().isFinishing) {
-                            customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-                            customProgressDialog?.setText(getString(R.string.syncing_chat_history))
-                            customProgressDialog?.show()
-                        }
-                    }
-                }
-            }
-
-            override fun onSyncComplete() {
-                if (view != null && isAdded) {
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        if (isAdded) {
-                            customProgressDialog?.dismiss()
-                            customProgressDialog = null
-                            sharedPrefManager.setSynced(SharedPrefManager.SyncKey.CHAT_HISTORY, true)
-
-                            refreshChatHistory()
-                        }
-                    }
-                }
-            }
-
-            override fun onSyncFailed(msg: String?) {
-                if (view != null && isAdded) {
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        if (isAdded) {
-                            customProgressDialog?.dismiss()
-                            customProgressDialog = null
-                            refreshChatHistory()
-
-                            Snackbar.make(binding.root, "Sync failed: ${msg ?: "Unknown error"}", Snackbar.LENGTH_LONG)
-                                .setAction("Retry") { startChatHistorySync() }.show()
-                        }
-                    }
-                }
-            } }, "full", listOf("chat_history"))
-    }
-
-    private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
-        serverUrlMapper.updateServerIfNecessary(mapping, sharedPrefManager.rawPreferences) { url ->
-            isServerReachable(url)
-        }
     }
 
     fun refreshChatHistory() {
@@ -366,11 +289,6 @@ class ChatHistoryFragment : Fragment() {
         super.onDestroyView()
     }
 
-    override fun onDestroy() {
-        customProgressDialog?.dismiss()
-        customProgressDialog = null
-        super.onDestroy()
-    }
 }
 
 class ChatHistoryOnBackPressedCallback(private val slidingPaneLayout: SlidingPaneLayout) :

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -11,12 +11,10 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -31,7 +29,6 @@ import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.model.Tag
-import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.ui.resources.CollectionsFragment
@@ -51,13 +48,9 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     private lateinit var selectionController: CourseSelectionController
     var userModel: RealmUser? = null
     private lateinit var confirmation: AlertDialog
-    private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
     private var selectionJob: Job? = null
     private var pendingScrollState: android.os.Parcelable? = null
     private val viewModel: CoursesViewModel by viewModels()
-
-    @Inject
-    lateinit var prefManager: SharedPrefManager
 
     @Inject
     lateinit var userSessionManager: UserSessionManager
@@ -175,45 +168,8 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
                 }
             }
 
-        collectLatestWhenStarted(viewModel.syncStatus) { status ->
-            when (status) {
-                    is SyncStatus.Idle -> {}
-                    is SyncStatus.Syncing -> {
-                        if (isAdded && !requireActivity().isFinishing) {
-                            if (customProgressDialog == null) {
-                                customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-                            }
-                            customProgressDialog?.setText(getString(R.string.syncing_courses_data))
-                            customProgressDialog?.show()
-                        }
-                    }
-                    is SyncStatus.Success -> {
-                        if (isAdded) {
-                            customProgressDialog?.setText(getString(R.string.loading_courses))
-                            delay(3000)
-                            customProgressDialog?.dismiss()
-                            customProgressDialog = null
-                            loadDataAsync()
-                            prefManager.setSynced(SharedPrefManager.SyncKey.COURSES, true)
-                            viewModel.resetSyncStatus()
-                        }
-                    }
-                    is SyncStatus.Failed -> {
-                        if (isAdded) {
-                            customProgressDialog?.dismiss()
-                            customProgressDialog = null
-                            Snackbar.make(requireView(), "Sync failed: ${status.message ?: "Unknown error"}", Snackbar.LENGTH_LONG)
-                                .setAction("Retry") { viewModel.startCoursesSync() }
-                                .show()
-                            viewModel.resetSyncStatus()
-                        }
-                    }
-                }
-            }
-
         realtimeSyncHelper = RealtimeSyncHelper(this, this)
         realtimeSyncHelper.setupRealtimeSync()
-        viewModel.startCoursesSync()
     }
 
     private fun initializeView() {
@@ -446,12 +402,6 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
         if (::selectionController.isInitialized && ::adapterCourses.isInitialized) {
             selectionController.clearAll(adapterCourses)
         }
-    }
-
-    override fun onDestroy() {
-        customProgressDialog?.dismiss()
-        customProgressDialog = null
-        super.onDestroy()
     }
 
     override fun getWatchedTables(): List<String> = listOf("courses")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
@@ -13,23 +13,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.model.Course
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.Tag
 import org.ole.planet.myplanet.repository.CoursesRepository
-import org.ole.planet.myplanet.services.SharedPrefManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
-
-sealed class SyncStatus {
-    object Idle : SyncStatus()
-    object Syncing : SyncStatus()
-    object Success : SyncStatus()
-    data class Failed(val message: String?) : SyncStatus()
-}
 
 data class CoursesUiState(
     val courses: List<Course> = emptyList(),
@@ -41,62 +29,11 @@ data class CoursesUiState(
 @HiltViewModel
 class CoursesViewModel @Inject constructor(
     private val coursesRepository: CoursesRepository,
-    private val dispatcherProvider: DispatcherProvider,
-    private val syncManager: SyncManager,
-    private val serverUrlMapper: ServerUrlMapper,
-    private val prefManager: SharedPrefManager
+    private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
 
     private val _coursesState = MutableStateFlow(CoursesUiState())
     val coursesState: StateFlow<CoursesUiState> = _coursesState.asStateFlow()
-
-    private val _syncStatus = MutableStateFlow<SyncStatus>(SyncStatus.Idle)
-    val syncStatus: StateFlow<SyncStatus> = _syncStatus.asStateFlow()
-
-    fun resetSyncStatus() {
-        _syncStatus.value = SyncStatus.Idle
-    }
-
-    fun startCoursesSync() {
-        val isFastSync = prefManager.getFastSync()
-        if (isFastSync && !prefManager.isSynced(SharedPrefManager.SyncKey.COURSES)) {
-            checkServerAndStartSync()
-        }
-    }
-
-    private fun checkServerAndStartSync() {
-        val serverUrl = prefManager.getServerUrl()
-        val mapping = serverUrlMapper.processUrl(serverUrl)
-
-        viewModelScope.launch {
-            withContext(dispatcherProvider.io) {
-                updateServerIfNecessary(mapping)
-            }
-            startSyncManager()
-        }
-    }
-
-    private fun startSyncManager() {
-        syncManager.start(object : OnSyncListener {
-            override fun onSyncStarted() {
-                _syncStatus.value = SyncStatus.Syncing
-            }
-
-            override fun onSyncComplete() {
-                _syncStatus.value = SyncStatus.Success
-            }
-
-            override fun onSyncFailed(msg: String?) {
-                _syncStatus.value = SyncStatus.Failed(msg)
-            }
-        }, "full", listOf("courses"))
-    }
-
-    private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
-        serverUrlMapper.updateServerIfNecessary(mapping, prefManager.rawPreferences) { url ->
-            isServerReachable(url)
-        }
-    }
 
     private fun processCourses(
         isMyCourseLib: Boolean,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -8,52 +8,28 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
-import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.OnBaseRealtimeSyncListener
 import org.ole.planet.myplanet.callback.OnFeedbackSubmittedListener
 import org.ole.planet.myplanet.databinding.FragmentFeedbackListBinding
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.TableDataUpdate
-import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.utils.DialogUtils
-import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
-    @Inject lateinit var dispatcherProvider: DispatcherProvider
 
     private var _binding: FragmentFeedbackListBinding? = null
     private val binding get() = _binding!!
-    private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
     private val viewModel: FeedbackListViewModel by viewModels()
-
-    @Inject
-    lateinit var sharedPrefManager: SharedPrefManager
-
-    @Inject
-    lateinit var serverUrlMapper: ServerUrlMapper
-
-    private val serverUrl: String
-    get() = sharedPrefManager.getServerUrl()
 
     private val syncManagerInstance = RealtimeSyncManager.getInstance()
     private lateinit var onRealtimeSyncListener: OnBaseRealtimeSyncListener
     private lateinit var feedbackAdapter: FeedbackAdapter
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        startFeedbackSync()
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -93,30 +69,6 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
         viewModel.refreshFeedback()
     }
 
-    private fun startFeedbackSync() {
-        val isFastSync = sharedPrefManager.getFastSync()
-        if (isFastSync && !sharedPrefManager.isSynced(SharedPrefManager.SyncKey.FEEDBACK)) {
-            checkServerAndStartSync()
-        }
-    }
-
-    private fun checkServerAndStartSync() {
-        val mapping = serverUrlMapper.processUrl(serverUrl)
-
-        lifecycleScope.launch(dispatcherProvider.io) {
-            updateServerIfNecessary(mapping)
-            withContext(dispatcherProvider.main) {
-                viewModel.startFeedbackSync()
-            }
-        }
-    }
-
-    private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
-        serverUrlMapper.updateServerIfNecessary(mapping, sharedPrefManager.rawPreferences) { url ->
-            isServerReachable(url)
-        }
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         feedbackAdapter = FeedbackAdapter()
@@ -129,38 +81,6 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
         collectWhenStarted(viewModel.feedbackList) { feedbackList ->
             updatedFeedbackList(feedbackList)
         }
-
-        collectWhenStarted(viewModel.syncStatus) { status ->
-            when (status) {
-                is FeedbackListViewModel.SyncStatus.Idle -> {
-                    // Do nothing
-                }
-                is FeedbackListViewModel.SyncStatus.Syncing -> {
-                    if (isAdded && !requireActivity().isFinishing) {
-                        customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-                        customProgressDialog?.setText(getString(R.string.syncing_feedback))
-                        customProgressDialog?.show()
-                    }
-                }
-                is FeedbackListViewModel.SyncStatus.Success -> {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-                        refreshFeedbackListData()
-                        sharedPrefManager.setSynced(SharedPrefManager.SyncKey.FEEDBACK, true)
-                    }
-                }
-                is FeedbackListViewModel.SyncStatus.Error -> {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-
-                        Snackbar.make(binding.root, "Sync failed: ${status.message}", Snackbar.LENGTH_LONG)
-                            .setAction("Retry") { startFeedbackSync() }.show()
-                    }
-                }
-            }
-        }
     }
 
     override fun onDestroyView() {
@@ -169,12 +89,6 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener {
         }
         _binding = null
         super.onDestroyView()
-    }
-
-    override fun onDestroy() {
-        customProgressDialog?.dismiss()
-        customProgressDialog = null
-        super.onDestroy()
     }
 
     override fun onFeedbackSubmitted() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModel.kt
@@ -10,33 +10,20 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.services.UserSessionManager
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class FeedbackListViewModel @Inject constructor(
     private val feedbackRepository: FeedbackRepository,
     private val userSessionManager: UserSessionManager,
-    private val dispatcherProvider: DispatcherProvider,
-    private val syncManager: SyncManager
+    private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
-
-    sealed class SyncStatus {
-        object Idle : SyncStatus()
-        object Syncing : SyncStatus()
-        object Success : SyncStatus()
-        data class Error(val message: String) : SyncStatus()
-    }
 
     private val _feedbackList = MutableStateFlow<List<RealmFeedback>>(emptyList())
     val feedbackList: StateFlow<List<RealmFeedback>> = _feedbackList.asStateFlow()
-
-    private val _syncStatus = MutableStateFlow<SyncStatus>(SyncStatus.Idle)
-    val syncStatus: StateFlow<SyncStatus> = _syncStatus.asStateFlow()
 
     private var fetchJob: Job? = null
 
@@ -55,21 +42,5 @@ class FeedbackListViewModel @Inject constructor(
     }
     fun refreshFeedback() {
         loadFeedback()
-    }
-
-    fun startFeedbackSync() {
-        syncManager.start(object : OnSyncListener {
-            override fun onSyncStarted() {
-                _syncStatus.value = SyncStatus.Syncing
-            }
-
-            override fun onSyncComplete() {
-                _syncStatus.value = SyncStatus.Success
-            }
-
-            override fun onSyncFailed(msg: String?) {
-                _syncStatus.value = SyncStatus.Error(msg ?: "Unknown error")
-            }
-        }, "full", listOf("feedback"))
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Calendar
 import java.util.Locale
@@ -29,10 +28,8 @@ import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnBaseRealtimeSyncListener
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.databinding.AlertHealthListBinding
 import org.ole.planet.myplanet.databinding.AlertMyPersonalBinding
 import org.ole.planet.myplanet.databinding.FragmentVitalSignBinding
@@ -42,10 +39,7 @@ import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.ui.user.BecomeMemberActivity
-import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities
@@ -60,8 +54,6 @@ class MyHealthFragment : Fragment() {
     lateinit var userSessionManager: UserSessionManager
 
     @Inject
-    lateinit var syncManager: SyncManager
-    @Inject
     lateinit var userRepository: UserRepository
     private val syncManagerInstance = RealtimeSyncManager.getInstance()
     private lateinit var onRealtimeSyncListener: OnBaseRealtimeSyncListener
@@ -75,81 +67,18 @@ class MyHealthFragment : Fragment() {
     lateinit var adapter: HealthUsersAdapter
     private lateinit var healthAdapter: HealthExaminationAdapter
     var dialog: AlertDialog? = null
-    private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
     @Inject
     lateinit var sharedPrefManager: SharedPrefManager
-    @Inject
-    lateinit var serverUrlMapper: ServerUrlMapper
-    private val serverUrl: String
-        get() = sharedPrefManager.getServerUrl()
     private var textWatcher: TextWatcher? = null
     private var searchJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        startHealthSync()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentVitalSignBinding.inflate(inflater, container, false)
         return binding.root
-    }
-
-    private fun startHealthSync() {
-        val isFastSync = sharedPrefManager.getFastSync()
-        if (isFastSync && !sharedPrefManager.isSynced(SharedPrefManager.SyncKey.HEALTH)) {
-            checkServerAndStartSync()
-        }
-    }
-
-    private fun checkServerAndStartSync() {
-        val mapping = serverUrlMapper.processUrl(serverUrl)
-
-        lifecycleScope.launch {
-            updateServerIfNecessary(mapping)
-            startSyncManager()
-        }
-    }
-
-    private fun startSyncManager() {
-        syncManager.start(object : OnSyncListener {
-            override fun onSyncStarted() {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded && !requireActivity().isFinishing) {
-                        customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-                        customProgressDialog?.setText(getString(R.string.syncing_health_data))
-                        customProgressDialog?.show()
-                    }
-                }
-            }
-
-            override fun onSyncComplete() {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-                        refreshHealthData()
-                        sharedPrefManager.setSynced(SharedPrefManager.SyncKey.HEALTH, true)
-                    }
-                }
-            }
-
-            override fun onSyncFailed(msg: String?) {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-                        Snackbar.make(binding.root, "Sync failed: ${msg ?: "Unknown error"}", Snackbar.LENGTH_LONG).setAction("Retry") { startHealthSync() }.show()
-                    }
-                }
-            }
-        }, "full", listOf("health"))
-    }
-
-    private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
-        serverUrlMapper.updateServerIfNecessary(mapping, sharedPrefManager.rawPreferences) { url ->
-            isServerReachable(url)
-        }
     }
 
     private fun refreshHealthData() {
@@ -466,9 +395,4 @@ class MyHealthFragment : Fragment() {
         super.onDestroyView()
     }
 
-    override fun onDestroy() {
-        customProgressDialog?.dismiss()
-        customProgressDialog = null
-        super.onDestroy()
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -16,7 +16,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.snackbar.Snackbar
 import com.google.gson.JsonObject
 import dagger.hilt.android.AndroidEntryPoint
 import fisk.chipcloud.ChipCloud
@@ -44,7 +43,6 @@ import org.ole.planet.myplanet.model.TagItem
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncHelper
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
-import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.DialogUtils.guestDialog
 import org.ole.planet.myplanet.utils.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utils.Utilities
@@ -69,7 +67,6 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     var userModel: RealmUser ?= null
     var map: HashMap<String?, JsonObject>? = null
     private var confirmation: AlertDialog? = null
-    private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
     private var searchTextWatcher: TextWatcher? = null
     private var isFirstResume = true
     private var allResourceModels: List<org.ole.planet.myplanet.model.ResourceListModel> = emptyList()
@@ -84,7 +81,6 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModel.startResourcesSync()
     }
 
     override fun getLayout(): Int {
@@ -140,35 +136,6 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         initArrays()
         hideButton()
 
-        collectWhenStarted(viewModel.syncState) { state ->
-            when (state) {
-                is org.ole.planet.myplanet.model.SyncState.Syncing -> {
-                    if (!requireActivity().isFinishing) {
-                        customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-                        customProgressDialog?.setText(getString(R.string.syncing_resources))
-                        customProgressDialog?.show()
-                    }
-                }
-                is org.ole.planet.myplanet.model.SyncState.Success -> {
-                    customProgressDialog?.dismiss()
-                    customProgressDialog = null
-                    refreshResourcesData()
-                    viewModel.resetSyncState()
-                }
-                is org.ole.planet.myplanet.model.SyncState.Failed -> {
-                    customProgressDialog?.dismiss()
-                    customProgressDialog = null
-                    Snackbar.make(requireView(), "Sync failed: ${state.message ?: "Unknown error"}", Snackbar.LENGTH_LONG
-                    ).setAction("Retry") {
-                        viewModel.startResourcesSync()
-                    }.show()
-                    viewModel.resetSyncState()
-                }
-                is org.ole.planet.myplanet.model.SyncState.Idle -> {
-                    // Do nothing
-                }
-            }
-        }
         collectWhenStarted(viewModel.downloadComplete) { completed ->
             if (completed) {
                 refreshResourcesData()
@@ -592,11 +559,6 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         }
         confirmation = null
 
-        if (customProgressDialog?.isShowing() == true) {
-            customProgressDialog?.dismiss()
-        }
-        customProgressDialog = null
-
         _binding = null
         super.onDestroyView()
     }
@@ -632,11 +594,6 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         }
     }
 
-    override fun onDestroy() {
-        customProgressDialog?.dismiss()
-        customProgressDialog = null
-        super.onDestroy()
-    }
 
     private fun additionalSetup() {
         val bottomSheet = binding.cardFilter

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
@@ -10,30 +10,16 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.model.ResourceItem
 import org.ole.planet.myplanet.model.ResourceListModel
-import org.ole.planet.myplanet.model.SyncState
 import org.ole.planet.myplanet.model.TagItem
 import org.ole.planet.myplanet.repository.ResourcesRepository
-import org.ole.planet.myplanet.services.SharedPrefManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
-import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class ResourcesViewModel @Inject constructor(
-    private val syncManager: SyncManager,
-    private val sharedPrefManager: SharedPrefManager,
-    private val serverUrlMapper: ServerUrlMapper,
-    private val resourcesRepository: ResourcesRepository,
-    private val dispatcherProvider: DispatcherProvider
+    private val resourcesRepository: ResourcesRepository
 ) : ViewModel() {
 
-    private val _syncState = MutableStateFlow<SyncState>(SyncState.Idle)
-    val syncState: StateFlow<SyncState> = _syncState.asStateFlow()
     private val _downloadComplete = MutableStateFlow(false)
     val downloadComplete: StateFlow<Boolean> = _downloadComplete.asStateFlow()
 
@@ -54,47 +40,6 @@ class ResourcesViewModel @Inject constructor(
                 _openedResourceIds.value = ids
             }
         }
-    }
-
-    fun startResourcesSync() {
-        val isFastSync = sharedPrefManager.getFastSync()
-        if (isFastSync && !sharedPrefManager.isSynced(SharedPrefManager.SyncKey.RESOURCES)) {
-            checkServerAndStartSync()
-        }
-    }
-
-    private fun checkServerAndStartSync() {
-        val mapping = serverUrlMapper.processUrl(sharedPrefManager.getServerUrl())
-
-        viewModelScope.launch {
-            withContext(dispatcherProvider.io) {
-                serverUrlMapper.updateServerIfNecessary(mapping, sharedPrefManager.rawPreferences) { url ->
-                    isServerReachable(url)
-                }
-            }
-            startSyncManager()
-        }
-    }
-
-    private fun startSyncManager() {
-        syncManager.start(object : OnSyncListener {
-            override fun onSyncStarted() {
-                _syncState.value = SyncState.Syncing
-            }
-
-            override fun onSyncComplete() {
-                _syncState.value = SyncState.Success
-                sharedPrefManager.setSynced(SharedPrefManager.SyncKey.RESOURCES, true)
-            }
-
-            override fun onSyncFailed(msg: String?) {
-                _syncState.value = SyncState.Failed(msg)
-            }
-        }, "full", listOf("resources"))
-    }
-
-    fun resetSyncState() {
-        _syncState.value = SyncState.Idle
     }
 
     suspend fun addResourcesToUserLibrary(resourceIds: List<String>, userId: String): Result<Unit> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -243,15 +243,6 @@ class SettingsActivity : AppCompatActivity() {
                 true
             }
 
-            val fastSync = findPreference<SwitchPreference>("beta_fast_sync")
-            val isFastSync = sharedPrefManager.getFastSync()
-            fastSync?.isChecked = isFastSync
-            fastSync?.onPreferenceChangeListener = OnPreferenceChangeListener { _, newValue ->
-                val isChecked = newValue as Boolean
-                sharedPrefManager.setFastSync(isChecked)
-                true
-            }
-
             clearDataButtonInit()
             initRetryQueueDebug()
             initStorageBreakdown()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
@@ -65,8 +65,6 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), OnSurveyAdoptList
         super.onCreate(savedInstanceState)
         isTeam = arguments?.getBoolean("isTeam", false) == true
         teamId = arguments?.getString("teamId", null)
-        
-        viewModel.startExamSync()
     }
 
     override fun onAdoptSurvey(surveyId: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysViewModel.kt
@@ -10,29 +10,18 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.SurveyFormState
 import org.ole.planet.myplanet.model.SurveyInfo
 import org.ole.planet.myplanet.repository.SurveysRepository
-import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
-import org.ole.planet.myplanet.utils.DispatcherProvider
 
 private val DIACRITICS_REGEX = Regex("\\p{InCombiningDiacriticalMarks}+")
 
 @HiltViewModel
 class SurveysViewModel @Inject constructor(
     private val surveysRepository: SurveysRepository,
-    private val syncManager: SyncManager,
-    private val userSessionManager: UserSessionManager,
-    private val sharedPrefManager: SharedPrefManager,
-    private val serverUrlMapper: ServerUrlMapper,
-    private val dispatcherProvider: DispatcherProvider
+    private val userSessionManager: UserSessionManager
 ) : ViewModel() {
 
     enum class SortOption {
@@ -166,48 +155,6 @@ class SurveysViewModel @Inject constructor(
     private fun normalizeText(str: String): String {
         return Normalizer.normalize(str.lowercase(Locale.getDefault()), Normalizer.Form.NFD)
             .replace(DIACRITICS_REGEX, "")
-    }
-
-    fun startExamSync() {
-        val isFastSync = sharedPrefManager.getFastSync()
-        val isExamsSynced = sharedPrefManager.isSynced(SharedPrefManager.SyncKey.EXAMS)
-
-        if (isFastSync && !isExamsSynced) {
-            checkServerAndStartSync()
-        }
-    }
-
-    private fun checkServerAndStartSync() {
-        val serverUrl = sharedPrefManager.getServerUrl()
-        val mapping = serverUrlMapper.processUrl(serverUrl)
-
-        viewModelScope.launch {
-            withContext(dispatcherProvider.io) {
-                serverUrlMapper.updateServerIfNecessary(mapping, sharedPrefManager.rawPreferences) { url ->
-                    MainApplication.isServerReachable(url)
-                }
-            }
-            startSyncManager()
-        }
-    }
-
-    private fun startSyncManager() {
-        syncManager.start(object : OnSyncListener {
-            override fun onSyncStarted() {
-                _isLoading.value = true
-            }
-
-            override fun onSyncComplete() {
-                sharedPrefManager.setSynced(SharedPrefManager.SyncKey.EXAMS, true)
-                _isLoading.value = false
-                loadSurveys(isTeam, teamId, _isTeamShareAllowed.value)
-            }
-
-            override fun onSyncFailed(msg: String?) {
-                _isLoading.value = false
-                _errorMessage.value = "Sync failed: $msg"
-            }
-        }, "full", listOf("exams"))
     }
 
     fun adoptSurvey(surveyId: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
@@ -249,13 +249,6 @@ fun SyncActivity.setRadioProtocolListener(binding: DialogServerUrlBinding) {
     }
 }
 
-fun SyncActivity.setupFastSyncOption(binding: DialogServerUrlBinding) {
-    binding.fastSync.isChecked = prefData.getFastSync()
-    binding.fastSync.setOnCheckedChangeListener { _: CompoundButton?, checked: Boolean ->
-        prefData.setFastSync(checked)
-    }
-}
-
 fun SyncActivity.handleManualConfiguration(
     binding: DialogServerUrlBinding,
     configurationId: String?,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -691,7 +691,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         binding.clearData.setOnClickListener {
             clearDataDialog(getString(R.string.are_you_sure_you_want_to_clear_data), false)
         }
-        setupFastSyncOption(binding)
 
         showAdditionalServers = false
         if (serverListAddresses.isNotEmpty() && prefData.getServerUrl().isNotEmpty()) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
@@ -16,23 +16,18 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseTeamFragment
 import org.ole.planet.myplanet.callback.OnBaseRealtimeSyncListener
 import org.ole.planet.myplanet.callback.OnMemberChangeListener
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.callback.OnTeamPageListener
 import org.ole.planet.myplanet.callback.OnTeamUpdateListener
 import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TableDataUpdate
-import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.CalendarPage
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.ChatPage
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.CoursesPage
@@ -45,7 +40,6 @@ import org.ole.planet.myplanet.ui.teams.TeamPageConfig.ReportsPage
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.ResourcesPage
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.SurveyPage
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.TasksPage
-import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.Utilities
 
 @AndroidEntryPoint
@@ -54,9 +48,6 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
     @Inject
     lateinit var userSessionManager: UserSessionManager
     
-    @Inject
-    lateinit var syncManager: SyncManager
-
     private val syncManagerInstance = RealtimeSyncManager.getInstance()
     private lateinit var onRealtimeSyncListener: OnBaseRealtimeSyncListener
 
@@ -65,12 +56,7 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
     private var directTeamName: String? = null
     private var directTeamType: String? = null
     private var directTeamId: String? = null
-    private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
-    @Inject
-    lateinit var serverUrlMapper: ServerUrlMapper
     private val teamLastPage = mutableMapOf<String, String>()
-    private val serverUrl: String
-        get() = prefData.getServerUrl()
     private var pageConfigs: List<TeamPageConfig> = emptyList()
     private var loadTeamJob: Job? = null
 
@@ -109,7 +95,6 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        startTeamSync()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -181,66 +166,6 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
         binding.btnAddDoc.isEnabled = false
         binding.btnLeave.isEnabled = false
         binding.viewPager2.adapter = null
-    }
-
-    private fun startTeamSync() {
-        val isFastSync = prefData.getFastSync()
-        if (isFastSync && prefData.isSynced(SharedPrefManager.SyncKey.TEAMS)) {
-            checkServerAndStartSync()
-        }
-    }
-
-    private fun checkServerAndStartSync() {
-        val mapping = serverUrlMapper.processUrl(serverUrl)
-
-        lifecycleScope.launch {
-            updateServerIfNecessary(mapping)
-            startSyncManager()
-        }
-    }
-
-    private fun startSyncManager() {
-        syncManager.start(object : OnSyncListener {
-            override fun onSyncStarted() {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded && !requireActivity().isFinishing) {
-                        customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-                        customProgressDialog?.setText(requireContext().getString(R.string.syncing_team_data))
-                        customProgressDialog?.show()
-                    }
-                }
-            }
-
-            override fun onSyncComplete() {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-                        refreshTeamDetails()
-                        prefData.setSynced(SharedPrefManager.SyncKey.TEAMS, true)
-                    }
-                }
-            }
-
-            override fun onSyncFailed(msg: String?) {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-
-                        Snackbar.make(binding.root, "Sync failed: ${msg ?: "Unknown error"}", Snackbar.LENGTH_LONG)
-                            .setAction("Retry") { startTeamSync() }
-                            .show()
-                    }
-                }
-            }
-        }, "full", listOf("tasks", "meetups", "team_activities"))
-    }
-
-    private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
-        serverUrlMapper.updateServerIfNecessary(mapping, prefData.rawPreferences) { url ->
-            isServerReachable(url)
-        }
     }
 
     private fun setupTeamDetails(isMyTeam: Boolean, user: RealmUser?, hasPendingRequest: Boolean) {
@@ -534,11 +459,6 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
         _binding = null
     }
 
-    override fun onDestroy() {
-        customProgressDialog?.dismiss()
-        customProgressDialog = null
-        super.onDestroy()
-    }
 
     companion object {
         fun newInstance(

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/AchievementFragment.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
-import com.google.android.material.snackbar.Snackbar
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import dagger.hilt.android.AndroidEntryPoint
@@ -20,13 +19,10 @@ import java.io.File
 import java.time.Instant
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.callback.OnBaseRealtimeSyncListener
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.databinding.FragmentAchievementBinding
 import org.ole.planet.myplanet.databinding.LayoutButtonPrimaryBinding
 import org.ole.planet.myplanet.databinding.RowAchievementBinding
@@ -34,15 +30,10 @@ import org.ole.planet.myplanet.model.AchievementData
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TableDataUpdate
-import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.ui.references.ReferencesAdapter
 import org.ole.planet.myplanet.ui.viewer.ResourceViewerActivity
 import org.ole.planet.myplanet.ui.viewer.ResourceViewerFragment
-import org.ole.planet.myplanet.utils.DialogUtils
-import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.JsonUtils.getString
@@ -50,28 +41,17 @@ import org.ole.planet.myplanet.utils.TimeUtils.getFormattedDateWithTime
 
 @AndroidEntryPoint
 class AchievementFragment : BaseContainerFragment() {
-    @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
 
     private var _binding: FragmentAchievementBinding? = null
     private val binding get() = _binding!!
     var user: RealmUser? = null
     var listener: OnHomeItemClickListener? = null
     private var achievementData: AchievementData? = null
-    private var customProgressDialog: DialogUtils.CustomProgressDialog? = null
-    @Inject
-    lateinit var serverUrlMapper: ServerUrlMapper
-
-    @Inject
-    lateinit var syncManager: SyncManager
     private val syncManagerInstance = RealtimeSyncManager.getInstance()
     private lateinit var onRealtimeSyncListener: OnBaseRealtimeSyncListener
-    private val serverUrl: String
-        get() = prefData.getServerUrl()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        startAchievementSync()
     }
 
     override fun onAttach(context: Context) {
@@ -93,67 +73,6 @@ class AchievementFragment : BaseContainerFragment() {
         }
         _binding = null
         super.onDestroyView()
-    }
-
-    private fun startAchievementSync() {
-        val isFastSync = prefData.getFastSync()
-        if (isFastSync && !prefData.isSynced(SharedPrefManager.SyncKey.ACHIEVEMENTS)) {
-            checkServerAndStartSync()
-        }
-    }
-
-    private fun checkServerAndStartSync() {
-        val mapping = serverUrlMapper.processUrl(serverUrl)
-
-        lifecycleScope.launch(dispatcherProvider.io) {
-            updateServerIfNecessary(mapping)
-            withContext(dispatcherProvider.main) {
-                startSyncManager()
-            }
-        }
-    }
-
-    private fun startSyncManager() {
-        syncManager.start(object : OnSyncListener {
-            override fun onSyncStarted() {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded && !requireActivity().isFinishing) {
-                        customProgressDialog = DialogUtils.CustomProgressDialog(requireContext())
-                        customProgressDialog?.setText(getString(R.string.syncing_achievements))
-                        customProgressDialog?.show()
-                    }
-                }
-            }
-
-            override fun onSyncComplete() {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-                        refreshAchievementData()
-                        prefData.setSynced(SharedPrefManager.SyncKey.ACHIEVEMENTS, true)
-                    }
-                }
-            }
-
-            override fun onSyncFailed(msg: String?) {
-                viewLifecycleOwner.lifecycleScope.launch {
-                    if (isAdded) {
-                        customProgressDialog?.dismiss()
-                        customProgressDialog = null
-                        Snackbar.make(binding.root, "Sync failed: ${msg ?: "Unknown error"}", Snackbar.LENGTH_LONG)
-                            .setAction("Retry") { startAchievementSync() }
-                            .show()
-                    }
-                }
-            }
-        }, "full", listOf("achievements"))
-    }
-
-    private suspend fun updateServerIfNecessary(mapping: ServerUrlMapper.UrlMapping) {
-        serverUrlMapper.updateServerIfNecessary(mapping, prefData.rawPreferences) { url ->
-            isServerReachable(url)
-        }
     }
 
     private fun refreshAchievementData() {
@@ -349,9 +268,4 @@ class AchievementFragment : BaseContainerFragment() {
     }
 
 
-    override fun onDestroy() {
-        customProgressDialog?.dismiss()
-        customProgressDialog = null
-        super.onDestroy()
-    }
 }

--- a/app/src/main/res/layout/dialog_server_url.xml
+++ b/app/src/main/res/layout/dialog_server_url.xml
@@ -221,16 +221,6 @@
             app:switchPadding="20dp" />
     </LinearLayout>
 
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/fastSync"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:padding="8dp"
-        android:text="@string/beta_fast_sync"
-        android:textColor="@color/daynight_textColor"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/linearLayout2" />
     <Button
         android:id="@+id/clearData"
         android:layout_width="wrap_content"
@@ -242,5 +232,5 @@
         android:textColor="@android:color/white"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/fastSync" />
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout2" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1101,7 +1101,6 @@
     <string name="fetching_ai_providers">جلب مزودي الذكاء الاصطناعي…</string>
     <string name="adopt_survey">تبنَّى الاستبيان</string>
     <string name="survey_adopted_successfully">تم تبني الاستبيان بنجاح!</string>
-    <string name="beta_fast_sync">مزامنة سريعة بيتا</string>
     <string name="beta_improved_sync">beta improved sync</string>
     <string name="beta_improved_sync_summary">Run the experimental sync manager during manual and auto syncs.</string>
     <string name="user_verification_in_progress">جارٍ التحقق من المستخدم. يرجى الانتظار أثناء معالجة البيانات.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1097,7 +1097,6 @@
     <string name="fetching_ai_providers">Obteniendo proveedores de IA…</string>
     <string name="adopt_survey">Adoptar encuesta</string>
     <string name="survey_adopted_successfully">¡Encuesta adoptada con éxito!</string>
-    <string name="beta_fast_sync">sincronización rápida beta</string>
     <string name="beta_improved_sync">beta improved sync</string>
     <string name="beta_improved_sync_summary">Run the experimental sync manager during manual and auto syncs.</string>
     <string name="user_verification_in_progress">Verificación de usuario en progreso. Por favor, espere mientras procesamos los datos.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1098,7 +1098,6 @@
     <string name="fetching_ai_providers">Récupération des fournisseurs d\'IA…</string>
     <string name="adopt_survey">Adopter le sondage</string>
     <string name="survey_adopted_successfully">Enquête adoptée avec succès !</string>
-    <string name="beta_fast_sync">synchronisation rapide bêta</string>
     <string name="beta_improved_sync">beta improved sync</string>
     <string name="beta_improved_sync_summary">Run the experimental sync manager during manual and auto syncs.</string>
     <string name="user_verification_in_progress">Vérification de l\'utilisateur en cours. Veuillez patienter pendant que nous traitons les données.</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -1097,7 +1097,6 @@
     <string name="fetching_ai_providers">एआई प्रदायकहरू प्राप्त गर्दै…</string>
     <string name="adopt_survey">सर्वेक्षण अपनाउनुहोस्</string>
     <string name="survey_adopted_successfully">सर्वेक्षण सफलतापूर्वक अपनाइयो!</string>
-    <string name="beta_fast_sync">बेटा फास्ट सिंक</string>
     <string name="beta_improved_sync">beta improved sync</string>
     <string name="beta_improved_sync_summary">Run the experimental sync manager during manual and auto syncs.</string>
     <string name="user_verification_in_progress">प्रयोगकर्ता प्रमाणीकरण प्रक्रिया भइरहेको छ। कृपया डेटा प्रशोधन भइरहेसम्म प्रतीक्षा गर्नुहोस्।</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -1097,7 +1097,6 @@
     <string name="fetching_ai_providers">Helitaanka bixiyeyaasha AI…</string>
     <string name="adopt_survey">Sahaminta qaado</string>
     <string name="survey_adopted_successfully">Sahanka si guul ah ayaa la qaatay!</string>
-    <string name="beta_fast_sync">beta sinkron degdeg ah</string>
     <string name="beta_improved_sync">beta improved sync</string>
     <string name="beta_improved_sync_summary">Run the experimental sync manager during manual and auto syncs.</string>
     <string name="user_verification_in_progress">Hubinta isticmaalaha ayaa socota. Fadlan sug inta aan xogta ka shaqeynayno.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1100,7 +1100,6 @@
     <string name="fetching_ai_providers">Fetching AI providers…</string>
     <string name="adopt_survey">Adopt survey</string>
     <string name="survey_adopted_successfully">Survey adopted successfully!</string>
-    <string name="beta_fast_sync">beta fast sync</string>
     <string name="beta_improved_sync">beta improved sync</string>
     <string name="beta_improved_sync_summary">Run the experimental sync manager during manual and auto syncs.</string>
     <string name="user_verification_in_progress">User verification in progress. Please wait while we process the data.</string>

--- a/app/src/main/res/xml/pref.xml
+++ b/app/src/main/res/xml/pref.xml
@@ -47,10 +47,6 @@
         android:title="@string/beta_functionality">
         <SwitchPreference
             android:defaultValue="false"
-            android:key="beta_fast_sync"
-            android:title="@string/beta_fast_sync" />
-        <SwitchPreference
-            android:defaultValue="false"
             android:key="beta_improved_sync"
             android:summary="@string/beta_improved_sync_summary"
             android:title="@string/beta_improved_sync" />

--- a/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
@@ -18,7 +18,6 @@ import org.junit.Test
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.User
 import org.ole.planet.myplanet.utils.Constants.PREFS_NAME
-import org.ole.planet.myplanet.utils.TestTimeProvider
 
 class SharedPrefManagerTest {
 
@@ -43,7 +42,7 @@ class SharedPrefManagerTest {
         every { mockEditor.putLong(any(), any()) } returns mockEditor
         every { mockEditor.remove(any()) } returns mockEditor
 
-        sharedPrefManager = SharedPrefManager(mockContext, org.ole.planet.myplanet.di.NetworkModule.provideGson(), TestTimeProvider())
+        sharedPrefManager = SharedPrefManager(mockContext, org.ole.planet.myplanet.di.NetworkModule.provideGson())
     }
 
     @Test
@@ -111,28 +110,6 @@ class SharedPrefManagerTest {
         sharedPrefManager.setPendingLanguageChange(null)
         verify { mockEditor.remove("pendingLanguageChange") }
         verify { mockEditor.apply() }
-    }
-
-    @Test
-    fun testSetSynced() {
-        // Test false synced
-        sharedPrefManager.setSynced(SharedPrefManager.SyncKey.CHAT_HISTORY, false)
-        verify { mockEditor.putBoolean("chat_history_synced", false) }
-        verify(exactly = 0) { mockEditor.putLong(eq("chat_history_synced_time"), any()) }
-        verify { mockEditor.apply() }
-
-        // Test true synced
-        sharedPrefManager.setSynced(SharedPrefManager.SyncKey.CHAT_HISTORY, true)
-        verify { mockEditor.putBoolean("chat_history_synced", true) }
-        verify { mockEditor.putLong(eq("chat_history_synced_time"), any()) }
-        verify { mockEditor.apply() }
-    }
-
-    @Test
-    fun testGetSyncTime() {
-        val testTime = 1634567890L
-        every { mockSharedPreferences.getLong("chat_history_synced_time", 0L) } returns testTime
-        assertEquals(testTime, sharedPrefManager.getSyncTime(SharedPrefManager.SyncKey.CHAT_HISTORY))
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/SyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/SyncManagerTest.kt
@@ -96,12 +96,11 @@ class SyncManagerTest {
     @Test
     fun `start with useImprovedSync=true and type=sync uses improved sync manager`() = runTest {
         every { sharedPrefManager.getUseImprovedSync() } returns true
-        every { sharedPrefManager.getFastSync() } returns true
 
         syncManager.start(listener, "sync", listOf("exams"))
 
         verify { listener.onSyncStarted() }
-        verify { improvedSyncManager.start(any(), SyncMode.Fast, listOf("exams")) }
+        verify { improvedSyncManager.start(any(), SyncMode.Standard, listOf("exams")) }
     }
 
     @Test
@@ -121,7 +120,6 @@ class SyncManagerTest {
     fun `cancelBackgroundSync clears background sync and listener`() = runTest {
         // Prevent immediate execution of background sync logic so we can cancel it
         every { sharedPrefManager.getUseImprovedSync() } returns true
-        every { sharedPrefManager.getFastSync() } returns true
 
         syncManager.start(listener, "sync", listOf())
         syncManager.cancelBackgroundSync()

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesViewModelTest.kt
@@ -8,9 +8,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.repository.CoursesRepository
-import org.ole.planet.myplanet.services.SharedPrefManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.MainDispatcherRule
 
@@ -21,9 +18,6 @@ class CoursesViewModelTest {
 
     private val coursesRepository = mockk<CoursesRepository>(relaxed = true)
     private val dispatcherProvider = mockk<DispatcherProvider>()
-    private val syncManager = mockk<SyncManager>(relaxed = true)
-    private val serverUrlMapper = mockk<ServerUrlMapper>(relaxed = true)
-    private val prefManager = mockk<SharedPrefManager>(relaxed = true)
 
     private lateinit var viewModel: CoursesViewModel
 
@@ -33,10 +27,7 @@ class CoursesViewModelTest {
         io.mockk.every { dispatcherProvider.main } returns Dispatchers.Unconfined
         viewModel = CoursesViewModel(
             coursesRepository,
-            dispatcherProvider,
-            syncManager,
-            serverUrlMapper,
-            prefManager
+            dispatcherProvider
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModelTest.kt
@@ -2,9 +2,7 @@ package org.ole.planet.myplanet.ui.feedback
 
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -14,12 +12,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.services.UserSessionManager
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.utils.MainDispatcherRule
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
 
@@ -34,14 +30,12 @@ class FeedbackListViewModelTest {
     private lateinit var viewModel: FeedbackListViewModel
     private lateinit var feedbackRepository: FeedbackRepository
     private lateinit var userSessionManager: UserSessionManager
-    private lateinit var syncManager: SyncManager
     private val dispatcherProvider = TestDispatcherProvider(testDispatcher)
 
     @Before
     fun setup() {
         feedbackRepository = mockk()
         userSessionManager = mockk()
-        syncManager = mockk()
 
         val user = mockk<RealmUser>()
         coEvery { userSessionManager.getUserModel() } returns user
@@ -50,8 +44,7 @@ class FeedbackListViewModelTest {
         viewModel = FeedbackListViewModel(
             feedbackRepository = feedbackRepository,
             userSessionManager = userSessionManager,
-            dispatcherProvider = dispatcherProvider,
-            syncManager = syncManager
+            dispatcherProvider = dispatcherProvider
         )
     }
 
@@ -75,8 +68,7 @@ class FeedbackListViewModelTest {
         viewModel = FeedbackListViewModel(
             feedbackRepository = feedbackRepository,
             userSessionManager = userSessionManager,
-            dispatcherProvider = dispatcherProvider,
-            syncManager = syncManager
+            dispatcherProvider = dispatcherProvider
         )
 
         advanceUntilIdle()
@@ -100,8 +92,7 @@ class FeedbackListViewModelTest {
         viewModel = FeedbackListViewModel(
             feedbackRepository = feedbackRepository,
             userSessionManager = userSessionManager,
-            dispatcherProvider = dispatcherProvider,
-            syncManager = syncManager
+            dispatcherProvider = dispatcherProvider
         )
         advanceUntilIdle()
         assertEquals(initialFeedback, viewModel.feedbackList.value)
@@ -116,26 +107,5 @@ class FeedbackListViewModelTest {
         assertEquals(updatedFeedback, viewModel.feedbackList.value)
         // Verify it was called twice: once in init, once in refreshFeedback
         coVerify(exactly = 2) { feedbackRepository.getFeedback(user) }
-    }
-
-    @Test
-    fun testStartFeedbackSyncUpdatesSyncStatus() {
-        val listenerSlot = slot<OnSyncListener>()
-        every { syncManager.start(capture(listenerSlot), "full", listOf("feedback")) } answers {
-            // Do nothing, just capture the listener
-        }
-
-        assertEquals(FeedbackListViewModel.SyncStatus.Idle, viewModel.syncStatus.value)
-
-        viewModel.startFeedbackSync()
-
-        listenerSlot.captured.onSyncStarted()
-        assertEquals(FeedbackListViewModel.SyncStatus.Syncing, viewModel.syncStatus.value)
-
-        listenerSlot.captured.onSyncComplete()
-        assertEquals(FeedbackListViewModel.SyncStatus.Success, viewModel.syncStatus.value)
-
-        listenerSlot.captured.onSyncFailed("Error message")
-        assertEquals(FeedbackListViewModel.SyncStatus.Error("Error message"), viewModel.syncStatus.value)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModelTest.kt
@@ -14,18 +14,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.repository.ResourcesRepository
-import org.ole.planet.myplanet.services.SharedPrefManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
-import org.ole.planet.myplanet.utils.TestDispatcherProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ResourcesViewModelTest {
 
     private lateinit var viewModel: ResourcesViewModel
-    private val syncManager = mockk<SyncManager>(relaxed = true)
-    private val sharedPrefManager = mockk<SharedPrefManager>(relaxed = true)
-    private val serverUrlMapper = mockk<ServerUrlMapper>(relaxed = true)
     private val resourcesRepository = mockk<ResourcesRepository>(relaxed = true)
     private val testDispatcher = StandardTestDispatcher()
 
@@ -33,11 +26,7 @@ class ResourcesViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         viewModel = ResourcesViewModel(
-            syncManager,
-            sharedPrefManager,
-            serverUrlMapper,
-            resourcesRepository,
-            TestDispatcherProvider(testDispatcher)
+            resourcesRepository
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/surveys/SurveysViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/surveys/SurveysViewModelTest.kt
@@ -1,10 +1,7 @@
 package org.ole.planet.myplanet.ui.surveys
 
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -15,23 +12,16 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.repository.SurveysRepository
-import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
-import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SurveysViewModelTest {
 
     private lateinit var surveysRepository: SurveysRepository
-    private lateinit var syncManager: SyncManager
     private lateinit var userSessionManager: UserSessionManager
-    private lateinit var sharedPrefManager: SharedPrefManager
-    private lateinit var serverUrlMapper: ServerUrlMapper
     private lateinit var viewModel: SurveysViewModel
     private val testDispatcher = StandardTestDispatcher()
     private val testDispatcherProvider = TestDispatcherProvider(testDispatcher)
@@ -40,18 +30,11 @@ class SurveysViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         surveysRepository = mockk()
-        syncManager = mockk(relaxed = true)
         userSessionManager = mockk()
-        sharedPrefManager = mockk(relaxed = true)
-        serverUrlMapper = mockk(relaxed = true)
 
         viewModel = SurveysViewModel(
             surveysRepository,
-            syncManager,
-            userSessionManager,
-            sharedPrefManager,
-            serverUrlMapper,
-            testDispatcherProvider
+            userSessionManager
         )
     }
 
@@ -190,63 +173,5 @@ class SurveysViewModelTest {
         viewModel.search("The dog")
         assertEquals(1, viewModel.surveys.value.size)
         assertEquals("2", viewModel.surveys.value[0].id)
-    }
-
-    @Test
-    fun `test startExamSync when fastSync is false`() {
-        every { sharedPrefManager.getFastSync() } returns false
-        every { sharedPrefManager.isSynced(SharedPrefManager.SyncKey.EXAMS) } returns false
-
-        viewModel.startExamSync()
-
-        verify(exactly = 0) { syncManager.start(any(), any(), any()) }
-    }
-
-    @Test
-    fun `test startExamSync when isExamsSynced is true`() {
-        every { sharedPrefManager.getFastSync() } returns true
-        every { sharedPrefManager.isSynced(SharedPrefManager.SyncKey.EXAMS) } returns true
-
-        viewModel.startExamSync()
-
-        verify(exactly = 0) { syncManager.start(any(), any(), any()) }
-    }
-
-    @Test
-    fun `test startExamSync triggers sync and handles error state mapping`() = runTest {
-        every { sharedPrefManager.getFastSync() } returns true
-        every { sharedPrefManager.isSynced(SharedPrefManager.SyncKey.EXAMS) } returns false
-        every { sharedPrefManager.getServerUrl() } returns "http://test.com"
-        every { serverUrlMapper.processUrl(any()) } returns mockk()
-
-        stubLoadSurveys(emptyList())
-
-        // Mock serverUrlMapper.updateServerIfNecessary
-        coEvery { serverUrlMapper.updateServerIfNecessary(any(), any(), any()) } answers {
-            // execute callback directly if we want
-        }
-
-        viewModel.startExamSync()
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        val listenerSlot = slot<OnSyncListener>()
-        verify { syncManager.start(capture(listenerSlot), any(), any()) }
-
-        val listener = listenerSlot.captured
-
-        // Test onSyncStarted
-        listener.onSyncStarted()
-        assertEquals(true, viewModel.isLoading.value)
-
-        // Test onSyncFailed
-        listener.onSyncFailed("Network Error")
-        assertEquals(false, viewModel.isLoading.value)
-        assertEquals("Sync failed: Network Error", viewModel.errorMessage.value)
-
-        // Test onSyncComplete
-        listener.onSyncComplete()
-        verify { sharedPrefManager.setSynced(SharedPrefManager.SyncKey.EXAMS, true) }
-        testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(false, viewModel.isLoading.value)
     }
 }


### PR DESCRIPTION
fixes #14270
This drops the experimental fast-sync path across the app and standardizes sync behavior on the existing standard/improved managers. It removes fast-sync preferences, server dialog and settings toggles, per-screen fast-sync triggers/progress handling, and the related sync state models/flags in `SharedPrefManager`, `SyncManager`, and `SyncMode`.