### PR TITLE
Suppress FlowPreview warnings in Collections and Resources fragments

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.collections.ArrayList
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
@@ -59,6 +60,7 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
         setListeners()
     }
 
+    @OptIn(FlowPreview::class)
     private fun setListeners() {
         binding.btnOk.setOnClickListener {
             listener?.onOkClicked(selectedItemsList)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -23,6 +23,7 @@ import fisk.chipcloud.ChipDeletedListener
 import java.text.Normalizer
 import java.util.Locale
 import javax.inject.Inject
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -251,6 +252,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         }
     }
 
+    @OptIn(FlowPreview::class)
     private fun setupSearchTextListener() {
         etSearch.textChanges()
             .debounce(300L)


### PR DESCRIPTION
- Added `@OptIn(FlowPreview::class)` to `setListeners()` in `CollectionsFragment.kt`
- Added `@OptIn(FlowPreview::class)` to `setupSearchTextListener()` in `ResourcesFragment.kt`
- Verified warnings no longer appear during compilation.

---
*PR created automatically by Jules for task [9349177785198843894](https://jules.google.com/task/9349177785198843894) started by @dogi*