### PR TITLE
courses: less repository methods is more (fixes #14555)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5986
-        versionName = "0.59.86"
+        versionCode = 5987
+        versionName = "0.59.87"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
@@ -17,7 +17,6 @@ interface CoursesRepository {
     suspend fun getMyCourses(userId: String): List<RealmMyCourse>
     suspend fun getMyCoursesFlow(userId: String): Flow<List<RealmMyCourse>>
     suspend fun getCourseById(courseId: String): RealmMyCourse?
-    suspend fun getCourseByCourseId(courseId: String): RealmMyCourse?
     fun getCourseByCourseIdFlow(courseId: String): Flow<RealmMyCourse?>
     suspend fun getCoursesByIds(courseIds: List<String>): List<RealmMyCourse>
     suspend fun getCourseOnlineResources(courseId: String?): List<RealmMyLibrary>
@@ -25,7 +24,6 @@ interface CoursesRepository {
     suspend fun getCourseOfflineResources(courseIds: List<String>): List<RealmMyLibrary>
     suspend fun getCourseExamCount(courseId: String?): Int
     suspend fun getCourseSteps(courseId: String): List<RealmCourseStep>
-    suspend fun getCourseStepIds(courseId: String): List<String?>
     suspend fun batchInsertMyCourses(shelfId: String?, documents: List<JsonObject>): Int
     suspend fun markCoursesAdded(courseIds: List<String>, userId: String?): Result<Boolean>
     suspend fun joinCourse(courseId: String, userId: String): Result<Unit>
@@ -59,12 +57,9 @@ interface CoursesRepository {
     suspend fun getCourseProgress(userId: String?, courseIds: List<String>): HashMap<String?, JsonObject>
     suspend fun isStepCompleted(stepId: String?, userId: String?): Boolean
     suspend fun hasUnfinishedSurveys(courseId: String, userId: String?): Boolean
-    suspend fun getCourseTags(courseId: String): List<RealmTag>
     suspend fun getCourseTagsBulk(courseIds: List<String>): Map<String, List<RealmTag>>
     suspend fun getCourseRatings(userId: String?): HashMap<String?, JsonObject>
     suspend fun deleteCourseProgress(courseId: String?)
-    suspend fun filterCoursesByTag(query: String, tags: List<RealmTag>, isMyCourseLib: Boolean, userId: String?): List<RealmMyCourse>
     fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: JsonArray)
     fun bulkInsertCertificationsFromSync(realm: io.realm.Realm, jsonArray: JsonArray)
-    fun insertCertification(realm: io.realm.Realm, doc: JsonObject)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -81,16 +81,6 @@ class CoursesRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getCourseByCourseId(courseId: String): RealmMyCourse? {
-        if (courseId.isBlank()) {
-            return null
-        }
-        return withRealm { realm ->
-            val course = realm.where(RealmMyCourse::class.java).equalTo("courseId", courseId).findFirst()
-            course?.let { realm.copyFromRealm(it) }
-        }
-    }
-
     override fun getCourseByCourseIdFlow(courseId: String): Flow<RealmMyCourse?> {
         return queryListFlow(RealmMyCourse::class.java) {
             equalTo("courseId", courseId)
@@ -141,16 +131,6 @@ class CoursesRepositoryImpl @Inject constructor(
             val course = realm.where(RealmMyCourse::class.java).equalTo("courseId", courseId).findFirst()
             val steps = course?.courseSteps
             if (steps != null) Collections.unmodifiableList(realm.copyFromRealm(steps)) else emptyList()
-        }
-    }
-
-    override suspend fun getCourseStepIds(courseId: String): List<String?> {
-        if (courseId.isBlank()) {
-            return emptyList()
-        }
-        return withRealm { realm ->
-            val course = realm.where(RealmMyCourse::class.java).equalTo("courseId", courseId).findFirst()
-            course?.courseSteps?.map { it.id } ?: emptyList()
         }
     }
 
@@ -597,10 +577,6 @@ class CoursesRepositoryImpl @Inject constructor(
         return submissionsRepository.hasUnfinishedSurveys(courseId, userId)
     }
 
-    override suspend fun getCourseTags(courseId: String): List<RealmTag> {
-        return tagsRepository.getTagsForCourse(courseId)
-    }
-
     override suspend fun getCourseTagsBulk(courseIds: List<String>): Map<String, List<RealmTag>> {
         return tagsRepository.getTagsForCourses(courseIds)
     }
@@ -621,66 +597,6 @@ class CoursesRepositoryImpl @Inject constructor(
                     .findAll()
                     .deleteAllFromRealm()
             }
-        }
-    }
-
-    override suspend fun filterCoursesByTag(
-        query: String,
-        tags: List<RealmTag>,
-        isMyCourseLib: Boolean,
-        userId: String?
-    ): List<RealmMyCourse> {
-        return withRealm { realm ->
-            var realmQuery = realm.where(RealmMyCourse::class.java)
-
-            if (tags.isNotEmpty()) {
-                val tagIds = tags.mapNotNull { it.id }.toTypedArray()
-                val linkedCourseIds = realm.where(RealmTag::class.java)
-                    .equalTo("db", "courses")
-                    .`in`("tagId", tagIds)
-                    .findAll()
-                    .mapNotNull { it.linkId }
-                    .toTypedArray()
-
-                if (linkedCourseIds.isEmpty()) {
-                    return@withRealm emptyList()
-                }
-                realmQuery = realmQuery.`in`("courseId", linkedCourseIds)
-            }
-
-            if (isMyCourseLib && !userId.isNullOrBlank()) {
-                realmQuery = realmQuery.equalTo("userId", userId)
-            }
-
-            val data = realmQuery.findAll()
-
-            val list: List<RealmMyCourse> = if (query.isEmpty()) {
-                realm.copyFromRealm(data)
-            } else {
-                val queryParts = query.split(" ").filterNot { it.isEmpty() }
-                val normalizedQueryParts = queryParts.map { normalizeText(it) }
-                val normalizedQuery = normalizeText(query)
-                val startsWithQuery = mutableListOf<RealmMyCourse>()
-                val containsQuery = mutableListOf<RealmMyCourse>()
-
-                for (item in data) {
-                    val title = item.courseTitle?.let { normalizeText(it) } ?: continue
-
-                    if (title.startsWith(normalizedQuery)) {
-                        startsWithQuery.add(item)
-                    } else if (matchesAllParts(title, normalizedQueryParts)) {
-                        containsQuery.add(item)
-                    }
-                }
-                val filteredData = startsWithQuery + containsQuery
-                realm.copyFromRealm(filteredData)
-            }
-
-            if (!isMyCourseLib) {
-                list.forEach { it.isMyCourse = it.userId?.contains(userId) == true }
-            }
-
-            list.distinctBy { it.courseId }
         }
     }
 
@@ -728,7 +644,7 @@ class CoursesRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun insertCertification(realm: Realm, doc: JsonObject) {
+    private fun insertCertification(realm: Realm, doc: JsonObject) {
         val id = JsonUtils.getString("_id", doc)
         var certification = realm.where(RealmCertification::class.java).equalTo("_id", id).findFirst()
         if (certification == null) {


### PR DESCRIPTION
Removed uncalled `CoursesRepository` methods to streamline the interface, converting `insertCertification` into a private sync helper.

---
*PR created automatically by Jules for task [15543887052655392114](https://jules.google.com/task/15543887052655392114) started by @dogi*