### PR TITLE
Refactor `bulkInsertFromSync` in `CoursesRepository`

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
@@ -63,7 +63,7 @@ interface CoursesRepository {
     suspend fun getCourseRatings(userId: String?): HashMap<String?, com.google.gson.JsonObject>
     suspend fun deleteCourseProgress(courseId: String?)
     suspend fun filterCoursesByTag(query: String, tags: List<RealmTag>, isMyCourseLib: Boolean, userId: String?): List<RealmMyCourse>
-    fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
+    suspend fun insertCoursesFromSync(docs: List<JsonObject>)
     fun bulkInsertCertificationsFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
     fun insertCertification(realm: io.realm.Realm, doc: com.google.gson.JsonObject)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -679,31 +679,10 @@ class CoursesRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun bulkInsertFromSync(realm: Realm, jsonArray: JsonArray) {
-        val documentList = ArrayList<JsonObject>(jsonArray.size())
-        for (j in jsonArray) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
-            val id = JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
-            }
-        }
-        documentList.forEach { jsonDoc ->
-            val startedTransaction = !realm.isInTransaction
-            if (startedTransaction) {
-                realm.beginTransaction()
-            }
-            try {
+    override suspend fun insertCoursesFromSync(docs: List<JsonObject>) {
+        executeTransaction { realm ->
+            docs.forEach { jsonDoc ->
                 insertMyCourse("", jsonDoc, realm, sharedPrefManager)
-                if (startedTransaction) {
-                    realm.commitTransaction()
-                }
-            } catch (e: Exception) {
-                if (startedTransaction && realm.isInTransaction) {
-                    realm.cancelTransaction()
-                }
-                throw e
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -252,7 +252,7 @@ class TransactionSyncManager @Inject constructor(
                             "ratings" -> ratingsRepository.bulkInsertFromSync(mRealm, arr)
                             "submissions" -> submissionsRepository.bulkInsertFromSync(mRealm, arr)
                             "courses" -> {
-                                coursesRepository.bulkInsertFromSync(mRealm, arr)
+                                kotlinx.coroutines.runBlocking { coursesRepository.insertCoursesFromSync((0 until arr.size()).map { org.ole.planet.myplanet.utils.JsonUtils.getJsonObject("doc", arr.get(it).asJsonObject) }.filter { !org.ole.planet.myplanet.utils.JsonUtils.getString("_id", it).startsWith("_design") }) }
                                 org.ole.planet.myplanet.model.RealmMyCourse.saveConcatenatedLinksToPrefs(sharedPrefManager)
                             }
                             "achievements" -> userSyncRepository.bulkInsertAchievementsFromSync(mRealm, arr)


### PR DESCRIPTION
This refactors the `CoursesRepository.bulkInsertFromSync` logic to leverage Coroutines and streamlined transaction execution. `bulkInsertFromSync` has been replaced with `insertCoursesFromSync`, taking a pre-processed `List<JsonObject>`. A single `executeTransaction` block handles the bulk insertion for better performance. The invocation in `TransactionSyncManager` has been appropriately updated with a `runBlocking` wrapper to adapt to the asynchronous API while observing line constraints.

---
*PR created automatically by Jules for task [14608316156872642577](https://jules.google.com/task/14608316156872642577) started by @dogi*