### PR TITLE
resources: less repository methods is more (fixes #14559)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5986
-        versionName = "0.59.86"
+        versionCode = 5991
+        versionName = "0.59.91"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -12,23 +12,6 @@ data class LibraryWithMetadata(
     val tags: List<RealmTag>
 )
 
-data class ResourceUploadData(
-    val libraryId: String?,
-    val title: String?,
-    val isPrivate: Boolean,
-    val privateFor: String?,
-    val serialized: JsonObject
-)
-
-data class UploadedResourceInfo(
-    val libraryId: String,
-    val id: String,
-    val rev: String,
-    val isPrivate: Boolean,
-    val privateFor: String?,
-    val title: String?
-)
-
 data class LocalResourceRequest(
     val title: String?,
     val addedBy: String?,
@@ -52,7 +35,6 @@ data class LocalResourceRequest(
 
 interface ResourcesRepository {
     suspend fun getAllLibraries(): List<RealmMyLibrary>
-    suspend fun getAllLibraryItems(): List<RealmMyLibrary>
     suspend fun getLibraryItemById(id: String): RealmMyLibrary?
     suspend fun search(query: String, isMyCourseLib: Boolean, userId: String?): List<RealmMyLibrary>
     suspend fun getLibraryItemByResourceId(resourceId: String): RealmMyLibrary?
@@ -61,20 +43,16 @@ interface ResourcesRepository {
     suspend fun getLibraryListForUser(userId: String?): List<RealmMyLibrary>
     suspend fun getLibraryForSelectedUser(userId: String): List<RealmMyLibrary>
     suspend fun getMyLibrary(userId: String?): List<RealmMyLibrary>
-    suspend fun getStepResources(stepId: String?, resourceOffline: Boolean): List<RealmMyLibrary>
     suspend fun getAllStepResources(stepId: String?): List<RealmMyLibrary>
     fun getRecentResources(userId: String): Flow<List<RealmMyLibrary>>
     fun getPendingDownloads(userId: String): Flow<List<RealmMyLibrary>>
-    suspend fun getPrivateImagesCreatedAfter(timestamp: Long): List<RealmMyLibrary>
     suspend fun countLibrariesNeedingUpdate(userId: String?): Int
     suspend fun resourceTitleExists(title: String): Boolean
-    suspend fun saveLibraryItem(item: RealmMyLibrary)
     suspend fun saveLocalResource(request: LocalResourceRequest): Result<Unit>
     suspend fun markResourceAdded(userId: String?, resourceId: String)
     suspend fun updateUserLibrary(resourceId: String, userId: String, isAdd: Boolean): RealmMyLibrary?
     suspend fun updateLibraryItem(id: String, updater: (RealmMyLibrary) -> Unit)
     suspend fun markResourceOfflineByUrl(url: String)
-    suspend fun markResourceOfflineByLocalAddress(localAddress: String)
     suspend fun markAllResourcesOffline(isOffline: Boolean)
     suspend fun saveSearchActivity(
         userName: String,
@@ -94,7 +72,6 @@ interface ResourcesRepository {
     suspend fun addAllResourcesToUserLibrary(resources: List<RealmMyLibrary>, userId: String): Result<Unit>
     suspend fun observeOpenedResourceIds(userId: String): Flow<Set<String>>
     suspend fun getDownloadSuggestionList(userId: String? = null): List<RealmMyLibrary>
-    suspend fun getLibraryByUserId(userId: String): List<RealmMyLibrary>
     suspend fun removeDeletedResources(currentIds: List<String?>)
     suspend fun getMyLibIds(userId: String): JsonArray
     suspend fun removeResourceFromShelf(resourceId: String, userId: String)
@@ -102,10 +79,6 @@ interface ResourcesRepository {
     suspend fun getFilterFacets(libraries: List<RealmMyLibrary>): Map<String, Set<String>>
     suspend fun batchInsertResources(documents: List<JsonObject>): List<String>
     suspend fun batchInsertMyLibrary(shelfId: String?, documents: List<JsonObject>): Int
-    suspend fun getResourceRatings(resourceId: String): JsonObject?
-    suspend fun getResourceTags(resourceId: String): List<RealmTag>
-    suspend fun getResourceRatingsBulk(ids: List<String>, userId: String?): Map<String?, JsonObject>
-    suspend fun getResourceTagsBulk(ids: List<String>): Map<String, List<RealmTag>>
     suspend fun getEnrichedLibraries(isMyCourseLib: Boolean, modelId: String?): List<LibraryWithMetadata>
     suspend fun getLibraryItemsByResourceIds(ids: Collection<String>): List<RealmMyLibrary>
     suspend fun getTeamPrivateResources(teamId: String): List<RealmMyLibrary>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmRemovedLog
 import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmSearchActivity
@@ -47,12 +46,6 @@ class ResourcesRepositoryImpl @Inject constructor(
 
     override suspend fun getAllLibraries(): List<RealmMyLibrary> {
         return queryList(RealmMyLibrary::class.java)
-    }
-
-    override suspend fun getAllLibraryItems(): List<RealmMyLibrary> {
-        return queryList(RealmMyLibrary::class.java, ensureLatest = true) {
-            equalTo("isPrivate", false)
-        }
     }
 
     override suspend fun search(query: String, isMyCourseLib: Boolean, userId: String?): List<RealmMyLibrary> {
@@ -156,16 +149,6 @@ class ResourcesRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getStepResources(stepId: String?, resourceOffline: Boolean): List<RealmMyLibrary> {
-        if (stepId == null) return emptyList()
-
-        return queryList(RealmMyLibrary::class.java) {
-            equalTo("stepId", stepId)
-            equalTo("resourceOffline", resourceOffline)
-            isNotNull("resourceLocalAddress")
-        }
-    }
-
     override suspend fun getAllStepResources(stepId: String?): List<RealmMyLibrary> {
         if (stepId == null) return emptyList()
 
@@ -190,7 +173,7 @@ class ResourcesRepositoryImpl @Inject constructor(
         } > 0
     }
 
-    override suspend fun saveLibraryItem(item: RealmMyLibrary) {
+    private suspend fun saveLibraryItem(item: RealmMyLibrary) {
         save(item)
     }
 
@@ -287,7 +270,7 @@ class ResourcesRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun markResourceOfflineByLocalAddress(localAddress: String) {
+    private suspend fun markResourceOfflineByLocalAddress(localAddress: String) {
         executeTransaction { realm ->
             val results = realm.where(RealmMyLibrary::class.java)
                 .equalTo("resourceLocalAddress", localAddress)
@@ -316,14 +299,6 @@ class ResourcesRepositoryImpl @Inject constructor(
             equalTo("userId", userId)
                 .equalTo("resourceOffline", false)
                 .isNotNull("resourceLocalAddress")
-        }
-    }
-
-    override suspend fun getPrivateImagesCreatedAfter(timestamp: Long): List<RealmMyLibrary> {
-        return queryList(RealmMyLibrary::class.java) {
-            equalTo("isPrivate", true)
-                .greaterThan("createdDate", timestamp)
-                .equalTo("mediaType", "image")
         }
     }
 
@@ -458,32 +433,6 @@ class ResourcesRepositoryImpl @Inject constructor(
         return filterLibrariesNeedingUpdate(results)
     }
 
-    override suspend fun getLibraryByUserId(userId: String): List<RealmMyLibrary> {
-        val teamIds = queryList(RealmMyTeam::class.java) {
-            equalTo("userId", userId)
-            equalTo("docType", "membership")
-        }.mapNotNull { it.teamId }
-
-        val resourceIdsFromTeams = if (teamIds.isNotEmpty()) {
-            queryList(RealmMyTeam::class.java) {
-                `in`("teamId", teamIds.toTypedArray())
-                equalTo("docType", "resourceLink")
-            }.mapNotNull { it.resourceId }
-        } else {
-            emptyList()
-        }
-
-        return queryList(RealmMyLibrary::class.java) {
-            beginGroup()
-            equalTo("userId", userId)
-            if (resourceIdsFromTeams.isNotEmpty()) {
-                or()
-                `in`("resourceId", resourceIdsFromTeams.toTypedArray())
-            }
-            endGroup()
-        }
-    }
-
     override suspend fun removeDeletedResources(currentIds: List<String?>) {
         val validCurrentIds = currentIds.filterNotNull().toSet()
         executeTransaction { realm ->
@@ -606,15 +555,7 @@ class ResourcesRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getResourceRatings(resourceId: String): JsonObject? {
-        return ratingsRepository.getRatingsById("resource", resourceId, null)
-    }
-
-    override suspend fun getResourceTags(resourceId: String): List<RealmTag> {
-        return tagsRepository.getTagsForResource(resourceId)
-    }
-
-    override suspend fun getResourceRatingsBulk(ids: List<String>, userId: String?): Map<String?, JsonObject> {
+    private suspend fun getResourceRatingsBulk(ids: List<String>, userId: String?): Map<String?, JsonObject> {
         val allRatings = ratingsRepository.getResourceRatings(userId)
         val filteredRatings = HashMap<String?, JsonObject>(ceil(ids.size / 0.75).toInt())
         for (id in ids) {
@@ -625,7 +566,7 @@ class ResourcesRepositoryImpl @Inject constructor(
         return filteredRatings
     }
 
-    override suspend fun getResourceTagsBulk(ids: List<String>): Map<String, List<RealmTag>> {
+    private suspend fun getResourceTagsBulk(ids: List<String>): Map<String, List<RealmTag>> {
         return tagsRepository.getTagsForResources(ids)
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -165,18 +165,6 @@ class ResourcesRepositoryImplTest {
     }
 
     @Test
-    fun `getAllLibraryItems returns non-private libraries`() = runTest {
-        val mockLibrary = RealmMyLibrary().apply { title = "Public Library" }
-        val mockQuery = mockQueryResults(listOf(mockLibrary))
-
-        val result = repository.getAllLibraryItems()
-
-        assertEquals(1, result.size)
-        assertEquals("Public Library", result[0].title)
-        verify { mockQuery.equalTo("isPrivate", false) }
-    }
-
-    @Test
     fun `getLibraryItemById returns correct item`() = runTest {
         val mockLibrary = RealmMyLibrary().apply { id = "id1"; title = "Item 1" }
         val mockQuery = mockQueryResults(listOf(mockLibrary))


### PR DESCRIPTION
This submission deletes 9 uncalled methods from `ResourcesRepository.kt` and its implementation to clean up dead code and reduce the API surface area.

Specifically, it:
1. Deletes unused interface methods completely if they have no active call sites outside of tests (`getAllLibraryItems`, `getStepResources`, `getPrivateImagesCreatedAfter`, `getLibraryByUserId`, `getResourceTags`, `getResourceRatings`).
2. Privatizes implementation methods that are only used internally by `ResourcesRepositoryImpl.kt` (`saveLibraryItem`, `markResourceOfflineByLocalAddress`, `getResourceRatingsBulk`, `getResourceTagsBulk`).
3. Removes the orphaned unit test `getAllLibraryItems returns non-private libraries` to avoid test failures on non-existent methods.
4. Removes completely unused data classes (`ResourceUploadData`, `UploadedResourceInfo`).
5. Retains the `RealmTag` and `JsonObject` imports because they remain in active use by other interface signatures and active data classes (like `LibraryWithMetadata` and `saveSearchActivity`).

---
*PR created automatically by Jules for task [8377054013852437552](https://jules.google.com/task/8377054013852437552) started by @dogi*