### PR TITLE
all: smoother service module importing (fixes #14263)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5893
-        versionName = "0.58.93"
+        versionCode = 5901
+        versionName = "0.59.1"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -67,13 +67,21 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideSyncManager(
-        @ApplicationContext context: Context, sharedPrefManager: SharedPrefManager,
-        apiInterface: ApiInterface, improvedSyncManager: Lazy<ImprovedSyncManager>,
-        transactionSyncManager: TransactionSyncManager, resourcesRepository: ResourcesRepository,
-        loginSyncManager: LoginSyncManager, @ApplicationScope scope: CoroutineScope,
-        activitiesRepository: ActivitiesRepository, dispatcherProvider: DispatcherProvider,
-        timeProvider: TimeProvider, teamsRepository: TeamsRepository, teamsSyncRepository: TeamsSyncRepository,
-        coursesRepository: CoursesRepository, eventsRepository: EventsRepository
+        @ApplicationContext context: Context,
+        sharedPrefManager: SharedPrefManager,
+        apiInterface: ApiInterface,
+        improvedSyncManager: Lazy<ImprovedSyncManager>,
+        transactionSyncManager: TransactionSyncManager,
+        resourcesRepository: ResourcesRepository,
+        loginSyncManager: LoginSyncManager,
+        @ApplicationScope scope: CoroutineScope,
+        activitiesRepository: ActivitiesRepository,
+        dispatcherProvider: DispatcherProvider,
+        timeProvider: TimeProvider,
+        teamsRepository: TeamsRepository,
+        teamsSyncRepository: TeamsSyncRepository,
+        coursesRepository: CoursesRepository,
+        eventsRepository: EventsRepository
     ): SyncManager {
         return SyncManager(context, sharedPrefManager, apiInterface, improvedSyncManager, transactionSyncManager, resourcesRepository, loginSyncManager, scope, activitiesRepository, dispatcherProvider, timeProvider, teamsRepository, teamsSyncRepository, coursesRepository, eventsRepository)
     }
@@ -81,15 +89,26 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideUploadManager(
-        @ApplicationContext context: Context, submissionsRepository: SubmissionsRepository,
-        sharedPrefManager: SharedPrefManager, gson: Gson, uploadCoordinator: UploadCoordinator,
-        personalsRepository: PersonalsRepository, userRepository: UserRepository,
-        chatRepository: ChatRepository, voicesRepository: VoicesRepository,
-        uploadConfigs: UploadConfigs, resourcesRepository: ResourcesRepository,
-        teamsRepository: Lazy<TeamsRepository>, teamsSyncRepository: Lazy<TeamsSyncRepository>,
-        activitiesRepository: ActivitiesRepository, apiInterface: ApiInterface,
-        @ApplicationScope scope: CoroutineScope, dispatcherProvider: DispatcherProvider,
-        photoUploader: PhotoUploader, achievementUploader: AchievementUploader, timeProvider: TimeProvider
+        @ApplicationContext context: Context,
+        submissionsRepository: SubmissionsRepository,
+        sharedPrefManager: SharedPrefManager,
+        gson: Gson,
+        uploadCoordinator: UploadCoordinator,
+        personalsRepository: PersonalsRepository,
+        userRepository: UserRepository,
+        chatRepository: ChatRepository,
+        voicesRepository: VoicesRepository,
+        uploadConfigs: UploadConfigs,
+        resourcesRepository: ResourcesRepository,
+        teamsRepository: Lazy<TeamsRepository>,
+        teamsSyncRepository: Lazy<TeamsSyncRepository>,
+        activitiesRepository: ActivitiesRepository,
+        apiInterface: ApiInterface,
+        @ApplicationScope scope: CoroutineScope,
+        dispatcherProvider: DispatcherProvider,
+        photoUploader: PhotoUploader,
+        achievementUploader: AchievementUploader,
+        timeProvider: TimeProvider
     ): UploadManager {
         return UploadManager(context, submissionsRepository, sharedPrefManager, gson, uploadCoordinator, personalsRepository, userRepository, chatRepository, voicesRepository, uploadConfigs, resourcesRepository, teamsRepository, teamsSyncRepository, apiInterface, activitiesRepository, dispatcherProvider, scope, photoUploader, achievementUploader, timeProvider)
     }
@@ -97,10 +116,15 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideUploadToShelfService(
-        @ApplicationContext context: Context, @AppPreferences preferences: SharedPreferences,
-        sharedPrefManager: SharedPrefManager, userRepository: UserRepository,
-        userSyncRepository: UserSyncRepository, healthRepository: HealthRepository,
-        @ApplicationScope appScope: CoroutineScope, dispatcherProvider: DispatcherProvider, apiInterface: ApiInterface
+        @ApplicationContext context: Context,
+        @AppPreferences preferences: SharedPreferences,
+        sharedPrefManager: SharedPrefManager,
+        userRepository: UserRepository,
+        userSyncRepository: UserSyncRepository,
+        healthRepository: HealthRepository,
+        @ApplicationScope appScope: CoroutineScope,
+        dispatcherProvider: DispatcherProvider,
+        apiInterface: ApiInterface
     ): UploadToShelfService {
         return UploadToShelfService(context, preferences, sharedPrefManager, userRepository, userSyncRepository, healthRepository, appScope, dispatcherProvider, apiInterface)
     }
@@ -108,14 +132,28 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideTransactionSyncManager(
-        apiInterface: ApiInterface, databaseService: DatabaseService, @ApplicationContext context: Context,
-        voicesRepository: VoicesRepository, chatRepository: ChatRepository, feedbackRepository: FeedbackRepository,
-        sharedPrefManager: SharedPrefManager, userRepository: UserRepository, userSyncRepository: UserSyncRepository,
-        activitiesRepository: ActivitiesRepository, teamsRepository: Lazy<TeamsRepository>,
-        teamsSyncRepository: Lazy<TeamsSyncRepository>, notificationsRepository: NotificationsRepository,
-        tagsRepository: TagsRepository, ratingsRepository: RatingsRepository, submissionsRepository: SubmissionsRepository,
-        coursesRepository: CoursesRepository, communityRepository: CommunityRepository, healthRepository: HealthRepository,
-        progressRepository: ProgressRepository, surveysRepository: SurveysRepository, @ApplicationScope scope: CoroutineScope,
+        apiInterface: ApiInterface,
+        databaseService: DatabaseService,
+        @ApplicationContext context: Context,
+        voicesRepository: VoicesRepository,
+        chatRepository: ChatRepository,
+        feedbackRepository: FeedbackRepository,
+        sharedPrefManager: SharedPrefManager,
+        userRepository: UserRepository,
+        userSyncRepository: UserSyncRepository,
+        activitiesRepository: ActivitiesRepository,
+        teamsRepository: Lazy<TeamsRepository>,
+        teamsSyncRepository: Lazy<TeamsSyncRepository>,
+        notificationsRepository: NotificationsRepository,
+        tagsRepository: TagsRepository,
+        ratingsRepository: RatingsRepository,
+        submissionsRepository: SubmissionsRepository,
+        coursesRepository: CoursesRepository,
+        communityRepository: CommunityRepository,
+        healthRepository: HealthRepository,
+        progressRepository: ProgressRepository,
+        surveysRepository: SurveysRepository,
+        @ApplicationScope scope: CoroutineScope,
         dispatcherProvider: DispatcherProvider
     ): TransactionSyncManager {
         return TransactionSyncManager(apiInterface, databaseService, context, voicesRepository, chatRepository, feedbackRepository, sharedPrefManager, userRepository, userSyncRepository, activitiesRepository, teamsRepository, teamsSyncRepository, notificationsRepository, tagsRepository, ratingsRepository, submissionsRepository, coursesRepository, communityRepository, healthRepository, progressRepository, surveysRepository, scope, dispatcherProvider)

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -15,13 +15,39 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.repository.ActivitiesRepository
+import org.ole.planet.myplanet.repository.ChatRepository
+import org.ole.planet.myplanet.repository.CommunityRepository
+import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.EventsRepository
+import org.ole.planet.myplanet.repository.FeedbackRepository
+import org.ole.planet.myplanet.repository.HealthRepository
+import org.ole.planet.myplanet.repository.NotificationsRepository
 import org.ole.planet.myplanet.repository.PersonalsRepository
+import org.ole.planet.myplanet.repository.ProgressRepository
+import org.ole.planet.myplanet.repository.RatingsRepository
+import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
+import org.ole.planet.myplanet.repository.SurveysRepository
+import org.ole.planet.myplanet.repository.TagsRepository
+import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.repository.TeamsSyncRepository
+import org.ole.planet.myplanet.repository.UserRepository
+import org.ole.planet.myplanet.repository.UserSyncRepository
+import org.ole.planet.myplanet.repository.VoicesRepository
+import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UploadManager
 import org.ole.planet.myplanet.services.UploadToShelfService
 import org.ole.planet.myplanet.services.sync.ImprovedSyncManager
+import org.ole.planet.myplanet.services.sync.LoginSyncManager
 import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.services.sync.TransactionSyncManager
+import org.ole.planet.myplanet.services.upload.AchievementUploader
+import org.ole.planet.myplanet.services.upload.PhotoUploader
+import org.ole.planet.myplanet.services.upload.UploadConfigs
+import org.ole.planet.myplanet.services.upload.UploadCoordinator
+import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TimeProvider
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -34,28 +60,20 @@ object ServiceModule {
     @Provides
     @Singleton
     @ApplicationScope
-    fun provideApplicationScope(dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider): CoroutineScope {
+    fun provideApplicationScope(dispatcherProvider: DispatcherProvider): CoroutineScope {
         return CoroutineScope(SupervisorJob() + dispatcherProvider.io)
     }
 
     @Provides
     @Singleton
     fun provideSyncManager(
-        @ApplicationContext context: Context,
-        sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager,
-        apiInterface: ApiInterface,
-        improvedSyncManager: Lazy<ImprovedSyncManager>,
-        transactionSyncManager: TransactionSyncManager,
-        resourcesRepository: org.ole.planet.myplanet.repository.ResourcesRepository,
-        loginSyncManager: org.ole.planet.myplanet.services.sync.LoginSyncManager,
-        @ApplicationScope scope: CoroutineScope,
-        activitiesRepository: org.ole.planet.myplanet.repository.ActivitiesRepository,
-        dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider,
-        timeProvider: org.ole.planet.myplanet.utils.TimeProvider,
-        teamsRepository: org.ole.planet.myplanet.repository.TeamsRepository,
-        teamsSyncRepository: org.ole.planet.myplanet.repository.TeamsSyncRepository,
-        coursesRepository: org.ole.planet.myplanet.repository.CoursesRepository,
-        eventsRepository: org.ole.planet.myplanet.repository.EventsRepository
+        @ApplicationContext context: Context, sharedPrefManager: SharedPrefManager,
+        apiInterface: ApiInterface, improvedSyncManager: Lazy<ImprovedSyncManager>,
+        transactionSyncManager: TransactionSyncManager, resourcesRepository: ResourcesRepository,
+        loginSyncManager: LoginSyncManager, @ApplicationScope scope: CoroutineScope,
+        activitiesRepository: ActivitiesRepository, dispatcherProvider: DispatcherProvider,
+        timeProvider: TimeProvider, teamsRepository: TeamsRepository, teamsSyncRepository: TeamsSyncRepository,
+        coursesRepository: CoursesRepository, eventsRepository: EventsRepository
     ): SyncManager {
         return SyncManager(context, sharedPrefManager, apiInterface, improvedSyncManager, transactionSyncManager, resourcesRepository, loginSyncManager, scope, activitiesRepository, dispatcherProvider, timeProvider, teamsRepository, teamsSyncRepository, coursesRepository, eventsRepository)
     }
@@ -63,26 +81,15 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideUploadManager(
-        @ApplicationContext context: Context,
-        submissionsRepository: SubmissionsRepository,
-        sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager,
-        gson: Gson,
-        uploadCoordinator: org.ole.planet.myplanet.services.upload.UploadCoordinator,
-        personalsRepository: PersonalsRepository,
-        userRepository: org.ole.planet.myplanet.repository.UserRepository,
-        chatRepository: org.ole.planet.myplanet.repository.ChatRepository,
-        voicesRepository: org.ole.planet.myplanet.repository.VoicesRepository,
-        uploadConfigs: org.ole.planet.myplanet.services.upload.UploadConfigs,
-        resourcesRepository: org.ole.planet.myplanet.repository.ResourcesRepository,
-        teamsRepository: Lazy<org.ole.planet.myplanet.repository.TeamsRepository>,
-        teamsSyncRepository: Lazy<org.ole.planet.myplanet.repository.TeamsSyncRepository>,
-        activitiesRepository: org.ole.planet.myplanet.repository.ActivitiesRepository,
-        apiInterface: ApiInterface,
-        @ApplicationScope scope: CoroutineScope,
-        dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider,
-        photoUploader: org.ole.planet.myplanet.services.upload.PhotoUploader,
-        achievementUploader: org.ole.planet.myplanet.services.upload.AchievementUploader,
-        timeProvider: org.ole.planet.myplanet.utils.TimeProvider
+        @ApplicationContext context: Context, submissionsRepository: SubmissionsRepository,
+        sharedPrefManager: SharedPrefManager, gson: Gson, uploadCoordinator: UploadCoordinator,
+        personalsRepository: PersonalsRepository, userRepository: UserRepository,
+        chatRepository: ChatRepository, voicesRepository: VoicesRepository,
+        uploadConfigs: UploadConfigs, resourcesRepository: ResourcesRepository,
+        teamsRepository: Lazy<TeamsRepository>, teamsSyncRepository: Lazy<TeamsSyncRepository>,
+        activitiesRepository: ActivitiesRepository, apiInterface: ApiInterface,
+        @ApplicationScope scope: CoroutineScope, dispatcherProvider: DispatcherProvider,
+        photoUploader: PhotoUploader, achievementUploader: AchievementUploader, timeProvider: TimeProvider
     ): UploadManager {
         return UploadManager(context, submissionsRepository, sharedPrefManager, gson, uploadCoordinator, personalsRepository, userRepository, chatRepository, voicesRepository, uploadConfigs, resourcesRepository, teamsRepository, teamsSyncRepository, apiInterface, activitiesRepository, dispatcherProvider, scope, photoUploader, achievementUploader, timeProvider)
     }
@@ -90,15 +97,10 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideUploadToShelfService(
-        @ApplicationContext context: Context,
-        @AppPreferences preferences: SharedPreferences,
-        sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager,
-        userRepository: org.ole.planet.myplanet.repository.UserRepository,
-        userSyncRepository: org.ole.planet.myplanet.repository.UserSyncRepository,
-        healthRepository: org.ole.planet.myplanet.repository.HealthRepository,
-        @ApplicationScope appScope: CoroutineScope,
-        dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider,
-        apiInterface: org.ole.planet.myplanet.data.api.ApiInterface
+        @ApplicationContext context: Context, @AppPreferences preferences: SharedPreferences,
+        sharedPrefManager: SharedPrefManager, userRepository: UserRepository,
+        userSyncRepository: UserSyncRepository, healthRepository: HealthRepository,
+        @ApplicationScope appScope: CoroutineScope, dispatcherProvider: DispatcherProvider, apiInterface: ApiInterface
     ): UploadToShelfService {
         return UploadToShelfService(context, preferences, sharedPrefManager, userRepository, userSyncRepository, healthRepository, appScope, dispatcherProvider, apiInterface)
     }
@@ -106,29 +108,15 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideTransactionSyncManager(
-        apiInterface: ApiInterface,
-        databaseService: DatabaseService,
-        @ApplicationContext context: Context,
-        voicesRepository: org.ole.planet.myplanet.repository.VoicesRepository,
-        chatRepository: org.ole.planet.myplanet.repository.ChatRepository,
-        feedbackRepository: org.ole.planet.myplanet.repository.FeedbackRepository,
-        sharedPrefManager: org.ole.planet.myplanet.services.SharedPrefManager,
-        userRepository: org.ole.planet.myplanet.repository.UserRepository,
-        userSyncRepository: org.ole.planet.myplanet.repository.UserSyncRepository,
-        activitiesRepository: org.ole.planet.myplanet.repository.ActivitiesRepository,
-        teamsRepository: dagger.Lazy<org.ole.planet.myplanet.repository.TeamsRepository>,
-        teamsSyncRepository: dagger.Lazy<org.ole.planet.myplanet.repository.TeamsSyncRepository>,
-        notificationsRepository: org.ole.planet.myplanet.repository.NotificationsRepository,
-        tagsRepository: org.ole.planet.myplanet.repository.TagsRepository,
-        ratingsRepository: org.ole.planet.myplanet.repository.RatingsRepository,
-        submissionsRepository: org.ole.planet.myplanet.repository.SubmissionsRepository,
-        coursesRepository: org.ole.planet.myplanet.repository.CoursesRepository,
-        communityRepository: org.ole.planet.myplanet.repository.CommunityRepository,
-        healthRepository: org.ole.planet.myplanet.repository.HealthRepository,
-        progressRepository: org.ole.planet.myplanet.repository.ProgressRepository,
-        surveysRepository: org.ole.planet.myplanet.repository.SurveysRepository,
-        @ApplicationScope scope: CoroutineScope,
-        dispatcherProvider: org.ole.planet.myplanet.utils.DispatcherProvider
+        apiInterface: ApiInterface, databaseService: DatabaseService, @ApplicationContext context: Context,
+        voicesRepository: VoicesRepository, chatRepository: ChatRepository, feedbackRepository: FeedbackRepository,
+        sharedPrefManager: SharedPrefManager, userRepository: UserRepository, userSyncRepository: UserSyncRepository,
+        activitiesRepository: ActivitiesRepository, teamsRepository: Lazy<TeamsRepository>,
+        teamsSyncRepository: Lazy<TeamsSyncRepository>, notificationsRepository: NotificationsRepository,
+        tagsRepository: TagsRepository, ratingsRepository: RatingsRepository, submissionsRepository: SubmissionsRepository,
+        coursesRepository: CoursesRepository, communityRepository: CommunityRepository, healthRepository: HealthRepository,
+        progressRepository: ProgressRepository, surveysRepository: SurveysRepository, @ApplicationScope scope: CoroutineScope,
+        dispatcherProvider: DispatcherProvider
     ): TransactionSyncManager {
         return TransactionSyncManager(apiInterface, databaseService, context, voicesRepository, chatRepository, feedbackRepository, sharedPrefManager, userRepository, userSyncRepository, activitiesRepository, teamsRepository, teamsSyncRepository, notificationsRepository, tagsRepository, ratingsRepository, submissionsRepository, coursesRepository, communityRepository, healthRepository, progressRepository, surveysRepository, scope, dispatcherProvider)
     }


### PR DESCRIPTION
fixes #14263
Cleaned up `ServiceModule.kt` by replacing fully qualified class names with direct imports and simplifying provider method signatures. This improves readability and maintainability of DI wiring for sync/upload-related services (`SyncManager`, `UploadManager`, `UploadToShelfService`, and `TransactionSyncManager`) without changing runtime behavior.