### PR TITLE
Migrate team activity logs to Room

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -20,6 +20,7 @@ import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
+import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TagDao
@@ -41,6 +42,7 @@ import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmRetryOperation
 import org.ole.planet.myplanet.model.RealmResourceActivity
+import org.ole.planet.myplanet.model.RealmRemovedLog
 import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmSubmitPhotos
 import org.ole.planet.myplanet.model.RealmTag
@@ -79,6 +81,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmTeamLog::class,
         RealmOfflineActivity::class,
         RealmCourseProgress::class,
+        RealmRemovedLog::class,
     ],
     version = 1,
     exportSchema = false,
@@ -107,4 +110,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun teamLogDao(): TeamLogDao
     abstract fun offlineActivityDao(): OfflineActivityDao
     abstract fun courseProgressDao(): CourseProgressDao
+    abstract fun removedLogDao(): RemovedLogDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -9,6 +9,7 @@ import org.ole.planet.myplanet.data.room.dao.CertificationDao
 import org.ole.planet.myplanet.data.room.dao.ChatDao
 import org.ole.planet.myplanet.data.room.dao.CommunityDao
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
@@ -30,6 +31,7 @@ import org.ole.planet.myplanet.model.RealmCertification
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmCommunity
 import org.ole.planet.myplanet.model.RealmCourseActivity
+import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyLife
@@ -76,6 +78,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmNewsLog::class,
         RealmTeamLog::class,
         RealmOfflineActivity::class,
+        RealmCourseProgress::class,
     ],
     version = 1,
     exportSchema = false,
@@ -103,4 +106,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun newsLogDao(): NewsLogDao
     abstract fun teamLogDao(): TeamLogDao
     abstract fun offlineActivityDao(): OfflineActivityDao
+    abstract fun courseProgressDao(): CourseProgressDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -14,6 +14,7 @@ import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
 import org.ole.planet.myplanet.data.room.dao.NewsLogDao
+import org.ole.planet.myplanet.data.room.dao.OfflineActivityDao
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
@@ -34,6 +35,7 @@ import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.model.RealmNewsLog
+import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmRetryOperation
 import org.ole.planet.myplanet.model.RealmResourceActivity
@@ -73,6 +75,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmSubmitPhotos::class,
         RealmNewsLog::class,
         RealmTeamLog::class,
+        RealmOfflineActivity::class,
     ],
     version = 1,
     exportSchema = false,
@@ -99,4 +102,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun submitPhotosDao(): SubmitPhotosDao
     abstract fun newsLogDao(): NewsLogDao
     abstract fun teamLogDao(): TeamLogDao
+    abstract fun offlineActivityDao(): OfflineActivityDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -22,6 +22,7 @@ import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TagDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
+import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.model.RealmCertification
@@ -40,6 +41,7 @@ import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmSubmitPhotos
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmTeamNotification
+import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmUserChallengeActions
 
 /**
@@ -70,6 +72,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmResourceActivity::class,
         RealmSubmitPhotos::class,
         RealmNewsLog::class,
+        RealmTeamLog::class,
     ],
     version = 1,
     exportSchema = false,
@@ -95,4 +98,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun resourceActivityDao(): ResourceActivityDao
     abstract fun submitPhotosDao(): SubmitPhotosDao
     abstract fun newsLogDao(): NewsLogDao
+    abstract fun teamLogDao(): TeamLogDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseProgressDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseProgressDao.kt
@@ -1,0 +1,42 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import org.ole.planet.myplanet.model.RealmCourseProgress
+
+@Dao
+interface CourseProgressDao {
+    @Query("SELECT * FROM course_progress WHERE userId = :userId AND courseId IN (:courseIds)")
+    suspend fun getByUserAndCourseIds(userId: String?, courseIds: List<String>): List<RealmCourseProgress>
+
+    @Query("SELECT * FROM course_progress WHERE userId = :userId AND courseId = :courseId")
+    suspend fun getByUserAndCourse(userId: String?, courseId: String?): List<RealmCourseProgress>
+
+    @Query("SELECT * FROM course_progress WHERE userId = :userId")
+    suspend fun getByUser(userId: String?): List<RealmCourseProgress>
+
+    @Query("SELECT * FROM course_progress WHERE courseId = :courseId AND userId = :userId AND stepNum = :stepNum LIMIT 1")
+    suspend fun findByCourseUserAndStep(courseId: String?, userId: String?, stepNum: Int): RealmCourseProgress?
+
+    @Query("SELECT * FROM course_progress WHERE id IN (:ids)")
+    suspend fun getByIds(ids: List<String>): List<RealmCourseProgress>
+
+    @Query("SELECT * FROM course_progress WHERE courseId IN (:courseIds) AND userId IN (:userIds) AND stepNum IN (:stepNums)")
+    suspend fun getByCourseUsersAndSteps(courseIds: List<String>, userIds: List<String>, stepNums: List<Int>): List<RealmCourseProgress>
+
+    @Query("SELECT * FROM course_progress WHERE _id IS NULL AND userId NOT LIKE 'guest%'")
+    suspend fun getPendingUploads(): List<RealmCourseProgress>
+
+    @Query("UPDATE course_progress SET _id = :remoteId, _rev = :rev WHERE id = :localId")
+    suspend fun markUploaded(localId: String, remoteId: String, rev: String): Int
+
+    @Query("UPDATE course_progress SET passed = :passed WHERE courseId = :courseId AND stepNum = :stepNum")
+    suspend fun updatePassedByCourseAndStep(courseId: String, stepNum: Int, passed: Boolean): Int
+
+    @Upsert
+    suspend fun upsert(progress: RealmCourseProgress)
+
+    @Upsert
+    suspend fun upsertAll(progress: List<RealmCourseProgress>)
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/OfflineActivityDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/OfflineActivityDao.kt
@@ -1,0 +1,54 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+import org.ole.planet.myplanet.model.RealmOfflineActivity
+
+@Dao
+interface OfflineActivityDao {
+    @Query("SELECT COUNT(*) FROM offline_activity WHERE userId = :userId AND type = :type")
+    suspend fun countByUserIdAndType(userId: String, type: String): Int
+
+    @Query("SELECT COUNT(*) FROM offline_activity WHERE userName = :userName AND type = :type")
+    suspend fun countByUserNameAndType(userName: String, type: String): Int
+
+    @Query("SELECT * FROM offline_activity WHERE userName = :userName AND type = :type")
+    fun observeByUserNameAndType(userName: String, type: String): Flow<List<RealmOfflineActivity>>
+
+    @Query("SELECT * FROM offline_activity WHERE userId = :userId AND loginTime BETWEEN :startMillis AND :endMillis")
+    suspend fun getByUserIdAndLoginTimeBetween(userId: String, startMillis: Long, endMillis: Long): List<RealmOfflineActivity>
+
+    @Query("SELECT * FROM offline_activity WHERE _rev IS NULL AND type = 'login'")
+    suspend fun getPendingLoginUploads(): List<RealmOfflineActivity>
+
+    @Query("SELECT MAX(loginTime) FROM offline_activity")
+    suspend fun getGlobalLastVisit(): Long?
+
+    @Query("SELECT MAX(loginTime) FROM offline_activity WHERE userName = :userName")
+    suspend fun getLastVisit(userName: String): Long?
+
+    @Query("SELECT * FROM offline_activity WHERE type = :type ORDER BY loginTime DESC LIMIT 1")
+    suspend fun getLatestByType(type: String): RealmOfflineActivity?
+
+    @Query("SELECT * FROM offline_activity WHERE id IN (:ids)")
+    suspend fun getByIds(ids: List<String>): List<RealmOfflineActivity>
+
+    @Query("SELECT * FROM offline_activity WHERE _id IN (:remoteIds)")
+    suspend fun getByRemoteIds(remoteIds: List<String>): List<RealmOfflineActivity>
+
+    @Query("SELECT * FROM offline_activity WHERE loginTime IN (:loginTimes) AND userName IN (:userNames)")
+    suspend fun getByLoginTimesAndUserNames(loginTimes: List<Long>, userNames: List<String>): List<RealmOfflineActivity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(activity: RealmOfflineActivity)
+
+    @Upsert
+    suspend fun upsertAll(activities: List<RealmOfflineActivity>)
+
+    @Query("UPDATE offline_activity SET logoutTime = :logoutTime WHERE id = :id")
+    suspend fun updateLogoutTime(id: String, logoutTime: Long): Int
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/RemovedLogDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/RemovedLogDao.kt
@@ -1,0 +1,22 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import org.ole.planet.myplanet.model.RealmRemovedLog
+
+@Dao
+interface RemovedLogDao {
+    @Query("DELETE FROM removed_log WHERE type = :type AND userId = :userId AND docId = :docId")
+    suspend fun deleteByTypeUserAndDoc(type: String?, userId: String?, docId: String?)
+
+    @Query("DELETE FROM removed_log WHERE type = :type AND userId = :userId AND docId IN (:docIds)")
+    suspend fun deleteByTypeUserAndDocs(type: String, userId: String?, docIds: List<String>)
+
+    @Query("SELECT docId FROM removed_log WHERE type = :type AND userId = :userId")
+    suspend fun getRemovedDocIds(type: String, userId: String?): List<String?>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(log: RealmRemovedLog)
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamLogDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamLogDao.kt
@@ -1,0 +1,36 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Upsert
+import org.ole.planet.myplanet.model.RealmTeamLog
+
+@Dao
+interface TeamLogDao {
+    @Query("SELECT * FROM team_log WHERE _rev IS NULL")
+    suspend fun getPendingUploads(): List<RealmTeamLog>
+
+    @Query("SELECT * FROM team_log WHERE type = 'teamVisit' AND time > :cutoff AND teamId IN (:teamIds)")
+    suspend fun getRecentTeamVisits(cutoff: Long, teamIds: List<String>): List<RealmTeamLog>
+
+    @Query("SELECT * FROM team_log WHERE type = 'teamVisit' AND teamId = :teamId AND user IN (:userNames)")
+    suspend fun getTeamVisitsForUsers(teamId: String, userNames: List<String>): List<RealmTeamLog>
+
+    @Query("SELECT MAX(time) FROM team_log WHERE type = 'teamVisit' AND user = :userName AND teamId = :teamId")
+    suspend fun getLastVisit(userName: String?, teamId: String?): Long?
+
+    @Query("SELECT * FROM team_log WHERE _id IN (:ids)")
+    suspend fun getByRemoteIds(ids: List<String>): List<RealmTeamLog>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(log: RealmTeamLog)
+
+    @Upsert
+    suspend fun upsertAll(logs: List<RealmTeamLog>)
+
+    /** Returns the number of rows updated (0 means the local row was gone). */
+    @Query("UPDATE team_log SET _id = :remoteId, _rev = :rev WHERE id = :localId")
+    suspend fun markUploaded(localId: String, remoteId: String, rev: String): Int
+}

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -20,6 +20,7 @@ import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
 import org.ole.planet.myplanet.data.room.dao.NewsLogDao
