### PR TITLE
chore: remove unused color resources

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,22 +17,16 @@
     <color name="light_dark">#FFFFFF</color>
     <color name="mainColor">@color/colorPrimary</color>
     <color name="mainColorLight">@color/colorPrimaryLight</color>
-    <color name="dashboard_item_alternative">@color/md_grey_300</color>
     <color name="total_color">@color/md_blue_900</color>
 
     <color name="black_overlay">#66000000</color>
     <color name="bg_white">#FFFFFF</color>
-    <color name="green">#C304E019</color>
 
-    <color name="selected_color">#80B0E0E6</color>
     <color name="empty_rating">@color/md_grey_500</color>
     <color name="ic_download">#000000</color>
     <color name="profile_pic">#BDBDBD</color>
     <color name="user_profile_label">@color/md_blue_700</color>
     <color name="user_profile_description">@color/md_grey_700</color>
-    <color name="user_profile_background">@color/md_grey_300</color>
-    <color name="multi_select_grey">@color/md_grey_300</color>
-    <color name="background_color">#FFFFFF</color>
     <color name="text_color">#000000</color>
     <color name="teams_heading">#000000</color>
 
@@ -49,10 +43,7 @@
     <color name="warning_color">#FF9800</color>
 
     <color name="status_not_started">#9E9E9E</color>
-    <color name="status_in_progress">#FFC107</color>
-    <color name="status_completed">#4CAF50</color>
 
     <color name="field_fill">#E8EEF5</color>
     <color name="md_blue_100">#BBDEFB</color>
-    <color name="md_blue_200">#90CAF9</color>
 </resources>


### PR DESCRIPTION
## Summary

This PR removes 9 unused color resources that were defined in `app/src/main/res/values/colors.xml` but were never referenced anywhere in the codebase (neither in Kotlin code nor XML layouts).

### Removed Colors

| Color Name | Value |
|-----------|-------|
| dashboard_item_alternative | @color/md_grey_300 |
| green | #C304E019 |
| selected_color | #80B0E0E6 |
| user_profile_background | @color/md_grey_300 |
| multi_select_grey | @color/md_grey_300 |
| background_color | #FFFFFF |
| status_in_progress | #FFC107 |
| status_completed | #4CAF50 |
| md_blue_200 | #90CAF9 |

### Analysis Findings

This PR is part of a comprehensive dead code analysis that examined:

- **Kotlin/Java classes**: 460 source files analyzed
- **XML resources**: 179 layout files, 123 drawable files
- **Gradle dependencies**: All dependencies verified as in-use
- **String resources**: 51 unused strings identified (all have translations - require careful review)

### Why Only Colors?

The unused strings identified (51 total) all exist in translation files (Arabic, Spanish, French, Nepali, Somali), meaning they may be:
- Legacy strings from deprecated features
- Prepared for future use
- Translations that are out of sync with code

These require careful review before removal to avoid breaking translations.

### Verification

Confirmed unused by checking for:
- Direct `R.color.xxx` references in Kotlin code
- `@color/xxx` references in XML layouts
- ViewBinding/DataBinding generated references

This PR was created by an AI agent (OpenHands) following the repository's CLAUDE.md guidelines.

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7b8531b-f21b-4f5e-9471-a378252ba8ed)