### PR TITLE
Refactor RatingsRepository.bulkInsertFromSync

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepository.kt
@@ -15,7 +15,7 @@ interface RatingsRepository {
         rating: Float,
         comment: String,
     ): RatingSummary
-    fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray)
+    suspend fun insertRatingsFromSync(docs: List<com.google.gson.JsonObject>)
 }
 
 data class RatingEntry(

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepositoryImpl.kt
@@ -206,18 +206,11 @@ class RatingsRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: com.google.gson.JsonArray) {
-        val documentList = ArrayList<com.google.gson.JsonObject>(jsonArray.size())
-        for (j in jsonArray) {
-            var jsonDoc = j.asJsonObject
-            jsonDoc = org.ole.planet.myplanet.utils.JsonUtils.getJsonObject("doc", jsonDoc)
-            val id = org.ole.planet.myplanet.utils.JsonUtils.getString("_id", jsonDoc)
-            if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
+    override suspend fun insertRatingsFromSync(docs: List<JsonObject>) {
+        executeTransaction { realm ->
+            docs.forEach { jsonDoc ->
+                org.ole.planet.myplanet.model.RealmRating.insert(realm, jsonDoc)
             }
-        }
-        documentList.forEach { jsonDoc ->
-            org.ole.planet.myplanet.model.RealmRating.insert(realm, jsonDoc)
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -105,8 +105,8 @@ class TransactionSyncManager @Inject constructor(
                 val r = ob.rows?.firstOrNull()
                 r?.id?.let { id ->
                     val jsonDoc = apiInterface.getJsonObject(header, "${UrlUtils.getUrl()}/$table/$id").body()
-                    val key = getString("key", jsonDoc)
-                    val iv = getString("iv", jsonDoc)
+                    val key = org.ole.planet.myplanet.utils.JsonUtils.getString("key", jsonDoc)
+                    val iv = org.ole.planet.myplanet.utils.JsonUtils.getString("iv", jsonDoc)
 
                     if (key.isNotEmpty() || iv.isNotEmpty()) {
                         userModel.id?.let {
@@ -205,8 +205,8 @@ class TransactionSyncManager @Inject constructor(
                     val docs = ArrayList<JsonObject>(arr.size())
                     for (j in arr) {
                         var jsonDoc = j.asJsonObject
-                        jsonDoc = getJsonObject("doc", jsonDoc)
-                        val id = getString("_id", jsonDoc)
+                        jsonDoc = org.ole.planet.myplanet.utils.JsonUtils.getJsonObject("doc", jsonDoc)
+                        val id = org.ole.planet.myplanet.utils.JsonUtils.getString("_id", jsonDoc)
                         if (!id.startsWith("_design")) {
                             docs.add(jsonDoc)
                         }
@@ -224,13 +224,32 @@ class TransactionSyncManager @Inject constructor(
                     val docs = ArrayList<JsonObject>(arr.size())
                     for (j in arr) {
                         var jsonDoc = j.asJsonObject
-                        jsonDoc = getJsonObject("doc", jsonDoc)
-                        val id = getString("_id", jsonDoc)
+                        jsonDoc = org.ole.planet.myplanet.utils.JsonUtils.getJsonObject("doc", jsonDoc)
+                        val id = org.ole.planet.myplanet.utils.JsonUtils.getString("_id", jsonDoc)
                         if (!id.startsWith("_design")) {
                             docs.add(jsonDoc)
                         }
                     }
                     feedbackRepository.insertFeedbackList(docs)
+                    val insertDuration = SystemClock.elapsedRealtime() - insertStartTime
+                    org.ole.planet.myplanet.utils.SyncTimeLogger.logRealmOperation(
+                        "insert_batch",
+                        table,
+                        insertDuration,
+                        arr.size()
+                    )
+                } else if (table == "ratings") {
+                    val insertStartTime = SystemClock.elapsedRealtime()
+                    val docs = ArrayList<JsonObject>(arr.size())
+                    for (j in arr) {
+                        var jsonDoc = j.asJsonObject
+                        jsonDoc = org.ole.planet.myplanet.utils.JsonUtils.getJsonObject("doc", jsonDoc)
+                        val id = org.ole.planet.myplanet.utils.JsonUtils.getString("_id", jsonDoc)
+                        if (!id.startsWith("_design")) {
+                            docs.add(jsonDoc)
+                        }
+                    }
+                    ratingsRepository.insertRatingsFromSync(docs)
                     val insertDuration = SystemClock.elapsedRealtime() - insertStartTime
                     org.ole.planet.myplanet.utils.SyncTimeLogger.logRealmOperation(
                         "insert_batch",
@@ -249,7 +268,7 @@ class TransactionSyncManager @Inject constructor(
                             "team_activities" -> teamsSyncRepository.get().bulkInsertTeamActivitiesFromSync(mRealm, arr)
                             "login_activities" -> activitiesRepository.bulkInsertLoginActivitiesFromSync(mRealm, arr)
                             "tags" -> tagsRepository.bulkInsertFromSync(mRealm, arr)
-                            "ratings" -> ratingsRepository.bulkInsertFromSync(mRealm, arr)
+
                             "submissions" -> submissionsRepository.bulkInsertFromSync(mRealm, arr)
                             "courses" -> {
                                 coursesRepository.bulkInsertFromSync(mRealm, arr)
@@ -317,10 +336,10 @@ class TransactionSyncManager @Inject constructor(
 
     private suspend fun downloadCvAttachmentsFromBatch(arr: com.google.gson.JsonArray) {
         for (j in arr) {
-            val jsonDoc = getJsonObject("doc", j.asJsonObject)
-            val docId = getString("_id", jsonDoc)
+            val jsonDoc = org.ole.planet.myplanet.utils.JsonUtils.getJsonObject("doc", j.asJsonObject)
+            val docId = org.ole.planet.myplanet.utils.JsonUtils.getString("_id", jsonDoc)
             if (docId.startsWith("_design")) continue
-            val resumeFileName = getString("resumeFileName", jsonDoc)
+            val resumeFileName = org.ole.planet.myplanet.utils.JsonUtils.getString("resumeFileName", jsonDoc)
             val hasAttachment = jsonDoc.getAsJsonObject("_attachments")?.has("resume.pdf") == true
             if (resumeFileName.isNotEmpty() && hasAttachment) {
                 val destFile = java.io.File(
@@ -335,8 +354,8 @@ class TransactionSyncManager @Inject constructor(
 
     private suspend fun downloadTeamAttachmentsFromBatch(arr: com.google.gson.JsonArray) {
         for (j in arr) {
-            val jsonDoc = getJsonObject("doc", j.asJsonObject)
-            val docId = getString("_id", jsonDoc)
+            val jsonDoc = org.ole.planet.myplanet.utils.JsonUtils.getJsonObject("doc", j.asJsonObject)
+            val docId = org.ole.planet.myplanet.utils.JsonUtils.getString("_id", jsonDoc)
             if (docId.startsWith("_design")) continue
             val attachmentName = org.ole.planet.myplanet.model.RealmMyTeam
                 .getFirstAttachmentName(jsonDoc) ?: continue

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RatingsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RatingsRepositoryImplTest.kt
@@ -353,26 +353,22 @@ class RatingsRepositoryImplTest {
     }
 
     @Test
-    fun `bulkInsertFromSync processes JSON array properly`() {
+    fun `insertRatingsFromSync processes JSON array properly`() = runTest {
         mockkObject(RealmRating.Companion)
         every { RealmRating.insert(any(), any()) } returns Unit
 
-        val jsonArray = JsonArray().apply {
-            add(JsonObject().apply {
-                add("doc", JsonObject().apply {
-                    addProperty("_id", "rating1")
-                })
-            })
-            add(JsonObject().apply {
-                add("doc", JsonObject().apply {
-                    addProperty("_id", "_design/rating")
-                })
-            })
-        }
+        val docs = listOf(
+            JsonObject().apply {
+                addProperty("_id", "rating1")
+            },
+            JsonObject().apply {
+                addProperty("_id", "_design/rating")
+            }
+        )
 
-        repository.bulkInsertFromSync(mockRealm, jsonArray)
+        repository.insertRatingsFromSync(docs)
 
-        verify(exactly = 1) { RealmRating.insert(mockRealm, any()) }
+        verify(exactly = 2) { RealmRating.insert(mockRealm, any()) }
 
         unmockkObject(RealmRating.Companion)
     }


### PR DESCRIPTION
Replaced `bulkInsertFromSync` with a suspending method `insertRatingsFromSync` that encapsulates its own database transaction, and updated the call-site in `TransactionSyncManager` to use it. Update tests to verify the new signature and document processing logic.

---
*PR created automatically by Jules for task [2772003882345567812](https://jules.google.com/task/2772003882345567812) started by @dogi*