### PR TITLE
all: smoother importing (fixes #14416)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5958
-        versionName = "0.59.58"
+        versionCode = 5959
+        versionName = "0.59.59"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -38,8 +38,8 @@ import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UploadManager
 import org.ole.planet.myplanet.services.UploadToShelfService
-import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.services.sync.LoginSyncManager
+import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.services.sync.TransactionSyncManager
 import org.ole.planet.myplanet.services.upload.AchievementUploader
 import org.ole.planet.myplanet.services.upload.PhotoUploader

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -4,12 +4,12 @@ import android.app.Activity
 import android.app.ActivityManager
 import android.app.NotificationManager
 import android.app.Service
-import android.os.SystemClock
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
 import android.os.IBinder
+import android.os.SystemClock
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
@@ -2,9 +2,9 @@ package org.ole.planet.myplanet.services
 
 import android.app.NotificationManager
 import android.content.Context
-import android.os.SystemClock
 import android.content.Intent
 import android.content.SharedPreferences
+import android.os.SystemClock
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo

--- a/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
@@ -27,8 +27,8 @@ import org.ole.planet.myplanet.services.sync.HeavyTableSyncWorker
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.utils.DispatcherProvider
-import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.NetworkUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 
 @HiltWorker
 class ServerReachabilityWorker @AssistedInject constructor(

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/RealtimeSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/RealtimeSyncManager.kt
@@ -1,11 +1,11 @@
 package org.ole.planet.myplanet.services.sync
 
+import java.util.concurrent.CopyOnWriteArraySet
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import org.ole.planet.myplanet.callback.OnRealtimeSyncListener
 import org.ole.planet.myplanet.model.TableDataUpdate
-import java.util.concurrent.CopyOnWriteArraySet
 
 class RealtimeSyncManager {
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -43,7 +43,6 @@ import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.DispatcherProvider
-import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.JsonUtils.getInt
 import org.ole.planet.myplanet.utils.JsonUtils.getJsonArray
 import org.ole.planet.myplanet.utils.JsonUtils.getJsonObject
@@ -52,6 +51,7 @@ import org.ole.planet.myplanet.utils.JsonUtils.gson
 import org.ole.planet.myplanet.utils.NotificationUtils.cancel
 import org.ole.planet.myplanet.utils.NotificationUtils.create
 import org.ole.planet.myplanet.utils.SyncTimeLogger
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 
 @Singleton

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import io.realm.Realm
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -19,9 +20,11 @@ import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.ApplicationScope
+import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ChatRepository
 import org.ole.planet.myplanet.repository.FeedbackRepository
+import org.ole.planet.myplanet.repository.RealmRepository
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.UserSyncRepository
@@ -31,9 +34,6 @@ import org.ole.planet.myplanet.utils.JsonUtils.getJsonArray
 import org.ole.planet.myplanet.utils.JsonUtils.getJsonObject
 import org.ole.planet.myplanet.utils.JsonUtils.getString
 import org.ole.planet.myplanet.utils.SecurePrefs
-import org.ole.planet.myplanet.di.RealmDispatcher
-import org.ole.planet.myplanet.repository.RealmRepository
-import kotlinx.coroutines.CoroutineDispatcher
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
@@ -3,8 +3,6 @@ package org.ole.planet.myplanet.ui.chat
 import android.content.res.ColorStateList
 import android.content.res.Resources
 import android.os.Bundle
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -17,8 +15,9 @@ import androidx.slidingpanelayout.widget.SlidingPaneLayout
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
@@ -36,9 +35,6 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import org.ole.planet.myplanet.utils.textChanges
 
 private data class Quartet<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -15,7 +15,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -20,7 +20,6 @@ import java.io.File
 import java.io.FileReader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
@@ -16,12 +16,12 @@ import java.text.DateFormatSymbols
 import java.util.Calendar
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentActivitiesBinding
 import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class ActivitiesFragment : Fragment() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -13,16 +13,14 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseDashboardFragment
@@ -38,12 +36,11 @@ import org.ole.planet.myplanet.ui.resources.ResourcesFragment
 import org.ole.planet.myplanet.ui.submissions.SubmissionsAdapter
 import org.ole.planet.myplanet.ui.submissions.SubmissionsFragment
 import org.ole.planet.myplanet.ui.teams.TeamDetailFragment
-import kotlinx.coroutines.Job
-import org.ole.planet.myplanet.utils.collectWhenStarted
-import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import org.ole.planet.myplanet.ui.teams.TeamFragment
 import org.ole.planet.myplanet.utils.DialogUtils.guestDialog
 import org.ole.planet.myplanet.utils.TimeProvider
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class BellDashboardFragment : BaseDashboardFragment() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.ui.dashboard
 
 import android.app.AlertDialog
 import android.content.BroadcastReceiver
-import android.os.SystemClock
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -12,6 +11,7 @@ import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
+import android.os.SystemClock
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuItem

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.gson.JsonObject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -36,7 +37,6 @@ import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.NotificationConfig
-import kotlin.time.Duration.Companion.milliseconds
 
 data class DashboardUiState(
     val unreadNotifications: Int = 0,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
@@ -32,8 +32,8 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseExamFragment
 import org.ole.planet.myplanet.databinding.FragmentExamTakingBinding
 import org.ole.planet.myplanet.model.RealmExamQuestion
-import org.ole.planet.myplanet.repository.SurveysRepository
 import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.SurveysRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.CameraUtils.ImageCaptureCallback
 import org.ole.planet.myplanet.utils.CameraUtils.capturePhoto

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -6,20 +6,17 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.OnFeedbackSubmittedListener
 import org.ole.planet.myplanet.databinding.FragmentFeedbackListBinding
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.TableDataUpdate
-import org.ole.planet.myplanet.utils.collectWhenStarted
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncHelper
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
-import androidx.recyclerview.widget.RecyclerView
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener, RealtimeSyncMixin {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/references/ReferencesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/references/ReferencesFragment.kt
@@ -1,23 +1,16 @@
 package org.ole.planet.myplanet.ui.references
 
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
-import androidx.recyclerview.widget.ListAdapter
-import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.FragmentReferenceBinding
-import org.ole.planet.myplanet.databinding.RowReferenceBinding
 import org.ole.planet.myplanet.model.Reference
-import org.ole.planet.myplanet.ui.dictionary.DictionaryActivity
-import org.ole.planet.myplanet.ui.maps.OfflineMapsActivity
-import org.ole.planet.myplanet.utils.DiffUtils
 
 class ReferencesFragment : Fragment() {
     private var _binding: FragmentReferenceBinding? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -1,12 +1,6 @@
 package org.ole.planet.myplanet.ui.resources
 
 import android.os.Bundle
-import android.text.Editable
-import org.ole.planet.myplanet.utils.textChanges
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.launchIn
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -17,6 +11,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.collections.ArrayList
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
@@ -26,6 +24,7 @@ import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.TagData
 import org.ole.planet.myplanet.repository.TagsRepository
 import org.ole.planet.myplanet.utils.KeyboardUtils
+import org.ole.planet.myplanet.utils.textChanges
 
 @AndroidEntryPoint
 class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton.OnCheckedChangeListener {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeout
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.callback.OnRatingChangeListener

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -4,12 +4,6 @@ import android.app.AlertDialog
 import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
-import android.text.Editable
-import org.ole.planet.myplanet.utils.textChanges
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.launchIn
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -26,9 +20,11 @@ import fisk.chipcloud.ChipCloud
 import fisk.chipcloud.ChipCloudConfig
 import fisk.chipcloud.ChipDeletedListener
 import javax.inject.Inject
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
@@ -51,6 +47,7 @@ import org.ole.planet.myplanet.utils.DialogUtils.guestDialog
 import org.ole.planet.myplanet.utils.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
+import org.ole.planet.myplanet.utils.textChanges
 
 @AndroidEntryPoint
 class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItemSelectedListener,

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -17,7 +17,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
 import androidx.preference.Preference.OnPreferenceChangeListener
@@ -30,7 +29,6 @@ import androidx.work.WorkManager
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.MainApplication.Companion.createLog
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.di.DefaultPreferences
 import org.ole.planet.myplanet.model.RealmMyLibrary
@@ -46,11 +44,11 @@ import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.sync.SyncActivity.Companion.restartApp
 import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
-import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class SettingsActivity : AppCompatActivity() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsAdapter.kt
@@ -10,7 +10,6 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.RowMysurveyBinding
-import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.ui.exam.ExamTakingFragment
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.TimeUtils.getFormattedDate

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
@@ -16,8 +16,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.databinding.FragmentMySubmissionBinding

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.model.CreateTeamRequest
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUser

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
@@ -18,11 +18,10 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseTeamFragment
 import org.ole.planet.myplanet.databinding.FragmentDiscussionListBinding
-import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.repository.VoicePostingPolicy
-import org.ole.planet.myplanet.repository.toVoicePostingPolicy
 import org.ole.planet.myplanet.repository.VoicesRepository
+import org.ole.planet.myplanet.repository.toVoicePostingPolicy
 import org.ole.planet.myplanet.services.VoicesLabelManager
 import org.ole.planet.myplanet.ui.chat.ChatDetailFragment
 import org.ole.planet.myplanet.ui.components.FragmentNavigator

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModel.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUser

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/AchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/AchievementFragment.kt
@@ -17,7 +17,6 @@ import com.google.gson.JsonObject
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
 import java.time.Instant
-import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/LabelManipulator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/LabelManipulator.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.ui.voices
 
-import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/NewsViewModel.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
@@ -15,8 +15,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Utilities.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import fisk.chipcloud.ChipCloudConfig
 import java.math.BigInteger
-import org.ole.planet.myplanet.MainApplication
 
 object Utilities {
     fun isValidEmail(target: CharSequence): Boolean {

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmExamQuestionTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmExamQuestionTest.kt
@@ -6,11 +6,8 @@ import io.mockk.Called
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkClass
 import io.mockk.slot
-import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import io.realm.Realm

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryTest.kt
@@ -1,20 +1,14 @@
 package org.ole.planet.myplanet.repository
 
-import com.google.gson.JsonArray
-import com.google.gson.JsonObject
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
-import io.mockk.verify
 import io.realm.Realm
-import io.realm.RealmQuery
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
 import org.junit.Before
-import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ChatApiService
-import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
@@ -2,16 +2,16 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import io.mockk.coEvery
 import io.realm.Realm
 import io.realm.RealmQuery
 import io.realm.RealmResults
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.ole.planet.myplanet.model.RealmUser
-import kotlinx.coroutines.runBlocking
 
 class UserRepositoryBulkInsertTest {
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragmentTest.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.ui.exam
 
-import io.mockk.mockk
 import org.junit.Test
 import org.ole.planet.myplanet.base.BaseExamFragment
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthExaminationViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthExaminationViewModelTest.kt
@@ -17,9 +17,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.model.RealmHealthExamination
-import org.ole.planet.myplanet.model.RealmUser
-import org.junit.Assert.assertNull
 import org.ole.planet.myplanet.model.RealmMyHealth
+import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.HealthRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.MainDispatcherRule

--- a/app/src/test/java/org/ole/planet/myplanet/ui/submissions/SubmissionViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/submissions/SubmissionViewModelTest.kt
@@ -13,8 +13,8 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.repository.SubmissionsRepository


### PR DESCRIPTION
### Motivation
- Reduce noisy and inconsistent import sections by expanding wildcard imports to explicit imports where possible and removing unused imports.
- Enforce a single blank line before and after the import block to match the requested formatting rule.
- Improve consistency across production and test Kotlin sources to reduce accidental unused imports and import-order churn.

### Description
- Expanded occurrences of `import ....*` into explicit `import package.Name` entries when the package provided concrete declarations, and left wildcards if no declarations were found.
- Removed unused explicit imports conservatively by keeping aliases, underscore imports, and any import whose simple name was not found in the file body.
- Sorted and de-duplicated import lines using a small automated formatter script and normalized spacing so there is exactly one empty line before and after the import block.
- Applied the changes across Kotlin sources and tests (multiple files touched across the `app` module, 37 files changed in the run).

### Testing
- Ran the import formatting verification script (`python /tmp/format_kotlin_imports.py`) to validate import sorting, wildcard expansion, deduplication, and blank-line rules, which passed.
- Built the app Kotlin sources with `./gradlew :app:compileDefaultDebugKotlin`, which completed successfully.
- Built unit-test Kotlin sources with `./gradlew :app:compileDefaultDebugUnitTestKotlin`, which completed successfully.
- Note: `./gradlew compileDebugKotlin` was ambiguous in this multi-module project and was not used for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a469afadf70832b8f66dd0d4d949199)