### PR TITLE
courses: less realm step exam model creation time is more (fixes #14564)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5986
-        versionName = "0.59.86"
+        versionCode = 5996
+        versionName = "0.59.96"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmStepExam.kt
@@ -133,9 +133,5 @@ open class RealmStepExam : RealmObject() {
             return ids
         }
 
-        fun getSurveyCreationTime(surveyId: String, mRealm: Realm): Long? {
-            val survey = mRealm.where(RealmStepExam::class.java).equalTo("id", surveyId).findFirst()
-            return survey?.createdDate
-        }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmStepExamTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmStepExamTest.kt
@@ -218,19 +218,4 @@ class RealmStepExamTest {
         assertEquals("survey1", ids[1])
     }
 
-    @Test
-    fun testGetSurveyCreationTime() {
-        val surveyId = "survey1"
-        val expectedDate = 1620000000000L
-        val mockSurvey = mockk<RealmStepExam>(relaxed = true)
-        every { mockSurvey.createdDate } returns expectedDate
-
-        val mockQuery = mockk<RealmQuery<RealmStepExam>>(relaxed = true)
-        every { mockRealm.where(RealmStepExam::class.java) } returns mockQuery
-        every { mockQuery.equalTo("id", surveyId) } returns mockQuery
-        every { mockQuery.findFirst() } returns mockSurvey
-
-        val time = RealmStepExam.getSurveyCreationTime(surveyId, mockRealm)
-        assertEquals(expectedDate, time)
-    }
 }


### PR DESCRIPTION
🎯 **What:** Removed the unused method `getSurveyCreationTime` in `RealmStepExam.kt` and its corresponding test `testGetSurveyCreationTime` in `RealmStepExamTest.kt`.
💡 **Why:** The method was never called in the application. Removing dead code simplifies the codebase, reduces compilation time, and improves maintainability.
✅ **Verification:** Ran `git diff` to verify the exact removals. Executed `./gradlew app:testDefaultDebugUnitTest --tests org.ole.planet.myplanet.model.RealmStepExamTest` which passed successfully, confirming the safety of the deletion.
✨ **Result:** A cleaner codebase with less dead code and no loss of functionality.

---
*PR created automatically by Jules for task [6499235670725011208](https://jules.google.com/task/6499235670725011208) started by @dogi*