### PR TITLE
all: less repository injections is more (fixes #14560)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5986
-        versionName = "0.59.86"
+        versionCode = 5992
+        versionName = "0.59.92"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationActivity.kt
@@ -27,7 +27,6 @@ import org.ole.planet.myplanet.model.RealmExamination
 import org.ole.planet.myplanet.model.RealmHealthExamination
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
-import org.ole.planet.myplanet.repository.HealthRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.encrypt
 import org.ole.planet.myplanet.utils.AndroidDecrypter.Companion.generateIv
@@ -46,8 +45,6 @@ import org.ole.planet.myplanet.utils.collectWhenStarted
 class HealthExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedChangeListener {
     @Inject
     lateinit var userSessionManager: UserSessionManager
-    @Inject
-    lateinit var healthRepository: HealthRepository
 
     private val viewModel: HealthExaminationViewModel by viewModels()
     private lateinit var binding: ActivityHealthExaminationBinding

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -40,7 +40,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnAudioRecordListener
 import org.ole.planet.myplanet.databinding.AlertSoundRecorderBinding
 import org.ole.planet.myplanet.databinding.FragmentAddResourceBinding
-import org.ole.planet.myplanet.repository.PersonalsRepository
 import org.ole.planet.myplanet.services.AudioRecorder
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.FileUtils
@@ -61,8 +60,6 @@ class AddResourceFragment : BottomSheetDialogFragment() {
     private lateinit var requestCameraLauncher: ActivityResultLauncher<String>
     private var type: Int = 0
     private var teamId: String? = null
-    @Inject
-    lateinit var personalsRepository: PersonalsRepository
     @Inject
     lateinit var userSessionManager: UserSessionManager
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageBreakdownFragment.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentStorageBreakdownBinding
 import org.ole.planet.myplanet.databinding.ItemStorageCategoryBinding
-import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.FileUtils
 
@@ -29,9 +28,6 @@ class StorageBreakdownFragment : BottomSheetDialogFragment() {
 
     private var _binding: FragmentStorageBreakdownBinding? = null
     private val binding get() = _binding!!
-
-    @Inject
-    lateinit var resourcesRepository: ResourcesRepository
 
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -41,7 +41,6 @@ import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.User
-import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.ThemeManager
 import org.ole.planet.myplanet.services.sync.LoginSyncManager
@@ -63,8 +62,6 @@ import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class LoginActivity : SyncActivity(), OnUserProfileClickListener {
-    @Inject
-    lateinit var teamsRepository: TeamsRepository
     @Inject
     override lateinit var dispatcherProvider: DispatcherProvider
     @Inject


### PR DESCRIPTION
Removed the unused `@Inject` fields and their corresponding imports from:
- StorageBreakdownFragment (resourcesRepository)
- HealthExaminationActivity (healthRepository)
- LoginActivity (teamsRepository)
- AddResourceFragment (personalsRepository)

Note: The communityRepository injection in SyncActivity was NOT removed because it is actually used via ServerDialogExtensions.kt and inherited by LoginActivity.kt.

---
*PR created automatically by Jules for task [17803118969257344312](https://jules.google.com/task/17803118969257344312) started by @dogi*