### PR TITLE
resources: less webview progress bar increment is more (fixes #14830)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6141
-        versionName = "0.61.41"
+        versionCode = 6143
+        versionName = "0.61.43"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
@@ -280,7 +280,6 @@ class WebViewActivity : AppCompatActivity() {
                 if (view.url?.startsWith("file://") == false && view.url?.endsWith("/eng/") == true) {
                     finish()
                 }
-                activityWebViewBinding.contentWebView.pBar.incrementProgressBy(newProgress)
                 if (newProgress == 100 && activityWebViewBinding.contentWebView.pBar.isShown) {
                     activityWebViewBinding.contentWebView.pBar.visibility = View.GONE
                 }


### PR DESCRIPTION
fixes #14830
The incrementProgressBy call was unnecessary since the progress bar is only used as a loading indicator that gets hidden at 100%.
[2.webm](https://github.com/user-attachments/assets/c27f1e7d-377c-4a78-a575-b05a7161c1b3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Android WebView loading progress indicator to show progress more accurately.
  * Automatically closes the web viewer when navigation reaches an unsupported English-language `/eng/` page.
* **Chores**
  * Bumped the app version metadata for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->