### PR TITLE
sync: less gradle realm configuration is more (fixes #14433)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,9 +147,6 @@ android {
         it.buildConfigField 'String', 'PLANET_CAMBRIDGE_PIN', "\"${planetCambridgePin}\""
     }
 }
-realm {
-    syncEnabled = true
-}
 kapt {
     correctErrorTypes = true
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5959
-        versionName = "0.59.59"
+        versionCode = 5961
+        versionName = "0.59.61"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
fixes #14433
```
removing syncEnabled = true cut 10.1 MB off the APK: 68.1 MB → 58.0 MB (−14.8%). 
deleted the realm { syncEnabled = true } block from app/build.gradle:150. That flag made the Realm Gradle plugin bundle the Object Server/sync variant of Realm's    
native library, which the app never uses — it syncs via CouchDB RES

Verified by building before and after. Per-ABI librealm-jni.so:                                                                                                                                                                                                                                                                                                 
  ┌─────────────┬─────────┬────────┬────────┐                                                                                                                                        
  │     ABI     │ Before  │ After  │ Saved  │                                                                                                                                        
  ├─────────────┼─────────┼────────┼────────┤                                                                                                                                        
  │ arm64-v8a   │ 11.0 MB │ 8.5 MB │ 2.5 MB │                                                                                                                                        
  ├─────────────┼─────────┼────────┼────────┤                                                                                                                                        
  │ armeabi-v7a │ 7.7 MB  │ 5.8 MB │ 1.9 MB │                                                                                                                                        
  ├─────────────┼─────────┼────────┼────────┤                                                                                                                                        
  │ x86         │ 12.0 MB │ 9.2 MB │ 2.8 MB │                                                                                                                                        
  ├─────────────┼─────────┼────────┼────────┤                                                                                                                                        
  │ x86_64      │ 12.6 MB │ 9.9 MB │ 2.8 MB │                                                                                                                                        
  └─────────────┴─────────┴────────┴────────┘  
  ```