### PR TITLE
fix: address feedback on auto-refresh and imports

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
@@ -3,16 +3,18 @@ package org.ole.planet.myplanet.ui.dictionary
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
 import android.os.Build
 import android.os.Bundle
 import androidx.core.text.HtmlCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.gson.JsonArray
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.Case
 import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
@@ -36,6 +38,9 @@ class DictionaryActivity : BaseActivity() {
 
     @Inject
     override lateinit var dispatcherProvider: DispatcherProvider
+
+    @Inject
+    override lateinit var broadcastService: org.ole.planet.myplanet.services.BroadcastService
 
     private lateinit var fragmentDictionaryBinding: FragmentDictionaryBinding
 
@@ -78,21 +83,22 @@ class DictionaryActivity : BaseActivity() {
             Utilities.toast(this, getString(R.string.downloading_started_please_check_notificati))
             DownloadUtils.openDownloadService(this, list, false)
         }
+
+        registerReceiver()
     }
 
-    override fun onStart() {
-        super.onStart()
-        val filter = IntentFilter("message_progress")
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
-        } else {
-            registerReceiver(receiver, filter)
+    override fun registerReceiver() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                broadcastService.events.collect { intent ->
+                    if (isActive) {
+                        when (intent.action) {
+                            "message_progress" -> receiver.onReceive(this@DictionaryActivity, intent)
+                        }
+                    }
+                }
+            }
         }
-    }
-
-    override fun onStop() {
-        super.onStop()
-        unregisterReceiver(receiver)
     }
 
     private suspend fun loadDictionaryIfNeeded() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
@@ -117,28 +117,28 @@ class DictionaryActivity : BaseActivity() {
                 null
             }
             json?.let { jsonArray ->
-                databaseService.withRealm { realm ->
-                    realm.executeTransactionAsync { bgRealm ->
-                        jsonArray.forEach { js ->
-                            val doc = js.asJsonObject
-                            val dict = bgRealm.createObject(
-                                RealmDictionary::class.java, UUID.randomUUID().toString()
-                            )
-                            dict.code = JsonUtils.getString("code", doc)
-                            dict.language = JsonUtils.getString("language", doc)
-                            dict.advanceCode = JsonUtils.getString("advance_code", doc)
-                            dict.word = JsonUtils.getString("word", doc)
-                            dict.meaning = JsonUtils.getString("meaning", doc)
-                            dict.definition = JsonUtils.getString("definition", doc)
-                            dict.synonym = JsonUtils.getString("synonym", doc)
-                            dict.antonym = JsonUtils.getString("antonoym", doc)
-                        }
+                databaseService.executeTransactionAsync { bgRealm ->
+                    jsonArray.forEach { js ->
+                        val doc = js.asJsonObject
+                        val dict = bgRealm.createObject(
+                            RealmDictionary::class.java, UUID.randomUUID().toString()
+                        )
+                        dict.code = JsonUtils.getString("code", doc)
+                        dict.language = JsonUtils.getString("language", doc)
+                        dict.advanceCode = JsonUtils.getString("advance_code", doc)
+                        dict.word = JsonUtils.getString("word", doc)
+                        dict.meaning = JsonUtils.getString("meaning", doc)
+                        dict.definition = JsonUtils.getString("definition", doc)
+                        dict.synonym = JsonUtils.getString("synonym", doc)
+                        dict.antonym = JsonUtils.getString("antonoym", doc)
                     }
                 }
             }
-        } else {
-            setClickListener()
         }
+
+        val count = loadDictionaryCount()
+        fragmentDictionaryBinding.tvResult.text = getString(R.string.list_size, count)
+        setClickListener()
     }
 
     private suspend fun loadDictionaryCount(): Long {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/exam/ExamTakingFragment.kt
@@ -4,11 +4,11 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.StateListDrawable
-import android.util.Log
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextUtils
 import android.text.TextWatcher
+import android.util.Log
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -139,7 +139,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
     lateinit var transactionSyncManager: TransactionSyncManager
 
     @Inject
-    lateinit var broadcastService: org.ole.planet.myplanet.services.BroadcastService
+    open lateinit var broadcastService: org.ole.planet.myplanet.services.BroadcastService
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -769,7 +769,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         }
     }
 
-    fun registerReceiver() {
+    open fun registerReceiver() {
         collectWhenStarted(broadcastService.events) { intent ->
             if (intent.action == DashboardActivity.MESSAGE_PROGRESS) {
                 broadcastReceiver.onReceive(this@SyncActivity, intent)


### PR DESCRIPTION
The previous PR implementation of auto-refresh for the dictionary download used a system `BroadcastReceiver`. However, download progress in this app is delivered as an in-process flow via `BroadcastService.events`, meaning the system receiver would never be triggered. This commit addresses that by injecting `BroadcastService` and directly collecting its `events` flow to trigger the dictionary auto-refresh. It also fixes minor import sorting in `ExamTakingFragment.kt`.

---
*PR created automatically by Jules for task [7290878989602272391](https://jules.google.com/task/7290878989602272391) started by @dogi*