### PR TITLE
courses: less realm step exam model ids is more (fixes #14562)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5986
-        versionName = "0.59.86"
+        versionCode = 5994
+        versionName = "0.59.94"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
@@ -121,18 +121,6 @@ open class RealmStepExam : RealmObject() {
             return `object`
         }
 
-        fun getIds(list: List<RealmStepExam>): Array<String?> {
-            val ids = arrayOfNulls<String>(list.size)
-            for ((i, e) in list.withIndex()) {
-                if (e.type?.startsWith("survey") == true) {
-                    ids[i] = e.id
-                } else {
-                    ids[i] = e.id + "@" + e.courseId
-                }
-            }
-            return ids
-        }
-
         fun getSurveyCreationTime(surveyId: String, mRealm: Realm): Long? {
             val survey = mRealm.where(RealmStepExam::class.java).equalTo("id", surveyId).findFirst()
             return survey?.createdDate

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmStepExamTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmStepExamTest.kt
@@ -207,18 +207,6 @@ class RealmStepExamTest {
     }
 
     @Test
-    fun testGetIds() {
-        val exam1 = RealmStepExam().apply { id = "exam1"; courseId = "course1"; type = "exam" }
-        val exam2 = RealmStepExam().apply { id = "survey1"; type = "survey" }
-
-        val ids = RealmStepExam.getIds(listOf(exam1, exam2))
-
-        assertEquals(2, ids.size)
-        assertEquals("exam1@course1", ids[0])
-        assertEquals("survey1", ids[1])
-    }
-
-    @Test
     fun testGetSurveyCreationTime() {
         val surveyId = "survey1"
         val expectedDate = 1620000000000L


### PR DESCRIPTION
🎯 **What:** Removed the unused `getIds` method from `RealmStepExam.kt` and its associated unit test `testGetIds` from `RealmStepExamTest.kt`.
💡 **Why:** To improve code health and maintainability by removing dead code. The method was entirely unused in the codebase.
✅ **Verification:** Verified the removal manually and ran `./gradlew app:testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.model.RealmStepExamTest"`, which passed successfully, confirming no regressions or compilation errors were introduced.
✨ **Result:** A cleaner codebase with less dead code to maintain.

---
*PR created automatically by Jules for task [15570319651785445679](https://jules.google.com/task/15570319651785445679) started by @dogi*