### PR TITLE
sync: smoother post requests retrying (fixes #14415)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5958
-        versionName = "0.59.58"
+        versionCode = 5962
+        versionName = "0.59.62"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/api/RetryInterceptor.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/api/RetryInterceptor.kt
@@ -5,6 +5,7 @@ import java.io.IOException
 import javax.inject.Inject
 import kotlin.math.pow
 import okhttp3.Interceptor
+import okhttp3.Request
 import okhttp3.Response
 import org.ole.planet.myplanet.services.BroadcastService
 import org.ole.planet.myplanet.utils.Constants
@@ -18,10 +19,17 @@ class RetryInterceptor @Inject constructor(
 
     companion object {
         private const val MAX_BACKOFF_SLICE_MS = 250L
+        private val READ_ONLY_POST_PATH_SUFFIXES = listOf("/_find", "/_all_docs", "/_bulk_get")
+    }
+
+    private fun isRetrySafe(request: Request): Boolean {
+        if (request.method != "POST") return true
+        return READ_ONLY_POST_PATH_SUFFIXES.any { request.url.encodedPath.endsWith(it) }
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
+        val retryAllowed = isRetrySafe(request)
         var tryCount = 0
         var response: Response? = null
         var lastError: IOException? = null
@@ -42,7 +50,7 @@ class RetryInterceptor @Inject constructor(
                 lastError = e
             }
 
-            if (tryCount >= maxRetries) {
+            if (!retryAllowed || tryCount >= maxRetries) {
                 break
             }
             tryCount++

--- a/app/src/test/java/org/ole/planet/myplanet/data/api/RetryInterceptorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/api/RetryInterceptorTest.kt
@@ -10,6 +10,7 @@ import okhttp3.Call
 import okhttp3.Interceptor
 import okhttp3.Protocol
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -121,6 +122,69 @@ class RetryInterceptorTest {
     @Test
     fun testSuccessAfterIOException() {
         val request = Request.Builder().url("http://example.com").build()
+        val successResponse = createResponse(request, 200)
+
+        val chain = mockk<Interceptor.Chain>()
+        every { chain.request() } returns request
+        every { chain.proceed(request) } throws SocketTimeoutException("timeout") andThen successResponse
+        every { chain.call() } returns notCancelledCall()
+
+        val result = retryInterceptor.intercept(chain)
+
+        assertEquals(200, result.code)
+        verify(exactly = 2) { chain.proceed(request) }
+        verify(exactly = 1) { broadcastService.trySendBroadcast(any()) }
+    }
+
+    @Test
+    fun testDocumentCreatingPostIsNotRetriedOnIOException() {
+        val request = Request.Builder()
+            .url("http://example.com/submissions")
+            .post("{}".toRequestBody())
+            .build()
+
+        val chain = mockk<Interceptor.Chain>()
+        every { chain.request() } returns request
+        every { chain.proceed(request) } throws SocketTimeoutException("timeout")
+        every { chain.call() } returns notCancelledCall()
+
+        try {
+            retryInterceptor.intercept(chain)
+            fail("Expected IOException without retries")
+        } catch (e: IOException) {
+            assertTrue(e is SocketTimeoutException)
+        }
+
+        verify(exactly = 1) { chain.proceed(request) }
+        verify(exactly = 0) { broadcastService.trySendBroadcast(any()) }
+    }
+
+    @Test
+    fun testDocumentCreatingPostIsNotRetriedOn5xx() {
+        val request = Request.Builder()
+            .url("http://example.com/submissions")
+            .post("{}".toRequestBody())
+            .build()
+        val errorResponse = createResponse(request, 502)
+
+        val chain = mockk<Interceptor.Chain>()
+        every { chain.request() } returns request
+        every { chain.proceed(request) } returns errorResponse
+        every { chain.call() } returns notCancelledCall()
+
+        val result = retryInterceptor.intercept(chain)
+
+        assertEquals(502, result.code)
+        verify(exactly = 1) { chain.proceed(request) }
+        verify(exactly = 0) { broadcastService.trySendBroadcast(any()) }
+    }
+
+    @Test
+    fun testReadOnlyFindPostIsStillRetried() {
+        val request = Request.Builder()
+            .url("http://example.com/submissions/_find")
+            .post("{}".toRequestBody())
+            .build()
         val successResponse = createResponse(request, 200)
 
         val chain = mockk<Interceptor.Chain>()


### PR DESCRIPTION
fixes #14415
Update RetryInterceptor to only retry POST requests that are known read-only CouchDB query endpoints (`/_find`, `/_all_docs`, `/_bulk_get`). All other POST requests now fail fast on IO/5xx instead of being retried, preventing duplicate create/update operations. Added tests to cover non-retried document-creating POSTs and retained retry behavior for read-only POST queries.