### PR TITLE
sync: smoother network module requesting (fixes #14802)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6121
-        versionName = "0.61.21"
+        versionCode = 6136
+        versionName = "0.61.36"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 import javax.inject.Singleton
 import javax.net.SocketFactory
+import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.api.RetryInterceptor
@@ -54,9 +55,15 @@ object NetworkModule {
             .serializeNulls()
             .create()
     }
+    
+    private const val MAX_REQUESTS_PER_HOST = 20
 
     private fun buildOkHttpClient(connect: Long, read: Long, write: Long, retryInterceptor: RetryInterceptor? = null): OkHttpClient {
+        val dispatcher = Dispatcher().apply {
+            maxRequestsPerHost = MAX_REQUESTS_PER_HOST
+        }
         val builder = OkHttpClient.Builder()
+            .dispatcher(dispatcher)
             .connectTimeout(connect, TimeUnit.SECONDS)
             .readTimeout(read, TimeUnit.SECONDS)
             .writeTimeout(write, TimeUnit.SECONDS)


### PR DESCRIPTION
fixes #14802
Configures a custom Dispatcher on the OkHttpClient to allow up to 20 concurrent requests per host, improving parallel download/upload throughput.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved network request handling by controlling the number of simultaneous connections to each host.
  * Helps provide more consistent app performance during multiple concurrent network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->