### PR TITLE
build: Suppress unused Hilt kapt arguments to fix warning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,6 +150,22 @@ android {
 kapt {
     correctErrorTypes = true
 }
+
+// Disable Hilt annotation processing in kapt (since Hilt uses KSP)
+tasks.matching { it.name.startsWith("kapt") && it.name.endsWith("Kotlin") && !it.name.contains("GenerateStubs") }.configureEach { task ->
+    task.doFirst {
+        def providerList = task.annotationProcessorOptionProviders
+        for (int i = 0; i < providerList.size(); i++) {
+            def providers = providerList[i]
+            if (providers instanceof Iterable) {
+                def filtered = providers.findAll { provider ->
+                    !provider.class.name.contains("HiltCommandLineArgumentProvider")
+                }
+                providerList[i] = filtered
+            }
+        }
+    }
+}
 kotlin {
     compilerOptions {
         freeCompilerArgs.add("-Xannotation-default-target=param-property")


### PR DESCRIPTION
Fixes the `warning: The following options were not recognized by any processor: '[dagger.hilt.internal.useAggregatingRootProcessor, kapt.kotlin.generated, dagger.fastInit, dagger.hilt.android.internal.disableAndroidSuperclassValidation, dagger.hilt.android.internal.projectType]'` warning that occurs when KAPT runs for Realm, caused by the Hilt plugin injecting unused arguments despite using KSP.

---
*PR created automatically by Jules for task [14389775761177611682](https://jules.google.com/task/14389775761177611682) started by @dogi*