### PR TITLE
teams: less callback interfaces is more (fixes #14264)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5893
-        versionName = "0.58.93"
+        versionCode = 5899
+        versionName = "0.58.99"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnTeamActionsListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnTeamActionsListener.kt
@@ -1,9 +1,0 @@
-package org.ole.planet.myplanet.callback
-
-import org.ole.planet.myplanet.model.RealmUser
-import org.ole.planet.myplanet.model.TeamDetails
-
-interface OnTeamActionsListener {
-    fun onLeaveTeam(team: TeamDetails, user: RealmUser?)
-    fun onRequestToJoin(team: TeamDetails, user: RealmUser?)
-}

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnTeamEditListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnTeamEditListener.kt
@@ -1,7 +1,0 @@
-package org.ole.planet.myplanet.callback
-
-import org.ole.planet.myplanet.model.TeamDetails
-
-interface OnTeamEditListener {
-    fun onEditTeam(team: TeamDetails?)
-}

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnUpdateCompleteListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnUpdateCompleteListener.kt
@@ -1,5 +1,0 @@
-package org.ole.planet.myplanet.callback
-
-interface OnUpdateCompleteListener {
-    fun onUpdateComplete(itemCount: Int)
-}


### PR DESCRIPTION
fixes #14264
Deleted three callback interfaces from `callback/` (`OnTeamActionsListener`, `OnTeamEditListener`, and `OnUpdateCompleteListener`) as part of API cleanup, reducing dead code and simplifying the callback surface.