### PR TITLE
resources: smoother video viewing (fixes #14840)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6141
-        versionName = "0.61.41"
+        versionCode = 6146
+        versionName = "0.61.46"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ResourceViewerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ResourceViewerFragment.kt
@@ -89,6 +89,7 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
     private var auth: String = ""
 
     private var exoPlayer: ExoPlayer? = null
+    private var streamingHttpDataSourceFactory: DefaultHttpDataSource.Factory? = null
     private var videoLoadingOverlay: View? = null
     private var videoLoadingText: TextView? = null
     private var noisyReceiverRegistered = false
@@ -298,6 +299,7 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
             .setUserAgent("ExoPlayer")
             .setAllowCrossProtocolRedirects(true)
             .setDefaultRequestProperties(requestProperties)
+        streamingHttpDataSourceFactory = httpDataSourceFactory
 
         val mediaSource: MediaSource = ProgressiveMediaSource.Factory(httpDataSourceFactory)
             .createMediaSource(MediaItem.fromUri(uri))
@@ -490,7 +492,11 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
             val url = filePath ?: run {
                 return@launch
             }
-            streamVideoFromUrl(url, auth)
+            if (exoPlayer == null) {
+                streamVideoFromUrl(url, auth)
+            } else {
+                streamingHttpDataSourceFactory?.setDefaultRequestProperties(hashMapOf("Cookie" to auth))
+            }
             if (isOnline) {
                 withContext(dispatcherProvider.io) {
                     if (!FileUtils.checkFileExist(requireContext(), url)) {
@@ -515,6 +521,7 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
         authSessionUpdater?.stop()
         exoPlayer?.release()
         exoPlayer = null
+        streamingHttpDataSourceFactory = null
         if (noisyReceiverRegistered) {
             requireContext().unregisterReceiver(audioBecomingNoisyReceiver)
             noisyReceiverRegistered = false


### PR DESCRIPTION
fixes #14840
Instead of recreating the player when the auth session updates, update the streaming data source's request properties in place. This avoids interrupting video playback during token refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated online video streaming to correctly apply refreshed authentication cookies.
  - Existing playback now reuses the current stream and updates request headers instead of restarting.
  - Improved cleanup when exiting the video viewer to avoid retaining stale streaming configuration.
- **Chores**
  - Bumped app version code and version name for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->