### PR TITLE
all: less activities submissions repositories methods is more (fixes #14556)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5986
-        versionName = "0.59.86"
+        versionCode = 5988
+        versionName = "0.59.88"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
@@ -1,15 +1,10 @@
 package org.ole.planet.myplanet.repository
-
-import android.content.Context
 import com.google.gson.JsonObject
 import kotlinx.coroutines.flow.Flow
-import org.ole.planet.myplanet.model.LoginActivityData
-import org.ole.planet.myplanet.model.RealmNewsLog
 import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmUser
 
 interface ActivitiesRepository {
-    suspend fun getOfflineActivities(userName: String, type: String): List<RealmOfflineActivity>
     suspend fun getOfflineVisitCount(userId: String): Int
     suspend fun getOfflineLoginCount(userName: String): Int
     suspend fun getOfflineLogins(userName: String): Flow<List<RealmOfflineActivity>>
@@ -23,16 +18,10 @@ interface ActivitiesRepository {
     suspend fun logResourceOpen(userName: String?, parentCode: String?, planetCode: String?, title: String?, resourceId: String?, type: String?)
     suspend fun getResourceOpenCount(userName: String, type: String): Long
     suspend fun getMostOpenedResource(userName: String, type: String): Pair<String, Int>?
-    suspend fun getUnuploadedLoginActivities(): List<LoginActivityData>
-    suspend fun markActivitiesUploaded(ids: Array<String>, revMap: Map<String, JsonObject?>)
     suspend fun recordSyncActivity(userId: String)
     suspend fun recordSyncUserChallengeAction(userId: String)
-    suspend fun insertActivity(json: JsonObject)
     suspend fun hasUserSyncAction(userId: String?): Boolean
     suspend fun hasUserCompletedSync(userId: String): Boolean
-    suspend fun getRecentLogin(): RealmOfflineActivity?
-    suspend fun insertSearchActivityFromNewsLog(log: RealmNewsLog)
-    fun serializeLoginActivities(activity: RealmOfflineActivity, context: Context): JsonObject
     suspend fun insertLoginActivitiesFromSync(docs: List<JsonObject>)
     suspend fun uploadActivities()
     suspend fun uploadMyPlanetActivities(userModel: RealmUser)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -23,7 +23,6 @@ import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.LoginActivityData
 import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.model.RealmCourseActivity
-import org.ole.planet.myplanet.model.RealmNewsLog
 import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmRemovedLog
 import org.ole.planet.myplanet.model.RealmResourceActivity
@@ -48,13 +47,6 @@ class ActivitiesRepositoryImpl @Inject constructor(
     private val sharedPrefManager: SharedPrefManager,
     private val timeProvider: TimeProvider
 ) : RealmRepository(databaseService, realmDispatcher), ActivitiesRepository {
-    override suspend fun getOfflineActivities(userName: String, type: String): List<RealmOfflineActivity> {
-        return queryList(RealmOfflineActivity::class.java) {
-            equalTo("userName", userName)
-            equalTo("type", type)
-        }
-    }
-
     override suspend fun getOfflineVisitCount(userId: String): Int {
         return queryList(RealmOfflineActivity::class.java) {
             equalTo("userId", userId)
@@ -217,7 +209,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getUnuploadedLoginActivities(): List<LoginActivityData> {
+    private suspend fun getUnuploadedLoginActivities(): List<LoginActivityData> {
         return queryList(RealmOfflineActivity::class.java) {
             isNull("_rev")
             equalTo("type", "login")
@@ -236,7 +228,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun markActivitiesUploaded(ids: Array<String>, revMap: Map<String, JsonObject?>) {
+    private suspend fun markActivitiesUploaded(ids: Array<String>, revMap: Map<String, JsonObject?>) {
         executeTransaction { transactionRealm ->
             val activities = transactionRealm.where(RealmOfflineActivity::class.java)
                 .`in`("id", ids)
@@ -280,12 +272,6 @@ class ActivitiesRepositoryImpl @Inject constructor(
             activities.createdOn = createdOn
             activities.type = "sync"
             activities.time = Date().time
-        }
-    }
-
-    override suspend fun insertActivity(json: JsonObject) {
-        executeTransaction { realm ->
-            insertActivityInternal(realm, json)
         }
     }
 
@@ -352,24 +338,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         } > 0
     }
 
-    override suspend fun getRecentLogin(): RealmOfflineActivity? {
-        return withRealm { realm ->
-            realm.where(RealmOfflineActivity::class.java)
-                .equalTo("type", UserSessionManager.KEY_LOGIN).sort("loginTime", io.realm.Sort.DESCENDING)
-                .findFirst()?.let { realm.copyFromRealm(it) }
-        }
-    }
-
-    override suspend fun insertSearchActivityFromNewsLog(log: RealmNewsLog) {
-        executeTransaction { realm ->
-            val activity = realm.createObject(RealmSearchActivity::class.java, UUID.randomUUID().toString())
-            activity.user = log.userId ?: ""
-            activity.type = log.type ?: ""
-            activity.time = log.time ?: 0L
-        }
-    }
-
-    override fun serializeLoginActivities(activity: RealmOfflineActivity, context: Context): JsonObject {
+    private fun serializeLoginActivities(activity: RealmOfflineActivity, context: Context): JsonObject {
         val ob = JsonObject()
         ob.addProperty("user", activity.userName)
         ob.addProperty("type", activity.type)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -32,18 +32,15 @@ interface SubmissionsRepository {
     ): Boolean
     suspend fun hasPendingOfflineSubmissions(): Boolean
     suspend fun hasPendingExamResults(): Boolean
-    suspend fun createSurveySubmission(examId: String, userId: String?)
     suspend fun createBulkSurveySubmissions(examId: String, userIds: List<String>)
     suspend fun saveSubmission(submission: RealmSubmission)
     suspend fun markSubmissionComplete(id: String, payload: JsonObject)
     suspend fun getSubmissionDetail(submissionId: String): SubmissionDetail?
     fun getNormalizedSubmitterName(submission: RealmSubmission): String?
-    suspend fun getAllPendingSubmissions(): List<RealmSubmission>
     suspend fun getSubmissionsByParentId(parentId: String?, userId: String?, status: String? = null): List<RealmSubmission>
     suspend fun getSubmissionItems(parentId: String?, userId: String?): List<SubmissionItem>
     suspend fun deleteExamSubmissions(examId: String, courseId: String?, userId: String?)
     suspend fun isStepCompleted(stepId: String?, userId: String?): Boolean
-    suspend fun getSurveysByCourseId(courseId: String): List<RealmStepExam>
     suspend fun hasUnfinishedSurveys(courseId: String, userId: String?): Boolean
     suspend fun hasPendingSurvey(courseId: String, userId: String?): Boolean
     suspend fun addSubmissionPhoto(submissionId: String?, examId: String?, courseId: String?, memberId: String?, photoPath: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -225,18 +225,6 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         } > 0
     }
 
-    override suspend fun createSurveySubmission(examId: String, userId: String?) {
-        val parentId = withRealm { realm ->
-            val courseId = realm.where(RealmStepExam::class.java).equalTo("id", examId).findFirst()?.courseId
-            if (!courseId.isNullOrEmpty()) {
-                "$examId@$courseId"
-            } else {
-                examId
-            }
-        }
-        getOrCreateSubmission(userId, parentId)
-    }
-
     override suspend fun createBulkSurveySubmissions(examId: String, userIds: List<String>) {
         val parentId = withRealm { realm ->
             val courseId = realm.where(RealmStepExam::class.java).equalTo("id", examId).findFirst()?.courseId
@@ -353,12 +341,6 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         }.getOrNull()
     }
 
-    override suspend fun getAllPendingSubmissions(): List<RealmSubmission> {
-        return queryList(RealmSubmission::class.java) {
-            equalTo("status", "pending", Case.INSENSITIVE)
-        }
-    }
-
     override suspend fun getSubmissionsByParentId(parentId: String?, userId: String?, status: String?): List<RealmSubmission> {
         return queryList(RealmSubmission::class.java) {
             equalTo("parentId", parentId)
@@ -419,7 +401,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         } ?: false
     }
 
-    override suspend fun getSurveysByCourseId(courseId: String): List<RealmStepExam> {
+    private suspend fun getSurveysByCourseId(courseId: String): List<RealmStepExam> {
         return queryList(RealmStepExam::class.java) {
             equalTo("courseId", courseId)
             equalTo("type", "survey")


### PR DESCRIPTION
This PR cleans up the `ActivitiesRepository` and `SubmissionsRepository` interfaces by removing uncalled methods, as identified in the issue description.

- **ActivitiesRepository:**
  - Completely deleted: `getOfflineActivities`, `insertActivity`, `getRecentLogin`, `insertSearchActivityFromNewsLog`.
  - Made private in Impl (as they are still used internally): `getUnuploadedLoginActivities`, `markActivitiesUploaded`, `serializeLoginActivities`.
  - Removed unused imports: `Context`, `LoginActivityData`, `RealmNewsLog`.

- **SubmissionsRepository:**
  - Completely deleted: `createSurveySubmission`, `getAllPendingSubmissions`.
  - Made private in Impl: `getSurveysByCourseId`.

The test suite was run (`./gradlew testDefaultDebugUnitTest --offline`) to confirm that this refactor did not introduce any regressions and there were no orphaned tests left behind causing compilation errors.

---
*PR created automatically by Jules for task [14701290581861631027](https://jules.google.com/task/14701290581861631027) started by @dogi*