### PR TITLE
Refactor Flow Collectors to collectWhenStarted in AddExaminationActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/AddExaminationActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/AddExaminationActivity.kt
@@ -35,6 +35,8 @@ import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.encrypt
 import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.generateIv
 import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.generateKey
 import org.ole.planet.myplanet.utils.Constants
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
+import org.ole.planet.myplanet.utils.collectWhenStarted
 import org.ole.planet.myplanet.utils.DimenUtils.dpToPx
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.JsonUtils
@@ -133,20 +135,16 @@ class AddExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedChan
             btnSave.isEnabled = true
         }
 
-        lifecycleScope.launch {
-            viewModel.isSaving.collect { isSaving ->
-                btnSave.isEnabled = !isSaving
-            }
+        collectWhenStarted(viewModel.isSaving) { isSaving ->
+            btnSave.isEnabled = !isSaving
         }
 
-        lifecycleScope.launch {
-            viewModel.saveResult.collect { success ->
-                if (success) {
-                    Utilities.toast(this@AddExaminationActivity, getString(R.string.added_successfully))
-                    closeActivity()
-                } else {
-                    Utilities.toast(this@AddExaminationActivity, getString(R.string.unable_to_add_health_record))
-                }
+        collectLatestWhenStarted(viewModel.saveResult) { success ->
+            if (success) {
+                Utilities.toast(this@AddExaminationActivity, getString(R.string.added_successfully))
+                closeActivity()
+            } else {
+                Utilities.toast(this@AddExaminationActivity, getString(R.string.unable_to_add_health_record))
             }
         }
     }


### PR DESCRIPTION
Replaced the standard flow collector blocks with the more efficient, lifecycle-aware `collectWhenStarted` and `collectLatestWhenStarted` functions in `AddExaminationActivity.kt`. This ensures that Flow observation is properly scoped to the STARTED lifecycle state, preventing potential exceptions or missed data emissions when the UI is not visible. Also added the necessary utility imports.

---
*PR created automatically by Jules for task [17617090645685856092](https://jules.google.com/task/17617090645685856092) started by @dogi*