### PR TITLE
all: smoother notifications repository batch querying (fixes #14558)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5986
-        versionName = "0.59.86"
+        versionCode = 5990
+        versionName = "0.59.90"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -253,12 +253,7 @@ class NotificationsRepositoryImpl @Inject constructor(
         val map = mutableMapOf<String, String>()
 
         val tasks = queryList(RealmTeamTask::class.java) {
-            beginGroup()
-            taskIds.forEachIndexed { index, taskId ->
-                if (index > 0) or()
-                equalTo("id", taskId)
-            }
-            endGroup()
+            `in`("id", taskIds.toTypedArray())
         }
 
         val teamIds = tasks.mapNotNull { it.teamId }.filter { it.isNotEmpty() }.distinct()
@@ -327,12 +322,7 @@ class NotificationsRepositoryImpl @Inject constructor(
         val map = mutableMapOf<String, String>()
 
         val tasks = queryList(RealmTeamTask::class.java) {
-            beginGroup()
-            taskTitles.forEachIndexed { index, title ->
-                if (index > 0) or()
-                equalTo("title", title)
-            }
-            endGroup()
+            `in`("title", taskTitles.toTypedArray())
         }
 
         val teamIds = tasks.mapNotNull { it.teamId }.filter { it.isNotEmpty() }.distinct()
@@ -390,12 +380,7 @@ class NotificationsRepositoryImpl @Inject constructor(
         // 1. Fetch all relevant notifications in a single query
         val notificationsResult = queryList(RealmTeamNotification::class.java) {
             equalTo("type", "chat")
-            beginGroup()
-            teamIds.forEachIndexed { index, id ->
-                if (index > 0) or()
-                equalTo("parentId", id)
-            }
-            endGroup()
+            `in`("parentId", teamIds.toTypedArray())
         }
         val notificationsById = mutableMapOf<String, RealmTeamNotification>()
         notificationsResult.forEach {
@@ -407,12 +392,7 @@ class NotificationsRepositoryImpl @Inject constructor(
         // 2. Fetch all relevant chat counts in a single query
         val chatsResult = queryList(RealmNews::class.java) {
             equalTo("viewableBy", "teams")
-            beginGroup()
-            teamIds.forEachIndexed { index, id ->
-                if (index > 0) or()
-                equalTo("viewableId", id)
-            }
-            endGroup()
+            `in`("viewableId", teamIds.toTypedArray())
         }
         val chatCountsById = mutableMapOf<String, Long>()
         chatsResult.forEach {


### PR DESCRIPTION
Refactored multiple manual OR-chains in `NotificationsRepositoryImpl.kt` into standard Realm `in()` operator calls for improved code clarity and safety, mitigating edge cases with empty arrays.

Affected queries:
- `RealmTeamTask` by `id`
- `RealmTeamTask` by `title`
- `RealmTeamNotification` by `parentId`
- `RealmNews` by `viewableId`

---
*PR created automatically by Jules for task [14491129129122951389](https://jules.google.com/task/14491129129122951389) started by @dogi*