### PR TITLE
sync: smoother download queue starting (fixes #14841)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6141
-        versionName = "0.61.41"
+        versionCode = 6142
+        versionName = "0.61.42"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -111,9 +111,9 @@ class DownloadService : Service() {
         Log.d(TAG, "onStartCommand: fromSync=$fromSync queueRunning=$isQueueRunning")
 
         if (!isQueueRunning) {
+            isQueueRunning = true
             currentJob?.cancel()
             currentJob = appScope.launch {
-                isQueueRunning = true
                 try {
                     processDownloadQueue()
                 } finally {


### PR DESCRIPTION
fixes #14841
Set isQueueRunning flag before launching the coroutine to prevent multiple concurrent queue processors from being started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download queue startup reliability by marking the download queue as running immediately when the download service starts, before processing begins.
* **Chores**
  * Updated the app version (version code/name) for the next release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->