### PR TITLE
Migrate search activity uploads to Room

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -15,6 +15,7 @@ import org.ole.planet.myplanet.data.room.dao.MyLifeDao
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
+import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
@@ -28,6 +29,7 @@ import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmTeamNotification
 import org.ole.planet.myplanet.model.RealmUserChallengeActions
@@ -55,6 +57,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmRating::class,
         RealmSearchActivity::class,
         RealmCourseActivity::class,
+        RealmResourceActivity::class,
     ],
     version = 1,
     exportSchema = false,
@@ -75,4 +78,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun ratingDao(): RatingDao
     abstract fun searchActivityDao(): SearchActivityDao
     abstract fun courseActivityDao(): CourseActivityDao
+    abstract fun resourceActivityDao(): ResourceActivityDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -14,6 +14,7 @@ import org.ole.planet.myplanet.data.room.dao.MyLifeDao
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
+import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
 import org.ole.planet.myplanet.model.RealmApkLog
@@ -25,6 +26,7 @@ import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmTeamNotification
 import org.ole.planet.myplanet.model.RealmUserChallengeActions
 
@@ -49,6 +51,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmChatHistory::class,
         RealmFeedback::class,
         RealmRating::class,
+        RealmSearchActivity::class,
     ],
     version = 1,
     exportSchema = false,
@@ -67,4 +70,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun chatDao(): ChatDao
     abstract fun feedbackDao(): FeedbackDao
     abstract fun ratingDao(): RatingDao
+    abstract fun searchActivityDao(): SearchActivityDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -12,6 +12,7 @@ import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
+import org.ole.planet.myplanet.data.room.dao.NewsLogDao
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
@@ -28,6 +29,7 @@ import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.RealmNewsLog
 import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmRetryOperation
 import org.ole.planet.myplanet.model.RealmResourceActivity
@@ -61,6 +63,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmCourseActivity::class,
         RealmResourceActivity::class,
         RealmSubmitPhotos::class,
+        RealmNewsLog::class,
     ],
     version = 1,
     exportSchema = false,
@@ -83,4 +86,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun courseActivityDao(): CourseActivityDao
     abstract fun resourceActivityDao(): ResourceActivityDao
     abstract fun submitPhotosDao(): SubmitPhotosDao
+    abstract fun newsLogDao(): NewsLogDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -8,6 +8,7 @@ import org.ole.planet.myplanet.data.room.dao.UserChallengeActionsDao
 import org.ole.planet.myplanet.data.room.dao.CertificationDao
 import org.ole.planet.myplanet.data.room.dao.ChatDao
 import org.ole.planet.myplanet.data.room.dao.CommunityDao
+import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
@@ -21,6 +22,7 @@ import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.model.RealmCertification
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmCommunity
+import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyPersonal
@@ -52,6 +54,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmFeedback::class,
         RealmRating::class,
         RealmSearchActivity::class,
+        RealmCourseActivity::class,
     ],
     version = 1,
     exportSchema = false,
@@ -71,4 +74,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun feedbackDao(): FeedbackDao
     abstract fun ratingDao(): RatingDao
     abstract fun searchActivityDao(): SearchActivityDao
+    abstract fun courseActivityDao(): CourseActivityDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -17,6 +17,7 @@ import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
+import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
 import org.ole.planet.myplanet.model.RealmApkLog
@@ -31,6 +32,7 @@ import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmRetryOperation
 import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.RealmSubmitPhotos
 import org.ole.planet.myplanet.model.RealmTeamNotification
 import org.ole.planet.myplanet.model.RealmUserChallengeActions
 
@@ -58,6 +60,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmSearchActivity::class,
         RealmCourseActivity::class,
         RealmResourceActivity::class,
+        RealmSubmitPhotos::class,
     ],
     version = 1,
     exportSchema = false,
@@ -79,4 +82,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun searchActivityDao(): SearchActivityDao
     abstract fun courseActivityDao(): CourseActivityDao
     abstract fun resourceActivityDao(): ResourceActivityDao
