### PR TITLE
Refactor: Remove redundant dispatcher hops in DashboardViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -127,7 +127,7 @@ class DashboardViewModel @Inject constructor(
         if (userId == null) return
 
         libraryJob?.cancel()
-        libraryJob = viewModelScope.launch(dispatcherProvider.main) {
+        libraryJob = viewModelScope.launch {
             val myLibrary = withContext(dispatcherProvider.io) {
                 resourcesRepository.getMyLibrary(userId)
             }
@@ -135,7 +135,7 @@ class DashboardViewModel @Inject constructor(
         }
 
         coursesJob?.cancel()
-        coursesJob = viewModelScope.launch(dispatcherProvider.main) {
+        coursesJob = viewModelScope.launch {
             coursesRepository.getMyCoursesFlow(userId)
                 .flowOn(dispatcherProvider.io)
                 .collect { courses ->
@@ -144,7 +144,7 @@ class DashboardViewModel @Inject constructor(
         }
 
         teamsJob?.cancel()
-        teamsJob = viewModelScope.launch(dispatcherProvider.main) {
+        teamsJob = viewModelScope.launch {
             teamsRepository.getMyTeamsFlow(userId)
                 .flowOn(dispatcherProvider.io)
                 .collect { teams ->
@@ -153,7 +153,7 @@ class DashboardViewModel @Inject constructor(
         }
 
         profileJob?.cancel()
-        profileJob = viewModelScope.launch(dispatcherProvider.main) {
+        profileJob = viewModelScope.launch {
             val (userName, fullName) = withContext(dispatcherProvider.io) {
                 val user = userRepository.getUserById(userId)
                 val userName = user?.name


### PR DESCRIPTION
Removed the explicit `dispatcherProvider.main` context from the `viewModelScope.launch` calls within the `loadUserContent` function. This avoids unnecessary thread dispatch hops since `viewModelScope.launch` defaults to `Dispatchers.Main.immediate` and the IO work is already correctly wrapped in `withContext(dispatcherProvider.io)` or `.flowOn(dispatcherProvider.io)`. Constituent jobs and cancellation logic remain intact.

---
*PR created automatically by Jules for task [8679775107734675131](https://jules.google.com/task/8679775107734675131) started by @dogi*