### PR TITLE
Refactor: Consolidate withRealmAsync usage in SubmissionsRepositoryImpl

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -886,7 +886,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         return PayloadData(user, exam, questions)
     }
 
-    override suspend fun getExamUploadPayload(submission: RealmSubmission): JsonObject = databaseService.withRealmAsync { mRealm ->
+    override suspend fun getExamUploadPayload(submission: RealmSubmission): JsonObject = withRealmAsync { mRealm ->
         val `object` = JsonObject()
         val payloadData = getPayloadData(mRealm, submission)
         val user = payloadData.user
@@ -934,7 +934,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         `object`
     }
 
-    override suspend fun serializeSubmission(submission: RealmSubmission, context: android.content.Context, source: String, parentCode: String): JsonObject = databaseService.withRealmAsync { mRealm ->
+    override suspend fun serializeSubmission(submission: RealmSubmission, context: android.content.Context, source: String, parentCode: String): JsonObject = withRealmAsync { mRealm ->
         val jsonObject = JsonObject()
 
         try {


### PR DESCRIPTION
This change refactors `SubmissionsRepositoryImpl` to use the inherited `withRealmAsync` method from its base class `RealmRepository`, rather than calling `databaseService.withRealmAsync` directly. The change specifically targets `serializeSubmission` and `getExamUploadPayload`. This simplifies the code and consolidates database interactions.

---
*PR created automatically by Jules for task [2638341109574186747](https://jules.google.com/task/2638341109574186747) started by @dogi*