### PR TITLE
sync: smoother server reachability caching (fixes #14799)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6121
-        versionName = "0.61.21"
+        versionCode = 6135
+        versionName = "0.61.35"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -28,6 +28,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.util.Date
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
@@ -181,22 +182,36 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
                 ThemeMode.FOLLOW_SYSTEM -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
             }
         }
+        
+        private const val REACHABILITY_CACHE_TTL_MS = 30_000L
+        private val reachabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
 
         suspend fun isServerReachable(
             urlString: String,
             ioDispatcher: CoroutineDispatcher = coreDependenciesEntryPoint.dispatcherProvider().io
         ): Boolean {
             if (urlString.isBlank()) return false
+
+            reachabilityCache[urlString]?.let { (reachable, checkedAt) ->
+                if (System.currentTimeMillis() - checkedAt < REACHABILITY_CACHE_TTL_MS) {
+                    return reachable
+                }
+            }
+
             val serverUrlMapper = coreDependenciesEntryPoint.serverUrlMapper()
             val mapping = serverUrlMapper.processUrl(urlString)
             val urlsToTry = mutableListOf(urlString)
             mapping.alternativeUrl?.let { urlsToTry.add(it) }
 
+            var reachable = false
             for (url in urlsToTry) {
-                val reachable = tryConnect(url, ioDispatcher)
-                if (reachable) return true
+                if (tryConnect(url, ioDispatcher)) {
+                    reachable = true
+                    break
+                }
             }
-            return false
+            reachabilityCache[urlString] = reachable to System.currentTimeMillis()
+            return reachable
         }
 
         private suspend fun tryConnect(

--- a/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/ServerReachabilityWorker.kt
@@ -21,7 +21,6 @@ import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.repository.SubmissionsRepository
-import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.retry.RetryQueueWorker
 import org.ole.planet.myplanet.services.sync.HeavyTableSyncWorker
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
@@ -29,6 +28,7 @@ import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.TimeProvider
+import kotlin.time.Duration.Companion.milliseconds
 
 @HiltWorker
 class ServerReachabilityWorker @AssistedInject constructor(
@@ -161,12 +161,12 @@ class ServerReachabilityWorker @AssistedInject constructor(
         val mapping = serverUrlMapper.processUrl(updateUrl)
 
         try {
-            val primaryAvailable = withTimeoutOrNull(15000) {
+            val primaryAvailable = withTimeoutOrNull(15000.milliseconds) {
                 isServerReachable(mapping.primaryUrl)
             } ?: false
 
             val alternativeAvailable = if (mapping.alternativeUrl != null) {
-                withTimeoutOrNull(15000) {
+                withTimeoutOrNull(15000.milliseconds) {
                     isServerReachable(mapping.alternativeUrl)
                 } ?: false
             } else {
@@ -189,14 +189,17 @@ class ServerReachabilityWorker @AssistedInject constructor(
 
     private suspend fun uploadSubmissions() {
         try {
-            if (submissionsRepository.hasPendingOfflineSubmissions()) {
-                withContext(dispatcherProvider.io) {
-                    uploadManager.uploadSubmissions()
+            val syncAlreadyRunning = MainApplication.isSyncRunning.get()
+            if (!syncAlreadyRunning) {
+                if (submissionsRepository.hasPendingOfflineSubmissions()) {
+                    withContext(dispatcherProvider.io) {
+                        uploadManager.uploadSubmissions()
+                    }
                 }
+                uploadExamResultWrapper()
             }
-            uploadExamResultWrapper()
             HeavyTableSyncWorker.scheduleIfPending(applicationContext, sharedPrefManager)
-            if (!MainApplication.isSyncRunning.get()) {
+            if (!syncAlreadyRunning) {
                 RetryQueueWorker.triggerImmediateRetry(applicationContext)
             }
         } catch (e: Exception) {
@@ -210,10 +213,8 @@ class ServerReachabilityWorker @AssistedInject constructor(
         }
 
         try {
-            val successListener = object : OnSuccessListener {
-                override fun onSuccess(success: String?) {
-                    // No UI updates required for background sync completion.
-                }
+            val successListener = OnSuccessListener {
+                // No UI updates required for background sync completion.
             }
             uploadManager.uploadExamResult(successListener)
         } catch (e: Exception) {


### PR DESCRIPTION
fixes #14799
Add a 30-second TTL cache for isServerReachable results to reduce redundant network checks. Guard submission uploads and retry queue triggers against running syncs. Also migrate withTimeoutOrNull to Duration API and simplify OnSuccessListener to SAM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server connectivity checks by briefly reusing recent results, reducing unnecessary connection attempts.
  - Prevented overlapping background sync operations from uploading duplicate or conflicting data.
  - Preserved reliable handling of server timeouts and retry scheduling during background synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->