### PR TITLE
Fix Argument type mismatch in UploadCoordinator

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
@@ -99,11 +99,17 @@ class UploadCoordinator @Inject constructor(
     private suspend fun <T : RealmObject> queryItemsToUpload(
         config: UploadConfig<T>
     ): List<PreparedUpload<T>> {
-        val queryContract = UploadQueryContract<T>(
-            modelClass = config.modelClass,
-            queryBuilder = config.queryBuilder
-        )
-        val items = uploadRepository.queryPending(queryContract)
+        val items = if (config.fetchPendingItems != null) {
+            config.fetchPendingItems.invoke()
+        } else if (config.queryBuilder != null) {
+            val queryContract = UploadQueryContract<T>(
+                modelClass = config.modelClass,
+                queryBuilder = config.queryBuilder
+            )
+            uploadRepository.queryPending(queryContract)
+        } else {
+            emptyList()
+        }
 
         val tempResults = items.mapNotNull { copiedItem ->
             if (config.filterGuests && config.guestUserIdExtractor != null) {


### PR DESCRIPTION
Fixes a compilation error in `UploadCoordinator.kt` where `config.queryBuilder` (which is nullable) was being passed unconditionally to `UploadQueryContract` (which expects a non-null function type).

The fix conditionally checks for `fetchPendingItems` first, then falls back to `queryBuilder` with smart casting ensuring it's non-null before creating the `UploadQueryContract`.

---
*PR created automatically by Jules for task [372141153048561203](https://jules.google.com/task/372141153048561203) started by @dogi*