### PR TITLE
🔒 Replace hardcoded zero IV with secure random IV in AndroidDecrypter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/AndroidDecrypter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/AndroidDecrypter.kt
@@ -18,7 +18,12 @@ class AndroidDecrypter {
             val clean = plainText.toByteArray()
             val ivSize = 16
             val ivBytes = ByteArray(ivSize)
-            iv?.let { hexStringToByteArray(it) }?.let { System.arraycopy(it, 0, ivBytes, 0, ivBytes.size) }
+            if (iv != null) {
+                val decodedIv = hexStringToByteArray(iv)
+                System.arraycopy(decodedIv, 0, ivBytes, 0, minOf(decodedIv.size, ivBytes.size))
+            } else {
+                SecureRandom().nextBytes(ivBytes)
+            }
             val ivParameterSpec = IvParameterSpec(ivBytes)
             val keyBytes = ByteArray(32)
             key?.let { hexStringToByteArray(it) }?.let { System.arraycopy(it, 0, keyBytes, 0, keyBytes.size) }
@@ -53,24 +58,33 @@ class AndroidDecrypter {
 
         fun decrypt(encrypted: String?, key: String?, initVector: String?): String? {
             try {
-                if (encrypted == null || key == null || initVector == null) {
+                if (encrypted == null || key == null) {
                     return null
                 }
-                val ivBytes = hexStringToByteArray(initVector)
+                val encryptedBytes = hexStringToByteArray(encrypted)
+                val ivBytes: ByteArray
+                val actualEncryptedBytes: ByteArray
+
+                if (initVector == null) {
+                    if (encryptedBytes.size < 16) return null
+                    ivBytes = encryptedBytes.sliceArray(0 until 16)
+                    actualEncryptedBytes = encryptedBytes.sliceArray(16 until encryptedBytes.size)
+                } else {
+                    val providedIvBytes = hexStringToByteArray(initVector)
+                    if (encryptedBytes.size >= providedIvBytes.size && providedIvBytes.contentEquals(encryptedBytes.sliceArray(0 until providedIvBytes.size))) {
+                        ivBytes = providedIvBytes
+                        actualEncryptedBytes = encryptedBytes.sliceArray(providedIvBytes.size until encryptedBytes.size)
+                    } else {
+                        ivBytes = providedIvBytes
+                        actualEncryptedBytes = encryptedBytes
+                    }
+                }
+
                 val iv = IvParameterSpec(ivBytes)
                 val skeySpec = SecretKeySpec(hexStringToByteArray(key), "AES")
 
                 val cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING")
                 cipher.init(Cipher.DECRYPT_MODE, skeySpec, iv)
-                val encryptedBytes = hexStringToByteArray(encrypted)
-                // Invariant: New-format encrypted data prepends the IV to the ciphertext.
-                // We check if the payload starts with the provided IV to decide whether to strip it.
-                // This maintains backward compatibility with legacy data containing only the ciphertext.
-                val actualEncryptedBytes = if (encryptedBytes.size >= ivBytes.size && ivBytes.contentEquals(encryptedBytes.sliceArray(0 until ivBytes.size))) {
-                    encryptedBytes.sliceArray(ivBytes.size until encryptedBytes.size)
-                } else {
-                    encryptedBytes
-                }
                 val original = cipher.doFinal(actualEncryptedBytes)
                 return String(original)
             } catch (ex: Exception) {

--- a/app/src/test/java/org/ole/planet/myplanet/utils/AndroidDecrypterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/AndroidDecrypterTest.kt
@@ -56,8 +56,9 @@ class AndroidDecrypterTest {
         // Decrypt() returns null if the passed key is null, so we must explicitly pass
         // the equivalent all-zero hex strings to round-trip this.
         val zeroKey = "00".repeat(32)
-        val zeroIv = "00".repeat(16)
-        val decrypted = AndroidDecrypter.decrypt(encrypted, zeroKey, zeroIv)
+
+        // Pass null for initVector so decrypt automatically extracts the randomly generated prepended IV.
+        val decrypted = AndroidDecrypter.decrypt(encrypted, zeroKey, null)
         assertEquals(plainText, decrypted)
     }
 


### PR DESCRIPTION
🎯 **What:** Fixed a vulnerability in `AndroidDecrypter.encrypt` where passing a `null` IV resulted in a hardcoded, all-zero IV byte array being used for AES encryption.
⚠️ **Risk:** A hardcoded, predictable IV breaks the semantic security of block ciphers like AES-CBC. If an attacker observes multiple ciphertexts encrypted with the same key and the same all-zero IV, they can identify identical plaintext blocks and potentially perform chosen-plaintext attacks, severely compromising data confidentiality.
🛡️ **Solution:** Updated `encrypt` to securely generate a random IV using `SecureRandom().nextBytes()` whenever the provided `iv` is `null`. Updated `decrypt` to handle `null` fallback IVs safely by dynamically extracting the 16-byte random IV prepended to the ciphertext, while fully preserving backward compatibility for legacy data using explicitly provided IVs.

---
*PR created automatically by Jules for task [836664628873329941](https://jules.google.com/task/836664628873329941) started by @dogi*