### PR TITLE
Migrate team tasks from Realm to Room

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -26,6 +26,7 @@ import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TagDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
+import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.model.RealmCertification
@@ -48,6 +49,7 @@ import org.ole.planet.myplanet.model.RealmSubmitPhotos
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmTeamNotification
 import org.ole.planet.myplanet.model.RealmTeamLog
+import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUserChallengeActions
 
 /**
@@ -82,6 +84,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmOfflineActivity::class,
         RealmCourseProgress::class,
         RealmRemovedLog::class,
+        RealmTeamTask::class,
     ],
     version = 1,
     exportSchema = false,
@@ -111,4 +114,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun offlineActivityDao(): OfflineActivityDao
     abstract fun courseProgressDao(): CourseProgressDao
     abstract fun removedLogDao(): RemovedLogDao
+    abstract fun teamTaskDao(): TeamTaskDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -14,6 +14,7 @@ import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
+import org.ole.planet.myplanet.data.room.dao.NotificationDao
 import org.ole.planet.myplanet.data.room.dao.NewsLogDao
 import org.ole.planet.myplanet.data.room.dao.OfflineActivityDao
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
@@ -39,6 +40,7 @@ import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.model.RealmNewsLog
+import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmRetryOperation
@@ -85,6 +87,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmCourseProgress::class,
         RealmRemovedLog::class,
         RealmTeamTask::class,
+        RealmNotification::class,
     ],
     version = 1,
     exportSchema = false,
@@ -115,4 +118,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun courseProgressDao(): CourseProgressDao
     abstract fun removedLogDao(): RemovedLogDao
     abstract fun teamTaskDao(): TeamTaskDao
+    abstract fun notificationDao(): NotificationDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -13,6 +13,7 @@ import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
+import org.ole.planet.myplanet.data.room.dao.HealthExaminationDao
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
 import org.ole.planet.myplanet.data.room.dao.NotificationDao
@@ -38,6 +39,7 @@ import org.ole.planet.myplanet.model.RealmCommunity
 import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.RealmHealthExamination
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyPersonal
@@ -91,6 +93,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmTeamTask::class,
         RealmNotification::class,
         RealmAchievement::class,
+        RealmHealthExamination::class,
     ],
     version = 1,
     exportSchema = false,
@@ -123,4 +126,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun teamTaskDao(): TeamTaskDao
     abstract fun notificationDao(): NotificationDao
     abstract fun achievementDao(): AchievementDao
+    abstract fun healthExaminationDao(): HealthExaminationDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.data.room
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import org.ole.planet.myplanet.data.room.dao.AchievementDao
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.data.room.dao.UserChallengeActionsDao
 import org.ole.planet.myplanet.data.room.dao.CertificationDao
@@ -29,6 +30,7 @@ import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
+import org.ole.planet.myplanet.model.RealmAchievement
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.model.RealmCertification
 import org.ole.planet.myplanet.model.RealmChatHistory
@@ -88,6 +90,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmRemovedLog::class,
         RealmTeamTask::class,
         RealmNotification::class,
+        RealmAchievement::class,
     ],
     version = 1,
     exportSchema = false,
@@ -119,4 +122,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun removedLogDao(): RemovedLogDao
     abstract fun teamTaskDao(): TeamTaskDao
     abstract fun notificationDao(): NotificationDao
+    abstract fun achievementDao(): AchievementDao
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/Converters.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/Converters.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.data.room
 
 import androidx.room.TypeConverter
 import com.google.gson.reflect.TypeToken
+import java.util.Date
 import org.ole.planet.myplanet.model.RealmConversation
 import org.ole.planet.myplanet.utils.JsonUtils
 
@@ -13,6 +14,16 @@ import org.ole.planet.myplanet.utils.JsonUtils
  * self-describing and survives the drop-and-resync migration away from Realm.
  */
 class Converters {
+    @TypeConverter
+    fun fromDate(value: Date?): Long? {
+        return value?.time
+    }
+
+    @TypeConverter
+    fun toDate(value: Long?): Date? {
+        return value?.let(::Date)
+    }
+
     @TypeConverter
     fun fromStringList(value: List<String>?): String? {
         return value?.let { JsonUtils.gson.toJson(it) }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/AchievementDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/AchievementDao.kt
@@ -1,0 +1,24 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import org.ole.planet.myplanet.model.RealmAchievement
+
+@Dao
+interface AchievementDao {
+    @Query("SELECT * FROM achievements WHERE _id = :id LIMIT 1")
+    suspend fun getById(id: String): RealmAchievement?
+
+    @Upsert
+    suspend fun upsert(achievement: RealmAchievement)
+
+    @Upsert
+    suspend fun upsertAll(achievements: List<RealmAchievement>)
+
+    @Query("SELECT * FROM achievements WHERE _id NOT LIKE 'guest%' AND isUpdated = 1")
+    suspend fun getPendingUploads(): List<RealmAchievement>
+
+    @Query("UPDATE achievements SET _rev = COALESCE(:rev, _rev), isUpdated = 0 WHERE _id = :id")
+    suspend fun markUploaded(id: String, rev: String?)
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/HealthExaminationDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/HealthExaminationDao.kt
@@ -1,0 +1,36 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import org.ole.planet.myplanet.model.RealmHealthExamination
+
+@Dao
+interface HealthExaminationDao {
+    @Query("SELECT * FROM health_examinations WHERE _id = :id OR userId = :id LIMIT 1")
+    suspend fun getByIdOrUserId(id: String): RealmHealthExamination?
+
+    @Query("SELECT * FROM health_examinations WHERE _id = :id LIMIT 1")
+    suspend fun getById(id: String): RealmHealthExamination?
+
+    @Query("SELECT * FROM health_examinations WHERE isUpdated = 1 AND userId != ''")
+    suspend fun getUpdated(): List<RealmHealthExamination>
+
+    @Query("SELECT * FROM health_examinations WHERE isUpdated = 1 AND userId = :userId")
+    suspend fun getUpdatedForUser(userId: String): List<RealmHealthExamination>
+
+    @Upsert
+    suspend fun upsert(examination: RealmHealthExamination)
+
+    @Upsert
+    suspend fun upsertAll(examinations: List<RealmHealthExamination>)
+
+    @Query("UPDATE health_examinations SET _rev = :rev, isUpdated = 0 WHERE _id = :id")
+    suspend fun markUploaded(id: String, rev: String?)
+
+    @Query("UPDATE health_examinations SET userId = :userId WHERE _id = :id")
+    suspend fun updateUserId(id: String, userId: String)
+
+    @Query("SELECT * FROM health_examinations WHERE profileId = :profileId")
+    suspend fun getByProfileId(profileId: String): List<RealmHealthExamination>
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NotificationDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NotificationDao.kt
@@ -1,0 +1,52 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import java.util.Date
+import org.ole.planet.myplanet.model.RealmNotification
+
+@Dao
+interface NotificationDao {
+    @Query("UPDATE notifications SET isRead = 1, needsSync = CASE WHEN isFromServer = 1 THEN 1 ELSE needsSync END WHERE userId = :userId AND type = :type AND isRead = 0")
+    suspend fun markSummaryAsRead(userId: String?, type: String): Int
+
+    @Query("UPDATE notifications SET isRead = 1, needsSync = CASE WHEN isFromServer = 1 THEN 1 ELSE needsSync END WHERE id = :notificationId")
+    suspend fun markAsRead(notificationId: String): Int
+
+    @Query("SELECT COUNT(*) FROM notifications WHERE (userId = :userId OR (:isAdmin = 1 AND userId = 'SYSTEM')) AND isRead = 0")
+    suspend fun getUnreadCount(userId: String, isAdmin: Boolean): Int
+
+    @Query("SELECT * FROM notifications WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): RealmNotification?
+
+    @Upsert
+    suspend fun upsert(notification: RealmNotification)
+
+    @Upsert
+    suspend fun upsertAll(notifications: List<RealmNotification>)
+
+    @Query("DELETE FROM notifications WHERE id = :id")
+    suspend fun deleteById(id: String): Int
+
+    @Query("SELECT * FROM notifications WHERE (userId = :userId OR (:isAdmin = 1 AND userId = 'SYSTEM')) AND message != 'INVALID' AND message != '' AND (:filter = '' OR (:filter = 'read' AND isRead = 1) OR (:filter = 'unread' AND isRead = 0)) ORDER BY isRead ASC, createdAt DESC")
+    suspend fun getNotifications(userId: String, filter: String, isAdmin: Boolean): List<RealmNotification>
+
+    @Query("SELECT * FROM notifications WHERE id IN (:ids)")
+    suspend fun getByIds(ids: List<String>): List<RealmNotification>
+
+    @Query("UPDATE notifications SET isRead = 1, createdAt = :createdAt, needsSync = CASE WHEN isFromServer = 1 THEN 1 ELSE needsSync END WHERE id IN (:ids)")
+    suspend fun markAsRead(ids: List<String>, createdAt: Date): Int
+
+    @Query("UPDATE notifications SET isRead = 1, createdAt = :createdAt, needsSync = CASE WHEN isFromServer = 1 THEN 1 ELSE needsSync END WHERE userId = :userId AND isRead = 0")
+    suspend fun markAllUnreadAsRead(userId: String, createdAt: Date): Int
+
+    @Query("SELECT * FROM notifications WHERE needsSync = 1 AND rev IS NOT NULL")
+    suspend fun getPendingSyncNotifications(): List<RealmNotification>
+
+    @Query("UPDATE notifications SET needsSync = 0, rev = COALESCE(:rev, rev) WHERE id = :id")
+    suspend fun markSynced(id: String, rev: String?)
+
+    @Query("DELETE FROM notifications WHERE id IN (:ids)")
+    suspend fun deleteByIds(ids: List<String>): Int
+}

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamTaskDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamTaskDao.kt
@@ -1,0 +1,52 @@
+package org.ole.planet.myplanet.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+import org.ole.planet.myplanet.model.RealmTeamTask
+
+@Dao
+interface TeamTaskDao {
+    @Query("SELECT * FROM team_tasks WHERE status != 'archived' AND completed = 0 AND assignee = :userId")
+    fun getOpenTasksForUser(userId: String?): Flow<List<RealmTeamTask>>
+
+    @Query("SELECT * FROM team_tasks WHERE completed = 0 AND assignee = :userId AND isNotified = 0 AND deadline BETWEEN :start AND :end")
+    suspend fun getPendingTasksForUser(userId: String, start: Long, end: Long): List<RealmTeamTask>
+
+    @Query("UPDATE team_tasks SET isNotified = 1 WHERE id IN (:taskIds)")
+    suspend fun markTasksNotified(taskIds: List<String>)
+
+    @Query("SELECT * FROM team_tasks WHERE teamId = :teamId AND status != 'archived'")
+    fun getTasksByTeamId(teamId: String): Flow<List<RealmTeamTask>>
+
+    @Query("SELECT * FROM team_tasks WHERE (_id IS NULL OR _id = '' OR isUpdated = 1)")
+    suspend fun getPendingUploads(): List<RealmTeamTask>
+
+    @Query("DELETE FROM team_tasks WHERE id = :taskId")
+    suspend fun deleteById(taskId: String)
+
+    @Upsert
+    suspend fun upsert(task: RealmTeamTask)
+
+    @Upsert
+    suspend fun upsertAll(tasks: List<RealmTeamTask>)
+
+    @Query("SELECT * FROM team_tasks WHERE id = :taskId LIMIT 1")
+    suspend fun getById(taskId: String): RealmTeamTask?
+
+    @Query("SELECT * FROM team_tasks WHERE id IN (:taskIds)")
+    suspend fun getByIds(taskIds: List<String>): List<RealmTeamTask>
+
+    @Query("SELECT * FROM team_tasks WHERE title = :title LIMIT 1")
+    suspend fun getByTitle(title: String): RealmTeamTask?
+
+    @Query("SELECT * FROM team_tasks WHERE title IN (:titles)")
+    suspend fun getByTitles(titles: List<String>): List<RealmTeamTask>
+
+    @Query("SELECT * FROM team_tasks WHERE assignee = :userId AND deadline BETWEEN :start AND :end")
+    suspend fun getTasksForUserBetween(userId: String, start: Long, end: Long): List<RealmTeamTask>
+
+    @Query("UPDATE team_tasks SET _id = :remoteId, _rev = :remoteRev, isUpdated = 0 WHERE id = :localId")
+    suspend fun markUploaded(localId: String, remoteId: String?, remoteRev: String?): Int
+}

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -20,6 +20,7 @@ import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
+import org.ole.planet.myplanet.data.room.dao.NotificationDao
 import org.ole.planet.myplanet.data.room.dao.NewsLogDao
 import org.ole.planet.myplanet.data.room.dao.OfflineActivityDao
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
@@ -167,5 +168,10 @@ object RoomModule {
     @Provides
     fun provideTeamTaskDao(database: AppDatabase): TeamTaskDao {
         return database.teamTaskDao()
+    }
+
+    @Provides
+    fun provideNotificationDao(database: AppDatabase): NotificationDao {
+        return database.notificationDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -32,6 +32,7 @@ import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TagDao
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
+import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -161,5 +162,10 @@ object RoomModule {
     @Provides
     fun provideRemovedLogDao(database: AppDatabase): RemovedLogDao {
         return database.removedLogDao()
+    }
+
+    @Provides
+    fun provideTeamTaskDao(database: AppDatabase): TeamTaskDao {
+        return database.teamTaskDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 import org.ole.planet.myplanet.data.room.AppDatabase
+import org.ole.planet.myplanet.data.room.dao.AchievementDao
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.data.room.dao.UserChallengeActionsDao
 import org.ole.planet.myplanet.data.room.dao.CertificationDao
@@ -173,5 +174,10 @@ object RoomModule {
     @Provides
     fun provideNotificationDao(database: AppDatabase): NotificationDao {
         return database.notificationDao()
+    }
+
+    @Provides
+    fun provideAchievementDao(database: AppDatabase): AchievementDao {
+        return database.achievementDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RoomModule.kt
@@ -19,6 +19,7 @@ import org.ole.planet.myplanet.data.room.dao.CourseActivityDao
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.DictionaryDao
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
+import org.ole.planet.myplanet.data.room.dao.HealthExaminationDao
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
 import org.ole.planet.myplanet.data.room.dao.NotificationDao
@@ -179,5 +180,10 @@ object RoomModule {
     @Provides
     fun provideAchievementDao(database: AppDatabase): AchievementDao {
         return database.achievementDao()
+    }
+
+    @Provides
+    fun provideHealthExaminationDao(database: AppDatabase): HealthExaminationDao {
+        return database.healthExaminationDao()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmAchievement.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmAchievement.kt
@@ -3,26 +3,26 @@ package org.ole.planet.myplanet.model
 import android.text.TextUtils
 import android.util.LruCache
 import android.widget.EditText
+import androidx.room.Entity
+import androidx.room.Ignore
+import androidx.room.PrimaryKey
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
-import io.realm.RealmList
-import io.realm.RealmObject
-import io.realm.annotations.Ignore
-import io.realm.annotations.PrimaryKey
 import org.ole.planet.myplanet.utils.JsonUtils
 
-open class RealmAchievement : RealmObject() {
-    var achievements: RealmList<String>? = null
-    var references: RealmList<String>? = null
-    var links: RealmList<String>? = null
-    var otherInfo: RealmList<String>? = null
+@Entity(tableName = "achievements")
+class RealmAchievement {
+    var achievements: List<String>? = null
+    var references: List<String>? = null
+    var links: List<String>? = null
+    var otherInfo: List<String>? = null
     var purpose: String? = null
     var achievementsHeader: String? = null
     var sendToNation: String? = null
     var _rev: String? = null
     @PrimaryKey
-    var _id: String? = null
+    var _id: String = ""
     var goals: String? = null
     var dateSortOrder: String? = null
     var createdOn: String? = null
@@ -48,41 +48,41 @@ open class RealmAchievement : RealmObject() {
         get() = parseStringListToJsonArray(otherInfo)
 
     fun setLinks(la: JsonArray?) {
-        links = RealmList()
+        links = mutableListOf()
         if (la == null) return
         for (el in la) {
             val e = JsonUtils.gson.toJson(el)
-            if (links?.contains(e) != true) links?.add(e)
+            if (links?.contains(e) != true) links = links.orEmpty() + e
         }
     }
 
     fun setOtherInfo(oi: JsonArray?) {
-        otherInfo = RealmList()
+        otherInfo = mutableListOf()
         if (oi == null) return
         for (el in oi) {
             val e = JsonUtils.gson.toJson(el)
-            if (otherInfo?.contains(e) != true) otherInfo?.add(e)
+            if (otherInfo?.contains(e) != true) otherInfo = otherInfo.orEmpty() + e
         }
     }
 
     fun setAchievements(ac: JsonArray) {
-        achievements = RealmList()
+        achievements = mutableListOf()
         for (el in ac) {
             val achievement = JsonUtils.gson.toJson(el)
             if (achievements?.contains(achievement) != true) {
-                achievements?.add(achievement)
+                achievements = achievements.orEmpty() + achievement
             }
         }
     }
 
     fun setReferences(of: JsonArray?) {
         cachedReferencesArray = null
-        references = RealmList()
+        references = mutableListOf()
         if (of == null) return
         for (el in of) {
             val e = JsonUtils.gson.toJson(el)
             if (references?.contains(e) != true) {
-                references?.add(e)
+                references = references.orEmpty() + e
             }
         }
     }
@@ -90,7 +90,7 @@ open class RealmAchievement : RealmObject() {
     companion object {
         private val parsedJsonCache = LruCache<String, JsonElement>(1000)
 
-        private fun parseStringListToJsonArray(list: RealmList<String>?): JsonArray {
+        private fun parseStringListToJsonArray(list: List<String>?): JsonArray {
             val array = JsonArray()
             for (s in list ?: emptyList()) {
                 var ob = parsedJsonCache.get(s)
@@ -101,6 +101,27 @@ open class RealmAchievement : RealmObject() {
                 array.add(ob?.deepCopy())
             }
             return array
+        }
+
+        fun fromJson(act: JsonObject): RealmAchievement {
+            return RealmAchievement().apply {
+                _id = JsonUtils.getString("_id", act)
+                _rev = JsonUtils.getString("_rev", act)
+                purpose = JsonUtils.getString("purpose", act)
+                goals = JsonUtils.getString("goals", act)
+                achievementsHeader = JsonUtils.getString("achievementsHeader", act)
+                sendToNation = act.get("sendToNation")?.asString ?: "false"
+                dateSortOrder = JsonUtils.getString("dateSortOrder", act)
+                createdOn = JsonUtils.getString("createdOn", act)
+                username = JsonUtils.getString("username", act)
+                parentCode = JsonUtils.getString("parentCode", act)
+                isUpdated = false
+                setReferences(JsonUtils.getJsonArray("references", act))
+                setAchievements(JsonUtils.getJsonArray("achievements", act))
+                setLinks(JsonUtils.getJsonArray("links", act))
+                setOtherInfo(JsonUtils.getJsonArray("otherInfo", act))
+                resumeFileName = JsonUtils.getString("resumeFileName", act)
+            }
         }
 
         fun serialize(sub: RealmAchievement): JsonObject {

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmDictionary.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmDictionary.kt
@@ -1,10 +1,11 @@
 package org.ole.planet.myplanet.model
 
-import io.realm.RealmObject
-import io.realm.annotations.PrimaryKey
-
-open class RealmDictionary(
-    @PrimaryKey var id: String = "",
+/**
+ * Legacy dictionary DTO kept for source compatibility while dictionary persistence lives in Room
+ * via `DictionaryEntity`/`DictionaryDao`.
+ */
+data class RealmDictionary(
+    var id: String = "",
     var word: String = "",
     var meaning: String = "",
     var synonym: String = "",
@@ -13,4 +14,4 @@ open class RealmDictionary(
     var definition: String = "",
     var language: String = "",
     var antonym: String = ""
-) : RealmObject()
+)

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmHealthExamination.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmHealthExamination.kt
@@ -2,16 +2,16 @@ package org.ole.planet.myplanet.model
 
 import android.text.TextUtils
 import com.google.gson.JsonObject
-import io.realm.RealmObject
-import io.realm.annotations.Index
-import io.realm.annotations.PrimaryKey
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import org.ole.planet.myplanet.utils.AndroidDecrypter
 import org.ole.planet.myplanet.utils.JsonUtils
 
-open class RealmHealthExamination : RealmObject() {
+@Entity(tableName = "health_examinations", indices = [Index("userId")])
+class RealmHealthExamination {
     @PrimaryKey
-    var _id: String? = null
-    @Index
+    var _id: String = ""
     var userId: String? = null
     var isUpdated = false
     var _rev: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmNotification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmNotification.kt
@@ -1,20 +1,19 @@
 package org.ole.planet.myplanet.model
 
-import io.realm.RealmObject
-import io.realm.annotations.Index
-import io.realm.annotations.PrimaryKey
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import java.util.Date
 import java.util.UUID
 
-open class RealmNotification : RealmObject() {
+@Entity(tableName = "notifications", indices = [Index("userId"), Index("type")])
+class RealmNotification {
     @PrimaryKey
     var id: String = UUID.randomUUID().toString()
-    @Index
     var userId: String = ""
     var message: String = ""
     var isRead: Boolean = false
     var createdAt: Date = Date()
-    @Index
     var type: String = ""
     var relatedId: String? = null
     var title: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamTask.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmTeamTask.kt
@@ -2,22 +2,23 @@ package org.ole.planet.myplanet.model
 
 import android.text.TextUtils
 import com.google.gson.JsonObject
-import io.realm.Realm
-import io.realm.RealmObject
-import io.realm.annotations.Index
-import io.realm.annotations.PrimaryKey
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
 import org.ole.planet.myplanet.utils.JsonUtils
 
-open class RealmTeamTask : RealmObject() {
+@Entity(tableName = "team_tasks", indices = [Index("teamId")])
+class RealmTeamTask {
     @PrimaryKey
-    var id: String? = null
+    @JvmField
+    var id: String = ""
+    @JvmField
     var _id: String? = null
     var _rev: String? = null
     var title: String? = null
     var description: String? = null
     var link: String? = null
     var sync: String? = null
-    @Index
     var teamId: String? = null
     var isUpdated = false
     var assignee: String? = null
@@ -32,28 +33,25 @@ open class RealmTeamTask : RealmObject() {
     }
 
     companion object {
-        fun insert(mRealm: Realm, obj: JsonObject?) {
-            var task = mRealm.where(RealmTeamTask::class.java).equalTo("_id", JsonUtils.getString("_id", obj)).findFirst()
-            if (task == null) {
-                task = mRealm.createObject(RealmTeamTask::class.java, JsonUtils.getString("_id", obj))
+        fun fromJson(obj: JsonObject?): RealmTeamTask {
+            val task = RealmTeamTask()
+            task.id = JsonUtils.getString("_id", obj)
+            task._id = JsonUtils.getString("_id", obj)
+            task._rev = JsonUtils.getString("_rev", obj)
+            task.title = JsonUtils.getString("title", obj)
+            task.status = JsonUtils.getString("status", obj)
+            task.deadline = JsonUtils.getLong("deadline", obj)
+            task.completedTime = JsonUtils.getLong("completedTime", obj)
+            task.description = JsonUtils.getString("description", obj)
+            task.link = JsonUtils.gson.toJson(JsonUtils.getJsonObject("link", obj))
+            task.sync = JsonUtils.gson.toJson(JsonUtils.getJsonObject("sync", obj))
+            task.teamId = JsonUtils.getString("teams", JsonUtils.getJsonObject("link", obj))
+            val user = JsonUtils.getJsonObject("assignee", obj)
+            if (user.has("_id")) {
+                task.assignee = JsonUtils.getString("_id", user)
             }
-            if (task != null) {
-                task._id = JsonUtils.getString("_id", obj)
-                task._rev = JsonUtils.getString("_rev", obj)
-                task.title = JsonUtils.getString("title", obj)
-                task.status = JsonUtils.getString("status", obj)
-                task.deadline = JsonUtils.getLong("deadline", obj)
-                task.completedTime = JsonUtils.getLong("completedTime", obj)
-                task.description = JsonUtils.getString("description", obj)
-                task.link = JsonUtils.gson.toJson(JsonUtils.getJsonObject("link", obj))
-                task.sync = JsonUtils.gson.toJson(JsonUtils.getJsonObject("sync", obj))
-                task.teamId = JsonUtils.getString("teams", JsonUtils.getJsonObject("link", obj))
-                val user = JsonUtils.getJsonObject("assignee", obj)
-                if (user.has("_id")) {
-                    task.assignee = JsonUtils.getString("_id", user)
-                }
-                task.completed = JsonUtils.getBoolean("completed", obj)
-            }
+            task.completed = JsonUtils.getBoolean("completed", obj)
+            return task
         }
 
         fun serialize(task: RealmTeamTask, user: RealmUser?): JsonObject {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
@@ -14,7 +14,7 @@ interface HealthRepository {
     suspend fun getUpdatedHealthForUser(userId: String): List<RealmHealthExamination>
     suspend fun markHealthExaminationsUploaded(idToRevMap: Map<String, String?>)
     suspend fun updateExaminationUserId(id: String, userId: String)
-    fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: JsonArray)
+    suspend fun bulkInsertFromSync(jsonArray: JsonArray)
     suspend fun uploadHealthData(myHealths: List<RealmHealthExamination>): Map<String, String?>
     suspend fun getExaminationConditions(examination: RealmHealthExamination?): Map<String, Boolean>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.data.room.dao.HealthExaminationDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmHealthExamination
 import org.ole.planet.myplanet.model.RealmHealthExamination.Companion.serialize
@@ -27,19 +28,19 @@ class HealthRepositoryImpl @Inject constructor(
     private val apiInterface: ApiInterface,
     databaseService: DatabaseService,
     @RealmDispatcher realmDispatcher: CoroutineDispatcher,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
+    private val healthExaminationDao: HealthExaminationDao
 ) : RealmRepository(databaseService, realmDispatcher), HealthRepository {
     override suspend fun getHealthEntry(userId: String): Pair<RealmUser?, RealmHealthExamination?> {
         val userCopy = findByField(RealmUser::class.java, "_id", userId)
             ?: findByField(RealmUser::class.java, "id", userId)
-        val pojoCopy = findByField(RealmHealthExamination::class.java, "_id", userId)
-            ?: findByField(RealmHealthExamination::class.java, "userId", userId)
+        val pojoCopy = healthExaminationDao.getByIdOrUserId(userId)
 
         return Pair(userCopy, pojoCopy)
     }
 
     override suspend fun getExaminationById(id: String): RealmHealthExamination? {
-        return findByField(RealmHealthExamination::class.java, "_id", id)
+        return healthExaminationDao.getById(id)
     }
 
     override suspend fun initHealth(): RealmMyHealth {
@@ -54,63 +55,40 @@ class HealthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUpdatedHealthExaminations(): List<RealmHealthExamination> {
-        return queryList(RealmHealthExamination::class.java) {
-            equalTo("isUpdated", true)
-            notEqualTo("userId", "")
-        }
+        return healthExaminationDao.getUpdated()
     }
 
     override suspend fun getUpdatedHealthForUser(userId: String): List<RealmHealthExamination> {
-        return queryList(RealmHealthExamination::class.java) {
-            equalTo("isUpdated", true)
-            equalTo("userId", userId)
-        }
+        return healthExaminationDao.getUpdatedForUser(userId)
     }
 
     override suspend fun markHealthExaminationsUploaded(idToRevMap: Map<String, String?>) {
-        if (idToRevMap.isNotEmpty()) {
-            executeTransaction { realm ->
-                idToRevMap.keys.chunked(999).forEach { chunk ->
-                    val managedPojos = realm.where(RealmHealthExamination::class.java)
-                        .`in`("_id", chunk.toTypedArray())
-                        .findAll()
-                    managedPojos.forEach { managedPojo ->
-                        managedPojo._rev = idToRevMap[managedPojo._id]
-                        managedPojo.isUpdated = false
-                    }
-                }
-            }
+        idToRevMap.forEach { (id, rev) ->
+            healthExaminationDao.markUploaded(id, rev)
         }
     }
 
     override suspend fun saveExamination(examination: RealmHealthExamination?, pojo: RealmHealthExamination?, user: RealmUser?) {
-        executeTransaction { realm ->
-            user?.let { realm.copyToRealmOrUpdate(it) }
-            pojo?.let { realm.copyToRealmOrUpdate(it) }
-            examination?.let { realm.copyToRealmOrUpdate(it) }
-        }
+        user?.let { save(it) }
+        pojo?.let { healthExaminationDao.upsert(it) }
+        examination?.let { healthExaminationDao.upsert(it) }
     }
 
     override suspend fun updateExaminationUserId(id: String, userId: String) {
-        update(RealmHealthExamination::class.java, "_id", id) { examination ->
-            examination.userId = userId
-        }
+        healthExaminationDao.updateUserId(id, userId)
     }
 
-    override fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: JsonArray) {
-        val documentList = ArrayList<JsonObject>(jsonArray.size())
+    override suspend fun bulkInsertFromSync(jsonArray: JsonArray) {
+        val examinations = ArrayList<RealmHealthExamination>(jsonArray.size())
         for (j in jsonArray) {
             var jsonDoc = j.asJsonObject
             jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
             val id = JsonUtils.getString("_id", jsonDoc)
             if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
+                examinations.add(RealmHealthExamination.fromJson(jsonDoc))
             }
         }
-        val examinations = documentList.map { jsonDoc ->
-            RealmHealthExamination.fromJson(jsonDoc)
-        }
-        realm.insertOrUpdate(examinations)
+        healthExaminationDao.upsertAll(examinations)
     }
 
     override suspend fun getExaminationConditions(examination: RealmHealthExamination?): Map<String, Boolean> {
@@ -147,10 +125,7 @@ class HealthRepositoryImpl @Inject constructor(
 
                             if (res.body() != null && res.body()?.has("id") == true) {
                                 val rev = res.body()?.get("rev")?.asString
-                                val id = pojo._id
-                                if (id != null) {
-                                    return@async id to rev
-                                }
+                                return@async pojo._id to rev
                             }
                         } catch (e: Throwable) {
                             e.printStackTrace()

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepository.kt
@@ -28,7 +28,7 @@ interface NotificationsRepository {
     suspend fun getTaskTeamNamesByTaskTitles(taskTitles: List<String>): Map<String, String>
     suspend fun getPendingSyncNotifications(): List<RealmNotification>
     suspend fun markNotificationsSynced(syncResults: List<Pair<String, String?>>)
-    fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: JsonArray)
+    suspend fun bulkInsertFromSync(jsonArray: JsonArray)
     suspend fun insert(doc: JsonObject)
     suspend fun deleteNotifications(ids: Set<String>): Set<String>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -14,6 +14,7 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
+import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.model.RealmTeamNotification
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.TaskNotificationResult
@@ -29,7 +30,8 @@ class NotificationsRepositoryImpl @Inject constructor(
     private val userRepository: Lazy<UserRepository>,
     private val teamsRepository: Lazy<TeamsRepository>,
     private val timeProvider: TimeProvider,
-    private val teamNotificationDao: TeamNotificationDao
+    private val teamNotificationDao: TeamNotificationDao,
+    private val teamTaskDao: TeamTaskDao
 ) : RealmRepository(databaseService, realmDispatcher), NotificationsRepository {
     override suspend fun refresh() {
         withRealm { it.refresh() }
@@ -216,7 +218,7 @@ class NotificationsRepositoryImpl @Inject constructor(
 
     override suspend fun getTaskDetails(relatedId: String?): TaskNotificationResult? {
         return relatedId?.let {
-            val task = findByField(RealmTeamTask::class.java, "id", it)
+            val task = teamTaskDao.getById(it)
             val linkJson = org.json.JSONObject(task?.link ?: "{}")
             val teamId = linkJson.optString("teams")
             if (teamId.isNotEmpty()) {
@@ -254,9 +256,7 @@ class NotificationsRepositoryImpl @Inject constructor(
         if (taskIds.isEmpty()) return emptyMap()
         val map = mutableMapOf<String, String>()
 
-        val tasks = queryList(RealmTeamTask::class.java) {
-            `in`("id", taskIds.toTypedArray())
-        }
+        val tasks = teamTaskDao.getByIds(taskIds)
 
         val teamIds = tasks.mapNotNull { it.teamId }.filter { it.isNotEmpty() }.distinct()
         if (teamIds.isNotEmpty()) {
@@ -314,7 +314,7 @@ class NotificationsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getTaskTeamName(taskTitle: String): String? {
-        val taskObj = findByField(RealmTeamTask::class.java, "title", taskTitle)
+        val taskObj = teamTaskDao.getByTitle(taskTitle)
         val teamInfo = taskObj?.teamId?.let { teamsRepository.get().getTeamLabelInfo(it) }
         return teamInfo?.name
     }
@@ -323,9 +323,7 @@ class NotificationsRepositoryImpl @Inject constructor(
         if (taskTitles.isEmpty()) return emptyMap()
         val map = mutableMapOf<String, String>()
 
-        val tasks = queryList(RealmTeamTask::class.java) {
-            `in`("title", taskTitles.toTypedArray())
-        }
+        val tasks = teamTaskDao.getByTitles(taskTitles)
 
         val teamIds = tasks.mapNotNull { it.teamId }.filter { it.isNotEmpty() }.distinct()
         if (teamIds.isNotEmpty()) {
@@ -358,10 +356,7 @@ class NotificationsRepositoryImpl @Inject constructor(
 
         val hasChat = notification != null && notification.lastCount < chatCount
 
-        val tasks = queryList(RealmTeamTask::class.java) {
-            equalTo("assignee", userId)
-            between("deadline", current, tomorrow.timeInMillis)
-        }
+        val tasks = teamTaskDao.getTasksForUserBetween(userId, current, tomorrow.timeInMillis)
 
         val hasTask = tasks.isNotEmpty()
 
@@ -399,10 +394,7 @@ class NotificationsRepositoryImpl @Inject constructor(
         // 3. Fetch all relevant tasks once
         val current = timeProvider.now()
         val tomorrow = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 1) }
-        val tasks = queryList(RealmTeamTask::class.java) {
-            equalTo("assignee", userId)
-            between("deadline", current, tomorrow.timeInMillis)
-        }
+        val tasks = teamTaskDao.getTasksForUserBetween(userId, current, tomorrow.timeInMillis)
         val hasTask = tasks.isNotEmpty()
 
         // 4. Combine the results in memory

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -8,13 +8,14 @@ import java.util.Date
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.NotificationDao
+import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
+import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.NotificationPayload
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmStepExam
-import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
-import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.model.RealmTeamNotification
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.TaskNotificationResult
@@ -25,12 +26,13 @@ import org.ole.planet.myplanet.utils.TimeProvider
 private const val STORAGE_WARNING_AVAILABLE_PERCENT = 10
 
 class NotificationsRepositoryImpl @Inject constructor(
-        databaseService: DatabaseService,
+    databaseService: DatabaseService,
     @RealmDispatcher realmDispatcher: CoroutineDispatcher,
     private val userRepository: Lazy<UserRepository>,
     private val teamsRepository: Lazy<TeamsRepository>,
     private val timeProvider: TimeProvider,
     private val teamNotificationDao: TeamNotificationDao,
+    private val notificationDao: NotificationDao,
     private val teamTaskDao: TeamTaskDao
 ) : RealmRepository(databaseService, realmDispatcher), NotificationsRepository {
     override suspend fun refresh() {
@@ -40,45 +42,23 @@ class NotificationsRepositoryImpl @Inject constructor(
     override suspend fun markNotificationAsRead(notificationId: String, userId: String?) {
         if (notificationId.startsWith("summary_")) {
             val type = notificationId.removePrefix("summary_")
-            executeTransaction { realm ->
-                realm.where(RealmNotification::class.java)
-                    .equalTo("userId", userId)
-                    .equalTo("type", type)
-                    .equalTo("isRead", false)
-                    .findAll()
-                    .forEach { it.isRead = true; it.needsSync = it.isFromServer }
-            }
+            notificationDao.markSummaryAsRead(userId, type)
         } else {
-            executeTransaction { realm ->
-                val notification = realm.where(RealmNotification::class.java)
-                    .equalTo("id", notificationId)
-                    .findFirst()
-                notification?.isRead = true
-                notification?.needsSync = notification.isFromServer == true
-            }
+            notificationDao.markAsRead(notificationId)
         }
     }
 
     override suspend fun getUnreadCount(userId: String?, isAdmin: Boolean): Int {
         if (userId == null) return 0
 
-        return count(RealmNotification::class.java) {
-            beginGroup()
-            equalTo("userId", userId)
-            if (isAdmin) {
-                or()
-                equalTo("userId", "SYSTEM")
-            }
-            endGroup()
-            equalTo("isRead", false)
-        }.toInt()
+        return notificationDao.getUnreadCount(userId, isAdmin)
     }
 
     override suspend fun updateResourceNotification(userId: String?, resourceCount: Int) {
         userId ?: return
 
         val notificationId = "$userId:resource:count"
-        val existingNotification = findByField(RealmNotification::class.java, "id", notificationId)
+        val existingNotification = notificationDao.getById(notificationId)
 
         if (resourceCount > 0) {
             val previousCount = existingNotification?.message?.toIntOrNull() ?: 0
@@ -99,9 +79,9 @@ class NotificationsRepositoryImpl @Inject constructor(
                 this.relatedId = "$resourceCount"
                 this.createdAt = Date()
             }
-            save(notification)
+            notificationDao.upsert(notification)
         } else {
-            existingNotification?.let { delete(RealmNotification::class.java, "id", it.id) }
+            existingNotification?.let { notificationDao.deleteById(it.id) }
         }
     }
 
@@ -109,7 +89,7 @@ class NotificationsRepositoryImpl @Inject constructor(
         userId ?: return
 
         val notificationId = "$userId:storage"
-        val existingNotification = findByField(RealmNotification::class.java, "id", notificationId)
+        val existingNotification = notificationDao.getById(notificationId)
 
         if (availablePercent <= STORAGE_WARNING_AVAILABLE_PERCENT) {
             val previousPercent = existingNotification?.message?.replace("%", "")?.toIntOrNull()
@@ -130,68 +110,35 @@ class NotificationsRepositoryImpl @Inject constructor(
                 this.relatedId = "storage"
                 this.createdAt = Date()
             }
-            save(notification)
+            notificationDao.upsert(notification)
         } else {
-            existingNotification?.let { delete(RealmNotification::class.java, "id", it.id) }
+            existingNotification?.let { notificationDao.deleteById(it.id) }
         }
     }
 
     override suspend fun markNotificationsAsRead(notificationIds: Set<String>): Set<String> {
         if (notificationIds.isEmpty()) return emptySet()
 
-        val updatedIds = mutableSetOf<String>()
-        val now = Date()
-        executeTransaction { realm ->
-            val notifications = realm.where(RealmNotification::class.java)
-                .`in`("id", notificationIds.toTypedArray())
-                .findAll()
-
-            notifications.forEach { notification ->
-                notification.isRead = true
-                notification.createdAt = now
-                if (notification.isFromServer) notification.needsSync = true
-                updatedIds.add(notification.id)
-            }
-        }
-        return updatedIds
+        val existingIds = notificationDao.getByIds(notificationIds.toList()).map { it.id }.toSet()
+        if (existingIds.isEmpty()) return emptySet()
+        notificationDao.markAsRead(existingIds.toList(), Date())
+        return existingIds
     }
 
     override suspend fun markAllUnreadAsRead(userId: String?): Set<String> {
         val actualUserId = userId ?: return emptySet()
-        val updatedIds = mutableSetOf<String>()
-        val now = Date()
-        executeTransaction { realm ->
-            realm.where(RealmNotification::class.java)
-                .equalTo("userId", actualUserId)
-                .equalTo("isRead", false)
-                .findAll()
-                ?.forEach { notification ->
-                    notification.isRead = true
-                    notification.createdAt = now
-                    if (notification.isFromServer) notification.needsSync = true
-                    updatedIds.add(notification.id)
-                }
-        }
-        return updatedIds
+        val unreadIds = notificationDao.getNotifications(actualUserId, "unread", false).map { it.id }.toSet()
+        if (unreadIds.isEmpty()) return emptySet()
+        notificationDao.markAllUnreadAsRead(actualUserId, Date())
+        return unreadIds
     }
 
     override suspend fun getNotifications(userId: String, filter: String, isAdmin: Boolean): List<NotificationPayload> {
-        return queryList(RealmNotification::class.java) {
-            beginGroup()
-            equalTo("userId", userId)
-            if (isAdmin) {
-                or()
-                equalTo("userId", "SYSTEM")
-            }
-            endGroup()
-            notEqualTo("message", "INVALID")
-            isNotEmpty("message")
-            when (filter) {
-                "read" -> equalTo("isRead", true)
-                "unread" -> equalTo("isRead", false)
-            }
-            sort("isRead", io.realm.Sort.ASCENDING, "createdAt", io.realm.Sort.DESCENDING)
-        }.map {
+        val normalizedFilter = when (filter) {
+            "read", "unread" -> filter
+            else -> ""
+        }
+        return notificationDao.getNotifications(userId, normalizedFilter, isAdmin).map {
             NotificationPayload(
                 id = it.id,
                 userId = it.userId,
@@ -408,27 +355,13 @@ class NotificationsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getPendingSyncNotifications(): List<RealmNotification> {
-        return queryList(RealmNotification::class.java) {
-            equalTo("needsSync", true)
-            isNotNull("rev")
-        }
+        return notificationDao.getPendingSyncNotifications()
     }
 
     override suspend fun markNotificationsSynced(syncResults: List<Pair<String, String?>>) {
         if (syncResults.isEmpty()) return
-        val ids = syncResults.map { it.first }.toTypedArray()
-        val revMap = syncResults.toMap()
-        executeTransaction { realm ->
-            val notifications = realm.where(RealmNotification::class.java)
-                .`in`("id", ids)
-                .findAll()
-
-            notifications.forEach { notification ->
-                notification.needsSync = false
-                revMap[notification.id]?.let { newRev ->
-                    notification.rev = newRev
-                }
-            }
+        syncResults.forEach { (id, rev) ->
+            notificationDao.markSynced(id, rev)
         }
     }
 
@@ -450,30 +383,24 @@ class NotificationsRepositoryImpl @Inject constructor(
 
     override suspend fun insert(doc: JsonObject) {
         val parsed = parseNotification(doc) ?: return
-        executeTransaction { realm ->
-            val existing = realm.where(RealmNotification::class.java).equalTo("id", parsed.id).findFirst()
-            if (existing?.needsSync == true) {
-                parsed.needsSync = true
-                parsed.isRead = existing.isRead
-            }
-            realm.copyToRealmOrUpdate(parsed)
+        val existing = notificationDao.getById(parsed.id)
+        if (existing?.needsSync == true) {
+            parsed.needsSync = true
+            parsed.isRead = existing.isRead
         }
+        notificationDao.upsert(parsed)
     }
 
     override suspend fun deleteNotifications(ids: Set<String>): Set<String> {
         if (ids.isEmpty()) return emptySet()
-        val deletedIds = mutableSetOf<String>()
-        executeTransaction { realm ->
-            val notifications = realm.where(RealmNotification::class.java)
-                .`in`("id", ids.toTypedArray())
-                .findAll()
-            notifications.forEach { deletedIds.add(it.id) }
-            notifications.deleteAllFromRealm()
+        val deletedIds = notificationDao.getByIds(ids.toList()).map { it.id }.toSet()
+        if (deletedIds.isNotEmpty()) {
+            notificationDao.deleteByIds(deletedIds.toList())
         }
         return deletedIds
     }
 
-    override fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: JsonArray) {
+    override suspend fun bulkInsertFromSync(jsonArray: JsonArray) {
         val documentList = ArrayList<JsonObject>(jsonArray.size())
         for (j in jsonArray) {
             var jsonDoc = j.asJsonObject
@@ -484,12 +411,8 @@ class NotificationsRepositoryImpl @Inject constructor(
             }
         }
         val parsedList = documentList.mapNotNull { parseNotification(it) }
-        val ids = parsedList.map { it.id }.toTypedArray()
-        val existingNotifications = if (ids.isNotEmpty()) {
-            realm.where(RealmNotification::class.java)
-                .`in`("id", ids)
-                .findAll()
-                .associateBy { it.id }
+        val existingNotifications = if (parsedList.isNotEmpty()) {
+            notificationDao.getByIds(parsedList.map { it.id }).associateBy { it.id }
         } else {
             emptyMap()
         }
@@ -499,7 +422,7 @@ class NotificationsRepositoryImpl @Inject constructor(
                 parsed.needsSync = true
                 parsed.isRead = existing.isRead
             }
-            realm.copyToRealmOrUpdate(parsed)
         }
+        notificationDao.upsertAll(parsedList)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
+import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CreateTeamRequest
@@ -70,13 +71,10 @@ class TeamsRepositoryImpl @Inject constructor(
     private val resourcesRepositoryLazy: dagger.Lazy<ResourcesRepository>,
     private val timeProvider: TimeProvider,
     private val teamLogDao: TeamLogDao,
+    private val teamTaskDao: TeamTaskDao,
 ) : RealmRepository(databaseService, realmDispatcher), TeamsRepository, TeamsSyncRepository {
     override fun getTasksFlow(userId: String?): Flow<List<RealmTeamTask>> {
-        return queryListFlow(RealmTeamTask::class.java) {
-            notEqualTo("status", "archived")
-                .equalTo("completed", false)
-                .equalTo("assignee", userId)
-        }
+        return teamTaskDao.getOpenTasksForUser(userId)
     }
 
     override suspend fun getTeamsForUpload(): List<TeamUploadData> {
@@ -484,7 +482,7 @@ class TeamsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getTaskTeamInfo(taskId: String): Triple<String, String, String>? {
-        val task = findByField(RealmTeamTask::class.java, "id", taskId)
+        val task = teamTaskDao.getById(taskId)
 
         return task?.let {
             val linkJson = org.json.JSONObject(it.link ?: "{}")
@@ -965,33 +963,18 @@ class TeamsRepositoryImpl @Inject constructor(
         end: Long,
     ): List<RealmTeamTask> {
         if (userId.isBlank() || start > end) return emptyList()
-        return queryList(RealmTeamTask::class.java) {
-            equalTo("completed", false)
-            equalTo("assignee", userId)
-            equalTo("isNotified", false)
-            between("deadline", start, end)
-        }
+        return teamTaskDao.getPendingTasksForUser(userId, start, end)
     }
 
     override suspend fun markTasksNotified(taskIds: Collection<String>) {
         if (taskIds.isEmpty()) return
         val validIds = taskIds.mapNotNull { it.takeIf(String::isNotBlank) }.distinct()
         if (validIds.isEmpty()) return
-        executeTransaction { realm ->
-            val tasks = realm.where(RealmTeamTask::class.java)
-                .`in`("id", validIds.toTypedArray())
-                .findAll()
-            tasks.forEach { task ->
-                task.isNotified = true
-            }
-        }
+        teamTaskDao.markTasksNotified(validIds)
     }
 
     override suspend fun getTasksByTeamId(teamId: String): Flow<List<RealmTeamTask>> {
-        return queryListFlow(RealmTeamTask::class.java) {
-            equalTo("teamId", teamId)
-            notEqualTo("status", "archived")
-        }
+        return teamTaskDao.getTasksByTeamId(teamId)
     }
 
     override suspend fun getReportsFlow(teamId: String): Flow<List<RealmMyTeam>> {
@@ -1018,7 +1001,7 @@ class TeamsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteTask(taskId: String) {
-        delete(RealmTeamTask::class.java, "id", taskId)
+        teamTaskDao.deleteById(taskId)
     }
 
     private suspend fun upsertTask(task: RealmTeamTask) {
@@ -1033,7 +1016,7 @@ class TeamsRepositoryImpl @Inject constructor(
             }
             task.sync = gson.toJson(syncObj)
         }
-        save(task)
+        teamTaskDao.upsert(task)
     }
 
     override suspend fun createTask(
@@ -1062,27 +1045,30 @@ class TeamsRepositoryImpl @Inject constructor(
         deadline: Long,
         assigneeId: String?
     ) {
-        update(RealmTeamTask::class.java, "id", taskId) { task ->
+        teamTaskDao.getById(taskId)?.let { task ->
             task.title = title
             task.description = description
             task.deadline = deadline
             task.assignee = assigneeId
             task.isUpdated = true
+            teamTaskDao.upsert(task)
         }
     }
 
     override suspend fun assignTask(taskId: String, assigneeId: String?) {
-        update(RealmTeamTask::class.java, "id", taskId) { task ->
+        teamTaskDao.getById(taskId)?.let { task ->
             task.assignee = assigneeId
             task.isUpdated = true
+            teamTaskDao.upsert(task)
         }
     }
 
     override suspend fun setTaskCompletion(taskId: String, completed: Boolean) {
-        update(RealmTeamTask::class.java, "id", taskId) { task ->
+        teamTaskDao.getById(taskId)?.let { task ->
             task.completed = completed
             task.completedTime = if (completed) Date().time else 0
             task.isUpdated = true
+            teamTaskDao.upsert(task)
         }
     }
 
@@ -1630,19 +1616,17 @@ class TeamsRepositoryImpl @Inject constructor(
             insertMyTeam(realm, jsonDoc, existingTeams)
         }
     }
-    override fun bulkInsertTasksFromSync(realm: Realm, jsonArray: JsonArray) {
-        val documentList = ArrayList<JsonObject>(jsonArray.size())
+    override suspend fun bulkInsertTasksFromSync(jsonArray: JsonArray) {
+        val tasks = ArrayList<RealmTeamTask>(jsonArray.size())
         for (j in jsonArray) {
             var jsonDoc = j.asJsonObject
             jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
             val id = JsonUtils.getString("_id", jsonDoc)
             if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
+                tasks.add(RealmTeamTask.fromJson(jsonDoc))
             }
         }
-        documentList.forEach { jsonDoc ->
-            RealmTeamTask.insert(realm, jsonDoc)
-        }
+        teamTaskDao.upsertAll(tasks)
     }
     override suspend fun bulkInsertTeamActivitiesFromSync(jsonArray: JsonArray) {
         val documentList = ArrayList<JsonObject>(jsonArray.size())

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsSyncRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsSyncRepository.kt
@@ -19,6 +19,6 @@ interface TeamsSyncRepository {
     fun insertMyTeam(realm: Realm, doc: JsonObject)
     suspend fun batchInsertMyTeams(documents: List<JsonObject>): Int
     fun bulkInsertFromSync(realm: Realm, jsonArray: JsonArray)
-    fun bulkInsertTasksFromSync(realm: Realm, jsonArray: JsonArray)
+    suspend fun bulkInsertTasksFromSync(jsonArray: JsonArray)
     suspend fun bulkInsertTeamActivitiesFromSync(jsonArray: JsonArray)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.AchievementDao
+import org.ole.planet.myplanet.data.room.dao.HealthExaminationDao
 import org.ole.planet.myplanet.data.room.dao.OfflineActivityDao
 import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.di.AppPreferences
@@ -76,7 +77,8 @@ class UserRepositoryImpl @Inject constructor(
     private val meetupDao: MeetupDao,
     private val offlineActivityDao: OfflineActivityDao,
     private val removedLogDao: RemovedLogDao,
-    private val achievementDao: AchievementDao
+    private val achievementDao: AchievementDao,
+    private val healthExaminationDao: HealthExaminationDao
 ) : RealmRepository(databaseService, realmDispatcher), UserRepository, UserSyncRepository {
     override suspend fun getDashboardProfile(userId: String): DashboardProfile {
         val user = getUserById(userId)
@@ -929,15 +931,8 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun getHealthRecordsAndAssociatedUsers(
         userId: String,
         currentUser: RealmUser
-    ): HealthRecord? = withRealm { realm ->
-        var mh = realm.where(RealmHealthExamination::class.java).equalTo("_id", userId).findFirst()
-        if (mh == null) {
-            mh = realm.where(RealmHealthExamination::class.java).equalTo("userId", userId).findFirst()
-        }
-        if (mh == null) return@withRealm null
-
-        val mhCopy = realm.copyFromRealm(mh)
-
+    ): HealthRecord? {
+        val mh = healthExaminationDao.getByIdOrUserId(userId) ?: return null
         val json = AndroidDecrypter.decrypt(mh.data, currentUser.key, currentUser.iv)
         val mm = if (TextUtils.isEmpty(json)) {
             null
@@ -948,13 +943,11 @@ class UserRepositoryImpl @Inject constructor(
                 e.printStackTrace()
                 null
             }
-        }
-        if (mm == null) return@withRealm null
+        } ?: return null
 
-        val healths = realm.where(RealmHealthExamination::class.java).equalTo("profileId", mm.userKey).findAll()
-        val list = realm.copyFromRealm(healths)
+        val list = healthExaminationDao.getByProfileId(mm.userKey ?: "")
         if (list.isEmpty()) {
-            return@withRealm HealthRecord(mhCopy, mm, emptyList(), emptyMap())
+            return HealthRecord(mh, mm, emptyList(), emptyMap())
         }
 
         val userIds = list.mapNotNull {
@@ -966,101 +959,89 @@ class UserRepositoryImpl @Inject constructor(
         val userMap = if (userIds.isEmpty()) {
             emptyMap()
         } else {
-            val users = realm.where(RealmUser::class.java).isNotNull("id").`in`("id", userIds.toTypedArray()).findAll()
-            realm.copyFromRealm(users).associateBy { it.id ?: "" }
+            withRealm { realm ->
+                val users = realm.where(RealmUser::class.java).isNotNull("id").`in`("id", userIds.toTypedArray()).findAll()
+                realm.copyFromRealm(users).associateBy { it.id ?: "" }
+            }
         }
-        HealthRecord(mhCopy, mm, list, userMap)
+        return HealthRecord(mh, mm, list, userMap)
     }
 
     override suspend fun getHealthProfile(userId: String): RealmMyHealth? {
-        return withRealm { realm ->
-            val userModel = realm.where(RealmUser::class.java).equalTo("_id", userId).findFirst()
-                ?: realm.where(RealmUser::class.java).equalTo("id", userId).findFirst()
-            val healthPojo = realm.where(RealmHealthExamination::class.java).equalTo("_id", userId).findFirst()
-                ?: realm.where(RealmHealthExamination::class.java).equalTo("userId", userId).findFirst()
+        val userModel = getUserByAnyId(userId)
+        val healthPojo = healthExaminationDao.getByIdOrUserId(userId)
 
-            if (healthPojo != null && !TextUtils.isEmpty(healthPojo.data)) {
-                try {
-                    val decrypted = AndroidDecrypter.decrypt(healthPojo.data, userModel?.key, userModel?.iv)
-                    return@withRealm JsonUtils.gson.fromJson(decrypted, RealmMyHealth::class.java)
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
-            null
-        }
-    }
-
-    override suspend fun updateUserHealthProfile(userId: String, userData: Map<String, Any?>) {
-        executeTransaction { transactionRealm ->
-            val userModel = transactionRealm.where(RealmUser::class.java).equalTo("_id", userId).findFirst()
-                ?: transactionRealm.where(RealmUser::class.java).equalTo("id", userId).findFirst()
-            val healthPojo = transactionRealm.where(RealmHealthExamination::class.java).equalTo("_id", userId).findFirst()
-                ?: transactionRealm.where(RealmHealthExamination::class.java).equalTo("userId", userId).findFirst()
-                ?: transactionRealm.createObject(RealmHealthExamination::class.java, userId)
-
-            userModel?.apply {
-                firstName = (userData["firstName"] as? String)?.trim()
-                middleName = (userData["middleName"] as? String)?.trim()
-                lastName = (userData["lastName"] as? String)?.trim()
-                email = (userData["email"] as? String)?.trim()
-                phoneNumber = (userData["phoneNumber"] as? String)?.trim()
-                birthPlace = (userData["birthPlace"] as? String)?.trim()
-                userData["dob"]?.let { dobVal ->
-                    val dobInput = (dobVal as String).trim()
-                    dob = TimeUtils.convertDDMMYYYYToISO(dobInput)
-                }
-                isUpdated = true
-            }
-
-            var myHealth: RealmMyHealth? = null
-            if (!TextUtils.isEmpty(healthPojo.data)) {
-                try {
-                    val decrypted = AndroidDecrypter.decrypt(healthPojo.data, userModel?.key, userModel?.iv)
-                    myHealth = JsonUtils.gson.fromJson(decrypted, RealmMyHealth::class.java)
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
-
-            if (myHealth == null) {
-                myHealth = RealmMyHealth()
-            }
-            if (TextUtils.isEmpty(myHealth.userKey)) {
-                myHealth.userKey = AndroidDecrypter.generateKey()
-            }
-
-            val profile = myHealth.profile ?: RealmMyHealthProfile().also { myHealth.profile = it }
-
-            profile.emergencyContactName = (userData["emergencyContactName"] as? String)?.trim() ?: ""
-            val newEmergencyContact = (userData["emergencyContact"] as? String)?.trim() ?: ""
-            profile.emergencyContact = if (TextUtils.isEmpty(newEmergencyContact)) {
-                 profile.emergencyContact
-            } else {
-                 newEmergencyContact
-            }
-
-            val newEmergencyContactType = (userData["emergencyContactType"] as? String)?.trim() ?: ""
-            profile.emergencyContactType = if (TextUtils.isEmpty(newEmergencyContactType)) {
-                 profile.emergencyContactType
-            } else {
-                 newEmergencyContactType
-            }
-
-            profile.specialNeeds = (userData["specialNeeds"] as? String)?.trim() ?: ""
-            profile.notes = (userData["notes"] as? String)?.trim() ?: ""
-
-            healthPojo.userId = userModel?._id
-            healthPojo.isUpdated = true
-
+        if (healthPojo != null && !TextUtils.isEmpty(healthPojo.data)) {
             try {
-                val key = userModel?.key ?: AndroidDecrypter.generateKey().also { newKey -> userModel?.key = newKey }
-                val iv = userModel?.iv ?: AndroidDecrypter.generateIv().also { newIv -> userModel?.iv = newIv }
-                healthPojo.data = AndroidDecrypter.encrypt(JsonUtils.gson.toJson(myHealth), key, iv)
+                val decrypted = AndroidDecrypter.decrypt(healthPojo.data, userModel?.key, userModel?.iv)
+                return JsonUtils.gson.fromJson(decrypted, RealmMyHealth::class.java)
             } catch (e: Exception) {
                 e.printStackTrace()
             }
         }
+        return null
+    }
+
+    override suspend fun updateUserHealthProfile(userId: String, userData: Map<String, Any?>) {
+        val userModel = getUserByAnyId(userId)
+        val healthPojo = healthExaminationDao.getByIdOrUserId(userId) ?: RealmHealthExamination().apply { _id = userId }
+
+        userModel?.apply {
+            firstName = (userData["firstName"] as? String)?.trim()
+            middleName = (userData["middleName"] as? String)?.trim()
+            lastName = (userData["lastName"] as? String)?.trim()
+            email = (userData["email"] as? String)?.trim()
+            phoneNumber = (userData["phoneNumber"] as? String)?.trim()
+            birthPlace = (userData["birthPlace"] as? String)?.trim()
+            userData["dob"]?.let { dobVal ->
+                val dobInput = (dobVal as String).trim()
+                dob = TimeUtils.convertDDMMYYYYToISO(dobInput)
+            }
+            isUpdated = true
+            save(this)
+        }
+
+        var myHealth: RealmMyHealth? = null
+        if (!TextUtils.isEmpty(healthPojo.data)) {
+            try {
+                val decrypted = AndroidDecrypter.decrypt(healthPojo.data, userModel?.key, userModel?.iv)
+                myHealth = JsonUtils.gson.fromJson(decrypted, RealmMyHealth::class.java)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+
+        if (myHealth == null) {
+            myHealth = RealmMyHealth()
+        }
+        if (TextUtils.isEmpty(myHealth.userKey)) {
+            myHealth.userKey = AndroidDecrypter.generateKey()
+        }
+
+        val profile = myHealth.profile ?: RealmMyHealthProfile().also { myHealth.profile = it }
+
+        profile.emergencyContactName = (userData["emergencyContactName"] as? String)?.trim() ?: ""
+        val newEmergencyContact = (userData["emergencyContact"] as? String)?.trim() ?: ""
+        profile.emergencyContact = if (TextUtils.isEmpty(newEmergencyContact)) profile.emergencyContact else newEmergencyContact
+
+        val newEmergencyContactType = (userData["emergencyContactType"] as? String)?.trim() ?: ""
+        profile.emergencyContactType = if (TextUtils.isEmpty(newEmergencyContactType)) profile.emergencyContactType else newEmergencyContactType
+
+        profile.specialNeeds = (userData["specialNeeds"] as? String)?.trim() ?: ""
+        profile.notes = (userData["notes"] as? String)?.trim() ?: ""
+
+        healthPojo.userId = userModel?._id
+        healthPojo.isUpdated = true
+
+        try {
+            val key = userModel?.key ?: AndroidDecrypter.generateKey().also { newKey -> userModel?.key = newKey }
+            val iv = userModel?.iv ?: AndroidDecrypter.generateIv().also { newIv -> userModel?.iv = newIv }
+            healthPojo.data = AndroidDecrypter.encrypt(JsonUtils.gson.toJson(myHealth), key, iv)
+            userModel?.let { save(it) }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        healthExaminationDao.upsert(healthPojo)
     }
 
     override suspend fun validateUsername(username: String): String? {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -27,6 +27,7 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.data.room.dao.AchievementDao
 import org.ole.planet.myplanet.data.room.dao.OfflineActivityDao
 import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.di.AppPreferences
@@ -74,7 +75,8 @@ class UserRepositoryImpl @Inject constructor(
     private val activitiesRepositoryLazy: dagger.Lazy<ActivitiesRepository>,
     private val meetupDao: MeetupDao,
     private val offlineActivityDao: OfflineActivityDao,
-    private val removedLogDao: RemovedLogDao
+    private val removedLogDao: RemovedLogDao,
+    private val achievementDao: AchievementDao
 ) : RealmRepository(databaseService, realmDispatcher), UserRepository, UserSyncRepository {
     override suspend fun getDashboardProfile(userId: String): DashboardProfile {
         val user = getUserById(userId)
@@ -1140,17 +1142,11 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun initializeAchievement(achievementId: String): RealmAchievement? {
-        executeTransaction { transactionRealm ->
-            val achievement = transactionRealm.where(RealmAchievement::class.java)
-                .equalTo("_id", achievementId)
-                .findFirst()
-
-            if (achievement == null) {
-                transactionRealm.createObject(RealmAchievement::class.java, achievementId)
-            }
-        }
-
-        return findByField(RealmAchievement::class.java, "_id", achievementId)
+        val existing = achievementDao.getById(achievementId)
+        if (existing != null) return existing
+        val achievement = RealmAchievement().apply { _id = achievementId }
+        achievementDao.upsert(achievement)
+        return achievement
     }
 
     override suspend fun updateAchievement(
@@ -1166,24 +1162,19 @@ class UserRepositoryImpl @Inject constructor(
         parentCode: String,
         resumeFileName: String
     ) {
-        executeTransaction { transactionRealm ->
-            val achievement = transactionRealm.where(RealmAchievement::class.java)
-                .equalTo("_id", achievementId)
-                .findFirst()
-            if (achievement != null) {
-                achievement.achievementsHeader = header
-                achievement.goals = goals
-                achievement.purpose = purpose
-                achievement.sendToNation = sendToNation
-                achievement.createdOn = createdOn
-                achievement.username = username
-                achievement.parentCode = parentCode
-                achievement.setAchievements(achievements)
-                achievement.setReferences(references)
-                achievement.resumeFileName = resumeFileName
-                achievement.isUpdated = true
-            }
-        }
+        val achievement = achievementDao.getById(achievementId) ?: return
+        achievement.achievementsHeader = header
+        achievement.goals = goals
+        achievement.purpose = purpose
+        achievement.sendToNation = sendToNation
+        achievement.createdOn = createdOn
+        achievement.username = username
+        achievement.parentCode = parentCode
+        achievement.setAchievements(achievements)
+        achievement.setReferences(references)
+        achievement.resumeFileName = resumeFileName
+        achievement.isUpdated = true
+        achievementDao.upsert(achievement)
     }
 
     override suspend fun markUserUploaded(userId: String, id: String, rev: String) {
@@ -1213,48 +1204,39 @@ class UserRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun getAchievementData(userId: String, planetCode: String): AchievementData = withRealm { realm ->
-        val achievement = realm.where(RealmAchievement::class.java)
-            .equalTo("_id", "$userId@$planetCode")
-            .findFirst()
+    override suspend fun getAchievementData(userId: String, planetCode: String): AchievementData {
+        val achievement = achievementDao.getById("$userId@$planetCode") ?: return AchievementData()
+        val resourceIds = achievement.achievements?.mapNotNull { json ->
+            JsonUtils.gson.fromJson(json, JsonObject::class.java)
+                ?.getAsJsonArray("resources")
+                ?.mapNotNull { it.asJsonObject?.get("_id")?.asString }
+        }?.flatten()?.distinct()?.toTypedArray() ?: emptyArray()
 
-        if (achievement != null) {
-            val achievementCopy = realm.copyFromRealm(achievement)
-            val resourceIds = achievementCopy.achievements?.mapNotNull { json ->
-                JsonUtils.gson.fromJson(json, JsonObject::class.java)
-                    ?.getAsJsonArray("resources")
-                    ?.mapNotNull { it.asJsonObject?.get("_id")?.asString }
-            }?.flatten()?.distinct()?.toTypedArray() ?: emptyArray()
-
-            val resources = if (resourceIds.isNotEmpty()) {
+        val resources = if (resourceIds.isNotEmpty()) {
+            withRealm { realm ->
                 realm.copyFromRealm(
                     realm.where(RealmMyLibrary::class.java)
                         .`in`("id", resourceIds)
                         .findAll()
                 )
-            } else {
-                emptyList()
             }
-
-            AchievementData(
-                goals = achievementCopy.goals ?: "",
-                purpose = achievementCopy.purpose ?: "",
-                achievementsHeader = achievementCopy.achievementsHeader ?: "",
-                achievements = achievementCopy.achievements ?: emptyList(),
-                achievementResources = resources,
-                references = achievementCopy.references ?: emptyList(),
-                resumeFileName = achievementCopy.resumeFileName ?: ""
-            )
         } else {
-            AchievementData()
+            emptyList()
         }
+
+        return AchievementData(
+            goals = achievement.goals ?: "",
+            purpose = achievement.purpose ?: "",
+            achievementsHeader = achievement.achievementsHeader ?: "",
+            achievements = achievement.achievements ?: emptyList(),
+            achievementResources = resources,
+            references = achievement.references ?: emptyList(),
+            resumeFileName = achievement.resumeFileName ?: ""
+        )
     }
 
     override suspend fun getAchievementsForUpload(): List<JsonObject> {
-        return queryList(RealmAchievement::class.java) {
-            not().beginsWith("_id", "guest")
-            equalTo("isUpdated", true)
-        }.map { RealmAchievement.serialize(it) }
+        return achievementDao.getPendingUploads().map { RealmAchievement.serialize(it) }
     }
 
     override suspend fun getSavedUsers(): List<User> = sharedPrefManager.getSavedUsers()
@@ -1316,63 +1298,20 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markAchievementUploaded(id: String, rev: String?) {
-        executeTransaction { transactionRealm ->
-            val achievement = transactionRealm.where(RealmAchievement::class.java)
-                .equalTo("_id", id)
-                .findFirst()
-            if (achievement != null) {
-                if (!rev.isNullOrEmpty()) achievement._rev = rev
-                achievement.isUpdated = false
-            }
-        }
+        achievementDao.markUploaded(id, rev)
     }
 
-    override fun bulkInsertAchievementsFromSync(realm: io.realm.Realm, jsonArray: JsonArray) {
-        val documentList = ArrayList<JsonObject>(jsonArray.size())
-        val ids = mutableListOf<String>()
+    override suspend fun bulkInsertAchievementsFromSync(jsonArray: JsonArray) {
+        val achievements = ArrayList<RealmAchievement>(jsonArray.size())
         for (j in jsonArray) {
             var jsonDoc = j.asJsonObject
             jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
             val id = JsonUtils.getString("_id", jsonDoc)
             if (!id.startsWith("_design")) {
-                documentList.add(jsonDoc)
-                ids.add(id)
+                achievements.add(RealmAchievement.fromJson(jsonDoc))
             }
         }
-
-        if (ids.isEmpty()) return
-
-        val existingAchievements = realm.where(RealmAchievement::class.java)
-            .`in`("_id", ids.toTypedArray())
-            .findAll()
-            .associateBy { it._id }
-            .toMutableMap()
-
-        documentList.forEach { act ->
-            val id = JsonUtils.getString("_id", act)
-            var achievement = existingAchievements[id]
-
-            if (achievement == null) {
-                achievement = realm.createObject(RealmAchievement::class.java, id)
-                existingAchievements[id] = achievement
-            }
-
-            achievement?._rev = JsonUtils.getString("_rev", act)
-            achievement?.purpose = JsonUtils.getString("purpose", act)
-            achievement?.goals = JsonUtils.getString("goals", act)
-            achievement?.achievementsHeader = JsonUtils.getString("achievementsHeader", act)
-            achievement?.sendToNation = act.get("sendToNation")?.asString ?: "false"
-            achievement?.dateSortOrder = JsonUtils.getString("dateSortOrder", act)
-            achievement?.createdOn = JsonUtils.getString("createdOn", act)
-            achievement?.username = JsonUtils.getString("username", act)
-            achievement?.parentCode = JsonUtils.getString("parentCode", act)
-            achievement?.isUpdated = false
-            achievement?.setReferences(JsonUtils.getJsonArray("references", act))
-            achievement?.setAchievements(JsonUtils.getJsonArray("achievements", act))
-            achievement?.setLinks(JsonUtils.getJsonArray("links", act))
-            achievement?.setOtherInfo(JsonUtils.getJsonArray("otherInfo", act))
-            achievement?.resumeFileName = JsonUtils.getString("resumeFileName", act)
-        }
+        achievementDao.upsertAll(achievements)
     }
 
     override suspend fun insertUsersFromSync(docs: List<JsonObject>) {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserSyncRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserSyncRepository.kt
@@ -12,7 +12,7 @@ interface UserSyncRepository {
     suspend fun uploadNewUser(model: RealmUser, updateHealthFn: suspend (String, String) -> Unit)
     suspend fun updateExistingUser(header: String, model: RealmUser)
     suspend fun saveUser(jsonDoc: JsonObject?, key: String? = null, iv: String? = null): RealmUser?
-    fun bulkInsertAchievementsFromSync(realm: io.realm.Realm, jsonArray: JsonArray)
+    suspend fun bulkInsertAchievementsFromSync(jsonArray: JsonArray)
     suspend fun insertUsersFromSync(docs: List<JsonObject>)
     suspend fun uploadShelfData(user: RealmUser)
     suspend fun checkShelfBatchForDataOptimized(shelfIds: List<String>): List<String>

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -252,7 +252,7 @@ class UploadManager @Inject constructor(
     }
 
     suspend fun uploadTeamTask() {
-        uploadCoordinator.upload(uploadConfigs.TeamTask)
+        uploadCoordinator.uploadRoom(uploadConfigs.TeamTask)
     }
 
     suspend fun uploadSubmissions(buttonClickTime: Long = 0L) {

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -259,6 +259,9 @@ class TransactionSyncManager @Inject constructor(
                     "team_activities" -> timedBatchInsert(table, arr.size()) {
                         teamsSyncRepository.get().bulkInsertTeamActivitiesFromSync(arr)
                     }
+                    "tasks" -> timedBatchInsert(table, arr.size()) {
+                        teamsSyncRepository.get().bulkInsertTasksFromSync(arr)
+                    }
                     else -> {
                         // Use async transaction to avoid blocking (ANR-safe)
                         executeTransaction { mRealm: Realm ->
@@ -269,7 +272,6 @@ class TransactionSyncManager @Inject constructor(
                                 "courses" -> coursesRepository.bulkInsertFromSync(mRealm, arr)
                                 "achievements" -> userSyncRepository.bulkInsertAchievementsFromSync(mRealm, arr)
                                 "teams" -> teamsSyncRepository.get().bulkInsertFromSync(mRealm, arr)
-                                "tasks" -> teamsSyncRepository.get().bulkInsertTasksFromSync(mRealm, arr)
                                 "health" -> healthRepository.bulkInsertFromSync(mRealm, arr)
                                 "notifications" -> notificationsRepository.bulkInsertFromSync(mRealm, arr)
                                 else -> Log.e("SyncPerf", "Unknown table: $table")

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -262,6 +262,9 @@ class TransactionSyncManager @Inject constructor(
                     "tasks" -> timedBatchInsert(table, arr.size()) {
                         teamsSyncRepository.get().bulkInsertTasksFromSync(arr)
                     }
+                    "notifications" -> timedBatchInsert(table, arr.size()) {
+                        notificationsRepository.bulkInsertFromSync(arr)
+                    }
                     else -> {
                         // Use async transaction to avoid blocking (ANR-safe)
                         executeTransaction { mRealm: Realm ->
@@ -273,7 +276,6 @@ class TransactionSyncManager @Inject constructor(
                                 "achievements" -> userSyncRepository.bulkInsertAchievementsFromSync(mRealm, arr)
                                 "teams" -> teamsSyncRepository.get().bulkInsertFromSync(mRealm, arr)
                                 "health" -> healthRepository.bulkInsertFromSync(mRealm, arr)
-                                "notifications" -> notificationsRepository.bulkInsertFromSync(mRealm, arr)
                                 else -> Log.e("SyncPerf", "Unknown table: $table")
                             }
                             val insertDuration = SystemClock.elapsedRealtime() - insertStartTime

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -265,6 +265,9 @@ class TransactionSyncManager @Inject constructor(
                     "notifications" -> timedBatchInsert(table, arr.size()) {
                         notificationsRepository.bulkInsertFromSync(arr)
                     }
+                    "achievements" -> timedBatchInsert(table, arr.size()) {
+                        userSyncRepository.bulkInsertAchievementsFromSync(arr)
+                    }
                     else -> {
                         // Use async transaction to avoid blocking (ANR-safe)
                         executeTransaction { mRealm: Realm ->
@@ -273,7 +276,6 @@ class TransactionSyncManager @Inject constructor(
                                 "exams" -> surveysRepository.bulkInsertExamsFromSync(mRealm, arr)
                                 "submissions" -> submissionsRepository.bulkInsertFromSync(mRealm, arr)
                                 "courses" -> coursesRepository.bulkInsertFromSync(mRealm, arr)
-                                "achievements" -> userSyncRepository.bulkInsertAchievementsFromSync(mRealm, arr)
                                 "teams" -> teamsSyncRepository.get().bulkInsertFromSync(mRealm, arr)
                                 "health" -> healthRepository.bulkInsertFromSync(mRealm, arr)
                                 else -> Log.e("SyncPerf", "Unknown table: $table")

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -268,6 +268,9 @@ class TransactionSyncManager @Inject constructor(
                     "achievements" -> timedBatchInsert(table, arr.size()) {
                         userSyncRepository.bulkInsertAchievementsFromSync(arr)
                     }
+                    "health" -> timedBatchInsert(table, arr.size()) {
+                        healthRepository.bulkInsertFromSync(arr)
+                    }
                     else -> {
                         // Use async transaction to avoid blocking (ANR-safe)
                         executeTransaction { mRealm: Realm ->
@@ -277,7 +280,6 @@ class TransactionSyncManager @Inject constructor(
                                 "submissions" -> submissionsRepository.bulkInsertFromSync(mRealm, arr)
                                 "courses" -> coursesRepository.bulkInsertFromSync(mRealm, arr)
                                 "teams" -> teamsSyncRepository.get().bulkInsertFromSync(mRealm, arr)
-                                "health" -> healthRepository.bulkInsertFromSync(mRealm, arr)
                                 else -> Log.e("SyncPerf", "Unknown table: $table")
                             }
                             val insertDuration = SystemClock.elapsedRealtime() - insertStartTime

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -12,6 +12,7 @@ import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
+import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmCourseProgress
@@ -59,7 +60,8 @@ class UploadConfigs @Inject constructor(
     private val resourceActivityDao: ResourceActivityDao,
     private val submitPhotosDao: SubmitPhotosDao,
     private val newsLogDao: NewsLogDao,
-    private val teamLogDao: TeamLogDao
+    private val teamLogDao: TeamLogDao,
+    private val teamTaskDao: TeamTaskDao
 ) {
     val NewsActivities = RoomUploadConfig(
         endpoint = "myplanet_activities",
@@ -87,19 +89,20 @@ class UploadConfigs @Inject constructor(
         }
     )
 
-    val TeamTask = UploadConfig(
-        modelClass = RealmTeamTask::class,
+    val TeamTask = RoomUploadConfig(
         endpoint = "tasks",
-        queryBuilder = { query ->
-            query.beginGroup()
-                .isNull("_id").or().isEmpty("_id").or().equalTo("isUpdated", true)
-                .endGroup()
-        },
+        modelClassName = "RealmTeamTask",
+        fetchPendingItems = { teamTaskDao.getPendingUploads() },
         serializer = UploadSerializer.Async { task ->
             val user = userRepository.getUserById(task.assignee ?: "")
             RealmTeamTask.serialize(task, user)
         },
-        idExtractor = { it.id }
+        idExtractor = { it.id },
+        markUploaded = { results ->
+            results.filter { result ->
+                teamTaskDao.markUploaded(result.localId, result.remoteId, result.remoteRev) == 0
+            }
+        }
     )
 
     val TeamActivities = RoomUploadConfig(

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationActivity.kt
@@ -380,7 +380,7 @@ class HealthExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedC
         try {
             if (pojo == null) {
                 pojo = RealmHealthExamination()
-                pojo?._id = userId
+                pojo?._id = userId.orEmpty()
                 pojo?.userId = user?._id
             }
             health?.lastExamination = Date().time

--- a/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.repository
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -28,6 +29,7 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.data.room.dao.HealthExaminationDao
 import org.ole.planet.myplanet.data.applyEqualTo
 import org.ole.planet.myplanet.data.findCopyByField
 import org.ole.planet.myplanet.data.queryList
@@ -45,6 +47,7 @@ class HealthRepositoryImplTest {
     private val testScope = TestScope(testDispatcher)
     private val databaseService: DatabaseService = mockk(relaxed = true)
     private val mockApiInterface: ApiInterface = mockk(relaxed = true)
+    private val healthExaminationDao: HealthExaminationDao = mockk(relaxed = true)
     private val realm: Realm = mockk(relaxed = true)
     private val healthQuery: RealmQuery<RealmHealthExamination> = mockk(relaxed = true)
     private val userQuery: RealmQuery<RealmUser> = mockk(relaxed = true)
@@ -65,7 +68,6 @@ class HealthRepositoryImplTest {
             operation(realm)
         }
 
-        every { realm.where(RealmHealthExamination::class.java) } returns healthQuery
         every { realm.where(RealmUser::class.java) } returns userQuery
 
         every { healthQuery.equalTo(any<String>(), any<String>()) } returns healthQuery
@@ -76,14 +78,7 @@ class HealthRepositoryImplTest {
 
         every { userQuery.equalTo(any<String>(), any<String>()) } returns userQuery
 
-        every { healthResults.iterator() } answers { healthResultsIterable.toMutableList().iterator() }
-        every { healthResults.isValid } returns true
 
-        every { realm.copyFromRealm(any<Iterable<RealmHealthExamination>>()) } answers {
-            val list = arg<Iterable<RealmHealthExamination>>(0)
-            list.toList()
-        }
-        every { realm.copyFromRealm(any<RealmHealthExamination>()) } answers { arg<RealmHealthExamination>(0) }
         every { realm.copyFromRealm(any<RealmUser>()) } answers { arg<RealmUser>(0) }
 
         mockkStatic("org.ole.planet.myplanet.data.DatabaseServiceKt")
@@ -92,7 +87,8 @@ class HealthRepositoryImplTest {
             mockApiInterface,
             databaseService,
             UnconfinedTestDispatcher(),
-            dispatcherProvider
+            dispatcherProvider,
+            healthExaminationDao
         )
     }
 
@@ -126,7 +122,7 @@ class HealthRepositoryImplTest {
 
         every { realm.findCopyByField(RealmUser::class.java, "_id", "user1") } returns null
         every { realm.findCopyByField(RealmUser::class.java, "id", "user1") } returns user
-        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "user1") } returns examination
+        coEvery { healthExaminationDao.getByIdOrUserId("user1") } returns examination
 
         val result = repository.getHealthEntry("user1")
         advanceUntilIdle()
@@ -145,8 +141,7 @@ class HealthRepositoryImplTest {
 
         every { realm.findCopyByField(RealmUser::class.java, "_id", "user1") } returns null
         every { realm.findCopyByField(RealmUser::class.java, "id", "user1") } returns user
-        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "user1") } returns null
-        every { realm.findCopyByField(RealmHealthExamination::class.java, "userId", "user1") } returns examination
+        coEvery { healthExaminationDao.getByIdOrUserId("user1") } returns examination
 
         val result = repository.getHealthEntry("user1")
         advanceUntilIdle()
@@ -160,7 +155,7 @@ class HealthRepositoryImplTest {
         val examination = RealmHealthExamination()
         examination._id = "exam1"
 
-        every { realm.findCopyByField(RealmHealthExamination::class.java, "_id", "exam1") } returns examination
+        coEvery { healthExaminationDao.getById("exam1") } returns examination
 
         val result = repository.getExaminationById("exam1")
         advanceUntilIdle()
@@ -170,20 +165,13 @@ class HealthRepositoryImplTest {
 
     @Test
     fun getUpdatedHealthExaminations_returns_list() = testScope.runTest {
-        val examination = RealmHealthExamination()
-        examination._id = "exam1"
-        examination.isUpdated = true
-
-        healthResultsIterable.clear()
-        healthResultsIterable.add(examination)
-
-        val builderSlot = slot<(RealmQuery<RealmHealthExamination>) -> Unit>()
-        every { realm.queryList(RealmHealthExamination::class.java, capture(builderSlot)) } returns healthResultsIterable
+        val examination = RealmHealthExamination().apply {
+            _id = "exam1"
+            isUpdated = true
+        }
+        coEvery { healthExaminationDao.getUpdated() } returns listOf(examination)
 
         val result = repository.getUpdatedHealthExaminations()
-        builderSlot.captured.invoke(healthQuery)
-        verify { healthQuery.equalTo("isUpdated", true) }
-        verify { healthQuery.notEqualTo("userId", "") }
         advanceUntilIdle()
 
         assertEquals(1, result.size)
@@ -192,21 +180,14 @@ class HealthRepositoryImplTest {
 
     @Test
     fun getUpdatedHealthForUser_returns_list() = testScope.runTest {
-        val examination = RealmHealthExamination()
-        examination._id = "exam1"
-        examination.isUpdated = true
-        examination.userId = "user1"
-
-        healthResultsIterable.clear()
-        healthResultsIterable.add(examination)
-
-        val builderSlot = slot<(RealmQuery<RealmHealthExamination>) -> Unit>()
-        every { realm.queryList(RealmHealthExamination::class.java, capture(builderSlot)) } returns healthResultsIterable
+        val examination = RealmHealthExamination().apply {
+            _id = "exam1"
+            isUpdated = true
+            userId = "user1"
+        }
+        coEvery { healthExaminationDao.getUpdatedForUser("user1") } returns listOf(examination)
 
         val result = repository.getUpdatedHealthForUser("user1")
-        builderSlot.captured.invoke(healthQuery)
-        verify { healthQuery.equalTo("isUpdated", true) }
-        verify { healthQuery.equalTo("userId", "user1") }
         advanceUntilIdle()
 
         assertEquals(1, result.size)
@@ -216,25 +197,12 @@ class HealthRepositoryImplTest {
     @Test
     fun markHealthExaminationsUploaded_updates_revisions() = testScope.runTest {
         val idToRevMap = mapOf("exam1" to "rev1", "exam2" to "rev2")
-        val exam1 = RealmHealthExamination()
-        exam1._id = "exam1"
-        val exam2 = RealmHealthExamination()
-        exam2._id = "exam2"
-
-        healthResultsIterable.clear()
-        healthResultsIterable.add(exam1)
-        healthResultsIterable.add(exam2)
-
-        every { healthQuery.`in`("_id", any<Array<String>>()) } returns healthQuery
 
         repository.markHealthExaminationsUploaded(idToRevMap)
         advanceUntilIdle()
 
-        verify { healthQuery.`in`(eq("_id"), match<Array<String>> { it.toSet() == setOf("exam1", "exam2") }) }
-        assertEquals("rev1", exam1._rev)
-        assertEquals(false, exam1.isUpdated)
-        assertEquals("rev2", exam2._rev)
-        assertEquals(false, exam2.isUpdated)
+        coVerify { healthExaminationDao.markUploaded("exam1", "rev1") }
+        coVerify { healthExaminationDao.markUploaded("exam2", "rev2") }
     }
 
     @Test
@@ -243,28 +211,21 @@ class HealthRepositoryImplTest {
         val pojo = RealmHealthExamination()
         val user = RealmUser()
 
-        every { realm.copyToRealmOrUpdate(any<RealmHealthExamination>()) } returns examination
-        every { realm.copyToRealmOrUpdate(any<RealmUser>()) } returns user
-
         repository.saveExamination(examination, pojo, user)
         advanceUntilIdle()
 
-        verify(exactly = 1) { realm.copyToRealmOrUpdate(user) }
-        verify(exactly = 1) { realm.copyToRealmOrUpdate(pojo) }
-        verify(exactly = 1) { realm.copyToRealmOrUpdate(examination) }
+        coVerify(exactly = 1) { healthExaminationDao.upsert(pojo) }
+        coVerify(exactly = 1) { healthExaminationDao.upsert(examination) }
     }
 
     @Test
     fun saveExamination_handles_nulls() = testScope.runTest {
         val examination = RealmHealthExamination()
 
-        every { realm.copyToRealmOrUpdate(any<RealmHealthExamination>()) } returns examination
-
         repository.saveExamination(examination, null, null)
         advanceUntilIdle()
 
-        verify(exactly = 0) { realm.copyToRealmOrUpdate(any<RealmUser>()) }
-        verify(exactly = 1) { realm.copyToRealmOrUpdate(examination) }
+        coVerify(exactly = 1) { healthExaminationDao.upsert(examination) }
     }
 
     @Test
@@ -273,13 +234,10 @@ class HealthRepositoryImplTest {
         examination._id = "exam1"
         examination.userId = "old_user"
 
-        every { healthQuery.applyEqualTo("_id", "exam1") } returns healthQuery
-        every { healthQuery.findFirst() } returns examination
-
         repository.updateExaminationUserId("exam1", "new_user")
         advanceUntilIdle()
 
-        assertEquals("new_user", examination.userId)
+        coVerify { healthExaminationDao.updateUserId("exam1", "new_user") }
     }
 
     @Test
@@ -348,13 +306,11 @@ class HealthRepositoryImplTest {
 
         val detachedExamination = mockk<RealmHealthExamination>()
         every { RealmHealthExamination.fromJson(doc1) } returns detachedExamination
-        every { realm.insertOrUpdate(any<List<RealmHealthExamination>>()) } returns Unit
-
-        repository.bulkInsertFromSync(realm, jsonArray)
+        repository.bulkInsertFromSync(jsonArray)
         advanceUntilIdle()
 
         verify(exactly = 1) { RealmHealthExamination.fromJson(doc1) }
         verify(exactly = 0) { RealmHealthExamination.fromJson(doc2) }
-        verify(exactly = 1) { realm.insertOrUpdate(listOf(detachedExamination)) }
+        coVerify(exactly = 1) { healthExaminationDao.upsertAll(listOf(detachedExamination)) }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
@@ -2,13 +2,9 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonObject
 import io.mockk.coEvery
-import io.mockk.every
-import io.mockk.invoke
+import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
-import io.realm.Realm
-import io.realm.RealmQuery
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -19,6 +15,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.NotificationDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.utils.TestTimeProvider
@@ -30,6 +27,7 @@ class NotificationsRepositoryImplTest {
     private lateinit var userRepository: dagger.Lazy<UserRepository>
     private lateinit var teamsRepository: dagger.Lazy<TeamsRepository>
     private lateinit var repository: NotificationsRepositoryImpl
+    private lateinit var notificationDao: NotificationDao
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @Before
@@ -37,8 +35,9 @@ class NotificationsRepositoryImplTest {
         databaseService = mockk(relaxed = true)
         userRepository = mockk(relaxed = true)
         teamsRepository = mockk(relaxed = true)
+        notificationDao = mockk(relaxed = true)
         repository = NotificationsRepositoryImpl(databaseService, testDispatcher, userRepository, teamsRepository,
-            TestTimeProvider(), mockk(relaxed = true), mockk<TeamTaskDao>(relaxed = true)
+            TestTimeProvider(), mockk(relaxed = true), notificationDao, mockk<TeamTaskDao>(relaxed = true)
         )
     }
 
@@ -62,29 +61,15 @@ class NotificationsRepositoryImplTest {
 
     @Test
     fun `insert with missing id does nothing`() = runTest {
-        val realm = mockk<Realm>(relaxed = true)
         val jsonObject = JsonObject() // Missing _id
-
-        val transactionSlot = slot<(Realm) -> Unit>()
-        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
-            transactionSlot.captured.invoke(realm)
-        }
-        coEvery { databaseService.withRealmAsync<Any?>(any()) } answers {
-            val operation = firstArg<(Realm) -> Any?>()
-            operation(realm)
-        }
 
         repository.insert(jsonObject)
 
-        verify(exactly = 0) { realm.where(RealmNotification::class.java) }
-        verify(exactly = 0) { realm.createObject(RealmNotification::class.java, any<String>()) }
+        coVerify(exactly = 0) { notificationDao.upsert(any()) }
     }
 
     @Test
     fun `insert creates new notification when not found`() = runTest {
-        val realm = mockk<Realm>(relaxed = true)
-        val query = mockk<RealmQuery<RealmNotification>>()
-        val notification = RealmNotification()
         val jsonObject = JsonObject().apply {
             addProperty("_id", "testId")
             addProperty("user", "testUser")
@@ -96,45 +81,27 @@ class NotificationsRepositoryImplTest {
             addProperty("status", "read")
             addProperty("time", 123456789L)
         }
-
-        val transactionSlot = slot<(Realm) -> Unit>()
-        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
-            transactionSlot.captured.invoke(realm)
-        }
-        coEvery { databaseService.withRealmAsync<Any?>(any()) } answers {
-            val operation = firstArg<(Realm) -> Any?>()
-            operation(realm)
-        }
-
-        every { realm.where(RealmNotification::class.java) } returns query
-        every { query.equalTo("id", "testId") } returns query
-        every { query.findFirst() } returns null
-        every { realm.createObject(RealmNotification::class.java, "testId") } returns notification
-        every { realm.copyFromRealm(notification) } returns notification
-        val copyToRealmOrUpdateSlot = slot<RealmNotification>()
-        every { realm.copyToRealmOrUpdate(capture(copyToRealmOrUpdateSlot)) } answers { copyToRealmOrUpdateSlot.captured }
+        coEvery { notificationDao.getById("testId") } returns null
+        val upsertSlot = slot<RealmNotification>()
+        coEvery { notificationDao.upsert(capture(upsertSlot)) } returns Unit
 
         repository.insert(jsonObject)
 
-        // Capture the notification saved
-        val savedNotification = copyToRealmOrUpdateSlot.captured
-
+        val savedNotification = upsertSlot.captured
         assertEquals("testUser", savedNotification.userId)
         assertEquals("testMessage", savedNotification.message)
         assertEquals("testType", savedNotification.type)
         assertEquals("testLink", savedNotification.link)
         assertEquals(1, savedNotification.priority)
         assertEquals("testRev", savedNotification.rev)
-        assertTrue(savedNotification.isRead) // "read" != "unread"
+        assertTrue(savedNotification.isRead)
         assertEquals(123456789L, savedNotification.createdAt.time)
         assertTrue(savedNotification.isFromServer)
     }
 
     @Test
     fun `insert updates existing notification`() = runTest {
-        val realm = mockk<Realm>(relaxed = true)
-        val query = mockk<RealmQuery<RealmNotification>>()
-        val notification = RealmNotification()
+        val existing = RealmNotification().apply { id = "testId" }
         val jsonObject = JsonObject().apply {
             addProperty("_id", "testId")
             addProperty("user", "updatedUser")
@@ -143,42 +110,25 @@ class NotificationsRepositoryImplTest {
             addProperty("status", "unread")
             addProperty("time", 987654321L)
         }
-
-        val transactionSlot = slot<(Realm) -> Unit>()
-        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
-            transactionSlot.captured.invoke(realm)
-        }
-        coEvery { databaseService.withRealmAsync<Any?>(any()) } answers {
-            val operation = firstArg<(Realm) -> Any?>()
-            operation(realm)
-        }
-
-        every { realm.where(RealmNotification::class.java) } returns query
-        every { query.equalTo("id", "testId") } returns query
-        every { query.findFirst() } returns notification
-        every { realm.copyFromRealm(notification) } returns notification
-        val copyToRealmOrUpdateSlot = slot<RealmNotification>()
-        every { realm.copyToRealmOrUpdate(capture(copyToRealmOrUpdateSlot)) } answers { copyToRealmOrUpdateSlot.captured }
+        coEvery { notificationDao.getById("testId") } returns existing
+        val upsertSlot = slot<RealmNotification>()
+        coEvery { notificationDao.upsert(capture(upsertSlot)) } returns Unit
 
         repository.insert(jsonObject)
 
-        val savedNotification = copyToRealmOrUpdateSlot.captured
-
+        val savedNotification = upsertSlot.captured
         assertEquals("updatedUser", savedNotification.userId)
         assertEquals("updatedMessage", savedNotification.message)
         assertEquals("updatedType", savedNotification.type)
-        assertFalse(savedNotification.isRead) // "unread" == "unread" -> isRead = false
+        assertFalse(savedNotification.isRead)
         assertEquals(987654321L, savedNotification.createdAt.time)
         assertTrue(savedNotification.isFromServer)
-
-        verify(exactly = 0) { realm.createObject(any<Class<RealmNotification>>(), any<String>()) }
     }
 
     @Test
     fun `insert preserves read status if needsSync is true`() = runTest {
-        val realm = mockk<Realm>(relaxed = true)
-        val query = mockk<RealmQuery<RealmNotification>>()
-        val notification = RealmNotification().apply {
+        val existing = RealmNotification().apply {
+            id = "testId"
             isRead = true
             needsSync = true
         }
@@ -186,28 +136,12 @@ class NotificationsRepositoryImplTest {
             addProperty("_id", "testId")
             addProperty("status", "unread")
         }
-
-        val transactionSlot = slot<(Realm) -> Unit>()
-        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
-            transactionSlot.captured.invoke(realm)
-        }
-        coEvery { databaseService.withRealmAsync<Any?>(any()) } answers {
-            val operation = firstArg<(Realm) -> Any?>()
-            operation(realm)
-        }
-
-        every { realm.where(RealmNotification::class.java) } returns query
-        every { query.equalTo("id", "testId") } returns query
-        every { query.findFirst() } returns notification
-        every { realm.copyFromRealm(notification) } returns notification
-        val copyToRealmOrUpdateSlot = slot<RealmNotification>()
-        every { realm.copyToRealmOrUpdate(capture(copyToRealmOrUpdateSlot)) } answers { copyToRealmOrUpdateSlot.captured }
+        coEvery { notificationDao.getById("testId") } returns existing
+        val upsertSlot = slot<RealmNotification>()
+        coEvery { notificationDao.upsert(capture(upsertSlot)) } returns Unit
 
         repository.insert(jsonObject)
 
-        val savedNotification = copyToRealmOrUpdateSlot.captured
-
-        // isRead should be preserved (true) even though status is "unread", because needsSync is true
-        assertTrue(savedNotification.isRead)
+        assertTrue(upsertSlot.captured.isRead)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.utils.TestTimeProvider
 
@@ -37,7 +38,7 @@ class NotificationsRepositoryImplTest {
         userRepository = mockk(relaxed = true)
         teamsRepository = mockk(relaxed = true)
         repository = NotificationsRepositoryImpl(databaseService, testDispatcher, userRepository, teamsRepository,
-            TestTimeProvider(), mockk(relaxed = true)
+            TestTimeProvider(), mockk(relaxed = true), mockk<TeamTaskDao>(relaxed = true)
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
@@ -17,6 +17,7 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
+import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UploadManager
@@ -71,7 +72,8 @@ class TeamsRepositoryBenchmarkTest {
             userRepository,
             resourcesRepositoryLazy,
             TestTimeProvider(),
-            teamLogDao
+            teamLogDao,
+            mockk<TeamTaskDao>(relaxed = true)
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
@@ -20,6 +20,7 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
+import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.User
@@ -80,7 +81,8 @@ class TeamsRepositoryImplTest {
             mockUserRepository,
             mockk(),
             TestTimeProvider(),
-            teamLogDao
+            teamLogDao,
+            mockk<TeamTaskDao>(relaxed = true)
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
@@ -34,6 +34,7 @@ class UserRepositoryBulkInsertTest {
             mockk(relaxed = true),
             mockk(relaxed = true),
             mockk(relaxed = true),
+            mockk(relaxed = true),
             mockk(relaxed = true)
         )
         val realm = mockk<Realm>(relaxed = true)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
@@ -35,6 +35,7 @@ class UserRepositoryBulkInsertTest {
             mockk(relaxed = true),
             mockk(relaxed = true),
             mockk(relaxed = true),
+            mockk(relaxed = true),
             mockk(relaxed = true)
         )
         val realm = mockk<Realm>(relaxed = true)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
@@ -104,6 +104,7 @@ class UserRepositoryImplTest {
             activitiesRepositoryLazy,
             mockk(relaxed = true),
             mockk(relaxed = true),
+            mockk(relaxed = true),
             mockk(relaxed = true)
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
@@ -105,6 +105,7 @@ class UserRepositoryImplTest {
             mockk(relaxed = true),
             mockk(relaxed = true),
             mockk(relaxed = true),
+            mockk(relaxed = true),
             mockk(relaxed = true)
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -32,7 +32,6 @@ import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmSearchActivity
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
-import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.ChatRepository
 import org.ole.planet.myplanet.repository.PersonalsRepository
@@ -217,10 +216,10 @@ class UploadManagerTest {
 
     @Test
     fun `uploadTeamTask delegates to uploadCoordinator`() = testScope.runTest {
-        coEvery { uploadCoordinator.upload<RealmTeamTask>(any()) } returns UploadResult.Success(1, emptyList())
+        coEvery { uploadCoordinator.uploadRoom(uploadConfigs.TeamTask) } returns UploadResult.Success(1, emptyList())
         uploadManager.uploadTeamTask()
         advanceUntilIdle()
-        coVerify { uploadCoordinator.upload(uploadConfigs.TeamTask) }
+        coVerify { uploadCoordinator.uploadRoom(uploadConfigs.TeamTask) }
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -16,6 +16,7 @@ import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
+import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmNewsLog
 import org.ole.planet.myplanet.model.RealmResourceActivity
@@ -49,7 +50,8 @@ class UploadConfigsTest {
         resourceActivityDao = resourceActivityDao,
         submitPhotosDao = submitPhotosDao,
         newsLogDao = newsLogDao,
-        teamLogDao = teamLogDao
+        teamLogDao = teamLogDao,
+        teamTaskDao = mockk<TeamTaskDao>(relaxed = true)
     )
 
     @Test

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -191,7 +191,11 @@ wired through `di/RoomModule`.
       Room `@Entity`; `NotificationDao` owns unread counts, read/sync marking, list filters,
       deletes, single-doc upserts, and sync bulk upserts. Notification sync now runs outside the
       legacy Realm transaction path.
-- [ ] Remaining ~30 model domains.
+- [x] **Achievement** migrated (synced + custom uploaded profile achievement docs).
+      `RealmAchievement` is now a Room `@Entity` with JSON-backed `List<String>` fields;
+      `AchievementDao` owns initialization, edits, pending-upload reads, upload acknowledgements,
+      and sync bulk upserts. Achievement sync now runs outside the legacy Realm transaction path.
+- [ ] Remaining ~29 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.
 

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -182,7 +182,11 @@ wired through `di/RoomModule`.
 - [x] **RemovedLog** migrated (local shelf tombstones). `RealmRemovedLog` is now a Room
       `@Entity`; `RemovedLogDao` owns add/remove tombstone writes, bulk cleanup when resources or
       courses are re-added, and shelf merge filtering for removed resources/courses.
-- [ ] Migrate the remaining ~8 uploadable models to `RoomUploadConfig` + the synced-only domains.
+- [x] **TeamTask** migrated (uploaded + synced task rows). `RealmTeamTask` is now a Room
+      `@Entity`; `TeamTaskDao` owns task flows, due-task notification lookups, title/id lookups,
+      sync upserts, pending-upload reads, and upload acknowledgements; task repository and
+      notification lookups use the DAO, and the upload config now uses `RoomUploadConfig`.
+- [ ] Migrate the remaining ~7 uploadable models to `RoomUploadConfig` + the synced-only domains.
 - [ ] Remaining ~31 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -70,7 +70,7 @@ wired through `di/RoomModule`.
 - [x] Room deps added (coexisting with Realm).
 - [x] Foundation: `Converters`, `AppDatabase`, `RoomModule`.
 - [x] **Dictionary** domain migrated end-to-end (`DictionaryEntity`, `DictionaryDao`,
-      `DictionaryActivity`). First proven template (raw-Realm activity).
+      `DictionaryActivity`; legacy `RealmDictionary` is now a plain compatibility DTO). First proven template (raw-Realm activity).
 - [x] Realm transition config: `DatabaseService` now uses `deleteRealmIfMigrationNeeded()` so a
       model leaving the Realm schema recreates the Realm file instead of crashing (drop-and-resync).
 - [x] **Life** domain migrated end-to-end (`RealmMyLife` is now a Room `@Entity`, `MyLifeDao`,

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -195,7 +195,11 @@ wired through `di/RoomModule`.
       `RealmAchievement` is now a Room `@Entity` with JSON-backed `List<String>` fields;
       `AchievementDao` owns initialization, edits, pending-upload reads, upload acknowledgements,
       and sync bulk upserts. Achievement sync now runs outside the legacy Realm transaction path.
-- [ ] Remaining ~29 model domains.
+- [x] **HealthExamination** migrated (synced + custom uploaded health records).
+      `RealmHealthExamination` is now a Room `@Entity`; `HealthExaminationDao` owns profile/id
+      lookups, pending upload reads, upload acknowledgements, user-id fixes after user upload,
+      and sync bulk upserts. Health sync now runs outside the legacy Realm transaction path.
+- [ ] Remaining ~28 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.
 

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -187,7 +187,11 @@ wired through `di/RoomModule`.
       sync upserts, pending-upload reads, and upload acknowledgements; task repository and
       notification lookups use the DAO, and the upload config now uses `RoomUploadConfig`.
 - [ ] Migrate the remaining ~7 uploadable models to `RoomUploadConfig` + the synced-only domains.
-- [ ] Remaining ~31 model domains.
+- [x] **Notification** migrated (synced local notification rows). `RealmNotification` is now a
+      Room `@Entity`; `NotificationDao` owns unread counts, read/sync marking, list filters,
+      deletes, single-doc upserts, and sync bulk upserts. Notification sync now runs outside the
+      legacy Realm transaction path.
+- [ ] Remaining ~30 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.
 


### PR DESCRIPTION
### Motivation
- Remove Realm usage for the team-task domain as part of the ongoing Realm→Room migration and make task reads, writes, sync and uploads use Room-backed DAOs.
- Replace Realm-only upload path for tasks with the database-agnostic Room upload path so uploads work consistently with other migrated domains.

### Description
- Convert `RealmTeamTask` into a Room entity (`@Entity` `RealmTeamTask`) and add a pure `fromJson` mapper plus the existing `serialize` helper to preserve JSON round-tripping for sync/upload. 
- Add `TeamTaskDao` to provide Flow queries, pending-upload lookups, upserts, batch upserts, title/id lookups, `markUploaded` and notification updates, and register the DAO in `AppDatabase` and `RoomModule`.
- Update repositories and sync/upload code to use Room APIs: `TeamsRepositoryImpl` now delegates task flows/queries/creates/updates/deletes/bulk-insert-to-sync to `TeamTaskDao`, `NotificationsRepositoryImpl` uses `TeamTaskDao` for task lookups, `TeamsSyncRepository` signature for task bulk-insert is converted to `suspend`, and `TransactionSyncManager` dispatches `tasks` into the new suspend path.
- Switch the upload path for tasks from `UploadConfig` (Realm) to `RoomUploadConfig` and call `uploadCoordinator.uploadRoom(...)` from `UploadManager`; update `UploadConfigs` to fetch pending items via `teamTaskDao` and to call `markUploaded` on the DAO.

### Testing
- Ran `./gradlew compileDefaultDebugKotlin --no-daemon` which completed successfully after the migration changes. 
- Ran `./gradlew testDefaultDebugUnitTest --no-daemon`; the build and unit test run executed but the suite failed in this environment due to multiple Robolectric/artifact-fetch network errors (`java.net.SocketException` from `MavenArtifactFetcher`) causing test failures (716 tests executed, 34 failures reported), so functional test coverage for the migration is blocked by the test environment network issue rather than the migration code itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ae7730a64832b95d8f563ba2a54eb)