### PR TITLE
all: less base recycler methods is more (fixes #14568)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5986
-        versionName = "0.59.86"
+        versionCode = 5994
+        versionName = "0.59.94"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -218,22 +218,6 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         }
     }
 
-    fun applyFilter(libraries: List<RealmMyLibrary>): List<RealmMyLibrary> {
-        val newList: MutableList<RealmMyLibrary> = ArrayList()
-        for (l in libraries) {
-            if (isValidFilter(l)) newList.add(l)
-        }
-        return newList
-    }
-
-    private fun isValidFilter(l: RealmMyLibrary): Boolean {
-        val sub = subjects.isEmpty() || subjects.let { l.subject?.containsAll(it) } == true
-        val lev = levels.isEmpty() || l.level?.containsAll(levels) == true
-        val lan = languages.isEmpty() || languages.contains(l.language)
-        val med = mediums.isEmpty() || mediums.contains(l.mediaType)
-        return sub && lev && lan && med
-    }
-
     override fun onDetach() {
         super.onDetach()
         cleanupReferences()

--- a/app/src/test/java/org/ole/planet/myplanet/base/BaseRecyclerFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/base/BaseRecyclerFragmentTest.kt
@@ -66,52 +66,6 @@ class BaseRecyclerFragmentTest {
     }
 
     @Test
-    fun testApplyFilter() {
-        val fragment = TestBaseRecyclerFragment()
-
-        val lib1 = RealmMyLibrary().apply {
-            subject = RealmList("Math")
-            level = RealmList("Beginner")
-            language = "English"
-            mediaType = "Video"
-        }
-
-        val lib2 = RealmMyLibrary().apply {
-            subject = RealmList("Science")
-            level = RealmList("Advanced")
-            language = "Spanish"
-            mediaType = "PDF"
-        }
-
-        val libraries = listOf(lib1, lib2)
-
-        // No filters
-        assertEquals(2, fragment.applyFilter(libraries).size)
-
-        // Subject filter
-        fragment.subjects = mutableSetOf("Math")
-        assertEquals(1, fragment.applyFilter(libraries).size)
-        assertEquals(lib1, fragment.applyFilter(libraries)[0])
-
-        // Reset and apply Language filter
-        fragment.subjects = mutableSetOf()
-        fragment.languages = mutableSetOf("Spanish")
-        assertEquals(1, fragment.applyFilter(libraries).size)
-        assertEquals(lib2, fragment.applyFilter(libraries)[0])
-
-        // Multiple filters matching one
-        fragment.languages = mutableSetOf("English")
-        fragment.mediums = mutableSetOf("Video")
-        assertEquals(1, fragment.applyFilter(libraries).size)
-        assertEquals(lib1, fragment.applyFilter(libraries)[0])
-
-        // Multiple filters matching none
-        fragment.languages = mutableSetOf("English")
-        fragment.mediums = mutableSetOf("PDF")
-        assertEquals(0, fragment.applyFilter(libraries).size)
-    }
-
-    @Test
     fun testCountSelected_withNullSelectedItems() {
         val fragment = TestBaseRecyclerFragment()
         fragment.selectedItems = null


### PR DESCRIPTION
🎯 **What:** Removed unused `applyFilter` and `isValidFilter` methods from `BaseRecyclerFragment.kt`, along with their associated tests in `BaseRecyclerFragmentTest.kt`.
💡 **Why:** To improve code health and maintainability by removing dead code.
✅ **Verification:** Checked via `grep` that both methods were fully unused. Verified that local unit tests (`BaseRecyclerFragmentTest`) pass locally after removal.
✨ **Result:** A cleaner codebase with less dead code.

---
*PR created automatically by Jules for task [1774350247392918422](https://jules.google.com/task/1774350247392918422) started by @dogi*