### PR TITLE
sync: smoother retry intercepting (fixes #14265)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5893
-        versionName = "0.58.93"
+        versionCode = 5900
+        versionName = "0.59.0"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/api/RetryInterceptor.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/api/RetryInterceptor.kt
@@ -19,12 +19,30 @@ class RetryInterceptor @Inject constructor(
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        var response = chain.proceed(request)
         var tryCount = 0
+        var response: Response? = null
+        var lastError: IOException? = null
 
-        while (response.code in 500..599 && tryCount < maxRetries) {
+        while (true) {
+            response?.close()
+            response = null
+
+            try {
+                response = chain.proceed(request)
+                lastError = null
+                // Success (any non-5xx) is returned immediately.
+                if (response.code !in 500..599) {
+                    return response
+                }
+            } catch (e: IOException) {
+                // Network failures (e.g. SocketTimeoutException) are retried like 5xx.
+                lastError = e
+            }
+
+            if (tryCount >= maxRetries) {
+                break
+            }
             tryCount++
-            response.close()
 
             val delay = (initialDelay * factor.pow(tryCount - 1)).toLong()
 
@@ -42,10 +60,9 @@ class RetryInterceptor @Inject constructor(
                 Thread.currentThread().interrupt()
                 throw IOException("Interrupted during retry delay", e)
             }
-
-            response = chain.proceed(request)
         }
 
-        return response
+        // Retries exhausted: return the last 5xx response, or rethrow the last network error.
+        return response ?: throw (lastError ?: IOException("Request failed without a response"))
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/data/api/RetryInterceptorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/api/RetryInterceptorTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.io.IOException
+import java.net.SocketTimeoutException
 import okhttp3.Interceptor
 import okhttp3.Protocol
 import okhttp3.Request
@@ -22,7 +23,6 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33], application = Application::class)
 class RetryInterceptorTest {
-
     private lateinit var broadcastService: BroadcastService
     private lateinit var retryInterceptor: RetryInterceptor
 
@@ -84,6 +84,42 @@ class RetryInterceptorTest {
         val chain = mockk<Interceptor.Chain>()
         every { chain.request() } returns request
         every { chain.proceed(request) } returnsMany listOf(errorResponse, successResponse)
+
+        val result = retryInterceptor.intercept(chain)
+
+        assertEquals(200, result.code)
+        verify(exactly = 2) { chain.proceed(request) }
+        verify(exactly = 1) { broadcastService.trySendBroadcast(any()) }
+    }
+
+    @Test
+    fun testRetriesUpToMaxRetriesOnIOException() {
+        val request = Request.Builder().url("http://example.com").build()
+
+        val chain = mockk<Interceptor.Chain>()
+        every { chain.request() } returns request
+        every { chain.proceed(request) } throws SocketTimeoutException("timeout")
+
+        try {
+            retryInterceptor.intercept(chain)
+            fail("Expected IOException after retries are exhausted")
+        } catch (e: IOException) {
+            assertTrue(e is SocketTimeoutException)
+        }
+
+        // 1 initial + 3 retries = 4
+        verify(exactly = 4) { chain.proceed(request) }
+        verify(exactly = 3) { broadcastService.trySendBroadcast(any()) }
+    }
+
+    @Test
+    fun testSuccessAfterIOException() {
+        val request = Request.Builder().url("http://example.com").build()
+        val successResponse = createResponse(request, 200)
+
+        val chain = mockk<Interceptor.Chain>()
+        every { chain.request() } returns request
+        every { chain.proceed(request) } throws SocketTimeoutException("timeout") andThen successResponse
 
         val result = retryInterceptor.intercept(chain)
 


### PR DESCRIPTION
fixes #14265
Refactors `RetryInterceptor` to retry not only 5xx responses but also network `IOException`s (such as `SocketTimeoutException`) using the same backoff flow. The interceptor now closes stale responses between attempts, returns immediately on non-5xx success, and when retries are exhausted it returns the last 5xx response or rethrows the last network error. Tests were expanded to cover retry exhaustion on IO exceptions and recovery after an initial IO failure.