### PR TITLE
Refactor CourseFilterController to use DispatcherProvider

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.utils.DispatcherProvider
 
 data class FilterState(
     val searchText: String,
@@ -28,10 +29,11 @@ data class FilterState(
 
 class CourseFilterController(
     private val rootView: View,
-    private val scope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
     private val onFilterChanged: (FilterState) -> Unit,
     private val onScrollToTop: () -> Unit
 ) {
+    private val scope: CoroutineScope = CoroutineScope(dispatcherProvider.main)
     private lateinit var etSearch: EditText
     private lateinit var spnGrade: Spinner
     private lateinit var spnSubject: Spinner

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -179,7 +179,7 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
 
         filterController = CourseFilterController(
             rootView = requireView(),
-            scope = viewLifecycleOwner.lifecycleScope,
+            dispatcherProvider = dispatcherProvider,
             onFilterChanged = { state ->
                 viewModel.filterCourses(isMyCourseLib, model?.id, state.searchText, state.grade,
                     state.subject, state.tagNames, state.progressFilter)


### PR DESCRIPTION
Refactored `CourseFilterController` to replace its reliance on a raw `CoroutineScope` with a `DispatcherProvider`. Instantiations of the controller in `CoursesFragment` were similarly updated to pass in the `dispatcherProvider` instead of `viewLifecycleOwner.lifecycleScope`.

---
*PR created automatically by Jules for task [2735283668417678361](https://jules.google.com/task/2735283668417678361) started by @dogi*