### PR TITLE
Introduce tiny sorted query helper in RealmRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/DatabaseService.kt
@@ -89,6 +89,15 @@ fun <T : RealmModel> Realm.queryList(clazz: Class<T>, maxDepth: Int, builder: Re
     return where(clazz).apply(builder).findAll().let { copyFromRealm(it, maxDepth) }
 }
 
+fun <T : RealmModel> Realm.queryListSorted(
+    clazz: Class<T>,
+    sortField: String,
+    sortOrder: io.realm.Sort,
+    builder: RealmQuery<T>.() -> Unit = {}
+): List<T> {
+    return where(clazz).apply(builder).sort(sortField, sortOrder).findAll().let { copyFromRealm(it) }
+}
+
 fun <T : RealmModel, V : Any> Realm.findCopyByField(
     clazz: Class<T>,
     fieldName: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CommunityRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CommunityRepositoryImpl.kt
@@ -42,9 +42,7 @@ class CommunityRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getAllSorted(): List<RealmCommunity> {
-        return queryList(RealmCommunity::class.java) {
-            sort("weight", Sort.ASCENDING)
-        }
+        return queryListSorted(RealmCommunity::class.java, "weight", Sort.ASCENDING)
     }
 
     override suspend fun syncCommunityDocs(): Boolean {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RealmRepository.kt
@@ -18,6 +18,7 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.applyEqualTo
 import org.ole.planet.myplanet.data.findCopyByField
 import org.ole.planet.myplanet.data.queryList
+import org.ole.planet.myplanet.data.queryListSorted
 
 open class RealmRepository(
     protected val databaseService: DatabaseService,
@@ -40,6 +41,24 @@ open class RealmRepository(
     protected suspend fun <T : RealmObject> queryList(clazz: Class<T>, maxDepth: Int, builder: RealmQuery<T>.() -> Unit = {}): List<T> = withRealm(false) { realm ->
         realm.queryList(clazz, maxDepth, builder)
     }
+
+    protected suspend fun <T : RealmObject> queryListSorted(
+        clazz: Class<T>,
+        sortField: String,
+        sortOrder: io.realm.Sort,
+        builder: RealmQuery<T>.() -> Unit = {},
+    ): List<T> = queryListSorted(clazz, sortField, sortOrder, false, builder)
+
+    protected suspend fun <T : RealmObject> queryListSorted(
+        clazz: Class<T>,
+        sortField: String,
+        sortOrder: io.realm.Sort,
+        ensureLatest: Boolean,
+        builder: RealmQuery<T>.() -> Unit = {},
+    ): List<T> =
+        withRealm(ensureLatest) { realm ->
+            realm.queryListSorted(clazz, sortField, sortOrder, builder)
+        }
 
     protected suspend fun <T : RealmObject> findFirstCopy(
         clazz: Class<T>,

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RealmRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RealmRepositoryTest.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.repository
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
+import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -36,6 +37,7 @@ class TestRealmRepository(
     realmDispatcher: CoroutineDispatcher
 ) : RealmRepository(databaseService, realmDispatcher) {
     suspend fun queryFlow() = queryListFlow(TestRealmObject::class.java)
+    suspend fun querySorted() = queryListSorted(TestRealmObject::class.java, "testField", io.realm.Sort.ASCENDING)
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -58,6 +60,9 @@ class RealmRepositoryTest {
 
         every { databaseService.ioDispatcher } returns testDispatcher
         every { databaseService.createManagedRealmInstance() } returns realm
+        coEvery { databaseService.withRealmAsync<Any>(any()) } answers {
+            firstArg<(Realm) -> Any>().invoke(realm)
+        }
 
         // Mock RealmLog to prevent UnsatisfiedLinkError during tests when exceptions are caught
         io.mockk.mockkStatic(RealmLog::class)
@@ -246,5 +251,24 @@ class RealmRepositoryTest {
         assertEquals(emptyList<TestRealmObject>(), emittedLists[0])
         verify(exactly = 0) { frozenRealmInitial.copyFromRealm(any<RealmResults<TestRealmObject>>()) }
         job.cancel()
+    }
+
+    @Test
+    fun `queryListSorted applies sort and copies objects`() = runTest {
+        val realmQuery = mockk<RealmQuery<TestRealmObject>>(relaxed = true)
+        val initialResults = mockk<RealmResults<TestRealmObject>>(relaxed = true)
+        val copiedList = listOf(TestRealmObject())
+
+        every { realm.where(TestRealmObject::class.java) } returns realmQuery
+        every { realmQuery.sort("testField", io.realm.Sort.ASCENDING) } returns realmQuery
+        every { realmQuery.findAll() } returns initialResults
+        every { realm.copyFromRealm(initialResults) } returns copiedList
+
+        val result = repository.querySorted()
+
+        assertEquals(copiedList, result)
+        verify { realmQuery.sort("testField", io.realm.Sort.ASCENDING) }
+        verify { realmQuery.findAll() }
+        verify { realm.copyFromRealm(initialResults) }
     }
 }


### PR DESCRIPTION
Added a sorted query helper (`queryListSorted`) to `RealmRepository` and `DatabaseService` to apply sorting directly to the query builder before fetching and copying detached objects. Migrated `CommunityRepositoryImpl.getAllSorted()` as a proof of concept and added test coverage.

---
*PR created automatically by Jules for task [5919250526037205265](https://jules.google.com/task/5919250526037205265) started by @dogi*