### PR TITLE
Fix test compilation errors in Voices and Teams view models and repositories

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/repository/VoicesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/VoicesRepositoryImplTest.kt
@@ -73,7 +73,8 @@ class VoicesRepositoryImplTest {
             UnconfinedTestDispatcher(),
             dispatcherProvider,
             realGson,
-            sharedPrefManager
+            sharedPrefManager,
+            dagger.Lazy { userRepository }
         ), recordPrivateCalls = true)
 
         coEvery { databaseService.withRealmAsync<Any>(any()) } answers {

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModelTest.kt
@@ -12,7 +12,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.repository.TeamsRepository
-import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.MainDispatcherRule
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
@@ -28,12 +27,11 @@ class TeamsVoicesViewModelTest {
     private lateinit var viewModel: TeamsVoicesViewModel
     private val voicesRepository: VoicesRepository = mockk(relaxed = true)
     private val teamsRepository: TeamsRepository = mockk(relaxed = true)
-    private val userRepository: UserRepository = mockk(relaxed = true)
     private val dispatcherProvider = TestDispatcherProvider(testDispatcher)
 
     @Before
     fun setup() {
-        viewModel = TeamsVoicesViewModel(voicesRepository, teamsRepository, userRepository, dispatcherProvider)
+        viewModel = TeamsVoicesViewModel(voicesRepository, teamsRepository, dispatcherProvider)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/ui/voices/VoicesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/voices/VoicesViewModelTest.kt
@@ -15,7 +15,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.repository.TeamsRepository
-import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.MainDispatcherRule
@@ -27,7 +26,6 @@ class VoicesViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private lateinit var voicesRepository: VoicesRepository
-    private lateinit var userRepository: UserRepository
     private lateinit var teamsRepository: TeamsRepository
     private lateinit var viewModel: VoicesViewModel
 
@@ -41,9 +39,8 @@ class VoicesViewModelTest {
     @Before
     fun setup() {
         voicesRepository = mockk(relaxed = true)
-        userRepository = mockk(relaxed = true)
         teamsRepository = mockk(relaxed = true)
-        viewModel = VoicesViewModel(voicesRepository, userRepository, teamsRepository, testDispatcherProvider)
+        viewModel = VoicesViewModel(voicesRepository, teamsRepository, testDispatcherProvider)
     }
 
     @Test


### PR DESCRIPTION
Fixed Kotlin compilation errors in the `compileDefaultDebugUnitTestKotlin` task caused by recent changes to `VoicesRepositoryImpl`, `TeamsVoicesViewModel`, and `VoicesViewModel` constructors. The test classes were updated to reflect the new dependency requirements.

---
*PR created automatically by Jules for task [2486844450076340778](https://jules.google.com/task/2486844450076340778) started by @dogi*