### PR TITLE
Fix DialogUtils compiler errors

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/DialogUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/DialogUtils.kt
@@ -13,7 +13,6 @@ import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.DialogProgressBinding
@@ -53,14 +52,9 @@ object DialogUtils {
 
         becomeMember.setOnClickListener {
             val guest = true
-            MainApplication.applicationScope.launch {
-                val username = profileDbHandler.getUserModel()?.name
-                withContext(Dispatchers.Main) {
-                    val intent = Intent(context, BecomeMemberActivity::class.java)
-                    intent.putExtra("guest", guest)
-                    context.startActivity(intent)
-                }
-            }
+            val intent = Intent(context, BecomeMemberActivity::class.java)
+            intent.putExtra("guest", guest)
+            context.startActivity(intent)
         }
         cancel.setOnClickListener {
             dialog.dismiss()


### PR DESCRIPTION
This submission resolves the Kotlin compiler errors (`Unresolved reference 'profileDbHandler'` and `Unresolved reference 'Dispatchers'`) in `DialogUtils.kt` by removing the unused coroutine launch and `withContext` import from `guestDialog()`. The intent to launch `BecomeMemberActivity` now runs properly on the main thread when the listener is triggered.

---
*PR created automatically by Jules for task [9289327985415768404](https://jules.google.com/task/9289327985415768404) started by @dogi*