### PR TITLE
teams: less repository methods is more (fixes #14557)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5986
-        versionName = "0.59.86"
+        versionCode = 5989
+        versionName = "0.59.89"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -72,15 +72,12 @@ interface TeamsRepository {
     suspend fun getAllActiveTeams(): List<RealmMyTeam>
     suspend fun getMyTeamsFlow(userId: String): Flow<List<RealmMyTeam>>
     suspend fun getResourceIds(teamId: String): List<String>
-    suspend fun getResourceIdsByUser(userId: String?): List<String>
     suspend fun getTeamSummaries(userId: String?): List<TeamSummary>
-    suspend fun getShareableEnterprises(): List<RealmMyTeam>
     suspend fun getShareableEnterpriseSummaries(userId: String?): List<TeamSummary>
     fun getMyTeamDetailsFlow(userId: String): Flow<List<TeamDetails>>
     suspend fun getShareableEnterpriseDetails(userId: String?): List<TeamDetails>
     suspend fun getTeamDetails(userId: String?): List<TeamDetails>
 
-    suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
     suspend fun getTeamCourseIds(teamId: String): List<String>
     suspend fun addCoursesToTeam(teamId: String, courseIds: List<String>): Result<Unit>
     suspend fun removeCourseFromTeam(teamId: String, courseId: String): Result<Unit>
@@ -90,28 +87,21 @@ interface TeamsRepository {
     suspend fun getTeamSummaryById(teamId: String): TeamSummary?
     suspend fun getTaskTeamInfo(taskId: String): Triple<String, String, String>?
     suspend fun getJoinRequestTeamId(requestId: String): String?
-    suspend fun getJoinRequestById(id: String?): RealmMyTeam?
     suspend fun getTeamLabelInfo(teamId: String): TeamLabelInfo?
     suspend fun getJoinRequestInfo(requestId: String?): JoinRequestInfo?
     suspend fun getJoinRequestsInfo(requestIds: List<String>): List<JoinRequestInfo>
 
     suspend fun getTeamNamesByIds(ids: List<String>): Map<String, String>
-    suspend fun getTaskNotifications(userId: String?): List<Triple<String, String, String>>
-    suspend fun getJoinRequestNotifications(userId: String?): List<JoinRequestNotification>
     fun getTasksFlow(userId: String?): Flow<List<RealmTeamTask>>
-    suspend fun getTasks(userId: String?): List<RealmTeamTask>
     suspend fun isMember(userId: String?, teamId: String): Boolean
     suspend fun isTeamLeader(teamId: String, userId: String?): Boolean
     suspend fun hasPendingRequest(teamId: String, userId: String?): Boolean
-    suspend fun getTeamMemberStatuses(userId: String?, teamIds: Collection<String>): Map<String, TeamMemberStatus>
-    suspend fun getRecentVisitCounts(teamIds: Collection<String>): Map<String, Long>
     suspend fun requestToJoin(teamId: String, userId: String?, userPlanetCode: String?, teamType: String?)
     suspend fun leaveTeam(teamId: String, userId: String?)
     suspend fun removeMember(teamId: String, userId: String)
     suspend fun addResourceLinks(teamId: String, resources: List<TeamResourceDto>, userId: String?)
     suspend fun removeResourceLink(teamId: String, resourceId: String)
     suspend fun deleteTask(taskId: String)
-    suspend fun upsertTask(task: RealmTeamTask)
     suspend fun createTask(title: String, description: String, deadline: Long, teamId: String, assigneeId: String?)
     suspend fun updateTask(taskId: String, title: String, description: String, deadline: Long, assigneeId: String?)
     suspend fun assignTask(taskId: String, assigneeId: String?)
@@ -154,14 +144,10 @@ interface TeamsRepository {
     suspend fun getAssignee(userId: String): RealmUser?
     suspend fun getRequestedMembers(teamId: String): List<RealmUser>
     suspend fun isTeamNameExists(name: String, type: String, excludeTeamId: String? = null): Boolean
-    suspend fun createEnterprise(name: String, description: String, services: String,
-        rules: String, isPublic: Boolean, user: RealmUser
-    ): Result<String>
     suspend fun updateTeamLeader(teamId: String, newLeaderId: String): Boolean
     suspend fun getNextLeaderCandidate(teamId: String, excludeUserId: String?): RealmUser?
     suspend fun getTeamCreator(teamId: String): String?
     suspend fun getAvailableResourcesToAdd(teamId: String): List<RealmMyLibrary>
-    suspend fun getTeamVisitCount(userName: String?, teamId: String?): Long
 
     suspend fun getLastVisit(userName: String?, teamId: String?): Long?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -78,6 +78,7 @@ interface TeamsRepository {
     suspend fun getShareableEnterpriseDetails(userId: String?): List<TeamDetails>
     suspend fun getTeamDetails(userId: String?): List<TeamDetails>
 
+    suspend fun getTeamResources(teamId: String): List<RealmMyLibrary>
     suspend fun getTeamCourseIds(teamId: String): List<String>
     suspend fun addCoursesToTeam(teamId: String, courseIds: List<String>): Result<Unit>
     suspend fun removeCourseFromTeam(teamId: String, courseId: String): Result<Unit>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -341,7 +341,7 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
 
-    private suspend fun getTeamResources(teamId: String): List<RealmMyLibrary> {
+    override suspend fun getTeamResources(teamId: String): List<RealmMyLibrary> {
         val resourceIds = getResourceIds(teamId)
         val linkedResources = resourcesRepositoryLazy.get().getLibraryItemsByResourceIds(resourceIds)
         val privateResources = resourcesRepositoryLazy.get().getTeamPrivateResources(teamId)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -156,13 +156,6 @@ class TeamsRepositoryImpl @Inject constructor(
             teamId
         }
     }
-    override suspend fun getTasks(userId: String?): List<RealmTeamTask> {
-        return queryList(RealmTeamTask::class.java) {
-            notEqualTo("status", "archived")
-                .equalTo("completed", false)
-                .equalTo("assignee", userId)
-        }
-    }
 
     override suspend fun getAllActiveTeams(): List<RealmMyTeam> {
         return queryList(RealmMyTeam::class.java) {
@@ -229,7 +222,7 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getShareableEnterprises(): List<RealmMyTeam> {
+    private suspend fun getShareableEnterprises(): List<RealmMyTeam> {
         return queryList(RealmMyTeam::class.java) {
             isEmpty("teamId")
             notEqualTo("status", "archived")
@@ -348,7 +341,7 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getTeamResources(teamId: String): List<RealmMyLibrary> {
+    private suspend fun getTeamResources(teamId: String): List<RealmMyLibrary> {
         val resourceIds = getResourceIds(teamId)
         val linkedResources = resourcesRepositoryLazy.get().getLibraryItemsByResourceIds(resourceIds)
         val privateResources = resourcesRepositoryLazy.get().getTeamPrivateResources(teamId)
@@ -493,10 +486,6 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getJoinRequestById(id: String?): RealmMyTeam? {
-        if (id.isNullOrEmpty()) return null
-        return findByField(RealmMyTeam::class.java, "_id", id)
-    }
 
     override suspend fun getTeamNamesByIds(ids: List<String>): Map<String, String> {
         if (ids.isEmpty()) return emptyMap()
@@ -516,65 +505,7 @@ class TeamsRepositoryImpl @Inject constructor(
         return if (request?.docType == "request") request.teamId else null
     }
 
-    override suspend fun getTaskNotifications(userId: String?): List<Triple<String, String, String>> {
-        if (userId.isNullOrEmpty()) return emptyList()
-        return queryList(RealmTeamTask::class.java) {
-            notEqualTo("status", "archived")
-            equalTo("completed", false)
-            equalTo("assignee", userId)
-        }.mapNotNull { task ->
-            val title = task.title ?: return@mapNotNull null
-            val id = task.id ?: return@mapNotNull null
-            Triple(title, formatDate(task.deadline), id)
-        }
-    }
 
-    override suspend fun getJoinRequestNotifications(userId: String?): List<JoinRequestNotification> {
-        if (userId.isNullOrEmpty()) return emptyList()
-
-        val teamIds = queryList(RealmMyTeam::class.java) {
-            equalTo("userId", userId)
-            equalTo("docType", "membership")
-            equalTo("isLeader", true)
-        }.mapNotNull { it.teamId }.distinct()
-
-        if (teamIds.isEmpty()) {
-            return emptyList()
-        }
-
-        val joinRequests = queryList(RealmMyTeam::class.java) {
-            `in`("teamId", teamIds.toTypedArray())
-            equalTo("docType", "request")
-        }
-
-        if (joinRequests.isEmpty()) return emptyList()
-
-        val requestsByGroup = joinRequests.groupBy { "${it.userId}_${it.teamId}" }
-        val mostRecentRequests = requestsByGroup.mapNotNull { (_, requests) ->
-            requests.maxByOrNull { it.createdDate }
-        }
-
-        val relevantTeamIds = mostRecentRequests.mapNotNull { it.teamId }.distinct().toTypedArray()
-        val relevantUserIds = mostRecentRequests.mapNotNull { it.userId }.distinct().toTypedArray()
-
-        val teamsMap = if (relevantTeamIds.isNotEmpty()) {
-            queryList(RealmMyTeam::class.java) { `in`("_id", relevantTeamIds) }.associateBy { it._id }
-        } else emptyMap()
-
-        val usersMap = if (relevantUserIds.isNotEmpty()) {
-            queryList(RealmUser::class.java) { `in`("id", relevantUserIds) }.associateBy { it.id }
-        } else emptyMap()
-
-        return mostRecentRequests.mapNotNull { request ->
-            val requestId = request._id ?: return@mapNotNull null
-            val team = teamsMap[request.teamId]
-            val requester = usersMap[request.userId]
-
-            val requesterName = requester?.name ?: "Unknown User"
-            val teamName = team?.name ?: "Unknown Team"
-            JoinRequestNotification(requesterName, teamName, requestId)
-        }
-    }
 
     override suspend fun getTeamTransactionsWithBalance(
         teamId: String,
@@ -747,7 +678,7 @@ class TeamsRepositoryImpl @Inject constructor(
         } > 0
     }
 
-    override suspend fun getTeamMemberStatuses(userId: String?, teamIds: Collection<String>): Map<String, TeamMemberStatus> {
+    private suspend fun getTeamMemberStatuses(userId: String?, teamIds: Collection<String>): Map<String, TeamMemberStatus> {
         if (userId.isNullOrBlank() || teamIds.isEmpty()) return emptyMap()
 
         val validIds = teamIds.filter { it.isNotBlank() }.distinct()
@@ -788,7 +719,7 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getRecentVisitCounts(teamIds: Collection<String>): Map<String, Long> {
+    private suspend fun getRecentVisitCounts(teamIds: Collection<String>): Map<String, Long> {
         if (teamIds.isEmpty()) return emptyMap()
 
         val validIds = teamIds.filter { it.isNotBlank() }.distinct()
@@ -1014,7 +945,7 @@ class TeamsRepositoryImpl @Inject constructor(
         delete(RealmTeamTask::class.java, "id", taskId)
     }
 
-    override suspend fun upsertTask(task: RealmTeamTask) {
+    private suspend fun upsertTask(task: RealmTeamTask) {
         if (task.link.isNullOrBlank()) {
             val linkObj = JsonObject().apply { addProperty("teams", task.teamId) }
             task.link = gson.toJson(linkObj)
@@ -1100,47 +1031,6 @@ class TeamsRepositoryImpl @Inject constructor(
         save(log)
     }
 
-    override suspend fun createEnterprise(
-        name: String,
-        description: String,
-        services: String,
-        rules: String,
-        isPublic: Boolean,
-        user: RealmUser,
-    ): Result<String> {
-        return runCatching {
-            val enterpriseId = AndroidDecrypter.generateIv()
-            executeTransaction { realm ->
-                val enterprise = realm.createObject(RealmMyTeam::class.java, enterpriseId)
-                enterprise.status = "active"
-                enterprise.createdDate = Date().time
-                enterprise.type = "enterprise"
-                enterprise.services = services
-                enterprise.rules = rules
-                enterprise.name = name
-                enterprise.description = description
-                enterprise.createdBy = user._id
-                enterprise.teamId = ""
-                enterprise.isPublic = isPublic
-                enterprise.userId = user.id
-                enterprise.parentCode = user.parentCode
-                enterprise.teamPlanetCode = user.planetCode
-                enterprise.updated = true
-
-                val membershipId = AndroidDecrypter.generateIv()
-                val membership = realm.createObject(RealmMyTeam::class.java, membershipId)
-                membership.userId = user._id
-                membership.teamId = enterpriseId
-                membership.teamPlanetCode = user.planetCode
-                membership.userPlanetCode = user.planetCode
-                membership.docType = "membership"
-                membership.isLeader = true
-                membership.teamType = "enterprise"
-                membership.updated = true
-            }
-            enterpriseId
-        }
-    }
 
     override suspend fun updateTeam(
         teamId: String,
@@ -1251,20 +1141,6 @@ class TeamsRepositoryImpl @Inject constructor(
         }.mapNotNull { it.resourceId }
     }
 
-    override suspend fun getResourceIdsByUser(userId: String?): List<String> {
-        if (userId.isNullOrBlank()) return emptyList()
-        val teamIds = queryList(RealmMyTeam::class.java) {
-            equalTo("userId", userId)
-            equalTo("docType", "membership")
-        }.mapNotNull { it.teamId }
-
-        if (teamIds.isEmpty()) return emptyList()
-
-        return queryList(RealmMyTeam::class.java) {
-            `in`("teamId", teamIds.toTypedArray())
-            equalTo("docType", "resourceLink")
-        }.mapNotNull { it.resourceId }
-    }
 
     override suspend fun getTeamType(teamId: String): String? {
         if (teamId.isBlank()) return null
@@ -1511,14 +1387,6 @@ class TeamsRepositoryImpl @Inject constructor(
         return allLibraryItems.filter { it._id !in existingIds }
     }
 
-    override suspend fun getTeamVisitCount(userName: String?, teamId: String?): Long {
-        if (userName == null || teamId == null) return 0
-        return count(RealmTeamLog::class.java) {
-            equalTo("type", "teamVisit")
-            equalTo("user", userName)
-            equalTo("teamId", teamId)
-        }
-    }
 
     override suspend fun insertTeamLog(json: JsonObject) {
         executeTransaction { realm ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
@@ -69,7 +69,7 @@ class TeamResourcesFragment : BaseTeamFragment(), OnTeamPageListener, OnResource
         val safeActivity = activity ?: return
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val libraries = resourcesRepository.getLibraryItemsByIds(teamsRepository.getResourceIds(teamId))
+            val libraries = teamsRepository.getTeamResources(teamId)
             val canRemoveResources = teamsRepository.isTeamLeader(teamId, user?.id)
 
             if (!::adapterLibrary.isInitialized) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/resources/TeamResourcesFragment.kt
@@ -69,7 +69,7 @@ class TeamResourcesFragment : BaseTeamFragment(), OnTeamPageListener, OnResource
         val safeActivity = activity ?: return
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val libraries = teamsRepository.getTeamResources(teamId)
+            val libraries = resourcesRepository.getLibraryItemsByIds(teamsRepository.getResourceIds(teamId))
             val canRemoveResources = teamsRepository.isTeamLeader(teamId, user?.id)
 
             if (!::adapterLibrary.isInitialized) {


### PR DESCRIPTION
Fixes the issue by:
1. Identifying and removing 11 unused methods from `TeamsRepository.kt` and `TeamsRepositoryImpl.kt` (e.g., `createEnterprise`, `getTasks`, `getJoinRequestById`, etc.).
2. Modifying `getTeamResources` to be a private method in `TeamsRepositoryImpl.kt` to stop exposing `RealmMyLibrary` from the teams domain interface.
3. Updating `TeamResourcesFragment` to query resources via the inherited `resourcesRepository.getLibraryItemsByIds(...)` instead of via `teamsRepository`.
4. Ensuring no orphaned tests were left behind. Tests compile and run successfully.

---
*PR created automatically by Jules for task [13283420980582198513](https://jules.google.com/task/13283420980582198513) started by @dogi*