### PR TITLE
Refactor date calculation into ActivitiesViewModel

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
@@ -16,6 +16,8 @@ import java.text.DateFormatSymbols
 import java.util.Calendar
 import javax.inject.Inject
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.combine
+import androidx.fragment.app.viewModels
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentActivitiesBinding
 import org.ole.planet.myplanet.model.RealmOfflineActivity
@@ -27,6 +29,8 @@ import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 class ActivitiesFragment : Fragment() {
     private var _binding: FragmentActivitiesBinding? = null
     private val binding get() = _binding!!
+    private val viewModel: ActivitiesViewModel by viewModels()
+
     @Inject
     lateinit var userSessionManager: UserSessionManager
     @Inject
@@ -41,13 +45,16 @@ class ActivitiesFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         val daynightTextColor = ResourcesCompat.getColor(resources, R.color.daynight_textColor, null)
 
-        val endMillis = Calendar.getInstance().timeInMillis
-        val startMillis = Calendar.getInstance().apply { add(Calendar.YEAR, -1) }.timeInMillis
-
         viewLifecycleOwner.lifecycleScope.launch {
             val userName = userSessionManager.getUserModel()?.name ?: return@launch
             val loginsFlow = activitiesRepository.getOfflineLogins(userName)
-            collectLatestWhenStarted(loginsFlow) { logins ->
+
+            val combinedFlow = loginsFlow.combine(viewModel.dateRange) { logins, dateRange ->
+                Pair(logins, dateRange)
+            }
+
+            collectLatestWhenStarted(combinedFlow) { (logins, dateRange) ->
+                val (startMillis, endMillis) = dateRange
                 val monthlyCounts = computeMonthlyCounts(logins, startMillis, endMillis)
                 renderChart(monthlyCounts, daynightTextColor)
             }
@@ -69,7 +76,7 @@ class ActivitiesFragment : Fragment() {
             }
             .groupingBy { it }
             .eachCount()
-            .toSortedMap()
+            .toSortedMap<Int, Int>()
     }
 
     private fun renderChart(monthlyCounts: Map<Int, Int>, textColor: Int) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesViewModel.kt
@@ -1,0 +1,22 @@
+package org.ole.planet.myplanet.ui.dashboard
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.Calendar
+import javax.inject.Inject
+
+@HiltViewModel
+class ActivitiesViewModel @Inject constructor() : ViewModel() {
+
+    private val _dateRange = MutableStateFlow(calculateDateRange())
+    val dateRange: StateFlow<Pair<Long, Long>> = _dateRange.asStateFlow()
+
+    private fun calculateDateRange(): Pair<Long, Long> {
+        val endMillis = Calendar.getInstance().timeInMillis
+        val startMillis = Calendar.getInstance().apply { add(Calendar.YEAR, -1) }.timeInMillis
+        return Pair(startMillis, endMillis)
+    }
+}


### PR DESCRIPTION
Resolves issue where date calculation was tightly coupled in `ActivitiesFragment`.
    
- Created `ActivitiesViewModel` annotated with `@HiltViewModel`.
- Extracted logic to compute `startMillis` and `endMillis` to the ViewModel.
- Exposed pre-calculated values via a `StateFlow<Pair<Long, Long>>`.
- Updated `ActivitiesFragment` to inject the ViewModel and observe `dateRange` using the `combine` flow operator.

---
*PR created automatically by Jules for task [3031546350264269591](https://jules.google.com/task/3031546350264269591) started by @dogi*