+    abstract fun submitPhotosDao(): SubmitPhotosDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseActivityDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseActivityDao.kt
@@ -1,0 +1,20 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import org.ole.planet.myplanet.model.RealmCourseActivity
+
+@Dao
+interface CourseActivityDao {
+    @Query("SELECT * FROM course_activity WHERE _rev IS NULL AND type != 'sync'")
+    suspend fun getPendingUploads(): List<RealmCourseActivity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(activity: RealmCourseActivity)
+
+    /** Returns the number of rows updated (0 means the local row was gone). */
+    @Query("UPDATE course_activity SET _id = :remoteId, _rev = :rev WHERE id = :localId")
+    suspend fun markUploaded(localId: String, remoteId: String, rev: String): Int
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NewsLogDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NewsLogDao.kt
@@ -1,0 +1,20 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import org.ole.planet.myplanet.model.RealmNewsLog
+
+@Dao
+interface NewsLogDao {
+    @Query("SELECT * FROM news_log WHERE _id IS NULL OR _id = ''")
+    suspend fun getPendingUploads(): List<RealmNewsLog>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(log: RealmNewsLog)
+
+    /** Returns the number of rows updated (0 means the local row was gone). */
+    @Query("UPDATE news_log SET _id = :remoteId, _rev = :rev WHERE id = :localId")
+    suspend fun markUploaded(localId: String, remoteId: String, rev: String): Int
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ResourceActivityDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ResourceActivityDao.kt
@@ -1,0 +1,33 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+import org.ole.planet.myplanet.model.RealmResourceActivity
+
+@Dao
+interface ResourceActivityDao {
+    @Query("SELECT * FROM resource_activity WHERE _rev IS NULL AND type != 'sync'")
+    suspend fun getPendingUploads(): List<RealmResourceActivity>
+
+    @Query("SELECT * FROM resource_activity WHERE _rev IS NULL AND type = 'sync'")
+    suspend fun getPendingSyncUploads(): List<RealmResourceActivity>
+
+    @Query("SELECT * FROM resource_activity WHERE user = :userName AND type = :type")
+    suspend fun getByUserAndType(userName: String, type: String): List<RealmResourceActivity>
+
+    @Query("SELECT COUNT(*) FROM resource_activity WHERE user = :userName AND type = :type")
+    suspend fun countByUserAndType(userName: String, type: String): Long
+
+    @Query("SELECT * FROM resource_activity WHERE user = :userName AND type = :type")
+    fun observeByUserAndType(userName: String, type: String): Flow<List<RealmResourceActivity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(activity: RealmResourceActivity)
+
+    /** Returns the number of rows updated (0 means the local row was gone). */
+    @Query("UPDATE resource_activity SET _id = :remoteId, _rev = :rev WHERE id = :localId")
+    suspend fun markUploaded(localId: String, remoteId: String, rev: String): Int
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/SearchActivityDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/SearchActivityDao.kt
@@ -15,6 +15,6 @@ interface SearchActivityDao {
     suspend fun insert(activity: RealmSearchActivity)
 
     /** Returns the number of rows updated (0 means the local row was gone). */
-    @Query("UPDATE search_activity SET _id = :id, _rev = :rev WHERE id = :localId")
-    suspend fun markUploaded(localId: String, id: String, rev: String): Int
+    @Query("UPDATE search_activity SET _id = :remoteId, _rev = :rev WHERE id = :localId")
+    suspend fun markUploaded(localId: String, remoteId: String, rev: String): Int
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/SearchActivityDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/SearchActivityDao.kt
@@ -1,0 +1,20 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import org.ole.planet.myplanet.model.RealmSearchActivity
+
+@Dao
+interface SearchActivityDao {
+    @Query("SELECT * FROM search_activity WHERE _rev = ''")
+    suspend fun getPendingUploads(): List<RealmSearchActivity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(activity: RealmSearchActivity)
+
+    /** Returns the number of rows updated (0 means the local row was gone). */
+    @Query("UPDATE search_activity SET _id = :id, _rev = :rev WHERE id = :localId")
+    suspend fun markUploaded(localId: String, id: String, rev: String): Int
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/SubmitPhotosDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/SubmitPhotosDao.kt
@@ -1,0 +1,23 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import org.ole.planet.myplanet.model.RealmSubmitPhotos
+
+@Dao
+interface SubmitPhotosDao {
+    @Query("SELECT * FROM submit_photos WHERE uploaded = 0")
+    suspend fun getUnuploaded(): List<RealmSubmitPhotos>
+
+    @Query("SELECT * FROM submit_photos WHERE id IN (:ids)")
+    suspend fun getByIds(ids: Array<String>): List<RealmSubmitPhotos>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(photo: RealmSubmitPhotos)
+
+    /** Returns the number of rows updated (0 means the local row was gone). */
+    @Query("UPDATE submit_photos SET uploaded = 1, _rev = :rev, _id = :remoteId WHERE id = :photoId")
+    suspend fun markUploaded(photoId: String, rev: String, remoteId: String): Int
+}

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -20,6 +20,7 @@ import org.ole.planet.myplanet.data.room.dao.MyLifeDao
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
+import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 
 @Module
@@ -95,5 +96,10 @@ object RoomModule {
     @Provides
     fun provideRatingDao(database: AppDatabase): RatingDao {
         return database.ratingDao()
+    }
+
+    @Provides
+    fun provideSearchActivityDao(database: AppDatabase): SearchActivityDao {
+        return database.searchActivityDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -18,6 +18,7 @@ import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
+import org.ole.planet.myplanet.data.room.dao.NewsLogDao
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
@@ -119,5 +120,10 @@ object RoomModule {
     @Provides
     fun provideSubmitPhotosDao(database: AppDatabase): SubmitPhotosDao {
         return database.submitPhotosDao()
+    }
+
+    @Provides
+    fun provideNewsLogDao(database: AppDatabase): NewsLogDao {
+        return database.newsLogDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -21,6 +21,7 @@ import org.ole.planet.myplanet.data.room.dao.MyLifeDao
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
+import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 
@@ -107,5 +108,10 @@ object RoomModule {
     @Provides
     fun provideCourseActivityDao(database: AppDatabase): CourseActivityDao {
         return database.courseActivityDao()
+    }
+
+    @Provides
+    fun provideResourceActivityDao(database: AppDatabase): ResourceActivityDao {
+        return database.resourceActivityDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -14,6 +14,7 @@ import org.ole.planet.myplanet.data.room.dao.UserChallengeActionsDao
 import org.ole.planet.myplanet.data.room.dao.CertificationDao
 import org.ole.planet.myplanet.data.room.dao.ChatDao
 import org.ole.planet.myplanet.data.room.dao.CommunityDao
+import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
@@ -101,5 +102,10 @@ object RoomModule {
     @Provides
     fun provideSearchActivityDao(database: AppDatabase): SearchActivityDao {
         return database.searchActivityDao()
+    }
+
+    @Provides
+    fun provideCourseActivityDao(database: AppDatabase): CourseActivityDao {
+        return database.courseActivityDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -23,6 +23,7 @@ import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
+import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 
 @Module
@@ -113,5 +114,10 @@ object RoomModule {
     @Provides
     fun provideResourceActivityDao(database: AppDatabase): ResourceActivityDao {
         return database.resourceActivityDao()
+    }
+
+    @Provides
+    fun provideSubmitPhotosDao(database: AppDatabase): SubmitPhotosDao {
+        return database.submitPhotosDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseActivity.kt
@@ -1,23 +1,27 @@
 package org.ole.planet.myplanet.model
 
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import com.google.gson.JsonObject
-import io.realm.RealmObject
-import io.realm.annotations.Index
-import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.utils.NetworkUtils
 
-open class RealmCourseActivity : RealmObject() {
+@Entity(
+    tableName = "course_activity",
+    indices = [Index("_rev"), Index("courseId"), Index("type")]
+)
+open class RealmCourseActivity {
     @PrimaryKey
-    var id: String? = null
+    @JvmField
+    var id: String = ""
+    @JvmField
     var _id: String? = null
     var createdOn: String? = null
     var _rev: String? = null
     var time: Long = 0
     var title: String? = null
-    @Index
     var courseId: String? = null
     var parentCode: String? = null
-    @Index
     var type: String? = null
     var user: String? = null
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmNewsLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmNewsLog.kt
@@ -1,18 +1,22 @@
 package org.ole.planet.myplanet.model
 
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import com.google.gson.JsonObject
-import io.realm.RealmObject
-import io.realm.annotations.Index
-import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.utils.NetworkUtils
 
-open class RealmNewsLog : RealmObject() {
+@Entity(
+    tableName = "news_log",
+    indices = [Index("_id"), Index("_rev")]
+)
+open class RealmNewsLog {
     @PrimaryKey
-    var id: String? = null
-    @Index
+    @JvmField
+    var id: String = ""
+    @JvmField
     var _id: String? = null
-    @Index
     var _rev: String? = null
     var type: String? = null
     var time: Long? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmResourceActivity.kt
@@ -1,12 +1,18 @@
 package org.ole.planet.myplanet.model
 
-import io.realm.RealmObject
-import io.realm.annotations.Index
-import io.realm.annotations.PrimaryKey
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 
-open class RealmResourceActivity : RealmObject() {
+@Entity(
+    tableName = "resource_activity",
+    indices = [Index("_rev"), Index("type"), Index("user")]
+)
+open class RealmResourceActivity {
     @PrimaryKey
-    var id: String? = null
+    @JvmField
+    var id: String = ""
+    @JvmField
     var _id: String? = null
     var createdOn: String? = null
     var _rev: String? = null
@@ -14,7 +20,6 @@ open class RealmResourceActivity : RealmObject() {
     var title: String? = null
     var resourceId: String? = null
     var parentCode: String? = null
-    @Index
     var type: String? = null
     var user: String? = null
     var androidId: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
@@ -1,15 +1,21 @@
 package org.ole.planet.myplanet.model
 
 import com.google.gson.JsonObject
-import io.realm.RealmObject
-import io.realm.annotations.PrimaryKey
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.VersionUtils
 
+@Entity(
+    tableName = "search_activity",
+    indices = [Index("_rev"), Index("type"), Index("user")]
+)
 open class RealmSearchActivity(
     @PrimaryKey
+    @JvmField
     var id: String = "",
     var _id: String = "",
     var _rev: String = "",
@@ -20,7 +26,7 @@ open class RealmSearchActivity(
     var filter: String = "",
     var createdOn: String = "",
     var parentCode: String = ""
-) : RealmObject() {
+) {
     fun serialize(): JsonObject {
         val obj = JsonObject()
         obj.addProperty("text", text)

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
@@ -1,9 +1,9 @@
 package org.ole.planet.myplanet.model
 
-import com.google.gson.JsonObject
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.google.gson.JsonObject
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.NetworkUtils

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSearchActivity.kt
@@ -17,6 +17,7 @@ open class RealmSearchActivity(
     @PrimaryKey
     @JvmField
     var id: String = "",
+    @JvmField
     var _id: String = "",
     var _rev: String = "",
     var text: String = "",

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmitPhotos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmSubmitPhotos.kt
@@ -1,12 +1,15 @@
 package org.ole.planet.myplanet.model
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import com.google.gson.JsonObject
-import io.realm.RealmObject
-import io.realm.annotations.PrimaryKey
 
-open class RealmSubmitPhotos : RealmObject() {
+@Entity(tableName = "submit_photos")
+open class RealmSubmitPhotos {
     @PrimaryKey
-    var id: String? = null
+    @JvmField
+    var id: String = ""
+    @JvmField
     var _id: String? = null
     var _rev: String? = null
     var submissionId: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.UserChallengeActionsDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.LoginActivityData
 import org.ole.planet.myplanet.model.MyPlanet
@@ -27,7 +29,6 @@ import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmRemovedLog
 import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmUser
-import org.ole.planet.myplanet.data.room.dao.UserChallengeActionsDao
 import org.ole.planet.myplanet.model.RealmUserChallengeActions
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
@@ -46,7 +47,8 @@ class ActivitiesRepositoryImpl @Inject constructor(
     private val apiInterface: ApiInterface,
     private val sharedPrefManager: SharedPrefManager,
     private val timeProvider: TimeProvider,
-    private val userChallengeActionsDao: UserChallengeActionsDao
+    private val userChallengeActionsDao: UserChallengeActionsDao,
+    private val courseActivityDao: CourseActivityDao
 ) : RealmRepository(databaseService, realmDispatcher), ActivitiesRepository {
     override suspend fun getOfflineVisitCount(userId: String): Int {
         return queryList(RealmOfflineActivity::class.java) {
@@ -93,19 +95,21 @@ class ActivitiesRepositoryImpl @Inject constructor(
         val parentCode = user?.parentCode
         val createdOn = user?.planetCode
 
-        executeTransaction { realm ->
-            val activity = realm.createObject(RealmCourseActivity::class.java, UUID.randomUUID().toString())
-            activity.type = "visit"
-            activity.title = title
-            activity.courseId = courseId
-            activity.time = Date().time
-            activity.user = userId
+        courseActivityDao.insert(
+            RealmCourseActivity().apply {
+                id = UUID.randomUUID().toString()
+                type = "visit"
+                this.title = title
+                this.courseId = courseId
+                time = Date().time
+                this.user = userId
 
-            if (user != null) {
-                activity.parentCode = parentCode
-                activity.createdOn = createdOn
+                if (user != null) {
+                    this.parentCode = parentCode
+                    this.createdOn = createdOn
+                }
             }
-        }
+        )
     }
 
     override suspend fun logLogin(

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.UserChallengeActionsDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.LoginActivityData
@@ -48,7 +49,8 @@ class ActivitiesRepositoryImpl @Inject constructor(
     private val sharedPrefManager: SharedPrefManager,
     private val timeProvider: TimeProvider,
     private val userChallengeActionsDao: UserChallengeActionsDao,
-    private val courseActivityDao: CourseActivityDao
+    private val courseActivityDao: CourseActivityDao,
+    private val resourceActivityDao: ResourceActivityDao
 ) : RealmRepository(databaseService, realmDispatcher), ActivitiesRepository {
     override suspend fun getOfflineVisitCount(userId: String): Int {
         return queryList(RealmOfflineActivity::class.java) {
@@ -164,53 +166,45 @@ class ActivitiesRepositoryImpl @Inject constructor(
         resourceId: String?,
         type: String?
     ) {
-        executeTransaction { realm ->
-            val offlineActivities =
-                realm.createObject(RealmResourceActivity::class.java, "${UUID.randomUUID()}")
-            offlineActivities.user = userName
-            offlineActivities.parentCode = parentCode
-            offlineActivities.createdOn = planetCode
-            offlineActivities.type = type
-            offlineActivities.title = title
-            offlineActivities.resourceId = resourceId
-            offlineActivities.time = Date().time
-        }
+        resourceActivityDao.insert(
+            RealmResourceActivity().apply {
+                id = UUID.randomUUID().toString()
+                user = userName
+                this.parentCode = parentCode
+                createdOn = planetCode
+                this.type = type
+                this.title = title
+                this.resourceId = resourceId
+                time = Date().time
+            }
+        )
     }
 
     override suspend fun getResourceOpenCount(userName: String, type: String): Long {
-        return count(RealmResourceActivity::class.java) {
-            equalTo("user", userName)
-            equalTo("type", type)
-        }
+        return resourceActivityDao.countByUserAndType(userName, type)
     }
 
     override suspend fun getMostOpenedResource(userName: String, type: String): Pair<String, Int>? {
-        return withRealm { realm ->
-            val activities = realm.where(RealmResourceActivity::class.java)
-                .equalTo("user", userName)
-                .equalTo("type", type)
-                .findAll()
+        val activities = resourceActivityDao.getByUserAndType(userName, type)
+        if (activities.isEmpty()) {
+            return null
+        }
 
-            if (activities.isEmpty()) {
-                return@withRealm null
+        val resourceCounts = activities
+            .groupBy { it.resourceId }
+            .mapValues { entry ->
+                val count = entry.value.size
+                val title = entry.value.first().title
+                Pair(count, title)
             }
+            .filterValues { it.second != null }
 
-            val resourceCounts = activities
-                .groupBy { it.resourceId }
-                .mapValues { entry ->
-                    val count = entry.value.size
-                    val title = entry.value.first().title
-                    Pair(count, title)
-                }
-                .filterValues { it.second != null }
+        val maxEntry = resourceCounts.maxByOrNull { it.value.first }
 
-            val maxEntry = resourceCounts.maxByOrNull { it.value.first }
-
-            if (maxEntry == null || maxEntry.value.first == 0) {
-                null
-            } else {
-                Pair(maxEntry.value.second ?: "", maxEntry.value.first)
-            }
+        return if (maxEntry == null || maxEntry.value.first == 0) {
+            null
+        } else {
+            Pair(maxEntry.value.second ?: "", maxEntry.value.first)
         }
     }
 
@@ -266,16 +260,18 @@ class ActivitiesRepositoryImpl @Inject constructor(
         val parentCode = user.parentCode
         val createdOn = user.planetCode
 
-        executeTransaction { realm ->
-            val activities = realm.createObject(RealmResourceActivity::class.java, UUID.randomUUID().toString())
-            activities.user = userName
-            activities._rev = null
-            activities._id = null
-            activities.parentCode = parentCode
-            activities.createdOn = createdOn
-            activities.type = "sync"
-            activities.time = Date().time
-        }
+        resourceActivityDao.insert(
+            RealmResourceActivity().apply {
+                id = UUID.randomUUID().toString()
+                this.user = userName
+                _rev = null
+                _id = null
+                this.parentCode = parentCode
+                this.createdOn = createdOn
+                type = "sync"
+                time = Date().time
+            }
+        )
     }
 
     private fun insertActivityInternal(

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -19,6 +19,7 @@ import org.ole.planet.myplanet.model.CourseProgressData
 import org.ole.planet.myplanet.model.CourseStepData
 import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.data.room.dao.CertificationDao
+import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmCertification
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
@@ -48,7 +49,8 @@ class CoursesRepositoryImpl @Inject constructor(
     private val tagsRepository: TagsRepository,
     private val ratingsRepository: RatingsRepository,
     private val sharedPrefManager: SharedPrefManager,
-    private val certificationDao: CertificationDao
+    private val certificationDao: CertificationDao,
+    private val searchActivityDao: SearchActivityDao
 ) : RealmRepository(databaseService, realmDispatcher), CoursesRepository {
 
     override suspend fun getAllCourses(): List<RealmMyCourse> {
@@ -272,24 +274,23 @@ class CoursesRepositoryImpl @Inject constructor(
         grade: String,
         subject: String
     ) {
-        executeTransaction { realm ->
-            val activity = realm.createObject(
-                RealmSearchActivity::class.java,
-                UUID.randomUUID().toString()
-            )
-            activity.user = userName
-            activity.time = Calendar.getInstance().timeInMillis
-            activity.createdOn = planetCode
-            activity.parentCode = parentCode
-            activity.text = searchText
-            activity.type = "courses"
-            val filter = JsonObject()
-
-            filter.add("tags", RealmTag.getTagsArray(tags))
-            filter.addProperty("doc.gradeLevel", grade)
-            filter.addProperty("doc.subjectLevel", subject)
-            activity.filter = JsonUtils.gson.toJson(filter)
+        val filter = JsonObject().apply {
+            add("tags", RealmTag.getTagsArray(tags))
+            addProperty("doc.gradeLevel", grade)
+            addProperty("doc.subjectLevel", subject)
         }
+        searchActivityDao.insert(
+            RealmSearchActivity(
+                id = UUID.randomUUID().toString(),
+                user = userName,
+                time = Calendar.getInstance().timeInMillis,
+                createdOn = planetCode,
+                parentCode = parentCode,
+                text = searchText,
+                type = "courses",
+                filter = JsonUtils.gson.toJson(filter)
+            )
+        )
     }
 
     override suspend fun joinCourse(courseId: String, userId: String): Result<Unit> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmMyLibrary
@@ -42,6 +43,7 @@ class ResourcesRepositoryImpl @Inject constructor(
     private val ratingsRepository: RatingsRepository,
     private val tagsRepository: TagsRepository,
     private val searchActivityDao: SearchActivityDao,
+    private val resourceActivityDao: ResourceActivityDao,
     private val teamsRepositoryLazy: dagger.Lazy<TeamsRepository>,
     private val teamsSyncRepositoryLazy: dagger.Lazy<TeamsSyncRepository>
 ) : RealmRepository(databaseService, realmDispatcher), ResourcesRepository {
@@ -462,10 +464,8 @@ class ResourcesRepositoryImpl @Inject constructor(
         val user = findByField(RealmUser::class.java, "id", userId)
         val userName = user?.name ?: return flowOf(emptySet())
 
-        return queryListFlow(RealmResourceActivity::class.java) {
-            equalTo("user", userName)
-            equalTo("type", "resource_opened")
-        }.map { activities -> activities.mapNotNull { it.resourceId }.toSet() }
+        return resourceActivityDao.observeByUserAndType(userName, "resource_opened")
+            .map { activities -> activities.mapNotNull { it.resourceId }.toSet() }
     }
 
     override suspend fun getDownloadSuggestionList(userId: String?): List<RealmMyLibrary> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmRemovedLog
@@ -40,6 +41,7 @@ class ResourcesRepositoryImpl @Inject constructor(
     private val sharedPrefManager: SharedPrefManager,
     private val ratingsRepository: RatingsRepository,
     private val tagsRepository: TagsRepository,
+    private val searchActivityDao: SearchActivityDao,
     private val teamsRepositoryLazy: dagger.Lazy<TeamsRepository>,
     private val teamsSyncRepositoryLazy: dagger.Lazy<TeamsSyncRepository>
 ) : RealmRepository(databaseService, realmDispatcher), ResourcesRepository {
@@ -379,16 +381,18 @@ class ResourcesRepositoryImpl @Inject constructor(
         }
         val filterPayload = JsonUtils.gson.toJson(filter)
 
-        executeTransaction { realm ->
-            val activity = realm.createObject(RealmSearchActivity::class.java, UUID.randomUUID().toString())
-            activity.user = userName
-            activity.time = Calendar.getInstance().timeInMillis
-            activity.createdOn = planetCode
-            activity.parentCode = parentCode
-            activity.text = searchText
-            activity.type = "resources"
-            activity.filter = filterPayload
-        }
+        searchActivityDao.insert(
+            RealmSearchActivity(
+                id = UUID.randomUUID().toString(),
+                user = userName,
+                time = Calendar.getInstance().timeInMillis,
+                createdOn = planetCode,
+                parentCode = parentCode,
+                text = searchText,
+                type = "resources",
+                filter = filterPayload
+            )
+        )
     }
 
     private fun getJsonArrayFromList(list: Set<String>): JsonArray {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CreateExamSubmissionRequest
 import org.ole.planet.myplanet.model.ExamAnswerData
@@ -44,7 +45,8 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     private val surveysRepositoryProvider: Provider<SurveysRepository>,
     @ApplicationContext private val context: Context,
     private val sharedPrefManager: SharedPrefManager,
-    private val exporter: SubmissionsRepositoryExporter
+    private val exporter: SubmissionsRepositoryExporter,
+    private val submitPhotosDao: SubmitPhotosDao
 ) : RealmRepository(databaseService, realmDispatcher), SubmissionsRepository {
 
     override suspend fun generateSubmissionPdf(submissionId: String): File? {
@@ -439,18 +441,19 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         memberId: String?,
         photoPath: String?
     ) {
-        executeTransaction { realm ->
-            val id = UUID.randomUUID().toString()
-            val submit = realm.createObject(RealmSubmitPhotos::class.java, id)
-            submit.submissionId = submissionId
-            submit.examId = examId
-            submit.courseId = courseId
-            submit.memberId = memberId
-            submit.date = Date().toString()
-            submit.uniqueId = NetworkUtils.getUniqueIdentifier()
-            submit.photoLocation = photoPath
-            submit.uploaded = false
-        }
+        submitPhotosDao.insert(
+            RealmSubmitPhotos().apply {
+                id = UUID.randomUUID().toString()
+                this.submissionId = submissionId
+                this.examId = examId
+                this.courseId = courseId
+                this.memberId = memberId
+                date = Date().toString()
+                uniqueId = NetworkUtils.getUniqueIdentifier()
+                photoLocation = photoPath
+                uploaded = false
+            }
+        )
     }
 
     override suspend fun createExamSubmission(request: CreateExamSubmissionRequest): RealmSubmission? {
@@ -657,34 +660,18 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
     }
 
     override suspend fun getUnuploadedPhotos(): List<Pair<String?, JsonObject>> {
-        return withRealm { realm ->
-            val data = realm.where(RealmSubmitPhotos::class.java).equalTo("uploaded", false).findAll()
-            if (data.isEmpty()) {
-                emptyList()
-            } else {
-                data.map { photo ->
-                    Pair(photo.id, RealmSubmitPhotos.serializeRealmSubmitPhotos(photo))
-                }
-            }
+        return submitPhotosDao.getUnuploaded().map { photo ->
+            Pair(photo.id, RealmSubmitPhotos.serializeRealmSubmitPhotos(photo))
         }
     }
 
     override suspend fun markPhotoUploaded(photoId: String?, rev: String, id: String) {
-        update(RealmSubmitPhotos::class.java, "id", photoId ?: "") { sub ->
-            sub.uploaded = true
-            sub._rev = rev
-            sub._id = id
-        }
+        photoId?.let { submitPhotosDao.markUploaded(it, rev, id) }
     }
 
     override suspend fun getPhotosByIds(ids: Array<String>): List<RealmSubmitPhotos> {
         if (ids.isEmpty()) return emptyList()
-        return withRealm { realm ->
-            val results = realm.where(RealmSubmitPhotos::class.java)
-                .`in`("id", ids)
-                .findAll()
-            realm.copyFromRealm(results)
-        }
+        return submitPhotosDao.getByIds(ids)
     }
 
     override suspend fun getOrCreateSubmission(userId: String?, parentId: String): RealmSubmission {

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -551,7 +551,7 @@ class UploadManager @Inject constructor(
     }
 
     suspend fun uploadCourseActivities() {
-        uploadCoordinator.upload(uploadConfigs.CourseActivities)
+        uploadCoordinator.uploadRoom(uploadConfigs.CourseActivities)
     }
 
     suspend fun uploadMeetups() {

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -538,7 +538,7 @@ class UploadManager @Inject constructor(
     }
 
     suspend fun uploadSearchActivity() {
-        uploadCoordinator.upload(uploadConfigs.SearchActivity)
+        uploadCoordinator.uploadRoom(uploadConfigs.SearchActivity)
     }
 
     suspend fun uploadResourceActivities(type: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -547,7 +547,7 @@ class UploadManager @Inject constructor(
         } else {
             uploadConfigs.ResourceActivities
         }
-        uploadCoordinator.upload(config)
+        uploadCoordinator.uploadRoom(config)
     }
 
     suspend fun uploadCourseActivities() {

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -85,7 +85,7 @@ class UploadManager @Inject constructor(
 ) : FileUploader(apiInterface, scope) {
 
     private suspend fun uploadNewsActivities() {
-        uploadCoordinator.upload(uploadConfigs.NewsActivities)
+        uploadCoordinator.uploadRoom(uploadConfigs.NewsActivities)
     }
 
     private suspend fun notifyListener(listener: OnSuccessListener?, message: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -6,6 +6,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.NewsLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
@@ -51,16 +52,20 @@ class UploadConfigs @Inject constructor(
     private val searchActivityDao: SearchActivityDao,
     private val courseActivityDao: CourseActivityDao,
     private val resourceActivityDao: ResourceActivityDao,
-    private val submitPhotosDao: SubmitPhotosDao
+    private val submitPhotosDao: SubmitPhotosDao,
+    private val newsLogDao: NewsLogDao
 ) {
-    val NewsActivities = UploadConfig(
-        modelClass = RealmNewsLog::class,
+    val NewsActivities = RoomUploadConfig(
         endpoint = "myplanet_activities",
-        queryBuilder = { query ->
-            query.isNull("_id").or().isEmpty("_id")
-        },
+        modelClassName = "RealmNewsLog",
+        fetchPendingItems = { newsLogDao.getPendingUploads() },
         serializer = UploadSerializer.Simple(RealmNewsLog::serialize),
-        idExtractor = { it.id }
+        idExtractor = { it.id },
+        markUploaded = { results ->
+            results.filter { result ->
+                newsLogDao.markUploaded(result.localId, result.remoteId, result.remoteRev) == 0
+            }
+        }
     )
 
     val CourseProgress = UploadConfig(

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
+import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.model.RealmCourseActivity
@@ -45,7 +46,8 @@ class UploadConfigs @Inject constructor(
     private val feedbackRepository: FeedbackRepository,
     private val ratingsRepository: RatingsRepository,
     private val apkLogDao: ApkLogDao,
-    private val searchActivityDao: SearchActivityDao
+    private val searchActivityDao: SearchActivityDao,
+    private val courseActivityDao: CourseActivityDao
 ) {
     val NewsActivities = UploadConfig(
         modelClass = RealmNewsLog::class,
@@ -127,14 +129,21 @@ class UploadConfigs @Inject constructor(
         idExtractor = { it._id }
     )
 
-    val CourseActivities = UploadConfig(
-        modelClass = RealmCourseActivity::class,
+    val CourseActivities = RoomUploadConfig(
         endpoint = "course_activities",
-        queryBuilder = { query ->
-            query.isNull("_rev").notEqualTo("type", "sync")
-        },
+        modelClassName = "RealmCourseActivity",
+        fetchPendingItems = { courseActivityDao.getPendingUploads() },
         serializer = UploadSerializer.Simple(RealmCourseActivity::serializeSerialize),
-        idExtractor = { it._id }
+        idExtractor = { it.id },
+        markUploaded = { results ->
+            results.filter { result ->
+                courseActivityDao.markUploaded(
+                    localId = result.localId,
+                    remoteId = result.remoteId,
+                    rev = result.remoteRev
+                ) == 0
+            }
+        }
     )
 
     val Meetups = UploadConfig(

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
+import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmCourseProgress
@@ -43,7 +44,8 @@ class UploadConfigs @Inject constructor(
     private val surveysRepository: SurveysRepository,
     private val feedbackRepository: FeedbackRepository,
     private val ratingsRepository: RatingsRepository,
-    private val apkLogDao: ApkLogDao
+    private val apkLogDao: ApkLogDao,
+    private val searchActivityDao: SearchActivityDao
 ) {
     val NewsActivities = UploadConfig(
         modelClass = RealmNewsLog::class,
@@ -88,12 +90,17 @@ class UploadConfigs @Inject constructor(
         idExtractor = { it.id }
     )
 
-    val SearchActivity = UploadConfig(
-        modelClass = RealmSearchActivity::class,
+    val SearchActivity = RoomUploadConfig(
         endpoint = "search_activities",
-        queryBuilder = { query -> query.isEmpty("_rev") },
+        modelClassName = "RealmSearchActivity",
+        fetchPendingItems = { searchActivityDao.getPendingUploads() },
         serializer = UploadSerializer.Simple { it.serialize() },
-        idExtractor = { it._id }
+        idExtractor = { it.id },
+        markUploaded = { results ->
+            results.filter { result ->
+                searchActivityDao.markUploaded(result.localId, result.remoteId, result.remoteRev) == 0
+            }
+        }
     )
 
     val ResourceActivities = UploadConfig(

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -6,6 +6,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.model.RealmCourseActivity
@@ -47,7 +48,8 @@ class UploadConfigs @Inject constructor(
     private val ratingsRepository: RatingsRepository,
     private val apkLogDao: ApkLogDao,
     private val searchActivityDao: SearchActivityDao,
-    private val courseActivityDao: CourseActivityDao
+    private val courseActivityDao: CourseActivityDao,
+    private val resourceActivityDao: ResourceActivityDao
 ) {
     val NewsActivities = UploadConfig(
         modelClass = RealmNewsLog::class,
@@ -109,24 +111,30 @@ class UploadConfigs @Inject constructor(
         }
     )
 
-    val ResourceActivities = UploadConfig(
-        modelClass = RealmResourceActivity::class,
+    val ResourceActivities = RoomUploadConfig(
         endpoint = "resource_activities",
-        queryBuilder = { query ->
-            query.isNull("_rev").notEqualTo("type", "sync")
-        },
+        modelClassName = "RealmResourceActivity",
+        fetchPendingItems = { resourceActivityDao.getPendingUploads() },
         serializer = UploadSerializer.Simple { org.ole.planet.myplanet.repository.serializeResourceActivities(it) },
-        idExtractor = { it._id }
+        idExtractor = { it.id },
+        markUploaded = { results ->
+            results.filter { result ->
+                resourceActivityDao.markUploaded(result.localId, result.remoteId, result.remoteRev) == 0
+            }
+        }
     )
 
-    val ResourceActivitiesSync = UploadConfig(
-        modelClass = RealmResourceActivity::class,
+    val ResourceActivitiesSync = RoomUploadConfig(
         endpoint = "admin_activities",
-        queryBuilder = { query ->
-            query.isNull("_rev").equalTo("type", "sync")
-        },
+        modelClassName = "RealmResourceActivity",
+        fetchPendingItems = { resourceActivityDao.getPendingSyncUploads() },
         serializer = UploadSerializer.Simple { org.ole.planet.myplanet.repository.serializeResourceActivities(it) },
-        idExtractor = { it._id }
+        idExtractor = { it.id },
+        markUploaded = { results ->
+            results.filter { result ->
+                resourceActivityDao.markUploaded(result.localId, result.remoteId, result.remoteRev) == 0
+            }
+        }
     )
 
     val CourseActivities = RoomUploadConfig(

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -98,7 +98,11 @@ class UploadConfigs @Inject constructor(
         idExtractor = { it.id },
         markUploaded = { results ->
             results.filter { result ->
-                searchActivityDao.markUploaded(result.localId, result.remoteId, result.remoteRev) == 0
+                searchActivityDao.markUploaded(
+                    localId = result.localId,
+                    remoteId = result.remoteId,
+                    rev = result.remoteRev
+                ) == 0
             }
         }
     )

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -8,6 +8,7 @@ import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
+import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmCourseProgress
@@ -49,7 +50,8 @@ class UploadConfigs @Inject constructor(
     private val apkLogDao: ApkLogDao,
     private val searchActivityDao: SearchActivityDao,
     private val courseActivityDao: CourseActivityDao,
-    private val resourceActivityDao: ResourceActivityDao
+    private val resourceActivityDao: ResourceActivityDao,
+    private val submitPhotosDao: SubmitPhotosDao
 ) {
     val NewsActivities = UploadConfig(
         modelClass = RealmNewsLog::class,
@@ -216,14 +218,16 @@ class UploadConfigs @Inject constructor(
         }
     )
 
-    val SubmitPhotos = UploadConfig(
-        modelClass = RealmSubmitPhotos::class,
+    val SubmitPhotos = RoomUploadConfig(
         endpoint = "submissions",
-        queryBuilder = { query -> query.equalTo("uploaded", false) },
+        modelClassName = "RealmSubmitPhotos",
+        fetchPendingItems = { submitPhotosDao.getUnuploaded() },
         serializer = UploadSerializer.Simple(RealmSubmitPhotos::serializeRealmSubmitPhotos),
         idExtractor = { it.id },
-        additionalUpdates = { _, photo, _ ->
-            photo.uploaded = true
+        markUploaded = { results ->
+            results.filter { result ->
+                submitPhotosDao.markUploaded(result.localId, result.remoteRev, result.remoteId) == 0
+            }
         }
     )
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.repository
 
+import com.google.gson.JsonParser
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -191,9 +192,10 @@ class CoursesRepositoryImplTest {
         assertEquals("parent", savedActivity.captured.parentCode)
         assertEquals("algebra", savedActivity.captured.text)
         assertEquals("courses", savedActivity.captured.type)
-        assertTrue(savedActivity.captured.filter.contains("doc.gradeLevel"))
-        assertTrue(savedActivity.captured.filter.contains("6"))
-        assertTrue(savedActivity.captured.filter.contains("doc.subjectLevel"))
-        assertTrue(savedActivity.captured.filter.contains("math"))
+
+        val filter = JsonParser.parseString(savedActivity.captured.filter).asJsonObject
+        assertEquals("6", filter["doc.gradeLevel"].asString)
+        assertEquals("math", filter["doc.subjectLevel"].asString)
+        assertTrue(filter.getAsJsonArray("tags").isEmpty)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -1,7 +1,9 @@
 package org.ole.planet.myplanet.repository
 
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import io.realm.Realm
 import io.realm.RealmQuery
@@ -11,12 +13,14 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmMyCourse
+import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.Utilities
 
@@ -165,5 +169,30 @@ class CoursesRepositoryImplTest {
         val result = repository.getCoursesByIds(listOf("id1", "id2"))
         assertEquals(2, result.size)
         verify { mockQuery.`in`("courseId", arrayOf("id1", "id2")) }
+    }
+
+    @Test
+    fun `saveSearchActivity writes course search activity to Room`() = runTest {
+        val savedActivity = slot<RealmSearchActivity>()
+
+        repository.saveSearchActivity(
+            searchText = "algebra",
+            userName = "learner",
+            planetCode = "planet",
+            parentCode = "parent",
+            tags = emptyList(),
+            grade = "6",
+            subject = "math"
+        )
+
+        coVerify { searchActivityDao.insert(capture(savedActivity)) }
+        assertNotNull(savedActivity.captured.id)
+        assertEquals("learner", savedActivity.captured.user)
+        assertEquals("planet", savedActivity.captured.createdOn)
+        assertEquals("parent", savedActivity.captured.parentCode)
+        assertEquals("algebra", savedActivity.captured.text)
+        assertEquals("courses", savedActivity.captured.type)
+        assertTrue(savedActivity.captured.filter.contains("doc.gradeLevel"))
+        assertTrue(savedActivity.captured.filter.contains("doc.subjectLevel"))
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -185,14 +184,16 @@ class CoursesRepositoryImplTest {
             subject = "math"
         )
 
-        coVerify { searchActivityDao.insert(capture(savedActivity)) }
-        assertNotNull(savedActivity.captured.id)
+        coVerify(exactly = 1) { searchActivityDao.insert(capture(savedActivity)) }
+        assertTrue(savedActivity.captured.id.isNotBlank())
         assertEquals("learner", savedActivity.captured.user)
         assertEquals("planet", savedActivity.captured.createdOn)
         assertEquals("parent", savedActivity.captured.parentCode)
         assertEquals("algebra", savedActivity.captured.text)
         assertEquals("courses", savedActivity.captured.type)
         assertTrue(savedActivity.captured.filter.contains("doc.gradeLevel"))
+        assertTrue(savedActivity.captured.filter.contains("6"))
         assertTrue(savedActivity.captured.filter.contains("doc.subjectLevel"))
+        assertTrue(savedActivity.captured.filter.contains("math"))
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.Utilities
@@ -30,6 +31,7 @@ class CoursesRepositoryImplTest {
     private val tagsRepository: TagsRepository = mockk(relaxed = true)
     private val ratingsRepository: RatingsRepository = mockk(relaxed = true)
     private val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
+    private val searchActivityDao: SearchActivityDao = mockk(relaxed = true)
 
     private val mockRealm: Realm = mockk(relaxed = true)
     private lateinit var repository: CoursesRepositoryImpl
@@ -53,7 +55,8 @@ class CoursesRepositoryImplTest {
             tagsRepository,
             ratingsRepository,
             sharedPrefManager,
-            mockk(relaxed = true)
+            mockk(relaxed = true),
+            searchActivityDao
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.repository
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.google.gson.JsonParser
 import dagger.Lazy
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -301,9 +302,12 @@ class ResourcesRepositoryImplTest {
         assertEquals("parent", savedActivity.captured.parentCode)
         assertEquals("physics", savedActivity.captured.text)
         assertEquals("resources", savedActivity.captured.type)
-        assertTrue(savedActivity.captured.filter.contains("science"))
-        assertTrue(savedActivity.captured.filter.contains("en"))
-        assertTrue(savedActivity.captured.filter.contains("beginner"))
-        assertTrue(savedActivity.captured.filter.contains("video"))
+
+        val filter = JsonParser.parseString(savedActivity.captured.filter).asJsonObject
+        assertEquals(listOf("science"), filter.getAsJsonArray("subjects").map { it.asString })
+        assertEquals(listOf("en"), filter.getAsJsonArray("language").map { it.asString })
+        assertEquals(listOf("beginner"), filter.getAsJsonArray("level").map { it.asString })
+        assertEquals(listOf("video"), filter.getAsJsonArray("mediaType").map { it.asString })
+        assertTrue(filter.getAsJsonArray("tags").isEmpty)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.Utilities
@@ -36,6 +37,7 @@ class ResourcesRepositoryImplTest {
     private val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
     private val ratingsRepository: RatingsRepository = mockk(relaxed = true)
     private val tagsRepository: TagsRepository = mockk(relaxed = true)
+    private val searchActivityDao: SearchActivityDao = mockk(relaxed = true)
     private val teamsRepositoryLazy: Lazy<TeamsRepository> = mockk(relaxed = true)
     private val teamsSyncRepositoryLazy: Lazy<TeamsSyncRepository> = mockk(relaxed = true)
 
@@ -65,6 +67,7 @@ class ResourcesRepositoryImplTest {
             sharedPrefManager,
             ratingsRepository,
             tagsRepository,
+            searchActivityDao,
             teamsRepositoryLazy,
             teamsSyncRepositoryLazy
         )

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -23,6 +23,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmSearchActivity
@@ -42,6 +43,7 @@ class ResourcesRepositoryImplTest {
     private val ratingsRepository: RatingsRepository = mockk(relaxed = true)
     private val tagsRepository: TagsRepository = mockk(relaxed = true)
     private val searchActivityDao: SearchActivityDao = mockk(relaxed = true)
+    private val resourceActivityDao: ResourceActivityDao = mockk(relaxed = true)
     private val teamsRepositoryLazy: Lazy<TeamsRepository> = mockk(relaxed = true)
     private val teamsSyncRepositoryLazy: Lazy<TeamsSyncRepository> = mockk(relaxed = true)
 
@@ -72,6 +74,7 @@ class ResourcesRepositoryImplTest {
             ratingsRepository,
             tagsRepository,
             searchActivityDao,
+            resourceActivityDao,
             teamsRepositoryLazy,
             teamsSyncRepositoryLazy
         )

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -295,14 +294,16 @@ class ResourcesRepositoryImplTest {
             mediums = setOf("video")
         )
 
-        coVerify { searchActivityDao.insert(capture(savedActivity)) }
-        assertNotNull(savedActivity.captured.id)
+        coVerify(exactly = 1) { searchActivityDao.insert(capture(savedActivity)) }
+        assertTrue(savedActivity.captured.id.isNotBlank())
         assertEquals("learner", savedActivity.captured.user)
         assertEquals("planet", savedActivity.captured.createdOn)
         assertEquals("parent", savedActivity.captured.parentCode)
         assertEquals("physics", savedActivity.captured.text)
         assertEquals("resources", savedActivity.captured.type)
         assertTrue(savedActivity.captured.filter.contains("science"))
+        assertTrue(savedActivity.captured.filter.contains("en"))
+        assertTrue(savedActivity.captured.filter.contains("beginner"))
         assertTrue(savedActivity.captured.filter.contains("video"))
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import android.content.SharedPreferences
 import dagger.Lazy
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import io.realm.Realm
 import io.realm.RealmQuery
@@ -16,12 +18,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmMyLibrary
+import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.Utilities
 
@@ -273,5 +277,32 @@ class ResourcesRepositoryImplTest {
         verify { mockQuery.contains("titleNormal", "tree") }
         assertEquals(1, result.size)
         assertEquals(matchLib, result[0])
+    }
+
+    @Test
+    fun `saveSearchActivity writes resource search activity to Room`() = runTest {
+        val savedActivity = slot<RealmSearchActivity>()
+
+        repository.saveSearchActivity(
+            userName = "learner",
+            searchText = "physics",
+            planetCode = "planet",
+            parentCode = "parent",
+            tags = emptyList(),
+            subjects = setOf("science"),
+            languages = setOf("en"),
+            levels = setOf("beginner"),
+            mediums = setOf("video")
+        )
+
+        coVerify { searchActivityDao.insert(capture(savedActivity)) }
+        assertNotNull(savedActivity.captured.id)
+        assertEquals("learner", savedActivity.captured.user)
+        assertEquals("planet", savedActivity.captured.createdOn)
+        assertEquals("parent", savedActivity.captured.parentCode)
+        assertEquals("physics", savedActivity.captured.text)
+        assertEquals("resources", savedActivity.captured.type)
+        assertTrue(savedActivity.captured.filter.contains("science"))
+        assertTrue(savedActivity.captured.filter.contains("video"))
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -25,6 +25,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.model.CreateExamSubmissionRequest
 import org.ole.planet.myplanet.model.ExamAnswerData
 import org.ole.planet.myplanet.model.RealmAnswer
@@ -44,6 +45,7 @@ class SubmissionsRepositoryImplTest {
     private lateinit var exporter: SubmissionsRepositoryExporter
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    private val submitPhotosDao: SubmitPhotosDao = mockk(relaxed = true)
     private lateinit var repository: SubmissionsRepositoryImpl
 
     @Before
@@ -72,7 +74,8 @@ class SubmissionsRepositoryImplTest {
             surveysRepositoryProvider,
             context,
             sharedPrefManager,
-            exporter
+            exporter,
+            submitPhotosDao
         ), recordPrivateCalls = true)
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -29,6 +29,7 @@ import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.model.RealmRating
+import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.RealmTeamTask
@@ -134,6 +135,15 @@ class UploadManagerTest {
         uploadManager.uploadCrashLog()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.CrashLog) }
+    }
+
+
+    @Test
+    fun `uploadSearchActivity delegates to Room uploadCoordinator`() = testScope.runTest {
+        coEvery { uploadCoordinator.uploadRoom<RealmSearchActivity>(any()) } returns UploadResult.Success(1, emptyList())
+        uploadManager.uploadSearchActivity()
+        advanceUntilIdle()
+        coVerify { uploadCoordinator.uploadRoom(uploadConfigs.SearchActivity) }
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -137,7 +137,6 @@ class UploadManagerTest {
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.CrashLog) }
     }
 
-
     @Test
     fun `uploadSearchActivity delegates to Room uploadCoordinator`() = testScope.runTest {
         coEvery { uploadCoordinator.uploadRoom<RealmSearchActivity>(any()) } returns UploadResult.Success(1, emptyList())

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -147,10 +147,10 @@ class UploadManagerTest {
 
     @Test
     fun `uploadCourseActivities delegates to uploadCoordinator`() = testScope.runTest {
-        coEvery { uploadCoordinator.upload<RealmCourseActivity>(any()) } returns UploadResult.Success(1, emptyList())
+        coEvery { uploadCoordinator.uploadRoom<RealmCourseActivity>(any()) } returns UploadResult.Success(1, emptyList())
         uploadManager.uploadCourseActivities()
         advanceUntilIdle()
-        coVerify { uploadCoordinator.upload(uploadConfigs.CourseActivities) }
+        coVerify { uploadCoordinator.uploadRoom(uploadConfigs.CourseActivities) }
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -1,0 +1,62 @@
+package org.ole.planet.myplanet.services.upload
+
+import dagger.Lazy
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.ole.planet.myplanet.data.room.dao.ApkLogDao
+import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
+import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.repository.TeamsSyncRepository
+import org.ole.planet.myplanet.repository.UploadedItemResult
+
+class UploadConfigsTest {
+    private val searchActivityDao: SearchActivityDao = mockk(relaxed = true)
+    private val uploadConfigs = UploadConfigs(
+        voicesRepository = mockk(relaxed = true),
+        submissionsRepository = mockk(relaxed = true),
+        activitiesRepository = mockk(relaxed = true),
+        teamsSyncRepository = mockk<Lazy<TeamsSyncRepository>>(relaxed = true),
+        sharedPrefManager = mockk(relaxed = true),
+        userRepository = mockk(relaxed = true),
+        surveysRepository = mockk(relaxed = true),
+        feedbackRepository = mockk(relaxed = true),
+        ratingsRepository = mockk(relaxed = true),
+        apkLogDao = mockk<ApkLogDao>(relaxed = true),
+        searchActivityDao = searchActivityDao
+    )
+
+    @Test
+    fun `SearchActivity config fetches pending Room rows from DAO`() = runTest {
+        val pending = listOf(RealmSearchActivity(id = "local-1", text = "math"))
+        coEvery { searchActivityDao.getPendingUploads() } returns pending
+
+        val result = uploadConfigs.SearchActivity.fetchPendingItems()
+
+        assertEquals(pending, result)
+    }
+
+    @Test
+    fun `SearchActivity config marks successful uploads with remote id and rev`() = runTest {
+        val result = UploadedItemResult(
+            localId = "local-1",
+            remoteId = "remote-1",
+            remoteRev = "1-rev",
+            response = mockk(relaxed = true)
+        )
+        coEvery {
+            searchActivityDao.markUploaded(localId = "local-1", remoteId = "remote-1", rev = "1-rev")
+        } returns 1
+
+        val failures = uploadConfigs.SearchActivity.markUploaded(listOf(result))
+
+        assertTrue(failures.isEmpty())
+        coVerify {
+            searchActivityDao.markUploaded(localId = "local-1", remoteId = "remote-1", rev = "1-rev")
+        }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -10,10 +10,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.NewsLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.model.RealmCourseActivity
+import org.ole.planet.myplanet.model.RealmNewsLog
 import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.repository.TeamsSyncRepository
@@ -22,6 +24,7 @@ import org.ole.planet.myplanet.repository.UploadedItemResult
 class UploadConfigsTest {
     private val searchActivityDao: SearchActivityDao = mockk(relaxed = true)
     private val courseActivityDao: CourseActivityDao = mockk(relaxed = true)
+    private val newsLogDao: NewsLogDao = mockk(relaxed = true)
     private val resourceActivityDao: ResourceActivityDao = mockk(relaxed = true)
     private val submitPhotosDao: SubmitPhotosDao = mockk(relaxed = true)
     private val uploadConfigs = UploadConfigs(
@@ -38,7 +41,8 @@ class UploadConfigsTest {
         searchActivityDao = searchActivityDao,
         courseActivityDao = courseActivityDao,
         resourceActivityDao = resourceActivityDao,
-        submitPhotosDao = submitPhotosDao
+        submitPhotosDao = submitPhotosDao,
+        newsLogDao = newsLogDao
     )
 
     @Test
@@ -141,6 +145,16 @@ class UploadConfigsTest {
         coEvery { resourceActivityDao.getPendingSyncUploads() } returns pending
 
         val result = uploadConfigs.ResourceActivitiesSync.fetchPendingItems()
+
+        assertEquals(pending, result)
+    }
+
+    @Test
+    fun `NewsActivities config fetches pending Room rows from DAO`() = runTest {
+        val pending = listOf(RealmNewsLog().apply { id = "news-local-1" })
+        coEvery { newsLogDao.getPendingUploads() } returns pending
+
+        val result = uploadConfigs.NewsActivities.fetchPendingItems()
 
         assertEquals(pending, result)
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -59,4 +59,21 @@ class UploadConfigsTest {
             searchActivityDao.markUploaded(localId = "local-1", remoteId = "remote-1", rev = "1-rev")
         }
     }
+
+    @Test
+    fun `SearchActivity config reports rows that cannot be marked uploaded`() = runTest {
+        val result = UploadedItemResult(
+            localId = "missing-local",
+            remoteId = "remote-1",
+            remoteRev = "1-rev",
+            response = mockk(relaxed = true)
+        )
+        coEvery {
+            searchActivityDao.markUploaded(localId = "missing-local", remoteId = "remote-1", rev = "1-rev")
+        } returns 0
+
+        val failures = uploadConfigs.SearchActivity.markUploaded(listOf(result))
+
+        assertEquals(listOf(result), failures)
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -9,13 +9,16 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
+import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
+import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.repository.TeamsSyncRepository
 import org.ole.planet.myplanet.repository.UploadedItemResult
 
 class UploadConfigsTest {
     private val searchActivityDao: SearchActivityDao = mockk(relaxed = true)
+    private val courseActivityDao: CourseActivityDao = mockk(relaxed = true)
     private val uploadConfigs = UploadConfigs(
         voicesRepository = mockk(relaxed = true),
         submissionsRepository = mockk(relaxed = true),
@@ -27,7 +30,8 @@ class UploadConfigsTest {
         feedbackRepository = mockk(relaxed = true),
         ratingsRepository = mockk(relaxed = true),
         apkLogDao = mockk<ApkLogDao>(relaxed = true),
-        searchActivityDao = searchActivityDao
+        searchActivityDao = searchActivityDao,
+        courseActivityDao = courseActivityDao
     )
 
     @Test
@@ -75,5 +79,43 @@ class UploadConfigsTest {
         val failures = uploadConfigs.SearchActivity.markUploaded(listOf(result))
 
         assertEquals(listOf(result), failures)
+    }
+
+    @Test
+    fun `CourseActivities config fetches pending Room rows from DAO`() = runTest {
+        val pending = listOf(RealmCourseActivity().apply { id = "course-local-1" })
+        coEvery { courseActivityDao.getPendingUploads() } returns pending
+
+        val result = uploadConfigs.CourseActivities.fetchPendingItems()
+
+        assertEquals(pending, result)
+    }
+
+    @Test
+    fun `CourseActivities config marks successful uploads with remote id and rev`() = runTest {
+        val result = UploadedItemResult(
+            localId = "course-local-1",
+            remoteId = "course-remote-1",
+            remoteRev = "1-rev",
+            response = mockk(relaxed = true)
+        )
+        coEvery {
+            courseActivityDao.markUploaded(
+                localId = "course-local-1",
+                remoteId = "course-remote-1",
+                rev = "1-rev"
+            )
+        } returns 1
+
+        val failures = uploadConfigs.CourseActivities.markUploaded(listOf(result))
+
+        assertTrue(failures.isEmpty())
+        coVerify {
+            courseActivityDao.markUploaded(
+                localId = "course-local-1",
+                remoteId = "course-remote-1",
+                rev = "1-rev"
+            )
+        }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -12,6 +12,7 @@ import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
+import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmSearchActivity
@@ -22,6 +23,7 @@ class UploadConfigsTest {
     private val searchActivityDao: SearchActivityDao = mockk(relaxed = true)
     private val courseActivityDao: CourseActivityDao = mockk(relaxed = true)
     private val resourceActivityDao: ResourceActivityDao = mockk(relaxed = true)
+    private val submitPhotosDao: SubmitPhotosDao = mockk(relaxed = true)
     private val uploadConfigs = UploadConfigs(
         voicesRepository = mockk(relaxed = true),
         submissionsRepository = mockk(relaxed = true),
@@ -35,7 +37,8 @@ class UploadConfigsTest {
         apkLogDao = mockk<ApkLogDao>(relaxed = true),
         searchActivityDao = searchActivityDao,
         courseActivityDao = courseActivityDao,
-        resourceActivityDao = resourceActivityDao
+        resourceActivityDao = resourceActivityDao,
+        submitPhotosDao = submitPhotosDao
     )
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -10,8 +10,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmCourseActivity
+import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.repository.TeamsSyncRepository
 import org.ole.planet.myplanet.repository.UploadedItemResult
@@ -19,6 +21,7 @@ import org.ole.planet.myplanet.repository.UploadedItemResult
 class UploadConfigsTest {
     private val searchActivityDao: SearchActivityDao = mockk(relaxed = true)
     private val courseActivityDao: CourseActivityDao = mockk(relaxed = true)
+    private val resourceActivityDao: ResourceActivityDao = mockk(relaxed = true)
     private val uploadConfigs = UploadConfigs(
         voicesRepository = mockk(relaxed = true),
         submissionsRepository = mockk(relaxed = true),
@@ -31,7 +34,8 @@ class UploadConfigsTest {
         ratingsRepository = mockk(relaxed = true),
         apkLogDao = mockk<ApkLogDao>(relaxed = true),
         searchActivityDao = searchActivityDao,
-        courseActivityDao = courseActivityDao
+        courseActivityDao = courseActivityDao,
+        resourceActivityDao = resourceActivityDao
     )
 
     @Test
@@ -118,4 +122,24 @@ class UploadConfigsTest {
             )
         }
     }
+    @Test
+    fun `ResourceActivities config fetches pending Room rows from DAO`() = runTest {
+        val pending = listOf(RealmResourceActivity().apply { id = "resource-local-1" })
+        coEvery { resourceActivityDao.getPendingUploads() } returns pending
+
+        val result = uploadConfigs.ResourceActivities.fetchPendingItems()
+
+        assertEquals(pending, result)
+    }
+
+    @Test
+    fun `ResourceActivitiesSync config fetches pending sync Room rows from DAO`() = runTest {
+        val pending = listOf(RealmResourceActivity().apply { id = "resource-sync-local-1"; type = "sync" })
+        coEvery { resourceActivityDao.getPendingSyncUploads() } returns pending
+
+        val result = uploadConfigs.ResourceActivitiesSync.fetchPendingItems()
+
+        assertEquals(pending, result)
+    }
+
 }

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -126,7 +126,11 @@ wired through `di/RoomModule`.
       `RealmRepository` only for still-Realm `RealmUser` lookups; upload config ->
       `RoomUploadConfig`. Repo aggregation moved from Realm `average()`/`RealmResults` to
       in-memory over DAO lists. Repo test + model test + UploadManager test updated.
-- [ ] Migrate the remaining 15 uploadable models to `RoomUploadConfig` + the synced-only domains.
+- [x] **SearchActivity** migrated (uploaded-only local activity log). `RealmSearchActivity` is now
+      a Room `@Entity`; `SearchActivityDao` owns pending upload lookup, inserts, and upload
+      acknowledgements; course/resource search logging now writes through the DAO; upload config
+      uses `RoomUploadConfig`.
+- [ ] Migrate the remaining 14 uploadable models to `RoomUploadConfig` + the synced-only domains.
 - [ ] Remaining ~32 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -138,7 +138,11 @@ wired through `di/RoomModule`.
       now a Room `@Entity`; `ResourceActivityDao` owns resource-open/sync inserts, counts,
       most-opened lookups, opened-resource observation, pending upload lookup, and upload
       acknowledgements; both regular and sync upload configs use `RoomUploadConfig`.
-- [ ] Migrate the remaining 12 uploadable models to `RoomUploadConfig` + the synced-only domains.
+- [x] **SubmitPhotos** migrated (uploaded photo submissions). `RealmSubmitPhotos` is now a
+      Room `@Entity`; `SubmitPhotosDao` owns photo inserts, pending lookup, id lookups, and
+      upload acknowledgements; repository/photo uploader paths use the DAO, and the legacy upload
+      config is Room-capable.
+- [ ] Migrate the remaining 11 uploadable models to `RoomUploadConfig` + the synced-only domains.
 - [ ] Remaining ~32 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -134,7 +134,11 @@ wired through `di/RoomModule`.
       a Room `@Entity`; `CourseActivityDao` owns visit inserts, pending upload lookup, and upload
       acknowledgements; course visit logging writes through the DAO; upload config uses
       `RoomUploadConfig`.
-- [ ] Migrate the remaining 13 uploadable models to `RoomUploadConfig` + the synced-only domains.
+- [x] **ResourceActivity** migrated (uploaded + local read paths). `RealmResourceActivity` is
+      now a Room `@Entity`; `ResourceActivityDao` owns resource-open/sync inserts, counts,
+      most-opened lookups, opened-resource observation, pending upload lookup, and upload
+      acknowledgements; both regular and sync upload configs use `RoomUploadConfig`.
+- [ ] Migrate the remaining 12 uploadable models to `RoomUploadConfig` + the synced-only domains.
 - [ ] Remaining ~32 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -142,7 +142,10 @@ wired through `di/RoomModule`.
       Room `@Entity`; `SubmitPhotosDao` owns photo inserts, pending lookup, id lookups, and
       upload acknowledgements; repository/photo uploader paths use the DAO, and the legacy upload
       config is Room-capable.
-- [ ] Migrate the remaining 11 uploadable models to `RoomUploadConfig` + the synced-only domains.
+- [x] **NewsLog** migrated (uploaded-only activity log). `RealmNewsLog` is now a Room
+      `@Entity`; `NewsLogDao` owns pending lookup, inserts, and upload acknowledgements; upload
+      config uses `RoomUploadConfig`.
+- [ ] Migrate the remaining 10 uploadable models to `RoomUploadConfig` + the synced-only domains.
 - [ ] Remaining ~32 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -130,7 +130,11 @@ wired through `di/RoomModule`.
       a Room `@Entity`; `SearchActivityDao` owns pending upload lookup, inserts, and upload
       acknowledgements; course/resource search logging now writes through the DAO; upload config
       uses `RoomUploadConfig`.
-- [ ] Migrate the remaining 14 uploadable models to `RoomUploadConfig` + the synced-only domains.
+- [x] **CourseActivity** migrated (uploaded-only course visit log). `RealmCourseActivity` is now
+      a Room `@Entity`; `CourseActivityDao` owns visit inserts, pending upload lookup, and upload
+      acknowledgements; course visit logging writes through the DAO; upload config uses
+      `RoomUploadConfig`.
+- [ ] Migrate the remaining 13 uploadable models to `RoomUploadConfig` + the synced-only domains.
 - [ ] Remaining ~32 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.


### PR DESCRIPTION
### Motivation
- Move the local search-activity logging and upload path off Realm and onto Room as part of the ongoing Realm→Room migration so uploads and local inserts use the new Room schema and DAOs.

### Description
- Converted `RealmSearchActivity` from a `RealmObject` into a Room `@Entity` (keeps `serialize()` payload intact) and added `@JvmField` on the primary key to avoid accessor ambiguity.
- Added `SearchActivityDao` with `getPendingUploads()`, `insert()` and `markUploaded()` and registered the DAO and entity in `AppDatabase` and `RoomModule`.
- Replaced Realm transaction-based inserts for course/resource search logging with DAO `insert()` calls in `CoursesRepositoryImpl` and `ResourcesRepositoryImpl` so records are written to Room.
- Switched the upload config for search activity to `RoomUploadConfig` (uses `SearchActivityDao.getPendingUploads()` and `markUploaded`), updated `UploadManager` to call `uploadRoom` for search activity, and updated the migration tracker doc to mark SearchActivity migrated.

### Testing
- Ran `./gradlew compileDefaultDebugKotlin` and the build completed successfully.
- Ran `git diff --check` to verify no whitespace/index issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a7ee7d3dc832ba84b3ba4a1d55f85)