### PR TITLE
login: less shared preferences url port is more (fixes #14563)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5986
-        versionName = "0.59.86"
+        versionCode = 5995
+        versionName = "0.59.95"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/SharedPrefManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/SharedPrefManager.kt
@@ -46,7 +46,6 @@ class SharedPrefManager @Inject constructor(
         private const val URL_PWD = "url_pwd"
         private const val URL_SCHEME = "url_Scheme"
         private const val URL_HOST = "url_Host"
-        private const val URL_PORT = "url_Port"
         private const val ALTERNATIVE_URL = "alternativeUrl"
         private const val PROCESSED_ALTERNATIVE_URL = "processedAlternativeUrl"
         private const val IS_ALTERNATIVE_URL = "isAlternativeUrl"
@@ -164,9 +163,6 @@ class SharedPrefManager @Inject constructor(
 
     fun getUrlHost(): String = pref.getString(URL_HOST, "") ?: ""
     fun setUrlHost(host: String) = pref.edit { putString(URL_HOST, host) }
-
-    fun getUrlPort(): Int = pref.getInt(URL_PORT, 443)
-    fun setUrlPort(port: Int) = pref.edit { putInt(URL_PORT, port) }
 
     fun getAlternativeUrl(): String = pref.getString(ALTERNATIVE_URL, "") ?: ""
     fun setAlternativeUrl(url: String) = pref.edit { putString(ALTERNATIVE_URL, url) }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -144,7 +144,6 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
         prefData.setServerPin(password)
         prefData.setUrlScheme(uri.scheme ?: "")
         prefData.setUrlHost(uri.host ?: "")
-        prefData.setUrlPort(if (uri.port == -1) (if (uri.scheme == "http") 80 else 443) else uri.port)
         prefData.setServerUrl(url)
         prefData.setCouchdbUrl(couchdbURL)
         prefData.setUrlUser(urlUser)

--- a/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/SharedPrefManagerTest.kt
@@ -144,16 +144,6 @@ class SharedPrefManagerTest {
     }
 
     @Test
-    fun testGetAndSetUrlPort() {
-        every { mockSharedPreferences.getInt("url_Port", 443) } returns 8080
-        assertEquals(8080, sharedPrefManager.getUrlPort())
-
-        sharedPrefManager.setUrlPort(8081)
-        verify { mockEditor.putInt("url_Port", 8081) }
-        verify { mockEditor.apply() }
-    }
-
-    @Test
     fun testGetAndSetLoggedIn() {
         every { mockSharedPreferences.getBoolean(SharedPrefManager.KEY_LOGIN, false) } returns true
         assertTrue(sharedPrefManager.isLoggedIn())


### PR DESCRIPTION
🎯 **What:** Removed unused `getUrlPort` method and its associated unused setter, constants, and tests.
💡 **Why:** `getUrlPort` was completely dead code. Since the getter was never used, the value written by `setUrlPort` was never read, making the setter a useless, write-only operation. Removing both cleans up the API and prevents unnecessary SharedPreferences transactions.
✅ **Verification:** Verified via `grep` that there are no remaining usages of `getUrlPort` or `setUrlPort`. Executed the `SharedPrefManagerTest` suite successfully to confirm no regressions.
✨ **Result:** A cleaner `SharedPrefManager` class with no dead code.

---
*PR created automatically by Jules for task [14691412493784226987](https://jules.google.com/task/14691412493784226987) started by @dogi*