### PR TITLE
Fix: Remove deprecated Thread.id call in MainApplication traffic tagging

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -107,6 +107,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
         private const val AUTO_SYNC_WORK_TAG = "autoSyncWork"
         private const val TASK_NOTIFICATION_WORK_TAG = "taskNotificationWork"
         private const val ANR_LOG_TYPE = "anr"
+        private const val THREAD_STATS_TAG = 1001
         private lateinit var instance: MainApplication
 
         @VisibleForTesting
@@ -208,7 +209,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
                 }
                 val url = URL(formattedUrl)
                 val responseCode = withContext(ioDispatcher) {
-                    TrafficStats.setThreadStatsTag(Thread.currentThread().id.toInt())
+                    TrafficStats.setThreadStatsTag(THREAD_STATS_TAG)
                     val connection = url.openConnection() as HttpURLConnection
                     try {
                         connection.requestMethod = "GET"


### PR DESCRIPTION
Replaces the deprecated `Thread.currentThread().id.toInt()` in `MainApplication.kt` with a newly defined constant `THREAD_STATS_TAG` for `TrafficStats.setThreadStatsTag` to fix the deprecation warning. Evaluated to have no regressions and unit tests for `MainApplicationTest` successfully pass.

---
*PR created automatically by Jules for task [4778453495408344513](https://jules.google.com/task/4778453495408344513) started by @dogi*