### PR TITLE
Annotate ChatHistoryFragment debounce with @OptIn(FlowPreview)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
@@ -69,6 +69,7 @@ class ChatHistoryFragment : Fragment() {
         return binding.root
     }
 
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val slidingPaneLayout = binding.slidingPaneLayout


### PR DESCRIPTION
Annotate ChatHistoryFragment debounce with @OptIn(FlowPreview)

Added `@OptIn(kotlinx.coroutines.FlowPreview::class)` to the `onViewCreated` method in `ChatHistoryFragment.kt` to suppress the compiler warning related to the experimental `debounce` coroutine API. No functionality changes were made.

---
*PR created automatically by Jules for task [10527706798737953849](https://jules.google.com/task/10527706798737953849) started by @dogi*