### PR TITLE
chore: Annotate SurveyFragment debounce with @OptIn(FlowPreview)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
@@ -87,6 +87,7 @@ class SurveyFragment : BaseRecyclerFragment<RealmStepExam?>(), OnSurveyAdoptList
         return requireNotNull(adapter) { "SurveysAdapter must be initialized inside mutex" }
     }
 
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         realtimeSyncHelper = RealtimeSyncHelper(this, this)


### PR DESCRIPTION
This PR annotates `SurveyFragment.kt` to suppress the `FlowPreview` compiler warning for `debounce(300)`.

---
*PR created automatically by Jules for task [7388789955118904288](https://jules.google.com/task/7388789955118904288) started by @dogi*