### PR TITLE
🔒 Fix insecure randomness for AES key generation

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/AndroidDecrypter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/AndroidDecrypter.kt
@@ -113,7 +113,7 @@ class AndroidDecrypter {
             val secretKey: SecretKey
             try {
                 keyGenerator = KeyGenerator.getInstance("AES")
-                keyGenerator.init(256)
+                keyGenerator.init(256, SecureRandom())
                 secretKey = keyGenerator.generateKey()
                 val binary = secretKey.encoded
                 return bytesToHex(binary)


### PR DESCRIPTION
🎯 **What:** The `generateKey` method in `AndroidDecrypter.kt` initialized the AES `KeyGenerator` without explicitly providing a secure randomness source (`SecureRandom`).
⚠️ **Risk:** Although Android's default behavior is generally acceptable, omitting a `SecureRandom` instance does not explicitly guarantee cryptographic strength and is flagged by security best practices as potentially insecure. This could theoretically weaken the unpredictability of generated encryption keys.
🛡️ **Solution:** Updated `keyGenerator.init(256)` to `keyGenerator.init(256, SecureRandom())`, explicitly tying a secure random number generator to the AES key generation process.

---
*PR created automatically by Jules for task [6542887598571901513](https://jules.google.com/task/6542887598571901513) started by @dogi*