### PR TITLE
Optimize RealmRepository queryListFlow copying

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -121,8 +121,7 @@ open class RealmRepository(
             safeCloseRealm()
             throw e
         }
-    }.flowOn(realmDispatcher)
-        .conflate()
+    }.conflate()
         .map { frozenResults ->
             if (frozenResults.isEmpty()) {
                 emptyList()
@@ -130,7 +129,7 @@ open class RealmRepository(
                 frozenResults.realm.copyFromRealm(frozenResults)
             }
         }
-        .flowOn(databaseService.ioDispatcher)
+        .flowOn(realmDispatcher)
 
     protected suspend fun <T : RealmObject, V : Any> findByField(
         clazz: Class<T>,


### PR DESCRIPTION
Optimized `RealmRepository.queryListFlow` by consolidating flow context operations onto a single `realmDispatcher`. Since frozen Realm objects are inherently thread-safe, copying them via `copyFromRealm` can safely execute on the `realmDispatcher` without needing to hop to an IO dispatcher, reducing overhead. Tested existing Realm flow behavior which remains correct.

---
*PR created automatically by Jules for task [1885953180634514735](https://jules.google.com/task/1885953180634514735) started by @dogi*