+import org.ole.planet.myplanet.data.room.dao.OfflineActivityDao
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
@@ -143,5 +144,10 @@ object RoomModule {
     @Provides
     fun provideTeamLogDao(database: AppDatabase): TeamLogDao {
         return database.teamLogDao()
+    }
+
+    @Provides
+    fun provideOfflineActivityDao(database: AppDatabase): OfflineActivityDao {
+        return database.offlineActivityDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -26,6 +26,7 @@ import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.data.room.dao.RetryDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
+import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TagDao
@@ -155,5 +156,10 @@ object RoomModule {
     @Provides
     fun provideCourseProgressDao(database: AppDatabase): CourseProgressDao {
         return database.courseProgressDao()
+    }
+
+    @Provides
+    fun provideRemovedLogDao(database: AppDatabase): RemovedLogDao {
+        return database.removedLogDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -15,6 +15,7 @@ import org.ole.planet.myplanet.data.room.dao.CertificationDao
 import org.ole.planet.myplanet.data.room.dao.ChatDao
 import org.ole.planet.myplanet.data.room.dao.CommunityDao
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
@@ -149,5 +150,10 @@ object RoomModule {
     @Provides
     fun provideOfflineActivityDao(database: AppDatabase): OfflineActivityDao {
         return database.offlineActivityDao()
+    }
+
+    @Provides
+    fun provideCourseProgressDao(database: AppDatabase): CourseProgressDao {
+        return database.courseProgressDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TagDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
+import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -137,5 +138,10 @@ object RoomModule {
     @Provides
     fun provideNewsLogDao(database: AppDatabase): NewsLogDao {
         return database.newsLogDao()
+    }
+
+    @Provides
+    fun provideTeamLogDao(database: AppDatabase): TeamLogDao {
+        return database.teamLogDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseProgress.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmCourseProgress.kt
@@ -1,14 +1,19 @@
 package org.ole.planet.myplanet.model
 
 import com.google.gson.JsonObject
-import io.realm.RealmObject
-import io.realm.annotations.Index
-import io.realm.annotations.PrimaryKey
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 
-open class RealmCourseProgress : RealmObject() {
+@Entity(
+    tableName = "course_progress",
+    indices = [Index("_id"), Index("userId"), Index("courseId"), Index(value = ["courseId", "userId", "stepNum"])]
+)
+open class RealmCourseProgress {
     @PrimaryKey
-    var id: String? = null
-    @Index
+    @JvmField
+    var id: String = ""
+    @JvmField
     var _id: String? = null
     var createdOn: String? = null
     var createdDate: Long = 0
@@ -16,9 +21,7 @@ open class RealmCourseProgress : RealmObject() {
     var _rev: String? = null
     var stepNum = 0
     var passed = false
-    @Index
     var userId: String? = null
-    @Index
     var courseId: String? = null
     var parentCode: String? = null
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmOfflineActivity.kt
@@ -1,21 +1,24 @@
 package org.ole.planet.myplanet.model
 
 import com.google.gson.JsonObject
-import io.realm.RealmObject
-import io.realm.annotations.Index
-import io.realm.annotations.PrimaryKey
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import org.ole.planet.myplanet.utils.JsonUtils
 
-open class RealmOfflineActivity : RealmObject() {
+@Entity(
+    tableName = "offline_activity",
+    indices = [Index("_rev"), Index("userId"), Index("type"), Index("_id"), Index("loginTime"), Index("userName")]
+)
+open class RealmOfflineActivity {
     @PrimaryKey
-    var id: String? = null
+    @JvmField
+    var id: String = ""
+    @JvmField
     var _id: String? = null
-    @Index
     var _rev: String? = null
     var userName: String? = null
-    @Index
     var userId: String? = null
-    @Index
     var type: String? = null
     var description: String? = null
     var createdOn: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmRemovedLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmRemovedLog.kt
@@ -1,78 +1,18 @@
 package org.ole.planet.myplanet.model
 
-import io.realm.Realm
-import io.realm.RealmObject
-import io.realm.annotations.Index
-import io.realm.annotations.PrimaryKey
-import java.util.UUID
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 
-open class RealmRemovedLog : RealmObject() {
+@Entity(
+    tableName = "removed_log",
+    indices = [Index("userId"), Index("type"), Index("docId")]
+)
+open class RealmRemovedLog {
     @PrimaryKey
-    var id: String? = null
-    @Index
+    @JvmField
+    var id: String = ""
     var userId: String? = null
-    @Index
     var type: String? = null
     var docId: String? = null
-
-    companion object {
-        fun onAdd(mRealm: Realm, type: String?, userId: String?, docId: String?) {
-            val startedTransaction = !mRealm.isInTransaction
-            if (startedTransaction) {
-                mRealm.beginTransaction()
-            }
-            try {
-                mRealm.where(RealmRemovedLog::class.java)
-                    .equalTo("type", type)
-                    .equalTo("userId", userId)
-                    .equalTo("docId", docId)
-                    .findAll().deleteAllFromRealm()
-                if (startedTransaction) {
-                    mRealm.commitTransaction()
-                }
-            } catch (e: Exception) {
-                if (startedTransaction && mRealm.isInTransaction) {
-                    mRealm.cancelTransaction()
-                }
-                throw e
-            }
-        }
-
-        fun onRemove(mRealm: Realm, type: String, userId: String?, docId: String?) {
-            val startedTransaction = !mRealm.isInTransaction
-            if (startedTransaction) {
-                mRealm.beginTransaction()
-            }
-            try {
-                val log = mRealm.createObject(RealmRemovedLog::class.java, UUID.randomUUID().toString())
-                log.docId = docId
-                log.userId = userId
-                log.type = type
-                if (startedTransaction) {
-                    mRealm.commitTransaction()
-                }
-            } catch (e: Exception) {
-                if (startedTransaction && mRealm.isInTransaction) {
-                    mRealm.cancelTransaction()
-                }
-                throw e
-            }
-        }
-
-        fun removedIds(realm: Realm?, type: String, userId: String?): Array<String> {
-            val removedLibs = realm?.where(RealmRemovedLog::class.java)
-                ?.equalTo("userId", userId)
-                ?.equalTo("type", type)
-                ?.findAll()
-
-            if (removedLibs != null) {
-                val ids = Array(removedLibs.size) { "" }
-                for ((i, removed) in removedLibs.withIndex()) {
-                    ids[i] = removed.docId ?: ""
-                }
-                return ids
-            }
-            return arrayOf()
-        }
-    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamLog.kt
@@ -1,18 +1,22 @@
 package org.ole.planet.myplanet.model
 
-import io.realm.RealmObject
-import io.realm.annotations.Index
-import io.realm.annotations.PrimaryKey
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 
-open class RealmTeamLog : RealmObject() {
+@Entity(
+    tableName = "team_log",
+    indices = [Index("teamId"), Index("type"), Index("_id"), Index("_rev")]
+)
+open class RealmTeamLog {
     @PrimaryKey
-    var id: String? = null
+    @JvmField
+    var id: String = ""
+    @JvmField
     var _id: String? = null
     var _rev: String? = null
-    @Index
     var teamId: String? = null
     var user: String? = null
-    @Index
     var type: String? = null
     var teamType: String? = null
     var createdOn: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -22,6 +22,7 @@ import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.OfflineActivityDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
+import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.UserChallengeActionsDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.LoginActivityData
@@ -52,7 +53,8 @@ class ActivitiesRepositoryImpl @Inject constructor(
     private val userChallengeActionsDao: UserChallengeActionsDao,
     private val courseActivityDao: CourseActivityDao,
     private val resourceActivityDao: ResourceActivityDao,
-    private val offlineActivityDao: OfflineActivityDao
+    private val offlineActivityDao: OfflineActivityDao,
+    private val removedLogDao: RemovedLogDao
 ) : RealmRepository(databaseService, realmDispatcher), ActivitiesRepository {
     override suspend fun getOfflineVisitCount(userId: String): Int {
         return offlineActivityDao.countByUserIdAndType(userId, UserSessionManager.KEY_LOGIN)
@@ -67,22 +69,18 @@ class ActivitiesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markResourceAdded(userId: String?, resourceId: String) {
-        executeTransaction { realm ->
-            realm.where(RealmRemovedLog::class.java)
-                .equalTo("type", "resources")
-                .equalTo("userId", userId)
-                .equalTo("docId", resourceId)
-                .findAll().deleteAllFromRealm()
-        }
+        removedLogDao.deleteByTypeUserAndDoc("resources", userId, resourceId)
     }
 
     override suspend fun markResourceRemoved(userId: String, resourceId: String) {
-        executeTransaction { realm ->
-            val log = realm.createObject(RealmRemovedLog::class.java, UUID.randomUUID().toString())
-            log.docId = resourceId
-            log.userId = userId
-            log.type = "resources"
-        }
+        removedLogDao.insert(
+            RealmRemovedLog().apply {
+                id = UUID.randomUUID().toString()
+                docId = resourceId
+                this.userId = userId
+                type = "resources"
+            }
+        )
     }
 
     override suspend fun logCourseVisit(courseId: String, title: String, userId: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.OfflineActivityDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.UserChallengeActionsDao
 import org.ole.planet.myplanet.di.RealmDispatcher
@@ -50,27 +51,19 @@ class ActivitiesRepositoryImpl @Inject constructor(
     private val timeProvider: TimeProvider,
     private val userChallengeActionsDao: UserChallengeActionsDao,
     private val courseActivityDao: CourseActivityDao,
-    private val resourceActivityDao: ResourceActivityDao
+    private val resourceActivityDao: ResourceActivityDao,
+    private val offlineActivityDao: OfflineActivityDao
 ) : RealmRepository(databaseService, realmDispatcher), ActivitiesRepository {
     override suspend fun getOfflineVisitCount(userId: String): Int {
-        return queryList(RealmOfflineActivity::class.java) {
-            equalTo("userId", userId)
-            equalTo("type", UserSessionManager.KEY_LOGIN)
-        }.size
+        return offlineActivityDao.countByUserIdAndType(userId, UserSessionManager.KEY_LOGIN)
     }
 
     override suspend fun getOfflineLoginCount(userName: String): Int {
-        return count(RealmOfflineActivity::class.java) {
-            equalTo("userName", userName)
-            equalTo("type", UserSessionManager.KEY_LOGIN)
-        }.toInt()
+        return offlineActivityDao.countByUserNameAndType(userName, UserSessionManager.KEY_LOGIN)
     }
 
     override suspend fun getOfflineLogins(userName: String): Flow<List<RealmOfflineActivity>> {
-        return queryListFlow(RealmOfflineActivity::class.java) {
-            equalTo("userName", userName)
-            equalTo("type", UserSessionManager.KEY_LOGIN)
-        }
+        return offlineActivityDao.observeByUserNameAndType(userName, UserSessionManager.KEY_LOGIN)
     }
 
     override suspend fun markResourceAdded(userId: String?, resourceId: String) {
@@ -120,42 +113,34 @@ class ActivitiesRepositoryImpl @Inject constructor(
         parentCode: String?,
         planetCode: String?
     ) {
-        executeTransaction { realm ->
-            val offlineActivities =
-                realm.createObject(RealmOfflineActivity::class.java, UUID.randomUUID().toString())
-            offlineActivities.userId = userId
-            offlineActivities.userName = userName
-            offlineActivities.parentCode = parentCode
-            offlineActivities.createdOn = planetCode
-            offlineActivities.type = UserSessionManager.KEY_LOGIN
-            offlineActivities._rev = null
-            offlineActivities._id = null
-            offlineActivities.description = "Member login on offline application"
-            offlineActivities.loginTime = Date().time
-        }
+        offlineActivityDao.insert(
+            RealmOfflineActivity().apply {
+                id = UUID.randomUUID().toString()
+                this.userId = userId
+                this.userName = userName
+                this.parentCode = parentCode
+                createdOn = planetCode
+                type = UserSessionManager.KEY_LOGIN
+                _rev = null
+                _id = null
+                description = "Member login on offline application"
+                loginTime = Date().time
+            }
+        )
     }
 
     override suspend fun logLogout(userName: String?) {
-        executeTransaction { realm ->
-            realm.where(RealmOfflineActivity::class.java)
-                .equalTo("type", UserSessionManager.KEY_LOGIN).sort("loginTime", io.realm.Sort.DESCENDING)
-                .findFirst()
-                ?.logoutTime = Date().time
+        offlineActivityDao.getLatestByType(UserSessionManager.KEY_LOGIN)?.let { activity ->
+            offlineActivityDao.updateLogoutTime(activity.id, Date().time)
         }
     }
 
     override suspend fun getGlobalLastVisit(): Long? {
-        return withRealm { realm ->
-            realm.where(RealmOfflineActivity::class.java).max("loginTime") as Long?
-        }
+        return offlineActivityDao.getGlobalLastVisit()
     }
 
     override suspend fun getLastVisit(userName: String): Long? {
-        return withRealm { realm ->
-            realm.where(RealmOfflineActivity::class.java)
-                .equalTo("userName", userName)
-                .max("loginTime") as Long?
-        }
+        return offlineActivityDao.getLastVisit(userName)
     }
 
     override suspend fun logResourceOpen(
@@ -209,18 +194,13 @@ class ActivitiesRepositoryImpl @Inject constructor(
     }
 
     private suspend fun getUnuploadedLoginActivities(): List<LoginActivityData> {
-        return queryList(RealmOfflineActivity::class.java) {
-            isNull("_rev")
-            equalTo("type", "login")
-        }.mapNotNull { activity ->
-            if (activity.userId?.startsWith("guest") == true || activity.id == null || activity.userId == null) {
+        return offlineActivityDao.getPendingLoginUploads().mapNotNull { activity ->
+            if (activity.userId?.startsWith("guest") == true || activity.userId == null) {
                 null
             } else {
-                val actId = activity.id ?: return@mapNotNull null
-                val actUserId = activity.userId ?: return@mapNotNull null
                 LoginActivityData(
-                    actId,
-                    actUserId,
+                    activity.id,
+                    activity.userId ?: return@mapNotNull null,
                     serializeLoginActivities(activity, context)
                 )
             }
@@ -228,14 +208,12 @@ class ActivitiesRepositoryImpl @Inject constructor(
     }
 
     private suspend fun markActivitiesUploaded(ids: Array<String>, revMap: Map<String, JsonObject?>) {
-        executeTransaction { transactionRealm ->
-            val activities = transactionRealm.where(RealmOfflineActivity::class.java)
-                .`in`("id", ids)
-                .findAll()
-
-            activities.forEach { activity ->
-                revMap[activity.id]?.let { activity.changeRev(it) }
-            }
+        val activities = offlineActivityDao.getByIds(ids.toList())
+        activities.forEach { activity ->
+            revMap[activity.id]?.let { activity.changeRev(it) }
+        }
+        if (activities.isNotEmpty()) {
+            offlineActivityDao.upsertAll(activities)
         }
     }
 
@@ -274,54 +252,35 @@ class ActivitiesRepositoryImpl @Inject constructor(
         )
     }
 
-    private fun insertActivityInternal(
-        realm: io.realm.Realm,
+    private fun activityFromJson(
         json: JsonObject,
-        existingActivitiesMap: MutableMap<String, RealmOfflineActivity>? = null,
-        fallbackActivitiesMap: MutableMap<String, RealmOfflineActivity>? = null
-    ) {
-        val serverIdStr = JsonUtils.getString("_id", json)
+        existingActivitiesMap: MutableMap<String, RealmOfflineActivity>,
+        fallbackActivitiesMap: MutableMap<String, RealmOfflineActivity>
+    ): RealmOfflineActivity {
+        val serverId = JsonUtils.getString("_id", json)
         val loginTime = JsonUtils.getLong("loginTime", json)
         val userName = JsonUtils.getString("user", json)
 
-        var activities = if (existingActivitiesMap != null) {
-            existingActivitiesMap[serverIdStr]
-        } else {
-            realm.where(RealmOfflineActivity::class.java)
-                .equalTo("_id", serverIdStr)
-                .findFirst()
-        }
+        val fallbackKey = "${loginTime}_${userName}"
+        val activity = existingActivitiesMap[serverId]
+            ?: fallbackActivitiesMap[fallbackKey]
+            ?: RealmOfflineActivity().apply { id = serverId }
 
-        if (activities == null && loginTime > 0 && userName.isNotEmpty()) {
-            activities = if (fallbackActivitiesMap != null) {
-                fallbackActivitiesMap["${loginTime}_${userName}"]
-            } else {
-                realm.where(RealmOfflineActivity::class.java)
-                    .equalTo("loginTime", loginTime)
-                    .equalTo("userName", userName)
-                    .findFirst()
-            }
-        }
+        activity._rev = JsonUtils.getString("_rev", json)
+        activity._id = serverId
+        activity.loginTime = loginTime
+        activity.type = JsonUtils.getString("type", json)
+        activity.userName = userName
+        activity.parentCode = JsonUtils.getString("parentCode", json)
+        activity.createdOn = JsonUtils.getString("createdOn", json)
+        activity.logoutTime = JsonUtils.getLong("logoutTime", json)
+        activity.androidId = JsonUtils.getString("androidId", json)
 
-        if (activities == null) {
-            activities = realm.createObject(RealmOfflineActivity::class.java, serverIdStr)
-            existingActivitiesMap?.put(serverIdStr, activities)
-
-            if (loginTime > 0 && userName.isNotEmpty()) {
-                fallbackActivitiesMap?.put("${loginTime}_${userName}", activities)
-            }
+        existingActivitiesMap[serverId] = activity
+        if (loginTime > 0 && userName.isNotEmpty()) {
+            fallbackActivitiesMap.putIfAbsent(fallbackKey, activity)
         }
-        if (activities != null) {
-            activities._rev = JsonUtils.getString("_rev", json)
-            activities._id = serverIdStr
-            activities.loginTime = loginTime
-            activities.type = JsonUtils.getString("type", json)
-            activities.userName = userName
-            activities.parentCode = JsonUtils.getString("parentCode", json)
-            activities.createdOn = JsonUtils.getString("createdOn", json)
-            activities.logoutTime = JsonUtils.getLong("logoutTime", json)
-            activities.androidId = JsonUtils.getString("androidId", json)
-        }
+        return activity
     }
 
     override suspend fun hasUserSyncAction(userId: String?): Boolean {
@@ -354,7 +313,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         return ob
     }
 
-        override suspend fun uploadActivities() {
+    override suspend fun uploadActivities() {
         val activitiesToUpload = getUnuploadedLoginActivities()
 
         activitiesToUpload.chunked(50).forEach { batch ->
@@ -391,59 +350,32 @@ class ActivitiesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun insertLoginActivitiesFromSync(docs: List<JsonObject>) {
-        executeTransaction { realm ->
-            val documentList = ArrayList<JsonObject>(docs.size)
-            val ids = mutableListOf<String>()
-
-            for (jsonDoc in docs) {
-                val id = JsonUtils.getString("_id", jsonDoc)
-                if (!id.startsWith("_design")) {
-                    documentList.add(jsonDoc)
-                    if (id.isNotEmpty()) {
-                        ids.add(id)
-                    }
-                }
-            }
-
-            val existingActivitiesMap = if (ids.isNotEmpty()) {
-                realm.where(RealmOfflineActivity::class.java)
-                    .`in`("_id", ids.toTypedArray())
-                    .findAll()
-                    .associateBy { it._id ?: "" }
-                    .toMutableMap()
-            } else {
-                mutableMapOf<String, RealmOfflineActivity>()
-            }
-
-            val fallbackCandidates = if (documentList.isNotEmpty()) {
-                val loginTimes = documentList.map { JsonUtils.getLong("loginTime", it) }.filter { it > 0 }.distinct().toTypedArray()
-                val userNames = documentList.map { JsonUtils.getString("user", it) }.filter { it.isNotEmpty() }.distinct().toTypedArray()
-
-                if (loginTimes.isNotEmpty() && userNames.isNotEmpty()) {
-                    val results = realm.where(RealmOfflineActivity::class.java)
-                        .`in`("loginTime", loginTimes)
-                        .`in`("userName", userNames)
-                        .findAll()
-
-                    val map = mutableMapOf<String, RealmOfflineActivity>()
-                    for (activity in results) {
-                        val key = "${activity.loginTime}_${activity.userName}"
-                        if (!map.containsKey(key)) {
-                            map[key] = activity
-                        }
-                    }
-                    map
-                } else {
-                    mutableMapOf()
-                }
-            } else {
-                mutableMapOf()
-            }
-
-            documentList.forEach { jsonDoc ->
-                insertActivityInternal(realm, jsonDoc, existingActivitiesMap, fallbackCandidates)
-            }
+        val documentList = docs.filter { jsonDoc ->
+            !JsonUtils.getString("_id", jsonDoc).startsWith("_design")
         }
+        if (documentList.isEmpty()) return
+
+        val ids = documentList.map { JsonUtils.getString("_id", it) }.filter { it.isNotEmpty() }.distinct()
+        val existingActivitiesMap = if (ids.isNotEmpty()) {
+            offlineActivityDao.getByRemoteIds(ids).associateBy { it._id ?: "" }.toMutableMap()
+        } else {
+            mutableMapOf()
+        }
+
+        val loginTimes = documentList.map { JsonUtils.getLong("loginTime", it) }.filter { it > 0 }.distinct()
+        val userNames = documentList.map { JsonUtils.getString("user", it) }.filter { it.isNotEmpty() }.distinct()
+        val fallbackActivitiesMap = if (loginTimes.isNotEmpty() && userNames.isNotEmpty()) {
+            offlineActivityDao.getByLoginTimesAndUserNames(loginTimes, userNames)
+                .associateBy { "${it.loginTime}_${it.userName}" }
+                .toMutableMap()
+        } else {
+            mutableMapOf()
+        }
+
+        val activities = documentList.map { jsonDoc ->
+            activityFromJson(jsonDoc, existingActivitiesMap, fallbackActivitiesMap)
+        }
+        offlineActivityDao.upsertAll(activities)
     }
 
     override suspend fun uploadMyPlanetActivities(userModel: RealmUser) {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -20,6 +20,7 @@ import org.ole.planet.myplanet.model.CourseStepData
 import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.data.room.dao.CertificationDao
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
+import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TagDao
 import org.ole.planet.myplanet.model.RealmCertification
@@ -53,7 +54,8 @@ class CoursesRepositoryImpl @Inject constructor(
     private val certificationDao: CertificationDao,
     private val tagDao: TagDao,
     private val searchActivityDao: SearchActivityDao,
-    private val courseProgressDao: CourseProgressDao
+    private val courseProgressDao: CourseProgressDao,
+    private val removedLogDao: RemovedLogDao
 ) : RealmRepository(databaseService, realmDispatcher), CoursesRepository {
 
     override suspend fun getAllCourses(): List<RealmMyCourse> {
@@ -135,45 +137,30 @@ class CoursesRepositoryImpl @Inject constructor(
 
     override suspend fun markCoursesAdded(courseIds: List<String>, userId: String?): Result<Boolean> {
         return runCatching {
-            if (courseIds.isEmpty()) {
-                return@runCatching false
-            }
+            val validCourseIds = courseIds.filter { it.isNotBlank() }
+            if (validCourseIds.isEmpty()) return@runCatching false
 
             var courseFound = false
             executeTransaction { realm ->
-                    val validCourseIds = courseIds.filter { it.isNotBlank() }
-                    if (validCourseIds.isEmpty()) return@executeTransaction
+                validCourseIds.chunked(1000).forEach { chunk ->
+                    val courses = realm.where(RealmMyCourse::class.java)
+                        .`in`("courseId", chunk.toTypedArray())
+                        .findAll()
 
-                    val allFoundCourseIds = mutableListOf<String>()
-                    val chunkSize = 1000
-                    validCourseIds.chunked(chunkSize).forEach { chunk ->
-                        val courses = realm.where(RealmMyCourse::class.java)
-                            .`in`("courseId", chunk.toTypedArray())
-                            .findAll()
-
-                        if (courses.isNotEmpty()) {
-                            courses.forEach { course ->
-                                course.setUserId(userId)
-                            }
-
-                            allFoundCourseIds.addAll(courses.mapNotNull { it.courseId })
-                            courseFound = true
-                        }
-                    }
-
-                    if (!userId.isNullOrBlank() && allFoundCourseIds.isNotEmpty()) {
-                        allFoundCourseIds.chunked(chunkSize).forEach { chunk ->
-                            realm.where(RealmRemovedLog::class.java)
-                                .equalTo("type", "courses")
-                                .equalTo("userId", userId)
-                                .`in`("docId", chunk.toTypedArray())
-                                .findAll()
-                                .deleteAllFromRealm()
-                        }
+                    if (courses.isNotEmpty()) {
+                        courses.forEach { course -> course.setUserId(userId) }
+                        courseFound = true
                     }
                 }
+            }
 
-                courseFound
+            if (!userId.isNullOrBlank() && courseFound) {
+                validCourseIds.chunked(1000).forEach { chunk ->
+                    removedLogDao.deleteByTypeUserAndDocs("courses", userId, chunk)
+                }
+            }
+
+            courseFound
         }
     }
 
@@ -307,15 +294,9 @@ class CoursesRepositoryImpl @Inject constructor(
                         it.setUserId(userId)
                     }
 
-                    val removedLog = realm.where(RealmRemovedLog::class.java)
-                        .equalTo("type", "courses")
-                        .equalTo("userId", userId)
-                        .equalTo("docId", courseId)
-                        .findFirst()
-
-                    removedLog?.deleteFromRealm()
                 }
             }
+            removedLogDao.deleteByTypeUserAndDoc("courses", userId, courseId)
         }
     }
 
@@ -326,8 +307,13 @@ class CoursesRepositoryImpl @Inject constructor(
                     .equalTo("courseId", courseId)
                     .findFirst()
                 course?.removeUserId(userId)
-                RealmRemovedLog.onRemove(realm, "courses", userId, courseId)
             }
+            removedLogDao.insert(RealmRemovedLog().apply {
+                id = UUID.randomUUID().toString()
+                type = "courses"
+                this.userId = userId
+                docId = courseId
+            })
             RealtimeSyncManager.getInstance().notifyTableUpdated(TableDataUpdate("courses", 0, 1))
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -19,10 +19,10 @@ import org.ole.planet.myplanet.model.CourseProgressData
 import org.ole.planet.myplanet.model.CourseStepData
 import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.data.room.dao.CertificationDao
+import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TagDao
 import org.ole.planet.myplanet.model.RealmCertification
-import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmExamQuestion
 import org.ole.planet.myplanet.model.RealmMyCourse
@@ -52,7 +52,8 @@ class CoursesRepositoryImpl @Inject constructor(
     private val sharedPrefManager: SharedPrefManager,
     private val certificationDao: CertificationDao,
     private val tagDao: TagDao,
-    private val searchActivityDao: SearchActivityDao
+    private val searchActivityDao: SearchActivityDao,
+    private val courseProgressDao: CourseProgressDao
 ) : RealmRepository(databaseService, realmDispatcher), CoursesRepository {
 
     override suspend fun getAllCourses(): List<RealmMyCourse> {
@@ -484,13 +485,7 @@ class CoursesRepositoryImpl @Inject constructor(
 
     override suspend fun updateCourseProgress(courseId: String?, stepNum: Int, passed: Boolean) {
         if (courseId.isNullOrEmpty()) return
-        executeTransaction { realm ->
-            val progress = realm.where(RealmCourseProgress::class.java)
-                .equalTo("courseId", courseId)
-                .equalTo("stepNum", stepNum)
-                .findFirst()
-            progress?.passed = passed
-        }
+        courseProgressDao.updatePassedByCourseAndStep(courseId, stepNum, passed)
     }
 
     override suspend fun getCourseStepData(stepId: String, userId: String?): CourseStepData {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
@@ -2,13 +2,13 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import io.realm.Realm
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CourseCompletion
 import org.ole.planet.myplanet.model.RealmAnswer
@@ -25,17 +25,15 @@ class ProgressRepositoryImpl @Inject constructor(
     @RealmDispatcher realmDispatcher: CoroutineDispatcher,
     private val dispatcherProvider: DispatcherProvider,
     private val coursesRepositoryLazy: dagger.Lazy<CoursesRepository>,
-    private val activitiesRepositoryLazy: dagger.Lazy<ActivitiesRepository>
+    private val activitiesRepositoryLazy: dagger.Lazy<ActivitiesRepository>,
+    private val courseProgressDao: CourseProgressDao
 ) : RealmRepository(databaseService, realmDispatcher), ProgressRepository {
     override suspend fun getCourseProgress(courseIds: List<String>, userId: String?): HashMap<String?, JsonObject> {
         val courseIdsArray = courseIds.toTypedArray()
         val allSteps = if (courseIdsArray.isEmpty()) emptyList() else queryList(RealmCourseStep::class.java) {
             `in`("courseId", courseIdsArray)
         }
-        val allProgresses = if (courseIdsArray.isEmpty()) emptyList() else queryList(RealmCourseProgress::class.java) {
-            equalTo("userId", userId)
-            `in`("courseId", courseIdsArray)
-        }
+        val allProgresses = if (courseIds.isEmpty()) emptyList() else courseProgressDao.getByUserAndCourseIds(userId, courseIds)
 
         val stepsByCourseId = allSteps.groupBy { it.courseId }
         val progressesByCourseId = allProgresses.groupBy { it.courseId }
@@ -92,10 +90,7 @@ class ProgressRepositoryImpl @Inject constructor(
     override suspend fun getCurrentProgress(
         steps: List<RealmCourseStep?>?, userId: String?, courseId: String?
     ): Int {
-        val progresses = queryList(RealmCourseProgress::class.java) {
-            equalTo("userId", userId)
-            equalTo("courseId", courseId)
-        }
+        val progresses = courseProgressDao.getByUserAndCourse(userId, courseId)
         return calculateCurrentProgress(steps, progresses)
     }
 
@@ -154,9 +149,7 @@ class ProgressRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getProgressRecords(userId: String?): List<RealmCourseProgress> {
-        return queryList(RealmCourseProgress::class.java) {
-            equalTo("userId", userId)
-        }
+        return courseProgressDao.getByUser(userId)
     }
 
     override suspend fun getCompletedCourses(userId: String): List<CourseCompletion> {
@@ -200,120 +193,92 @@ class ProgressRepositoryImpl @Inject constructor(
         stepNum: Int,
         passed: Boolean?
     ) {
-        executeTransaction { realm ->
-            var courseProgress = realm.where(RealmCourseProgress::class.java)
-                .equalTo("courseId", courseId)
-                .equalTo("userId", userId)
-                .equalTo("stepNum", stepNum)
-                .findFirst()
-            if (courseProgress == null) {
-                courseProgress =
-                    realm.createObject(RealmCourseProgress::class.java, UUID.randomUUID().toString())
-                courseProgress.createdDate = Date().time
+        val now = Date().time
+        val courseProgress = courseProgressDao.findByCourseUserAndStep(courseId, userId, stepNum)
+            ?: RealmCourseProgress().apply {
+                id = UUID.randomUUID().toString()
+                createdDate = now
             }
-            courseProgress?.courseId = courseId
-            courseProgress?.stepNum = stepNum
-            if (passed != null) {
-                courseProgress?.passed = passed
-            }
-            courseProgress?.createdOn = planetCode
-            courseProgress?.updatedDate = Date().time
-            courseProgress?.parentCode = parentCode
-            courseProgress?.userId = userId
+        courseProgress.courseId = courseId
+        courseProgress.stepNum = stepNum
+        if (passed != null) {
+            courseProgress.passed = passed
         }
+        courseProgress.createdOn = planetCode
+        courseProgress.updatedDate = now
+        courseProgress.parentCode = parentCode
+        courseProgress.userId = userId
+        courseProgressDao.upsert(courseProgress)
     }
 
     override suspend fun hasUserCompletedSync(userId: String): Boolean = withContext(dispatcherProvider.io) {
         activitiesRepositoryLazy.get().hasUserCompletedSync(userId)
     }
 
-    private fun insertCourseProgress(
-        mRealm: Realm,
-        act: JsonObject?,
+    private fun courseProgressFromJson(
+        act: JsonObject,
         existingProgress: RealmCourseProgress?,
         localRecord: RealmCourseProgress?
-    ) {
+    ): RealmCourseProgress {
         val docId = JsonUtils.getString("_id", act)
-        val courseId = JsonUtils.getString("courseId", act)
-        val userId = JsonUtils.getString("userId", act)
-        val stepNum = JsonUtils.getInt("stepNum", act)
+        val localPassed = localRecord?.passed ?: false
+        val courseProgress = existingProgress
+            ?: localRecord
+            ?: RealmCourseProgress().apply { id = docId }
 
-        var courseProgress = existingProgress
-        if (courseProgress == null) {
-            val localPassed = localRecord?.passed ?: false
-            localRecord?.deleteFromRealm()
-
-            courseProgress = mRealm.createObject(RealmCourseProgress::class.java, docId)
-            // Preserve a locally-confirmed passed=true in case the server hasn't caught up yet.
-            if (localPassed) courseProgress.passed = true
+        courseProgress.id = docId
+        courseProgress._id = docId
+        courseProgress._rev = JsonUtils.getString("_rev", act)
+        if (courseProgress.passed != true) {
+            courseProgress.passed = JsonUtils.getBoolean("passed", act) || localPassed
         }
-        courseProgress?._id = docId
-        courseProgress?._rev = JsonUtils.getString("_rev", act)
-        if (courseProgress?.passed != true) {
-            courseProgress?.passed = JsonUtils.getBoolean("passed", act)
-        }
-        courseProgress?.stepNum = stepNum
-        courseProgress?.userId = userId
-        courseProgress?.parentCode = JsonUtils.getString("parentCode", act)
-        courseProgress?.courseId = courseId
-        courseProgress?.createdOn = JsonUtils.getString("createdOn", act)
-        courseProgress?.createdDate = JsonUtils.getLong("createdDate", act)
-        courseProgress?.updatedDate = JsonUtils.getLong("updatedDate", act)
+        courseProgress.stepNum = JsonUtils.getInt("stepNum", act)
+        courseProgress.userId = JsonUtils.getString("userId", act)
+        courseProgress.parentCode = JsonUtils.getString("parentCode", act)
+        courseProgress.courseId = JsonUtils.getString("courseId", act)
+        courseProgress.createdOn = JsonUtils.getString("createdOn", act)
+        courseProgress.createdDate = JsonUtils.getLong("createdDate", act)
+        courseProgress.updatedDate = JsonUtils.getLong("updatedDate", act)
+        return courseProgress
     }
 
     override suspend fun insertCourseProgressFromSync(docs: List<JsonObject>) {
-        val docIds = ArrayList<String>()
-        val courseIds = mutableSetOf<String>()
-        val userIds = mutableSetOf<String>()
-        val stepNums = mutableSetOf<Int>()
+        val docIds = docs.map { JsonUtils.getString("_id", it) }.filter { it.isNotEmpty() }.distinct()
+        val courseIds = docs.map { JsonUtils.getString("courseId", it) }.filter { it.isNotEmpty() }.distinct()
+        val userIds = docs.map { JsonUtils.getString("userId", it) }.filter { it.isNotEmpty() }.distinct()
+        val stepNums = docs.map { JsonUtils.getInt("stepNum", it) }.distinct()
 
-        docs.forEach { jsonDoc ->
-            docIds.add(JsonUtils.getString("_id", jsonDoc))
-            courseIds.add(JsonUtils.getString("courseId", jsonDoc))
-            userIds.add(JsonUtils.getString("userId", jsonDoc))
-            stepNums.add(JsonUtils.getInt("stepNum", jsonDoc))
+        val existingProgresses = if (docIds.isNotEmpty()) {
+            courseProgressDao.getByIds(docIds).associateBy { it.id }
+        } else {
+            emptyMap()
         }
 
-        executeTransaction { realm ->
-            val existingProgresses = if (docIds.isNotEmpty()) {
-                realm.where(RealmCourseProgress::class.java)
-                    .`in`("id", docIds.toTypedArray())
-                    .findAll()
-                    .associateBy { it.id }
+        val localRecords = if (courseIds.isNotEmpty() && userIds.isNotEmpty() && stepNums.isNotEmpty()) {
+            courseProgressDao.getByCourseUsersAndSteps(courseIds, userIds, stepNums)
+        } else {
+            emptyList()
+        }
+
+        val localRecordsByKey = localRecords.groupBy { Triple(it.courseId, it.userId, it.stepNum) }
+
+        val progress = docs.map { act ->
+            val docId = JsonUtils.getString("_id", act)
+            val courseId = JsonUtils.getString("courseId", act)
+            val userId = JsonUtils.getString("userId", act)
+            val stepNum = JsonUtils.getInt("stepNum", act)
+            val existingProgress = existingProgresses[docId]
+            val localRecord = if (existingProgress == null) {
+                localRecordsByKey[Triple<String?, String?, Int>(courseId, userId, stepNum)]
+                    ?.find { it._id == null || it._id == docId }
             } else {
-                emptyMap()
+                null
             }
+            courseProgressFromJson(act, existingProgress, localRecord)
+        }
 
-            val localRecords = if (courseIds.isNotEmpty() && userIds.isNotEmpty() && stepNums.isNotEmpty()) {
-                realm.where(RealmCourseProgress::class.java)
-                    .`in`("courseId", courseIds.toTypedArray())
-                    .`in`("userId", userIds.toTypedArray())
-                    .`in`("stepNum", stepNums.toTypedArray())
-                    .findAll()
-            } else {
-                emptyList()
-            }
-
-            val localRecordsByKey = localRecords
-                .filter { it.isValid }
-                .groupBy { Triple(it.courseId, it.userId, it.stepNum) }
-
-            docs.forEach { act ->
-                val docId = JsonUtils.getString("_id", act)
-                val courseId = JsonUtils.getString("courseId", act)
-                val userId = JsonUtils.getString("userId", act)
-                val stepNum = JsonUtils.getInt("stepNum", act)
-
-                val existingProgress = existingProgresses[docId]
-
-                // Find local record manually instead of querying Realm again
-                val localRecord = if (existingProgress == null) {
-                    localRecordsByKey[Triple<String?, String?, Int>(courseId, userId, stepNum)]
-                        ?.find { it._id == null || it._id == docId }
-                } else null
-
-                insertCourseProgress(realm, act, existingProgress, localRecord)
-            }
+        if (progress.isNotEmpty()) {
+            courseProgressDao.upsertAll(progress)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -18,11 +18,11 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmRemovedLog
 import org.ole.planet.myplanet.model.RealmResourceActivity
 import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmTag
@@ -44,6 +44,7 @@ class ResourcesRepositoryImpl @Inject constructor(
     private val tagsRepository: TagsRepository,
     private val searchActivityDao: SearchActivityDao,
     private val resourceActivityDao: ResourceActivityDao,
+    private val removedLogDao: RemovedLogDao,
     private val teamsRepositoryLazy: dagger.Lazy<TeamsRepository>,
     private val teamsSyncRepositoryLazy: dagger.Lazy<TeamsSyncRepository>
 ) : RealmRepository(databaseService, realmDispatcher), ResourcesRepository {
@@ -433,25 +434,16 @@ class ResourcesRepositoryImpl @Inject constructor(
             if (resourceIds.isEmpty() || userId.isBlank()) return@runCatching
 
             executeTransaction { realm ->
-                if (resourceIds.isNotEmpty()) {
-                    val libraryItems = realm.where(RealmMyLibrary::class.java)
-                        .`in`("resourceId", resourceIds.toTypedArray())
-                        .not().equalTo("userId", userId)
-                        .findAll()
+                val libraryItems = realm.where(RealmMyLibrary::class.java)
+                    .`in`("resourceId", resourceIds.toTypedArray())
+                    .not().equalTo("userId", userId)
+                    .findAll()
 
-                    libraryItems.forEach { libraryItem ->
-                        libraryItem.setUserId(userId)
-                    }
-
-                    val removedLogs = realm.where(RealmRemovedLog::class.java)
-                        .equalTo("type", "resources")
-                        .equalTo("userId", userId)
-                        .`in`("docId", resourceIds.toTypedArray())
-                        .findAll()
-
-                    removedLogs.deleteAllFromRealm()
+                libraryItems.forEach { libraryItem ->
+                    libraryItem.setUserId(userId)
                 }
             }
+            removedLogDao.deleteByTypeUserAndDocs("resources", userId, resourceIds)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CreateTeamRequest
@@ -68,6 +69,7 @@ class TeamsRepositoryImpl @Inject constructor(
     private val userRepository: UserRepository,
     private val resourcesRepositoryLazy: dagger.Lazy<ResourcesRepository>,
     private val timeProvider: TimeProvider,
+    private val teamLogDao: TeamLogDao,
 ) : RealmRepository(databaseService, realmDispatcher), TeamsRepository, TeamsSyncRepository {
     override fun getTasksFlow(userId: String?): Flow<List<RealmTeamTask>> {
         return queryListFlow(RealmTeamTask::class.java) {
@@ -805,11 +807,7 @@ class TeamsRepositoryImpl @Inject constructor(
 
         val cutoff = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, -30) }.timeInMillis
 
-        val recentLogs = queryList(RealmTeamLog::class.java) {
-            equalTo("type", "teamVisit")
-            greaterThan("time", cutoff)
-            `in`("teamId", validIds.toTypedArray())
-        }
+        val recentLogs = teamLogDao.getRecentTeamVisits(cutoff, validIds)
 
         return recentLogs
             .mapNotNull { it.teamId }
@@ -1106,7 +1104,7 @@ class TeamsRepositoryImpl @Inject constructor(
             parentCode = userParentCode
             time = Date().time
         }
-        save(log)
+        teamLogDao.insert(log)
     }
 
 
@@ -1313,11 +1311,7 @@ class TeamsRepositoryImpl @Inject constructor(
 
         val userNames = orderedMembers.mapNotNull { it.name }.distinct().toTypedArray()
         val logs = if (userNames.isNotEmpty()) {
-            queryList(RealmTeamLog::class.java) {
-                equalTo("type", "teamVisit")
-                equalTo("teamId", teamId)
-                `in`("user", userNames)
-            }
+            teamLogDao.getTeamVisitsForUsers(teamId, userNames.toList())
         } else {
             emptyList()
         }
@@ -1434,11 +1428,7 @@ class TeamsRepositoryImpl @Inject constructor(
 
         val userNames = users.mapNotNull { it.name }.distinct().toTypedArray()
         val logs = if (userNames.isNotEmpty()) {
-            queryList(RealmTeamLog::class.java) {
-                equalTo("type", "teamVisit")
-                equalTo("teamId", teamId)
-                `in`("user", userNames)
-            }
+            teamLogDao.getTeamVisitsForUsers(teamId, userNames.toList())
         } else {
             emptyList()
         }
@@ -1468,66 +1458,31 @@ class TeamsRepositoryImpl @Inject constructor(
 
 
     override suspend fun insertTeamLog(json: JsonObject) {
-        executeTransaction { realm ->
-            var tag = realm.where(RealmTeamLog::class.java)
-                .equalTo("_id", JsonUtils.getString("_id", json)).findFirst()
-            if (tag == null) {
-                tag = realm.createObject(RealmTeamLog::class.java, JsonUtils.getString("_id", json))
-            }
-            if (tag != null) {
-                tag._rev = JsonUtils.getString("_rev", json)
-                tag._id = JsonUtils.getString("_id", json)
-                tag.type = JsonUtils.getString("type", json)
-                tag.user = JsonUtils.getString("user", json)
-                tag.createdOn = JsonUtils.getString("createdOn", json)
-                tag.parentCode = JsonUtils.getString("parentCode", json)
-                tag.time = JsonUtils.getLong("time", json)
-                tag.teamId = JsonUtils.getString("teamId", json)
-                tag.teamType = JsonUtils.getString("teamType", json)
-            }
-        }
+        teamLogDao.upsertAll(listOf(teamLogFromJson(json)))
     }
 
     override suspend fun insertTeamLogs(logs: List<JsonObject>) {
-        executeTransaction { realm ->
-            val ids = logs.map { JsonUtils.getString("_id", it) }.toTypedArray()
-            val existingLogs = if (ids.isNotEmpty()) {
-                realm.where(RealmTeamLog::class.java).`in`("_id", ids).findAll().associateBy { it._id }.toMutableMap()
-            } else {
-                mutableMapOf()
-            }
-            val newLogs = mutableListOf<RealmTeamLog>()
-            for (json in logs) {
-                val id = JsonUtils.getString("_id", json)
-                var tag = existingLogs[id]
-                if (tag == null) {
-                    tag = RealmTeamLog()
-                    tag.id = id
-                    existingLogs[id] = tag
-                    newLogs.add(tag)
-                }
-                tag._rev = JsonUtils.getString("_rev", json)
-                tag._id = JsonUtils.getString("_id", json)
-                tag.type = JsonUtils.getString("type", json)
-                tag.user = JsonUtils.getString("user", json)
-                tag.createdOn = JsonUtils.getString("createdOn", json)
-                tag.parentCode = JsonUtils.getString("parentCode", json)
-                tag.time = JsonUtils.getLong("time", json)
-                tag.teamId = JsonUtils.getString("teamId", json)
-                tag.teamType = JsonUtils.getString("teamType", json)
-            }
-            if (newLogs.isNotEmpty()) {
-                realm.insert(newLogs)
-            }
-        }
+        teamLogDao.upsertAll(logs.map(::teamLogFromJson))
     }
 
     override suspend fun getLastVisit(userName: String?, teamId: String?): Long? {
-        return queryList(RealmTeamLog::class.java) {
-            equalTo("type", "teamVisit")
-            equalTo("user", userName)
-            equalTo("teamId", teamId)
-        }.maxOfOrNull { it.time ?: 0 }
+        return teamLogDao.getLastVisit(userName, teamId)
+    }
+
+    private fun teamLogFromJson(json: JsonObject): RealmTeamLog {
+        val remoteId = JsonUtils.getString("_id", json)
+        return RealmTeamLog().apply {
+            id = remoteId
+            _rev = JsonUtils.getString("_rev", json)
+            _id = remoteId
+            type = JsonUtils.getString("type", json)
+            user = JsonUtils.getString("user", json)
+            createdOn = JsonUtils.getString("createdOn", json)
+            parentCode = JsonUtils.getString("parentCode", json)
+            time = JsonUtils.getLong("time", json)
+            teamId = JsonUtils.getString("teamId", json)
+            teamType = JsonUtils.getString("teamType", json)
+        }
     }
 
     override fun serializeTeamActivities(log: RealmTeamLog, context: Context): JsonObject {
@@ -1689,7 +1644,7 @@ class TeamsRepositoryImpl @Inject constructor(
             RealmTeamTask.insert(realm, jsonDoc)
         }
     }
-    override fun bulkInsertTeamActivitiesFromSync(realm: Realm, jsonArray: JsonArray) {
+    override suspend fun bulkInsertTeamActivitiesFromSync(jsonArray: JsonArray) {
         val documentList = ArrayList<JsonObject>(jsonArray.size())
         for (j in jsonArray) {
             var jsonDoc = j.asJsonObject
@@ -1699,34 +1654,6 @@ class TeamsRepositoryImpl @Inject constructor(
                 documentList.add(jsonDoc)
             }
         }
-        val ids = documentList.map { JsonUtils.getString("_id", it) }.toTypedArray()
-        val existingLogs = if (ids.isNotEmpty()) {
-            realm.where(RealmTeamLog::class.java).`in`("_id", ids).findAll().associateBy { it._id }.toMutableMap()
-        } else {
-            mutableMapOf()
-        }
-        val newLogs = mutableListOf<RealmTeamLog>()
-        for (json in documentList) {
-            val id = JsonUtils.getString("_id", json)
-            var tag = existingLogs[id]
-            if (tag == null) {
-                tag = RealmTeamLog()
-                tag.id = id
-                existingLogs[id] = tag
-                newLogs.add(tag)
-            }
-            tag._rev = JsonUtils.getString("_rev", json)
-            tag._id = JsonUtils.getString("_id", json)
-            tag.type = JsonUtils.getString("type", json)
-            tag.user = JsonUtils.getString("user", json)
-            tag.createdOn = JsonUtils.getString("createdOn", json)
-            tag.parentCode = JsonUtils.getString("parentCode", json)
-            tag.time = JsonUtils.getLong("time", json)
-            tag.teamId = JsonUtils.getString("teamId", json)
-            tag.teamType = JsonUtils.getString("teamType", json)
-        }
-        if (newLogs.isNotEmpty()) {
-            realm.insert(newLogs)
-        }
+        insertTeamLogs(documentList)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsSyncRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsSyncRepository.kt
@@ -20,5 +20,5 @@ interface TeamsSyncRepository {
     suspend fun batchInsertMyTeams(documents: List<JsonObject>): Int
     fun bulkInsertFromSync(realm: Realm, jsonArray: JsonArray)
     fun bulkInsertTasksFromSync(realm: Realm, jsonArray: JsonArray)
-    fun bulkInsertTeamActivitiesFromSync(realm: Realm, jsonArray: JsonArray)
+    suspend fun bulkInsertTeamActivitiesFromSync(jsonArray: JsonArray)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.OfflineActivityDao
+import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.di.ApplicationScope
 import org.ole.planet.myplanet.di.RealmDispatcher
@@ -42,7 +43,6 @@ import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmMyHealth.RealmMyHealthProfile
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.removedIds
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.User
 import org.ole.planet.myplanet.services.SharedPrefManager
@@ -73,7 +73,8 @@ class UserRepositoryImpl @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val activitiesRepositoryLazy: dagger.Lazy<ActivitiesRepository>,
     private val meetupDao: MeetupDao,
-    private val offlineActivityDao: OfflineActivityDao
+    private val offlineActivityDao: OfflineActivityDao,
+    private val removedLogDao: RemovedLogDao
 ) : RealmRepository(databaseService, realmDispatcher), UserRepository, UserSyncRepository {
     override suspend fun getDashboardProfile(userId: String): DashboardProfile {
         val user = getUserById(userId)
@@ -1482,18 +1483,16 @@ class UserRepositoryImpl @Inject constructor(
             meetupDao.getByUserId(userId)
         }
         val myMeetups = RealmMeetup.getMyMeetUpIds(userMeetups)
-        return withRealm { realm ->
-            val removedResources = listOf(*removedIds(realm, "resources", userId))
-            val removedCourses = listOf(*removedIds(realm, "courses", userId))
-            val mergedResourceIds = mergeJsonArray(myLibs, JsonUtils.getJsonArray("resourceIds", jsonDoc), removedResources)
-            val mergedCourseIds = mergeJsonArray(myCourseIds, JsonUtils.getJsonArray("courseIds", jsonDoc), removedCourses)
-            val `object` = JsonObject()
-            `object`.addProperty("_id", sharedPrefManager.getUserId())
-            `object`.add("meetupIds", mergeJsonArray(myMeetups, JsonUtils.getJsonArray("meetupIds", jsonDoc), removedResources))
-            `object`.add("resourceIds", mergedResourceIds)
-            `object`.add("courseIds", mergedCourseIds)
-            `object`
-        }
+        val removedResources = removedLogDao.getRemovedDocIds("resources", userId).filterNotNull()
+        val removedCourses = removedLogDao.getRemovedDocIds("courses", userId).filterNotNull()
+        val mergedResourceIds = mergeJsonArray(myLibs, JsonUtils.getJsonArray("resourceIds", jsonDoc), removedResources)
+        val mergedCourseIds = mergeJsonArray(myCourseIds, JsonUtils.getJsonArray("courseIds", jsonDoc), removedCourses)
+        val `object` = JsonObject()
+        `object`.addProperty("_id", sharedPrefManager.getUserId())
+        `object`.add("meetupIds", mergeJsonArray(myMeetups, JsonUtils.getJsonArray("meetupIds", jsonDoc), removedResources))
+        `object`.add("resourceIds", mergedResourceIds)
+        `object`.add("courseIds", mergedCourseIds)
+        return `object`
     }
 
     private fun mergeJsonArray(array1: JsonArray?, array2: JsonArray, removedIds: List<String>): JsonArray {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -27,6 +27,7 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.data.room.dao.OfflineActivityDao
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.di.ApplicationScope
 import org.ole.planet.myplanet.di.RealmDispatcher
@@ -41,7 +42,6 @@ import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmMyHealth.RealmMyHealthProfile
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmRemovedLog.Companion.removedIds
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.User
@@ -72,7 +72,8 @@ class UserRepositoryImpl @Inject constructor(
     @ApplicationScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val activitiesRepositoryLazy: dagger.Lazy<ActivitiesRepository>,
-    private val meetupDao: MeetupDao
+    private val meetupDao: MeetupDao,
+    private val offlineActivityDao: OfflineActivityDao
 ) : RealmRepository(databaseService, realmDispatcher), UserRepository, UserSyncRepository {
     override suspend fun getDashboardProfile(userId: String): DashboardProfile {
         val user = getUserById(userId)
@@ -418,10 +419,7 @@ class UserRepositoryImpl @Inject constructor(
             return emptyMap()
         }
 
-        val activities = queryList(RealmOfflineActivity::class.java) {
-            equalTo("userId", userId)
-            between("loginTime", startMillis, endMillis)
-        }
+        val activities = offlineActivityDao.getByUserIdAndLoginTimeBetween(userId, startMillis, endMillis)
 
         if (activities.isEmpty()) {
             return emptyMap()

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -160,7 +160,7 @@ class UploadManager @Inject constructor(
     }
 
     private suspend fun uploadCourseProgress() {
-        uploadCoordinator.upload(uploadConfigs.CourseProgress)
+        uploadCoordinator.uploadRoom(uploadConfigs.CourseProgress)
     }
 
     suspend fun uploadFeedback(): Boolean {

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -408,7 +408,7 @@ class UploadManager @Inject constructor(
     }
 
     suspend fun uploadTeamActivities() {
-        uploadCoordinator.upload(uploadConfigs.TeamActivities)
+        uploadCoordinator.uploadRoom(uploadConfigs.TeamActivities)
     }
 
     suspend fun uploadRating() {

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -256,13 +256,15 @@ class TransactionSyncManager @Inject constructor(
                     "tags" -> timedBatchInsert(table, arr.size()) {
                         tagsRepository.insert(extractDocs(arr))
                     }
+                    "team_activities" -> timedBatchInsert(table, arr.size()) {
+                        teamsSyncRepository.get().bulkInsertTeamActivitiesFromSync(arr)
+                    }
                     else -> {
                         // Use async transaction to avoid blocking (ANR-safe)
                         executeTransaction { mRealm: Realm ->
                             val insertStartTime = SystemClock.elapsedRealtime()
                             when (table) {
                                 "exams" -> surveysRepository.bulkInsertExamsFromSync(mRealm, arr)
-                                "team_activities" -> teamsSyncRepository.get().bulkInsertTeamActivitiesFromSync(mRealm, arr)
                                 "submissions" -> submissionsRepository.bulkInsertFromSync(mRealm, arr)
                                 "courses" -> coursesRepository.bulkInsertFromSync(mRealm, arr)
                                 "achievements" -> userSyncRepository.bulkInsertAchievementsFromSync(mRealm, arr)

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -6,6 +6,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.NewsLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
@@ -54,6 +55,7 @@ class UploadConfigs @Inject constructor(
     private val apkLogDao: ApkLogDao,
     private val searchActivityDao: SearchActivityDao,
     private val courseActivityDao: CourseActivityDao,
+    private val courseProgressDao: CourseProgressDao,
     private val resourceActivityDao: ResourceActivityDao,
     private val submitPhotosDao: SubmitPhotosDao,
     private val newsLogDao: NewsLogDao,
@@ -72,14 +74,17 @@ class UploadConfigs @Inject constructor(
         }
     )
 
-    val CourseProgress = UploadConfig(
-        modelClass = RealmCourseProgress::class,
+    val CourseProgress = RoomUploadConfig(
         endpoint = "courses_progress",
-        queryBuilder = { query -> query.isNull("_id") },
-        filterGuests = true,
-        guestUserIdExtractor = { it.userId },
+        modelClassName = "RealmCourseProgress",
+        fetchPendingItems = { courseProgressDao.getPendingUploads() },
         serializer = UploadSerializer.Simple(RealmCourseProgress::serializeProgress),
-        idExtractor = { it.id }
+        idExtractor = { it.id },
+        markUploaded = { results ->
+            results.filter { result ->
+                courseProgressDao.markUploaded(result.localId, result.remoteId, result.remoteRev) == 0
+            }
+        }
     )
 
     val TeamTask = UploadConfig(

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -10,6 +10,7 @@ import org.ole.planet.myplanet.data.room.dao.NewsLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
+import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmCourseProgress
@@ -55,7 +56,8 @@ class UploadConfigs @Inject constructor(
     private val courseActivityDao: CourseActivityDao,
     private val resourceActivityDao: ResourceActivityDao,
     private val submitPhotosDao: SubmitPhotosDao,
-    private val newsLogDao: NewsLogDao
+    private val newsLogDao: NewsLogDao,
+    private val teamLogDao: TeamLogDao
 ) {
     val NewsActivities = RoomUploadConfig(
         endpoint = "myplanet_activities",
@@ -95,12 +97,17 @@ class UploadConfigs @Inject constructor(
         idExtractor = { it.id }
     )
 
-    val TeamActivities = UploadConfig(
-        modelClass = RealmTeamLog::class,
+    val TeamActivities = RoomUploadConfig(
         endpoint = "team_activities",
-        queryBuilder = { query -> query.isNull("_rev") },
+        modelClassName = "RealmTeamLog",
+        fetchPendingItems = { teamLogDao.getPendingUploads() },
         serializer = UploadSerializer.WithContext { log, context -> teamsSyncRepository.get().serializeTeamActivities(log, context) },
-        idExtractor = { it.id }
+        idExtractor = { it.id },
+        markUploaded = { results ->
+            results.filter { result ->
+                teamLogDao.markUploaded(result.localId, result.remoteId, result.remoteRev) == 0
+            }
+        }
     )
 
     val SearchActivity = RoomUploadConfig(

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmRemovedLogTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmRemovedLogTest.kt
@@ -1,181 +1,21 @@
 package org.ole.planet.myplanet.model
 
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
-import io.realm.Realm
-import io.realm.RealmQuery
-import io.realm.RealmResults
-import org.junit.Assert.assertThrows
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class RealmRemovedLogTest {
-
     @Test
-    fun testOnAddThrowsExceptionAndCancelsTransaction() {
-        val mockRealm = mockk<Realm>(relaxed = true)
-        val mockQuery = mockk<RealmQuery<RealmRemovedLog>>()
-        val mockResults = mockk<RealmResults<RealmRemovedLog>>()
-
-        // First call: false (not in transaction), Second call: true (in catch block, so cancelTransaction is called)
-        every { mockRealm.isInTransaction } returnsMany listOf(false, true)
-
-        every { mockRealm.where(RealmRemovedLog::class.java) } returns mockQuery
-        every { mockQuery.equalTo("type", any<String>()) } returns mockQuery
-        every { mockQuery.equalTo("userId", any<String>()) } returns mockQuery
-        every { mockQuery.equalTo("docId", any<String>()) } returns mockQuery
-        every { mockQuery.findAll() } returns mockResults
-
-        val expectedException = RuntimeException("Test Exception")
-        every { mockResults.deleteAllFromRealm() } throws expectedException
-
-        val exception = assertThrows(RuntimeException::class.java) {
-            RealmRemovedLog.onAdd(mockRealm, "testType", "testUserId", "testDocId")
+    fun `removed log stores resource removal data`() {
+        val log = RealmRemovedLog().apply {
+            id = "log1"
+            type = "resources"
+            userId = "user1"
+            docId = "resource1"
         }
 
-        assert(exception == expectedException)
-
-        verify(exactly = 1) { mockRealm.beginTransaction() }
-        verify(exactly = 1) { mockRealm.cancelTransaction() }
-        verify(exactly = 0) { mockRealm.commitTransaction() }
-    }
-
-    @Test
-    fun testOnAddCommitsOnSuccess() {
-        val mockRealm = mockk<Realm>(relaxed = true)
-        val mockQuery = mockk<RealmQuery<RealmRemovedLog>>()
-        val mockResults = mockk<RealmResults<RealmRemovedLog>>()
-
-        every { mockRealm.isInTransaction } returns false // Trigger startedTransaction = true
-
-        every { mockRealm.where(RealmRemovedLog::class.java) } returns mockQuery
-        every { mockQuery.equalTo("type", any<String>()) } returns mockQuery
-        every { mockQuery.equalTo("userId", any<String>()) } returns mockQuery
-        every { mockQuery.equalTo("docId", any<String>()) } returns mockQuery
-        every { mockQuery.findAll() } returns mockResults
-
-        every { mockResults.deleteAllFromRealm() } returns true
-
-        RealmRemovedLog.onAdd(mockRealm, "testType", "testUserId", "testDocId")
-
-        verify(exactly = 1) { mockRealm.beginTransaction() }
-        verify(exactly = 1) { mockRealm.commitTransaction() }
-        verify(exactly = 0) { mockRealm.cancelTransaction() }
-    }
-
-    @Test
-    fun testOnAddDoesNotManageTransactionIfAlreadyInOne() {
-        val mockRealm = mockk<Realm>(relaxed = true)
-        val mockQuery = mockk<RealmQuery<RealmRemovedLog>>()
-        val mockResults = mockk<RealmResults<RealmRemovedLog>>()
-
-        every { mockRealm.isInTransaction } returns true // Trigger startedTransaction = false
-
-        every { mockRealm.where(RealmRemovedLog::class.java) } returns mockQuery
-        every { mockQuery.equalTo("type", any<String>()) } returns mockQuery
-        every { mockQuery.equalTo("userId", any<String>()) } returns mockQuery
-        every { mockQuery.equalTo("docId", any<String>()) } returns mockQuery
-        every { mockQuery.findAll() } returns mockResults
-
-        every { mockResults.deleteAllFromRealm() } returns true
-
-        RealmRemovedLog.onAdd(mockRealm, "testType", "testUserId", "testDocId")
-
-        verify(exactly = 0) { mockRealm.beginTransaction() }
-        verify(exactly = 0) { mockRealm.commitTransaction() }
-        verify(exactly = 0) { mockRealm.cancelTransaction() }
-    }
-
-    @Test
-    fun testOnRemoveThrowsExceptionAndCancelsTransaction() {
-        val mockRealm = mockk<Realm>(relaxed = true)
-
-        // First call: false (not in transaction), Second call: true (in catch block)
-        every { mockRealm.isInTransaction } returnsMany listOf(false, true)
-
-        val expectedException = RuntimeException("Test Exception")
-        every { mockRealm.createObject(RealmRemovedLog::class.java, any<String>()) } throws expectedException
-
-        val exception = assertThrows(RuntimeException::class.java) {
-            RealmRemovedLog.onRemove(mockRealm, "testType", "testUserId", "testDocId")
-        }
-
-        assert(exception == expectedException)
-
-        verify(exactly = 1) { mockRealm.beginTransaction() }
-        verify(exactly = 1) { mockRealm.cancelTransaction() }
-        verify(exactly = 0) { mockRealm.commitTransaction() }
-    }
-
-    @Test
-    fun testOnRemoveCommitsOnSuccess() {
-        val mockRealm = mockk<Realm>(relaxed = true)
-        val mockLog = mockk<RealmRemovedLog>(relaxed = true)
-
-        every { mockRealm.isInTransaction } returns false // Trigger startedTransaction = true
-        every { mockRealm.createObject(RealmRemovedLog::class.java, any<String>()) } returns mockLog
-
-        RealmRemovedLog.onRemove(mockRealm, "testType", "testUserId", "testDocId")
-
-        verify(exactly = 1) { mockRealm.beginTransaction() }
-        verify(exactly = 1) { mockRealm.commitTransaction() }
-        verify(exactly = 0) { mockRealm.cancelTransaction() }
-        verify(exactly = 1) { mockLog.docId = "testDocId" }
-        verify(exactly = 1) { mockLog.userId = "testUserId" }
-        verify(exactly = 1) { mockLog.type = "testType" }
-    }
-
-    @Test
-    fun testOnRemoveDoesNotManageTransactionIfAlreadyInOne() {
-        val mockRealm = mockk<Realm>(relaxed = true)
-        val mockLog = mockk<RealmRemovedLog>(relaxed = true)
-
-        every { mockRealm.isInTransaction } returns true // Trigger startedTransaction = false
-        every { mockRealm.createObject(RealmRemovedLog::class.java, any<String>()) } returns mockLog
-
-        RealmRemovedLog.onRemove(mockRealm, "testType", "testUserId", "testDocId")
-
-        verify(exactly = 0) { mockRealm.beginTransaction() }
-        verify(exactly = 0) { mockRealm.commitTransaction() }
-        verify(exactly = 0) { mockRealm.cancelTransaction() }
-        verify(exactly = 1) { mockLog.docId = "testDocId" }
-        verify(exactly = 1) { mockLog.userId = "testUserId" }
-        verify(exactly = 1) { mockLog.type = "testType" }
-    }
-
-    @Test
-    fun testOnRemove_throwsException_cancelsTransaction() {
-        val realm = mockk<Realm>(relaxed = true)
-
-        // Initial state: not in a transaction
-        every { realm.isInTransaction } returns false andThen true
-
-        // Throw an exception when trying to create the object
-        every { realm.createObject(RealmRemovedLog::class.java, any<String>()) } throws RuntimeException("Test Exception")
-
-        assertThrows(RuntimeException::class.java) {
-            RealmRemovedLog.onRemove(realm, "testType", "testUserId", "testDocId")
-        }
-
-        // Verify that cancelTransaction was called because we started the transaction and were in it when the exception occurred
-        verify(exactly = 1) { realm.cancelTransaction() }
-    }
-
-    @Test
-    fun testOnRemove_throwsException_doesNotCancelTransactionIfAlreadyInTransaction() {
-        val realm = mockk<Realm>(relaxed = true)
-
-        // Initial state: already in a transaction
-        every { realm.isInTransaction } returns true
-
-        // Throw an exception when trying to create the object
-        every { realm.createObject(RealmRemovedLog::class.java, any<String>()) } throws RuntimeException("Test Exception")
-
-        assertThrows(RuntimeException::class.java) {
-            RealmRemovedLog.onRemove(realm, "testType", "testUserId", "testDocId")
-        }
-
-        // Verify that cancelTransaction was NOT called because we didn't start the transaction
-        verify(exactly = 0) { realm.cancelTransaction() }
+        assertEquals("log1", log.id)
+        assertEquals("resources", log.type)
+        assertEquals("user1", log.userId)
+        assertEquals("resource1", log.docId)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -64,7 +64,8 @@ class CoursesRepositoryImplTest {
             mockk(relaxed = true),
             mockk(relaxed = true),
             searchActivityDao,
-            courseProgressDao
+            courseProgressDao,
+            mockk(relaxed = true)
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -18,6 +18,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmSearchActivity
@@ -36,6 +37,7 @@ class CoursesRepositoryImplTest {
     private val ratingsRepository: RatingsRepository = mockk(relaxed = true)
     private val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
     private val searchActivityDao: SearchActivityDao = mockk(relaxed = true)
+    private val courseProgressDao: CourseProgressDao = mockk(relaxed = true)
 
     private val mockRealm: Realm = mockk(relaxed = true)
     private lateinit var repository: CoursesRepositoryImpl
@@ -61,7 +63,8 @@ class CoursesRepositoryImplTest {
             sharedPrefManager,
             mockk(relaxed = true),
             mockk(relaxed = true),
-            searchActivityDao
+            searchActivityDao,
+            courseProgressDao
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
@@ -3,11 +3,11 @@ package org.ole.planet.myplanet.repository
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.unmockkAll
-import io.mockk.verify
 import io.realm.RealmQuery
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -20,6 +20,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
@@ -38,6 +39,7 @@ class ProgressRepositoryImplTest {
     private val testScope = TestScope(testDispatcher)
     private val databaseService: DatabaseService = mockk(relaxed = true)
     private lateinit var mockCoursesRepository: CoursesRepository
+    private val courseProgressDao: CourseProgressDao = mockk(relaxed = true)
 
     @Before
     fun setUp() {
@@ -49,7 +51,8 @@ class ProgressRepositoryImplTest {
             UnconfinedTestDispatcher(),
             dispatcherProvider,
             { mockCoursesRepository },
-            { mockk(relaxed = true) }
+            { mockk(relaxed = true) },
+            courseProgressDao
         ), recordPrivateCalls = true)
     }
 
@@ -74,9 +77,7 @@ class ProgressRepositoryImplTest {
             RealmCourseStep().apply { id = "step2" }
         )
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseProgress::class.java, any<Function1<RealmQuery<RealmCourseProgress>, Unit>>())
-        } returns emptyList<RealmCourseProgress>()
+        coEvery { courseProgressDao.getByUserAndCourse("user1", "course1") } returns emptyList()
 
         val progress = repository.getCurrentProgress(steps, "user1", "course1")
         advanceUntilIdle()
@@ -98,9 +99,7 @@ class ProgressRepositoryImplTest {
             RealmCourseProgress().apply { stepNum = 3 }
         )
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseProgress::class.java, any<Function1<RealmQuery<RealmCourseProgress>, Unit>>())
-        } returns progresses
+        coEvery { courseProgressDao.getByUserAndCourse("user1", "course1") } returns progresses
 
         var progress = repository.getCurrentProgress(steps, "user1", "course1")
         advanceUntilIdle()
@@ -113,9 +112,7 @@ class ProgressRepositoryImplTest {
             RealmCourseProgress().apply { stepNum = 3 }
         )
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseProgress::class.java, any<Function1<RealmQuery<RealmCourseProgress>, Unit>>())
-        } returns progresses2
+        coEvery { courseProgressDao.getByUserAndCourse("user1", "course1") } returns progresses2
 
         progress = repository.getCurrentProgress(steps, "user1", "course1")
         advanceUntilIdle()
@@ -134,9 +131,7 @@ class ProgressRepositoryImplTest {
             RealmCourseProgress().apply { stepNum = 2 }
         )
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseProgress::class.java, any<Function1<RealmQuery<RealmCourseProgress>, Unit>>())
-        } returns progresses
+        coEvery { courseProgressDao.getByUserAndCourse("user1", "course1") } returns progresses
 
         val progress = repository.getCurrentProgress(steps, "user1", "course1")
         advanceUntilIdle()
@@ -192,9 +187,7 @@ class ProgressRepositoryImplTest {
             repository invoke "queryList" withArguments listOf(RealmCourseStep::class.java, any<Function1<RealmQuery<RealmCourseStep>, Unit>>())
         } returns steps
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseProgress::class.java, any<Function1<RealmQuery<RealmCourseProgress>, Unit>>())
-        } returns listOf(RealmCourseProgress().apply {
+        coEvery { courseProgressDao.getByUserAndCourseIds("user1", listOf("course1")) } returns listOf(RealmCourseProgress().apply {
             stepNum = 1
             courseId = "course1"
         })
@@ -245,9 +238,7 @@ class ProgressRepositoryImplTest {
             repository invoke "queryList" withArguments listOf(RealmCourseStep::class.java, any<Function1<RealmQuery<RealmCourseStep>, Unit>>())
         } returns steps1 + steps2
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseProgress::class.java, any<Function1<RealmQuery<RealmCourseProgress>, Unit>>())
-        } returns progresses1
+        coEvery { courseProgressDao.getByUserAndCourseIds("user1", courseIds) } returns progresses1
 
         val result = repository.getCourseProgress(courseIds, "user1")
         advanceUntilIdle()
@@ -267,9 +258,7 @@ class ProgressRepositoryImplTest {
             RealmCourseProgress().apply { userId = "user1"; courseId = "course2" }
         )
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseProgress::class.java, any<Function1<RealmQuery<RealmCourseProgress>, Unit>>())
-        } returns progresses
+        coEvery { courseProgressDao.getByUser("user1") } returns progresses
 
         val result = repository.getProgressRecords("user1")
         advanceUntilIdle()
@@ -299,9 +288,7 @@ class ProgressRepositoryImplTest {
         )
 
         coEvery { mockCoursesRepository.getMyCourses("user1") } returns myCourses
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseProgress::class.java, any<Function1<RealmQuery<RealmCourseProgress>, Unit>>())
-        } returns progresses
+        coEvery { courseProgressDao.getByUser("user1") } returns progresses
 
         val result = repository.getCompletedCourses("user1")
         advanceUntilIdle()
@@ -319,7 +306,8 @@ class ProgressRepositoryImplTest {
             UnconfinedTestDispatcher(),
             dispatcherProvider,
             { mockCoursesRepository },
-            { activitiesRepo }
+            { activitiesRepo },
+            courseProgressDao
         )
 
         coEvery { activitiesRepo.hasUserCompletedSync("user1") } returns true
@@ -339,42 +327,25 @@ class ProgressRepositoryImplTest {
 
     @Test
     fun testSaveCourseProgress() = testScope.runTest {
-        val mockProgress = RealmCourseProgress()
-
-        coEvery {
-            repository invoke "executeTransaction" withArguments listOf(any<Function1<io.realm.Realm, Unit>>())
-        } answers {
-            val transaction = firstArg<Function1<io.realm.Realm, Unit>>()
-            val mockRealm = mockk<io.realm.Realm>(relaxed = true)
-            val mockQuery = mockk<RealmQuery<RealmCourseProgress>>(relaxed = true)
-            every { mockRealm.where(RealmCourseProgress::class.java) } returns mockQuery
-            every { mockQuery.equalTo(any<String>(), any<String>()) } returns mockQuery
-            every { mockQuery.equalTo(any<String>(), any<Int>()) } returns mockQuery
-            every { mockQuery.findFirst() } returns null
-
-            every { mockRealm.createObject(RealmCourseProgress::class.java, any<String>()) } returns mockProgress
-
-            transaction.invoke(mockRealm)
-        }
+        coEvery { courseProgressDao.findByCourseUserAndStep("course1", "user1", 1) } returns null
 
         repository.saveCourseProgress("user1", "planet1", "parent1", "course1", 1, true)
         advanceUntilIdle()
 
-        io.mockk.coVerify { repository invoke "executeTransaction" withArguments listOf(any<Function1<io.realm.Realm, Unit>>()) }
-
-        assertEquals("course1", mockProgress.courseId)
-        assertEquals("user1", mockProgress.userId)
-        assertEquals(1, mockProgress.stepNum)
-        assertEquals(true, mockProgress.passed)
-        assertEquals("planet1", mockProgress.createdOn)
-        assertEquals("parent1", mockProgress.parentCode)
+        coVerify {
+            courseProgressDao.upsert(match { progress ->
+                progress.courseId == "course1" &&
+                    progress.userId == "user1" &&
+                    progress.stepNum == 1 &&
+                    progress.passed &&
+                    progress.createdOn == "planet1" &&
+                    progress.parentCode == "parent1"
+            })
+        }
     }
 
     @Test
     fun testInsertCourseProgressFromSync() = testScope.runTest {
-        val mockRealm = mockk<io.realm.Realm>(relaxed = true)
-        val jsonArray = JsonArray()
-
         val doc1 = JsonObject().apply {
             addProperty("_id", "doc1")
             addProperty("courseId", "course1")
@@ -382,42 +353,26 @@ class ProgressRepositoryImplTest {
             addProperty("stepNum", 1)
             addProperty("passed", true)
         }
-
-        val mockQuery = mockk<io.realm.RealmQuery<RealmCourseProgress>>(relaxed = true)
-        val mockResults = mockk<io.realm.RealmResults<RealmCourseProgress>>(relaxed = true)
-
-        every { mockRealm.where(RealmCourseProgress::class.java) } returns mockQuery
-        every { mockRealm.copyFromRealm(any<io.realm.RealmResults<RealmCourseProgress>>()) } answers { firstArg<io.realm.RealmResults<RealmCourseProgress>>().toList() }
-        every { mockQuery.`in`(any<String>(), any<Array<String>>()) } returns mockQuery
-        every { mockQuery.`in`(any<String>(), any<Array<Int>>()) } returns mockQuery
-        every { mockQuery.findAll() } returns mockResults
-        every { mockResults.iterator() } returns mutableListOf<RealmCourseProgress>().iterator()
-
-        val mockProgress = RealmCourseProgress()
-        every { mockRealm.createObject(RealmCourseProgress::class.java, any<String>()) } returns mockProgress
-
-        coEvery { repository invoke "executeTransaction" withArguments listOf(any<Function1<io.realm.Realm, Unit>>()) } answers {
-            val transaction = args[0] as Function1<io.realm.Realm, Unit>
-            transaction.invoke(mockRealm)
-        }
+        coEvery { courseProgressDao.getByIds(listOf("doc1")) } returns emptyList()
+        coEvery { courseProgressDao.getByCourseUsersAndSteps(listOf("course1"), listOf("user1"), listOf(1)) } returns emptyList()
 
         repository.insertCourseProgressFromSync(listOf(doc1))
 
-        verify { mockRealm.where(RealmCourseProgress::class.java) }
-        verify { mockRealm.createObject(RealmCourseProgress::class.java, "doc1") }
-
-        assertEquals("doc1", mockProgress._id)
-        assertEquals("course1", mockProgress.courseId)
-        assertEquals("user1", mockProgress.userId)
-        assertEquals(1, mockProgress.stepNum)
-        assertEquals(true, mockProgress.passed)
+        coVerify {
+            courseProgressDao.upsertAll(match { progress ->
+                progress.size == 1 &&
+                    progress.first().id == "doc1" &&
+                    progress.first()._id == "doc1" &&
+                    progress.first().courseId == "course1" &&
+                    progress.first().userId == "user1" &&
+                    progress.first().stepNum == 1 &&
+                    progress.first().passed
+            })
+        }
     }
 
     @Test
     fun testInsertCourseProgressFromSync_dedup() = testScope.runTest {
-        val mockRealm = mockk<io.realm.Realm>(relaxed = true)
-        val jsonArray = JsonArray()
-
         val doc1 = JsonObject().apply {
             addProperty("_id", "doc1")
             addProperty("courseId", "course1")
@@ -425,52 +380,28 @@ class ProgressRepositoryImplTest {
             addProperty("stepNum", 1)
             addProperty("passed", false)
         }
-
-        val mockQuery = mockk<io.realm.RealmQuery<RealmCourseProgress>>(relaxed = true)
-        val mockResults = mockk<io.realm.RealmResults<RealmCourseProgress>>(relaxed = true)
-
-        every { mockRealm.where(RealmCourseProgress::class.java) } returns mockQuery
-        every { mockQuery.`in`(any<String>(), any<Array<String>>()) } returns mockQuery
-        every { mockQuery.`in`(any<String>(), any<Array<Int>>()) } returns mockQuery
-        every { mockQuery.findAll() } returns mockResults
-
-        val existingProgress = mockk<RealmCourseProgress>(relaxed = true)
-        every { existingProgress._id } returns null
-        every { existingProgress.passed } returns true
-        every { existingProgress.courseId } returns "course1"
-        every { existingProgress.userId } returns "user1"
-        every { existingProgress.stepNum } returns 1
-        every { existingProgress.isValid } returns true
-
-        // For the first query (ID lookup), return empty list. For the second (local records lookup), return the existing record.
-        val emptyResults = mockk<io.realm.RealmResults<RealmCourseProgress>>(relaxed = true)
-        every { emptyResults.iterator() } returns mutableListOf<RealmCourseProgress>().iterator()
-
-        val localResults = mockk<io.realm.RealmResults<RealmCourseProgress>>(relaxed = true)
-        every { localResults.iterator() } returns mutableListOf(existingProgress).iterator()
-
-        every { mockQuery.findAll() } returnsMany listOf(emptyResults, localResults)
-        every { mockRealm.copyFromRealm(emptyResults) } returns emptyList()
-        every { mockRealm.copyFromRealm(localResults) } returns listOf(existingProgress)
-
-        val mockProgress = RealmCourseProgress()
-        every { mockRealm.createObject(RealmCourseProgress::class.java, any<String>()) } returns mockProgress
-
-        coEvery { repository invoke "executeTransaction" withArguments listOf(any<Function1<io.realm.Realm, Unit>>()) } answers {
-            val transaction = args[0] as Function1<io.realm.Realm, Unit>
-            transaction.invoke(mockRealm)
+        val existingProgress = RealmCourseProgress().apply {
+            id = "local1"
+            _id = null
+            passed = true
+            courseId = "course1"
+            userId = "user1"
+            stepNum = 1
         }
+        coEvery { courseProgressDao.getByIds(listOf("doc1")) } returns emptyList()
+        coEvery { courseProgressDao.getByCourseUsersAndSteps(listOf("course1"), listOf("user1"), listOf(1)) } returns listOf(existingProgress)
 
         repository.insertCourseProgressFromSync(listOf(doc1))
 
-        verify { existingProgress.deleteFromRealm() }
-        verify { mockRealm.createObject(RealmCourseProgress::class.java, "doc1") }
-
-        assertEquals("doc1", mockProgress._id)
-        assertEquals(true, mockProgress.passed) // Should preserve local true despite remote false
+        coVerify {
+            courseProgressDao.upsertAll(match { progress ->
+                progress.size == 1 &&
+                    progress.first().id == "doc1" &&
+                    progress.first()._id == "doc1" &&
+                    progress.first().passed
+            })
+        }
     }
-
-
 
     @Test
     fun testGetCompletedCourses_nullSteps() = testScope.runTest {
@@ -487,9 +418,7 @@ class ProgressRepositoryImplTest {
         )
 
         coEvery { mockCoursesRepository.getMyCourses("user1") } returns myCourses
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseProgress::class.java, any<Function1<RealmQuery<RealmCourseProgress>, Unit>>())
-        } returns progresses
+        coEvery { courseProgressDao.getByUser("user1") } returns progresses
 
         val result = repository.getCompletedCourses("user1")
         advanceUntilIdle()

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -75,6 +75,7 @@ class ResourcesRepositoryImplTest {
             tagsRepository,
             searchActivityDao,
             resourceActivityDao,
+            mockk(relaxed = true),
             teamsRepositoryLazy,
             teamsSyncRepositoryLazy
         )

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
@@ -6,10 +6,8 @@ import com.google.gson.JsonObject
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.coVerify
 import io.realm.Realm
-import io.realm.RealmQuery
-import io.realm.RealmResults
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -18,6 +16,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UploadManager
@@ -41,6 +40,7 @@ class TeamsRepositoryBenchmarkTest {
     private val userRepository: UserRepository = mockk(relaxed = true)
     private val resourcesRepositoryLazy: dagger.Lazy<ResourcesRepository> = mockk()
     private val realm: Realm = mockk(relaxed = true)
+    private val teamLogDao: TeamLogDao = mockk(relaxed = true)
 
     private val testDispatcher = StandardTestDispatcher()
 
@@ -70,7 +70,8 @@ class TeamsRepositoryBenchmarkTest {
             dispatcherProvider,
             userRepository,
             resourcesRepositoryLazy,
-            TestTimeProvider()
+            TestTimeProvider(),
+            teamLogDao
         )
     }
 
@@ -83,19 +84,9 @@ class TeamsRepositoryBenchmarkTest {
             }
         }
 
-        val query: RealmQuery<RealmTeamLog> = mockk(relaxed = true)
-        val results: RealmResults<RealmTeamLog> = mockk(relaxed = true)
-
-        every { realm.where(RealmTeamLog::class.java) } returns query
-        every { query.`in`(any<String>(), any<Array<String>>()) } returns query
-        every { query.findAll() } returns results
-        every { results.iterator() } returns mutableListOf<RealmTeamLog>().iterator()
-
-        every { realm.createObject(RealmTeamLog::class.java, any()) } returns RealmTeamLog()
-
         teamsRepository.insertTeamLogs(logs)
 
-        verify(exactly = 1) { realm.where(RealmTeamLog::class.java) }
+        coVerify(exactly = 1) { teamLogDao.upsertAll(match { it.size == 100 && it.first().id == "id_1" }) }
     }
 
     @Test
@@ -105,23 +96,8 @@ class TeamsRepositoryBenchmarkTest {
             JsonObject().apply { addProperty("_id", "dup_id"); addProperty("_rev", "rev2") }
         )
 
-        val query: RealmQuery<RealmTeamLog> = mockk(relaxed = true)
-        val results: RealmResults<RealmTeamLog> = mockk(relaxed = true)
-
-        every { realm.where(RealmTeamLog::class.java) } returns query
-        every { query.`in`(any<String>(), any<Array<String>>()) } returns query
-        every { query.findAll() } returns results
-        every { results.iterator() } returns mutableListOf<RealmTeamLog>().iterator()
-
-        // We now use bulk inserts with unmanaged objects, so createObject is not called.
-        // Instead, we just verify it runs without throwing.
-        every { realm.insert(any<List<RealmTeamLog>>()) } returns Unit
-
         teamsRepository.insertTeamLogs(logs)
 
-        // Verify that createObject is never called anymore
-        verify(exactly = 0) { realm.createObject(RealmTeamLog::class.java, "dup_id") }
-        // Verify bulk insert is called
-        verify(exactly = 1) { realm.insert(any<List<RealmTeamLog>>()) }
+        coVerify(exactly = 1) { teamLogDao.upsertAll(match { it.size == 2 && it.all { log -> log.id == "dup_id" } }) }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
@@ -19,6 +19,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.User
@@ -43,6 +44,7 @@ class TeamsRepositoryImplTest {
     private val serverUrlMapper: ServerUrlMapper = mockk(relaxed = true)
     private val dispatcherProvider: DispatcherProvider = mockk()
     private val apiInterfaceMock = mockk<ApiInterface>(relaxed = true)
+    private val teamLogDao: TeamLogDao = mockk(relaxed = true)
 
     private val testDispatcher = StandardTestDispatcher()
 
@@ -77,7 +79,8 @@ class TeamsRepositoryImplTest {
             dispatcherProvider,
             mockUserRepository,
             mockk(),
-            TestTimeProvider()
+            TestTimeProvider(),
+            teamLogDao
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
@@ -32,6 +32,7 @@ class UserRepositoryBulkInsertTest {
             mockk(relaxed = true),
             mockk(relaxed = true),
             mockk(relaxed = true),
+            mockk(relaxed = true),
             mockk(relaxed = true)
         )
         val realm = mockk<Realm>(relaxed = true)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
@@ -33,6 +33,7 @@ class UserRepositoryBulkInsertTest {
             mockk(relaxed = true),
             mockk(relaxed = true),
             mockk(relaxed = true),
+            mockk(relaxed = true),
             mockk(relaxed = true)
         )
         val realm = mockk<Realm>(relaxed = true)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
@@ -102,6 +102,7 @@ class UserRepositoryImplTest {
             appScope,
             dispatcherProvider,
             activitiesRepositoryLazy,
+            mockk(relaxed = true),
             mockk(relaxed = true)
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
@@ -103,6 +103,7 @@ class UserRepositoryImplTest {
             dispatcherProvider,
             activitiesRepositoryLazy,
             mockk(relaxed = true),
+            mockk(relaxed = true),
             mockk(relaxed = true)
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -14,6 +14,7 @@ import org.ole.planet.myplanet.data.room.dao.NewsLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
+import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmNewsLog
 import org.ole.planet.myplanet.model.RealmResourceActivity
@@ -27,6 +28,7 @@ class UploadConfigsTest {
     private val newsLogDao: NewsLogDao = mockk(relaxed = true)
     private val resourceActivityDao: ResourceActivityDao = mockk(relaxed = true)
     private val submitPhotosDao: SubmitPhotosDao = mockk(relaxed = true)
+    private val teamLogDao: TeamLogDao = mockk(relaxed = true)
     private val uploadConfigs = UploadConfigs(
         voicesRepository = mockk(relaxed = true),
         submissionsRepository = mockk(relaxed = true),
@@ -43,7 +45,8 @@ class UploadConfigsTest {
         courseActivityDao = courseActivityDao,
         resourceActivityDao = resourceActivityDao,
         submitPhotosDao = submitPhotosDao,
-        newsLogDao = newsLogDao
+        newsLogDao = newsLogDao,
+        teamLogDao = teamLogDao
     )
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -10,6 +10,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
+import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.NewsLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
@@ -25,6 +26,7 @@ import org.ole.planet.myplanet.repository.UploadedItemResult
 class UploadConfigsTest {
     private val searchActivityDao: SearchActivityDao = mockk(relaxed = true)
     private val courseActivityDao: CourseActivityDao = mockk(relaxed = true)
+    private val courseProgressDao: CourseProgressDao = mockk(relaxed = true)
     private val newsLogDao: NewsLogDao = mockk(relaxed = true)
     private val resourceActivityDao: ResourceActivityDao = mockk(relaxed = true)
     private val submitPhotosDao: SubmitPhotosDao = mockk(relaxed = true)
@@ -43,6 +45,7 @@ class UploadConfigsTest {
         apkLogDao = mockk<ApkLogDao>(relaxed = true),
         searchActivityDao = searchActivityDao,
         courseActivityDao = courseActivityDao,
+        courseProgressDao = courseProgressDao,
         resourceActivityDao = resourceActivityDao,
         submitPhotosDao = submitPhotosDao,
         newsLogDao = newsLogDao,

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -171,6 +171,10 @@ wired through `di/RoomModule`.
       now a Room `@Entity`; `TeamLogDao` owns visit counts, last-visit lookups, sync upserts,
       pending uploads, and upload acknowledgements; team activity sync now runs outside the legacy
       Realm transaction path and upload config uses `RoomUploadConfig`.
+- [x] **OfflineActivity / login activities** migrated (custom uploaded + synced login log).
+      `RealmOfflineActivity` is now a Room `@Entity`; `OfflineActivityDao` owns offline login
+      counts/flows, last-login lookups, pending upload reads, upload acknowledgements, and sync
+      upserts with the existing `_id` plus `loginTime`/`user` fallback dedupe behavior.
 - [ ] Migrate the remaining ~9 uploadable models to `RoomUploadConfig` + the synced-only domains.
 - [ ] Remaining ~32 model domains.
 - [ ] Migrate 39 Realm-based test files.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -179,8 +179,11 @@ wired through `di/RoomModule`.
       now a Room `@Entity`; `CourseProgressDao` owns user/course progress reads, completion
       records, save/update paths, pending upload reads, upload acknowledgements, and sync upserts
       that preserve locally-passed steps when server progress lags.
+- [x] **RemovedLog** migrated (local shelf tombstones). `RealmRemovedLog` is now a Room
+      `@Entity`; `RemovedLogDao` owns add/remove tombstone writes, bulk cleanup when resources or
+      courses are re-added, and shelf merge filtering for removed resources/courses.
 - [ ] Migrate the remaining ~8 uploadable models to `RoomUploadConfig` + the synced-only domains.
-- [ ] Remaining ~32 model domains.
+- [ ] Remaining ~31 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.
 

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -175,7 +175,11 @@ wired through `di/RoomModule`.
       `RealmOfflineActivity` is now a Room `@Entity`; `OfflineActivityDao` owns offline login
       counts/flows, last-login lookups, pending upload reads, upload acknowledgements, and sync
       upserts with the existing `_id` plus `loginTime`/`user` fallback dedupe behavior.
-- [ ] Migrate the remaining ~9 uploadable models to `RoomUploadConfig` + the synced-only domains.
+- [x] **CourseProgress** migrated (uploaded + synced progress records). `RealmCourseProgress` is
+      now a Room `@Entity`; `CourseProgressDao` owns user/course progress reads, completion
+      records, save/update paths, pending upload reads, upload acknowledgements, and sync upserts
+      that preserve locally-passed steps when server progress lags.
+- [ ] Migrate the remaining ~8 uploadable models to `RoomUploadConfig` + the synced-only domains.
 - [ ] Remaining ~32 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -167,7 +167,11 @@ wired through `di/RoomModule`.
 - [x] **NewsLog** migrated (uploaded-only activity log). `RealmNewsLog` is now a Room
       `@Entity`; `NewsLogDao` owns pending lookup, inserts, and upload acknowledgements; upload
       config uses `RoomUploadConfig`.
-- [ ] Migrate the remaining ~10 uploadable models to `RoomUploadConfig` + the synced-only domains.
+- [x] **TeamActivities / TeamLog** migrated (uploaded + synced team visit log). `RealmTeamLog` is
+      now a Room `@Entity`; `TeamLogDao` owns visit counts, last-visit lookups, sync upserts,
+      pending uploads, and upload acknowledgements; team activity sync now runs outside the legacy
+      Realm transaction path and upload config uses `RoomUploadConfig`.
+- [ ] Migrate the remaining ~9 uploadable models to `RoomUploadConfig` + the synced-only domains.
 - [ ] Remaining ~32 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.


### PR DESCRIPTION
### Motivation
- Move the team activity (team_activities / team visit) domain off Realm into Room as part of the broader Realm→Room migration and to make uploads/syncs database-agnostic. 
- Use Room DAOs for upload pending lookups and acknowledgements to reuse the existing `RoomUploadConfig`/`uploadRoom` path and avoid keeping upload logic tied to Realm runtime APIs.

### Description
- Converted `RealmTeamLog` from a Realm model to a Room `@Entity(tableName = "team_log")` with appropriate indexes and non-null `id` fields. 
- Added `TeamLogDao` providing pending-upload queries, recent-visit/team-visit queries, last-visit lookup, insert/upsert, and `markUploaded` update. 
- Wired the DAO into `AppDatabase` and `RoomModule`, and switched the `TeamActivities` upload config to a `RoomUploadConfig` that calls `teamLogDao.getPendingUploads()` and uses `teamLogDao.markUploaded(...)` for acknowledgements. 
- Reworked `TeamsRepositoryImpl` to use `TeamLogDao` for logging visits, recent counts, team-visit lookups, sync upserts and last-visit reads, and adjusted `TeamsSyncRepository`/`TransactionSyncManager` to call the new suspend `bulkInsertTeamActivitiesFromSync` path that upserts via the DAO. 
- Updated `UploadManager` to call the Room upload path for team activities and adapted unit tests to mock `TeamLogDao` instead of Realm operations, and updated the migration tracker docs to mark TeamActivities/TeamLog as migrated.

### Testing
- Ran `./gradlew compileDefaultDebugKotlin --no-daemon`, which completed successfully. 
- Ran `./gradlew testDefaultDebugUnitTest --no-daemon`, which compiled and executed unit tests but the suite failed in the CI environment during Robolectric / Maven artifact fetching with `java.net.SocketException` affecting multiple tests (34 failing tests); failures appear environment/network-related rather than compile-time errors. 
- Updated and re-ran the build after edits; compilation remains green for the modified Kotlin code (`compileDefaultDebugKotlin` successful) while test-suite instability is reported as above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ac206ea4c832b84a180a7dd72660e)