### PR TITLE
🧹 Inline parameter-heavy `insertExam` and `insertSurvey` methods in CoursesRepositoryImpl

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -796,31 +796,26 @@ class CoursesRepositoryImpl @Inject constructor(
                 RealmMyCourse.addConcatenatedLink("$baseUrl/$stepLink")
             }
             insertCourseStepsAttachments(myMyCoursesDB?.courseId, stepId, JsonUtils.getJsonArray("resources", stepJson), realmTx, spm)
-            insertExam(stepJson, realmTx, stepId, i + 1, myMyCoursesDB?.courseId, examCache)
-            insertSurvey(stepJson, realmTx, stepId, i + 1, myMyCoursesDB?.courseId, myMyCoursesDB?.createdDate, examCache)
+
+            if (stepJson.has("exam")) {
+                val obj = stepJson.getAsJsonObject("exam")
+                obj.addProperty("stepNumber", i + 1)
+                insertCourseStepsExams(myMyCoursesDB?.courseId, stepId, obj, "", realmTx, examCache)
+            }
+
+            if (stepJson.has("survey")) {
+                val obj = stepJson.getAsJsonObject("survey")
+                obj.addProperty("stepNumber", i + 1)
+                obj.addProperty("createdDate", myMyCoursesDB?.createdDate)
+                insertCourseStepsExams(myMyCoursesDB?.courseId, stepId, obj, "", realmTx, examCache)
+            }
+
             step.noOfResources = JsonUtils.getJsonArray("resources", stepJson).size()
             step.courseId = myMyCoursesDB?.courseId
             courseStepsList.add(step)
         }
         myMyCoursesDB?.courseSteps = RealmList()
         myMyCoursesDB?.courseSteps?.addAll(courseStepsList)
-    }
-
-    private fun insertExam(stepContainer: JsonObject, mRealm: Realm, stepId: String, i: Int, myCoursesID: String?, examCache: HashMap<String, RealmStepExam>? = null) {
-        if (stepContainer.has("exam")) {
-            val obj = stepContainer.getAsJsonObject("exam")
-            obj.addProperty("stepNumber", i)
-            insertCourseStepsExams(myCoursesID, stepId, obj, "", mRealm, examCache)
-        }
-    }
-
-    private fun insertSurvey(stepContainer: JsonObject, mRealm: Realm, stepId: String, i: Int, myCoursesID: String?, createdDate: Long?, examCache: HashMap<String, RealmStepExam>? = null) {
-        if (stepContainer.has("survey")) {
-            val obj = stepContainer.getAsJsonObject("survey")
-            obj.addProperty("stepNumber", i)
-            obj.addProperty("createdDate", createdDate)
-            insertCourseStepsExams(myCoursesID, stepId, obj, "", mRealm, examCache)
-        }
     }
 
     private fun insertCourseStepsAttachments(myCoursesID: String?, stepId: String?, resources: JsonArray, mRealm: Realm?, spm: SharedPrefManager) {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was functions with too many parameters. Specifically, the private `insertExam` and `insertSurvey` helper functions in `CoursesRepositoryImpl.kt`.

💡 **Why:** These functions required a large number of parameters (6 and 7 respectively) just to extract a JsonObject and pass it to `insertCourseStepsExams`. Since they were only called once from within the same loop in `insertMyCourse`, inlining them directly at the call site removes unnecessary boilerplate, reduces cognitive load, and eliminates the parameter-heavy abstraction.

✅ **Verification:** I successfully ran `./gradlew app:compileDefaultDebugKotlin` to verify that the refactoring did not introduce any compilation errors. I also ran `./gradlew app:testDefaultDebugUnitTest --tests "*CoursesRepositoryImplTest*"` to ensure the repository tests still pass successfully.

✨ **Result:** The code footprint is reduced, and the `insertMyCourse` loop's logic is much easier to follow without needing to context switch into small wrapper functions. Maintainability is significantly improved.

---
*PR created automatically by Jules for task [8854280477563698813](https://jules.google.com/task/8854280477563698813) started by @dogi*