### PR TITLE
sync: smoother upload managing (fixes #14794)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6133
-        versionName = "0.61.33"
+        versionCode = 6134
+        versionName = "0.61.34"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -33,12 +33,14 @@ import org.ole.planet.myplanet.repository.SurveysRepository
 import org.ole.planet.myplanet.repository.TagsRepository
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.TeamsSyncRepository
+import org.ole.planet.myplanet.repository.UploadRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.UserSyncRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UploadManager
 import org.ole.planet.myplanet.services.UploadToShelfService
+import org.ole.planet.myplanet.services.retry.RetryQueue
 import org.ole.planet.myplanet.services.sync.LoginSyncManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
 import org.ole.planet.myplanet.services.sync.SyncManager
@@ -94,6 +96,8 @@ object ServiceModule {
         sharedPrefManager: SharedPrefManager,
         gson: Gson,
         uploadCoordinator: UploadCoordinator,
+        uploadRepository: UploadRepository,
+        retryQueue: RetryQueue,
         personalsRepository: PersonalsRepository,
         userRepository: UserRepository,
         chatRepository: ChatRepository,
@@ -110,7 +114,7 @@ object ServiceModule {
         achievementUploader: AchievementUploader,
         timeProvider: TimeProvider
     ): UploadManager {
-        return UploadManager(context, submissionsRepository, sharedPrefManager, gson, uploadCoordinator, personalsRepository, userRepository, chatRepository, voicesRepository, uploadConfigs, resourcesRepository, teamsRepository, teamsSyncRepository, apiInterface, activitiesRepository, dispatcherProvider, scope, photoUploader, achievementUploader, timeProvider)
+        return UploadManager(context, submissionsRepository, sharedPrefManager, gson, uploadCoordinator, uploadRepository, retryQueue, personalsRepository, userRepository, chatRepository, voicesRepository, uploadConfigs, resourcesRepository, teamsRepository, teamsSyncRepository, apiInterface, activitiesRepository, dispatcherProvider, scope, photoUploader, achievementUploader, timeProvider)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -29,18 +29,23 @@ import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.ChatRepository
 import org.ole.planet.myplanet.repository.NewsUpdateData
+import org.ole.planet.myplanet.repository.NewsUploadData
 import org.ole.planet.myplanet.repository.PersonalsRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
+import org.ole.planet.myplanet.repository.TeamUploadData
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.TeamsSyncRepository
+import org.ole.planet.myplanet.repository.UploadRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
+import org.ole.planet.myplanet.services.retry.RetryQueue
 import org.ole.planet.myplanet.services.upload.AchievementUploader
 import org.ole.planet.myplanet.services.upload.PhotoUploader
 import org.ole.planet.myplanet.services.upload.UploadConfigs
 import org.ole.planet.myplanet.services.upload.UploadConstants.BATCH_SIZE
 import org.ole.planet.myplanet.services.upload.UploadCoordinator
+import org.ole.planet.myplanet.services.upload.UploadError
 import org.ole.planet.myplanet.services.upload.UploadResult
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.FileUtils
@@ -60,6 +65,8 @@ class UploadManager @Inject constructor(
     private val sharedPrefManager: SharedPrefManager,
     private val gson: Gson,
     private val uploadCoordinator: UploadCoordinator,
+    private val uploadRepository: UploadRepository,
+    private val retryQueue: RetryQueue,
     private val personalsRepository: PersonalsRepository,
     private val userRepository: UserRepository,
     private val chatRepository: ChatRepository,
@@ -289,31 +296,34 @@ class UploadManager @Inject constructor(
                     try {
                         if (teamData.isDeletePending) {
                             val id = teamData.teamId ?: return@forEach
-                            val response = apiInterface.putDoc(
-                                UrlUtils.header, "application/json",
+                            val response = uploadRepository.putUpload(
                                 "${UrlUtils.getUrl()}/teams/$id", teamData.serialized
                             )
                             if (response.isSuccessful) {
                                 deletedIds.add(id)
+                            } else {
+                                queueTeamRetry(teamData, response.code(), "PUT", id)
                             }
                         } else {
-                            val response = apiInterface.postDoc(
-                                UrlUtils.header, "application/json",
+                            val response = uploadRepository.postUpload(
                                 "${UrlUtils.getUrl()}/teams", teamData.serialized
                             )
 
                             val `object` = response.body()
 
-                            if (`object` != null) {
+                            if (response.isSuccessful && `object` != null) {
                                 var rev = getString("rev", `object`)
                                 if (!teamData.imageName.isNullOrEmpty() && teamData.teamId != null && rev.isNotEmpty()) {
                                     rev = uploadTeamImageAttachment(teamData.teamId, rev, teamData.imageName)
                                 }
                                 teamData.teamId?.let { uploadedTeams[it] = rev }
+                            } else {
+                                queueTeamRetry(teamData, response.code(), "POST", null)
                             }
                         }
                     } catch (e: IOException) {
                         Log.e(TAG, "Exception in UploadManager", e)
+                        queueTeamRetry(teamData, null, if (teamData.isDeletePending) "PUT" else "POST", teamData.teamId, e)
                     }
                 }
 
@@ -325,6 +335,31 @@ class UploadManager @Inject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun queueTeamRetry(
+        teamData: TeamUploadData,
+        httpCode: Int?,
+        httpMethod: String,
+        dbId: String?,
+        exception: Exception? = null
+    ) {
+        val retryable = exception != null || (httpCode != null && httpCode >= 500)
+        if (!retryable) return
+        retryQueue.queueFailedOperation(
+            uploadType = "RealmMyTeam",
+            error = UploadError(
+                itemId = teamData.teamId ?: "",
+                exception = exception ?: Exception("Upload failed: HTTP $httpCode"),
+                retryable = true,
+                httpCode = httpCode
+            ),
+            payload = teamData.serialized,
+            endpoint = "teams",
+            httpMethod = httpMethod,
+            dbId = dbId,
+            modelClassName = "RealmMyTeam"
+        )
     }
 
     private suspend fun uploadTeamImageAttachment(teamId: String, rev: String, imageName: String): String {
@@ -383,8 +418,10 @@ class UploadManager @Inject constructor(
     suspend fun uploadNews() {
         // Note: uploadNews has unique logic that requires uploading images BEFORE the news document,
         // then modifying the serialized JSON based on image upload responses. This doesn't fit the
-        // standard UploadCoordinator pattern, so we handle it with custom logic but still use
-        // the coordinator for the core upload/update flow where possible.
+        // standard UploadCoordinator pattern (a single serialize-then-POST/PUT per item), so the
+        // orchestration stays custom here — but the actual doc-level network calls and retry-queueing
+        // now reuse the same UploadRepository/RetryQueue primitives UploadCoordinator uses, instead of
+        // reimplementing them.
         val user = userRepository.getUserModelSuspending()
         val newsItems = voicesRepository.getNewsForUpload()
 
@@ -392,6 +429,7 @@ class UploadManager @Inject constructor(
             newsItems.processInBatches { batch ->
                 val successfulUpdates = mutableListOf<NewsUpdateData>()
                 batch.forEach { news ->
+                    val isCreate = TextUtils.isEmpty(news._id)
                     try {
                         // Upload images first and collect metadata
                         val imagesArray = JsonArray()
@@ -402,9 +440,7 @@ class UploadManager @Inject constructor(
 
                             // Create image resource document
                             val imageDoc = createImage(user, imgObject)
-                            val imageResponse = apiInterface.postDoc(
-                                UrlUtils.header,
-                                "application/json",
+                            val imageResponse = uploadRepository.postUpload(
                                 "${UrlUtils.getUrl()}/resources",
                                 imageDoc
                             ).body()
@@ -440,20 +476,10 @@ class UploadManager @Inject constructor(
                         newsJson.add("images", imagesArray)
 
                         // Upload news document (POST or PUT)
-                        val newsResponse = if (TextUtils.isEmpty(news._id)) {
-                            apiInterface.postDoc(
-                                UrlUtils.header,
-                                "application/json",
-                                "${UrlUtils.getUrl()}/news",
-                                newsJson
-                            )
+                        val newsResponse = if (isCreate) {
+                            uploadRepository.postUpload("${UrlUtils.getUrl()}/news", newsJson)
                         } else {
-                            apiInterface.putDoc(
-                                UrlUtils.header,
-                                "application/json",
-                                "${UrlUtils.getUrl()}/news/${news._id}",
-                                newsJson
-                            )
+                            uploadRepository.putUpload("${UrlUtils.getUrl()}/news/${news._id}", newsJson)
                         }
 
                         // Update database on success
@@ -465,9 +491,12 @@ class UploadManager @Inject constructor(
                                 _rev = getString("rev", body),
                                 imagesArray = imagesArray
                             ))
+                        } else {
+                            queueNewsRetry(news, newsJson, newsResponse.code(), if (isCreate) "POST" else "PUT")
                         }
                     } catch (e: Exception) {
                         Log.e(TAG, "Exception in UploadManager", e)
+                        queueNewsRetry(news, news.newsJson, null, if (isCreate) "POST" else "PUT", e)
                     }
                 }
 
@@ -477,6 +506,31 @@ class UploadManager @Inject constructor(
             }
         }
         uploadNewsActivities()
+    }
+
+    private suspend fun queueNewsRetry(
+        news: NewsUploadData,
+        payload: JsonObject,
+        httpCode: Int?,
+        httpMethod: String,
+        exception: Exception? = null
+    ) {
+        val retryable = exception != null || (httpCode != null && httpCode >= 500)
+        if (!retryable) return
+        retryQueue.queueFailedOperation(
+            uploadType = "RealmNews",
+            error = UploadError(
+                itemId = news.id ?: "",
+                exception = exception ?: Exception("Upload failed: HTTP $httpCode"),
+                retryable = true,
+                httpCode = httpCode
+            ),
+            payload = payload,
+            endpoint = "news",
+            httpMethod = httpMethod,
+            dbId = news._id,
+            modelClassName = "RealmNews"
+        )
     }
 
     suspend fun uploadCrashLog() {

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -39,8 +39,10 @@ import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.TeamsSyncRepository
+import org.ole.planet.myplanet.repository.UploadRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
+import org.ole.planet.myplanet.services.retry.RetryQueue
 import org.ole.planet.myplanet.services.upload.AchievementUploader
 import org.ole.planet.myplanet.services.upload.PhotoUploader
 import org.ole.planet.myplanet.services.upload.UploadConfig
@@ -60,6 +62,8 @@ class UploadManagerTest {
     private val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
     private val gson: Gson = mockk(relaxed = true)
     private val uploadCoordinator: UploadCoordinator = mockk(relaxed = true)
+    private val uploadRepository: UploadRepository = mockk(relaxed = true)
+    private val retryQueue: RetryQueue = mockk(relaxed = true)
     private val personalsRepository: PersonalsRepository = mockk(relaxed = true)
     private val userRepository: UserRepository = mockk(relaxed = true)
     private val chatRepository: ChatRepository = mockk(relaxed = true)
@@ -97,6 +101,8 @@ class UploadManagerTest {
                 sharedPrefManager,
                 gson,
                 uploadCoordinator,
+                uploadRepository,
+                retryQueue,
                 personalsRepository,
                 userRepository,
                 chatRepository,


### PR DESCRIPTION
fixes #14794
Refactor team and news uploads to use UploadRepository for network calls and RetryQueue for failed operations instead of calling apiInterface directly. This aligns with the UploadCoordinator pattern and adds retry support for server errors and network exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved team and news uploads with more reliable processing.
  * Failed uploads can now be retried automatically when errors are temporary.
  * Upload failures preserve the operation details needed for retrying.

* **Bug Fixes**
  * Upload operations now handle server and network errors more consistently.
  * Successful uploads correctly update local records and remove completed items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->