### PR TITLE
Use IO dispatcher for chat history repository reads

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
@@ -87,16 +87,23 @@ class ChatViewModel @Inject constructor(
         communityName: String?
     ) {
         viewModelScope.launch {
-            val currentUser = cachedUser ?: loadCurrentUser(userId).also { cachedUser = it }
-            val newsMessages = voicesRepository.getPlanetNewsMessages(currentUser?.planetCode)
-            val chatHistory = chatRepository.getChatHistoryForUser(currentUser?.name)
-            val targets = cachedShareTargets ?: loadShareTargets(parentCode, communityName, currentUser?._id).also { cachedShareTargets = it }
+            var currentUser: RealmUser? = null
+            var newsMessages: List<org.ole.planet.myplanet.model.RealmNews> = emptyList()
+            var chatHistory: List<RealmChatHistory> = emptyList()
+            var targets: ChatShareTargets? = null
+
+            withContext(dispatcherProvider.io) {
+                currentUser = cachedUser ?: loadCurrentUser(userId).also { cachedUser = it }
+                newsMessages = voicesRepository.getPlanetNewsMessages(currentUser?.planetCode)
+                chatHistory = chatRepository.getChatHistoryForUser(currentUser?.name)
+                targets = cachedShareTargets ?: loadShareTargets(parentCode, communityName, currentUser?._id).also { cachedShareTargets = it }
+            }
 
             withContext(dispatcherProvider.default) {
                 allChats = sortChats(chatHistory)
                 precomputedChats = buildPrecomputedChats(allChats)
             }
-            val data = ChatHistoryScreenData(currentUser, chatHistory, newsMessages, targets)
+            val data = ChatHistoryScreenData(currentUser, chatHistory, newsMessages, targets ?: ChatShareTargets(null, emptyList(), emptyList()))
             _screenData.value = data
             _filteredChats.value = allChats
         }


### PR DESCRIPTION
Refactored `loadChatHistoryScreenData` in `ChatViewModel.kt` to utilize the IO dispatcher for repository reads (current user, news messages, chat history, and share targets).

1. Moved repository operations into `withContext(dispatcherProvider.io)`.
2. Initialized nullable placeholder variables to bypass suspending lambda initialization limitations gracefully.
3. Left `sortChats` and `buildPrecomputedChats` operations in their existing `withContext(dispatcherProvider.default)` block.
4. Passed all necessary tests to ensure correct execution context and behavior.

---
*PR created automatically by Jules for task [981717199530575](https://jules.google.com/task/981717199530575) started by @dogi*