### PR TITLE
all: smoother onboarding server hint handling (fixes #14810)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6124
-        versionName = "0.61.24"
+        versionCode = 6139
+        versionName = "0.61.39"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/onboarding/OnboardingActivity.kt
@@ -101,9 +101,11 @@ class OnboardingActivity : AppCompatActivity() {
                 if (position == mAdapter.count - 1) {
                     binding.skip.visibility = View.GONE
                     binding.next.setText(R.string.get_started)
+                    binding.serverPrepHint.visibility = View.VISIBLE
                 } else {
                     binding.skip.visibility = View.VISIBLE
                     binding.next.setText(R.string.next)
+                    binding.serverPrepHint.visibility = View.GONE
                 }
             }
 

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -22,11 +22,25 @@
         android:id="@+id/viewPagerCountDots"
         android:layout_width="match_parent"
         android:layout_height="16dp"
-        android:layout_above="@+id/next"
+        android:layout_above="@+id/serverPrepHint"
         android:layout_alignParentStart="true"
         android:layout_margin="10dp"
         android:gravity="center"
         android:orientation="horizontal" />
+    <TextView
+        android:id="@+id/serverPrepHint"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/next"
+        android:layout_alignParentStart="true"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginBottom="12dp"
+        android:gravity="center"
+        android:text="@string/onboarding_server_prep_hint"
+        android:textColor="@color/daynight_textColor"
+        android:textSize="13sp"
+        android:visibility="gone" />
     <Button
         android:id="@+id/next"
         style="?android:attr/borderlessButtonStyle"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -927,6 +927,7 @@
     <string name="ob_desc4_3">🎯 مخصص: اصنع مسار تعلمك الشخصي.</string>
     <string name="ob_desc4_4">📚 تفاعلي: تفاعل مع الفيديوهات والكتب والألعاب.</string>
     <string name="ob_desc4_5">ابدأ رحلتك التعليمية اللا حدود مع myPlanet!</string>
+    <string name="onboarding_server_prep_hint">قبل تسجيل الدخول، ستحتاج إلى عنوان خادم Planet ورقم التعريف الشخصي (PIN). اسأل مسؤول مجتمعك إذا لم تكن تملكهما بعد.</string>
     <string name="recycler_chat_label">محادثات</string>
     <string name="completed_course">دورة مكتملة</string>
     <string name="menu">القائمة الجانبية</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -923,6 +923,7 @@
     <string name="ob_desc4_3">🎯 Personalizado: Adapta tu camino de aprendizaje.</string>
     <string name="ob_desc4_4">📚 Interactivo: Involúcrate con vídeos, libros, juegos.</string>
     <string name="ob_desc4_5">¡Comienza tu viaje de aprendizaje ilimitado con myPlanet!</string>
+    <string name="onboarding_server_prep_hint">Antes de iniciar sesión, necesitarás la dirección del servidor de Planet y el PIN. Pregunta a tu administrador comunitario si aún no los tienes.</string>
     <string name="recycler_chat_label">conversaciones</string>
     <string name="completed_course">curso completado</string>
     <string name="menu">menú lateral</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -924,6 +924,7 @@
     <string name="ob_desc4_3">🎯 Personnalisé : Adaptez votre parcours d\'apprentissage.</string>
     <string name="ob_desc4_4">📚 Interactif : Engagez-vous avec des vidéos, des livres, des jeux.</string>
     <string name="ob_desc4_5">Commencez votre parcours d\'apprentissage illimité avec myPlanet!</string>
+    <string name="onboarding_server_prep_hint">Avant de vous connecter, vous aurez besoin de l\'adresse du serveur Planet et du code PIN. Demandez à l\'administrateur de votre communauté si vous ne les avez pas encore.</string>
     <string name="recycler_chat_label">conversations</string>
     <string name="completed_course">cours terminé</string>
     <string name="menu">menu latéral</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -923,6 +923,7 @@
     <string name="ob_desc4_3">🎯 व्यक्तिगत: तपाईंको शिक्षा मार्गलाई समायोजित गर्नुहोस्।</string>
     <string name="ob_desc4_4">📚 इन्टर्याक्टिभ: भिडियो, पुस्तकहरू, खेलहरूसँग संलग्न हुनुहोस्।</string>
     <string name="ob_desc4_5">मेरो प्ल्यानेटसँग असीमित शिक्षा यात्रा सुरु गर्नुहोस्!</string>
+    <string name="onboarding_server_prep_hint">साइन इन गर्नु अघि, तपाईंलाई आफ्नो Planet सर्भर ठेगाना र PIN आवश्यक पर्नेछ। यदि तपाईंसँग अझै छैन भने आफ्नो सामुदायिक प्रशासकलाई सोध्नुहोस्।</string>
     <string name="recycler_chat_label">चर्चाहरू</string>
     <string name="completed_course">समाप्त पाठ्यक्रम</string>
     <string name="menu">साइड मेนู</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -923,6 +923,7 @@
     <string name="ob_desc4_3">🎯 Gaarsiin: Dalka aqoonsigaaga hoos u gaar ah.</string>
     <string name="ob_desc4_4">📚 Isweydaarsan: Iskaashiga filimada, buugagga, ciyaaraha.</string>
     <string name="ob_desc4_5">Bilaan ee waxbarasho aan dheeraad ahayn soo bila myPlanet!</string>
+    <string name="onboarding_server_prep_hint">Ka hor inta aadan gelin, waxaad u baahan doontaa cinwaanka server-ka Planet iyo PIN-ka. Weydii maamulaha bulshadaada haddii aadan weli haysan.</string>
     <string name="recycler_chat_label">dhaqameed</string>
     <string name="completed_course">koorso la dhammaaday</string>
     <string name="menu">liiska dhinaca</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -923,6 +923,7 @@
     <string name="ob_desc4_3">🎯 Personalized: Tailor your learning path.</string>
     <string name="ob_desc4_4">📚 Interactive: Engage with videos, books, games.</string>
     <string name="ob_desc4_5">Begin your limitless learning journey with myPlanet!</string>
+    <string name="onboarding_server_prep_hint">Before you sign in, you\'ll need your Planet server address and PIN. Ask your community administrator if you don\'t have them yet.</string>
     <string name="recycler_chat_label">conversations</string>
     <string name="completed_course">completed course</string>
     <string name="menu">side menu</string>


### PR DESCRIPTION
fixes #14810
Shows a hint on the final onboarding slide reminding users they need a Planet server address and PIN before signing in. Includes translations for all supported languages.
<img width="1410" height="2968" alt="Screenshot_20260716_210951" src="https://github.com/user-attachments/assets/235f22d7-fa1f-455d-a5b0-c5c9a73e5763" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “server preparation” hint to the final onboarding screen.
  * The hint appears only on the last page and guides users to have the required server address and PIN before signing in.
  * If details are missing, users are prompted to ask their community administrator.
  * Added the hint text to English, Arabic, Spanish, French, Nepali, and Somali.
* **UI Updates**
  * Repositioned the onboarding page indicator so the hint sits between the dots and the Next button.
* **Chores**
  * Updated the app version (versionCode/versionName).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->