### PR TITLE
fix: cache offline-resource lookups in CoursesFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -51,6 +51,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     private var selectionJob: Job? = null
     private var pendingScrollState: android.os.Parcelable? = null
     private val viewModel: CoursesViewModel by viewModels()
+    private var cachedCourseIds: Set<String>? = null
 
     @Inject
     lateinit var userSessionManager: UserSessionManager
@@ -147,7 +148,11 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
 
                 if (isMyCourseLib) {
                     val courseIds = state.courses.mapNotNull { it.courseId }
-                    resources = coursesRepository.getCourseOfflineResources(courseIds)
+                    val currentCourseIdSet = courseIds.toSet()
+                    if (cachedCourseIds != currentCourseIdSet) {
+                        cachedCourseIds = currentCourseIdSet
+                        resources = coursesRepository.getCourseOfflineResources(courseIds)
+                    }
                     courseLib = "courses"
                 }
 


### PR DESCRIPTION
Cache offline resources to optimize loading when the My Courses course-id set doesn't change, improving performance on frequent list refreshes.

---
*PR created automatically by Jules for task [11516947116663015057](https://jules.google.com/task/11516947116663015057) started by @dogi*