### PR TITLE
Switch app startup logging to Room

### DIFF
--- a/app/src/androidTest/java/org/ole/planet/myplanet/data/DatabaseServiceTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/data/DatabaseServiceTest.kt
@@ -15,7 +15,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.utils.DefaultDispatcherProvider
 
 @RunWith(AndroidJUnit4::class)
@@ -84,14 +84,14 @@ class DatabaseServiceTest {
     @Test
     fun testExecuteTransactionAsync_commitsData() = runBlocking {
         databaseService.executeTransactionAsync { realm ->
-            val meetup = realm.createObject(RealmMeetup::class.java, "test-id")
+            val meetup = realm.createObject(Meetup::class.java, "test-id")
             meetup.meetupId = "test-id"
             meetup.title = "Test Meetup"
         }
         awaitGlobalInstanceCount(1)
 
         databaseService.withRealmAsync { realm ->
-            val meetup = realm.where(RealmMeetup::class.java).equalTo("meetupId", "test-id").findFirst()
+            val meetup = realm.where(Meetup::class.java).equalTo("meetupId", "test-id").findFirst()
             assertNotNull(meetup)
             assertEquals("Test Meetup", meetup?.title)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -44,7 +44,7 @@ import org.ole.planet.myplanet.data.room.AppDatabase
 import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
 import org.ole.planet.myplanet.di.DefaultPreferences
 import org.ole.planet.myplanet.di.NetworkDependenciesEntryPoint
-import org.ole.planet.myplanet.model.RealmApkLog
+import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.services.AutoSyncWorker
 import org.ole.planet.myplanet.services.NetworkMonitorWorker
@@ -151,7 +151,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
             val apkLogDao = entryPoint.apkLogDao()
             return try {
                 val model = userSessionManager.getUserModel()
-                val log = RealmApkLog().apply {
+                val log = ApkLog().apply {
                     id = "${UUID.randomUUID()}"
                     parentCode = spm.getParentCode()
                     createdOn = spm.getPlanetCode()
@@ -245,9 +245,9 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
         fun handleUncaughtException(e: Throwable) {
             e.printStackTrace()
             val error = e.stackTraceToString()
-            val pendingFile = CrashLogStore.save(context, RealmApkLog.ERROR_TYPE_CRASH, error)
+            val pendingFile = CrashLogStore.save(context, ApkLog.ERROR_TYPE_CRASH, error)
             applicationScope.launch {
-                if (saveLogToRoom(RealmApkLog.ERROR_TYPE_CRASH, error, "${Date().time}")) {
+                if (saveLogToRoom(ApkLog.ERROR_TYPE_CRASH, error, "${Date().time}")) {
                     pendingFile?.delete()
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -40,11 +40,10 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.callback.OnTeamPageListener
-import org.ole.planet.myplanet.data.DatabaseService
+import org.ole.planet.myplanet.data.room.AppDatabase
 import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
 import org.ole.planet.myplanet.di.DefaultPreferences
 import org.ole.planet.myplanet.di.NetworkDependenciesEntryPoint
-import org.ole.planet.myplanet.di.RealmDispatcherProvider
 import org.ole.planet.myplanet.model.RealmApkLog
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.services.AutoSyncWorker
@@ -76,14 +75,11 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
     lateinit var workerFactory: HiltWorkerFactory
 
     @Inject
-    lateinit var realmDispatcherProvider: RealmDispatcherProvider
-
-    @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
     @Inject
-    lateinit var databaseServiceProvider: Provider<DatabaseService>
-    val databaseService: DatabaseService by lazy { databaseServiceProvider.get() }
+    lateinit var appDatabaseProvider: Provider<AppDatabase>
+    val appDatabase: AppDatabase by lazy { appDatabaseProvider.get() }
 
     @Inject
     lateinit var sharedPrefManager: SharedPrefManager
@@ -138,14 +134,14 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
 
         fun createLog(type: String, error: String = "") {
             applicationScope.launch {
-                saveLogToRealm(type, error, "${Date().time}")
+                saveLogToRoom(type, error, "${Date().time}")
             }
         }
 
         // A report for a failure that may kill the process (crash/ANR) must be persisted
-        // to a plain file before this runs: the Realm write below waits on the shared
-        // write lock and dispatcher, so it can be lost if the process dies first.
-        suspend fun saveLogToRealm(type: String, error: String, time: String): Boolean {
+        // to a plain file before this runs: the Room write below can still be lost
+        // if the process dies before the coroutine persists the row.
+        suspend fun saveLogToRoom(type: String, error: String, time: String): Boolean {
             val entryPoint = EntryPointAccessors.fromApplication(
                 context,
                 CoreDependenciesEntryPoint::class.java
@@ -251,7 +247,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
             val error = e.stackTraceToString()
             val pendingFile = CrashLogStore.save(context, RealmApkLog.ERROR_TYPE_CRASH, error)
             applicationScope.launch {
-                if (saveLogToRealm(RealmApkLog.ERROR_TYPE_CRASH, error, "${Date().time}")) {
+                if (saveLogToRoom(RealmApkLog.ERROR_TYPE_CRASH, error, "${Date().time}")) {
                     pendingFile?.delete()
                 }
             }
@@ -264,7 +260,6 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
         }
     }
 
-    private var mainThreadRealm: io.realm.Realm? = null
     private var isFirstLaunch = true
     private lateinit var anrWatchdog: ANRWatchdog
 
@@ -274,7 +269,6 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
         init(sharedPrefManager)
         setupCriticalProperties()
         LocaleUtils.preload(this)
-        warmUpMainThreadRealm()
         performDeferredInitialization()
         setupStrictMode()
         registerExceptionHandler()
@@ -305,7 +299,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
                 CrashLogStore.loadPendingLogs(this@MainApplication)
             }
             for (pending in pendingLogs) {
-                if (saveLogToRealm(pending.type, pending.error, pending.time)) {
+                if (saveLogToRoom(pending.type, pending.error, pending.time)) {
                     withContext(dispatcherProvider.io) { pending.file.delete() }
                 }
             }
@@ -326,16 +320,10 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
         ).applicationScope()
     }
 
-    private fun warmUpMainThreadRealm() {
-        try {
-            mainThreadRealm = databaseService.createManagedRealmInstance()
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
     private suspend fun initializeDatabaseConnection() {
-        databaseService.withRealmAsync { }
+        withContext(dispatcherProvider.io) {
+            appDatabase.openHelper.writableDatabase
+        }
     }
 
     private fun setupStrictMode() {
@@ -364,7 +352,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
                         val error = "ANR detected! Duration: ${duration}ms\n $message"
                         val pendingFile = CrashLogStore.save(context, ANR_LOG_TYPE, error)
                         applicationScope.launch {
-                            if (saveLogToRealm(ANR_LOG_TYPE, error, "${Date().time}")) {
+                            if (saveLogToRoom(ANR_LOG_TYPE, error, "${Date().time}")) {
                                 pendingFile?.delete()
                             }
                         }
@@ -529,8 +517,6 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
         if (::anrWatchdog.isInitialized) {
             anrWatchdog.stop()
         }
-        mainThreadRealm?.close()
-        mainThreadRealm = null
         super.onTerminate()
         stopListenNetworkState()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -28,7 +28,7 @@ import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.CoursesRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
@@ -322,7 +322,7 @@ abstract class BaseResourceFragment : Fragment() {
         }
     }
 
-    fun showTagText(list: List<RealmTag>, tvSelected: TextView?) {
+    fun showTagText(list: List<TagEntity>, tvSelected: TextView?) {
         val selected = list.joinToString(separator = ",", prefix = getString(R.string.selected)) { it.name.orEmpty() }
         tvSelected?.text = selected
     }

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnPersonalSelectedListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnPersonalSelectedListener.kt
@@ -1,10 +1,10 @@
 package org.ole.planet.myplanet.callback
 
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Personal
 
 interface OnPersonalSelectedListener {
-    fun onUpload(personal: RealmMyPersonal?)
+    fun onUpload(personal: Personal?)
     fun onAddedResource()
-    fun onEditPersonal(personal: RealmMyPersonal)
-    fun onDeletePersonal(personal: RealmMyPersonal)
+    fun onEditPersonal(personal: Personal)
+    fun onDeletePersonal(personal: Personal)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnTagClickListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnTagClickListener.kt
@@ -1,15 +1,15 @@
 package org.ole.planet.myplanet.callback
 
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.TagData
 
 interface OnTagClickListener {
-    fun onTagClicked(tag: RealmTag)
+    fun onTagClicked(tag: TagEntity)
     fun onParentTagClicked(parent: TagData.Parent) {}
-    fun onCheckboxTagSelected(tag: RealmTag) {}
+    fun onCheckboxTagSelected(tag: TagEntity) {}
     fun hasChildren(tagId: String?): Boolean { return false }
     @JvmSuppressWildcards
-    fun onTagSelected(tag: RealmTag) {}
+    fun onTagSelected(tag: TagEntity) {}
     @JvmSuppressWildcards
-    fun onOkClicked(list: List<RealmTag>?) {}
+    fun onOkClicked(list: List<TagEntity>?) {}
 }

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnTaskCompletedListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnTaskCompletedListener.kt
@@ -1,10 +1,10 @@
 package org.ole.planet.myplanet.callback
 
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 
 interface OnTaskCompletedListener {
-    fun onCheckChange(realmTeamTask: RealmTeamTask?, completed: Boolean)
-    fun onEdit(task: RealmTeamTask?)
-    fun onDelete(task: RealmTeamTask?)
-    fun onClickMore(realmTeamTask: RealmTeamTask?)
+    fun onCheckChange(realmTeamTask: TeamTask?, completed: Boolean)
+    fun onEdit(task: TeamTask?)
+    fun onDelete(task: TeamTask?)
+    fun onClickMore(realmTeamTask: TeamTask?)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -37,17 +37,17 @@ import org.ole.planet.myplanet.model.Certification
 import org.ole.planet.myplanet.model.ChatHistory
 import org.ole.planet.myplanet.model.Community
 import org.ole.planet.myplanet.model.CourseActivity
-import org.ole.planet.myplanet.model.RealmCourseProgress
-import org.ole.planet.myplanet.model.RealmFeedback
-import org.ole.planet.myplanet.model.RealmHealthExamination
-import org.ole.planet.myplanet.model.RealmMeetup
-import org.ole.planet.myplanet.model.RealmMyLife
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.CourseProgress
+import org.ole.planet.myplanet.model.Feedback
+import org.ole.planet.myplanet.model.HealthExamination
+import org.ole.planet.myplanet.model.Meetup
+import org.ole.planet.myplanet.model.MyLife
+import org.ole.planet.myplanet.model.Personal
 import org.ole.planet.myplanet.model.NewsLog
-import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.model.AppNotification
 import org.ole.planet.myplanet.model.OfflineActivity
 import org.ole.planet.myplanet.model.Rating
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 import org.ole.planet.myplanet.model.ResourceActivity
 import org.ole.planet.myplanet.model.RemovedLog
 import org.ole.planet.myplanet.model.SearchActivity
@@ -55,7 +55,7 @@ import org.ole.planet.myplanet.model.SubmitPhotos
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.TeamNotification
 import org.ole.planet.myplanet.model.TeamLog
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.UserChallengeActions
 
 /**
@@ -68,19 +68,19 @@ import org.ole.planet.myplanet.model.UserChallengeActions
 @Database(
     entities = [
         DictionaryEntity::class,
-        RealmMyLife::class,
-        RealmMyPersonal::class,
-        RealmRetryOperation::class,
+        MyLife::class,
+        Personal::class,
+        RetryOperation::class,
         Community::class,
         ApkLog::class,
         UserChallengeActions::class,
         TeamNotification::class,
         Certification::class,
         ChatHistory::class,
-        RealmFeedback::class,
+        Feedback::class,
         Rating::class,
         RealmTag::class,
-        RealmMeetup::class,
+        Meetup::class,
         SearchActivity::class,
         CourseActivity::class,
         ResourceActivity::class,
@@ -88,12 +88,12 @@ import org.ole.planet.myplanet.model.UserChallengeActions
         NewsLog::class,
         TeamLog::class,
         OfflineActivity::class,
-        RealmCourseProgress::class,
+        CourseProgress::class,
         RemovedLog::class,
-        RealmTeamTask::class,
-        RealmNotification::class,
+        TeamTask::class,
+        AppNotification::class,
         Achievement::class,
-        RealmHealthExamination::class,
+        HealthExamination::class,
     ],
     version = 1,
     exportSchema = false,

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -52,7 +52,7 @@ import org.ole.planet.myplanet.model.ResourceActivity
 import org.ole.planet.myplanet.model.RemovedLog
 import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.SubmitPhotos
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.TeamNotification
 import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.TeamTask
@@ -79,7 +79,7 @@ import org.ole.planet.myplanet.model.UserChallengeActions
         ChatHistory::class,
         Feedback::class,
         Rating::class,
-        RealmTag::class,
+        TagEntity::class,
         Meetup::class,
         SearchActivity::class,
         CourseActivity::class,

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -32,7 +32,7 @@ import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
 import org.ole.planet.myplanet.model.RealmAchievement
-import org.ole.planet.myplanet.model.RealmApkLog
+import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.model.RealmCertification
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmCommunity
@@ -72,7 +72,7 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmMyPersonal::class,
         RealmRetryOperation::class,
         RealmCommunity::class,
-        RealmApkLog::class,
+        ApkLog::class,
         RealmUserChallengeActions::class,
         RealmTeamNotification::class,
         RealmCertification::class,

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -36,22 +36,22 @@ import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.model.RealmCertification
 import org.ole.planet.myplanet.model.RealmChatHistory
 import org.ole.planet.myplanet.model.RealmCommunity
-import org.ole.planet.myplanet.model.RealmCourseActivity
+import org.ole.planet.myplanet.model.CourseActivity
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmHealthExamination
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyPersonal
-import org.ole.planet.myplanet.model.RealmNewsLog
+import org.ole.planet.myplanet.model.NewsLog
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmOfflineActivity
 import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmRetryOperation
-import org.ole.planet.myplanet.model.RealmResourceActivity
-import org.ole.planet.myplanet.model.RealmRemovedLog
-import org.ole.planet.myplanet.model.RealmSearchActivity
-import org.ole.planet.myplanet.model.RealmSubmitPhotos
+import org.ole.planet.myplanet.model.ResourceActivity
+import org.ole.planet.myplanet.model.RemovedLog
+import org.ole.planet.myplanet.model.SearchActivity
+import org.ole.planet.myplanet.model.SubmitPhotos
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmTeamNotification
 import org.ole.planet.myplanet.model.RealmTeamLog
@@ -81,15 +81,15 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmRating::class,
         RealmTag::class,
         RealmMeetup::class,
-        RealmSearchActivity::class,
-        RealmCourseActivity::class,
-        RealmResourceActivity::class,
-        RealmSubmitPhotos::class,
-        RealmNewsLog::class,
+        SearchActivity::class,
+        CourseActivity::class,
+        ResourceActivity::class,
+        SubmitPhotos::class,
+        NewsLog::class,
         RealmTeamLog::class,
         RealmOfflineActivity::class,
         RealmCourseProgress::class,
-        RealmRemovedLog::class,
+        RemovedLog::class,
         RealmTeamTask::class,
         RealmNotification::class,
         RealmAchievement::class,

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -31,10 +31,10 @@ import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
-import org.ole.planet.myplanet.model.RealmAchievement
+import org.ole.planet.myplanet.model.Achievement
 import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.model.Certification
-import org.ole.planet.myplanet.model.RealmChatHistory
+import org.ole.planet.myplanet.model.ChatHistory
 import org.ole.planet.myplanet.model.Community
 import org.ole.planet.myplanet.model.CourseActivity
 import org.ole.planet.myplanet.model.RealmCourseProgress
@@ -46,7 +46,7 @@ import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.model.NewsLog
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.OfflineActivity
-import org.ole.planet.myplanet.model.RealmRating
+import org.ole.planet.myplanet.model.Rating
 import org.ole.planet.myplanet.model.RealmRetryOperation
 import org.ole.planet.myplanet.model.ResourceActivity
 import org.ole.planet.myplanet.model.RemovedLog
@@ -76,9 +76,9 @@ import org.ole.planet.myplanet.model.UserChallengeActions
         UserChallengeActions::class,
         TeamNotification::class,
         Certification::class,
-        RealmChatHistory::class,
+        ChatHistory::class,
         RealmFeedback::class,
-        RealmRating::class,
+        Rating::class,
         RealmTag::class,
         RealmMeetup::class,
         SearchActivity::class,
@@ -92,7 +92,7 @@ import org.ole.planet.myplanet.model.UserChallengeActions
         RemovedLog::class,
         RealmTeamTask::class,
         RealmNotification::class,
-        RealmAchievement::class,
+        Achievement::class,
         RealmHealthExamination::class,
     ],
     version = 1,

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -33,9 +33,9 @@ import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.data.room.entity.DictionaryEntity
 import org.ole.planet.myplanet.model.RealmAchievement
 import org.ole.planet.myplanet.model.ApkLog
-import org.ole.planet.myplanet.model.RealmCertification
+import org.ole.planet.myplanet.model.Certification
 import org.ole.planet.myplanet.model.RealmChatHistory
-import org.ole.planet.myplanet.model.RealmCommunity
+import org.ole.planet.myplanet.model.Community
 import org.ole.planet.myplanet.model.CourseActivity
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmFeedback
@@ -45,7 +45,7 @@ import org.ole.planet.myplanet.model.RealmMyLife
 import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.model.NewsLog
 import org.ole.planet.myplanet.model.RealmNotification
-import org.ole.planet.myplanet.model.RealmOfflineActivity
+import org.ole.planet.myplanet.model.OfflineActivity
 import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmRetryOperation
 import org.ole.planet.myplanet.model.ResourceActivity
@@ -53,10 +53,10 @@ import org.ole.planet.myplanet.model.RemovedLog
 import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.SubmitPhotos
 import org.ole.planet.myplanet.model.RealmTag
-import org.ole.planet.myplanet.model.RealmTeamNotification
-import org.ole.planet.myplanet.model.RealmTeamLog
+import org.ole.planet.myplanet.model.TeamNotification
+import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
-import org.ole.planet.myplanet.model.RealmUserChallengeActions
+import org.ole.planet.myplanet.model.UserChallengeActions
 
 /**
  * Room database that is progressively replacing the legacy Realm store.
@@ -71,11 +71,11 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         RealmMyLife::class,
         RealmMyPersonal::class,
         RealmRetryOperation::class,
-        RealmCommunity::class,
+        Community::class,
         ApkLog::class,
-        RealmUserChallengeActions::class,
-        RealmTeamNotification::class,
-        RealmCertification::class,
+        UserChallengeActions::class,
+        TeamNotification::class,
+        Certification::class,
         RealmChatHistory::class,
         RealmFeedback::class,
         RealmRating::class,
@@ -86,8 +86,8 @@ import org.ole.planet.myplanet.model.RealmUserChallengeActions
         ResourceActivity::class,
         SubmitPhotos::class,
         NewsLog::class,
-        RealmTeamLog::class,
-        RealmOfflineActivity::class,
+        TeamLog::class,
+        OfflineActivity::class,
         RealmCourseProgress::class,
         RemovedLog::class,
         RealmTeamTask::class,

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/AchievementDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/AchievementDao.kt
@@ -3,21 +3,21 @@ package org.ole.planet.myplanet.data.room.dao
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
-import org.ole.planet.myplanet.model.RealmAchievement
+import org.ole.planet.myplanet.model.Achievement
 
 @Dao
 interface AchievementDao {
     @Query("SELECT * FROM achievements WHERE _id = :id LIMIT 1")
-    suspend fun getById(id: String): RealmAchievement?
+    suspend fun getById(id: String): Achievement?
 
     @Upsert
-    suspend fun upsert(achievement: RealmAchievement)
+    suspend fun upsert(achievement: Achievement)
 
     @Upsert
-    suspend fun upsertAll(achievements: List<RealmAchievement>)
+    suspend fun upsertAll(achievements: List<Achievement>)
 
     @Query("SELECT * FROM achievements WHERE _id NOT LIKE 'guest%' AND isUpdated = 1")
-    suspend fun getPendingUploads(): List<RealmAchievement>
+    suspend fun getPendingUploads(): List<Achievement>
 
     @Query("UPDATE achievements SET _rev = COALESCE(:rev, _rev), isUpdated = 0 WHERE _id = :id")
     suspend fun markUploaded(id: String, rev: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ApkLogDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ApkLogDao.kt
@@ -4,16 +4,16 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.ole.planet.myplanet.model.RealmApkLog
+import org.ole.planet.myplanet.model.ApkLog
 
 @Dao
 interface ApkLogDao {
     // Pending = not yet acknowledged by the server (no _rev assigned).
     @Query("SELECT * FROM apk_log WHERE _rev IS NULL")
-    suspend fun getPending(): List<RealmApkLog>
+    suspend fun getPending(): List<ApkLog>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(log: RealmApkLog)
+    suspend fun insert(log: ApkLog)
 
     /** Returns the number of rows updated (0 means the local row was gone). */
     @Query("UPDATE apk_log SET _rev = :rev WHERE id = :id")

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CertificationDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CertificationDao.kt
@@ -4,7 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.ole.planet.myplanet.model.RealmCertification
+import org.ole.planet.myplanet.model.Certification
 
 @Dao
 interface CertificationDao {
@@ -13,5 +13,5 @@ interface CertificationDao {
     suspend fun countByCourseId(courseId: String): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsertAll(items: List<RealmCertification>)
+    suspend fun upsertAll(items: List<Certification>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ChatDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ChatDao.kt
@@ -5,22 +5,22 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import org.ole.planet.myplanet.model.RealmChatHistory
+import org.ole.planet.myplanet.model.ChatHistory
 
 @Dao
 interface ChatDao {
     @Query("SELECT * FROM chat_history WHERE user = :user ORDER BY id DESC")
-    suspend fun getByUser(user: String): List<RealmChatHistory>
+    suspend fun getByUser(user: String): List<ChatHistory>
 
     @Query("SELECT * FROM chat_history WHERE _id = :docId")
-    suspend fun getByDocId(docId: String): List<RealmChatHistory>
+    suspend fun getByDocId(docId: String): List<ChatHistory>
 
     @Query("SELECT * FROM chat_history WHERE _id = :docId LIMIT 1")
-    suspend fun findByDocId(docId: String): RealmChatHistory?
+    suspend fun findByDocId(docId: String): ChatHistory?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsertAll(items: List<RealmChatHistory>)
+    suspend fun upsertAll(items: List<ChatHistory>)
 
     @Update
-    suspend fun update(item: RealmChatHistory)
+    suspend fun update(item: ChatHistory)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CommunityDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CommunityDao.kt
@@ -5,21 +5,21 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
-import org.ole.planet.myplanet.model.RealmCommunity
+import org.ole.planet.myplanet.model.Community
 
 @Dao
 abstract class CommunityDao {
     @Query("SELECT * FROM community ORDER BY weight ASC")
-    abstract suspend fun getAllSorted(): List<RealmCommunity>
+    abstract suspend fun getAllSorted(): List<Community>
 
     @Query("DELETE FROM community")
     abstract suspend fun deleteAll()
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insertAll(items: List<RealmCommunity>)
+    abstract suspend fun insertAll(items: List<Community>)
 
     @Transaction
-    open suspend fun replaceAll(items: List<RealmCommunity>) {
+    open suspend fun replaceAll(items: List<Community>) {
         deleteAll()
         insertAll(items)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseActivityDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseActivityDao.kt
@@ -4,15 +4,15 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.ole.planet.myplanet.model.RealmCourseActivity
+import org.ole.planet.myplanet.model.CourseActivity
 
 @Dao
 interface CourseActivityDao {
     @Query("SELECT * FROM course_activity WHERE _rev IS NULL AND type != 'sync'")
-    suspend fun getPendingUploads(): List<RealmCourseActivity>
+    suspend fun getPendingUploads(): List<CourseActivity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(activity: RealmCourseActivity)
+    suspend fun insert(activity: CourseActivity)
 
     /** Returns the number of rows updated (0 means the local row was gone). */
     @Query("UPDATE course_activity SET _id = :remoteId, _rev = :rev WHERE id = :localId")

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseProgressDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/CourseProgressDao.kt
@@ -3,30 +3,30 @@ package org.ole.planet.myplanet.data.room.dao
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
-import org.ole.planet.myplanet.model.RealmCourseProgress
+import org.ole.planet.myplanet.model.CourseProgress
 
 @Dao
 interface CourseProgressDao {
     @Query("SELECT * FROM course_progress WHERE userId = :userId AND courseId IN (:courseIds)")
-    suspend fun getByUserAndCourseIds(userId: String?, courseIds: List<String>): List<RealmCourseProgress>
+    suspend fun getByUserAndCourseIds(userId: String?, courseIds: List<String>): List<CourseProgress>
 
     @Query("SELECT * FROM course_progress WHERE userId = :userId AND courseId = :courseId")
-    suspend fun getByUserAndCourse(userId: String?, courseId: String?): List<RealmCourseProgress>
+    suspend fun getByUserAndCourse(userId: String?, courseId: String?): List<CourseProgress>
 
     @Query("SELECT * FROM course_progress WHERE userId = :userId")
-    suspend fun getByUser(userId: String?): List<RealmCourseProgress>
+    suspend fun getByUser(userId: String?): List<CourseProgress>
 
     @Query("SELECT * FROM course_progress WHERE courseId = :courseId AND userId = :userId AND stepNum = :stepNum LIMIT 1")
-    suspend fun findByCourseUserAndStep(courseId: String?, userId: String?, stepNum: Int): RealmCourseProgress?
+    suspend fun findByCourseUserAndStep(courseId: String?, userId: String?, stepNum: Int): CourseProgress?
 
     @Query("SELECT * FROM course_progress WHERE id IN (:ids)")
-    suspend fun getByIds(ids: List<String>): List<RealmCourseProgress>
+    suspend fun getByIds(ids: List<String>): List<CourseProgress>
 
     @Query("SELECT * FROM course_progress WHERE courseId IN (:courseIds) AND userId IN (:userIds) AND stepNum IN (:stepNums)")
-    suspend fun getByCourseUsersAndSteps(courseIds: List<String>, userIds: List<String>, stepNums: List<Int>): List<RealmCourseProgress>
+    suspend fun getByCourseUsersAndSteps(courseIds: List<String>, userIds: List<String>, stepNums: List<Int>): List<CourseProgress>
 
     @Query("SELECT * FROM course_progress WHERE _id IS NULL AND userId NOT LIKE 'guest%'")
-    suspend fun getPendingUploads(): List<RealmCourseProgress>
+    suspend fun getPendingUploads(): List<CourseProgress>
 
     @Query("UPDATE course_progress SET _id = :remoteId, _rev = :rev WHERE id = :localId")
     suspend fun markUploaded(localId: String, remoteId: String, rev: String): Int
@@ -35,8 +35,8 @@ interface CourseProgressDao {
     suspend fun updatePassedByCourseAndStep(courseId: String, stepNum: Int, passed: Boolean): Int
 
     @Upsert
-    suspend fun upsert(progress: RealmCourseProgress)
+    suspend fun upsert(progress: CourseProgress)
 
     @Upsert
-    suspend fun upsertAll(progress: List<RealmCourseProgress>)
+    suspend fun upsertAll(progress: List<CourseProgress>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/FeedbackDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/FeedbackDao.kt
@@ -6,22 +6,22 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 
 @Dao
 interface FeedbackDao {
     @Query("SELECT * FROM feedback ORDER BY openTime DESC")
-    fun getAllSortedFlow(): Flow<List<RealmFeedback>>
+    fun getAllSortedFlow(): Flow<List<Feedback>>
 
     // `IS` so a null owner matches null rows, mirroring Realm equalTo(null).
     @Query("SELECT * FROM feedback WHERE owner IS :owner ORDER BY openTime DESC")
-    fun getByOwnerFlow(owner: String?): Flow<List<RealmFeedback>>
+    fun getByOwnerFlow(owner: String?): Flow<List<Feedback>>
 
     @Query("SELECT * FROM feedback WHERE isUploaded = 0")
-    suspend fun getPending(): List<RealmFeedback>
+    suspend fun getPending(): List<Feedback>
 
     @Query("SELECT * FROM feedback WHERE id = :id LIMIT 1")
-    suspend fun findById(id: String): RealmFeedback?
+    suspend fun findById(id: String): Feedback?
 
     @Query("UPDATE feedback SET status = 'Closed' WHERE id = :id")
     suspend fun closeById(id: String)
@@ -31,11 +31,11 @@ interface FeedbackDao {
     suspend fun markUploaded(id: String): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsert(item: RealmFeedback)
+    suspend fun upsert(item: Feedback)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsertAll(items: List<RealmFeedback>)
+    suspend fun upsertAll(items: List<Feedback>)
 
     @Update
-    suspend fun update(item: RealmFeedback)
+    suspend fun update(item: Feedback)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/HealthExaminationDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/HealthExaminationDao.kt
@@ -3,27 +3,27 @@ package org.ole.planet.myplanet.data.room.dao
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
-import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.HealthExamination
 
 @Dao
 interface HealthExaminationDao {
     @Query("SELECT * FROM health_examinations WHERE _id = :id OR userId = :id LIMIT 1")
-    suspend fun getByIdOrUserId(id: String): RealmHealthExamination?
+    suspend fun getByIdOrUserId(id: String): HealthExamination?
 
     @Query("SELECT * FROM health_examinations WHERE _id = :id LIMIT 1")
-    suspend fun getById(id: String): RealmHealthExamination?
+    suspend fun getById(id: String): HealthExamination?
 
     @Query("SELECT * FROM health_examinations WHERE isUpdated = 1 AND userId != ''")
-    suspend fun getUpdated(): List<RealmHealthExamination>
+    suspend fun getUpdated(): List<HealthExamination>
 
     @Query("SELECT * FROM health_examinations WHERE isUpdated = 1 AND userId = :userId")
-    suspend fun getUpdatedForUser(userId: String): List<RealmHealthExamination>
+    suspend fun getUpdatedForUser(userId: String): List<HealthExamination>
 
     @Upsert
-    suspend fun upsert(examination: RealmHealthExamination)
+    suspend fun upsert(examination: HealthExamination)
 
     @Upsert
-    suspend fun upsertAll(examinations: List<RealmHealthExamination>)
+    suspend fun upsertAll(examinations: List<HealthExamination>)
 
     @Query("UPDATE health_examinations SET _rev = :rev, isUpdated = 0 WHERE _id = :id")
     suspend fun markUploaded(id: String, rev: String?)
@@ -32,5 +32,5 @@ interface HealthExaminationDao {
     suspend fun updateUserId(id: String, userId: String)
 
     @Query("SELECT * FROM health_examinations WHERE profileId = :profileId")
-    suspend fun getByProfileId(profileId: String): List<RealmHealthExamination>
+    suspend fun getByProfileId(profileId: String): List<HealthExamination>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/MeetupDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/MeetupDao.kt
@@ -4,37 +4,37 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 
 @Dao
 interface MeetupDao {
     @Query("SELECT * FROM meetup WHERE teamId = :teamId")
-    suspend fun getByTeamId(teamId: String): List<RealmMeetup>
+    suspend fun getByTeamId(teamId: String): List<Meetup>
 
     @Query("SELECT * FROM meetup WHERE meetupId = :meetupId LIMIT 1")
-    suspend fun getByMeetupId(meetupId: String): RealmMeetup?
+    suspend fun getByMeetupId(meetupId: String): Meetup?
 
     @Query("SELECT * FROM meetup WHERE id = :id LIMIT 1")
-    suspend fun getById(id: String): RealmMeetup?
+    suspend fun getById(id: String): Meetup?
 
     @Query("SELECT * FROM meetup WHERE meetupId = :meetupId AND userId IS NOT NULL AND userId != ''")
-    suspend fun getMembersByMeetupId(meetupId: String): List<RealmMeetup>
+    suspend fun getMembersByMeetupId(meetupId: String): List<Meetup>
 
     @Query("SELECT * FROM meetup WHERE userId = :userId AND userId != ''")
-    suspend fun getByUserId(userId: String): List<RealmMeetup>
+    suspend fun getByUserId(userId: String): List<Meetup>
 
     @Query("SELECT * FROM meetup WHERE meetupId IN (:meetupIds)")
-    suspend fun getByMeetupIds(meetupIds: List<String>): List<RealmMeetup>
+    suspend fun getByMeetupIds(meetupIds: List<String>): List<Meetup>
 
     // Pending uploads: meetup was created locally (no server id yet) or was edited locally.
     @Query(
         "SELECT * FROM meetup WHERE meetupId IS NULL OR meetupId = '' OR updated = 1"
     )
-    suspend fun getPendingUploads(): List<RealmMeetup>
+    suspend fun getPendingUploads(): List<Meetup>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsert(item: RealmMeetup)
+    suspend fun upsert(item: Meetup)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsertAll(items: List<RealmMeetup>)
+    suspend fun upsertAll(items: List<Meetup>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/MyLifeDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/MyLifeDao.kt
@@ -5,29 +5,29 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import org.ole.planet.myplanet.model.RealmMyLife
+import org.ole.planet.myplanet.model.MyLife
 
 @Dao
 interface MyLifeDao {
     // `IS` (not `=`) so a null userId matches null rows, mirroring Realm's equalTo(null) semantics.
     @Query("SELECT * FROM my_life WHERE userId IS :userId ORDER BY weight")
-    suspend fun getByUserId(userId: String?): List<RealmMyLife>
+    suspend fun getByUserId(userId: String?): List<MyLife>
 
     @Query("SELECT * FROM my_life WHERE userId IS :userId AND isVisible = 1 ORDER BY weight")
-    suspend fun getVisibleByUserId(userId: String?): List<RealmMyLife>
+    suspend fun getVisibleByUserId(userId: String?): List<MyLife>
 
     @Query("SELECT COUNT(*) FROM my_life WHERE userId IS :userId")
     suspend fun countByUserId(userId: String?): Int
 
     @Query("SELECT * FROM my_life WHERE _id IN (:ids)")
-    suspend fun getByIds(ids: List<String>): List<RealmMyLife>
+    suspend fun getByIds(ids: List<String>): List<MyLife>
 
     @Query("UPDATE my_life SET isVisible = :isVisible WHERE _id = :id")
     suspend fun updateVisibility(id: String, isVisible: Boolean)
 
     @Update
-    suspend fun update(items: List<RealmMyLife>)
+    suspend fun update(items: List<MyLife>)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertAll(items: List<RealmMyLife>)
+    suspend fun insertAll(items: List<MyLife>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NewsLogDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NewsLogDao.kt
@@ -4,15 +4,15 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.ole.planet.myplanet.model.RealmNewsLog
+import org.ole.planet.myplanet.model.NewsLog
 
 @Dao
 interface NewsLogDao {
     @Query("SELECT * FROM news_log WHERE _id IS NULL OR _id = ''")
-    suspend fun getPendingUploads(): List<RealmNewsLog>
+    suspend fun getPendingUploads(): List<NewsLog>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(log: RealmNewsLog)
+    suspend fun insert(log: NewsLog)
 
     /** Returns the number of rows updated (0 means the local row was gone). */
     @Query("UPDATE news_log SET _id = :remoteId, _rev = :rev WHERE id = :localId")

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NotificationDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NotificationDao.kt
@@ -4,7 +4,7 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
 import java.util.Date
-import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.model.AppNotification
 
 @Dao
 interface NotificationDao {
@@ -18,22 +18,22 @@ interface NotificationDao {
     suspend fun getUnreadCount(userId: String, isAdmin: Boolean): Int
 
     @Query("SELECT * FROM notifications WHERE id = :id LIMIT 1")
-    suspend fun getById(id: String): RealmNotification?
+    suspend fun getById(id: String): AppNotification?
 
     @Upsert
-    suspend fun upsert(notification: RealmNotification)
+    suspend fun upsert(notification: AppNotification)
 
     @Upsert
-    suspend fun upsertAll(notifications: List<RealmNotification>)
+    suspend fun upsertAll(notifications: List<AppNotification>)
 
     @Query("DELETE FROM notifications WHERE id = :id")
     suspend fun deleteById(id: String): Int
 
     @Query("SELECT * FROM notifications WHERE (userId = :userId OR (:isAdmin = 1 AND userId = 'SYSTEM')) AND message != 'INVALID' AND message != '' AND (:filter = '' OR (:filter = 'read' AND isRead = 1) OR (:filter = 'unread' AND isRead = 0)) ORDER BY isRead ASC, createdAt DESC")
-    suspend fun getNotifications(userId: String, filter: String, isAdmin: Boolean): List<RealmNotification>
+    suspend fun getNotifications(userId: String, filter: String, isAdmin: Boolean): List<AppNotification>
 
     @Query("SELECT * FROM notifications WHERE id IN (:ids)")
-    suspend fun getByIds(ids: List<String>): List<RealmNotification>
+    suspend fun getByIds(ids: List<String>): List<AppNotification>
 
     @Query("UPDATE notifications SET isRead = 1, createdAt = :createdAt, needsSync = CASE WHEN isFromServer = 1 THEN 1 ELSE needsSync END WHERE id IN (:ids)")
     suspend fun markAsRead(ids: List<String>, createdAt: Date): Int
@@ -42,7 +42,7 @@ interface NotificationDao {
     suspend fun markAllUnreadAsRead(userId: String, createdAt: Date): Int
 
     @Query("SELECT * FROM notifications WHERE needsSync = 1 AND rev IS NOT NULL")
-    suspend fun getPendingSyncNotifications(): List<RealmNotification>
+    suspend fun getPendingSyncNotifications(): List<AppNotification>
 
     @Query("UPDATE notifications SET needsSync = 0, rev = COALESCE(:rev, rev) WHERE id = :id")
     suspend fun markSynced(id: String, rev: String?)

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/OfflineActivityDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/OfflineActivityDao.kt
@@ -6,7 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
-import org.ole.planet.myplanet.model.RealmOfflineActivity
+import org.ole.planet.myplanet.model.OfflineActivity
 
 @Dao
 interface OfflineActivityDao {
@@ -17,13 +17,13 @@ interface OfflineActivityDao {
     suspend fun countByUserNameAndType(userName: String, type: String): Int
 
     @Query("SELECT * FROM offline_activity WHERE userName = :userName AND type = :type")
-    fun observeByUserNameAndType(userName: String, type: String): Flow<List<RealmOfflineActivity>>
+    fun observeByUserNameAndType(userName: String, type: String): Flow<List<OfflineActivity>>
 
     @Query("SELECT * FROM offline_activity WHERE userId = :userId AND loginTime BETWEEN :startMillis AND :endMillis")
-    suspend fun getByUserIdAndLoginTimeBetween(userId: String, startMillis: Long, endMillis: Long): List<RealmOfflineActivity>
+    suspend fun getByUserIdAndLoginTimeBetween(userId: String, startMillis: Long, endMillis: Long): List<OfflineActivity>
 
     @Query("SELECT * FROM offline_activity WHERE _rev IS NULL AND type = 'login'")
-    suspend fun getPendingLoginUploads(): List<RealmOfflineActivity>
+    suspend fun getPendingLoginUploads(): List<OfflineActivity>
 
     @Query("SELECT MAX(loginTime) FROM offline_activity")
     suspend fun getGlobalLastVisit(): Long?
@@ -32,22 +32,22 @@ interface OfflineActivityDao {
     suspend fun getLastVisit(userName: String): Long?
 
     @Query("SELECT * FROM offline_activity WHERE type = :type ORDER BY loginTime DESC LIMIT 1")
-    suspend fun getLatestByType(type: String): RealmOfflineActivity?
+    suspend fun getLatestByType(type: String): OfflineActivity?
 
     @Query("SELECT * FROM offline_activity WHERE id IN (:ids)")
-    suspend fun getByIds(ids: List<String>): List<RealmOfflineActivity>
+    suspend fun getByIds(ids: List<String>): List<OfflineActivity>
 
     @Query("SELECT * FROM offline_activity WHERE _id IN (:remoteIds)")
-    suspend fun getByRemoteIds(remoteIds: List<String>): List<RealmOfflineActivity>
+    suspend fun getByRemoteIds(remoteIds: List<String>): List<OfflineActivity>
 
     @Query("SELECT * FROM offline_activity WHERE loginTime IN (:loginTimes) AND userName IN (:userNames)")
-    suspend fun getByLoginTimesAndUserNames(loginTimes: List<Long>, userNames: List<String>): List<RealmOfflineActivity>
+    suspend fun getByLoginTimesAndUserNames(loginTimes: List<Long>, userNames: List<String>): List<OfflineActivity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(activity: RealmOfflineActivity)
+    suspend fun insert(activity: OfflineActivity)
 
     @Upsert
-    suspend fun upsertAll(activities: List<RealmOfflineActivity>)
+    suspend fun upsertAll(activities: List<OfflineActivity>)
 
     @Query("UPDATE offline_activity SET logoutTime = :logoutTime WHERE id = :id")
     suspend fun updateLogoutTime(id: String, logoutTime: Long): Int

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/PersonalDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/PersonalDao.kt
@@ -6,7 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Personal
 
 @Dao
 interface PersonalDao {
@@ -19,22 +19,22 @@ interface PersonalDao {
     suspend fun countByTitle(title: String, userId: String?): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(item: RealmMyPersonal)
+    suspend fun insert(item: Personal)
 
     @Query("SELECT * FROM my_personal WHERE userId = :userId")
-    fun getByUserIdFlow(userId: String): Flow<List<RealmMyPersonal>>
+    fun getByUserIdFlow(userId: String): Flow<List<Personal>>
 
     @Query("SELECT * FROM my_personal WHERE userId = :userId AND isUploaded = 0")
-    suspend fun getPendingUploads(userId: String): List<RealmMyPersonal>
+    suspend fun getPendingUploads(userId: String): List<Personal>
 
     @Query("SELECT * FROM my_personal WHERE _id = :id LIMIT 1")
-    suspend fun findByDocId(id: String): RealmMyPersonal?
+    suspend fun findByDocId(id: String): Personal?
 
     @Query("SELECT * FROM my_personal WHERE id = :id LIMIT 1")
-    suspend fun findById(id: String): RealmMyPersonal?
+    suspend fun findById(id: String): Personal?
 
     @Update
-    suspend fun update(item: RealmMyPersonal)
+    suspend fun update(item: Personal)
 
     @Query("DELETE FROM my_personal WHERE _id = :id")
     suspend fun deleteByDocId(id: String)

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/RatingDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/RatingDao.kt
@@ -5,36 +5,36 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import org.ole.planet.myplanet.model.RealmRating
+import org.ole.planet.myplanet.model.Rating
 
 @Dao
 interface RatingDao {
     @Query("SELECT * FROM rating WHERE type IS :type")
-    suspend fun getByType(type: String?): List<RealmRating>
+    suspend fun getByType(type: String?): List<Rating>
 
     @Query("SELECT * FROM rating WHERE type IS :type AND item IS :item")
-    suspend fun getByTypeAndItem(type: String?, item: String?): List<RealmRating>
+    suspend fun getByTypeAndItem(type: String?, item: String?): List<Rating>
 
     @Query("SELECT * FROM rating WHERE type = :type AND userId = :userId AND item = :item LIMIT 1")
-    suspend fun findByTypeUserItem(type: String, userId: String, item: String): RealmRating?
+    suspend fun findByTypeUserItem(type: String, userId: String, item: String): Rating?
 
     @Query("SELECT * FROM rating WHERE id = :id LIMIT 1")
-    suspend fun findById(id: String): RealmRating?
+    suspend fun findById(id: String): Rating?
 
     // Pending upload = edited locally, excluding guest users (mirrors filterGuests).
     @Query("SELECT * FROM rating WHERE isUpdated = 1 AND (userId IS NULL OR userId NOT LIKE 'guest%')")
-    suspend fun getPendingUploads(): List<RealmRating>
+    suspend fun getPendingUploads(): List<Rating>
 
     /** Returns the number of rows updated (0 means the local row was gone). */
     @Query("UPDATE rating SET isUpdated = 0 WHERE id = :id")
     suspend fun markUploaded(id: String): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsert(item: RealmRating)
+    suspend fun upsert(item: Rating)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsertAll(items: List<RealmRating>)
+    suspend fun upsertAll(items: List<Rating>)
 
     @Update
-    suspend fun update(item: RealmRating)
+    suspend fun update(item: Rating)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/RemovedLogDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/RemovedLogDao.kt
@@ -4,7 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.ole.planet.myplanet.model.RealmRemovedLog
+import org.ole.planet.myplanet.model.RemovedLog
 
 @Dao
 interface RemovedLogDao {
@@ -18,5 +18,5 @@ interface RemovedLogDao {
     suspend fun getRemovedDocIds(type: String, userId: String?): List<String?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(log: RealmRemovedLog)
+    suspend fun insert(log: RemovedLog)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ResourceActivityDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/ResourceActivityDao.kt
@@ -5,27 +5,27 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
-import org.ole.planet.myplanet.model.RealmResourceActivity
+import org.ole.planet.myplanet.model.ResourceActivity
 
 @Dao
 interface ResourceActivityDao {
     @Query("SELECT * FROM resource_activity WHERE _rev IS NULL AND type != 'sync'")
-    suspend fun getPendingUploads(): List<RealmResourceActivity>
+    suspend fun getPendingUploads(): List<ResourceActivity>
 
     @Query("SELECT * FROM resource_activity WHERE _rev IS NULL AND type = 'sync'")
-    suspend fun getPendingSyncUploads(): List<RealmResourceActivity>
+    suspend fun getPendingSyncUploads(): List<ResourceActivity>
 
     @Query("SELECT * FROM resource_activity WHERE user = :userName AND type = :type")
-    suspend fun getByUserAndType(userName: String, type: String): List<RealmResourceActivity>
+    suspend fun getByUserAndType(userName: String, type: String): List<ResourceActivity>
 
     @Query("SELECT COUNT(*) FROM resource_activity WHERE user = :userName AND type = :type")
     suspend fun countByUserAndType(userName: String, type: String): Long
 
     @Query("SELECT * FROM resource_activity WHERE user = :userName AND type = :type")
-    fun observeByUserAndType(userName: String, type: String): Flow<List<RealmResourceActivity>>
+    fun observeByUserAndType(userName: String, type: String): Flow<List<ResourceActivity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(activity: RealmResourceActivity)
+    suspend fun insert(activity: ResourceActivity)
 
     /** Returns the number of rows updated (0 means the local row was gone). */
     @Query("UPDATE resource_activity SET _id = :remoteId, _rev = :rev WHERE id = :localId")

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/RetryDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/RetryDao.kt
@@ -5,28 +5,28 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 
 /**
- * Status literals below match [RealmRetryOperation]'s STATUS_* constants (pending / in_progress /
+ * Status literals below match [RetryOperation]'s STATUS_* constants (pending / in_progress /
  * completed / abandoned). Room validates the SQL at compile time.
  */
 @Dao
 interface RetryDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(operation: RealmRetryOperation)
+    suspend fun insert(operation: RetryOperation)
 
     @Update
-    suspend fun update(operation: RealmRetryOperation)
+    suspend fun update(operation: RetryOperation)
 
     @Query("SELECT * FROM retry_operation WHERE id = :id LIMIT 1")
-    suspend fun findById(id: String): RealmRetryOperation?
+    suspend fun findById(id: String): RetryOperation?
 
     @Query(
         "SELECT * FROM retry_operation WHERE status = 'pending' " +
             "AND nextRetryTime <= :now AND attemptCount < maxAttempts"
     )
-    suspend fun getPending(now: Long): List<RealmRetryOperation>
+    suspend fun getPending(now: Long): List<RetryOperation>
 
     @Query("SELECT COUNT(*) FROM retry_operation WHERE status = 'pending' OR status = 'in_progress'")
     suspend fun getActiveCount(): Long
@@ -41,7 +41,7 @@ interface RetryDao {
         "SELECT * FROM retry_operation WHERE itemId = :itemId AND uploadType = :uploadType " +
             "AND status != 'completed' AND status != 'abandoned' LIMIT 1"
     )
-    suspend fun findExisting(itemId: String, uploadType: String): RealmRetryOperation?
+    suspend fun findExisting(itemId: String, uploadType: String): RetryOperation?
 
     @Query("DELETE FROM retry_operation WHERE status = 'pending' OR status = 'abandoned'")
     suspend fun deletePendingAndAbandoned()

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/SearchActivityDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/SearchActivityDao.kt
@@ -4,15 +4,15 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.SearchActivity
 
 @Dao
 interface SearchActivityDao {
     @Query("SELECT * FROM search_activity WHERE _rev = ''")
-    suspend fun getPendingUploads(): List<RealmSearchActivity>
+    suspend fun getPendingUploads(): List<SearchActivity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(activity: RealmSearchActivity)
+    suspend fun insert(activity: SearchActivity)
 
     /** Returns the number of rows updated (0 means the local row was gone). */
     @Query("UPDATE search_activity SET _id = :remoteId, _rev = :rev WHERE id = :localId")

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/SubmitPhotosDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/SubmitPhotosDao.kt
@@ -4,18 +4,18 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.ole.planet.myplanet.model.RealmSubmitPhotos
+import org.ole.planet.myplanet.model.SubmitPhotos
 
 @Dao
 interface SubmitPhotosDao {
     @Query("SELECT * FROM submit_photos WHERE uploaded = 0")
-    suspend fun getUnuploaded(): List<RealmSubmitPhotos>
+    suspend fun getUnuploaded(): List<SubmitPhotos>
 
     @Query("SELECT * FROM submit_photos WHERE id IN (:ids)")
-    suspend fun getByIds(ids: Array<String>): List<RealmSubmitPhotos>
+    suspend fun getByIds(ids: Array<String>): List<SubmitPhotos>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(photo: RealmSubmitPhotos)
+    suspend fun insert(photo: SubmitPhotos)
 
     /** Returns the number of rows updated (0 means the local row was gone). */
     @Query("UPDATE submit_photos SET uploaded = 1, _rev = :rev, _id = :remoteId WHERE id = :photoId")

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TagDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TagDao.kt
@@ -4,7 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 
 @Dao
 interface TagDao {
@@ -13,26 +13,26 @@ interface TagDao {
         "SELECT * FROM tag WHERE (:db IS NULL OR db = :db) " +
             "AND name IS NOT NULL AND name != '' AND isAttached = 0"
     )
-    suspend fun getParentTags(db: String?): List<RealmTag>
+    suspend fun getParentTags(db: String?): List<TagEntity>
 
     @Query("SELECT * FROM tag")
-    suspend fun getAll(): List<RealmTag>
+    suspend fun getAll(): List<TagEntity>
 
     @Query("SELECT * FROM tag WHERE db = :db AND linkId = :linkId")
-    suspend fun getByDbAndLinkId(db: String, linkId: String): List<RealmTag>
+    suspend fun getByDbAndLinkId(db: String, linkId: String): List<TagEntity>
 
     @Query("SELECT * FROM tag WHERE db = :db AND linkId IN (:linkIds)")
-    suspend fun getByDbAndLinkIds(db: String, linkIds: List<String>): List<RealmTag>
+    suspend fun getByDbAndLinkIds(db: String, linkIds: List<String>): List<TagEntity>
 
     @Query("SELECT * FROM tag WHERE id IN (:ids)")
-    suspend fun getByIds(ids: List<String>): List<RealmTag>
+    suspend fun getByIds(ids: List<String>): List<TagEntity>
 
     @Query("SELECT * FROM tag WHERE name IN (:names)")
-    suspend fun getByNames(names: List<String>): List<RealmTag>
+    suspend fun getByNames(names: List<String>): List<TagEntity>
 
     @Query("SELECT * FROM tag WHERE db = :db AND tagId IN (:tagIds)")
-    suspend fun getByDbAndTagIds(db: String, tagIds: List<String>): List<RealmTag>
+    suspend fun getByDbAndTagIds(db: String, tagIds: List<String>): List<TagEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsertAll(items: List<RealmTag>)
+    suspend fun upsertAll(items: List<TagEntity>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamLogDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamLogDao.kt
@@ -5,30 +5,30 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Upsert
-import org.ole.planet.myplanet.model.RealmTeamLog
+import org.ole.planet.myplanet.model.TeamLog
 
 @Dao
 interface TeamLogDao {
     @Query("SELECT * FROM team_log WHERE _rev IS NULL")
-    suspend fun getPendingUploads(): List<RealmTeamLog>
+    suspend fun getPendingUploads(): List<TeamLog>
 
     @Query("SELECT * FROM team_log WHERE type = 'teamVisit' AND time > :cutoff AND teamId IN (:teamIds)")
-    suspend fun getRecentTeamVisits(cutoff: Long, teamIds: List<String>): List<RealmTeamLog>
+    suspend fun getRecentTeamVisits(cutoff: Long, teamIds: List<String>): List<TeamLog>
 
     @Query("SELECT * FROM team_log WHERE type = 'teamVisit' AND teamId = :teamId AND user IN (:userNames)")
-    suspend fun getTeamVisitsForUsers(teamId: String, userNames: List<String>): List<RealmTeamLog>
+    suspend fun getTeamVisitsForUsers(teamId: String, userNames: List<String>): List<TeamLog>
 
     @Query("SELECT MAX(time) FROM team_log WHERE type = 'teamVisit' AND user = :userName AND teamId = :teamId")
     suspend fun getLastVisit(userName: String?, teamId: String?): Long?
 
     @Query("SELECT * FROM team_log WHERE _id IN (:ids)")
-    suspend fun getByRemoteIds(ids: List<String>): List<RealmTeamLog>
+    suspend fun getByRemoteIds(ids: List<String>): List<TeamLog>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(log: RealmTeamLog)
+    suspend fun insert(log: TeamLog)
 
     @Upsert
-    suspend fun upsertAll(logs: List<RealmTeamLog>)
+    suspend fun upsertAll(logs: List<TeamLog>)
 
     /** Returns the number of rows updated (0 means the local row was gone). */
     @Query("UPDATE team_log SET _id = :remoteId, _rev = :rev WHERE id = :localId")

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamNotificationDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamNotificationDao.kt
@@ -5,19 +5,19 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import org.ole.planet.myplanet.model.RealmTeamNotification
+import org.ole.planet.myplanet.model.TeamNotification
 
 @Dao
 interface TeamNotificationDao {
     @Query("SELECT * FROM team_notification WHERE parentId = :parentId AND type = :type LIMIT 1")
-    suspend fun findByParentAndType(parentId: String, type: String): RealmTeamNotification?
+    suspend fun findByParentAndType(parentId: String, type: String): TeamNotification?
 
     @Query("SELECT * FROM team_notification WHERE type = :type AND parentId IN (:parentIds)")
-    suspend fun getByTypeAndParentIds(type: String, parentIds: List<String>): List<RealmTeamNotification>
+    suspend fun getByTypeAndParentIds(type: String, parentIds: List<String>): List<TeamNotification>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(item: RealmTeamNotification)
+    suspend fun insert(item: TeamNotification)
 
     @Update
-    suspend fun update(item: RealmTeamNotification)
+    suspend fun update(item: TeamNotification)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamTaskDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamTaskDao.kt
@@ -4,48 +4,48 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 
 @Dao
 interface TeamTaskDao {
     @Query("SELECT * FROM team_tasks WHERE status != 'archived' AND completed = 0 AND assignee = :userId")
-    fun getOpenTasksForUser(userId: String?): Flow<List<RealmTeamTask>>
+    fun getOpenTasksForUser(userId: String?): Flow<List<TeamTask>>
 
     @Query("SELECT * FROM team_tasks WHERE completed = 0 AND assignee = :userId AND isNotified = 0 AND deadline BETWEEN :start AND :end")
-    suspend fun getPendingTasksForUser(userId: String, start: Long, end: Long): List<RealmTeamTask>
+    suspend fun getPendingTasksForUser(userId: String, start: Long, end: Long): List<TeamTask>
 
     @Query("UPDATE team_tasks SET isNotified = 1 WHERE id IN (:taskIds)")
     suspend fun markTasksNotified(taskIds: List<String>)
 
     @Query("SELECT * FROM team_tasks WHERE teamId = :teamId AND status != 'archived'")
-    fun getTasksByTeamId(teamId: String): Flow<List<RealmTeamTask>>
+    fun getTasksByTeamId(teamId: String): Flow<List<TeamTask>>
 
     @Query("SELECT * FROM team_tasks WHERE (_id IS NULL OR _id = '' OR isUpdated = 1)")
-    suspend fun getPendingUploads(): List<RealmTeamTask>
+    suspend fun getPendingUploads(): List<TeamTask>
 
     @Query("DELETE FROM team_tasks WHERE id = :taskId")
     suspend fun deleteById(taskId: String)
 
     @Upsert
-    suspend fun upsert(task: RealmTeamTask)
+    suspend fun upsert(task: TeamTask)
 
     @Upsert
-    suspend fun upsertAll(tasks: List<RealmTeamTask>)
+    suspend fun upsertAll(tasks: List<TeamTask>)
 
     @Query("SELECT * FROM team_tasks WHERE id = :taskId LIMIT 1")
-    suspend fun getById(taskId: String): RealmTeamTask?
+    suspend fun getById(taskId: String): TeamTask?
 
     @Query("SELECT * FROM team_tasks WHERE id IN (:taskIds)")
-    suspend fun getByIds(taskIds: List<String>): List<RealmTeamTask>
+    suspend fun getByIds(taskIds: List<String>): List<TeamTask>
 
     @Query("SELECT * FROM team_tasks WHERE title = :title LIMIT 1")
-    suspend fun getByTitle(title: String): RealmTeamTask?
+    suspend fun getByTitle(title: String): TeamTask?
 
     @Query("SELECT * FROM team_tasks WHERE title IN (:titles)")
-    suspend fun getByTitles(titles: List<String>): List<RealmTeamTask>
+    suspend fun getByTitles(titles: List<String>): List<TeamTask>
 
     @Query("SELECT * FROM team_tasks WHERE assignee = :userId AND deadline BETWEEN :start AND :end")
-    suspend fun getTasksForUserBetween(userId: String, start: Long, end: Long): List<RealmTeamTask>
+    suspend fun getTasksForUserBetween(userId: String, start: Long, end: Long): List<TeamTask>
 
     @Query("UPDATE team_tasks SET _id = :remoteId, _rev = :remoteRev, isUpdated = 0 WHERE id = :localId")
     suspend fun markUploaded(localId: String, remoteId: String?, remoteRev: String?): Int

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserChallengeActionsDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserChallengeActionsDao.kt
@@ -4,12 +4,12 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.ole.planet.myplanet.model.RealmUserChallengeActions
+import org.ole.planet.myplanet.model.UserChallengeActions
 
 @Dao
 interface UserChallengeActionsDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(action: RealmUserChallengeActions)
+    suspend fun insert(action: UserChallengeActions)
 
     @Query("SELECT COUNT(*) FROM user_challenge_actions WHERE userId = :userId AND actionType = :actionType")
     suspend fun countByUserAndType(userId: String, actionType: String): Int

--- a/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
@@ -4,7 +4,6 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
-import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
@@ -16,7 +15,6 @@ import org.ole.planet.myplanet.utils.DispatcherProvider
 interface CoreDependenciesEntryPoint {
     @ApplicationScope fun applicationScope(): CoroutineScope
     fun sharedPrefManager(): SharedPrefManager
-    fun databaseService(): DatabaseService
     fun userSessionManager(): UserSessionManager
     fun serverUrlMapper(): ServerUrlMapper
     fun dispatcherProvider(): DispatcherProvider

--- a/app/src/main/java/org/ole/planet/myplanet/model/Achievement.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Achievement.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonObject
 import org.ole.planet.myplanet.utils.JsonUtils
 
 @Entity(tableName = "achievements")
-class RealmAchievement {
+class Achievement {
     var achievements: List<String>? = null
     var references: List<String>? = null
     var links: List<String>? = null
@@ -103,8 +103,8 @@ class RealmAchievement {
             return array
         }
 
-        fun fromJson(act: JsonObject): RealmAchievement {
-            return RealmAchievement().apply {
+        fun fromJson(act: JsonObject): Achievement {
+            return Achievement().apply {
                 _id = JsonUtils.getString("_id", act)
                 _rev = JsonUtils.getString("_rev", act)
                 purpose = JsonUtils.getString("purpose", act)
@@ -124,7 +124,7 @@ class RealmAchievement {
             }
         }
 
-        fun serialize(sub: RealmAchievement): JsonObject {
+        fun serialize(sub: Achievement): JsonObject {
             val `object` = JsonObject()
             `object`.addProperty("_id", sub._id)
             if (!TextUtils.isEmpty(sub._rev)) `object`.addProperty("_rev", sub._rev)

--- a/app/src/main/java/org/ole/planet/myplanet/model/ApkLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ApkLog.kt
@@ -7,7 +7,7 @@ import com.google.gson.JsonObject
 import org.ole.planet.myplanet.utils.NetworkUtils
 
 /**
- * Room replacement for the former Realm `RealmApkLog` model. Crash/ANR/error logs are written via
+ * Room entity for crash/ANR/error logs, replacing the former Realm APK log model. Logs are written via
  * [org.ole.planet.myplanet.data.room.dao.ApkLogDao] and uploaded through the Room upload path
  * (`UploadConfigs.CrashLog`). A row with a null `_rev` is considered pending upload.
  */

--- a/app/src/main/java/org/ole/planet/myplanet/model/ApkLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ApkLog.kt
@@ -12,7 +12,7 @@ import org.ole.planet.myplanet.utils.NetworkUtils
  * (`UploadConfigs.CrashLog`). A row with a null `_rev` is considered pending upload.
  */
 @Entity(tableName = "apk_log")
-open class RealmApkLog {
+open class ApkLog {
     @PrimaryKey
     var id: String = ""
     var userId: String? = null
@@ -28,7 +28,7 @@ open class RealmApkLog {
     companion object {
         const val ERROR_TYPE_CRASH = "crash"
 
-        fun serialize(log: RealmApkLog, context: Context): JsonObject {
+        fun serialize(log: ApkLog, context: Context): JsonObject {
             val `object` = JsonObject()
             `object`.addProperty("type", log.type)
             `object`.addProperty("error", log.error)

--- a/app/src/main/java/org/ole/planet/myplanet/model/AppNotification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/AppNotification.kt
@@ -7,7 +7,7 @@ import java.util.Date
 import java.util.UUID
 
 @Entity(tableName = "notifications", indices = [Index("userId"), Index("type")])
-class RealmNotification {
+class AppNotification {
     @PrimaryKey
     var id: String = UUID.randomUUID().toString()
     var userId: String = ""

--- a/app/src/main/java/org/ole/planet/myplanet/model/Certification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Certification.kt
@@ -6,12 +6,12 @@ import com.google.gson.JsonArray
 import org.ole.planet.myplanet.utils.JsonUtils
 
 /**
- * Room replacement for the former Realm `RealmCertification` model. Read-only sync data (not
+ * Room replacement for the former Realm `Certification` model. Read-only sync data (not
  * uploaded); persistence goes through [org.ole.planet.myplanet.data.room.dao.CertificationDao].
  * `courseIds` stores the certification's course-id array as a JSON string.
  */
 @Entity(tableName = "certification")
-open class RealmCertification {
+open class Certification {
     @PrimaryKey
     var _id: String = ""
     var _rev: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/ChatHistory.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ChatHistory.kt
@@ -4,12 +4,12 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 
 /**
- * Room replacement for the former Realm `RealmChatHistory` model. The nested conversation list is
+ * Room replacement for the former Realm `ChatHistory` model. The nested conversation list is
  * stored as embedded JSON (see [org.ole.planet.myplanet.data.room.Converters]); persistence goes
  * through [org.ole.planet.myplanet.data.room.dao.ChatDao].
  */
 @Entity(tableName = "chat_history")
-open class RealmChatHistory {
+open class ChatHistory {
     // @JvmField on id/_id so Room does not see ambiguous getId/get_id accessors.
     @PrimaryKey
     @JvmField

--- a/app/src/main/java/org/ole/planet/myplanet/model/Community.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Community.kt
@@ -4,12 +4,12 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 
 /**
- * Room replacement for the former Realm `RealmCommunity` model. Persistence goes through
+ * Room replacement for the former Realm `Community` model. Persistence goes through
  * [org.ole.planet.myplanet.data.room.dao.CommunityDao]; the class name is kept because the sync
  * dialog and server-config utilities use it as a plain data holder.
  */
 @Entity(tableName = "community")
-open class RealmCommunity {
+open class Community {
     @PrimaryKey
     var id: String = ""
     var weight: Int = 10

--- a/app/src/main/java/org/ole/planet/myplanet/model/CourseActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/CourseActivity.kt
@@ -10,7 +10,7 @@ import org.ole.planet.myplanet.utils.NetworkUtils
     tableName = "course_activity",
     indices = [Index("_rev"), Index("courseId"), Index("type")]
 )
-open class RealmCourseActivity {
+open class CourseActivity {
     @PrimaryKey
     @JvmField
     var id: String = ""
@@ -26,15 +26,15 @@ open class RealmCourseActivity {
     var user: String? = null
 
     companion object {
-        fun serializeSerialize(realmCourseActivities: RealmCourseActivity): JsonObject {
+        fun serialize(courseActivity: CourseActivity): JsonObject {
             val ob = JsonObject()
-            ob.addProperty("user", realmCourseActivities.user)
-            ob.addProperty("courseId", realmCourseActivities.courseId)
-            ob.addProperty("type", realmCourseActivities.type)
-            ob.addProperty("title", realmCourseActivities.title)
-            ob.addProperty("time", realmCourseActivities.time)
-            ob.addProperty("createdOn", realmCourseActivities.createdOn)
-            ob.addProperty("parentCode", realmCourseActivities.parentCode)
+            ob.addProperty("user", courseActivity.user)
+            ob.addProperty("courseId", courseActivity.courseId)
+            ob.addProperty("type", courseActivity.type)
+            ob.addProperty("title", courseActivity.title)
+            ob.addProperty("time", courseActivity.time)
+            ob.addProperty("createdOn", courseActivity.createdOn)
+            ob.addProperty("parentCode", courseActivity.parentCode)
             ob.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
             ob.addProperty("deviceName", NetworkUtils.getDeviceName())
             return ob

--- a/app/src/main/java/org/ole/planet/myplanet/model/CourseProgress.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/CourseProgress.kt
@@ -9,7 +9,7 @@ import androidx.room.PrimaryKey
     tableName = "course_progress",
     indices = [Index("_id"), Index("userId"), Index("courseId"), Index(value = ["courseId", "userId", "stepNum"])]
 )
-open class RealmCourseProgress {
+open class CourseProgress {
     @PrimaryKey
     @JvmField
     var id: String = ""
@@ -26,7 +26,7 @@ open class RealmCourseProgress {
     var parentCode: String? = null
 
     companion object {
-        fun serializeProgress(progress: RealmCourseProgress): JsonObject {
+        fun serializeProgress(progress: CourseProgress): JsonObject {
             val `object` = JsonObject()
             `object`.addProperty("userId", progress.userId)
             `object`.addProperty("parentCode", progress.parentCode)

--- a/app/src/main/java/org/ole/planet/myplanet/model/Feedback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Feedback.kt
@@ -12,13 +12,13 @@ import java.io.StringReader
 import org.ole.planet.myplanet.utils.JsonUtils
 
 /**
- * Room replacement for the former Realm `RealmFeedback` model. Uploaded (Room upload path) and
+ * Room replacement for the former Realm `Feedback` model. Uploaded (Room upload path) and
  * synced; persistence goes through [org.ole.planet.myplanet.data.room.dao.FeedbackDao]. The replies
  * are stored as a JSON array string in [messages]; the derived [messageList]/[message] views are
  * ignored by Room.
  */
 @Entity(tableName = "feedback")
-open class RealmFeedback {
+open class Feedback {
     // @JvmField on id/_id so Room does not see ambiguous getId/get_id accessors.
     @PrimaryKey
     @JvmField
@@ -88,7 +88,7 @@ open class RealmFeedback {
         }
 
     companion object {
-        fun serializeFeedback(feedback: RealmFeedback): JsonObject {
+        fun serializeFeedback(feedback: Feedback): JsonObject {
             val `object` = JsonObject()
             `object`.addProperty("title", feedback.title)
             `object`.addProperty("source", feedback.source)

--- a/app/src/main/java/org/ole/planet/myplanet/model/HealthExamination.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/HealthExamination.kt
@@ -9,7 +9,7 @@ import org.ole.planet.myplanet.utils.AndroidDecrypter
 import org.ole.planet.myplanet.utils.JsonUtils
 
 @Entity(tableName = "health_examinations", indices = [Index("userId")])
-class RealmHealthExamination {
+class HealthExamination {
     @PrimaryKey
     var _id: String = ""
     var userId: String? = null
@@ -49,8 +49,8 @@ class RealmHealthExamination {
     }
 
     companion object {
-        fun fromJson(act: JsonObject?): RealmHealthExamination {
-            val myHealth = RealmHealthExamination()
+        fun fromJson(act: JsonObject?): HealthExamination {
+            val myHealth = HealthExamination()
             myHealth._id = JsonUtils.getString("_id", act)
             myHealth.data = JsonUtils.getString("data", act)
             myHealth.userId = JsonUtils.getString("_id", act)
@@ -75,7 +75,7 @@ class RealmHealthExamination {
             return myHealth
         }
 
-        fun serialize(health: RealmHealthExamination): JsonObject {
+        fun serialize(health: HealthExamination): JsonObject {
             val `object` = JsonObject()
             if (!TextUtils.isEmpty(health.userId)) `object`.addProperty("_id", health.userId)
             if (!TextUtils.isEmpty(health._rev)) `object`.addProperty("_rev", health._rev)

--- a/app/src/main/java/org/ole/planet/myplanet/model/HealthRecord.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/HealthRecord.kt
@@ -1,12 +1,12 @@
 package org.ole.planet.myplanet.model
 
-import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.HealthExamination
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
 
 data class HealthRecord(
-    val healthPojo: RealmHealthExamination,
+    val healthPojo: HealthExamination,
     val healthProfile: RealmMyHealth,
-    val examinations: List<RealmHealthExamination>,
+    val examinations: List<HealthExamination>,
     val userMap: Map<String, RealmUser>
 )

--- a/app/src/main/java/org/ole/planet/myplanet/model/Meetup.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Meetup.kt
@@ -10,13 +10,13 @@ import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 
 /**
- * Room replacement for the former Realm `RealmMeetup` model. Meetups are both synced (pulled from
+ * Room replacement for the former Realm `Meetup` model. Meetups are both synced (pulled from
  * the server) and uploaded (locally created/edited meetups). All fields are simple scalars, so no
  * type converters are required. Persistence goes through
  * [org.ole.planet.myplanet.data.room.dao.MeetupDao].
  */
 @Entity(tableName = "meetup", indices = [Index("meetupId"), Index("teamId"), Index("userId")])
-open class RealmMeetup {
+open class Meetup {
     @PrimaryKey
     var id: String = ""
     var userId: String? = null
@@ -47,8 +47,8 @@ open class RealmMeetup {
          * Builds an unmanaged meetup from a CouchDB document. When [existingMeetup] is supplied its
          * local-only fields (created date, recurring number, sync/source metadata) are preserved.
          */
-        fun fromJson(meetupDoc: JsonObject, userId: String?, existingMeetup: RealmMeetup?): RealmMeetup {
-            val meetup = RealmMeetup()
+        fun fromJson(meetupDoc: JsonObject, userId: String?, existingMeetup: Meetup?): Meetup {
+            val meetup = Meetup()
             meetup.id = JsonUtils.getString("_id", meetupDoc)
             meetup.meetupId = JsonUtils.getString("_id", meetupDoc)
             meetup.userId = userId
@@ -79,7 +79,7 @@ open class RealmMeetup {
             return meetup
         }
 
-        fun getMyMeetUpIds(meetups: List<RealmMeetup>): JsonArray {
+        fun getMyMeetUpIds(meetups: List<Meetup>): JsonArray {
             val ids = JsonArray()
             for (meetup in meetups) {
                 ids.add(meetup.meetupId)
@@ -87,7 +87,7 @@ open class RealmMeetup {
             return ids
         }
 
-        fun getHashMap(meetups: RealmMeetup): HashMap<String, String> {
+        fun getHashMap(meetups: Meetup): HashMap<String, String> {
             val map = HashMap<String, String>()
             map["Meetup Title"] = checkNull(meetups.title)
             map["Created By"] = checkNull(meetups.creator)
@@ -120,7 +120,7 @@ open class RealmMeetup {
             return s.orEmpty()
         }
 
-        fun serialize(meetup: RealmMeetup): JsonObject {
+        fun serialize(meetup: Meetup): JsonObject {
             val `object` = JsonObject()
             if (!meetup.meetupId.isNullOrEmpty()) `object`.addProperty("_id", meetup.meetupId)
             if (!meetup.meetupIdRev.isNullOrEmpty()) `object`.addProperty("_rev", meetup.meetupIdRev)

--- a/app/src/main/java/org/ole/planet/myplanet/model/MyLife.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/MyLife.kt
@@ -6,13 +6,13 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /**
- * Room replacement for the former Realm `RealmMyLife` model.
+ * Room replacement for the former Realm `MyLife` model.
  *
  * The class name is kept so the UI (which uses it purely as a detached data holder) is unaffected
  * by the migration. Persistence now goes through [org.ole.planet.myplanet.data.room.dao.MyLifeDao].
  */
 @Entity(tableName = "my_life", indices = [Index("userId")])
-class RealmMyLife {
+class MyLife {
     @PrimaryKey
     var _id: String = ""
     var imageId: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/NewsLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/NewsLog.kt
@@ -11,7 +11,7 @@ import org.ole.planet.myplanet.utils.NetworkUtils
     tableName = "news_log",
     indices = [Index("_id"), Index("_rev")]
 )
-open class RealmNewsLog {
+open class NewsLog {
     @PrimaryKey
     @JvmField
     var id: String = ""
@@ -24,7 +24,7 @@ open class RealmNewsLog {
     var androidId: String? = null
 
     companion object {
-        fun serialize(log: RealmNewsLog): JsonObject {
+        fun serialize(log: NewsLog): JsonObject {
             val ob = JsonObject()
             ob.addProperty("user", log.userId)
             ob.addProperty("type", log.type)

--- a/app/src/main/java/org/ole/planet/myplanet/model/OfflineActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/OfflineActivity.kt
@@ -10,7 +10,7 @@ import org.ole.planet.myplanet.utils.JsonUtils
     tableName = "offline_activity",
     indices = [Index("_rev"), Index("userId"), Index("type"), Index("_id"), Index("loginTime"), Index("userName")]
 )
-open class RealmOfflineActivity {
+open class OfflineActivity {
     @PrimaryKey
     @JvmField
     var id: String = ""

--- a/app/src/main/java/org/ole/planet/myplanet/model/Personal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Personal.kt
@@ -10,12 +10,12 @@ import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
 
 /**
- * Room replacement for the former Realm `RealmMyPersonal` model. The class name is kept because
+ * Room replacement for the former Realm `Personal` model. The class name is kept because
  * the UI and upload path use it purely as a detached data holder. Persistence goes through
  * [org.ole.planet.myplanet.data.room.dao.PersonalDao].
  */
 @Entity(tableName = "my_personal", indices = [Index("userId")])
-open class RealmMyPersonal {
+open class Personal {
     // @JvmField (field access, no generated getters) so Room does not treat the local `id` and the
     // CouchDB `_id` as ambiguous accessors (getId vs get_id both normalise to "id").
     @PrimaryKey
@@ -33,7 +33,7 @@ open class RealmMyPersonal {
     var path: String? = null
 
     companion object {
-        fun serialize(personal: RealmMyPersonal, context: Context): JsonObject {
+        fun serialize(personal: Personal, context: Context): JsonObject {
             val `object` = JsonObject()
             `object`.addProperty("title", personal.title)
             `object`.addProperty("uploadDate", Date().time)

--- a/app/src/main/java/org/ole/planet/myplanet/model/Rating.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Rating.kt
@@ -8,14 +8,14 @@ import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.utils.NetworkUtils
 
 /**
- * Room replacement for the former Realm `RealmRating` model. Uploaded (Room upload path) and
+ * Room replacement for the former Realm `Rating` model. Uploaded (Room upload path) and
  * synced; persistence goes through [org.ole.planet.myplanet.data.room.dao.RatingDao].
  */
 @Entity(
     tableName = "rating",
     indices = [Index("userId"), Index("isUpdated"), Index("item"), Index("type")]
 )
-open class RealmRating {
+open class Rating {
     // @JvmField on id/_id so Room does not see ambiguous getId/get_id accessors.
     @PrimaryKey
     @JvmField
@@ -37,7 +37,7 @@ open class RealmRating {
     var user: String? = null
 
     companion object {
-        fun serializeRating(realmRating: RealmRating): JsonObject {
+        fun serializeRating(realmRating: Rating): JsonObject {
             val ob = JsonObject()
             if (realmRating._id != null) ob.addProperty("_id", realmRating._id)
             if (realmRating._rev != null) ob.addProperty("_rev", realmRating._rev)

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmConversation.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmConversation.kt
@@ -2,7 +2,7 @@ package org.ole.planet.myplanet.model
 
 /**
  * Former Realm `RealmConversation`, now a plain data holder. It has no independent identity and is
- * never queried on its own, so it is embedded inside [RealmChatHistory.conversations] as a JSON
+ * never queried on its own, so it is embedded inside [ChatHistory.conversations] as a JSON
  * list (see the Room type converter) rather than being its own table.
  */
 open class RealmConversation {

--- a/app/src/main/java/org/ole/planet/myplanet/model/RemovedLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RemovedLog.kt
@@ -8,7 +8,7 @@ import androidx.room.PrimaryKey
     tableName = "removed_log",
     indices = [Index("userId"), Index("type"), Index("docId")]
 )
-open class RealmRemovedLog {
+open class RemovedLog {
     @PrimaryKey
     @JvmField
     var id: String = ""

--- a/app/src/main/java/org/ole/planet/myplanet/model/ResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ResourceActivity.kt
@@ -8,7 +8,7 @@ import androidx.room.PrimaryKey
     tableName = "resource_activity",
     indices = [Index("_rev"), Index("type"), Index("user")]
 )
-open class RealmResourceActivity {
+open class ResourceActivity {
     @PrimaryKey
     @JvmField
     var id: String = ""

--- a/app/src/main/java/org/ole/planet/myplanet/model/RetryOperation.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RetryOperation.kt
@@ -6,7 +6,7 @@ import androidx.room.PrimaryKey
 import java.util.UUID
 
 /**
- * Room replacement for the former Realm `RealmRetryOperation` model. Persistence goes through
+ * Room replacement for the former Realm `RetryOperation` model. Persistence goes through
  * [org.ole.planet.myplanet.data.room.dao.RetryDao]; the class name is kept because the retry
  * worker/queue and settings screen use it as a plain data holder.
  */
@@ -14,7 +14,7 @@ import java.util.UUID
     tableName = "retry_operation",
     indices = [Index("uploadType"), Index("itemId"), Index("status")]
 )
-open class RealmRetryOperation {
+open class RetryOperation {
     @PrimaryKey
     var id: String = ""
 
@@ -61,8 +61,8 @@ open class RealmRetryOperation {
             dbId: String?,
             modelClassName: String,
             userId: String?
-        ): RealmRetryOperation {
-            return RealmRetryOperation().apply {
+        ): RetryOperation {
+            return RetryOperation().apply {
                 id = UUID.randomUUID().toString()
                 this.uploadType = uploadType
                 itemId = failure.itemId

--- a/app/src/main/java/org/ole/planet/myplanet/model/SearchActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/SearchActivity.kt
@@ -13,7 +13,7 @@ import org.ole.planet.myplanet.utils.VersionUtils
     tableName = "search_activity",
     indices = [Index("_rev"), Index("type"), Index("user")]
 )
-open class RealmSearchActivity(
+open class SearchActivity(
     @PrimaryKey
     @JvmField
     var id: String = "",

--- a/app/src/main/java/org/ole/planet/myplanet/model/SubmitPhotos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/SubmitPhotos.kt
@@ -5,7 +5,7 @@ import androidx.room.PrimaryKey
 import com.google.gson.JsonObject
 
 @Entity(tableName = "submit_photos")
-open class RealmSubmitPhotos {
+open class SubmitPhotos {
     @PrimaryKey
     @JvmField
     var id: String = ""
@@ -22,7 +22,7 @@ open class RealmSubmitPhotos {
     var uploaded = false
 
     companion object {
-        fun serializeRealmSubmitPhotos(submit: RealmSubmitPhotos): JsonObject {
+        fun serialize(submit: SubmitPhotos): JsonObject {
             val obj = JsonObject()
             obj.addProperty("id", submit.id)
             obj.addProperty("submissionId", submit.submissionId)

--- a/app/src/main/java/org/ole/planet/myplanet/model/TagData.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/TagData.kt
@@ -2,14 +2,14 @@ package org.ole.planet.myplanet.model
 
 sealed class TagData {
     data class Parent(
-        val tag: RealmTag,
+        val tag: TagEntity,
         var isExpanded: Boolean = false,
         val isSelected: Boolean = false,
         val isSelectMultiple: Boolean = false,
     ) : TagData()
 
     data class Child(
-        val tag: RealmTag,
+        val tag: TagEntity,
         val isSelected: Boolean = false,
         val isSelectMultiple: Boolean = false,
     ) : TagData()

--- a/app/src/main/java/org/ole/planet/myplanet/model/TagEntity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/TagEntity.kt
@@ -6,13 +6,13 @@ import androidx.room.PrimaryKey
 import com.google.gson.JsonArray
 
 /**
- * Room replacement for the former Realm `RealmTag` model. Synced (read-only from the server).
+ * Room replacement for the former Realm `TagEntity` model. Synced (read-only from the server).
  * `attachedTo` (formerly `RealmList<String>`) is a plain `List<String>` stored as JSON via the
  * shared [org.ole.planet.myplanet.data.room.Converters]. Persistence goes through
  * [org.ole.planet.myplanet.data.room.dao.TagDao].
  */
 @Entity(tableName = "tag", indices = [Index("name"), Index("tagId"), Index("db")])
-open class RealmTag {
+open class TagEntity {
     // @JvmField on id/_id so Room does not see ambiguous getId/get_id accessors.
     @PrimaryKey
     @JvmField
@@ -40,7 +40,7 @@ open class RealmTag {
     }
 
     companion object {
-        fun getTagsArray(list: List<RealmTag>): JsonArray {
+        fun getTagsArray(list: List<TagEntity>): JsonArray {
             val array = JsonArray()
             for (t in list) {
                 array.add(t._id)

--- a/app/src/main/java/org/ole/planet/myplanet/model/TeamLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/TeamLog.kt
@@ -8,7 +8,7 @@ import androidx.room.PrimaryKey
     tableName = "team_log",
     indices = [Index("teamId"), Index("type"), Index("_id"), Index("_rev")]
 )
-open class RealmTeamLog {
+open class TeamLog {
     @PrimaryKey
     @JvmField
     var id: String = ""

--- a/app/src/main/java/org/ole/planet/myplanet/model/TeamNotification.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/TeamNotification.kt
@@ -5,12 +5,12 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /**
- * Room replacement for the former Realm `RealmTeamNotification` model. Local-only (not synced or
+ * Room replacement for the former Realm `TeamNotification` model. Local-only (not synced or
  * uploaded); persistence goes through
  * [org.ole.planet.myplanet.data.room.dao.TeamNotificationDao].
  */
 @Entity(tableName = "team_notification", indices = [Index("type")])
-open class RealmTeamNotification {
+open class TeamNotification {
     @PrimaryKey
     var id: String = ""
     var type: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/model/TeamTask.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/TeamTask.kt
@@ -8,7 +8,7 @@ import androidx.room.PrimaryKey
 import org.ole.planet.myplanet.utils.JsonUtils
 
 @Entity(tableName = "team_tasks", indices = [Index("teamId")])
-class RealmTeamTask {
+class TeamTask {
     @PrimaryKey
     @JvmField
     var id: String = ""
@@ -33,8 +33,8 @@ class RealmTeamTask {
     }
 
     companion object {
-        fun fromJson(obj: JsonObject?): RealmTeamTask {
-            val task = RealmTeamTask()
+        fun fromJson(obj: JsonObject?): TeamTask {
+            val task = TeamTask()
             task.id = JsonUtils.getString("_id", obj)
             task._id = JsonUtils.getString("_id", obj)
             task._rev = JsonUtils.getString("_rev", obj)
@@ -54,7 +54,7 @@ class RealmTeamTask {
             return task
         }
 
-        fun serialize(task: RealmTeamTask, user: RealmUser?): JsonObject {
+        fun serialize(task: TeamTask, user: RealmUser?): JsonObject {
             val `object` = JsonObject()
             if (!TextUtils.isEmpty(task._id)) {
                 `object`.addProperty("_id", task._id)

--- a/app/src/main/java/org/ole/planet/myplanet/model/UserChallengeActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/UserChallengeActions.kt
@@ -5,7 +5,7 @@ import androidx.room.PrimaryKey
 import java.util.UUID
 
 @Entity(tableName = "user_challenge_actions")
-open class RealmUserChallengeActions {
+open class UserChallengeActions {
     @PrimaryKey
     var id: String = UUID.randomUUID().toString()
     var userId: String? = null

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
@@ -2,13 +2,13 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonObject
 import kotlinx.coroutines.flow.Flow
-import org.ole.planet.myplanet.model.RealmOfflineActivity
+import org.ole.planet.myplanet.model.OfflineActivity
 import org.ole.planet.myplanet.model.RealmUser
 
 interface ActivitiesRepository {
     suspend fun getOfflineVisitCount(userId: String): Int
     suspend fun getOfflineLoginCount(userName: String): Int
-    suspend fun getOfflineLogins(userName: String): Flow<List<RealmOfflineActivity>>
+    suspend fun getOfflineLogins(userName: String): Flow<List<OfflineActivity>>
     suspend fun markResourceAdded(userId: String?, resourceId: String)
     suspend fun markResourceRemoved(userId: String, resourceId: String)
     suspend fun logCourseVisit(courseId: String, title: String, userId: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -28,11 +28,11 @@ import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.LoginActivityData
 import org.ole.planet.myplanet.model.MyPlanet
 import org.ole.planet.myplanet.model.CourseActivity
-import org.ole.planet.myplanet.model.RealmOfflineActivity
+import org.ole.planet.myplanet.model.OfflineActivity
 import org.ole.planet.myplanet.model.RemovedLog
 import org.ole.planet.myplanet.model.ResourceActivity
 import org.ole.planet.myplanet.model.RealmUser
-import org.ole.planet.myplanet.model.RealmUserChallengeActions
+import org.ole.planet.myplanet.model.UserChallengeActions
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
@@ -64,7 +64,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         return offlineActivityDao.countByUserNameAndType(userName, UserSessionManager.KEY_LOGIN)
     }
 
-    override suspend fun getOfflineLogins(userName: String): Flow<List<RealmOfflineActivity>> {
+    override suspend fun getOfflineLogins(userName: String): Flow<List<OfflineActivity>> {
         return offlineActivityDao.observeByUserNameAndType(userName, UserSessionManager.KEY_LOGIN)
     }
 
@@ -112,7 +112,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         planetCode: String?
     ) {
         offlineActivityDao.insert(
-            RealmOfflineActivity().apply {
+            OfflineActivity().apply {
                 id = UUID.randomUUID().toString()
                 this.userId = userId
                 this.userName = userName
@@ -217,7 +217,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
 
 
     override suspend fun recordSyncUserChallengeAction(userId: String) {
-        val action = RealmUserChallengeActions().apply {
+        val action = UserChallengeActions().apply {
             id = UUID.randomUUID().toString()
             this.userId = userId
             actionType = "sync"
@@ -252,9 +252,9 @@ class ActivitiesRepositoryImpl @Inject constructor(
 
     private fun activityFromJson(
         json: JsonObject,
-        existingActivitiesMap: MutableMap<String, RealmOfflineActivity>,
-        fallbackActivitiesMap: MutableMap<String, RealmOfflineActivity>
-    ): RealmOfflineActivity {
+        existingActivitiesMap: MutableMap<String, OfflineActivity>,
+        fallbackActivitiesMap: MutableMap<String, OfflineActivity>
+    ): OfflineActivity {
         val serverId = JsonUtils.getString("_id", json)
         val loginTime = JsonUtils.getLong("loginTime", json)
         val userName = JsonUtils.getString("user", json)
@@ -262,7 +262,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         val fallbackKey = "${loginTime}_${userName}"
         val activity = existingActivitiesMap[serverId]
             ?: fallbackActivitiesMap[fallbackKey]
-            ?: RealmOfflineActivity().apply { id = serverId }
+            ?: OfflineActivity().apply { id = serverId }
 
         activity._rev = JsonUtils.getString("_rev", json)
         activity._id = serverId
@@ -291,7 +291,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         return userChallengeActionsDao.countByUserAndType(userId, "sync") > 0
     }
 
-    private fun serializeLoginActivities(activity: RealmOfflineActivity, context: Context): JsonObject {
+    private fun serializeLoginActivities(activity: OfflineActivity, context: Context): JsonObject {
         val ob = JsonObject()
         ob.addProperty("user", activity.userName)
         ob.addProperty("type", activity.type)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -27,10 +27,10 @@ import org.ole.planet.myplanet.data.room.dao.UserChallengeActionsDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.LoginActivityData
 import org.ole.planet.myplanet.model.MyPlanet
-import org.ole.planet.myplanet.model.RealmCourseActivity
+import org.ole.planet.myplanet.model.CourseActivity
 import org.ole.planet.myplanet.model.RealmOfflineActivity
-import org.ole.planet.myplanet.model.RealmRemovedLog
-import org.ole.planet.myplanet.model.RealmResourceActivity
+import org.ole.planet.myplanet.model.RemovedLog
+import org.ole.planet.myplanet.model.ResourceActivity
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.RealmUserChallengeActions
 import org.ole.planet.myplanet.repository.TeamsRepository
@@ -74,7 +74,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
 
     override suspend fun markResourceRemoved(userId: String, resourceId: String) {
         removedLogDao.insert(
-            RealmRemovedLog().apply {
+            RemovedLog().apply {
                 id = UUID.randomUUID().toString()
                 docId = resourceId
                 this.userId = userId
@@ -89,7 +89,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         val createdOn = user?.planetCode
 
         courseActivityDao.insert(
-            RealmCourseActivity().apply {
+            CourseActivity().apply {
                 id = UUID.randomUUID().toString()
                 type = "visit"
                 this.title = title
@@ -150,7 +150,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         type: String?
     ) {
         resourceActivityDao.insert(
-            RealmResourceActivity().apply {
+            ResourceActivity().apply {
                 id = UUID.randomUUID().toString()
                 user = userName
                 this.parentCode = parentCode
@@ -237,7 +237,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         val createdOn = user.planetCode
 
         resourceActivityDao.insert(
-            RealmResourceActivity().apply {
+            ResourceActivity().apply {
                 id = UUID.randomUUID().toString()
                 this.user = userName
                 _rev = null
@@ -408,7 +408,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
     }
 }
 
-internal fun serializeResourceActivities(activity: RealmResourceActivity): JsonObject {
+internal fun serializeResourceActivities(activity: ResourceActivity): JsonObject {
     val ob = JsonObject()
     ob.addProperty("user", activity.user)
     ob.addProperty("resourceId", activity.resourceId)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepository.kt
@@ -2,7 +2,7 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.AiProvider
-import org.ole.planet.myplanet.model.RealmChatHistory
+import org.ole.planet.myplanet.model.ChatHistory
 
 sealed class ChatResult {
     data class Success(val response: String, val id: String, val rev: String) : ChatResult()
@@ -13,7 +13,7 @@ interface ChatRepository {
     suspend fun sendNewChatRequest(query: String, user: String?, aiProvider: AiProvider): ChatResult
     suspend fun sendContinueChatRequest(message: String, user: String?, aiProvider: AiProvider, id: String, rev: String): ChatResult
     suspend fun fetchAiProviders(serverUrl: String): Map<String, Boolean>?
-    suspend fun getChatHistoryForUser(userName: String?): List<RealmChatHistory>
+    suspend fun getChatHistoryForUser(userName: String?): List<ChatHistory>
     suspend fun getLatestRev(id: String): String?
     suspend fun insertChatHistoryList(chats: List<JsonObject>)
     suspend fun insertChatHistoryFromSync(docs: List<JsonObject>)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ChatRepositoryImpl.kt
@@ -14,7 +14,7 @@ import org.ole.planet.myplanet.model.ChatRequest
 import org.ole.planet.myplanet.model.ContentData
 import org.ole.planet.myplanet.model.ContinueChatRequest
 import org.ole.planet.myplanet.model.Data
-import org.ole.planet.myplanet.model.RealmChatHistory
+import org.ole.planet.myplanet.model.ChatHistory
 import org.ole.planet.myplanet.model.RealmConversation
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
@@ -109,7 +109,7 @@ class ChatRepositoryImpl @Inject constructor(
         return chatApiService.fetchAiProviders()
     }
 
-    override suspend fun getChatHistoryForUser(userName: String?): List<RealmChatHistory> {
+    override suspend fun getChatHistoryForUser(userName: String?): List<ChatHistory> {
         if (userName.isNullOrEmpty()) {
             return emptyList()
         }
@@ -152,7 +152,7 @@ class ChatRepositoryImpl @Inject constructor(
         // conversations JSON), which subsumes the old "delete orphaned conversations" step.
         val entities = chats.map { json ->
             val chatHistoryId = JsonUtils.getString("_id", json)
-            RealmChatHistory().apply {
+            ChatHistory().apply {
                 id = chatHistoryId
                 _id = chatHistoryId
                 _rev = JsonUtils.getString("_rev", json)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CommunityRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CommunityRepository.kt
@@ -2,11 +2,11 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import org.ole.planet.myplanet.model.RealmCommunity
+import org.ole.planet.myplanet.model.Community
 
 interface CommunityRepository {
     suspend fun replaceAll(rows: JsonArray)
-    suspend fun getAllSorted(): List<RealmCommunity>
+    suspend fun getAllSorted(): List<Community>
     suspend fun syncCommunityDocs(): Boolean
     suspend fun insertMeetupsFromSync(docs: List<JsonObject>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CommunityRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CommunityRepositoryImpl.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.CommunityDao
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
-import org.ole.planet.myplanet.model.RealmCommunity
+import org.ole.planet.myplanet.model.Community
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.utils.JsonUtils
 
@@ -17,12 +17,12 @@ class CommunityRepositoryImpl @Inject constructor(
 ) : CommunityRepository {
 
     override suspend fun replaceAll(rows: JsonArray) {
-        val communities = mutableListOf<RealmCommunity>()
+        val communities = mutableListOf<Community>()
         for (j in rows) {
             var jsonDoc = j.asJsonObject
             jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
             val id = JsonUtils.getString("_id", jsonDoc)
-            val community = RealmCommunity()
+            val community = Community()
             community.id = id
             if (JsonUtils.getString("name", jsonDoc) == "learning") {
                 community.weight = 0
@@ -36,7 +36,7 @@ class CommunityRepositoryImpl @Inject constructor(
         communityDao.replaceAll(communities)
     }
 
-    override suspend fun getAllSorted(): List<RealmCommunity> {
+    override suspend fun getAllSorted(): List<Community> {
         return communityDao.getAllSorted()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CommunityRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CommunityRepositoryImpl.kt
@@ -7,7 +7,7 @@ import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.CommunityDao
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
 import org.ole.planet.myplanet.model.Community
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.utils.JsonUtils
 
 class CommunityRepositoryImpl @Inject constructor(
@@ -67,7 +67,7 @@ class CommunityRepositoryImpl @Inject constructor(
             if (existing?.updated == true) {
                 null
             } else {
-                RealmMeetup.fromJson(meetupDoc, "", existing)
+                Meetup.fromJson(meetupDoc, "", existing)
             }
         }
         if (meetupsToInsert.isNotEmpty()) {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
@@ -9,7 +9,7 @@ import org.ole.planet.myplanet.model.CourseStepData
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 
 interface CoursesRepository {
     suspend fun getAllCourses(): List<RealmMyCourse>
@@ -41,7 +41,7 @@ interface CoursesRepository {
         userName: String,
         planetCode: String,
         parentCode: String,
-        tags: List<RealmTag>,
+        tags: List<TagEntity>,
         grade: String,
         subject: String
     )
@@ -57,7 +57,7 @@ interface CoursesRepository {
     suspend fun getCourseProgress(userId: String?, courseIds: List<String>): HashMap<String?, JsonObject>
     suspend fun isStepCompleted(stepId: String?, userId: String?): Boolean
     suspend fun hasUnfinishedSurveys(courseId: String, userId: String?): Boolean
-    suspend fun getCourseTagsBulk(courseIds: List<String>): Map<String, List<RealmTag>>
+    suspend fun getCourseTagsBulk(courseIds: List<String>): Map<String, List<TagEntity>>
     suspend fun getCourseRatings(userId: String?): HashMap<String?, JsonObject>
     suspend fun deleteCourseProgress(courseId: String?)
     fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: JsonArray)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -28,8 +28,8 @@ import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmExamQuestion
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmRemovedLog
-import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.RemovedLog
+import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.insertCourseStepsExams
 import org.ole.planet.myplanet.model.RealmSubmission
@@ -267,7 +267,7 @@ class CoursesRepositoryImpl @Inject constructor(
             addProperty("doc.subjectLevel", subject)
         }
         searchActivityDao.insert(
-            RealmSearchActivity(
+            SearchActivity(
                 id = UUID.randomUUID().toString(),
                 user = userName,
                 time = Calendar.getInstance().timeInMillis,
@@ -308,7 +308,7 @@ class CoursesRepositoryImpl @Inject constructor(
                     .findFirst()
                 course?.removeUserId(userId)
             }
-            removedLogDao.insert(RealmRemovedLog().apply {
+            removedLogDao.insert(RemovedLog().apply {
                 id = UUID.randomUUID().toString()
                 type = "courses"
                 this.userId = userId

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -23,7 +23,7 @@ import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TagDao
-import org.ole.planet.myplanet.model.RealmCertification
+import org.ole.planet.myplanet.model.Certification
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmExamQuestion
 import org.ole.planet.myplanet.model.RealmMyCourse
@@ -587,13 +587,13 @@ class CoursesRepositoryImpl @Inject constructor(
         RealmMyCourse.saveConcatenatedLinksToPrefs(sharedPrefManager)
     }
     override suspend fun insertCertificationsFromSync(jsonArray: JsonArray) {
-        val certifications = ArrayList<RealmCertification>(jsonArray.size())
+        val certifications = ArrayList<Certification>(jsonArray.size())
         for (j in jsonArray) {
             val jsonDoc = JsonUtils.getJsonObject("doc", j.asJsonObject)
             val id = JsonUtils.getString("_id", jsonDoc)
             if (id.startsWith("_design")) continue
             certifications.add(
-                RealmCertification().apply {
+                Certification().apply {
                     _id = id
                     name = JsonUtils.getString("name", jsonDoc)
                     setCourseIds(JsonUtils.getJsonArray("courseIds", jsonDoc))

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -33,7 +33,7 @@ import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmStepExam.Companion.insertCourseStepsExams
 import org.ole.planet.myplanet.model.RealmSubmission
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
@@ -257,12 +257,12 @@ class CoursesRepositoryImpl @Inject constructor(
         userName: String,
         planetCode: String,
         parentCode: String,
-        tags: List<RealmTag>,
+        tags: List<TagEntity>,
         grade: String,
         subject: String
     ) {
         val filter = JsonObject().apply {
-            add("tags", RealmTag.getTagsArray(tags))
+            add("tags", TagEntity.getTagsArray(tags))
             addProperty("doc.gradeLevel", grade)
             addProperty("doc.subjectLevel", subject)
         }
@@ -534,7 +534,7 @@ class CoursesRepositoryImpl @Inject constructor(
         return submissionsRepository.hasUnfinishedSurveys(courseId, userId)
     }
 
-    override suspend fun getCourseTagsBulk(courseIds: List<String>): Map<String, List<RealmTag>> {
+    override suspend fun getCourseTagsBulk(courseIds: List<String>): Map<String, List<TagEntity>> {
         return tagsRepository.getTagsForCourses(courseIds)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepository.kt
@@ -2,22 +2,22 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.MeetupCreationParams
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.RealmUser
 
 interface EventsRepository {
     suspend fun createMeetup(params: MeetupCreationParams): Boolean
-    suspend fun getMeetupsForTeam(teamId: String): List<RealmMeetup>
-    suspend fun getMeetupById(meetupId: String): RealmMeetup?
-    suspend fun getMeetupByLocalId(id: String): RealmMeetup?
+    suspend fun getMeetupsForTeam(teamId: String): List<Meetup>
+    suspend fun getMeetupById(meetupId: String): Meetup?
+    suspend fun getMeetupByLocalId(id: String): Meetup?
     suspend fun getJoinedMembers(meetupId: String): List<RealmUser>
-    suspend fun toggleAttendance(meetupId: String, currentUserId: String?): RealmMeetup?
+    suspend fun toggleAttendance(meetupId: String, currentUserId: String?): Meetup?
     suspend fun batchInsertMeetups(documents: List<JsonObject>): Int
     suspend fun updateMeetup(meetupId: String, title: String, description: String,
                              startDate: Long, endDate: Long, startTime: String,
                              endTime: String, meetupLocation: String, meetupLink: String,
                              recurring: String): Boolean
     suspend fun getMeetupIdsForUser(userId: String?): List<String>
-    suspend fun getPendingMeetupUploads(): List<RealmMeetup>
+    suspend fun getPendingMeetupUploads(): List<Meetup>
     suspend fun markMeetupUploaded(localId: String, remoteId: String, remoteRev: String): Boolean
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepositoryImpl.kt
@@ -9,7 +9,7 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.MeetupCreationParams
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.TimeProvider
@@ -21,7 +21,7 @@ class EventsRepositoryImpl @Inject constructor(
     private val meetupDao: MeetupDao
 ) : RealmRepository(databaseService, realmDispatcher), EventsRepository {
 
-    override suspend fun getMeetupsForTeam(teamId: String): List<RealmMeetup> {
+    override suspend fun getMeetupsForTeam(teamId: String): List<Meetup> {
         return meetupDao.getByTeamId(teamId)
     }
 
@@ -51,14 +51,14 @@ class EventsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getMeetupById(meetupId: String): RealmMeetup? {
+    override suspend fun getMeetupById(meetupId: String): Meetup? {
         if (meetupId.isBlank()) {
             return null
         }
         return meetupDao.getByMeetupId(meetupId)
     }
 
-    override suspend fun getMeetupByLocalId(id: String): RealmMeetup? {
+    override suspend fun getMeetupByLocalId(id: String): Meetup? {
         if (id.isBlank()) return null
         return meetupDao.getById(id)
     }
@@ -82,7 +82,7 @@ class EventsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun toggleAttendance(meetupId: String, currentUserId: String?): RealmMeetup? {
+    override suspend fun toggleAttendance(meetupId: String, currentUserId: String?): Meetup? {
         if (meetupId.isBlank()) {
             return null
         }
@@ -108,7 +108,7 @@ class EventsRepositoryImpl @Inject constructor(
                 if (existing?.updated == true) {
                     null
                 } else {
-                    RealmMeetup.fromJson(meetupDoc, "", existing)
+                    Meetup.fromJson(meetupDoc, "", existing)
                 }
             }
             if (meetupsToInsert.isNotEmpty()) {
@@ -123,7 +123,7 @@ class EventsRepositoryImpl @Inject constructor(
 
     override suspend fun createMeetup(params: MeetupCreationParams): Boolean {
         val gson = Gson()
-        val meetup = RealmMeetup().apply {
+        val meetup = Meetup().apply {
             id = "${UUID.randomUUID()}"
             title = params.title
             meetupLink = params.meetupLink
@@ -162,7 +162,7 @@ class EventsRepositoryImpl @Inject constructor(
         return meetupDao.getByUserId(userId).mapNotNull { it.meetupId }
     }
 
-    override suspend fun getPendingMeetupUploads(): List<RealmMeetup> {
+    override suspend fun getPendingMeetupUploads(): List<Meetup> {
         return meetupDao.getPendingUploads()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepository.kt
@@ -2,7 +2,7 @@ package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonObject
 import kotlinx.coroutines.flow.Flow
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.model.RealmUser
 
 interface FeedbackRepository {
@@ -13,13 +13,13 @@ interface FeedbackRepository {
         message: String,
         item: String? = null,
         state: String? = null,
-    ): RealmFeedback
-    suspend fun getFeedback(userModel: RealmUser?): Flow<List<RealmFeedback>>
-    suspend fun getPendingFeedback(): List<RealmFeedback>
-    suspend fun getFeedbackById(id: String?): RealmFeedback?
+    ): Feedback
+    suspend fun getFeedback(userModel: RealmUser?): Flow<List<Feedback>>
+    suspend fun getPendingFeedback(): List<Feedback>
+    suspend fun getFeedbackById(id: String?): Feedback?
     suspend fun closeFeedback(id: String?)
     suspend fun addReply(id: String?, message: String, user: String?)
-    suspend fun saveFeedback(feedback: RealmFeedback)
+    suspend fun saveFeedback(feedback: Feedback)
     suspend fun insertFromJson(jsonObject: JsonObject)
     suspend fun insertFeedbackList(jsonObjects: List<JsonObject>)
     suspend fun markFeedbackUploaded(id: String): Boolean

--- a/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImpl.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.JsonUtils
 
@@ -24,8 +24,8 @@ class FeedbackRepositoryImpl @Inject constructor(
         message: String,
         item: String?,
         state: String?,
-    ): RealmFeedback {
-        val feedback = RealmFeedback()
+    ): Feedback {
+        val feedback = Feedback()
         feedback.id = UUID.randomUUID().toString()
         if (state != null) {
             feedback.title = "Question regarding /$state"
@@ -54,7 +54,7 @@ class FeedbackRepositoryImpl @Inject constructor(
         return feedback
     }
 
-    override suspend fun getFeedback(userModel: RealmUser?): Flow<List<RealmFeedback>> {
+    override suspend fun getFeedback(userModel: RealmUser?): Flow<List<Feedback>> {
         return if (userModel?.isManager() == true) {
             feedbackDao.getAllSortedFlow()
         } else {
@@ -62,11 +62,11 @@ class FeedbackRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getPendingFeedback(): List<RealmFeedback> {
+    override suspend fun getPendingFeedback(): List<Feedback> {
         return feedbackDao.getPending()
     }
 
-    override suspend fun getFeedbackById(id: String?): RealmFeedback? {
+    override suspend fun getFeedbackById(id: String?): Feedback? {
         return id?.let { feedbackDao.findById(it) }
     }
 
@@ -89,24 +89,24 @@ class FeedbackRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun saveFeedback(feedback: RealmFeedback) {
+    override suspend fun saveFeedback(feedback: Feedback) {
         feedbackDao.upsert(feedback)
     }
 
     override suspend fun insertFromJson(jsonObject: JsonObject) {
-        feedbackDao.upsert(mapToRealmFeedback(jsonObject))
+        feedbackDao.upsert(mapToFeedback(jsonObject))
     }
 
     override suspend fun insertFeedbackList(jsonObjects: List<JsonObject>) {
-        feedbackDao.upsertAll(jsonObjects.map { mapToRealmFeedback(it) })
+        feedbackDao.upsertAll(jsonObjects.map { mapToFeedback(it) })
     }
 
     override suspend fun markFeedbackUploaded(id: String): Boolean {
         return feedbackDao.markUploaded(id) > 0
     }
 
-    private fun mapToRealmFeedback(act: JsonObject): RealmFeedback {
-        return RealmFeedback().apply {
+    private fun mapToFeedback(act: JsonObject): Feedback {
+        return Feedback().apply {
             id = JsonUtils.getString("_id", act)
             _id = JsonUtils.getString("_id", act)
             title = JsonUtils.getString("title", act)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepository.kt
@@ -1,20 +1,20 @@
 package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonArray
-import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.HealthExamination
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
 
 interface HealthRepository {
-    suspend fun getHealthEntry(userId: String): Pair<RealmUser?, RealmHealthExamination?>
-    suspend fun getExaminationById(id: String): RealmHealthExamination?
+    suspend fun getHealthEntry(userId: String): Pair<RealmUser?, HealthExamination?>
+    suspend fun getExaminationById(id: String): HealthExamination?
     suspend fun initHealth(): RealmMyHealth
-    suspend fun saveExamination(examination: RealmHealthExamination?, pojo: RealmHealthExamination?, user: RealmUser?)
-    suspend fun getUpdatedHealthExaminations(): List<RealmHealthExamination>
-    suspend fun getUpdatedHealthForUser(userId: String): List<RealmHealthExamination>
+    suspend fun saveExamination(examination: HealthExamination?, pojo: HealthExamination?, user: RealmUser?)
+    suspend fun getUpdatedHealthExaminations(): List<HealthExamination>
+    suspend fun getUpdatedHealthForUser(userId: String): List<HealthExamination>
     suspend fun markHealthExaminationsUploaded(idToRevMap: Map<String, String?>)
     suspend fun updateExaminationUserId(id: String, userId: String)
     suspend fun bulkInsertFromSync(jsonArray: JsonArray)
-    suspend fun uploadHealthData(myHealths: List<RealmHealthExamination>): Map<String, String?>
-    suspend fun getExaminationConditions(examination: RealmHealthExamination?): Map<String, Boolean>
+    suspend fun uploadHealthData(myHealths: List<HealthExamination>): Map<String, String?>
+    suspend fun getExaminationConditions(examination: HealthExamination?): Map<String, Boolean>
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -15,8 +15,8 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.HealthExaminationDao
 import org.ole.planet.myplanet.di.RealmDispatcher
-import org.ole.planet.myplanet.model.RealmHealthExamination
-import org.ole.planet.myplanet.model.RealmHealthExamination.Companion.serialize
+import org.ole.planet.myplanet.model.HealthExamination
+import org.ole.planet.myplanet.model.HealthExamination.Companion.serialize
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.AndroidDecrypter
@@ -31,7 +31,7 @@ class HealthRepositoryImpl @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val healthExaminationDao: HealthExaminationDao
 ) : RealmRepository(databaseService, realmDispatcher), HealthRepository {
-    override suspend fun getHealthEntry(userId: String): Pair<RealmUser?, RealmHealthExamination?> {
+    override suspend fun getHealthEntry(userId: String): Pair<RealmUser?, HealthExamination?> {
         val userCopy = findByField(RealmUser::class.java, "_id", userId)
             ?: findByField(RealmUser::class.java, "id", userId)
         val pojoCopy = healthExaminationDao.getByIdOrUserId(userId)
@@ -39,7 +39,7 @@ class HealthRepositoryImpl @Inject constructor(
         return Pair(userCopy, pojoCopy)
     }
 
-    override suspend fun getExaminationById(id: String): RealmHealthExamination? {
+    override suspend fun getExaminationById(id: String): HealthExamination? {
         return healthExaminationDao.getById(id)
     }
 
@@ -54,11 +54,11 @@ class HealthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getUpdatedHealthExaminations(): List<RealmHealthExamination> {
+    override suspend fun getUpdatedHealthExaminations(): List<HealthExamination> {
         return healthExaminationDao.getUpdated()
     }
 
-    override suspend fun getUpdatedHealthForUser(userId: String): List<RealmHealthExamination> {
+    override suspend fun getUpdatedHealthForUser(userId: String): List<HealthExamination> {
         return healthExaminationDao.getUpdatedForUser(userId)
     }
 
@@ -68,7 +68,7 @@ class HealthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun saveExamination(examination: RealmHealthExamination?, pojo: RealmHealthExamination?, user: RealmUser?) {
+    override suspend fun saveExamination(examination: HealthExamination?, pojo: HealthExamination?, user: RealmUser?) {
         user?.let { save(it) }
         pojo?.let { healthExaminationDao.upsert(it) }
         examination?.let { healthExaminationDao.upsert(it) }
@@ -79,19 +79,19 @@ class HealthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun bulkInsertFromSync(jsonArray: JsonArray) {
-        val examinations = ArrayList<RealmHealthExamination>(jsonArray.size())
+        val examinations = ArrayList<HealthExamination>(jsonArray.size())
         for (j in jsonArray) {
             var jsonDoc = j.asJsonObject
             jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
             val id = JsonUtils.getString("_id", jsonDoc)
             if (!id.startsWith("_design")) {
-                examinations.add(RealmHealthExamination.fromJson(jsonDoc))
+                examinations.add(HealthExamination.fromJson(jsonDoc))
             }
         }
         healthExaminationDao.upsertAll(examinations)
     }
 
-    override suspend fun getExaminationConditions(examination: RealmHealthExamination?): Map<String, Boolean> {
+    override suspend fun getExaminationConditions(examination: HealthExamination?): Map<String, Boolean> {
         return withContext(dispatcherProvider.default) {
             val result = mutableMapOf<String, Boolean>()
             if (examination != null && !examination.conditions.isNullOrEmpty()) {
@@ -108,7 +108,7 @@ class HealthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun uploadHealthData(myHealths: List<RealmHealthExamination>): Map<String, String?> {
+    override suspend fun uploadHealthData(myHealths: List<HealthExamination>): Map<String, String?> {
         val uploadedHealths = mutableMapOf<String, String?>()
         val semaphore = Semaphore(5)
         supervisorScope {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepository.kt
@@ -1,12 +1,12 @@
 package org.ole.planet.myplanet.repository
 
-import org.ole.planet.myplanet.model.RealmMyLife
+import org.ole.planet.myplanet.model.MyLife
 
 interface LifeRepository {
     suspend fun updateVisibility(isVisible: Boolean, myLifeId: String)
-    suspend fun updateMyLifeListOrder(list: List<RealmMyLife>)
-    suspend fun getMyLifeByUserId(userId: String?, ensureLatest: Boolean = false): List<RealmMyLife>
-    suspend fun getVisibleMyLifeByUserId(userId: String?, ensureLatest: Boolean = false): List<RealmMyLife>
-    suspend fun getMyLifeForDashboard(userId: String, seedBase: List<RealmMyLife>): List<RealmMyLife>
-    suspend fun seedMyLifeIfEmpty(userId: String?, items: List<RealmMyLife>)
+    suspend fun updateMyLifeListOrder(list: List<MyLife>)
+    suspend fun getMyLifeByUserId(userId: String?, ensureLatest: Boolean = false): List<MyLife>
+    suspend fun getVisibleMyLifeByUserId(userId: String?, ensureLatest: Boolean = false): List<MyLife>
+    suspend fun getMyLifeForDashboard(userId: String, seedBase: List<MyLife>): List<MyLife>
+    suspend fun seedMyLifeIfEmpty(userId: String?, items: List<MyLife>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepositoryImpl.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
 import org.ole.planet.myplanet.di.ApplicationScope
 import org.ole.planet.myplanet.di.RealmDispatcher
-import org.ole.planet.myplanet.model.RealmMyLife
+import org.ole.planet.myplanet.model.MyLife
 import org.ole.planet.myplanet.services.SharedPrefManager
 
 data class CachedMyLifeItem(
@@ -35,7 +35,7 @@ class LifeRepositoryImpl @Inject constructor(
         myLifeDao.updateVisibility(myLifeId, isVisible)
     }
 
-    override suspend fun updateMyLifeListOrder(list: List<RealmMyLife>) {
+    override suspend fun updateMyLifeListOrder(list: List<MyLife>) {
         val userId = list.firstOrNull()?.userId
         val idToIndex = list.mapIndexed { index, item -> item._id to index }.toMap()
         val ids = idToIndex.keys.filter { it.isNotEmpty() }
@@ -61,15 +61,15 @@ class LifeRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getMyLifeByUserId(userId: String?, ensureLatest: Boolean): List<RealmMyLife> {
+    override suspend fun getMyLifeByUserId(userId: String?, ensureLatest: Boolean): List<MyLife> {
         return myLifeDao.getByUserId(userId)
     }
 
-    override suspend fun getVisibleMyLifeByUserId(userId: String?, ensureLatest: Boolean): List<RealmMyLife> {
+    override suspend fun getVisibleMyLifeByUserId(userId: String?, ensureLatest: Boolean): List<MyLife> {
         return myLifeDao.getVisibleByUserId(userId)
     }
 
-    override suspend fun getMyLifeForDashboard(userId: String, seedBase: List<RealmMyLife>): List<RealmMyLife> {
+    override suspend fun getMyLifeForDashboard(userId: String, seedBase: List<MyLife>): List<MyLife> {
         val json = sharedPrefManager.rawPreferences.getString("$MY_LIFE_CACHE_PREFIX$userId", null)
         if (json != null) {
             val cached: List<CachedMyLifeItem>? = try {
@@ -86,7 +86,7 @@ class LifeRepositoryImpl @Inject constructor(
                     }
                 }
                 return cached.filter { it.isVisible }.map { item ->
-                    RealmMyLife(item.imageId, userId, item.title).apply {
+                    MyLife(item.imageId, userId, item.title).apply {
                         isVisible = item.isVisible
                         weight = item.weight
                     }
@@ -107,17 +107,17 @@ class LifeRepositoryImpl @Inject constructor(
         return visibleItems
     }
 
-    private fun cacheMyLifeItems(userId: String, items: List<RealmMyLife>) {
+    private fun cacheMyLifeItems(userId: String, items: List<MyLife>) {
         val cached = items.map { CachedMyLifeItem(it.imageId, it.title, it.isVisible, it.weight) }
         sharedPrefManager.rawPreferences.edit { putString("$MY_LIFE_CACHE_PREFIX$userId", gson.toJson(cached)) }
     }
 
-    override suspend fun seedMyLifeIfEmpty(userId: String?, items: List<RealmMyLife>) {
+    override suspend fun seedMyLifeIfEmpty(userId: String?, items: List<MyLife>) {
         val existing = myLifeDao.countByUserId(userId)
         if (existing == 0) {
             var weight = 1
             val newItems = items.map { item ->
-                RealmMyLife().apply {
+                MyLife().apply {
                     _id = UUID.randomUUID().toString()
                     title = item.title
                     imageId = item.imageId

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepository.kt
@@ -3,7 +3,7 @@ package org.ole.planet.myplanet.repository
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.NotificationPayload
-import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.model.AppNotification
 import org.ole.planet.myplanet.model.TaskNotificationResult
 import org.ole.planet.myplanet.model.TeamNotificationInfo
 
@@ -26,7 +26,7 @@ interface NotificationsRepository {
     suspend fun getTeamNotificationInfo(teamId: String, userId: String): TeamNotificationInfo
     suspend fun getTeamNotifications(teamIds: List<String>, userId: String): Map<String, TeamNotificationInfo>
     suspend fun getTaskTeamNamesByTaskTitles(taskTitles: List<String>): Map<String, String>
-    suspend fun getPendingSyncNotifications(): List<RealmNotification>
+    suspend fun getPendingSyncNotifications(): List<AppNotification>
     suspend fun markNotificationsSynced(syncResults: List<Pair<String, String?>>)
     suspend fun bulkInsertFromSync(jsonArray: JsonArray)
     suspend fun insert(doc: JsonObject)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -16,7 +16,7 @@ import org.ole.planet.myplanet.model.NotificationPayload
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmStepExam
-import org.ole.planet.myplanet.model.RealmTeamNotification
+import org.ole.planet.myplanet.model.TeamNotification
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.TaskNotificationResult
 import org.ole.planet.myplanet.model.TeamNotificationInfo
@@ -318,7 +318,7 @@ class NotificationsRepositoryImpl @Inject constructor(
 
         // 1. Fetch all relevant notifications in a single query
         val notificationsResult = teamNotificationDao.getByTypeAndParentIds("chat", teamIds)
-        val notificationsById = mutableMapOf<String, RealmTeamNotification>()
+        val notificationsById = mutableMapOf<String, TeamNotification>()
         notificationsResult.forEach {
             it.parentId?.let { parentId ->
                 notificationsById[parentId] = it

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -14,10 +14,10 @@ import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.NotificationPayload
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.model.AppNotification
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.TeamNotification
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.TaskNotificationResult
 import org.ole.planet.myplanet.model.TeamNotificationInfo
 import org.ole.planet.myplanet.utils.JsonUtils
@@ -71,7 +71,7 @@ class NotificationsRepositoryImpl @Inject constructor(
                     this.isRead = false
                     this.createdAt = Date()
                 }
-            } ?: RealmNotification().apply {
+            } ?: AppNotification().apply {
                 this.id = notificationId
                 this.userId = userId
                 this.type = "resource"
@@ -102,7 +102,7 @@ class NotificationsRepositoryImpl @Inject constructor(
                     this.isRead = false
                     this.createdAt = Date()
                 }
-            } ?: RealmNotification().apply {
+            } ?: AppNotification().apply {
                 this.id = notificationId
                 this.userId = userId
                 this.type = "storage"
@@ -354,7 +354,7 @@ class NotificationsRepositoryImpl @Inject constructor(
         return notificationMap
     }
 
-    override suspend fun getPendingSyncNotifications(): List<RealmNotification> {
+    override suspend fun getPendingSyncNotifications(): List<AppNotification> {
         return notificationDao.getPendingSyncNotifications()
     }
 
@@ -365,9 +365,9 @@ class NotificationsRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun parseNotification(doc: JsonObject): RealmNotification? {
+    private fun parseNotification(doc: JsonObject): AppNotification? {
         val id = doc.get("_id")?.asString ?: return null
-        return RealmNotification().apply {
+        return AppNotification().apply {
             this.id = id
             userId = doc.get("user")?.asString ?: ""
             message = doc.get("message")?.asString ?: ""

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepository.kt
@@ -1,7 +1,7 @@
 package org.ole.planet.myplanet.repository
 
 import kotlinx.coroutines.flow.Flow
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Personal
 
 interface PersonalsRepository {
     suspend fun personalTitleExists(title: String, userId: String?): Boolean
@@ -14,15 +14,15 @@ interface PersonalsRepository {
         description: String?
     )
 
-    suspend fun getPersonalResources(userId: String?): Flow<List<RealmMyPersonal>>
+    suspend fun getPersonalResources(userId: String?): Flow<List<Personal>>
 
     suspend fun deletePersonalResource(id: String)
 
-    suspend fun updatePersonalResource(id: String, updater: (RealmMyPersonal) -> Unit)
+    suspend fun updatePersonalResource(id: String, updater: (Personal) -> Unit)
 
-    suspend fun getPendingPersonalUploads(userId: String): List<RealmMyPersonal>
+    suspend fun getPendingPersonalUploads(userId: String): List<Personal>
 
     suspend fun updatePersonalAfterSync(id: String, newId: String, rev: String)
 
-    suspend fun uploadPersonalDocument(personal: RealmMyPersonal): Pair<String, String>?
+    suspend fun uploadPersonalDocument(personal: Personal): Pair<String, String>?
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Personal
 import org.ole.planet.myplanet.utils.JsonUtils.getString
 import org.ole.planet.myplanet.utils.UrlUtils
 
@@ -30,7 +30,7 @@ class PersonalsRepositoryImpl @Inject constructor(
         path: String?,
         description: String?
     ) {
-        val personal = RealmMyPersonal().apply {
+        val personal = Personal().apply {
             id = UUID.randomUUID().toString()
             _id = id
             this.title = title
@@ -43,7 +43,7 @@ class PersonalsRepositoryImpl @Inject constructor(
         personalDao.insert(personal)
     }
 
-    override suspend fun getPersonalResources(userId: String?): Flow<List<RealmMyPersonal>> {
+    override suspend fun getPersonalResources(userId: String?): Flow<List<Personal>> {
         if (userId.isNullOrBlank()) {
             return flowOf(emptyList())
         }
@@ -55,7 +55,7 @@ class PersonalsRepositoryImpl @Inject constructor(
         personalDao.deleteById(id)
     }
 
-    override suspend fun updatePersonalResource(id: String, updater: (RealmMyPersonal) -> Unit) {
+    override suspend fun updatePersonalResource(id: String, updater: (Personal) -> Unit) {
         personalDao.findByDocId(id)?.let { personal ->
             updater(personal)
             personalDao.update(personal)
@@ -66,7 +66,7 @@ class PersonalsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getPendingPersonalUploads(userId: String): List<RealmMyPersonal> {
+    override suspend fun getPendingPersonalUploads(userId: String): List<Personal> {
         return personalDao.getPendingUploads(userId)
     }
 
@@ -79,10 +79,10 @@ class PersonalsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun uploadPersonalDocument(personal: RealmMyPersonal): Pair<String, String>? {
+    override suspend fun uploadPersonalDocument(personal: Personal): Pair<String, String>? {
         val response = apiInterface.postDoc(
             UrlUtils.header, "application/json",
-            "${UrlUtils.getUrl()}/resources", RealmMyPersonal.serialize(personal, context)
+            "${UrlUtils.getUrl()}/resources", Personal.serialize(personal, context)
         )
 
         val `object` = response.body()

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepository.kt
@@ -3,14 +3,14 @@ package org.ole.planet.myplanet.repository
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.CourseCompletion
-import org.ole.planet.myplanet.model.RealmCourseProgress
+import org.ole.planet.myplanet.model.CourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
 
 interface ProgressRepository {
     suspend fun getCourseProgress(courseIds: List<String>, userId: String?): HashMap<String?, JsonObject>
     suspend fun getCurrentProgress(steps: List<RealmCourseStep?>?, userId: String?, courseId: String?): Int
     suspend fun fetchCourseData(userId: String?): JsonArray
-    suspend fun getProgressRecords(userId: String?): List<RealmCourseProgress>
+    suspend fun getProgressRecords(userId: String?): List<CourseProgress>
     suspend fun getCompletedCourses(userId: String): List<CourseCompletion>
     suspend fun saveCourseProgress(
         userId: String?,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
@@ -12,7 +12,7 @@ import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CourseCompletion
 import org.ole.planet.myplanet.model.RealmAnswer
-import org.ole.planet.myplanet.model.RealmCourseProgress
+import org.ole.planet.myplanet.model.CourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmExamQuestion
 import org.ole.planet.myplanet.model.RealmStepExam
@@ -95,7 +95,7 @@ class ProgressRepositoryImpl @Inject constructor(
     }
 
     private fun calculateCurrentProgress(
-        steps: List<RealmCourseStep?>?, progresses: List<RealmCourseProgress>
+        steps: List<RealmCourseStep?>?, progresses: List<CourseProgress>
     ): Int {
         val stepsSize = steps?.size ?: 0
         val completed = BooleanArray(stepsSize + 1)
@@ -148,7 +148,7 @@ class ProgressRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getProgressRecords(userId: String?): List<RealmCourseProgress> {
+    override suspend fun getProgressRecords(userId: String?): List<CourseProgress> {
         return courseProgressDao.getByUser(userId)
     }
 
@@ -195,7 +195,7 @@ class ProgressRepositoryImpl @Inject constructor(
     ) {
         val now = Date().time
         val courseProgress = courseProgressDao.findByCourseUserAndStep(courseId, userId, stepNum)
-            ?: RealmCourseProgress().apply {
+            ?: CourseProgress().apply {
                 id = UUID.randomUUID().toString()
                 createdDate = now
             }
@@ -217,14 +217,14 @@ class ProgressRepositoryImpl @Inject constructor(
 
     private fun courseProgressFromJson(
         act: JsonObject,
-        existingProgress: RealmCourseProgress?,
-        localRecord: RealmCourseProgress?
-    ): RealmCourseProgress {
+        existingProgress: CourseProgress?,
+        localRecord: CourseProgress?
+    ): CourseProgress {
         val docId = JsonUtils.getString("_id", act)
         val localPassed = localRecord?.passed ?: false
         val courseProgress = existingProgress
             ?: localRecord
-            ?: RealmCourseProgress().apply { id = docId }
+            ?: CourseProgress().apply { id = docId }
 
         courseProgress.id = docId
         courseProgress._id = docId

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepository.kt
@@ -19,7 +19,7 @@ interface RatingsRepository {
         comment: String,
     ): RatingSummary
     suspend fun insertRatingsFromSync(documentList: List<JsonObject>)
-    suspend fun getPendingRatingUploads(): List<org.ole.planet.myplanet.model.RealmRating>
+    suspend fun getPendingRatingUploads(): List<org.ole.planet.myplanet.model.Rating>
     suspend fun markRatingUploaded(id: String): Boolean
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RatingsRepositoryImpl.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.RatingDao
 import org.ole.planet.myplanet.di.RealmDispatcher
-import org.ole.planet.myplanet.model.RealmRating
+import org.ole.planet.myplanet.model.Rating
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.JsonUtils
 
@@ -21,7 +21,7 @@ class RatingsRepositoryImpl @Inject constructor(
     private val ratingDao: RatingDao,
 ) : RealmRepository(databaseService, realmDispatcher), RatingsRepository {
     // Still extends RealmRepository for RealmUser lookups (RealmUser is not migrated yet);
-    // RealmRating itself is now stored in Room via ratingDao.
+    // Rating itself is now stored in Room via ratingDao.
 
     override suspend fun getRatings(type: String?, userId: String?): HashMap<String?, JsonObject> {
         val ratings = ratingDao.getByType(type)
@@ -83,7 +83,7 @@ class RatingsRepositoryImpl @Inject constructor(
         val existingRating = ratingDao.findByTypeUserItem(type, resolvedUserId, itemId)
 
         if (existingRating == null || existingRating.id.isBlank()) {
-            val newRating = RealmRating().apply {
+            val newRating = Rating().apply {
                 id = UUID.randomUUID().toString()
             }
             setRatingData(newRating, resolvedUser, type, itemId, title, rating, comment)
@@ -102,7 +102,7 @@ class RatingsRepositoryImpl @Inject constructor(
     override suspend fun insertRatingsFromSync(documentList: List<JsonObject>) {
         if (documentList.isEmpty()) return
         val entities = documentList.map { act ->
-            RealmRating().apply {
+            Rating().apply {
                 _rev = JsonUtils.getString("_rev", act)
                 _id = JsonUtils.getString("_id", act)
                 id = JsonUtils.getString("_id", act)
@@ -123,7 +123,7 @@ class RatingsRepositoryImpl @Inject constructor(
         ratingDao.upsertAll(entities)
     }
 
-    override suspend fun getPendingRatingUploads(): List<RealmRating> {
+    override suspend fun getPendingRatingUploads(): List<Rating> {
         return ratingDao.getPendingUploads()
     }
 
@@ -131,7 +131,7 @@ class RatingsRepositoryImpl @Inject constructor(
         return ratingDao.markUploaded(id) > 0
     }
 
-    private fun RealmRating.toRatingEntry(): RatingEntry =
+    private fun Rating.toRatingEntry(): RatingEntry =
         RatingEntry(
             id = id,
             comment = comment,
@@ -148,7 +148,7 @@ class RatingsRepositoryImpl @Inject constructor(
     }
 
     private fun setRatingData(
-        ratingObject: RealmRating,
+        ratingObject: Rating,
         userModel: RealmUser?,
         type: String,
         itemId: String,
@@ -178,7 +178,7 @@ class RatingsRepositoryImpl @Inject constructor(
     }
 
     private fun aggregateRatings(
-        ratings: Iterable<RealmRating>,
+        ratings: Iterable<Rating>,
         userId: String?
     ): Map<String?, RatingAggregation> {
         val aggregationMap = LinkedHashMap<String?, RatingAggregation>()

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -4,12 +4,12 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 
 data class LibraryWithMetadata(
     val library: RealmMyLibrary,
     val rating: JsonObject?,
-    val tags: List<RealmTag>
+    val tags: List<TagEntity>
 )
 
 data class LocalResourceRequest(
@@ -59,7 +59,7 @@ interface ResourcesRepository {
         searchText: String,
         planetCode: String,
         parentCode: String,
-        tags: List<RealmTag>,
+        tags: List<TagEntity>,
         subjects: Set<String>,
         languages: Set<String>,
         levels: Set<String>,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -23,8 +23,8 @@ import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmResourceActivity
-import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.ResourceActivity
+import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.services.SharedPrefManager
@@ -385,7 +385,7 @@ class ResourcesRepositoryImpl @Inject constructor(
         val filterPayload = JsonUtils.gson.toJson(filter)
 
         searchActivityDao.insert(
-            RealmSearchActivity(
+            SearchActivity(
                 id = UUID.randomUUID().toString(),
                 user = userName,
                 time = Calendar.getInstance().timeInMillis,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -25,7 +25,7 @@ import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.ResourceActivity
 import org.ole.planet.myplanet.model.SearchActivity
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.DownloadUtils
@@ -369,14 +369,14 @@ class ResourcesRepositoryImpl @Inject constructor(
         searchText: String,
         planetCode: String,
         parentCode: String,
-        tags: List<RealmTag>,
+        tags: List<TagEntity>,
         subjects: Set<String>,
         languages: Set<String>,
         levels: Set<String>,
         mediums: Set<String>
     ) {
         val filter = JsonObject().apply {
-            add("tags", RealmTag.getTagsArray(tags))
+            add("tags", TagEntity.getTagsArray(tags))
             add("subjects", getJsonArrayFromList(subjects))
             add("language", getJsonArrayFromList(languages))
             add("level", getJsonArrayFromList(levels))
@@ -618,7 +618,7 @@ class ResourcesRepositoryImpl @Inject constructor(
         return filteredRatings
     }
 
-    private suspend fun getResourceTagsBulk(ids: List<String>): Map<String, List<RealmTag>> {
+    private suspend fun getResourceTagsBulk(ids: List<String>): Map<String, List<TagEntity>> {
         return tagsRepository.getTagsForResources(ids)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepository.kt
@@ -1,6 +1,6 @@
 package org.ole.planet.myplanet.repository
 
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 import org.ole.planet.myplanet.model.RetryFailure
 
 interface RetryRepository {
@@ -21,11 +21,11 @@ interface RetryRepository {
     suspend fun markInProgress(operationId: String)
     suspend fun markCompleted(operationId: String)
     suspend fun markFailed(operationId: String, errorMessage: String?, httpCode: Int?)
-    suspend fun getPending(): List<RealmRetryOperation>
+    suspend fun getPending(): List<RetryOperation>
     suspend fun getPendingCount(): Long
     suspend fun cleanup()
     suspend fun resetAllPending()
-    suspend fun getExistingOperation(itemId: String, uploadType: String): RealmRetryOperation?
+    suspend fun getExistingOperation(itemId: String, uploadType: String): RetryOperation?
     suspend fun deletePendingAndAbandonedOperations()
     suspend fun recoverStuckOperations()
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepositoryImpl.kt
@@ -2,7 +2,7 @@ package org.ole.planet.myplanet.repository
 
 import javax.inject.Inject
 import org.ole.planet.myplanet.data.room.dao.RetryDao
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 import org.ole.planet.myplanet.model.RetryFailure
 import org.ole.planet.myplanet.utils.TimeProvider
 
@@ -21,7 +21,7 @@ class RetryRepositoryImpl @Inject constructor(
         modelClassName: String,
         userId: String?
     ) {
-        val operation = RealmRetryOperation.createFromRetryFailure(
+        val operation = RetryOperation.createFromRetryFailure(
             uploadType, failure, payload, endpoint,
             httpMethod, dbId, modelClassName, userId
         )
@@ -35,12 +35,12 @@ class RetryRepositoryImpl @Inject constructor(
         retryDao.findById(operationId)?.let { op ->
             op.attemptCount += 1
             op.lastAttemptTime = timeProvider.now()
-            op.nextRetryTime = RealmRetryOperation.calculateNextRetryTime(op.attemptCount)
+            op.nextRetryTime = RetryOperation.calculateNextRetryTime(op.attemptCount)
             op.errorMessage = failure.message
             op.httpCode = failure.httpCode
 
             if (op.attemptCount >= op.maxAttempts) {
-                op.status = RealmRetryOperation.STATUS_ABANDONED
+                op.status = RetryOperation.STATUS_ABANDONED
             }
             retryDao.update(op)
         }
@@ -48,14 +48,14 @@ class RetryRepositoryImpl @Inject constructor(
 
     override suspend fun markInProgress(operationId: String) {
         retryDao.findById(operationId)?.let { op ->
-            op.status = RealmRetryOperation.STATUS_IN_PROGRESS
+            op.status = RetryOperation.STATUS_IN_PROGRESS
             retryDao.update(op)
         }
     }
 
     override suspend fun markCompleted(operationId: String) {
         retryDao.findById(operationId)?.let { op ->
-            op.status = RealmRetryOperation.STATUS_COMPLETED
+            op.status = RetryOperation.STATUS_COMPLETED
             op.lastAttemptTime = timeProvider.now()
             retryDao.update(op)
         }
@@ -69,16 +69,16 @@ class RetryRepositoryImpl @Inject constructor(
             op.httpCode = httpCode
 
             if (op.attemptCount >= op.maxAttempts) {
-                op.status = RealmRetryOperation.STATUS_ABANDONED
+                op.status = RetryOperation.STATUS_ABANDONED
             } else {
-                op.status = RealmRetryOperation.STATUS_PENDING
-                op.nextRetryTime = RealmRetryOperation.calculateNextRetryTime(op.attemptCount)
+                op.status = RetryOperation.STATUS_PENDING
+                op.nextRetryTime = RetryOperation.calculateNextRetryTime(op.attemptCount)
             }
             retryDao.update(op)
         }
     }
 
-    override suspend fun getPending(): List<RealmRetryOperation> {
+    override suspend fun getPending(): List<RetryOperation> {
         return retryDao.getPending(timeProvider.now())
     }
 
@@ -95,7 +95,7 @@ class RetryRepositoryImpl @Inject constructor(
         retryDao.resetPendingRetryTime(timeProvider.now())
     }
 
-    override suspend fun getExistingOperation(itemId: String, uploadType: String): RealmRetryOperation? {
+    override suspend fun getExistingOperation(itemId: String, uploadType: String): RetryOperation? {
         return retryDao.findExisting(itemId, uploadType)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -9,7 +9,7 @@ import org.ole.planet.myplanet.model.CreateExamSubmissionRequest
 import org.ole.planet.myplanet.model.ExamAnswerData
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
-import org.ole.planet.myplanet.model.RealmSubmitPhotos
+import org.ole.planet.myplanet.model.SubmitPhotos
 import org.ole.planet.myplanet.model.SubmissionDetail
 import org.ole.planet.myplanet.model.SubmissionItem
 
@@ -53,7 +53,7 @@ interface SubmissionsRepository {
     suspend fun getUnuploadedPhotos(): List<Pair<String?, JsonObject>>
     suspend fun markPhotoUploaded(photoId: String?, rev: String, id: String)
     suspend fun getOrCreateSubmission(userId: String?, parentId: String): RealmSubmission
-    suspend fun getPhotosByIds(ids: Array<String>): List<RealmSubmitPhotos>
+    suspend fun getPhotosByIds(ids: Array<String>): List<SubmitPhotos>
     fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: JsonArray)
     suspend fun insertSubmission(submission: JsonObject)
     suspend fun getExamUploadPayload(submission: RealmSubmission): JsonObject

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -28,7 +28,7 @@ import org.ole.planet.myplanet.model.RealmExamQuestion
 import org.ole.planet.myplanet.model.RealmMembershipDoc
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
-import org.ole.planet.myplanet.model.RealmSubmitPhotos
+import org.ole.planet.myplanet.model.SubmitPhotos
 import org.ole.planet.myplanet.model.RealmTeamReference
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.SubmissionDetail
@@ -442,7 +442,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         photoPath: String?
     ) {
         submitPhotosDao.insert(
-            RealmSubmitPhotos().apply {
+            SubmitPhotos().apply {
                 id = UUID.randomUUID().toString()
                 this.submissionId = submissionId
                 this.examId = examId
@@ -661,7 +661,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
 
     override suspend fun getUnuploadedPhotos(): List<Pair<String?, JsonObject>> {
         return submitPhotosDao.getUnuploaded().map { photo ->
-            Pair(photo.id, RealmSubmitPhotos.serializeRealmSubmitPhotos(photo))
+            Pair(photo.id, SubmitPhotos.serialize(photo))
         }
     }
 
@@ -669,7 +669,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         photoId?.let { submitPhotosDao.markUploaded(it, rev, id) }
     }
 
-    override suspend fun getPhotosByIds(ids: Array<String>): List<RealmSubmitPhotos> {
+    override suspend fun getPhotosByIds(ids: Array<String>): List<SubmitPhotos> {
         if (ids.isEmpty()) return emptyList()
         return submitPhotosDao.getByIds(ids)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepository.kt
@@ -1,14 +1,14 @@
 package org.ole.planet.myplanet.repository
 
 import com.google.gson.JsonObject
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 
 interface TagsRepository {
-    suspend fun getTags(dbType: String?): List<RealmTag>
-    suspend fun getTagsWithChildren(dbType: String?): Map<RealmTag, List<RealmTag>>
-    suspend fun getTagsForResource(resourceId: String): List<RealmTag>
-    suspend fun getTagsForCourse(courseId: String): List<RealmTag>
-    suspend fun getTagsForResources(resourceIds: List<String>): Map<String, List<RealmTag>>
-    suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<RealmTag>>
+    suspend fun getTags(dbType: String?): List<TagEntity>
+    suspend fun getTagsWithChildren(dbType: String?): Map<TagEntity, List<TagEntity>>
+    suspend fun getTagsForResource(resourceId: String): List<TagEntity>
+    suspend fun getTagsForCourse(courseId: String): List<TagEntity>
+    suspend fun getTagsForResources(resourceIds: List<String>): Map<String, List<TagEntity>>
+    suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<TagEntity>>
     suspend fun insert(documentList: List<JsonObject>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TagsRepositoryImpl.kt
@@ -3,21 +3,21 @@ package org.ole.planet.myplanet.repository
 import com.google.gson.JsonObject
 import javax.inject.Inject
 import org.ole.planet.myplanet.data.room.dao.TagDao
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.utils.JsonUtils
 
 class TagsRepositoryImpl @Inject constructor(
     private val tagDao: TagDao,
 ) : TagsRepository {
 
-    override suspend fun getTags(dbType: String?): List<RealmTag> {
+    override suspend fun getTags(dbType: String?): List<TagEntity> {
         return tagDao.getParentTags(dbType)
     }
 
-    override suspend fun getTagsWithChildren(dbType: String?): Map<RealmTag, List<RealmTag>> {
+    override suspend fun getTagsWithChildren(dbType: String?): Map<TagEntity, List<TagEntity>> {
         val parentTags = getTags(dbType)
         val allTags = tagDao.getAll()
-        val childMap = mutableMapOf<String, MutableList<RealmTag>>()
+        val childMap = mutableMapOf<String, MutableList<TagEntity>>()
 
         for (t in allTags) {
             val attached = t.attachedTo
@@ -38,23 +38,23 @@ class TagsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getTagsForResource(resourceId: String): List<RealmTag> {
+    override suspend fun getTagsForResource(resourceId: String): List<TagEntity> {
         return getLinkedTags("resources", resourceId)
     }
 
-    override suspend fun getTagsForCourse(courseId: String): List<RealmTag> {
+    override suspend fun getTagsForCourse(courseId: String): List<TagEntity> {
         return getLinkedTags("courses", courseId)
     }
 
-    override suspend fun getTagsForResources(resourceIds: List<String>): Map<String, List<RealmTag>> {
+    override suspend fun getTagsForResources(resourceIds: List<String>): Map<String, List<TagEntity>> {
         return getLinkedTagsBulk("resources", resourceIds)
     }
 
-    override suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<RealmTag>> {
+    override suspend fun getTagsForCourses(courseIds: List<String>): Map<String, List<TagEntity>> {
         return getLinkedTagsBulk("courses", courseIds)
     }
 
-    private suspend fun getLinkedTagsBulk(db: String, linkIds: List<String>): Map<String, List<RealmTag>> {
+    private suspend fun getLinkedTagsBulk(db: String, linkIds: List<String>): Map<String, List<TagEntity>> {
         if (linkIds.isEmpty()) {
             return emptyMap()
         }
@@ -71,7 +71,7 @@ class TagsRepositoryImpl @Inject constructor(
 
         val parentTagsById = tagDao.getByIds(allTagIds).associateBy { it.id }
 
-        val tagsByLinkId = mutableMapOf<String, MutableList<RealmTag>>()
+        val tagsByLinkId = mutableMapOf<String, MutableList<TagEntity>>()
         val tagsSetByLinkId = mutableMapOf<String, MutableSet<String>>()
         links.forEach { link ->
             link.linkId?.let { linkId ->
@@ -89,7 +89,7 @@ class TagsRepositoryImpl @Inject constructor(
         return tagsByLinkId
     }
 
-    private suspend fun getLinkedTags(db: String, linkId: String): List<RealmTag> {
+    private suspend fun getLinkedTags(db: String, linkId: String): List<TagEntity> {
         val links = tagDao.getByDbAndLinkId(db, linkId)
         if (links.isEmpty()) {
             return emptyList()
@@ -118,8 +118,8 @@ class TagsRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun createUnmanagedTag(act: JsonObject): RealmTag {
-        val tag = RealmTag()
+    private fun createUnmanagedTag(act: JsonObject): TagEntity {
+        val tag = TagEntity()
         tag.id = JsonUtils.getString("_id", act)
         tag._rev = JsonUtils.getString("_rev", act)
         tag._id = JsonUtils.getString("_id", act)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -6,7 +6,7 @@ import org.ole.planet.myplanet.model.CreateTeamRequest
 import org.ole.planet.myplanet.model.FinanceReportParams
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TeamDetails
 import org.ole.planet.myplanet.model.TeamResourceDto
@@ -94,7 +94,7 @@ interface TeamsRepository {
     suspend fun getJoinRequestsInfo(requestIds: List<String>): List<JoinRequestInfo>
 
     suspend fun getTeamNamesByIds(ids: List<String>): Map<String, String>
-    fun getTasksFlow(userId: String?): Flow<List<RealmTeamTask>>
+    fun getTasksFlow(userId: String?): Flow<List<TeamTask>>
     suspend fun isMember(userId: String?, teamId: String): Boolean
     suspend fun isTeamLeader(teamId: String, userId: String?): Boolean
     suspend fun hasPendingRequest(teamId: String, userId: String?): Boolean
@@ -108,9 +108,9 @@ interface TeamsRepository {
     suspend fun updateTask(taskId: String, title: String, description: String, deadline: Long, assigneeId: String?)
     suspend fun assignTask(taskId: String, assigneeId: String?)
     suspend fun setTaskCompletion(taskId: String, completed: Boolean)
-    suspend fun getPendingTasksForUser(userId: String, start: Long, end: Long): List<RealmTeamTask>
+    suspend fun getPendingTasksForUser(userId: String, start: Long, end: Long): List<TeamTask>
     suspend fun markTasksNotified(taskIds: Collection<String>)
-    suspend fun getTasksByTeamId(teamId: String): Flow<List<RealmTeamTask>>
+    suspend fun getTasksByTeamId(teamId: String): Flow<List<TeamTask>>
     suspend fun getReportsFlow(teamId: String): Flow<List<RealmMyTeam>>
     suspend fun exportReportsAsCsv(reports: List<RealmMyTeam>, teamName: String): String
     suspend fun addReport(report: FinanceReportParams)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -35,7 +35,7 @@ import org.ole.planet.myplanet.model.CreateTeamRequest
 import org.ole.planet.myplanet.model.FinanceReportParams
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.model.RealmTeamLog
+import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TeamDetails
@@ -1080,7 +1080,7 @@ class TeamsRepositoryImpl @Inject constructor(
         teamType: String?,
     ) {
         if (teamId.isBlank() || userName.isNullOrBlank()) return
-        val log = RealmTeamLog().apply {
+        val log = TeamLog().apply {
             id = UUID.randomUUID().toString()
             this.teamId = teamId
             user = userName
@@ -1455,9 +1455,9 @@ class TeamsRepositoryImpl @Inject constructor(
         return teamLogDao.getLastVisit(userName, teamId)
     }
 
-    private fun teamLogFromJson(json: JsonObject): RealmTeamLog {
+    private fun teamLogFromJson(json: JsonObject): TeamLog {
         val remoteId = JsonUtils.getString("_id", json)
-        return RealmTeamLog().apply {
+        return TeamLog().apply {
             id = remoteId
             _rev = JsonUtils.getString("_rev", json)
             _id = remoteId
@@ -1471,7 +1471,7 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun serializeTeamActivities(log: RealmTeamLog, context: Context): JsonObject {
+    override fun serializeTeamActivities(log: TeamLog, context: Context): JsonObject {
         val ob = JsonObject()
         ob.addProperty("user", log.user)
         ob.addProperty("type", log.type)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -36,7 +36,7 @@ import org.ole.planet.myplanet.model.FinanceReportParams
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.TeamLog
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TeamDetails
 import org.ole.planet.myplanet.model.TeamResourceDto
@@ -73,7 +73,7 @@ class TeamsRepositoryImpl @Inject constructor(
     private val teamLogDao: TeamLogDao,
     private val teamTaskDao: TeamTaskDao,
 ) : RealmRepository(databaseService, realmDispatcher), TeamsRepository, TeamsSyncRepository {
-    override fun getTasksFlow(userId: String?): Flow<List<RealmTeamTask>> {
+    override fun getTasksFlow(userId: String?): Flow<List<TeamTask>> {
         return teamTaskDao.getOpenTasksForUser(userId)
     }
 
@@ -961,7 +961,7 @@ class TeamsRepositoryImpl @Inject constructor(
         userId: String,
         start: Long,
         end: Long,
-    ): List<RealmTeamTask> {
+    ): List<TeamTask> {
         if (userId.isBlank() || start > end) return emptyList()
         return teamTaskDao.getPendingTasksForUser(userId, start, end)
     }
@@ -973,7 +973,7 @@ class TeamsRepositoryImpl @Inject constructor(
         teamTaskDao.markTasksNotified(validIds)
     }
 
-    override suspend fun getTasksByTeamId(teamId: String): Flow<List<RealmTeamTask>> {
+    override suspend fun getTasksByTeamId(teamId: String): Flow<List<TeamTask>> {
         return teamTaskDao.getTasksByTeamId(teamId)
     }
 
@@ -1004,7 +1004,7 @@ class TeamsRepositoryImpl @Inject constructor(
         teamTaskDao.deleteById(taskId)
     }
 
-    private suspend fun upsertTask(task: RealmTeamTask) {
+    private suspend fun upsertTask(task: TeamTask) {
         if (task.link.isNullOrBlank()) {
             val linkObj = JsonObject().apply { addProperty("teams", task.teamId) }
             task.link = gson.toJson(linkObj)
@@ -1026,7 +1026,7 @@ class TeamsRepositoryImpl @Inject constructor(
         teamId: String,
         assigneeId: String?
     ) {
-        val realmTeamTask = RealmTeamTask().apply {
+        val realmTeamTask = TeamTask().apply {
             this.id = UUID.randomUUID().toString()
             this.title = title
             this.description = description
@@ -1617,13 +1617,13 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
     override suspend fun bulkInsertTasksFromSync(jsonArray: JsonArray) {
-        val tasks = ArrayList<RealmTeamTask>(jsonArray.size())
+        val tasks = ArrayList<TeamTask>(jsonArray.size())
         for (j in jsonArray) {
             var jsonDoc = j.asJsonObject
             jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
             val id = JsonUtils.getString("_id", jsonDoc)
             if (!id.startsWith("_design")) {
-                tasks.add(RealmTeamTask.fromJson(jsonDoc))
+                tasks.add(TeamTask.fromJson(jsonDoc))
             }
         }
         teamTaskDao.upsertAll(tasks)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsSyncRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsSyncRepository.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import io.realm.Realm
-import org.ole.planet.myplanet.model.RealmTeamLog
+import org.ole.planet.myplanet.model.TeamLog
 
 interface TeamsSyncRepository {
     suspend fun getTeamsForUpload(): List<TeamUploadData>
@@ -15,7 +15,7 @@ interface TeamsSyncRepository {
     suspend fun syncTeamActivities()
     suspend fun insertTeamLog(json: JsonObject)
     suspend fun insertTeamLogs(logs: List<JsonObject>)
-    fun serializeTeamActivities(log: RealmTeamLog, context: Context): JsonObject
+    fun serializeTeamActivities(log: TeamLog, context: Context): JsonObject
     fun insertMyTeam(realm: Realm, doc: JsonObject)
     suspend fun batchInsertMyTeams(documents: List<JsonObject>): Int
     fun bulkInsertFromSync(realm: Realm, jsonArray: JsonArray)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepository.kt
@@ -5,7 +5,7 @@ import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.AchievementData
 import org.ole.planet.myplanet.model.HealthRecord
 import org.ole.planet.myplanet.model.MemberInfo
-import org.ole.planet.myplanet.model.RealmAchievement
+import org.ole.planet.myplanet.model.Achievement
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.DashboardProfile
 import org.ole.planet.myplanet.model.RealmUser
@@ -91,7 +91,7 @@ interface UserRepository {
     suspend fun authenticateUser(username: String?, password: String?, isManagerMode: Boolean): RealmUser?
     suspend fun hasAtLeastOneUser(): Boolean
     suspend fun hasUserSyncAction(userId: String?): Boolean
-    suspend fun initializeAchievement(achievementId: String): RealmAchievement?
+    suspend fun initializeAchievement(achievementId: String): Achievement?
     suspend fun updateAchievement(
         achievementId: String,
         header: String,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -38,7 +38,7 @@ import org.ole.planet.myplanet.model.AchievementData
 import org.ole.planet.myplanet.model.DashboardProfile
 import org.ole.planet.myplanet.model.HealthRecord
 import org.ole.planet.myplanet.model.MemberInfo
-import org.ole.planet.myplanet.model.RealmAchievement
+import org.ole.planet.myplanet.model.Achievement
 import org.ole.planet.myplanet.model.RealmHealthExamination
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
 import org.ole.planet.myplanet.model.RealmMeetup
@@ -1122,10 +1122,10 @@ class UserRepositoryImpl @Inject constructor(
         return activitiesRepositoryLazy.get().hasUserSyncAction(userId)
     }
 
-    override suspend fun initializeAchievement(achievementId: String): RealmAchievement? {
+    override suspend fun initializeAchievement(achievementId: String): Achievement? {
         val existing = achievementDao.getById(achievementId)
         if (existing != null) return existing
-        val achievement = RealmAchievement().apply { _id = achievementId }
+        val achievement = Achievement().apply { _id = achievementId }
         achievementDao.upsert(achievement)
         return achievement
     }
@@ -1217,7 +1217,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getAchievementsForUpload(): List<JsonObject> {
-        return achievementDao.getPendingUploads().map { RealmAchievement.serialize(it) }
+        return achievementDao.getPendingUploads().map { Achievement.serialize(it) }
     }
 
     override suspend fun getSavedUsers(): List<User> = sharedPrefManager.getSavedUsers()
@@ -1283,13 +1283,13 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun bulkInsertAchievementsFromSync(jsonArray: JsonArray) {
-        val achievements = ArrayList<RealmAchievement>(jsonArray.size())
+        val achievements = ArrayList<Achievement>(jsonArray.size())
         for (j in jsonArray) {
             var jsonDoc = j.asJsonObject
             jsonDoc = JsonUtils.getJsonObject("doc", jsonDoc)
             val id = JsonUtils.getString("_id", jsonDoc)
             if (!id.startsWith("_design")) {
-                achievements.add(RealmAchievement.fromJson(jsonDoc))
+                achievements.add(Achievement.fromJson(jsonDoc))
             }
         }
         achievementDao.upsertAll(achievements)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -39,9 +39,9 @@ import org.ole.planet.myplanet.model.DashboardProfile
 import org.ole.planet.myplanet.model.HealthRecord
 import org.ole.planet.myplanet.model.MemberInfo
 import org.ole.planet.myplanet.model.Achievement
-import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.HealthExamination
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmMyHealth.RealmMyHealthProfile
 import org.ole.planet.myplanet.model.RealmMyLibrary
@@ -984,7 +984,7 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun updateUserHealthProfile(userId: String, userData: Map<String, Any?>) {
         val userModel = getUserByAnyId(userId)
-        val healthPojo = healthExaminationDao.getByIdOrUserId(userId) ?: RealmHealthExamination().apply { _id = userId }
+        val healthPojo = healthExaminationDao.getByIdOrUserId(userId) ?: HealthExamination().apply { _id = userId }
 
         userModel?.apply {
             firstName = (userData["firstName"] as? String)?.trim()
@@ -1402,7 +1402,7 @@ class UserRepositoryImpl @Inject constructor(
         } else {
             meetupDao.getByUserId(userId)
         }
-        val myMeetups = RealmMeetup.getMyMeetUpIds(userMeetups)
+        val myMeetups = Meetup.getMyMeetUpIds(userMeetups)
         val removedResources = removedLogDao.getRemovedDocIds("resources", userId).filterNotNull()
         val removedCourses = removedLogDao.getRemovedDocIds("courses", userId).filterNotNull()
         val mergedResourceIds = mergeJsonArray(myLibs, JsonUtils.getJsonArray("resourceIds", jsonDoc), removedResources)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/VoicesRepositoryImpl.kt
@@ -26,7 +26,7 @@ import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNews.Companion.createNews
 import org.ole.planet.myplanet.data.room.dao.TeamNotificationDao
-import org.ole.planet.myplanet.model.RealmTeamNotification
+import org.ole.planet.myplanet.model.TeamNotification
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
@@ -268,7 +268,7 @@ class VoicesRepositoryImpl @Inject constructor(
             existing.lastCount = count
             teamNotificationDao.update(existing)
         } else {
-            val notification = RealmTeamNotification().apply {
+            val notification = TeamNotification().apply {
                 id = UUID.randomUUID().toString()
                 parentId = teamId
                 type = "chat"

--- a/app/src/main/java/org/ole/planet/myplanet/services/FileUploader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/FileUploader.kt
@@ -10,7 +10,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Personal
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.UrlUtils
@@ -28,7 +28,7 @@ open class FileUploader(
     private val apiInterface: ApiInterface,
     private val scope: CoroutineScope
 ) {
-    fun uploadAttachment(id: String, rev: String, personal: RealmMyPersonal, listener: OnSuccessListener) {
+    fun uploadAttachment(id: String, rev: String, personal: Personal, listener: OnSuccessListener) {
         val f = personal.path?.let { File(it) }
         val name = FileUtils.getFileNameFromUrl(personal.path)
         if (f != null) {

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -23,7 +23,7 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.ApplicationScope
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Personal
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ActivitiesRepository
@@ -229,7 +229,7 @@ class UploadManager @Inject constructor(
         }
     }
 
-    suspend fun uploadMyPersonal(personal: RealmMyPersonal): String {
+    suspend fun uploadMyPersonal(personal: Personal): String {
         if (!personal.isUploaded) {
             return withContext(dispatcherProvider.io) {
                 try {

--- a/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueue.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueue.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 import org.ole.planet.myplanet.model.RetryFailure
 import org.ole.planet.myplanet.repository.RetryRepository
 import org.ole.planet.myplanet.services.upload.UploadError
@@ -85,7 +85,7 @@ class RetryQueue @Inject constructor(
         }
     }
 
-    suspend fun getPendingOperations(): List<RealmRetryOperation> {
+    suspend fun getPendingOperations(): List<RetryOperation> {
         return retryRepository.getPending()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueueWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueueWorker.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.data.api.ApiInterface
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 import org.ole.planet.myplanet.utils.UrlUtils
 
 @HiltWorker
@@ -149,7 +149,7 @@ class RetryQueueWorker @AssistedInject constructor(
         }
     }
 
-    private suspend fun processOperation(operation: RealmRetryOperation): Boolean {
+    private suspend fun processOperation(operation: RetryOperation): Boolean {
         return try {
             // Timeout for individual operation (30 seconds)
             withTimeout(30_000L) {
@@ -166,7 +166,7 @@ class RetryQueueWorker @AssistedInject constructor(
         }
     }
 
-    private suspend fun processOperationInternal(operation: RealmRetryOperation): Boolean {
+    private suspend fun processOperationInternal(operation: RetryOperation): Boolean {
         return try {
             retryQueue.markInProgress(operation.id)
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -15,9 +15,9 @@ import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.model.CourseActivity
-import org.ole.planet.myplanet.model.RealmCourseProgress
-import org.ole.planet.myplanet.model.RealmFeedback
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.CourseProgress
+import org.ole.planet.myplanet.model.Feedback
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.NewsLog
@@ -28,7 +28,7 @@ import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.SubmitPhotos
 import org.ole.planet.myplanet.model.TeamLog
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.EventsRepository
@@ -78,9 +78,9 @@ class UploadConfigs @Inject constructor(
 
     val CourseProgress = RoomUploadConfig(
         endpoint = "courses_progress",
-        modelClassName = "RealmCourseProgress",
+        modelClassName = "CourseProgress",
         fetchPendingItems = { courseProgressDao.getPendingUploads() },
-        serializer = UploadSerializer.Simple(RealmCourseProgress::serializeProgress),
+        serializer = UploadSerializer.Simple(org.ole.planet.myplanet.model.CourseProgress::serializeProgress),
         idExtractor = { it.id },
         markUploaded = { results ->
             results.filter { result ->
@@ -91,11 +91,11 @@ class UploadConfigs @Inject constructor(
 
     val TeamTask = RoomUploadConfig(
         endpoint = "tasks",
-        modelClassName = "RealmTeamTask",
+        modelClassName = "TeamTask",
         fetchPendingItems = { teamTaskDao.getPendingUploads() },
         serializer = UploadSerializer.Async { task ->
             val user = userRepository.getUserById(task.assignee ?: "")
-            RealmTeamTask.serialize(task, user)
+            org.ole.planet.myplanet.model.TeamTask.serialize(task, user)
         },
         idExtractor = { it.id },
         markUploaded = { results ->
@@ -181,9 +181,9 @@ class UploadConfigs @Inject constructor(
     // Migrated to Room: uses the database-agnostic RoomUploadConfig path in UploadCoordinator.
     val Meetups = RoomUploadConfig(
         endpoint = "meetups",
-        modelClassName = "RealmMeetup",
+        modelClassName = "Meetup",
         fetchPendingItems = { eventsRepository.getPendingMeetupUploads() },
-        serializer = UploadSerializer.Simple(RealmMeetup::serialize),
+        serializer = UploadSerializer.Simple(Meetup::serialize),
         idExtractor = { it.id },
         responseHandler = ResponseHandler.Custom("id", "rev"),
         markUploaded = { results ->
@@ -209,9 +209,9 @@ class UploadConfigs @Inject constructor(
     // Migrated to Room: uses the database-agnostic RoomUploadConfig path in UploadCoordinator.
     val Feedback = RoomUploadConfig(
         endpoint = "feedback",
-        modelClassName = "RealmFeedback",
+        modelClassName = "Feedback",
         fetchPendingItems = { feedbackRepository.getPendingFeedback() },
-        serializer = UploadSerializer.Simple(RealmFeedback::serializeFeedback),
+        serializer = UploadSerializer.Simple(org.ole.planet.myplanet.model.Feedback::serializeFeedback),
         idExtractor = { it.id },
         markUploaded = { results ->
             // Mark each uploaded feedback; rows that no longer exist are reported as failures.

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -13,7 +13,7 @@ import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
-import org.ole.planet.myplanet.model.RealmApkLog
+import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmFeedback
@@ -222,9 +222,9 @@ class UploadConfigs @Inject constructor(
     // Migrated to Room: uses the database-agnostic RoomUploadConfig path in UploadCoordinator.
     val CrashLog = RoomUploadConfig(
         endpoint = "apk_logs",
-        modelClassName = "RealmApkLog",
+        modelClassName = "ApkLog",
         fetchPendingItems = { apkLogDao.getPending() },
-        serializer = UploadSerializer.WithContext(RealmApkLog::serialize),
+        serializer = UploadSerializer.WithContext(ApkLog::serialize),
         idExtractor = { it.id },
         markUploaded = { results ->
             // A row is "pending" until it has a _rev; set it here. Rows that no longer exist

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -14,19 +14,19 @@ import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.model.ApkLog
-import org.ole.planet.myplanet.model.RealmCourseActivity
+import org.ole.planet.myplanet.model.CourseActivity
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
-import org.ole.planet.myplanet.model.RealmNewsLog
+import org.ole.planet.myplanet.model.NewsLog
 import org.ole.planet.myplanet.model.RealmRating
-import org.ole.planet.myplanet.model.RealmResourceActivity
-import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.ResourceActivity
+import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
-import org.ole.planet.myplanet.model.RealmSubmitPhotos
+import org.ole.planet.myplanet.model.SubmitPhotos
 import org.ole.planet.myplanet.model.RealmTeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUser
@@ -65,9 +65,9 @@ class UploadConfigs @Inject constructor(
 ) {
     val NewsActivities = RoomUploadConfig(
         endpoint = "myplanet_activities",
-        modelClassName = "RealmNewsLog",
+        modelClassName = "NewsLog",
         fetchPendingItems = { newsLogDao.getPendingUploads() },
-        serializer = UploadSerializer.Simple(RealmNewsLog::serialize),
+        serializer = UploadSerializer.Simple(NewsLog::serialize),
         idExtractor = { it.id },
         markUploaded = { results ->
             results.filter { result ->
@@ -120,7 +120,7 @@ class UploadConfigs @Inject constructor(
 
     val SearchActivity = RoomUploadConfig(
         endpoint = "search_activities",
-        modelClassName = "RealmSearchActivity",
+        modelClassName = "SearchActivity",
         fetchPendingItems = { searchActivityDao.getPendingUploads() },
         serializer = UploadSerializer.Simple { it.serialize() },
         idExtractor = { it.id },
@@ -137,7 +137,7 @@ class UploadConfigs @Inject constructor(
 
     val ResourceActivities = RoomUploadConfig(
         endpoint = "resource_activities",
-        modelClassName = "RealmResourceActivity",
+        modelClassName = "ResourceActivity",
         fetchPendingItems = { resourceActivityDao.getPendingUploads() },
         serializer = UploadSerializer.Simple { org.ole.planet.myplanet.repository.serializeResourceActivities(it) },
         idExtractor = { it.id },
@@ -150,7 +150,7 @@ class UploadConfigs @Inject constructor(
 
     val ResourceActivitiesSync = RoomUploadConfig(
         endpoint = "admin_activities",
-        modelClassName = "RealmResourceActivity",
+        modelClassName = "ResourceActivity",
         fetchPendingItems = { resourceActivityDao.getPendingSyncUploads() },
         serializer = UploadSerializer.Simple { org.ole.planet.myplanet.repository.serializeResourceActivities(it) },
         idExtractor = { it.id },
@@ -163,9 +163,9 @@ class UploadConfigs @Inject constructor(
 
     val CourseActivities = RoomUploadConfig(
         endpoint = "course_activities",
-        modelClassName = "RealmCourseActivity",
+        modelClassName = "CourseActivity",
         fetchPendingItems = { courseActivityDao.getPendingUploads() },
-        serializer = UploadSerializer.Simple(RealmCourseActivity::serializeSerialize),
+        serializer = UploadSerializer.Simple(CourseActivity::serialize),
         idExtractor = { it.id },
         markUploaded = { results ->
             results.filter { result ->
@@ -235,9 +235,9 @@ class UploadConfigs @Inject constructor(
 
     val SubmitPhotos = RoomUploadConfig(
         endpoint = "submissions",
-        modelClassName = "RealmSubmitPhotos",
+        modelClassName = "SubmitPhotos",
         fetchPendingItems = { submitPhotosDao.getUnuploaded() },
-        serializer = UploadSerializer.Simple(RealmSubmitPhotos::serializeRealmSubmitPhotos),
+        serializer = UploadSerializer.Simple(org.ole.planet.myplanet.model.SubmitPhotos::serialize),
         idExtractor = { it.id },
         markUploaded = { results ->
             results.filter { result ->

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -27,7 +27,7 @@ import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.model.SubmitPhotos
-import org.ole.planet.myplanet.model.RealmTeamLog
+import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.ActivitiesRepository
@@ -107,7 +107,7 @@ class UploadConfigs @Inject constructor(
 
     val TeamActivities = RoomUploadConfig(
         endpoint = "team_activities",
-        modelClassName = "RealmTeamLog",
+        modelClassName = "TeamLog",
         fetchPendingItems = { teamLogDao.getPendingUploads() },
         serializer = UploadSerializer.WithContext { log, context -> teamsSyncRepository.get().serializeTeamActivities(log, context) },
         idExtractor = { it.id },

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -21,7 +21,7 @@ import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.NewsLog
-import org.ole.planet.myplanet.model.RealmRating
+import org.ole.planet.myplanet.model.Rating
 import org.ole.planet.myplanet.model.ResourceActivity
 import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.RealmStepExam
@@ -323,9 +323,9 @@ class UploadConfigs @Inject constructor(
     // Guest filtering is folded into getPendingRatingUploads()'s DAO query.
     val Rating = RoomUploadConfig(
         endpoint = "ratings",
-        modelClassName = "RealmRating",
+        modelClassName = "Rating",
         fetchPendingItems = { ratingsRepository.getPendingRatingUploads() },
-        serializer = UploadSerializer.Simple(RealmRating::serializeRating),
+        serializer = UploadSerializer.Simple(org.ole.planet.myplanet.model.Rating::serializeRating),
         idExtractor = { it.id },
         dbIdExtractor = { it._id }, // Enables POST/PUT logic
         markUploaded = { results ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryAdapter.kt
@@ -18,7 +18,7 @@ import org.ole.planet.myplanet.databinding.ChatShareDialogBinding
 import org.ole.planet.myplanet.databinding.GrandChildRecyclerviewDialogBinding
 import org.ole.planet.myplanet.databinding.RowChatHistoryBinding
 import org.ole.planet.myplanet.model.ChatShareTargets
-import org.ole.planet.myplanet.model.RealmChatHistory
+import org.ole.planet.myplanet.model.ChatHistory
 import org.ole.planet.myplanet.model.RealmConversation
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUser
@@ -30,12 +30,12 @@ import org.ole.planet.myplanet.utils.JsonUtils
 
 class ChatHistoryAdapter(
     private val context: Context,
-    chatHistoryList: List<RealmChatHistory>,
+    chatHistoryList: List<ChatHistory>,
     private var currentUser: RealmUser?,
     private var newsList: List<RealmNews>,
     private var shareTargets: ChatShareTargets,
-    private val onShareChat: (HashMap<String?, String>, RealmChatHistory) -> Unit,
-) : ListAdapter<RealmChatHistory, ChatHistoryAdapter.ViewHolderChat>(
+    private val onShareChat: (HashMap<String?, String>, ChatHistory) -> Unit,
+) : ListAdapter<ChatHistory, ChatHistoryAdapter.ViewHolderChat>(
     DiffUtils.itemCallback(
         areItemsTheSame = { oldItem, newItem ->
             val oldId = oldItem._id
@@ -88,7 +88,7 @@ class ChatHistoryAdapter(
         return ViewHolderChat(rowChatHistoryBinding)
     }
 
-    fun updateChatHistory(newChatHistory: List<RealmChatHistory>) {
+    fun updateChatHistory(newChatHistory: List<ChatHistory>) {
         submitList(newChatHistory)
     }
 
@@ -125,7 +125,7 @@ class ChatHistoryAdapter(
         bindShareChat(holder, item)
     }
 
-    private fun bindShareChat(holder: ViewHolderChat, item: RealmChatHistory) {
+    private fun bindShareChat(holder: ViewHolderChat, item: ChatHistory) {
         holder.rowChatHistoryBinding.shareChat.setImageResource(R.drawable.baseline_share_24)
 
         holder.rowChatHistoryBinding.shareChat.setOnClickListener {
@@ -187,7 +187,7 @@ class ChatHistoryAdapter(
         return cachedSharedViewInIds[chatId] ?: emptySet()
     }
 
-    private fun showGrandChildRecyclerView(items: List<TeamSummary>, section: String, realmChatHistory: RealmChatHistory, sharedIds: Set<String> = emptySet()) {
+    private fun showGrandChildRecyclerView(items: List<TeamSummary>, section: String, realmChatHistory: ChatHistory, sharedIds: Set<String> = emptySet()) {
         val grandChildDialogBinding = GrandChildRecyclerviewDialogBinding.inflate(LayoutInflater.from(context))
         var dialog: AlertDialog? = null
 
@@ -215,7 +215,7 @@ class ChatHistoryAdapter(
         dialog.show()
     }
 
-    private fun showEditTextAndShareButton(team: TeamSummary? = null, section: String, chatHistory: RealmChatHistory) {
+    private fun showEditTextAndShareButton(team: TeamSummary? = null, section: String, chatHistory: ChatHistory) {
         val addNoteDialogBinding = AddNoteDialogBinding.inflate(LayoutInflater.from(context))
         val builder = AlertDialog.Builder(context, R.style.AlertDialogTheme)
         builder.setView(addNoteDialogBinding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryScreenData.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryScreenData.kt
@@ -1,13 +1,13 @@
 package org.ole.planet.myplanet.ui.chat
 
 import org.ole.planet.myplanet.model.ChatShareTargets
-import org.ole.planet.myplanet.model.RealmChatHistory
+import org.ole.planet.myplanet.model.ChatHistory
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUser
 
 data class ChatHistoryScreenData(
     val currentUser: RealmUser?,
-    val chatHistory: List<RealmChatHistory>,
+    val chatHistory: List<ChatHistory>,
     val newsMessages: List<RealmNews>,
     val shareTargets: ChatShareTargets
 )

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.model.ChatMessage
 import org.ole.planet.myplanet.model.ChatShareTargets
-import org.ole.planet.myplanet.model.RealmChatHistory
+import org.ole.planet.myplanet.model.ChatHistory
 import org.ole.planet.myplanet.model.RealmConversation
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TeamSummary
@@ -38,7 +38,7 @@ class ChatViewModel @Inject constructor(
     private val realtimeSyncManager: RealtimeSyncManager
 ) : ViewModel() {
     private data class PrecomputedChat(
-        val chat: RealmChatHistory,
+        val chat: ChatHistory,
         val normalizedTitle: String?,
         val normalizedQueries: List<String?>,
         val normalizedResponses: List<String?>
@@ -53,7 +53,7 @@ class ChatViewModel @Inject constructor(
     internal var allConversations: List<RealmConversation> = emptyList()
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var loadedCount = 0
-    private var allChats: List<RealmChatHistory> = emptyList()
+    private var allChats: List<ChatHistory> = emptyList()
     private var precomputedChats: List<PrecomputedChat> = emptyList()
 
     private val _refreshChatSignal = MutableSharedFlow<Unit>()
@@ -72,8 +72,8 @@ class ChatViewModel @Inject constructor(
     private val _screenData = MutableStateFlow<ChatHistoryScreenData?>(null)
     val screenData: StateFlow<ChatHistoryScreenData?> = _screenData.asStateFlow()
 
-    private val _filteredChats = MutableStateFlow<List<RealmChatHistory>>(emptyList())
-    val filteredChats: StateFlow<List<RealmChatHistory>> = _filteredChats.asStateFlow()
+    private val _filteredChats = MutableStateFlow<List<ChatHistory>>(emptyList())
+    val filteredChats: StateFlow<List<ChatHistory>> = _filteredChats.asStateFlow()
 
     private var cachedUser: RealmUser? = null
     private var cachedShareTargets: ChatShareTargets? = null
@@ -119,13 +119,13 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    private fun sortChats(chats: List<RealmChatHistory>): List<RealmChatHistory> {
+    private fun sortChats(chats: List<ChatHistory>): List<ChatHistory> {
         return chats.sortedByDescending { chat ->
             maxOf(chat.createdDate?.toLongOrNull() ?: 0L, chat.updatedDate?.toLongOrNull() ?: 0L)
         }
     }
 
-    private fun buildPrecomputedChats(chats: List<RealmChatHistory>): List<PrecomputedChat> {
+    private fun buildPrecomputedChats(chats: List<ChatHistory>): List<PrecomputedChat> {
         return chats.map { chat ->
             val title = if (chat.conversations != null && chat.conversations?.isNotEmpty() == true) {
                 chat.conversations?.get(0)?.query?.let { Utilities.normalizeText(it) }
@@ -157,15 +157,15 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    private fun fullConvoSearch(s: String, isQuestion: Boolean): List<RealmChatHistory> {
+    private fun fullConvoSearch(s: String, isQuestion: Boolean): List<ChatHistory> {
         var conversation: String?
         val queryParts = s.split(" ").filterNot { it.isEmpty() }
         val normalizedQueryParts = queryParts.map { Utilities.normalizeText(it) }
         val normalizedQuery = Utilities.normalizeText(s)
-        val inTitleStartQuery = mutableListOf<RealmChatHistory>()
-        val inTitleContainsQuery = mutableListOf<RealmChatHistory>()
-        val startsWithQuery = mutableListOf<RealmChatHistory>()
-        val containsQuery = mutableListOf<RealmChatHistory>()
+        val inTitleStartQuery = mutableListOf<ChatHistory>()
+        val inTitleContainsQuery = mutableListOf<ChatHistory>()
+        val startsWithQuery = mutableListOf<ChatHistory>()
+        val containsQuery = mutableListOf<ChatHistory>()
 
         for (pChat in precomputedChats) {
             val conversations = pChat.chat.conversations
@@ -190,13 +190,13 @@ class ChatViewModel @Inject constructor(
         return inTitleStartQuery + inTitleContainsQuery + startsWithQuery + containsQuery
     }
 
-    private fun searchByTitle(s: String): List<RealmChatHistory> {
+    private fun searchByTitle(s: String): List<ChatHistory> {
         var title: String?
         val queryParts = s.split(" ").filterNot { it.isEmpty() }
         val normalizedQueryParts = queryParts.map { Utilities.normalizeText(it) }
         val normalizedQuery = Utilities.normalizeText(s)
-        val startsWithQuery = mutableListOf<RealmChatHistory>()
-        val containsQuery = mutableListOf<RealmChatHistory>()
+        val startsWithQuery = mutableListOf<ChatHistory>()
+        val containsQuery = mutableListOf<ChatHistory>()
 
         for (pChat in precomputedChats) {
             title = pChat.normalizedTitle

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 
 data class FilterState(
     val searchText: String,
@@ -37,7 +37,7 @@ class CourseFilterController(
     private lateinit var spnSubject: Spinner
     private lateinit var spnProgress: Spinner
     private lateinit var tvSelected: TextView
-    val searchTags: MutableList<RealmTag> = ArrayList()
+    val searchTags: MutableList<TagEntity> = ArrayList()
     private var searchTextWatcher: TextWatcher? = null
     private var spinnerListener: AdapterView.OnItemSelectedListener? = null
 
@@ -95,21 +95,21 @@ class CourseFilterController(
         rootView.findViewById<View>(R.id.btn_clear_tags).setOnClickListener { clearAll() }
     }
 
-    fun addTag(tag: RealmTag) {
+    fun addTag(tag: TagEntity) {
         if (!searchTags.any { it.name == tag.name }) searchTags.add(tag)
         _filterState.value = currentState()
         refreshTagText()
         onScrollToTop()
     }
 
-    fun setTags(list: List<RealmTag>) {
+    fun setTags(list: List<TagEntity>) {
         searchTags.clear()
         list.forEach { tag -> if (!searchTags.any { it.name == tag.name }) searchTags.add(tag) }
         _filterState.value = currentState()
         onScrollToTop()
     }
 
-    fun setSingleTag(tag: RealmTag) {
+    fun setSingleTag(tag: TagEntity) {
         searchTags.clear()
         searchTags.add(tag)
         tvSelected.text = tvSelected.context.getString(R.string.tag_selected, tag.name)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -26,7 +26,7 @@ import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.callback.OnTagClickListener
 import org.ole.planet.myplanet.model.Course
 import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.model.Tag
@@ -337,25 +337,25 @@ class CoursesFragment : BaseRecyclerFragment<RealmMyCourse?>(), OnCourseItemSele
     }
 
     override fun onTagClicked(tag: Tag) {
-        val realmTag = RealmTag().apply {
+        val realmTag = TagEntity().apply {
             name = tag.name
             id = tag.id.orEmpty()
         }
         onTagClicked(realmTag)
     }
 
-    override fun onTagClicked(tag: RealmTag) {
+    override fun onTagClicked(tag: TagEntity) {
         if (::filterController.isInitialized) filterController.addTag(tag)
     }
 
-    override fun onTagSelected(tag: RealmTag) {
+    override fun onTagSelected(tag: TagEntity) {
         if (::filterController.isInitialized) {
             filterController.setSingleTag(tag)
             showNoData(tvMessage, adapterCourses.itemCount, "courses")
         }
     }
 
-    override fun onOkClicked(list: List<RealmTag>?) {
+    override fun onOkClicked(list: List<TagEntity>?) {
         if (::filterController.isInitialized) filterController.setTags(list ?: emptyList())
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentActivitiesBinding
-import org.ole.planet.myplanet.model.RealmOfflineActivity
+import org.ole.planet.myplanet.model.OfflineActivity
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
@@ -55,7 +55,7 @@ class ActivitiesFragment : Fragment() {
     }
 
     private fun computeMonthlyCounts(
-        logins: List<RealmOfflineActivity>,
+        logins: List<OfflineActivity>,
         startMillis: Long,
         endMillis: Long
     ): Map<Int, Int> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardPluginFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardPluginFragment.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.databinding.ItemMyLifeBinding
-import org.ole.planet.myplanet.model.RealmMyLife
+import org.ole.planet.myplanet.model.MyLife
 import org.ole.planet.myplanet.ui.calendar.CalendarFragment
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
 import org.ole.planet.myplanet.ui.events.EventsDetailFragment
@@ -145,15 +145,15 @@ open class DashboardPluginFragment : BaseContainerFragment() {
         return v
     }
 
-    fun getMyLifeListBase(userId: String?): List<RealmMyLife> {
-        val myLifeList: MutableList<RealmMyLife> = ArrayList()
-        myLifeList.add(RealmMyLife("ic_myhealth", userId, getString(R.string.myhealth)))
-        myLifeList.add(RealmMyLife("my_achievement", userId, getString(R.string.achievements)))
-        myLifeList.add(RealmMyLife("ic_submissions", userId, getString(R.string.submission)))
-        myLifeList.add(RealmMyLife("ic_my_survey", userId, getString(R.string.my_survey)))
-        myLifeList.add(RealmMyLife("ic_references", userId, getString(R.string.references)))
-        myLifeList.add(RealmMyLife("ic_calendar", userId, getString(R.string.calendar)))
-        myLifeList.add(RealmMyLife("ic_mypersonals", userId, getString(R.string.mypersonals)))
+    fun getMyLifeListBase(userId: String?): List<MyLife> {
+        val myLifeList: MutableList<MyLife> = ArrayList()
+        myLifeList.add(MyLife("ic_myhealth", userId, getString(R.string.myhealth)))
+        myLifeList.add(MyLife("my_achievement", userId, getString(R.string.achievements)))
+        myLifeList.add(MyLife("ic_submissions", userId, getString(R.string.submission)))
+        myLifeList.add(MyLife("ic_my_survey", userId, getString(R.string.my_survey)))
+        myLifeList.add(MyLife("ic_references", userId, getString(R.string.references)))
+        myLifeList.add(MyLife("ic_calendar", userId, getString(R.string.calendar)))
+        myLifeList.add(MyLife("ic_mypersonals", userId, getString(R.string.mypersonals)))
         return myLifeList
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsAdapter.kt
@@ -6,14 +6,14 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemMeetupBinding
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 
 class EventsAdapter(
-    private val onMeetupClick: ((RealmMeetup) -> Unit)? = null
-) : ListAdapter<RealmMeetup, EventsAdapter.EventsViewHolder>(
-    DiffUtils.itemCallback<RealmMeetup>(
+    private val onMeetupClick: ((Meetup) -> Unit)? = null
+) : ListAdapter<Meetup, EventsAdapter.EventsViewHolder>(
+    DiffUtils.itemCallback<Meetup>(
         areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id },
         areContentsTheSame = { oldItem, newItem -> oldItem.id == newItem.id && oldItem.title == newItem.title && oldItem.description == newItem.description && oldItem.startDate == newItem.startDate && oldItem.endDate == newItem.endDate && oldItem.startTime == newItem.startTime && oldItem.endTime == newItem.endTime && oldItem.meetupLocation == newItem.meetupLocation && oldItem.meetupLink == newItem.meetupLink && oldItem.recurring == newItem.recurring && oldItem.creator == newItem.creator },
         getChangePayload = { oldItem, newItem ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDetailFragment.kt
@@ -21,8 +21,8 @@ import java.util.HashMap
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.AddMeetupBinding
 import org.ole.planet.myplanet.databinding.FragmentEventsDetailBinding
-import org.ole.planet.myplanet.model.RealmMeetup
-import org.ole.planet.myplanet.model.RealmMeetup.Companion.getHashMap
+import org.ole.planet.myplanet.model.Meetup
+import org.ole.planet.myplanet.model.Meetup.Companion.getHashMap
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.Constants.showBetaFeature
@@ -201,7 +201,7 @@ class EventsDetailFragment : Fragment(), View.OnClickListener {
         tvJoined?.text = String.format(getString(R.string.joined_members_colon) + " %s", joinedText)
     }
 
-    private fun setUpData(meetup: RealmMeetup) {
+    private fun setUpData(meetup: Meetup) {
         binding.meetupTitle.text = meetup.title
         val map: HashMap<String, String> = getHashMap(meetup)
         val items = map.map { EventsDescriptionAdapter.DescriptionItem(it.key, it.value) }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDetailViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDetailViewModel.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.EventsRepository
 import org.ole.planet.myplanet.services.UserSessionManager
@@ -22,8 +22,8 @@ class EventsDetailViewModel @Inject constructor(
     private val _user = MutableStateFlow<RealmUser?>(null)
     val user: StateFlow<RealmUser?> = _user.asStateFlow()
 
-    private val _meetup = MutableStateFlow<RealmMeetup?>(null)
-    val meetup: StateFlow<RealmMeetup?> = _meetup.asStateFlow()
+    private val _meetup = MutableStateFlow<Meetup?>(null)
+    val meetup: StateFlow<Meetup?> = _meetup.asStateFlow()
 
     private val _members = MutableStateFlow<List<RealmUser>>(emptyList())
     val members: StateFlow<List<RealmUser>> = _members.asStateFlow()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackAdapter.kt
@@ -8,13 +8,13 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowFeedbackBinding
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.ui.feedback.FeedbackAdapter.FeedbackViewHolder
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.TimeUtils.getFormattedDate
 
 class FeedbackAdapter :
-    ListAdapter<RealmFeedback, FeedbackViewHolder>(
+    ListAdapter<Feedback, FeedbackViewHolder>(
         DiffUtils.itemCallback(
             { oldItem, newItem ->
                 oldItem.id == newItem.id

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ActivityFeedbackDetailBinding
 import org.ole.planet.myplanet.model.FeedbackReply
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
@@ -32,7 +32,7 @@ class FeedbackDetailActivity : AppCompatActivity() {
     private lateinit var activityFeedbackDetailBinding: ActivityFeedbackDetailBinding
     private var replyAdapter: FeedbackReplyAdapter? = null
     private var layoutManager: RecyclerView.LayoutManager? = null
-    private var feedback: RealmFeedback? = null
+    private var feedback: Feedback? = null
     private lateinit var feedbackId: String
     private val viewModel: FeedbackDetailViewModel by viewModels()
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.repository.FeedbackRepository
 
 @HiltViewModel
@@ -19,8 +19,8 @@ class FeedbackDetailViewModel @Inject constructor(
     private val feedbackRepository: FeedbackRepository
 ) : ViewModel() {
 
-    private val _feedback = MutableStateFlow<RealmFeedback?>(null)
-    val feedback: StateFlow<RealmFeedback?> = _feedback.asStateFlow()
+    private val _feedback = MutableStateFlow<Feedback?>(null)
+    val feedback: StateFlow<Feedback?> = _feedback.asStateFlow()
 
     private val _events = MutableSharedFlow<FeedbackDetailEvent>(extraBufferCapacity = 1)
     val events: SharedFlow<FeedbackDetailEvent> = _events.asSharedFlow()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -12,7 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.callback.OnFeedbackSubmittedListener
 import org.ole.planet.myplanet.databinding.FragmentFeedbackListBinding
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncHelper
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
@@ -77,7 +77,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener, RealtimeSy
         refreshFeedbackListData()
     }
 
-    private fun updatedFeedbackList(updatedList: List<RealmFeedback>?) {
+    private fun updatedFeedbackList(updatedList: List<Feedback>?) {
         if (_binding == null) return
         feedbackAdapter.submitList(updatedList) {
             binding.rvFeedback.scrollToPosition(0)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 
@@ -20,8 +20,8 @@ class FeedbackListViewModel @Inject constructor(
     private val userSessionManager: UserSessionManager
 ) : ViewModel() {
 
-    private val _feedbackList = MutableStateFlow<List<RealmFeedback>>(emptyList())
-    val feedbackList: StateFlow<List<RealmFeedback>> = _feedbackList.asStateFlow()
+    private val _feedbackList = MutableStateFlow<List<Feedback>>(emptyList())
+    val feedbackList: StateFlow<List<Feedback>> = _feedbackList.asStateFlow()
 
     private var fetchJob: Job? = null
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationActivity.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ActivityHealthExaminationBinding
 import org.ole.planet.myplanet.model.RealmExamination
-import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.HealthExamination
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.HealthRepository
@@ -53,13 +53,13 @@ class HealthExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedC
     var userId: String? = null
     var user: RealmUser? = null
     private var currentUser: RealmUser? = null
-    private var pojo: RealmHealthExamination? = null
+    private var pojo: HealthExamination? = null
     var health: RealmMyHealth? = null
     private var customDiag: MutableSet<String?>? = null
     private var mapConditions: HashMap<String?, Boolean>? = null
     var allowSubmission = true
     private lateinit var config: ChipCloudConfig
-    private var examination: RealmHealthExamination? = null
+    private var examination: HealthExamination? = null
     private var conditionsMap: Map<String, Boolean> = emptyMap()
     private fun initViews() {
         config = Utilities.getCloudConfig().selectMode(ChipCloud.SelectMode.close)
@@ -216,7 +216,7 @@ class HealthExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedC
         }
     }
 
-    private fun showCheckbox(examination: RealmHealthExamination?) {
+    private fun showCheckbox(examination: HealthExamination?) {
         val arr = resources.getStringArray(R.array.diagnosis_list)
         binding.containerCheckbox.removeAllViews()
         for (s in arr) {
@@ -248,7 +248,7 @@ class HealthExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedC
             createPojo()
             if (examination == null) {
                 val odUserId = generateIv()
-                examination = RealmHealthExamination()
+                examination = HealthExamination()
                 examination?._id = odUserId
                 examination?.userId = odUserId
             }
@@ -379,7 +379,7 @@ class HealthExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedC
     private fun createPojo() {
         try {
             if (pojo == null) {
-                pojo = RealmHealthExamination()
+                pojo = HealthExamination()
                 pojo?._id = userId.orEmpty()
                 pojo?.userId = user?._id
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationAdapter.kt
@@ -16,7 +16,7 @@ import com.google.gson.JsonObject
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.AlertExaminationBinding
 import org.ole.planet.myplanet.databinding.RowExaminationBinding
-import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.HealthExamination
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.ui.health.HealthExaminationAdapter.HealthExaminationViewHolder
 import org.ole.planet.myplanet.utils.DiffUtils
@@ -27,16 +27,16 @@ import org.ole.planet.myplanet.utils.Utilities
 
 class HealthExaminationAdapter(
     private val context: Context,
-    private var mh: RealmHealthExamination,
+    private var mh: HealthExamination,
     private var userModel: RealmUser?,
     private var userMap: Map<String, RealmUser>
-) : ListAdapter<RealmHealthExamination, HealthExaminationViewHolder>(diffCallback) {
+) : ListAdapter<HealthExamination, HealthExaminationViewHolder>(diffCallback) {
     private val displayNameCache = mutableMapOf<String, String>()
     private val colorGrey50 by lazy { ContextCompat.getColor(context, R.color.md_grey_50) }
     private val colorGreen50 by lazy { ContextCompat.getColor(context, R.color.md_green_50) }
     private val colorMultiSelectGrey by lazy { ContextCompat.getColor(context, R.color.multi_select_grey) }
 
-    fun updateData(mh: RealmHealthExamination, userModel: RealmUser?, userMap: Map<String, RealmUser>) {
+    fun updateData(mh: HealthExamination, userModel: RealmUser?, userMap: Map<String, RealmUser>) {
         this.mh = mh
         this.userModel = userModel
         this.userMap = userMap
@@ -117,7 +117,7 @@ class HealthExaminationAdapter(
         dialog.show()
     }
 
-    private fun showConditions(tvCondition: TextView, realmExamination: RealmHealthExamination?) {
+    private fun showConditions(tvCondition: TextView, realmExamination: HealthExamination?) {
         val conditionsMap = JsonUtils.gson.fromJson(realmExamination?.conditions, JsonObject::class.java)
         val keys = conditionsMap.keySet()
         val conditions = StringBuilder()
@@ -141,7 +141,7 @@ class HealthExaminationAdapter(
 
     companion object {
         private val colonRegex by lazy { ":".toRegex() }
-        private val diffCallback = DiffUtils.itemCallback<RealmHealthExamination>(
+        private val diffCallback = DiffUtils.itemCallback<HealthExamination>(
             { oldItem, newItem -> oldItem._id == newItem._id },
             { oldItem, newItem -> oldItem == newItem }
         )

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.HealthExamination
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.HealthRepository
@@ -24,9 +24,9 @@ import org.ole.planet.myplanet.utils.JsonUtils
 data class HealthExaminationState(
     val isLoading: Boolean = true,
     val user: RealmUser? = null,
-    val pojo: RealmHealthExamination? = null,
+    val pojo: HealthExamination? = null,
     val health: RealmMyHealth? = null,
-    val examination: RealmHealthExamination? = null
+    val examination: HealthExamination? = null
 )
 
 @HiltViewModel
@@ -50,9 +50,9 @@ class HealthExaminationViewModel @Inject constructor(
             _state.value = _state.value.copy(isLoading = true)
 
             var user: RealmUser? = null
-            var pojo: RealmHealthExamination? = null
+            var pojo: HealthExamination? = null
             var health: RealmMyHealth? = null
-            var examination: RealmHealthExamination? = null
+            var examination: HealthExamination? = null
 
             withContext(dispatcherProvider.io) {
                 if (userId != null) {
@@ -92,7 +92,7 @@ class HealthExaminationViewModel @Inject constructor(
         }
     }
 
-    fun saveExamination(examination: RealmHealthExamination?, pojo: RealmHealthExamination?, user: RealmUser?) {
+    fun saveExamination(examination: HealthExamination?, pojo: HealthExamination?, user: RealmUser?) {
         if (_isSaving.value) return
 
         viewModelScope.launch {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeAdapter.kt
@@ -20,7 +20,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnItemDragStateListener
 import org.ole.planet.myplanet.callback.OnItemMoveListener
 import org.ole.planet.myplanet.callback.OnStartDragListener
-import org.ole.planet.myplanet.model.RealmMyLife
+import org.ole.planet.myplanet.model.MyLife
 import org.ole.planet.myplanet.ui.calendar.CalendarFragment
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.ui.health.MyHealthFragment
@@ -34,9 +34,9 @@ import org.ole.planet.myplanet.utils.DiffUtils
 class LifeAdapter(
     private val context: Context,
     private val mDragStartListener: OnStartDragListener,
-    private val visibilityCallback: (RealmMyLife, Boolean) -> Unit,
-    private val reorderCallback: (List<RealmMyLife>) -> Unit
-) : ListAdapter<RealmMyLife, RecyclerView.ViewHolder>(DIFF_CALLBACK), OnItemMoveListener {
+    private val visibilityCallback: (MyLife, Boolean) -> Unit,
+    private val reorderCallback: (List<MyLife>) -> Unit
+) : ListAdapter<MyLife, RecyclerView.ViewHolder>(DIFF_CALLBACK), OnItemMoveListener {
     private val hide = 0.5f
     private val show = 1f
 
@@ -128,7 +128,7 @@ class LifeAdapter(
     }
 
     companion object {
-        private val DIFF_CALLBACK = DiffUtils.itemCallback<RealmMyLife>(
+        private val DIFF_CALLBACK = DiffUtils.itemCallback<MyLife>(
             areItemsTheSame = { oldItem, newItem -> oldItem._id == newItem._id },
             areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
         )

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
@@ -17,14 +17,14 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.callback.OnStartDragListener
 import org.ole.planet.myplanet.databinding.FragmentLifeBinding
-import org.ole.planet.myplanet.model.RealmMyLife
+import org.ole.planet.myplanet.model.MyLife
 import org.ole.planet.myplanet.repository.LifeRepository
 import org.ole.planet.myplanet.utils.ItemReorderHelper
 import org.ole.planet.myplanet.utils.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utils.Utilities
 
 @AndroidEntryPoint
-class LifeFragment : BaseRecyclerFragment<RealmMyLife?>(), OnStartDragListener {
+class LifeFragment : BaseRecyclerFragment<MyLife?>(), OnStartDragListener {
     private lateinit var lifeAdapter: LifeAdapter
     private var itemTouchHelper: ItemTouchHelper? = null
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsAdapter.kt
@@ -10,7 +10,7 @@ import androidx.recyclerview.widget.RecyclerView
 import java.io.File
 import org.ole.planet.myplanet.callback.OnPersonalSelectedListener
 import org.ole.planet.myplanet.databinding.RowMyPersonalBinding
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Personal
 import org.ole.planet.myplanet.ui.personals.PersonalsAdapter.PersonalsViewHolder
 import org.ole.planet.myplanet.ui.viewer.ResourceViewerActivity
 import org.ole.planet.myplanet.ui.viewer.ResourceViewerFragment
@@ -18,7 +18,7 @@ import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.IntentUtils.openAudioFile
 import org.ole.planet.myplanet.utils.TimeUtils.getFormattedDate
 
-class PersonalsAdapter(private val context: Context) : ListAdapter<RealmMyPersonal, PersonalsViewHolder>(DIFF_CALLBACK) {
+class PersonalsAdapter(private val context: Context) : ListAdapter<Personal, PersonalsViewHolder>(DIFF_CALLBACK) {
     private var listener: OnPersonalSelectedListener? = null
 
     fun setListener(listener: OnPersonalSelectedListener?) {
@@ -89,7 +89,7 @@ class PersonalsAdapter(private val context: Context) : ListAdapter<RealmMyPerson
 
     companion object {
         private val DIFF_CALLBACK =
-            DiffUtils.itemCallback<RealmMyPersonal>(
+            DiffUtils.itemCallback<Personal>(
                 areItemsTheSame = { old, new -> old._id == new._id },
                 areContentsTheSame = { old, new ->
                     old.title == new.title &&

--- a/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsFragment.kt
@@ -16,7 +16,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnPersonalSelectedListener
 import org.ole.planet.myplanet.databinding.AlertMyPersonalBinding
 import org.ole.planet.myplanet.databinding.FragmentMyPersonalsBinding
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Personal
 import org.ole.planet.myplanet.services.UploadManager
 import org.ole.planet.myplanet.ui.resources.AddResourceFragment
 import org.ole.planet.myplanet.utils.DialogUtils
@@ -80,7 +80,7 @@ class PersonalsFragment : Fragment(), OnPersonalSelectedListener {
         _binding = null
     }
 
-    override fun onUpload(personal: RealmMyPersonal?) {
+    override fun onUpload(personal: Personal?) {
         pg.setText("Please wait...")
         pg.show()
         if (personal != null) {
@@ -101,7 +101,7 @@ class PersonalsFragment : Fragment(), OnPersonalSelectedListener {
         // List updates are handled via repository flow
     }
 
-    override fun onEditPersonal(personal: RealmMyPersonal) {
+    override fun onEditPersonal(personal: Personal) {
         val alertMyPersonalBinding = AlertMyPersonalBinding.inflate(LayoutInflater.from(requireContext()))
         alertMyPersonalBinding.etDescription.setText(personal.description)
         alertMyPersonalBinding.etTitle.setText(personal.title)
@@ -128,7 +128,7 @@ class PersonalsFragment : Fragment(), OnPersonalSelectedListener {
             .show()
     }
 
-    override fun onDeletePersonal(personal: RealmMyPersonal) {
+    override fun onDeletePersonal(personal: Personal) {
         AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
             .setMessage(R.string.delete_record)
             .setPositiveButton(R.string.ok) { _, _ ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/personals/PersonalsViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Personal
 import org.ole.planet.myplanet.repository.PersonalsRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 
@@ -20,12 +20,12 @@ class PersonalsViewModel @Inject constructor(
     private val userSessionManager: UserSessionManager
 ) : ViewModel() {
 
-    val personals: StateFlow<List<RealmMyPersonal>> = flow {
+    val personals: StateFlow<List<Personal>> = flow {
         val user = userSessionManager.getUserModel()
         emitAll(personalsRepository.getPersonalResources(user?.id))
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
-    fun updatePersonalResource(id: String, updater: (RealmMyPersonal) -> Unit) {
+    fun updatePersonalResource(id: String, updater: (Personal) -> Unit) {
         viewModelScope.launch {
             personalsRepository.updatePersonalResource(id, updater)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -20,7 +20,7 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnTagClickListener
 import org.ole.planet.myplanet.databinding.FragmentCollectionsBinding
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.TagData
 import org.ole.planet.myplanet.repository.TagsRepository
 import org.ole.planet.myplanet.utils.KeyboardUtils
@@ -32,13 +32,13 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
     private val binding get() = _binding!!
     @Inject
     lateinit var tagsRepository: TagsRepository
-    private lateinit var list: List<RealmTag>
-    private lateinit var childMap: HashMap<String, List<RealmTag>>
-    private var filteredList: ArrayList<RealmTag> = ArrayList()
+    private lateinit var list: List<TagEntity>
+    private lateinit var childMap: HashMap<String, List<TagEntity>>
+    private var filteredList: ArrayList<TagEntity> = ArrayList()
     private lateinit var adapter: ResourcesTagsAdapter
     private var dbType: String? = null
     private var listener: OnTagClickListener? = null
-    private var selectedItemsList: ArrayList<RealmTag> = ArrayList()
+    private var selectedItemsList: ArrayList<TagEntity> = ArrayList()
     private var currentTagDataList = mutableListOf<TagData>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -100,7 +100,7 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
         }
     }
 
-    private fun buildTagDataList(parents: List<RealmTag>): List<TagData> {
+    private fun buildTagDataList(parents: List<TagEntity>): List<TagData> {
         val tagDataList = mutableListOf<TagData>()
         val isSelectMultiple = MainApplication.isCollectionSwitchOn
         for (parentTag in parents) {
@@ -120,7 +120,7 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
         return tagDataList
     }
 
-    override fun onTagClicked(tag: RealmTag) {
+    override fun onTagClicked(tag: TagEntity) {
         listener?.onTagSelected(tag)
         dismiss()
     }
@@ -131,7 +131,7 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
         adapter.submitList(currentTagDataList.toList())
     }
 
-    override fun onCheckboxTagSelected(tag: RealmTag) {
+    override fun onCheckboxTagSelected(tag: TagEntity) {
         if (selectedItemsList.contains(tag)) {
             selectedItemsList.remove(tag)
         } else {
@@ -158,8 +158,8 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
     }
 
     companion object {
-        private lateinit var recentList: MutableList<RealmTag>
-        fun getInstance(l: MutableList<RealmTag>, dbType: String): CollectionsFragment {
+        private lateinit var recentList: MutableList<TagEntity>
+        fun getInstance(l: MutableList<TagEntity>, dbType: String): CollectionsFragment {
             recentList = l
             val f = CollectionsFragment()
             val b = Bundle()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -38,7 +38,7 @@ import org.ole.planet.myplanet.callback.OnTagClickListener
 import org.ole.planet.myplanet.databinding.FragmentMyLibraryBinding
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.ResourceItem
 import org.ole.planet.myplanet.model.ResourceListModel
@@ -67,10 +67,10 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     private val clearTags get() = binding.btnClearTags
     private val selectAll get() = binding.selectAll
     private val filter get() = binding.filter
-    private lateinit var searchTags: MutableList<RealmTag>
+    private lateinit var searchTags: MutableList<TagEntity>
     private lateinit var config: ChipCloudConfig
     private lateinit var adapterLibrary: ResourcesAdapter
-    private var tagsMap: Map<String, List<RealmTag>> = emptyMap()
+    private var tagsMap: Map<String, List<TagEntity>> = emptyMap()
     var userModel: RealmUser ?= null
     var map: HashMap<String?, JsonObject>? = null
     private var confirmation: AlertDialog? = null
@@ -479,7 +479,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     override fun onTagClicked(tag: TagItem) {
         val realmTag = allResourceModels.flatMap { it.tags }.find { it.id == tag.id }
         if (realmTag != null) {
-            val rTag = searchTags.find { it.id == realmTag.id } ?: RealmTag().apply {
+            val rTag = searchTags.find { it.id == realmTag.id } ?: TagEntity().apply {
                 id = realmTag.id.orEmpty()
                 name = realmTag.name
             }
@@ -502,7 +502,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         }
     }
 
-    override fun onTagClicked(tag: RealmTag) {
+    override fun onTagClicked(tag: TagEntity) {
         tvSelected.visibility = View.VISIBLE
         flexBoxTags.removeAllViews()
         val chipCloud = ChipCloud(activity, flexBoxTags, config)
@@ -515,9 +515,9 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         }
     }
 
-    override fun onTagSelected(tag: RealmTag) {
+    override fun onTagSelected(tag: TagEntity) {
         tvSelected.visibility = View.VISIBLE
-        val li: MutableList<RealmTag> = ArrayList()
+        val li: MutableList<TagEntity> = ArrayList()
         li.add(tag)
         searchTags = li
         tvSelected.text = getString(R.string.tag_selected, tag.name)
@@ -526,7 +526,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         }
     }
 
-    override fun onOkClicked(list: List<RealmTag>?) {
+    override fun onOkClicked(list: List<TagEntity>?) {
         if (list?.isEmpty() == true) {
             searchTags.clear()
             viewLifecycleOwner.lifecycleScope.launch {
@@ -675,7 +675,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         return if (::recyclerView.isInitialized) recyclerView else null
     }
 
-    private fun filterLocalLibraryByTag(models: List<ResourceListModel>, s: String, tags: List<RealmTag>): List<ResourceListModel> {
+    private fun filterLocalLibraryByTag(models: List<ResourceListModel>, s: String, tags: List<TagEntity>): List<ResourceListModel> {
         var filteredList = ResourceSearchUtils.searchLocalModels(models, s)
 
         if (tags.isNotEmpty()) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesTagsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesTagsAdapter.kt
@@ -12,7 +12,7 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnTagClickListener
 import org.ole.planet.myplanet.databinding.RowNavigationChildAdapterBinding
 import org.ole.planet.myplanet.databinding.RowNavigationParentAdapterBinding
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.TagData
 import org.ole.planet.myplanet.utils.DiffUtils
 
@@ -104,7 +104,7 @@ class ResourcesTagsAdapter(
 
     private fun createCheckbox(
         convertView: View,
-        tag: RealmTag,
+        tag: TagEntity,
         isSelectMultiple: Boolean,
         isSelected: Boolean
     ) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.di.DefaultPreferences
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.services.FreeSpaceWorker
 import org.ole.planet.myplanet.services.SharedPrefManager
@@ -133,8 +133,8 @@ class SettingsActivity : AppCompatActivity() {
                         appendLine("Details:")
                         pendingOps.take(10).forEach { op ->
                             val statusIcon = when (op.status) {
-                                RealmRetryOperation.STATUS_IN_PROGRESS -> "🔄"
-                                RealmRetryOperation.STATUS_PENDING -> "⏸"
+                                RetryOperation.STATUS_IN_PROGRESS -> "🔄"
+                                RetryOperation.STATUS_PENDING -> "⏸"
                                 else -> "❓"
                             }
                             appendLine("$statusIcon ${op.uploadType}: ${op.status} (${op.attemptCount}/${op.maxAttempts})")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsViewModel.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 import org.ole.planet.myplanet.repository.ConfigurationsRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.services.ResourceDownloadCoordinator
@@ -20,7 +20,7 @@ import org.ole.planet.myplanet.utils.DownloadUtils.downloadAllFiles
 
 data class RetryQueueDetails(
     val pendingCount: Long = 0,
-    val pendingOps: List<RealmRetryOperation> = emptyList(),
+    val pendingOps: List<RetryOperation> = emptyList(),
     val isProcessing: Boolean = false
 )
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ServerDialogExtensions.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.BuildConfig
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.DialogServerUrlBinding
-import org.ole.planet.myplanet.model.RealmCommunity
+import org.ole.planet.myplanet.model.Community
 import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.ServerConfigUtils
@@ -71,7 +71,7 @@ fun SyncActivity.performSync(dialog: MaterialDialog) {
 
 fun SyncActivity.onChangeServerUrl() {
     val selected = spnCloud.selectedItem
-    if (selected is RealmCommunity) {
+    if (selected is Community) {
         val config = ServerConfigUtils.getCommunityConfig(selected, getString(R.string.https_protocol))
         serverUrl.setText(config.localDomain)
         protocolCheckIn.check(R.id.radio_https)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarFragment.kt
@@ -36,7 +36,7 @@ import org.ole.planet.myplanet.base.BaseTeamFragment
 import org.ole.planet.myplanet.databinding.AddMeetupBinding
 import org.ole.planet.myplanet.databinding.FragmentEnterpriseCalendarBinding
 import org.ole.planet.myplanet.model.MeetupCreationParams
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.ui.events.EventsAdapter
 import org.ole.planet.myplanet.utils.TimeUtils
@@ -52,8 +52,8 @@ class TeamCalendarFragment : BaseTeamFragment() {
     private lateinit var start: Calendar
     private lateinit var end: Calendar
     private lateinit var clickedCalendar: Calendar
-    private lateinit var calendarEventsMap: MutableMap<CalendarDay, RealmMeetup>
-    private var meetupList: List<RealmMeetup> = emptyList()
+    private lateinit var calendarEventsMap: MutableMap<CalendarDay, Meetup>
+    private var meetupList: List<Meetup> = emptyList()
     private val eventDates: MutableList<Calendar> = mutableListOf()
     private var addMeetupDialog: AlertDialog? = null
     private var meetupDialog: AlertDialog? = null
@@ -272,7 +272,7 @@ class TeamCalendarFragment : BaseTeamFragment() {
         setupCalendarClickListener()
     }
 
-    private fun showEditMeetupDialog(meetup: RealmMeetup) {
+    private fun showEditMeetupDialog(meetup: Meetup) {
         val dialogBinding = AddMeetupBinding.inflate(layoutInflater)
         dialogBinding.tvTitle.text = getString(R.string.edit_meetup)
         dialogBinding.etTitle.setText(meetup.title)
@@ -432,7 +432,7 @@ class TeamCalendarFragment : BaseTeamFragment() {
         }
     }
 
-    private fun showMeetupDialog(meetupList: List<RealmMeetup>) {
+    private fun showMeetupDialog(meetupList: List<Meetup>) {
         val dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.meetup_dialog, null)
         val recyclerView = dialogView.findViewById<RecyclerView>(R.id.rvMeetups)
         val dialogTitle = dialogView.findViewById< TextView>(R.id.tvTitle)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.MeetupCreationParams
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.repository.EventsRepository
 
 @HiltViewModel
@@ -20,8 +20,8 @@ class TeamCalendarViewModel @Inject constructor(
     private val eventsRepository: EventsRepository
 ) : ViewModel() {
 
-    private val _meetups = MutableStateFlow<List<RealmMeetup>>(emptyList())
-    val meetups: StateFlow<List<RealmMeetup>> = _meetups.asStateFlow()
+    private val _meetups = MutableStateFlow<List<Meetup>>(emptyList())
+    val meetups: StateFlow<List<Meetup>> = _meetups.asStateFlow()
 
     private val _createMeetupResult = MutableSharedFlow<Boolean>()
     val createMeetupResult: SharedFlow<Boolean> = _createMeetupResult.asSharedFlow()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.model.CreateTeamRequest
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.model.TeamDetails
 import org.ole.planet.myplanet.model.TeamStatus
@@ -37,8 +37,8 @@ class TeamViewModel @Inject constructor(
     private val _teamData = MutableStateFlow<List<TeamDetails>>(emptyList())
     val teamData: StateFlow<List<TeamDetails>> = _teamData
 
-    private val _taskList = MutableStateFlow<List<RealmTeamTask>>(emptyList())
-    val taskList: StateFlow<List<RealmTeamTask>> = _taskList
+    private val _taskList = MutableStateFlow<List<TeamTask>>(emptyList())
+    val taskList: StateFlow<List<TeamTask>> = _taskList
 
     fun getTeamUpdateFlow() = realtimeSyncManager.dataUpdateFlow
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksAdapter.kt
@@ -11,7 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnTaskCompletedListener
 import org.ole.planet.myplanet.databinding.RowTaskBinding
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.ui.teams.tasks.TeamsTasksAdapter.TeamsTasksViewHolder
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
@@ -19,7 +19,7 @@ import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 class TeamsTasksAdapter(
     private val context: Context,
     var nonTeamMember: Boolean
-) : ListAdapter<RealmTeamTask, TeamsTasksViewHolder>(DIFF_CALLBACK) {
+) : ListAdapter<TeamTask, TeamsTasksViewHolder>(DIFF_CALLBACK) {
     private val assigneeCache: MutableMap<String, String> = mutableMapOf()
     private var listener: OnTaskCompletedListener? = null
     fun setListener(listener: OnTaskCompletedListener?) {
@@ -101,7 +101,7 @@ class TeamsTasksAdapter(
         }
     }
 
-    private fun showAssignee(binding: RowTaskBinding, realmTeamTask: RealmTeamTask) {
+    private fun showAssignee(binding: RowTaskBinding, realmTeamTask: TeamTask) {
         val assigneeId = realmTeamTask.assignee
         if (assigneeId.isNullOrEmpty()) {
             binding.assignee.setText(R.string.no_assignee)
@@ -119,7 +119,7 @@ class TeamsTasksAdapter(
     class TeamsTasksViewHolder(val binding: RowTaskBinding) : RecyclerView.ViewHolder(binding.root)
 
     companion object {
-        private val DIFF_CALLBACK = DiffUtils.itemCallback<RealmTeamTask>(
+        private val DIFF_CALLBACK = DiffUtils.itemCallback<TeamTask>(
             areItemsTheSame = { old, new -> old.id == new.id },
             areContentsTheSame = { old, new ->
                 old.title == new.title &&

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
@@ -33,7 +33,7 @@ import org.ole.planet.myplanet.databinding.AlertTaskBinding
 import org.ole.planet.myplanet.databinding.AlertUsersSpinnerBinding
 import org.ole.planet.myplanet.databinding.FragmentTeamsTasksBinding
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.ui.teams.TeamViewModel
 import org.ole.planet.myplanet.ui.user.UserArrayAdapter
@@ -92,7 +92,7 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
         return binding.root
     }
 
-    private fun showTaskAlert(t: RealmTeamTask?) {
+    private fun showTaskAlert(t: TeamTask?) {
         val alertTaskBinding = AlertTaskBinding.inflate(layoutInflater)
         datePicker = alertTaskBinding.tvPick
         var selectedAssignee: RealmUser? = null
@@ -212,7 +212,7 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
         alertTaskBinding.tvAssignMember.setTextColor(requireContext().getColor(R.color.daynight_textColor))
     }
 
-    private fun createOrUpdateTask(task: String, desc: String, teamTask: RealmTeamTask?, assigneeId: String? = null) {
+    private fun createOrUpdateTask(task: String, desc: String, teamTask: TeamTask?, assigneeId: String? = null) {
         viewLifecycleOwner.lifecycleScope.launch {
             val deadlineMillis = teamsTasksViewModel.getDeadlineMillis()
 
@@ -278,15 +278,15 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
         }
     }
 
-    private fun allTasks(tasks: List<RealmTeamTask>): List<RealmTeamTask> {
-        return tasks.sortedWith(compareBy<RealmTeamTask> { it.completed }.thenByDescending { it.deadline })
+    private fun allTasks(tasks: List<TeamTask>): List<TeamTask> {
+        return tasks.sortedWith(compareBy<TeamTask> { it.completed }.thenByDescending { it.deadline })
     }
 
-    private fun completedTasks(tasks: List<RealmTeamTask>): List<RealmTeamTask> {
+    private fun completedTasks(tasks: List<TeamTask>): List<TeamTask> {
         return tasks.filter { it.completed }.sortedByDescending { it.deadline }
     }
 
-    private fun myTasks(tasks: List<RealmTeamTask>): List<RealmTeamTask> {
+    private fun myTasks(tasks: List<TeamTask>): List<TeamTask> {
         return tasks.filter { !it.completed && it.assignee == user?.id }.sortedByDescending { it.deadline }
     }
 
@@ -345,18 +345,18 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
         }
     }
 
-    override fun onCheckChange(realmTeamTask: RealmTeamTask?, completed: Boolean) {
+    override fun onCheckChange(realmTeamTask: TeamTask?, completed: Boolean) {
         val taskId = realmTeamTask?.id ?: return
         viewLifecycleOwner.lifecycleScope.launch {
             teamsRepository.setTaskCompletion(taskId, completed)
         }
     }
 
-    override fun onEdit(task: RealmTeamTask?) {
+    override fun onEdit(task: TeamTask?) {
         showTaskAlert(task)
     }
 
-    override fun onDelete(task: RealmTeamTask?) {
+    override fun onDelete(task: TeamTask?) {
         val taskId = task?.id ?: return
         viewLifecycleOwner.lifecycleScope.launch {
             teamsRepository.deleteTask(taskId)
@@ -364,7 +364,7 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
         }
     }
 
-    override fun onClickMore(realmTeamTask: RealmTeamTask?) {
+    override fun onClickMore(realmTeamTask: TeamTask?) {
         if (realmTeamTask?.completed == true) {
             Toast.makeText(context, R.string.cannot_assign_completed_task, Toast.LENGTH_SHORT).show()
             return

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
@@ -41,8 +41,8 @@ import org.ole.planet.myplanet.databinding.EditAttachementBinding
 import org.ole.planet.myplanet.databinding.EditOtherInfoBinding
 import org.ole.planet.myplanet.databinding.FragmentEditAchievementBinding
 import org.ole.planet.myplanet.databinding.MyLibraryAlertdialogBinding
-import org.ole.planet.myplanet.model.RealmAchievement
-import org.ole.planet.myplanet.model.RealmAchievement.Companion.createReference
+import org.ole.planet.myplanet.model.Achievement
+import org.ole.planet.myplanet.model.Achievement.Companion.createReference
 import org.ole.planet.myplanet.model.RealmMyLibrary
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.ui.components.CheckboxAdapter
@@ -65,7 +65,7 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
     private lateinit var myLibraryAlertdialogBinding: MyLibraryAlertdialogBinding
 
     var user: RealmUser? = null
-    private var achievement: RealmAchievement? = null
+    private var achievement: Achievement? = null
     private var referenceArray: JsonArray? = null
     private var achievementArray: JsonArray? = null
     private var resourceArray: JsonArray? = null

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Constants.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Constants.kt
@@ -4,18 +4,18 @@ import android.content.Context
 import androidx.preference.PreferenceManager
 import org.ole.planet.myplanet.model.Achievement
 import org.ole.planet.myplanet.model.Certification
-import org.ole.planet.myplanet.model.RealmCourseProgress
-import org.ole.planet.myplanet.model.RealmFeedback
-import org.ole.planet.myplanet.model.RealmHealthExamination
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.CourseProgress
+import org.ole.planet.myplanet.model.Feedback
+import org.ole.planet.myplanet.model.HealthExamination
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.model.AppNotification
 import org.ole.planet.myplanet.model.Rating
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.TeamLog
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 
 object Constants {
     const val HTTP_PROTOCOL = "http://"
@@ -58,15 +58,15 @@ object Constants {
         classList["ratings"] = Rating::class.java
         classList["courses"] = RealmMyCourse::class.java
         classList["achievements"] = Achievement::class.java
-        classList["feedback"] = RealmFeedback::class.java
+        classList["feedback"] = Feedback::class.java
         classList["teams"] = RealmMyTeam::class.java
-        classList["tasks"] = RealmTeamTask::class.java
-        classList["meetups"] = RealmMeetup::class.java
-        classList["health"] = RealmHealthExamination::class.java
+        classList["tasks"] = TeamTask::class.java
+        classList["meetups"] = Meetup::class.java
+        classList["health"] = HealthExamination::class.java
         classList["certifications"] = Certification::class.java
         classList["team_activities"] = TeamLog::class.java
-        classList["courses_progress"] = RealmCourseProgress::class.java
-        classList["notifications"] = RealmNotification::class.java
+        classList["courses_progress"] = CourseProgress::class.java
+        classList["notifications"] = AppNotification::class.java
     }
 
     fun showBetaFeature(s: String, context: Context): Boolean {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Constants.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Constants.kt
@@ -13,7 +13,7 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.AppNotification
 import org.ole.planet.myplanet.model.Rating
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.TeamTask
 
@@ -54,7 +54,7 @@ object Constants {
 
     private fun initClasses() {
         classList["news"] = RealmNews::class.java
-        classList["tags"] = RealmTag::class.java
+        classList["tags"] = TagEntity::class.java
         classList["ratings"] = Rating::class.java
         classList["courses"] = RealmMyCourse::class.java
         classList["achievements"] = Achievement::class.java

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Constants.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Constants.kt
@@ -3,7 +3,7 @@ package org.ole.planet.myplanet.utils
 import android.content.Context
 import androidx.preference.PreferenceManager
 import org.ole.planet.myplanet.model.RealmAchievement
-import org.ole.planet.myplanet.model.RealmCertification
+import org.ole.planet.myplanet.model.Certification
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmHealthExamination
@@ -14,7 +14,7 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmTag
-import org.ole.planet.myplanet.model.RealmTeamLog
+import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
 
 object Constants {
@@ -63,8 +63,8 @@ object Constants {
         classList["tasks"] = RealmTeamTask::class.java
         classList["meetups"] = RealmMeetup::class.java
         classList["health"] = RealmHealthExamination::class.java
-        classList["certifications"] = RealmCertification::class.java
-        classList["team_activities"] = RealmTeamLog::class.java
+        classList["certifications"] = Certification::class.java
+        classList["team_activities"] = TeamLog::class.java
         classList["courses_progress"] = RealmCourseProgress::class.java
         classList["notifications"] = RealmNotification::class.java
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Constants.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Constants.kt
@@ -2,7 +2,7 @@ package org.ole.planet.myplanet.utils
 
 import android.content.Context
 import androidx.preference.PreferenceManager
-import org.ole.planet.myplanet.model.RealmAchievement
+import org.ole.planet.myplanet.model.Achievement
 import org.ole.planet.myplanet.model.Certification
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmFeedback
@@ -12,7 +12,7 @@ import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNotification
-import org.ole.planet.myplanet.model.RealmRating
+import org.ole.planet.myplanet.model.Rating
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
@@ -55,9 +55,9 @@ object Constants {
     private fun initClasses() {
         classList["news"] = RealmNews::class.java
         classList["tags"] = RealmTag::class.java
-        classList["ratings"] = RealmRating::class.java
+        classList["ratings"] = Rating::class.java
         classList["courses"] = RealmMyCourse::class.java
-        classList["achievements"] = RealmAchievement::class.java
+        classList["achievements"] = Achievement::class.java
         classList["feedback"] = RealmFeedback::class.java
         classList["teams"] = RealmMyTeam::class.java
         classList["tasks"] = RealmTeamTask::class.java

--- a/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
@@ -7,7 +7,7 @@ import java.io.File
  * Synchronous, dependency-free persistence for crash/ANR reports. Reports are written
  * here before any coroutine or Realm machinery runs, because both share the dispatcher
  * and write lock with whatever workload caused the failure — the process may die before
- * an async Realm write commits. Files left behind are swept into RealmApkLog on the
+ * an async Realm write commits. Files left behind are swept into ApkLog on the
  * next app start.
  */
 object CrashLogStore {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
@@ -5,9 +5,8 @@ import java.io.File
 
 /**
  * Synchronous, dependency-free persistence for crash/ANR reports. Reports are written
- * here before any coroutine or Realm machinery runs, because both share the dispatcher
- * and write lock with whatever workload caused the failure — the process may die before
- * an async Realm write commits. Files left behind are swept into ApkLog on the
+ * here before any coroutine or Room machinery runs, because app shutdown can happen
+ * before launched coroutines finish persisting rows. Files left behind are swept into ApkLog on the
  * next app start.
  */
 object CrashLogStore {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/ServerConfigUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ServerConfigUtils.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.core.net.toUri
 import org.ole.planet.myplanet.BuildConfig
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.model.RealmCommunity
+import org.ole.planet.myplanet.model.Community
 import org.ole.planet.myplanet.model.ServerAddress
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.ui.sync.ProcessUserDataActivity
@@ -126,7 +126,7 @@ object ServerConfigUtils {
         val isPinEnabled: Boolean
     )
 
-    fun getCommunityConfig(selected: RealmCommunity, httpsProtocol: String): CommunityConfig {
+    fun getCommunityConfig(selected: Community, httpsProtocol: String): CommunityConfig {
         val domain = selected.localDomain
         val protocol = httpsProtocol
         val pin = if (selected.weight == 0) BuildConfig.PLANET_LEARNING_PIN else ""

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmCourseProgressTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmCourseProgressTest.kt
@@ -3,11 +3,11 @@ package org.ole.planet.myplanet.model
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class RealmCourseProgressTest {
+class CourseProgressTest {
 
     @Test
     fun testSerializeProgress() {
-        val progress = RealmCourseProgress().apply {
+        val progress = CourseProgress().apply {
             userId = "user123"
             parentCode = "parentCode123"
             courseId = "courseId123"
@@ -18,7 +18,7 @@ class RealmCourseProgressTest {
             updatedDate = 1672617600000L
         }
 
-        val jsonObject = RealmCourseProgress.serializeProgress(progress)
+        val jsonObject = CourseProgress.serializeProgress(progress)
 
         assertEquals("user123", jsonObject.get("userId").asString)
         assertEquals("parentCode123", jsonObject.get("parentCode").asString)

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmFeedbackTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmFeedbackTest.kt
@@ -13,7 +13,7 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
-class RealmFeedbackTest {
+class FeedbackTest {
 
     @Before
     fun setup() {
@@ -31,7 +31,7 @@ class RealmFeedbackTest {
 
     @Test
     fun testSetMessagesJsonArray() {
-        val feedback = RealmFeedback()
+        val feedback = Feedback()
         val jsonArray = JsonArray()
         val obj = JsonObject()
         obj.addProperty("message", "Test message")
@@ -43,7 +43,7 @@ class RealmFeedbackTest {
 
     @Test
     fun testSetMessagesString() {
-        val feedback = RealmFeedback()
+        val feedback = Feedback()
         val messageString = "[{\"message\":\"Test message\"}]"
         feedback.messages = messageString
         assertEquals(messageString, feedback.messages)
@@ -51,7 +51,7 @@ class RealmFeedbackTest {
 
     @Test
     fun testMessageListEmpty() {
-        val feedback = RealmFeedback()
+        val feedback = Feedback()
         feedback.messages = ""
         assertNull(feedback.messageList)
 
@@ -61,7 +61,7 @@ class RealmFeedbackTest {
 
     @Test
     fun testMessageListWithElements() {
-        val feedback = RealmFeedback()
+        val feedback = Feedback()
         val messageString = """
             [
               {"message": "msg0", "user": "user0", "time": "time0"},
@@ -83,7 +83,7 @@ class RealmFeedbackTest {
 
     @Test
     fun testMessageEmpty() {
-        val feedback = RealmFeedback()
+        val feedback = Feedback()
         feedback.messages = ""
         assertEquals("", feedback.message)
 
@@ -93,7 +93,7 @@ class RealmFeedbackTest {
 
     @Test
     fun testMessageWithElements() {
-        val feedback = RealmFeedback()
+        val feedback = Feedback()
         val messageString = """
             [
               {"message": "First message", "user": "user0", "time": "time0"},
@@ -106,7 +106,7 @@ class RealmFeedbackTest {
 
     @Test
     fun testSerializeFeedback() {
-        val feedback = RealmFeedback().apply {
+        val feedback = Feedback().apply {
             title = "Test Title"
             source = "Test Source"
             status = "Open"
@@ -124,7 +124,7 @@ class RealmFeedbackTest {
         val messageString = "[{\"message\":\"Test message\"}]"
         feedback.messages = messageString
 
-        val serialized = RealmFeedback.serializeFeedback(feedback)
+        val serialized = Feedback.serializeFeedback(feedback)
 
         assertEquals("Test Title", serialized.get("title").asString)
         assertEquals("Test Source", serialized.get("source").asString)
@@ -147,7 +147,7 @@ class RealmFeedbackTest {
 
     @Test
     fun testSerializeFeedbackWithInvalidMessagesException() {
-        val feedback = RealmFeedback()
+        val feedback = Feedback()
 
         feedback.messages = "invalid json"
 
@@ -158,7 +158,7 @@ class RealmFeedbackTest {
             }
         }
 
-        val jsonObject = RealmFeedback.serializeFeedback(feedback)
+        val jsonObject = Feedback.serializeFeedback(feedback)
 
         // When an exception is thrown, the "messages" property is not added
         assertNull(jsonObject.get("messages"))

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmMeetupTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmMeetupTest.kt
@@ -18,7 +18,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class)
-class RealmMeetupTest {
+class MeetupTest {
 
     @Before
     fun setup() {
@@ -57,7 +57,7 @@ class RealmMeetupTest {
             add("link", linkObj)
         }
 
-        val meetup = RealmMeetup.fromJson(meetupDoc, userId, null)
+        val meetup = Meetup.fromJson(meetupDoc, userId, null)
 
         assertEquals("meetup1", meetup.id)
         assertEquals("meetup1", meetup.meetupId)
@@ -88,11 +88,11 @@ class RealmMeetupTest {
             addProperty("title", "Updated Meetup")
         }
 
-        val existingMeetup = RealmMeetup()
+        val existingMeetup = Meetup()
         existingMeetup.createdDate = 12345L
         existingMeetup.sync = "synced"
 
-        val meetup = RealmMeetup.fromJson(meetupDoc, userId, existingMeetup)
+        val meetup = Meetup.fromJson(meetupDoc, userId, existingMeetup)
 
         assertEquals("meetup1", meetup.meetupId)
         assertEquals(userId, meetup.userId)
@@ -108,17 +108,17 @@ class RealmMeetupTest {
             addProperty("_id", "meetup1")
         }
 
-        val meetup = RealmMeetup.fromJson(meetupDoc, "", null)
+        val meetup = Meetup.fromJson(meetupDoc, "", null)
 
         assertEquals("", meetup.userId)
     }
 
     @Test
     fun `getMyMeetUpIds returns json array of ids`() {
-        val meetup1 = RealmMeetup().apply { meetupId = "id1" }
-        val meetup2 = RealmMeetup().apply { meetupId = "id2" }
+        val meetup1 = Meetup().apply { meetupId = "id1" }
+        val meetup2 = Meetup().apply { meetupId = "id2" }
 
-        val result = RealmMeetup.getMyMeetUpIds(listOf(meetup1, meetup2))
+        val result = Meetup.getMyMeetUpIds(listOf(meetup1, meetup2))
 
         assertEquals(2, result.size())
         assertEquals("id1", result[0].asString)
@@ -127,13 +127,13 @@ class RealmMeetupTest {
 
     @Test
     fun `getMyMeetUpIds with empty list returns empty array`() {
-        val result = RealmMeetup.getMyMeetUpIds(emptyList())
+        val result = Meetup.getMyMeetUpIds(emptyList())
         assertEquals(0, result.size())
     }
 
     @Test
     fun `getHashMap extracts correct map values`() {
-        val meetup = mockk<RealmMeetup>()
+        val meetup = mockk<Meetup>()
         every { meetup.title } returns "Test Title"
         every { meetup.creator } returns "Test Creator"
         every { meetup.category } returns "Tech"
@@ -150,7 +150,7 @@ class RealmMeetupTest {
         val expectedStartDate = TimeUtils.getFormattedDate(1600000000000)
         val expectedEndDate = TimeUtils.getFormattedDate(1600003600000)
 
-        val map = RealmMeetup.getHashMap(meetup)
+        val map = Meetup.getHashMap(meetup)
 
         assertEquals("Test Title", map["Meetup Title"])
         assertEquals("Test Creator", map["Created By"])
@@ -166,12 +166,12 @@ class RealmMeetupTest {
 
     @Test
     fun `getHashMap handles null values properly`() {
-        val meetup = mockk<RealmMeetup>(relaxed = true)
+        val meetup = mockk<Meetup>(relaxed = true)
         every { meetup.title } returns null
         every { meetup.creator } returns null
         every { meetup.day } returns "[]" // valid empty array to avoid JSONException console pollution
 
-        val map = RealmMeetup.getHashMap(meetup)
+        val map = Meetup.getHashMap(meetup)
 
         assertEquals("", map["Meetup Title"])
         assertEquals("", map["Created By"])
@@ -180,7 +180,7 @@ class RealmMeetupTest {
 
     @Test
     fun `serialize creates correct JsonObject`() {
-        val meetup = RealmMeetup().apply {
+        val meetup = Meetup().apply {
             meetupId = "meetup1"
             meetupIdRev = "rev1"
             title = "Test Meetup"
@@ -202,7 +202,7 @@ class RealmMeetupTest {
             link = """{"some":"data"}"""
         }
 
-        val jsonObject = RealmMeetup.serialize(meetup)
+        val jsonObject = Meetup.serialize(meetup)
 
         assertEquals("meetup1", jsonObject.get("_id").asString)
         assertEquals("rev1", jsonObject.get("_rev").asString)
@@ -227,13 +227,13 @@ class RealmMeetupTest {
 
     @Test
     fun `serialize skips null or empty id and link`() {
-        val meetup = RealmMeetup().apply {
+        val meetup = Meetup().apply {
             meetupId = ""
             meetupIdRev = null
             link = null
         }
 
-        val jsonObject = RealmMeetup.serialize(meetup)
+        val jsonObject = Meetup.serialize(meetup)
 
         assertEquals(false, jsonObject.has("_id"))
         assertEquals(false, jsonObject.has("_rev"))

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmMyPersonalTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmMyPersonalTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
 
-class RealmMyPersonalTest {
+class PersonalTest {
 
     private lateinit var mockContext: Context
 
@@ -34,7 +34,7 @@ class RealmMyPersonalTest {
 
     @Test
     fun testSerialize() {
-        val personal = RealmMyPersonal().apply {
+        val personal = Personal().apply {
             title = "My Personal Title"
             date = 1600000000000L
             path = "http://example.com/file.pdf"
@@ -49,7 +49,7 @@ class RealmMyPersonalTest {
         every { NetworkUtils.getDeviceName() } returns "device_name"
         every { NetworkUtils.getCustomDeviceName(any()) } returns "custom_device_name"
 
-        val serialized = RealmMyPersonal.serialize(personal, mockContext)
+        val serialized = Personal.serialize(personal, mockContext)
 
         assertEquals("My Personal Title", serialized.get("title").asString)
         assertTrue(serialized.has("uploadDate"))
@@ -71,14 +71,14 @@ class RealmMyPersonalTest {
 
     @Test
     fun testSerialize_withNullValues() {
-        val personal = RealmMyPersonal() // all nullable fields are null by default
+        val personal = Personal() // all nullable fields are null by default
 
         every { FileUtils.getFileNameFromUrl(null) } returns ""
         every { NetworkUtils.getUniqueIdentifier() } returns "unique_id"
         every { NetworkUtils.getDeviceName() } returns "device_name"
         every { NetworkUtils.getCustomDeviceName(any()) } returns "custom_device_name"
 
-        val serialized = RealmMyPersonal.serialize(personal, mockContext)
+        val serialized = Personal.serialize(personal, mockContext)
 
         assertTrue(serialized.get("title").isJsonNull)
         assertTrue(serialized.has("uploadDate"))

--- a/app/src/test/java/org/ole/planet/myplanet/model/RealmRatingTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RealmRatingTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.utils.NetworkUtils
 
-class RealmRatingTest {
+class RatingTest {
 
     @MockK
     lateinit var mockContext: Context
@@ -39,7 +39,7 @@ class RealmRatingTest {
 
     @Test
     fun testSerializeRating() {
-        val rating = RealmRating().apply {
+        val rating = Rating().apply {
             _id = "test_id"
             _rev = "test_rev"
             user = "{ \"_id\": \"test_user_id\" }"
@@ -54,7 +54,7 @@ class RealmRatingTest {
             planetCode = "test_planet_code"
         }
 
-        val serialized = RealmRating.serializeRating(rating)
+        val serialized = Rating.serializeRating(rating)
 
         assertEquals("test_id", serialized.get("_id").asString)
         assertEquals("test_rev", serialized.get("_rev").asString)

--- a/app/src/test/java/org/ole/planet/myplanet/model/RemovedLogTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/RemovedLogTest.kt
@@ -3,10 +3,10 @@ package org.ole.planet.myplanet.model
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class RealmRemovedLogTest {
+class RemovedLogTest {
     @Test
     fun `removed log stores resource removal data`() {
-        val log = RealmRemovedLog().apply {
+        val log = RemovedLog().apply {
             id = "log1"
             type = "resources"
             userId = "user1"

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ChatRepositoryImplTest.kt
@@ -22,7 +22,7 @@ import org.ole.planet.myplanet.data.room.dao.ChatDao
 import org.ole.planet.myplanet.model.AiProvider
 import org.ole.planet.myplanet.model.ChatResponse
 import org.ole.planet.myplanet.model.CouchDBResponse
-import org.ole.planet.myplanet.model.RealmChatHistory
+import org.ole.planet.myplanet.model.ChatHistory
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 
@@ -78,7 +78,7 @@ class ChatRepositoryImplTest {
     @Test
     fun getChatHistoryForUser_delegatesToDao() = runTest {
         val userName = "testUser"
-        val mockHistoryList = listOf(RealmChatHistory().apply { user = userName })
+        val mockHistoryList = listOf(ChatHistory().apply { user = userName })
         coEvery { chatDao.getByUser(userName) } returns mockHistoryList
 
         val result = chatRepository.getChatHistoryForUser(userName)
@@ -90,9 +90,9 @@ class ChatRepositoryImplTest {
     @Test
     fun getLatestRev_findsHighestRevByNumericPrefix() = runTest {
         val id = "123"
-        val item1 = RealmChatHistory().apply { _rev = "1-abc" }
-        val item2 = RealmChatHistory().apply { _rev = "10-def" }
-        val item3 = RealmChatHistory().apply { _rev = "2-ghi" }
+        val item1 = ChatHistory().apply { _rev = "1-abc" }
+        val item2 = ChatHistory().apply { _rev = "10-def" }
+        val item3 = ChatHistory().apply { _rev = "2-ghi" }
         coEvery { chatDao.getByDocId(id) } returns listOf(item1, item2, item3)
 
         val result = chatRepository.getLatestRev(id)
@@ -112,7 +112,7 @@ class ChatRepositoryImplTest {
             addProperty("_rev", "2-rev")
             add("conversations", JsonArray())
         }
-        val slot = slot<List<RealmChatHistory>>()
+        val slot = slot<List<ChatHistory>>()
         coEvery { chatDao.upsertAll(capture(slot)) } returns Unit
 
         chatRepository.insertChatHistoryList(listOf(chatObj1, chatObj2))
@@ -130,7 +130,7 @@ class ChatRepositoryImplTest {
             add("conversations", JsonArray())
         }
         val wrapper = JsonObject().apply { add("doc", chatDoc) }
-        val slot = slot<List<RealmChatHistory>>()
+        val slot = slot<List<ChatHistory>>()
         coEvery { chatDao.upsertAll(capture(slot)) } returns Unit
 
         chatRepository.insertChatHistoryFromSync(listOf(wrapper))

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -21,7 +21,7 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmMyCourse
-import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.Utilities
 
@@ -178,7 +178,7 @@ class CoursesRepositoryImplTest {
 
     @Test
     fun `saveSearchActivity writes course search activity to Room`() = runTest {
-        val savedActivity = slot<RealmSearchActivity>()
+        val savedActivity = slot<SearchActivity>()
 
         repository.saveSearchActivity(
             searchText = "algebra",

--- a/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
@@ -22,7 +22,7 @@ import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
 import org.ole.planet.myplanet.model.MeetupCreationParams
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.SystemTimeProvider
 
@@ -50,7 +50,7 @@ class EventsRepositoryImplTest {
 
     @Test
     fun getMeetupsForTeam() = runTest {
-        coEvery { meetupDao.getByTeamId("team1") } returns listOf(RealmMeetup().apply { id = "1" })
+        coEvery { meetupDao.getByTeamId("team1") } returns listOf(Meetup().apply { id = "1" })
 
         val result = repository.getMeetupsForTeam("team1")
 
@@ -60,7 +60,7 @@ class EventsRepositoryImplTest {
 
     @Test
     fun getMeetupById() = runTest {
-        val mockMeetup = RealmMeetup().apply { meetupId = "meetup1" }
+        val mockMeetup = Meetup().apply { meetupId = "meetup1" }
         coEvery { meetupDao.getByMeetupId("meetup1") } returns mockMeetup
 
         val result = repository.getMeetupById("meetup1")
@@ -78,9 +78,9 @@ class EventsRepositoryImplTest {
         val mockUserQuery = mockk<RealmQuery<RealmUser>>(relaxed = true)
 
         coEvery { meetupDao.getMembersByMeetupId("meetup1") } returns listOf(
-            RealmMeetup().apply { userId = "user1" },
-            RealmMeetup().apply { userId = "user2" },
-            RealmMeetup().apply { userId = "user1" } // duplicate
+            Meetup().apply { userId = "user1" },
+            Meetup().apply { userId = "user2" },
+            Meetup().apply { userId = "user1" } // duplicate
         )
 
         every { mockRealm.where(RealmUser::class.java) } returns mockUserQuery
@@ -105,7 +105,7 @@ class EventsRepositoryImplTest {
 
     @Test
     fun toggleAttendance() = runTest {
-        val meetup = RealmMeetup().apply { meetupId = "meetup1" }
+        val meetup = Meetup().apply { meetupId = "meetup1" }
         coEvery { meetupDao.getByMeetupId("meetup1") } returns meetup
 
         // Test joining (userId empty -> currentUserId)
@@ -138,7 +138,7 @@ class EventsRepositoryImplTest {
         val count = repository.batchInsertMeetups(docs)
         assertEquals(2, count)
 
-        val slot = slot<List<RealmMeetup>>()
+        val slot = slot<List<Meetup>>()
         coVerify(exactly = 1) { meetupDao.upsertAll(capture(slot)) }
         assertEquals(2, slot.captured.size)
     }
@@ -147,7 +147,7 @@ class EventsRepositoryImplTest {
     fun batchInsertMeetupsSkipsLocallyUpdated() = runTest {
         val docs = listOf(JsonObject().apply { addProperty("_id", "m1") })
         coEvery { meetupDao.getByMeetupIds(any()) } returns listOf(
-            RealmMeetup().apply { meetupId = "m1"; updated = true }
+            Meetup().apply { meetupId = "m1"; updated = true }
         )
 
         val count = repository.batchInsertMeetups(docs)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/FeedbackRepositoryImplTest.kt
@@ -10,7 +10,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.FeedbackDao
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FeedbackRepositoryImplTest {
@@ -26,8 +26,8 @@ class FeedbackRepositoryImplTest {
 
     @Test
     fun getPendingFeedback_returnsOnlyUnuploadedFeedback() = runTest {
-        val feedback1 = RealmFeedback().apply { isUploaded = false }
-        val feedback2 = RealmFeedback().apply { isUploaded = false }
+        val feedback1 = Feedback().apply { isUploaded = false }
+        val feedback2 = Feedback().apply { isUploaded = false }
         coEvery { feedbackDao.getPending() } returns listOf(feedback1, feedback2)
 
         val result = repository.getPendingFeedback()

--- a/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
@@ -33,7 +33,7 @@ import org.ole.planet.myplanet.data.room.dao.HealthExaminationDao
 import org.ole.planet.myplanet.data.applyEqualTo
 import org.ole.planet.myplanet.data.findCopyByField
 import org.ole.planet.myplanet.data.queryList
-import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.HealthExamination
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.utils.AndroidDecrypter
 import org.ole.planet.myplanet.utils.DispatcherProvider
@@ -49,10 +49,10 @@ class HealthRepositoryImplTest {
     private val mockApiInterface: ApiInterface = mockk(relaxed = true)
     private val healthExaminationDao: HealthExaminationDao = mockk(relaxed = true)
     private val realm: Realm = mockk(relaxed = true)
-    private val healthQuery: RealmQuery<RealmHealthExamination> = mockk(relaxed = true)
+    private val healthQuery: RealmQuery<HealthExamination> = mockk(relaxed = true)
     private val userQuery: RealmQuery<RealmUser> = mockk(relaxed = true)
-    private val healthResults: RealmResults<RealmHealthExamination> = mockk(relaxed = true)
-    private val healthResultsIterable = mutableListOf<RealmHealthExamination>()
+    private val healthResults: RealmResults<HealthExamination> = mockk(relaxed = true)
+    private val healthResultsIterable = mutableListOf<HealthExamination>()
 
     @Before
     fun setUp() {
@@ -97,7 +97,7 @@ class HealthRepositoryImplTest {
         unmockkObject(AndroidDecrypter)
         unmockkStatic("org.ole.planet.myplanet.data.DatabaseServiceKt")
         unmockkObject(JsonUtils)
-        unmockkObject(RealmHealthExamination.Companion)
+        unmockkObject(HealthExamination.Companion)
     }
 
     @Test
@@ -117,7 +117,7 @@ class HealthRepositoryImplTest {
     fun getHealthEntry_returns_user_and_examination() = testScope.runTest {
         val user = RealmUser()
         user.id = "user1"
-        val examination = RealmHealthExamination()
+        val examination = HealthExamination()
         examination._id = "user1"
 
         every { realm.findCopyByField(RealmUser::class.java, "_id", "user1") } returns null
@@ -135,7 +135,7 @@ class HealthRepositoryImplTest {
     fun getHealthEntry_fallback_to_userId() = testScope.runTest {
         val user = RealmUser()
         user.id = "user1"
-        val examination = RealmHealthExamination()
+        val examination = HealthExamination()
         examination._id = "exam1"
         examination.userId = "user1"
 
@@ -152,7 +152,7 @@ class HealthRepositoryImplTest {
 
     @Test
     fun getExaminationById_returns_examination() = testScope.runTest {
-        val examination = RealmHealthExamination()
+        val examination = HealthExamination()
         examination._id = "exam1"
 
         coEvery { healthExaminationDao.getById("exam1") } returns examination
@@ -165,7 +165,7 @@ class HealthRepositoryImplTest {
 
     @Test
     fun getUpdatedHealthExaminations_returns_list() = testScope.runTest {
-        val examination = RealmHealthExamination().apply {
+        val examination = HealthExamination().apply {
             _id = "exam1"
             isUpdated = true
         }
@@ -180,7 +180,7 @@ class HealthRepositoryImplTest {
 
     @Test
     fun getUpdatedHealthForUser_returns_list() = testScope.runTest {
-        val examination = RealmHealthExamination().apply {
+        val examination = HealthExamination().apply {
             _id = "exam1"
             isUpdated = true
             userId = "user1"
@@ -207,8 +207,8 @@ class HealthRepositoryImplTest {
 
     @Test
     fun saveExamination_saves_objects_to_realm() = testScope.runTest {
-        val examination = RealmHealthExamination()
-        val pojo = RealmHealthExamination()
+        val examination = HealthExamination()
+        val pojo = HealthExamination()
         val user = RealmUser()
 
         repository.saveExamination(examination, pojo, user)
@@ -220,7 +220,7 @@ class HealthRepositoryImplTest {
 
     @Test
     fun saveExamination_handles_nulls() = testScope.runTest {
-        val examination = RealmHealthExamination()
+        val examination = HealthExamination()
 
         repository.saveExamination(examination, null, null)
         advanceUntilIdle()
@@ -230,7 +230,7 @@ class HealthRepositoryImplTest {
 
     @Test
     fun updateExaminationUserId_updates_id() = testScope.runTest {
-        val examination = RealmHealthExamination()
+        val examination = HealthExamination()
         examination._id = "exam1"
         examination.userId = "old_user"
 
@@ -250,7 +250,7 @@ class HealthRepositoryImplTest {
     @Test
     fun getExaminationConditions_returns_map_for_valid_json() = testScope.runTest {
         mockkObject(JsonUtils)
-        val examination = RealmHealthExamination()
+        val examination = HealthExamination()
         examination.conditions = "{\"Fever\": true, \"Cough\": false}"
 
         val jsonObject = JsonObject()
@@ -270,7 +270,7 @@ class HealthRepositoryImplTest {
 
     @Test
     fun getExaminationConditions_returns_empty_map_for_malformed_json() = testScope.runTest {
-        val examination = RealmHealthExamination()
+        val examination = HealthExamination()
         examination.conditions = "malformed json"
 
         val result = repository.getExaminationConditions(examination)
@@ -282,7 +282,7 @@ class HealthRepositoryImplTest {
     @Test
     fun bulkInsertFromSync_inserts_items() = testScope.runTest {
         mockkObject(JsonUtils)
-        mockkObject(RealmHealthExamination.Companion)
+        mockkObject(HealthExamination.Companion)
 
         val jsonArray = JsonArray()
         val doc1 = JsonObject()
@@ -304,13 +304,13 @@ class HealthRepositoryImplTest {
         every { JsonUtils.getJsonObject("doc", item2) } returns doc2
         every { JsonUtils.getString("_id", doc2) } returns "_design/doc"
 
-        val detachedExamination = mockk<RealmHealthExamination>()
-        every { RealmHealthExamination.fromJson(doc1) } returns detachedExamination
+        val detachedExamination = mockk<HealthExamination>()
+        every { HealthExamination.fromJson(doc1) } returns detachedExamination
         repository.bulkInsertFromSync(jsonArray)
         advanceUntilIdle()
 
-        verify(exactly = 1) { RealmHealthExamination.fromJson(doc1) }
-        verify(exactly = 0) { RealmHealthExamination.fromJson(doc2) }
+        verify(exactly = 1) { HealthExamination.fromJson(doc1) }
+        verify(exactly = 0) { HealthExamination.fromJson(doc2) }
         coVerify(exactly = 1) { healthExaminationDao.upsertAll(listOf(detachedExamination)) }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/LifeRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/LifeRepositoryImplTest.kt
@@ -17,7 +17,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
-import org.ole.planet.myplanet.model.RealmMyLife
+import org.ole.planet.myplanet.model.MyLife
 import org.ole.planet.myplanet.services.SharedPrefManager
 
 class LifeRepositoryImplTest {
@@ -55,8 +55,8 @@ class LifeRepositoryImplTest {
     @Test
     fun getMyLifeByUserId_returnsDaoResult() = runTest {
         val userId = "user123"
-        val item1 = RealmMyLife().apply { weight = 1; this.userId = userId }
-        val item2 = RealmMyLife().apply { weight = 2; this.userId = userId }
+        val item1 = MyLife().apply { weight = 1; this.userId = userId }
+        val item2 = MyLife().apply { weight = 2; this.userId = userId }
         coEvery { myLifeDao.getByUserId(userId) } returns listOf(item1, item2)
 
         val result = repository.getMyLifeByUserId(userId)
@@ -89,17 +89,17 @@ class LifeRepositoryImplTest {
 
     @Test
     fun updateMyLifeListOrder_updatesWeightBasedOnListIndex() = runTest {
-        val item1 = RealmMyLife().apply { _id = "1"; weight = 0; userId = "u" }
-        val item2 = RealmMyLife().apply { _id = "2"; weight = 0; userId = "u" }
+        val item1 = MyLife().apply { _id = "1"; weight = 0; userId = "u" }
+        val item2 = MyLife().apply { _id = "2"; weight = 0; userId = "u" }
         val list = listOf(item1, item2)
 
         // Managed rows come back with mismatched weights so both need updating.
-        val managedItem1 = RealmMyLife().apply { _id = "1"; weight = 5 }
-        val managedItem2 = RealmMyLife().apply { _id = "2"; weight = 5 }
+        val managedItem1 = MyLife().apply { _id = "1"; weight = 5 }
+        val managedItem2 = MyLife().apply { _id = "2"; weight = 5 }
         coEvery { myLifeDao.getByIds(any()) } returns listOf(managedItem1, managedItem2)
         coEvery { myLifeDao.getByUserId("u") } returns emptyList()
 
-        val updatedSlot = slot<List<RealmMyLife>>()
+        val updatedSlot = slot<List<MyLife>>()
         coEvery { myLifeDao.update(capture(updatedSlot)) } returns Unit
 
         repository.updateMyLifeListOrder(list)
@@ -122,12 +122,12 @@ class LifeRepositoryImplTest {
     fun seedMyLifeIfEmpty_insertsItemsWhenNoExistingData() = runTest {
         val userId = "user123"
         val items = listOf(
-            RealmMyLife().apply { title = "Title1"; imageId = "img1"; this.userId = userId },
-            RealmMyLife().apply { title = "Title2"; imageId = "img2"; this.userId = userId }
+            MyLife().apply { title = "Title1"; imageId = "img1"; this.userId = userId },
+            MyLife().apply { title = "Title2"; imageId = "img2"; this.userId = userId }
         )
         coEvery { myLifeDao.countByUserId(userId) } returns 0
 
-        val insertedItemsSlot = slot<List<RealmMyLife>>()
+        val insertedItemsSlot = slot<List<MyLife>>()
         coEvery { myLifeDao.insertAll(capture(insertedItemsSlot)) } returns Unit
 
         repository.seedMyLifeIfEmpty(userId, items)
@@ -148,7 +148,7 @@ class LifeRepositoryImplTest {
     @Test
     fun seedMyLifeIfEmpty_skipsWhenDataExists() = runTest {
         val userId = "user123"
-        val items = listOf(RealmMyLife().apply { title = "Title1"; this.userId = userId })
+        val items = listOf(MyLife().apply { title = "Title1"; this.userId = userId })
         coEvery { myLifeDao.countByUserId(userId) } returns 3
 
         repository.seedMyLifeIfEmpty(userId, items)
@@ -181,8 +181,8 @@ class LifeRepositoryImplTest {
         val userId = "789"
         every { mockSharedPreferences.getString("myLifeCache_$userId", null) } returns "invalid_json"
 
-        val item1 = RealmMyLife().apply { weight = 1; this.userId = userId; this.isVisible = true }
-        val item2 = RealmMyLife().apply { weight = 2; this.userId = userId; this.isVisible = true }
+        val item1 = MyLife().apply { weight = 1; this.userId = userId; this.isVisible = true }
+        val item2 = MyLife().apply { weight = 2; this.userId = userId; this.isVisible = true }
         coEvery { myLifeDao.getByUserId(userId) } returns listOf(item1, item2)
 
         val result = repository.getMyLifeForDashboard(userId, emptyList())

--- a/app/src/test/java/org/ole/planet/myplanet/repository/LifeRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/LifeRepositoryTest.kt
@@ -15,7 +15,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.MyLifeDao
-import org.ole.planet.myplanet.model.RealmMyLife
+import org.ole.planet.myplanet.model.MyLife
 import org.ole.planet.myplanet.services.SharedPrefManager
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -52,11 +52,11 @@ class LifeRepositoryTest {
     @Test
     fun updateMyLifeListOrder_itemNotInList_weightNotUpdated() = runTest {
         // The reorder list only contains item with _id "3".
-        val listItem = RealmMyLife().apply { _id = "3"; userId = "u" }
+        val listItem = MyLife().apply { _id = "3"; userId = "u" }
 
         // The managed rows retrieved from the DB have ids "1" and "2" (not in the list).
-        val managedItem1 = RealmMyLife().apply { _id = "1"; weight = 99 }
-        val managedItem2 = RealmMyLife().apply { _id = "2"; weight = 99 }
+        val managedItem1 = MyLife().apply { _id = "1"; weight = 99 }
+        val managedItem2 = MyLife().apply { _id = "2"; weight = 99 }
         coEvery { myLifeDao.getByIds(any()) } returns listOf(managedItem1, managedItem2)
 
         repository.updateMyLifeListOrder(listOf(listItem))

--- a/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.NotificationDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
-import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.model.AppNotification
 import org.ole.planet.myplanet.utils.TestTimeProvider
 
 @ExperimentalCoroutinesApi
@@ -43,7 +43,7 @@ class NotificationsRepositoryImplTest {
 
     @Test
     fun `test default property values`() {
-        val notification = RealmNotification()
+        val notification = AppNotification()
         assertNotNull(notification.id)
         assertEquals("", notification.userId)
         assertEquals("", notification.message)
@@ -82,7 +82,7 @@ class NotificationsRepositoryImplTest {
             addProperty("time", 123456789L)
         }
         coEvery { notificationDao.getById("testId") } returns null
-        val upsertSlot = slot<RealmNotification>()
+        val upsertSlot = slot<AppNotification>()
         coEvery { notificationDao.upsert(capture(upsertSlot)) } returns Unit
 
         repository.insert(jsonObject)
@@ -101,7 +101,7 @@ class NotificationsRepositoryImplTest {
 
     @Test
     fun `insert updates existing notification`() = runTest {
-        val existing = RealmNotification().apply { id = "testId" }
+        val existing = AppNotification().apply { id = "testId" }
         val jsonObject = JsonObject().apply {
             addProperty("_id", "testId")
             addProperty("user", "updatedUser")
@@ -111,7 +111,7 @@ class NotificationsRepositoryImplTest {
             addProperty("time", 987654321L)
         }
         coEvery { notificationDao.getById("testId") } returns existing
-        val upsertSlot = slot<RealmNotification>()
+        val upsertSlot = slot<AppNotification>()
         coEvery { notificationDao.upsert(capture(upsertSlot)) } returns Unit
 
         repository.insert(jsonObject)
@@ -127,7 +127,7 @@ class NotificationsRepositoryImplTest {
 
     @Test
     fun `insert preserves read status if needsSync is true`() = runTest {
-        val existing = RealmNotification().apply {
+        val existing = AppNotification().apply {
             id = "testId"
             isRead = true
             needsSync = true
@@ -137,7 +137,7 @@ class NotificationsRepositoryImplTest {
             addProperty("status", "unread")
         }
         coEvery { notificationDao.getById("testId") } returns existing
-        val upsertSlot = slot<RealmNotification>()
+        val upsertSlot = slot<AppNotification>()
         coEvery { notificationDao.upsert(capture(upsertSlot)) } returns Unit
 
         repository.insert(jsonObject)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
@@ -20,7 +20,7 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.PersonalDao
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Personal
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PersonalsRepositoryImplTest {
@@ -64,7 +64,7 @@ class PersonalsRepositoryImplTest {
 
     @Test
     fun `savePersonalResource sets id and properties before saving`() = runTest {
-        val savedObjectSlot = slot<RealmMyPersonal>()
+        val savedObjectSlot = slot<Personal>()
         coEvery { personalDao.insert(capture(savedObjectSlot)) } returns Unit
 
         repository.savePersonalResource(
@@ -96,7 +96,7 @@ class PersonalsRepositoryImplTest {
 
     @Test
     fun `getPersonalResources returns flow of personals for valid userId`() = runTest {
-        val expectedList = listOf(RealmMyPersonal())
+        val expectedList = listOf(Personal())
         coEvery { personalDao.getByUserIdFlow("user1") } returns flowOf(expectedList)
 
         val result = repository.getPersonalResources("user1").first()
@@ -115,8 +115,8 @@ class PersonalsRepositoryImplTest {
 
     @Test
     fun `updatePersonalResource calls updater on matched _id and id`() = runTest {
-        val personalByDocId = RealmMyPersonal().apply { title = "Old" }
-        val personalById = RealmMyPersonal().apply { title = "Old" }
+        val personalByDocId = Personal().apply { title = "Old" }
+        val personalById = Personal().apply { title = "Old" }
         coEvery { personalDao.findByDocId("test-id") } returns personalByDocId
         coEvery { personalDao.findById("test-id") } returns personalById
 
@@ -135,7 +135,7 @@ class PersonalsRepositoryImplTest {
 
     @Test
     fun `getPendingPersonalUploads queries correctly`() = runTest {
-        coEvery { personalDao.getPendingUploads("user1") } returns listOf(RealmMyPersonal(), RealmMyPersonal())
+        coEvery { personalDao.getPendingUploads("user1") } returns listOf(Personal(), Personal())
 
         val results = repository.getPendingPersonalUploads("user1")
 
@@ -145,7 +145,7 @@ class PersonalsRepositoryImplTest {
 
     @Test
     fun `updatePersonalAfterSync updates fields properly`() = runTest {
-        val personal = RealmMyPersonal()
+        val personal = Personal()
         coEvery { personalDao.findById("test-id") } returns personal
 
         repository.updatePersonalAfterSync("test-id", "new-id", "rev-1")

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
@@ -22,7 +22,7 @@ import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.model.RealmAnswer
-import org.ole.planet.myplanet.model.RealmCourseProgress
+import org.ole.planet.myplanet.model.CourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmExamQuestion
 import org.ole.planet.myplanet.model.RealmMyCourse
@@ -95,8 +95,8 @@ class ProgressRepositoryImplTest {
 
         // Steps 1 and 3 are present, 2 is missing. The gap is at step 2, so progress should be 1.
         val progresses = listOf(
-            RealmCourseProgress().apply { stepNum = 1 },
-            RealmCourseProgress().apply { stepNum = 3 }
+            CourseProgress().apply { stepNum = 1 },
+            CourseProgress().apply { stepNum = 3 }
         )
 
         coEvery { courseProgressDao.getByUserAndCourse("user1", "course1") } returns progresses
@@ -107,9 +107,9 @@ class ProgressRepositoryImplTest {
 
         // Now test where 1, 2, 3 are present, 4 is missing, to ensure it doesn't just always return 1
         val progresses2 = listOf(
-            RealmCourseProgress().apply { stepNum = 1 },
-            RealmCourseProgress().apply { stepNum = 2 },
-            RealmCourseProgress().apply { stepNum = 3 }
+            CourseProgress().apply { stepNum = 1 },
+            CourseProgress().apply { stepNum = 2 },
+            CourseProgress().apply { stepNum = 3 }
         )
 
         coEvery { courseProgressDao.getByUserAndCourse("user1", "course1") } returns progresses2
@@ -127,8 +127,8 @@ class ProgressRepositoryImplTest {
         )
 
         val progresses = listOf(
-            RealmCourseProgress().apply { stepNum = 1 },
-            RealmCourseProgress().apply { stepNum = 2 }
+            CourseProgress().apply { stepNum = 1 },
+            CourseProgress().apply { stepNum = 2 }
         )
 
         coEvery { courseProgressDao.getByUserAndCourse("user1", "course1") } returns progresses
@@ -187,7 +187,7 @@ class ProgressRepositoryImplTest {
             repository invoke "queryList" withArguments listOf(RealmCourseStep::class.java, any<Function1<RealmQuery<RealmCourseStep>, Unit>>())
         } returns steps
 
-        coEvery { courseProgressDao.getByUserAndCourseIds("user1", listOf("course1")) } returns listOf(RealmCourseProgress().apply {
+        coEvery { courseProgressDao.getByUserAndCourseIds("user1", listOf("course1")) } returns listOf(CourseProgress().apply {
             stepNum = 1
             courseId = "course1"
         })
@@ -232,7 +232,7 @@ class ProgressRepositoryImplTest {
         val steps1 = listOf(RealmCourseStep().apply { courseId = "course1" })
         val steps2 = listOf(RealmCourseStep().apply { courseId = "course2" }, RealmCourseStep().apply { courseId = "course2" })
 
-        val progresses1 = listOf(RealmCourseProgress().apply { courseId = "course1"; stepNum = 1 })
+        val progresses1 = listOf(CourseProgress().apply { courseId = "course1"; stepNum = 1 })
 
         coEvery {
             repository invoke "queryList" withArguments listOf(RealmCourseStep::class.java, any<Function1<RealmQuery<RealmCourseStep>, Unit>>())
@@ -254,8 +254,8 @@ class ProgressRepositoryImplTest {
     @Test
     fun testGetProgressRecords() = testScope.runTest {
         val progresses = listOf(
-            RealmCourseProgress().apply { userId = "user1"; courseId = "course1" },
-            RealmCourseProgress().apply { userId = "user1"; courseId = "course2" }
+            CourseProgress().apply { userId = "user1"; courseId = "course1" },
+            CourseProgress().apply { userId = "user1"; courseId = "course2" }
         )
 
         coEvery { courseProgressDao.getByUser("user1") } returns progresses
@@ -283,8 +283,8 @@ class ProgressRepositoryImplTest {
         )
 
         val progresses = listOf(
-            RealmCourseProgress().apply { courseId = "course1"; stepNum = 1; passed = true },
-            RealmCourseProgress().apply { courseId = "course2"; stepNum = 1; passed = true }
+            CourseProgress().apply { courseId = "course1"; stepNum = 1; passed = true },
+            CourseProgress().apply { courseId = "course2"; stepNum = 1; passed = true }
         )
 
         coEvery { mockCoursesRepository.getMyCourses("user1") } returns myCourses
@@ -380,7 +380,7 @@ class ProgressRepositoryImplTest {
             addProperty("stepNum", 1)
             addProperty("passed", false)
         }
-        val existingProgress = RealmCourseProgress().apply {
+        val existingProgress = CourseProgress().apply {
             id = "local1"
             _id = null
             passed = true
@@ -414,7 +414,7 @@ class ProgressRepositoryImplTest {
         )
 
         val progresses = listOf(
-            RealmCourseProgress().apply { courseId = "course1"; stepNum = 1; passed = true }
+            CourseProgress().apply { courseId = "course1"; stepNum = 1; passed = true }
         )
 
         coEvery { mockCoursesRepository.getMyCourses("user1") } returns myCourses

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RatingsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RatingsRepositoryImplTest.kt
@@ -18,7 +18,7 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.RatingDao
-import org.ole.planet.myplanet.model.RealmRating
+import org.ole.planet.myplanet.model.Rating
 import org.ole.planet.myplanet.model.RealmUser
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -59,8 +59,8 @@ class RatingsRepositoryImplTest {
 
     @Test
     fun `getRatings aggregates ratings properly`() = runTest {
-        val rating1 = RealmRating().apply { type = "course"; item = "course1"; rate = 4; userId = "user1" }
-        val rating2 = RealmRating().apply { type = "course"; item = "course1"; rate = 5; userId = "user2" }
+        val rating1 = Rating().apply { type = "course"; item = "course1"; rate = 4; userId = "user1" }
+        val rating2 = Rating().apply { type = "course"; item = "course1"; rate = 5; userId = "user2" }
         coEvery { ratingDao.getByType("course") } returns listOf(rating1, rating2)
 
         val result = repository.getRatings("course", "user1")
@@ -75,7 +75,7 @@ class RatingsRepositoryImplTest {
 
     @Test
     fun `getRatingsById returns specific aggregated rating`() = runTest {
-        val rating = RealmRating().apply { type = "course"; item = "course1"; rate = 5; userId = "user1" }
+        val rating = Rating().apply { type = "course"; item = "course1"; rate = 5; userId = "user1" }
         coEvery { ratingDao.getByTypeAndItem("course", "course1") } returns listOf(rating)
 
         val result = repository.getRatingsById("course", "course1", "user1")
@@ -88,7 +88,7 @@ class RatingsRepositoryImplTest {
 
     @Test
     fun `getCourseRatings returns aggregated course ratings`() = runTest {
-        val rating = RealmRating().apply { type = "course"; item = "course1"; rate = 3; userId = "user1" }
+        val rating = Rating().apply { type = "course"; item = "course1"; rate = 3; userId = "user1" }
         coEvery { ratingDao.getByType("course") } returns listOf(rating)
 
         val result = repository.getCourseRatings("user1")
@@ -99,7 +99,7 @@ class RatingsRepositoryImplTest {
 
     @Test
     fun `getResourceRatings returns aggregated resource ratings`() = runTest {
-        val rating = RealmRating().apply { type = "resource"; item = "resource1"; rate = 5; userId = "user1" }
+        val rating = Rating().apply { type = "resource"; item = "resource1"; rate = 5; userId = "user1" }
         coEvery { ratingDao.getByType("resource") } returns listOf(rating)
 
         val result = repository.getResourceRatings("user1")
@@ -110,8 +110,8 @@ class RatingsRepositoryImplTest {
 
     @Test
     fun `getRatingSummary returns correct summary`() = runTest {
-        val userRating = RealmRating().apply { id = "rating1"; rate = 5; comment = "Great"; userId = "user1" }
-        val other = RealmRating().apply { id = "rating2"; rate = 4; userId = "user2" }
+        val userRating = Rating().apply { id = "rating1"; rate = 5; comment = "Great"; userId = "user1" }
+        val other = Rating().apply { id = "rating2"; rate = 4; userId = "user2" }
         coEvery { ratingDao.getByTypeAndItem("course", "course1") } returns listOf(userRating, other)
 
         val summary = repository.getRatingSummary("course", "course1", "user1")
@@ -140,10 +140,10 @@ class RatingsRepositoryImplTest {
     fun `submitRating inserts new rating if not exists`() = runTest {
         mockUserLookup(RealmUser().apply { id = "user1"; _id = "user1" })
         coEvery { ratingDao.findByTypeUserItem("course", "user1", "course1") } returns null
-        val savedSlot = slot<RealmRating>()
+        val savedSlot = slot<Rating>()
         coEvery { ratingDao.upsert(capture(savedSlot)) } returns Unit
         coEvery { ratingDao.getByTypeAndItem("course", "course1") } returns listOf(
-            RealmRating().apply { rate = 4; userId = "user1" }
+            Rating().apply { rate = 4; userId = "user1" }
         )
 
         val summary = repository.submitRating("course", "course1", "Good", "user1", 4f, "Nice")
@@ -159,7 +159,7 @@ class RatingsRepositoryImplTest {
     @Test
     fun `submitRating updates existing rating if it exists`() = runTest {
         mockUserLookup(RealmUser().apply { id = "user1"; _id = "user1" })
-        val existingRating = RealmRating().apply { id = "existing_id"; rate = 3 }
+        val existingRating = Rating().apply { id = "existing_id"; rate = 3 }
         coEvery { ratingDao.findByTypeUserItem("course", "user1", "course1") } returns existingRating
         coEvery { ratingDao.findById("existing_id") } returns existingRating
         coEvery { ratingDao.update(any()) } returns Unit
@@ -189,7 +189,7 @@ class RatingsRepositoryImplTest {
 
     @Test
     fun `insertRatingsFromSync upserts mapped entities`() = runTest {
-        val savedSlot = slot<List<RealmRating>>()
+        val savedSlot = slot<List<Rating>>()
         coEvery { ratingDao.upsertAll(capture(savedSlot)) } returns Unit
 
         val docs = listOf(

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -26,7 +26,7 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.Utilities
 
@@ -285,7 +285,7 @@ class ResourcesRepositoryImplTest {
 
     @Test
     fun `saveSearchActivity writes resource search activity to Room`() = runTest {
-        val savedActivity = slot<RealmSearchActivity>()
+        val savedActivity = slot<SearchActivity>()
 
         repository.saveSearchActivity(
             userName = "learner",

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
@@ -11,7 +11,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.RetryDao
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 import org.ole.planet.myplanet.model.RetryFailure
 import org.ole.planet.myplanet.utils.TestTimeProvider
 
@@ -34,7 +34,7 @@ class RetryRepositoryImplTest {
 
     @Test
     fun `enqueue inserts a created operation`() = runTest {
-        val insertedSlot = slot<RealmRetryOperation>()
+        val insertedSlot = slot<RetryOperation>()
         coEvery { retryDao.insert(capture(insertedSlot)) } returns Unit
 
         val retryFailure = RetryFailure("itemId", "test error", 500)
@@ -52,14 +52,14 @@ class RetryRepositoryImplTest {
         assertEquals("testDbId", op.dbId)
         assertEquals("TestClass", op.modelClassName)
         assertEquals("testUserId", op.userId)
-        assertEquals(RealmRetryOperation.STATUS_PENDING, op.status)
+        assertEquals(RetryOperation.STATUS_PENDING, op.status)
         assertEquals(1, op.attemptCount)
         assertEquals(500, op.httpCode)
     }
 
     @Test
     fun `updateAttempt updates operation fields`() = runTest {
-        val operation = RealmRetryOperation().apply { attemptCount = 1; maxAttempts = 5 }
+        val operation = RetryOperation().apply { attemptCount = 1; maxAttempts = 5 }
         coEvery { retryDao.findById("opId") } returns operation
 
         repository.updateAttempt("opId", RetryFailure("itemId", "Test Error", 503))
@@ -73,46 +73,46 @@ class RetryRepositoryImplTest {
 
     @Test
     fun `updateAttempt changes status to abandoned when max attempts reached`() = runTest {
-        val operation = RealmRetryOperation().apply {
-            attemptCount = 4; maxAttempts = 5; status = RealmRetryOperation.STATUS_PENDING
+        val operation = RetryOperation().apply {
+            attemptCount = 4; maxAttempts = 5; status = RetryOperation.STATUS_PENDING
         }
         coEvery { retryDao.findById("opId") } returns operation
 
         repository.updateAttempt("opId", RetryFailure("itemId", "Unknown error", null))
 
         assertEquals(5, operation.attemptCount)
-        assertEquals(RealmRetryOperation.STATUS_ABANDONED, operation.status)
+        assertEquals(RetryOperation.STATUS_ABANDONED, operation.status)
     }
 
     @Test
     fun `markInProgress updates status`() = runTest {
-        val operation = RealmRetryOperation().apply { status = RealmRetryOperation.STATUS_PENDING }
+        val operation = RetryOperation().apply { status = RetryOperation.STATUS_PENDING }
         coEvery { retryDao.findById("opId") } returns operation
 
         repository.markInProgress("opId")
 
-        assertEquals(RealmRetryOperation.STATUS_IN_PROGRESS, operation.status)
+        assertEquals(RetryOperation.STATUS_IN_PROGRESS, operation.status)
         coVerify { retryDao.update(operation) }
     }
 
     @Test
     fun `markCompleted updates status and timestamp`() = runTest {
-        val operation = RealmRetryOperation().apply {
-            status = RealmRetryOperation.STATUS_PENDING; lastAttemptTime = 0
+        val operation = RetryOperation().apply {
+            status = RetryOperation.STATUS_PENDING; lastAttemptTime = 0
         }
         coEvery { retryDao.findById("opId") } returns operation
 
         repository.markCompleted("opId")
 
-        assertEquals(RealmRetryOperation.STATUS_COMPLETED, operation.status)
+        assertEquals(RetryOperation.STATUS_COMPLETED, operation.status)
         assert(operation.lastAttemptTime > 0)
         coVerify { retryDao.update(operation) }
     }
 
     @Test
     fun `markFailed updates status to pending when attempts remain`() = runTest {
-        val operation = RealmRetryOperation().apply {
-            attemptCount = 1; maxAttempts = 5; status = RealmRetryOperation.STATUS_IN_PROGRESS
+        val operation = RetryOperation().apply {
+            attemptCount = 1; maxAttempts = 5; status = RetryOperation.STATUS_IN_PROGRESS
         }
         coEvery { retryDao.findById("opId") } returns operation
 
@@ -121,26 +121,26 @@ class RetryRepositoryImplTest {
         assertEquals(2, operation.attemptCount)
         assertEquals("Fail reason", operation.errorMessage)
         assertEquals(404, operation.httpCode)
-        assertEquals(RealmRetryOperation.STATUS_PENDING, operation.status)
+        assertEquals(RetryOperation.STATUS_PENDING, operation.status)
         assert(operation.nextRetryTime > 0)
     }
 
     @Test
     fun `markFailed updates status to abandoned when max attempts reached`() = runTest {
-        val operation = RealmRetryOperation().apply {
-            attemptCount = 4; maxAttempts = 5; status = RealmRetryOperation.STATUS_IN_PROGRESS
+        val operation = RetryOperation().apply {
+            attemptCount = 4; maxAttempts = 5; status = RetryOperation.STATUS_IN_PROGRESS
         }
         coEvery { retryDao.findById("opId") } returns operation
 
         repository.markFailed("opId", "Fail reason", 500)
 
         assertEquals(5, operation.attemptCount)
-        assertEquals(RealmRetryOperation.STATUS_ABANDONED, operation.status)
+        assertEquals(RetryOperation.STATUS_ABANDONED, operation.status)
     }
 
     @Test
     fun `getPending returns dao result for current time`() = runTest {
-        val operation1 = RealmRetryOperation().apply { attemptCount = 1; maxAttempts = 5 }
+        val operation1 = RetryOperation().apply { attemptCount = 1; maxAttempts = 5 }
         coEvery { retryDao.getPending(timeProvider.now()) } returns listOf(operation1)
 
         val pending = repository.getPending()
@@ -160,7 +160,7 @@ class RetryRepositoryImplTest {
 
     @Test
     fun `getExistingOperation returns dao result`() = runTest {
-        val operation = RealmRetryOperation()
+        val operation = RetryOperation()
         coEvery { retryDao.findExisting("item123", "typeA") } returns operation
 
         val result = repository.getExistingOperation("item123", "typeA")

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TagsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TagsRepositoryImplTest.kt
@@ -12,7 +12,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.TagDao
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TagsRepositoryImplTest {
@@ -29,7 +29,7 @@ class TagsRepositoryImplTest {
 
     @Test
     fun `getTags delegates to getParentTags`() = runTest {
-        val mockResult = listOf(RealmTag().apply { name = "Tag1" })
+        val mockResult = listOf(TagEntity().apply { name = "Tag1" })
         coEvery { tagDao.getParentTags("resources") } returns mockResult
 
         val result = repository.getTags("resources")
@@ -39,27 +39,27 @@ class TagsRepositoryImplTest {
 
     @Test
     fun `getTagsWithChildren correctly maps children to parent tags`() = runTest {
-        val parentTag1 = RealmTag().apply {
+        val parentTag1 = TagEntity().apply {
             id = "parent1"
             name = "Parent 1"
         }
-        val parentTag2 = RealmTag().apply {
+        val parentTag2 = TagEntity().apply {
             id = "parent2"
             name = "Parent 2"
         }
-        val childlessParentTag = RealmTag().apply {
+        val childlessParentTag = TagEntity().apply {
             id = "parent3"
             name = "Parent 3"
         }
-        val child1 = RealmTag().apply {
+        val child1 = TagEntity().apply {
             name = "Child1"
             attachedTo = listOf("parent1")
         }
-        val child2 = RealmTag().apply {
+        val child2 = TagEntity().apply {
             name = "Child2"
             attachedTo = listOf("parent1", "parent2")
         }
-        val unattachedChild = RealmTag().apply {
+        val unattachedChild = TagEntity().apply {
             name = "UnattachedChild"
         }
 
@@ -92,12 +92,12 @@ class TagsRepositoryImplTest {
     fun `getTagsForResource resolves linked tags through tagId lookup`() = runTest {
         val resourceId = "res1"
         val tagId = "tag1"
-        val linkTag = RealmTag().apply {
+        val linkTag = TagEntity().apply {
             db = "resources"
             linkId = resourceId
             this.tagId = tagId
         }
-        val parentTag = RealmTag().apply { id = tagId; name = "Parent Tag" }
+        val parentTag = TagEntity().apply { id = tagId; name = "Parent Tag" }
 
         coEvery { tagDao.getByDbAndLinkId("resources", resourceId) } returns listOf(linkTag)
         coEvery { tagDao.getByIds(listOf(tagId)) } returns listOf(parentTag)
@@ -111,18 +111,18 @@ class TagsRepositoryImplTest {
     @Test
     fun `getTagsForResources returns correct per-resource tag map`() = runTest {
         val resourceIds = listOf("res1", "res2")
-        val linkTag1 = RealmTag().apply {
+        val linkTag1 = TagEntity().apply {
             db = "resources"
             linkId = "res1"
             tagId = "tag1"
         }
-        val linkTag2 = RealmTag().apply {
+        val linkTag2 = TagEntity().apply {
             db = "resources"
             linkId = "res2"
             tagId = "tag2"
         }
-        val parentTag1 = RealmTag().apply { id = "tag1"; name = "Parent Tag 1" }
-        val parentTag2 = RealmTag().apply { id = "tag2"; name = "Parent Tag 2" }
+        val parentTag1 = TagEntity().apply { id = "tag1"; name = "Parent Tag 1" }
+        val parentTag2 = TagEntity().apply { id = "tag2"; name = "Parent Tag 2" }
 
         coEvery { tagDao.getByDbAndLinkIds("resources", resourceIds) } returns
             listOf(linkTag1, linkTag2)
@@ -160,7 +160,7 @@ class TagsRepositoryImplTest {
 
     @Test
     fun `getTagsForResource returns empty list when tags have no tagIds`() = runTest {
-        val linkWithoutTagId = RealmTag().apply {
+        val linkWithoutTagId = TagEntity().apply {
             db = "resources"
             linkId = "res1"
             tagId = null
@@ -172,7 +172,7 @@ class TagsRepositoryImplTest {
 
     @Test
     fun `getTagsForResources returns empty map when tags have no tagIds`() = runTest {
-        val linkWithoutTagId = RealmTag().apply {
+        val linkWithoutTagId = TagEntity().apply {
             db = "resources"
             linkId = "res1"
             tagId = null

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
@@ -18,7 +18,7 @@ import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
-import org.ole.planet.myplanet.model.RealmTeamLog
+import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UploadManager
 import org.ole.planet.myplanet.services.UserSessionManager

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -25,9 +25,9 @@ import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.model.CourseActivity
-import org.ole.planet.myplanet.model.RealmFeedback
-import org.ole.planet.myplanet.model.RealmMeetup
-import org.ole.planet.myplanet.model.RealmMyPersonal
+import org.ole.planet.myplanet.model.Feedback
+import org.ole.planet.myplanet.model.Meetup
+import org.ole.planet.myplanet.model.Personal
 import org.ole.planet.myplanet.model.Rating
 import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.RealmStepExam
@@ -154,7 +154,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadMeetups delegates to uploadCoordinator`() = testScope.runTest {
-        coEvery { uploadCoordinator.uploadRoom<RealmMeetup>(any()) } returns UploadResult.Success(1, emptyList())
+        coEvery { uploadCoordinator.uploadRoom<Meetup>(any()) } returns UploadResult.Success(1, emptyList())
         uploadManager.uploadMeetups()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.Meetups) }
@@ -170,7 +170,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadFeedback delegates to uploadCoordinator and returns true on Success`() = testScope.runTest {
-        coEvery { uploadCoordinator.uploadRoom<RealmFeedback>(any()) } returns UploadResult.Success(1, emptyList())
+        coEvery { uploadCoordinator.uploadRoom<Feedback>(any()) } returns UploadResult.Success(1, emptyList())
         val result = uploadManager.uploadFeedback()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.Feedback) }
@@ -179,7 +179,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadFeedback returns true on Empty`() = testScope.runTest {
-        coEvery { uploadCoordinator.uploadRoom<RealmFeedback>(any()) } returns UploadResult.Empty
+        coEvery { uploadCoordinator.uploadRoom<Feedback>(any()) } returns UploadResult.Empty
         val result = uploadManager.uploadFeedback()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.Feedback) }
@@ -188,7 +188,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadFeedback returns false on Failure`() = testScope.runTest {
-        coEvery { uploadCoordinator.uploadRoom<RealmFeedback>(any()) } returns UploadResult.Failure(emptyList())
+        coEvery { uploadCoordinator.uploadRoom<Feedback>(any()) } returns UploadResult.Failure(emptyList())
         val result = uploadManager.uploadFeedback()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.Feedback) }
@@ -197,7 +197,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadFeedback returns true on PartialSuccess with no failures`() = testScope.runTest {
-        coEvery { uploadCoordinator.uploadRoom<RealmFeedback>(any()) } returns UploadResult.PartialSuccess(emptyList(), emptyList())
+        coEvery { uploadCoordinator.uploadRoom<Feedback>(any()) } returns UploadResult.PartialSuccess(emptyList(), emptyList())
         val result = uploadManager.uploadFeedback()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.Feedback) }
@@ -207,7 +207,7 @@ class UploadManagerTest {
     @Test
     fun `uploadFeedback returns false on PartialSuccess with failures`() = testScope.runTest {
         val mockError = UploadError("id", Exception(), false)
-        coEvery { uploadCoordinator.uploadRoom<RealmFeedback>(any()) } returns UploadResult.PartialSuccess(emptyList(), listOf(mockError))
+        coEvery { uploadCoordinator.uploadRoom<Feedback>(any()) } returns UploadResult.PartialSuccess(emptyList(), listOf(mockError))
         val result = uploadManager.uploadFeedback()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.Feedback) }
@@ -299,7 +299,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadMyPersonal delegates to personalsRepository and calls uploadAttachment`() = testScope.runTest {
-        val mockPersonal = mockk<RealmMyPersonal>(relaxed = true)
+        val mockPersonal = mockk<Personal>(relaxed = true)
         every { mockPersonal.isUploaded } returns false
         every { mockPersonal.path } returns null
 
@@ -314,7 +314,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadMyPersonal returns failure message when response is null`() = testScope.runTest {
-        val mockPersonal = mockk<RealmMyPersonal>(relaxed = true)
+        val mockPersonal = mockk<Personal>(relaxed = true)
         every { mockPersonal.isUploaded } returns false
 
         coEvery { personalsRepository.uploadPersonalDocument(mockPersonal) } returns null
@@ -328,7 +328,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadMyPersonal returns already uploaded message`() = testScope.runTest {
-        val mockPersonal = mockk<RealmMyPersonal>(relaxed = true)
+        val mockPersonal = mockk<Personal>(relaxed = true)
         every { mockPersonal.isUploaded } returns true
 
         val result = uploadManager.uploadMyPersonal(mockPersonal)

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -24,12 +24,12 @@ import org.junit.Test
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.model.ApkLog
-import org.ole.planet.myplanet.model.RealmCourseActivity
+import org.ole.planet.myplanet.model.CourseActivity
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyPersonal
 import org.ole.planet.myplanet.model.RealmRating
-import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.repository.ActivitiesRepository
@@ -138,7 +138,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadSearchActivity delegates to Room uploadCoordinator`() = testScope.runTest {
-        coEvery { uploadCoordinator.uploadRoom<RealmSearchActivity>(any()) } returns UploadResult.Success(1, emptyList())
+        coEvery { uploadCoordinator.uploadRoom<SearchActivity>(any()) } returns UploadResult.Success(1, emptyList())
         uploadManager.uploadSearchActivity()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.SearchActivity) }
@@ -146,7 +146,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadCourseActivities delegates to uploadCoordinator`() = testScope.runTest {
-        coEvery { uploadCoordinator.uploadRoom<RealmCourseActivity>(any()) } returns UploadResult.Success(1, emptyList())
+        coEvery { uploadCoordinator.uploadRoom<CourseActivity>(any()) } returns UploadResult.Success(1, emptyList())
         uploadManager.uploadCourseActivities()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.CourseActivities) }

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -23,7 +23,7 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.data.api.ApiInterface
-import org.ole.planet.myplanet.model.RealmApkLog
+import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.model.RealmCourseActivity
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmMeetup
@@ -130,7 +130,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadCrashLog delegates to uploadCoordinator`() = testScope.runTest {
-        coEvery { uploadCoordinator.uploadRoom<RealmApkLog>(any()) } returns UploadResult.Success(1, emptyList())
+        coEvery { uploadCoordinator.uploadRoom<ApkLog>(any()) } returns UploadResult.Success(1, emptyList())
         uploadManager.uploadCrashLog()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.CrashLog) }

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadManagerTest.kt
@@ -28,7 +28,7 @@ import org.ole.planet.myplanet.model.CourseActivity
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmMeetup
 import org.ole.planet.myplanet.model.RealmMyPersonal
-import org.ole.planet.myplanet.model.RealmRating
+import org.ole.planet.myplanet.model.Rating
 import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
@@ -232,7 +232,7 @@ class UploadManagerTest {
 
     @Test
     fun `uploadRating delegates to uploadCoordinator`() = testScope.runTest {
-        coEvery { uploadCoordinator.uploadRoom<RealmRating>(any()) } returns UploadResult.Success(1, emptyList())
+        coEvery { uploadCoordinator.uploadRoom<Rating>(any()) } returns UploadResult.Success(1, emptyList())
         uploadManager.uploadRating()
         advanceUntilIdle()
         coVerify { uploadCoordinator.uploadRoom(uploadConfigs.Rating) }

--- a/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueTest.kt
@@ -22,7 +22,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 import org.ole.planet.myplanet.model.RetryFailure
 import org.ole.planet.myplanet.repository.RetryRepository
 import org.ole.planet.myplanet.services.upload.UploadError
@@ -134,7 +134,7 @@ class RetryQueueTest {
     @Test
     fun queueFailedOperation_retryableError_existingOp_updates() = runTest {
         val error = UploadError("item1", Exception("fail"), retryable = true)
-        val existingOp = RealmRetryOperation().apply { id = "op1" }
+        val existingOp = RetryOperation().apply { id = "op1" }
         coEvery { retryRepository.getExistingOperation("item1", "type") } returns existingOp
         coEvery { retryRepository.updateAttempt("op1", any()) } returns Unit
 

--- a/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueWorkerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueWorkerTest.kt
@@ -29,7 +29,7 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.data.api.ApiInterface
-import org.ole.planet.myplanet.model.RealmRetryOperation
+import org.ole.planet.myplanet.model.RetryOperation
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RetryQueueWorkerTest {
@@ -150,7 +150,7 @@ class RetryQueueWorkerTest {
         coEvery { retryQueue.setProcessing(any()) } returns Unit
         coEvery { retryQueue.cleanup() } returns Unit
 
-        val operation = RealmRetryOperation().apply { id = "testId" }
+        val operation = RetryOperation().apply { id = "testId" }
         coEvery { retryQueue.getPendingOperations() } returns listOf(operation)
 
         val result = worker.doWork()

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -17,10 +17,10 @@ import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
-import org.ole.planet.myplanet.model.RealmCourseActivity
-import org.ole.planet.myplanet.model.RealmNewsLog
-import org.ole.planet.myplanet.model.RealmResourceActivity
-import org.ole.planet.myplanet.model.RealmSearchActivity
+import org.ole.planet.myplanet.model.CourseActivity
+import org.ole.planet.myplanet.model.NewsLog
+import org.ole.planet.myplanet.model.ResourceActivity
+import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.repository.TeamsSyncRepository
 import org.ole.planet.myplanet.repository.UploadedItemResult
 
@@ -56,7 +56,7 @@ class UploadConfigsTest {
 
     @Test
     fun `SearchActivity config fetches pending Room rows from DAO`() = runTest {
-        val pending = listOf(RealmSearchActivity(id = "local-1", text = "math"))
+        val pending = listOf(SearchActivity(id = "local-1", text = "math"))
         coEvery { searchActivityDao.getPendingUploads() } returns pending
 
         val result = uploadConfigs.SearchActivity.fetchPendingItems()
@@ -103,7 +103,7 @@ class UploadConfigsTest {
 
     @Test
     fun `CourseActivities config fetches pending Room rows from DAO`() = runTest {
-        val pending = listOf(RealmCourseActivity().apply { id = "course-local-1" })
+        val pending = listOf(CourseActivity().apply { id = "course-local-1" })
         coEvery { courseActivityDao.getPendingUploads() } returns pending
 
         val result = uploadConfigs.CourseActivities.fetchPendingItems()
@@ -140,7 +140,7 @@ class UploadConfigsTest {
     }
     @Test
     fun `ResourceActivities config fetches pending Room rows from DAO`() = runTest {
-        val pending = listOf(RealmResourceActivity().apply { id = "resource-local-1" })
+        val pending = listOf(ResourceActivity().apply { id = "resource-local-1" })
         coEvery { resourceActivityDao.getPendingUploads() } returns pending
 
         val result = uploadConfigs.ResourceActivities.fetchPendingItems()
@@ -150,7 +150,7 @@ class UploadConfigsTest {
 
     @Test
     fun `ResourceActivitiesSync config fetches pending sync Room rows from DAO`() = runTest {
-        val pending = listOf(RealmResourceActivity().apply { id = "resource-sync-local-1"; type = "sync" })
+        val pending = listOf(ResourceActivity().apply { id = "resource-sync-local-1"; type = "sync" })
         coEvery { resourceActivityDao.getPendingSyncUploads() } returns pending
 
         val result = uploadConfigs.ResourceActivitiesSync.fetchPendingItems()
@@ -160,7 +160,7 @@ class UploadConfigsTest {
 
     @Test
     fun `NewsActivities config fetches pending Room rows from DAO`() = runTest {
-        val pending = listOf(RealmNewsLog().apply { id = "news-local-1" })
+        val pending = listOf(NewsLog().apply { id = "news-local-1" })
         coEvery { newsLogDao.getPendingUploads() } returns pending
 
         val result = uploadConfigs.NewsActivities.fetchPendingItems()

--- a/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatViewModelTest.kt
@@ -18,7 +18,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.ole.planet.myplanet.model.RealmChatHistory
+import org.ole.planet.myplanet.model.ChatHistory
 import org.ole.planet.myplanet.model.RealmConversation
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmUser
@@ -153,7 +153,7 @@ class ChatViewModelTest {
     @Test
     fun `loadChatHistoryScreenData fetches all data correctly when no caches are provided`() = runTest {
         val user = mockk<RealmUser>(relaxed = true)
-        val conversation = RealmChatHistory().apply {
+        val conversation = ChatHistory().apply {
             createdDate = "123"
             updatedDate = "123"
         }
@@ -204,8 +204,8 @@ class ChatViewModelTest {
 
     @Test
     fun `searchChats by title correctly filters list`() = runTest {
-        val chat1 = RealmChatHistory().apply { title = "First Chat" }
-        val chat2 = RealmChatHistory().apply { title = "Second Discussion" }
+        val chat1 = ChatHistory().apply { title = "First Chat" }
+        val chat2 = ChatHistory().apply { title = "Second Discussion" }
 
         coEvery { chatRepository.getChatHistoryForUser(any()) } returns listOf(chat1, chat2)
 
@@ -221,11 +221,11 @@ class ChatViewModelTest {
 
     @Test
     fun `searchChats by full conversation filters by question`() = runTest {
-        val chat1 = RealmChatHistory().apply {
+        val chat1 = ChatHistory().apply {
             title = "Chat 1"
             conversations = io.realm.RealmList(RealmConversation().apply { query = "How is the weather?" })
         }
-        val chat2 = RealmChatHistory().apply {
+        val chat2 = ChatHistory().apply {
             title = "Chat 2"
             conversations = io.realm.RealmList(RealmConversation().apply { query = "Tell me a joke." })
         }
@@ -244,8 +244,8 @@ class ChatViewModelTest {
 
     @Test
     fun `searchChats with empty query resets filtered list`() = runTest {
-        val chat1 = RealmChatHistory().apply { title = "Chat 1" }
-        val chat2 = RealmChatHistory().apply { title = "Chat 2" }
+        val chat1 = ChatHistory().apply { title = "Chat 1" }
+        val chat2 = ChatHistory().apply { title = "Chat 2" }
 
         coEvery { chatRepository.getChatHistoryForUser(any()) } returns listOf(chat1, chat2)
 
@@ -264,7 +264,7 @@ class ChatViewModelTest {
     @Test
     fun `loadChatHistoryScreenData uses cached data and handles nulls gracefully`() = runTest {
         val cachedUser = mockk<RealmUser>(relaxed = true)
-        val conversation = RealmChatHistory().apply {
+        val conversation = ChatHistory().apply {
             createdDate = "123"
             updatedDate = "123"
         }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/events/EventsAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/events/EventsAdapterTest.kt
@@ -9,7 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.Meetup
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
@@ -21,7 +21,7 @@ class EventsAdapterTest {
     private lateinit var context: Context
     private lateinit var adapter: EventsAdapter
 
-    private var clickedMeetup: RealmMeetup? = null
+    private var clickedMeetup: Meetup? = null
 
     @Before
     fun setup() {
@@ -33,7 +33,7 @@ class EventsAdapterTest {
 
     @Test
     fun `test adapter item binding and partial payload diff`() {
-        val oldMeetup = RealmMeetup().apply {
+        val oldMeetup = Meetup().apply {
             id = "1"
             title = "Old Title"
             description = "Old Desc"
@@ -64,7 +64,7 @@ class EventsAdapterTest {
         assertEquals("Old Desc", holder.binding.tvDescription.text.toString())
         assertEquals("Old Location", holder.binding.tvLocation.text.toString())
 
-        val newMeetup = RealmMeetup().apply {
+        val newMeetup = Meetup().apply {
             id = "1"
             title = "New Title"
             description = "Old Desc"

--- a/app/src/test/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailViewModelTest.kt
@@ -17,7 +17,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.repository.FeedbackRepository
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -42,7 +42,7 @@ class FeedbackDetailViewModelTest {
     @Test
     fun testLoadFeedback() = runTest(testDispatcher) {
         val feedbackId = "123"
-        val mockFeedback = mockk<RealmFeedback>()
+        val mockFeedback = mockk<Feedback>()
         coEvery { feedbackRepository.getFeedbackById(feedbackId) } returns mockFeedback
 
         viewModel.loadFeedback(feedbackId)
@@ -57,7 +57,7 @@ class FeedbackDetailViewModelTest {
         val feedbackId = "123"
         val mockMessage = "Test message"
         val mockUser = "testuser"
-        val mockFeedback = mockk<RealmFeedback>()
+        val mockFeedback = mockk<Feedback>()
         coEvery { feedbackRepository.addReply(feedbackId, mockMessage, mockUser) } returns Unit
         coEvery { feedbackRepository.getFeedbackById(feedbackId) } returns mockFeedback
 
@@ -72,7 +72,7 @@ class FeedbackDetailViewModelTest {
     @Test
     fun testCloseFeedback() = runTest(testDispatcher) {
         val feedbackId = "123"
-        val mockFeedback = mockk<RealmFeedback>()
+        val mockFeedback = mockk<Feedback>()
         coEvery { feedbackRepository.closeFeedback(feedbackId) } returns Unit
         coEvery { feedbackRepository.getFeedbackById(feedbackId) } returns mockFeedback
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModelTest.kt
@@ -12,7 +12,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.ole.planet.myplanet.model.RealmFeedback
+import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.FeedbackRepository
 import org.ole.planet.myplanet.services.UserSessionManager
@@ -50,14 +50,14 @@ class FeedbackListViewModelTest {
     @Test
     fun testInitialStateIsPreloadEmptyList() = runTest(testDispatcher) {
         // This test validates the pre-load default state of the StateFlow before the init coroutine has executed
-        assertEquals(emptyList<RealmFeedback>(), viewModel.feedbackList.value)
+        assertEquals(emptyList<Feedback>(), viewModel.feedbackList.value)
     }
 
     @Test
     fun testFeedbackListEmitsDataFromFeedbackRepository() = runTest(testDispatcher) {
         val user = mockk<RealmUser>()
-        val feedback1 = mockk<RealmFeedback>()
-        val feedback2 = mockk<RealmFeedback>()
+        val feedback1 = mockk<Feedback>()
+        val feedback2 = mockk<Feedback>()
         val feedbackList = listOf(feedback1, feedback2)
 
         coEvery { userSessionManager.getUserModel() } returns user
@@ -78,8 +78,8 @@ class FeedbackListViewModelTest {
     @Test
     fun testRefreshFeedbackCancelsPreviousJobAndRetriggersFlowCollection() = runTest(testDispatcher) {
         val user = mockk<RealmUser>()
-        val initialFeedback = listOf(mockk<RealmFeedback>())
-        val updatedFeedback = listOf(mockk<RealmFeedback>(), mockk<RealmFeedback>())
+        val initialFeedback = listOf(mockk<Feedback>())
+        val updatedFeedback = listOf(mockk<Feedback>(), mockk<Feedback>())
 
         coEvery { userSessionManager.getUserModel() } returns user
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthExaminationViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthExaminationViewModelTest.kt
@@ -16,7 +16,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.ole.planet.myplanet.model.RealmHealthExamination
+import org.ole.planet.myplanet.model.HealthExamination
 import org.ole.planet.myplanet.model.RealmMyHealth
 import org.ole.planet.myplanet.model.RealmUser
 import org.ole.planet.myplanet.repository.HealthRepository
@@ -48,9 +48,9 @@ class HealthExaminationViewModelTest {
     @Test
     fun loadData_success_updatesState() = runTest {
         val mockUser = mockk<RealmUser>()
-        val mockPojo = mockk<RealmHealthExamination>()
+        val mockPojo = mockk<HealthExamination>()
         val mockHealth = mockk<RealmMyHealth>()
-        val mockExamination = mockk<RealmHealthExamination>()
+        val mockExamination = mockk<HealthExamination>()
 
         coEvery { mockPojo.data } returns null
         coEvery { healthRepository.getHealthEntry("user_id") } returns Pair(mockUser, mockPojo)
@@ -81,8 +81,8 @@ class HealthExaminationViewModelTest {
 
     @Test
     fun saveExamination_success_emitsTrueAndResetsIsSaving() = runTest {
-        val examination = mockk<RealmHealthExamination>()
-        val pojo = mockk<RealmHealthExamination>()
+        val examination = mockk<HealthExamination>()
+        val pojo = mockk<HealthExamination>()
         val user = mockk<RealmUser>()
         coEvery { healthRepository.saveExamination(examination, pojo, user) } returns Unit
 
@@ -103,8 +103,8 @@ class HealthExaminationViewModelTest {
 
     @Test
     fun saveExamination_error_emitsFalseAndResetsIsSaving() = runTest {
-        val examination = mockk<RealmHealthExamination>()
-        val pojo = mockk<RealmHealthExamination>()
+        val examination = mockk<HealthExamination>()
+        val pojo = mockk<HealthExamination>()
         val user = mockk<RealmUser>()
         coEvery { healthRepository.saveExamination(examination, pojo, user) } throws RuntimeException("Network error")
 
@@ -125,8 +125,8 @@ class HealthExaminationViewModelTest {
 
     @Test
     fun saveExamination_alreadySaving_isNoOp() = runTest {
-        val examination = mockk<RealmHealthExamination>()
-        val pojo = mockk<RealmHealthExamination>()
+        val examination = mockk<HealthExamination>()
+        val pojo = mockk<HealthExamination>()
         val user = mockk<RealmUser>()
 
         coEvery { healthRepository.saveExamination(examination, pojo, user) } coAnswers { delay(100) }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModelTest.kt
@@ -16,7 +16,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.model.RealmMyLibrary
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.repository.LibraryWithMetadata
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
@@ -98,9 +98,9 @@ class ResourcesViewModelTest {
             every { isResourceOffline() } returns true
         }
         val mockRating = mockk<JsonObject>(relaxed = true)
-        // RealmTag is a Room entity whose id is a @JvmField (a Java field, not a getter), so it
+        // TagEntity is a Room entity whose id is a @JvmField (a Java field, not a getter), so it
         // cannot be stubbed with mockk `every { id }`; use a real instance instead.
-        val mockTag = RealmTag().apply {
+        val mockTag = TagEntity().apply {
             id = "tag1"
             name = "Tag 1"
         }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/TeamViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/TeamViewModelTest.kt
@@ -15,7 +15,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.TeamDetails
 import org.ole.planet.myplanet.model.TeamStatus
 import org.ole.planet.myplanet.repository.TeamsRepository
@@ -94,7 +94,7 @@ class TeamViewModelTest {
     }
     @Test
     fun `taskList state is updated when loadTasks is called`() = runTest(testDispatcher) {
-        val tasks = listOf(RealmTeamTask().apply { id = "task1" })
+        val tasks = listOf(TeamTask().apply { id = "task1" })
         coEvery { teamsRepository.getTasksByTeamId("team1") } returns flowOf(tasks)
 
         viewModel.loadTasks("team1")

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ConstantsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ConstantsTest.kt
@@ -22,7 +22,7 @@ import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.AppNotification
 import org.ole.planet.myplanet.model.Rating
-import org.ole.planet.myplanet.model.RealmTag
+import org.ole.planet.myplanet.model.TagEntity
 import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.TeamTask
 import org.robolectric.RobolectricTestRunner
@@ -78,7 +78,7 @@ class ConstantsTest {
         val classList = Constants.classList
         assertEquals(14, classList.size)
         assertEquals(RealmNews::class.java, classList["news"])
-        assertEquals(RealmTag::class.java, classList["tags"])
+        assertEquals(TagEntity::class.java, classList["tags"])
         assertEquals(Rating::class.java, classList["ratings"])
         assertEquals(RealmMyCourse::class.java, classList["courses"])
         assertEquals(Achievement::class.java, classList["achievements"])

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ConstantsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ConstantsTest.kt
@@ -12,7 +12,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.model.RealmAchievement
-import org.ole.planet.myplanet.model.RealmCertification
+import org.ole.planet.myplanet.model.Certification
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmFeedback
 import org.ole.planet.myplanet.model.RealmHealthExamination
@@ -23,7 +23,7 @@ import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNotification
 import org.ole.planet.myplanet.model.RealmRating
 import org.ole.planet.myplanet.model.RealmTag
-import org.ole.planet.myplanet.model.RealmTeamLog
+import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -87,8 +87,8 @@ class ConstantsTest {
         assertEquals(RealmTeamTask::class.java, classList["tasks"])
         assertEquals(RealmMeetup::class.java, classList["meetups"])
         assertEquals(RealmHealthExamination::class.java, classList["health"])
-        assertEquals(RealmCertification::class.java, classList["certifications"])
-        assertEquals(RealmTeamLog::class.java, classList["team_activities"])
+        assertEquals(Certification::class.java, classList["certifications"])
+        assertEquals(TeamLog::class.java, classList["team_activities"])
         assertEquals(RealmCourseProgress::class.java, classList["courses_progress"])
         assertEquals(RealmNotification::class.java, classList["notifications"])
     }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ConstantsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ConstantsTest.kt
@@ -13,18 +13,18 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.model.Achievement
 import org.ole.planet.myplanet.model.Certification
-import org.ole.planet.myplanet.model.RealmCourseProgress
-import org.ole.planet.myplanet.model.RealmFeedback
-import org.ole.planet.myplanet.model.RealmHealthExamination
-import org.ole.planet.myplanet.model.RealmMeetup
+import org.ole.planet.myplanet.model.CourseProgress
+import org.ole.planet.myplanet.model.Feedback
+import org.ole.planet.myplanet.model.HealthExamination
+import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
-import org.ole.planet.myplanet.model.RealmNotification
+import org.ole.planet.myplanet.model.AppNotification
 import org.ole.planet.myplanet.model.Rating
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.TeamLog
-import org.ole.planet.myplanet.model.RealmTeamTask
+import org.ole.planet.myplanet.model.TeamTask
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -82,15 +82,15 @@ class ConstantsTest {
         assertEquals(Rating::class.java, classList["ratings"])
         assertEquals(RealmMyCourse::class.java, classList["courses"])
         assertEquals(Achievement::class.java, classList["achievements"])
-        assertEquals(RealmFeedback::class.java, classList["feedback"])
+        assertEquals(Feedback::class.java, classList["feedback"])
         assertEquals(RealmMyTeam::class.java, classList["teams"])
-        assertEquals(RealmTeamTask::class.java, classList["tasks"])
-        assertEquals(RealmMeetup::class.java, classList["meetups"])
-        assertEquals(RealmHealthExamination::class.java, classList["health"])
+        assertEquals(TeamTask::class.java, classList["tasks"])
+        assertEquals(Meetup::class.java, classList["meetups"])
+        assertEquals(HealthExamination::class.java, classList["health"])
         assertEquals(Certification::class.java, classList["certifications"])
         assertEquals(TeamLog::class.java, classList["team_activities"])
-        assertEquals(RealmCourseProgress::class.java, classList["courses_progress"])
-        assertEquals(RealmNotification::class.java, classList["notifications"])
+        assertEquals(CourseProgress::class.java, classList["courses_progress"])
+        assertEquals(AppNotification::class.java, classList["notifications"])
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ConstantsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ConstantsTest.kt
@@ -11,7 +11,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.ole.planet.myplanet.model.RealmAchievement
+import org.ole.planet.myplanet.model.Achievement
 import org.ole.planet.myplanet.model.Certification
 import org.ole.planet.myplanet.model.RealmCourseProgress
 import org.ole.planet.myplanet.model.RealmFeedback
@@ -21,7 +21,7 @@ import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmNews
 import org.ole.planet.myplanet.model.RealmNotification
-import org.ole.planet.myplanet.model.RealmRating
+import org.ole.planet.myplanet.model.Rating
 import org.ole.planet.myplanet.model.RealmTag
 import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.RealmTeamTask
@@ -79,9 +79,9 @@ class ConstantsTest {
         assertEquals(14, classList.size)
         assertEquals(RealmNews::class.java, classList["news"])
         assertEquals(RealmTag::class.java, classList["tags"])
-        assertEquals(RealmRating::class.java, classList["ratings"])
+        assertEquals(Rating::class.java, classList["ratings"])
         assertEquals(RealmMyCourse::class.java, classList["courses"])
-        assertEquals(RealmAchievement::class.java, classList["achievements"])
+        assertEquals(Achievement::class.java, classList["achievements"])
         assertEquals(RealmFeedback::class.java, classList["feedback"])
         assertEquals(RealmMyTeam::class.java, classList["teams"])
         assertEquals(RealmTeamTask::class.java, classList["tasks"])

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -77,13 +77,13 @@ Important fields:
 - `resourceLocalAddress` / `resourceRemoteAddress` — local path vs server URL
 - `userId` — list of learner IDs who have added this resource to their personal library ("My Library")
 - `courseId` + `stepId` — if the resource belongs to a course step, these are set; a resource can exist both in the general library and inside a course step
-- `tag` — list of tag IDs linking to `RealmTag`; used for filtering
+- `tag` — list of tag IDs linking to `TagEntity`; used for filtering
 
 Resources are rated (1–5 stars) via `Rating`. The `type` field on a rating is `"resource"` or `"course"` to distinguish what's being rated.
 
 ### Tags
 
-Tags are labels attached to resources and courses for filtering and discovery. They are stored as `RealmTag` and linked to content via `tag` lists on `RealmMyLibrary` and via a separate tagging relationship on `RealmMyCourse`.
+Tags are labels attached to resources and courses for filtering and discovery. They are stored as `TagEntity` and linked to content via `tag` lists on `RealmMyLibrary` and via a separate tagging relationship on `RealmMyCourse`.
 
 ### Courses
 

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -79,7 +79,7 @@ Important fields:
 - `courseId` + `stepId` — if the resource belongs to a course step, these are set; a resource can exist both in the general library and inside a course step
 - `tag` — list of tag IDs linking to `RealmTag`; used for filtering
 
-Resources are rated (1–5 stars) via `RealmRating`. The `type` field on a rating is `"resource"` or `"course"` to distinguish what's being rated.
+Resources are rated (1–5 stars) via `Rating`. The `type` field on a rating is `"resource"` or `"course"` to distinguish what's being rated.
 
 ### Tags
 
@@ -227,11 +227,11 @@ The app computes an overall progress percentage from these records when displayi
 
 ### Achievements
 
-`RealmAchievement` is a learner's personal profile of accomplishments. They can record goals (`goals`), a purpose statement, personal achievements, references, links, and upload a resume. This is self-authored content, not auto-generated from course completions.
+`Achievement` is a learner's personal profile of accomplishments. They can record goals (`goals`), a purpose statement, personal achievements, references, links, and upload a resume. This is self-authored content, not auto-generated from course completions.
 
 ### Ratings
 
-`RealmRating` captures a learner's star rating and optional comment for a resource or course. Ratings are tied to the item via `item` (the resource/course ID) and `type` (`"resource"` or `"course"`). Aggregate rating data (average, count) is denormalized onto `RealmMyLibrary` (`averageRating`, `timesRated`) for display performance.
+`Rating` captures a learner's star rating and optional comment for a resource or course. Ratings are tied to the item via `item` (the resource/course ID) and `type` (`"resource"` or `"course"`). Aggregate rating data (average, count) is denormalized onto `RealmMyLibrary` (`averageRating`, `timesRated`) for display performance.
 
 ### Health Records
 
@@ -260,9 +260,9 @@ RealmUser (learner)
 │   └── learner progress → RealmCourseProgress (one per step)
 │
 ├── saves resource to library → RealmMyLibrary (userId list)
-│   └── learner rates → RealmRating (type = "resource")
+│   └── learner rates → Rating (type = "resource")
 │
-├── rates course → RealmRating (type = "course")
+├── rates course → Rating (type = "course")
 │
 ├── joins → RealmMyTeam (team or enterprise)
 │   ├── has tasks → RealmTeamTask
@@ -280,7 +280,7 @@ RealmUser (learner)
 │
 ├── earns certifications → Certification (groups courses)
 │
-└── writes achievements → RealmAchievement
+└── writes achievements → Achievement
 ```
 
 ---

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -99,9 +99,9 @@ How they connect:
 
 A learner's membership in a course is tracked by the `userId` list on `RealmMyCourse` — joining a course adds the learner's ID to that list. Progress through steps is tracked by `RealmCourseProgress` records (one per step, per learner).
 
-**Certifications:** `RealmCertification` is a static reference list synced down from the server — it just maps a certification `name` to a list of `courseIds`. It has no `userId` and no completion/progress field; nothing in the codebase marks a certification as "earned" by a learner.
+**Certifications:** `Certification` is a static reference list synced down from the server — it just maps a certification `name` to a list of `courseIds`. It has no `userId` and no completion/progress field; nothing in the codebase marks a certification as "earned" by a learner.
 
-Course completion itself is tracked separately and per-learner: `ProgressRepositoryImpl.getCompletedCourses(userId)` (`ProgressRepositoryImpl.kt:156-185`) checks `RealmCourseProgress` and counts a course complete once every one of its steps has a `passed = true` record. The dashboard (`BellDashboardFragment.showBadges()`) renders one star-icon badge per completed course in a row on the profile card. `isCourseCertified(courseId)` — a `RealmCertification` lookup with **no** `userId` parameter — is then used only to recolor that already-rendered badge: bright if the completed course happens to belong to some certification's `courseIds` list, dim grey otherwise. So "certification" in this app is a label on a course, surfaced as a color cue on a learner's completion badge — not a separate achievement a learner unlocks.
+Course completion itself is tracked separately and per-learner: `ProgressRepositoryImpl.getCompletedCourses(userId)` (`ProgressRepositoryImpl.kt:156-185`) checks `RealmCourseProgress` and counts a course complete once every one of its steps has a `passed = true` record. The dashboard (`BellDashboardFragment.showBadges()`) renders one star-icon badge per completed course in a row on the profile card. `isCourseCertified(courseId)` — a `Certification` lookup with **no** `userId` parameter — is then used only to recolor that already-rendered badge: bright if the completed course happens to belong to some certification's `courseIds` list, dim grey otherwise. So "certification" in this app is a label on a course, surfaced as a color cue on a learner's completion badge — not a separate achievement a learner unlocks.
 
 ---
 
@@ -278,7 +278,7 @@ RealmUser (learner)
 │
 ├── records health data → RealmHealthExamination
 │
-├── earns certifications → RealmCertification (groups courses)
+├── earns certifications → Certification (groups courses)
 │
 └── writes achievements → RealmAchievement
 ```

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -35,7 +35,7 @@ The app is designed for **low-connectivity environments**. Everything a learner 
 
 Learners are the primary users of myPlanet. They browse and download resources, enrol in courses, take exams, complete surveys, join teams, and post in community discussions. Most of what the app does is built for them.
 
-Their activity is tracked across courses (`RealmCourseProgress`), exams (`RealmSubmission`), and resource views (via activity logs).
+Their activity is tracked across courses (`CourseProgress`), exams (`RealmSubmission`), and resource views (via activity logs).
 
 ### Managers (Coaches / Administrators)
 
@@ -97,11 +97,11 @@ How they connect:
 - Resources attached to a specific step have both `courseId` and `stepId` set on their `RealmMyLibrary` record.
 - Exams and surveys are both optional per step, not guaranteed — a step can have zero, one, or more of each attached. Both share the same `RealmStepExam` model and are distinguished by the `type` field: `"courses"` for exams, `"surveys"` for surveys. When present, a `RealmStepExam` carries both `courseId` and `stepId`. `CoursesRepositoryImpl.getCourseStepData()` queries these separately — `stepExams` (`type = "courses"`) and `stepSurvey` (`type = "surveys"`) — both returned as `List<RealmStepExam>` that can be empty. `getCourseExamCount()` counts however many exam-type `RealmStepExam` rows exist for a course, with no constraint tying that count to the number of steps; there's no equivalent `getCourseSurveyCount()` helper for surveys.
 
-A learner's membership in a course is tracked by the `userId` list on `RealmMyCourse` — joining a course adds the learner's ID to that list. Progress through steps is tracked by `RealmCourseProgress` records (one per step, per learner).
+A learner's membership in a course is tracked by the `userId` list on `RealmMyCourse` — joining a course adds the learner's ID to that list. Progress through steps is tracked by `CourseProgress` records (one per step, per learner).
 
 **Certifications:** `Certification` is a static reference list synced down from the server — it just maps a certification `name` to a list of `courseIds`. It has no `userId` and no completion/progress field; nothing in the codebase marks a certification as "earned" by a learner.
 
-Course completion itself is tracked separately and per-learner: `ProgressRepositoryImpl.getCompletedCourses(userId)` (`ProgressRepositoryImpl.kt:156-185`) checks `RealmCourseProgress` and counts a course complete once every one of its steps has a `passed = true` record. The dashboard (`BellDashboardFragment.showBadges()`) renders one star-icon badge per completed course in a row on the profile card. `isCourseCertified(courseId)` — a `Certification` lookup with **no** `userId` parameter — is then used only to recolor that already-rendered badge: bright if the completed course happens to belong to some certification's `courseIds` list, dim grey otherwise. So "certification" in this app is a label on a course, surfaced as a color cue on a learner's completion badge — not a separate achievement a learner unlocks.
+Course completion itself is tracked separately and per-learner: `ProgressRepositoryImpl.getCompletedCourses(userId)` (`ProgressRepositoryImpl.kt:156-185`) checks `CourseProgress` and counts a course complete once every one of its steps has a `passed = true` record. The dashboard (`BellDashboardFragment.showBadges()`) renders one star-icon badge per completed course in a row on the profile card. `isCourseCertified(courseId)` — a `Certification` lookup with **no** `userId` parameter — is then used only to recolor that already-rendered badge: bright if the completed course happens to belong to some certification's `courseIds` list, dim grey otherwise. So "certification" in this app is a label on a course, surfaced as a color cue on a learner's completion badge — not a separate achievement a learner unlocks.
 
 ---
 
@@ -149,11 +149,11 @@ A **team** is a group of learners who collaborate on tasks, share courses and re
 Teams have:
 - **Members** — learners who belong to the team, tracked via `RealmMyTeam` records linking `userId` to `teamId`
 - **Leader** — one member with `isLeader = true` on their team record
-- **Tasks** (`RealmTeamTask`) — action items assigned to members with deadlines
+- **Tasks** (`TeamTask`) — action items assigned to members with deadlines
 - **Courses** — a list of course IDs the team has added (`courses` on `RealmMyTeam`)
 - **Resources** — linked via `resourceId`
 - **Surveys** — team-scoped surveys where `RealmStepExam.teamId` is set
-- **Meetups** (`RealmMeetup`) — scheduled events on the team calendar
+- **Meetups** (`Meetup`) — scheduled events on the team calendar
 - **News/discussions** — `RealmNews` records with `viewableBy = "team"` and `viewableId = teamId`
 - **Join requests** — stored in `requests` on the `RealmMyTeam` record, visible to the leader
 
@@ -207,11 +207,11 @@ The same `RealmNews` model is also used for **team chat** (inside `TeamDetailFra
 
 ### Meetups
 
-**Meetups** are scheduled events. They can be community-level or team-scoped. A meetup (`RealmMeetup`) has a title, description, start/end dates and times, location, category, and recurrence pattern. Team meetups carry a `teamId`.
+**Meetups** are scheduled events. They can be community-level or team-scoped. A meetup (`Meetup`) has a title, description, start/end dates and times, location, category, and recurrence pattern. Team meetups carry a `teamId`.
 
 ### Feedback
 
-Learners can submit feedback about the app or content via `FeedbackFragment`. Feedback (`RealmFeedback`) is synced to the server and can be viewed and responded to.
+Learners can submit feedback about the app or content via `FeedbackFragment`. Feedback (`Feedback`) is synced to the server and can be viewed and responded to.
 
 ---
 
@@ -219,7 +219,7 @@ Learners can submit feedback about the app or content via `FeedbackFragment`. Fe
 
 ### Course Progress
 
-`RealmCourseProgress` tracks a learner's progress through a course step-by-step. One record exists per learner per step:
+`CourseProgress` tracks a learner's progress through a course step-by-step. One record exists per learner per step:
 - `userId` + `courseId` + `stepNum` identify the record
 - `passed` — `true` once the learner has passed the step (including any embedded exam)
 
@@ -235,7 +235,7 @@ The app computes an overall progress percentage from these records when displayi
 
 ### Health Records
 
-`RealmHealthExamination` stores data recorded during community health screenings. The vital-sign and demographic fields — temperature, pulse, blood pressure, height, weight, vision, hearing, age, gender, and medical conditions (`conditions`) — are stored in plain Realm columns.
+`HealthExamination` stores data recorded during community health screenings. The vital-sign and demographic fields — temperature, pulse, blood pressure, height, weight, vision, hearing, age, gender, and medical conditions (`conditions`) — are stored in plain Realm columns.
 
 The sensitive free-text fields (observations, diagnosis, treatments, medications, immunizations, allergies, x-rays, lab tests, referrals) are serialized into a single JSON blob in the `data` field and encrypted with the subject's key before storage — `AndroidDecrypter` using `user.key` / `user.iv`. So encryption here is partial by design: the free-text clinical detail in `data` is encrypted at rest, while the vitals, dates, and codes are not.
 
@@ -243,7 +243,7 @@ Whether an exam was self-administered or entered by someone else is tracked by t
 
 ### Notifications
 
-`RealmNotification` holds in-app notifications — task deadlines, new survey assignments, sync events, etc. Notifications have a `type`, a `relatedId` pointing to the relevant entity, and a `link` for deep navigation.
+`AppNotification` holds in-app notifications — task deadlines, new survey assignments, sync events, etc. Notifications have a `type`, a `relatedId` pointing to the relevant entity, and a `link` for deep navigation.
 
 ---
 
@@ -257,7 +257,7 @@ RealmUser (learner)
 │   │   └── has exam/survey → RealmStepExam
 │   │       └── learner submits → RealmSubmission
 │   │           └── contains answers → RealmAnswer
-│   └── learner progress → RealmCourseProgress (one per step)
+│   └── learner progress → CourseProgress (one per step)
 │
 ├── saves resource to library → RealmMyLibrary (userId list)
 │   └── learner rates → Rating (type = "resource")
@@ -265,8 +265,8 @@ RealmUser (learner)
 ├── rates course → Rating (type = "course")
 │
 ├── joins → RealmMyTeam (team or enterprise)
-│   ├── has tasks → RealmTeamTask
-│   ├── has meetups → RealmMeetup
+│   ├── has tasks → TeamTask
+│   ├── has meetups → Meetup
 │   ├── has discussions → RealmNews (viewableBy = "team")
 │   ├── has surveys → RealmStepExam (teamId set)
 │   │   └── learner submits → RealmSubmission
@@ -276,7 +276,7 @@ RealmUser (learner)
 │
 ├── completes standalone survey → RealmSubmission (type = "survey")
 │
-├── records health data → RealmHealthExamination
+├── records health data → HealthExamination
 │
 ├── earns certifications → Certification (groups courses)
 │

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -126,7 +126,7 @@ wired through `di/RoomModule`.
       `RealmRepository` only for still-Realm `RealmUser` lookups; upload config ->
       `RoomUploadConfig`. Repo aggregation moved from Realm `average()`/`RealmResults` to
       in-memory over DAO lists. Repo test + model test + UploadManager test updated.
-- [x] **Tag** migrated (synced-only). `RealmTag` Room `@Entity` (@JvmField id/_id; `attachedTo`
+- [x] **Tag** migrated (synced-only). `TagEntity` Room `@Entity` (@JvmField id/_id; `attachedTo`
       `RealmList<String>` → `List<String>?` via `Converters`; `@Index` on name/tagId/db; kept the
       `toTag()`/`getTagsArray` POJO helpers); `TagDao` (parent-tag filter, by-db-and-linkId(s),
       by-ids, by-names, by-db-and-tagIds, upsert); `TagsRepositoryImpl` off `RealmRepository`
@@ -146,7 +146,7 @@ wired through `di/RoomModule`.
       `Meetups` upload config → `RoomUploadConfig` (markUploaded sets meetupId/rev + clears
       `updated` via the repo); `UploadManager.uploadMeetups` uses `uploadRoom`. Model + repo +
       upload-manager + user-repo constructor tests updated. Also fixed a latent Tag-migration
-      fallout: `ResourcesViewModelTest` can no longer mockk `RealmTag.id` (now a `@JvmField`), so
+      fallout: `ResourcesViewModelTest` can no longer mockk `TagEntity.id` (now a `@JvmField`), so
       it uses a real instance.
 - [x] **SearchActivity** migrated (uploaded-only local activity log). `SearchActivity` is now
       a Room `@Entity`; `SearchActivityDao` owns pending upload lookup, inserts, and upload

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -148,23 +148,23 @@ wired through `di/RoomModule`.
       upload-manager + user-repo constructor tests updated. Also fixed a latent Tag-migration
       fallout: `ResourcesViewModelTest` can no longer mockk `RealmTag.id` (now a `@JvmField`), so
       it uses a real instance.
-- [x] **SearchActivity** migrated (uploaded-only local activity log). `RealmSearchActivity` is now
+- [x] **SearchActivity** migrated (uploaded-only local activity log). `SearchActivity` is now
       a Room `@Entity`; `SearchActivityDao` owns pending upload lookup, inserts, and upload
       acknowledgements; course/resource search logging now writes through the DAO; upload config
       uses `RoomUploadConfig`.
-- [x] **CourseActivity** migrated (uploaded-only course visit log). `RealmCourseActivity` is now
+- [x] **CourseActivity** migrated (uploaded-only course visit log). `CourseActivity` is now
       a Room `@Entity`; `CourseActivityDao` owns visit inserts, pending upload lookup, and upload
       acknowledgements; course visit logging writes through the DAO; upload config uses
       `RoomUploadConfig`.
-- [x] **ResourceActivity** migrated (uploaded + local read paths). `RealmResourceActivity` is
+- [x] **ResourceActivity** migrated (uploaded + local read paths). `ResourceActivity` is
       now a Room `@Entity`; `ResourceActivityDao` owns resource-open/sync inserts, counts,
       most-opened lookups, opened-resource observation, pending upload lookup, and upload
       acknowledgements; both regular and sync upload configs use `RoomUploadConfig`.
-- [x] **SubmitPhotos** migrated (uploaded photo submissions). `RealmSubmitPhotos` is now a
+- [x] **SubmitPhotos** migrated (uploaded photo submissions). `SubmitPhotos` is now a
       Room `@Entity`; `SubmitPhotosDao` owns photo inserts, pending lookup, id lookups, and
       upload acknowledgements; repository/photo uploader paths use the DAO, and the legacy upload
       config is Room-capable.
-- [x] **NewsLog** migrated (uploaded-only activity log). `RealmNewsLog` is now a Room
+- [x] **NewsLog** migrated (uploaded-only activity log). `NewsLog` is now a Room
       `@Entity`; `NewsLogDao` owns pending lookup, inserts, and upload acknowledgements; upload
       config uses `RoomUploadConfig`.
 - [x] **TeamActivities / TeamLog** migrated (uploaded + synced team visit log). `RealmTeamLog` is
@@ -179,7 +179,7 @@ wired through `di/RoomModule`.
       now a Room `@Entity`; `CourseProgressDao` owns user/course progress reads, completion
       records, save/update paths, pending upload reads, upload acknowledgements, and sync upserts
       that preserve locally-passed steps when server progress lags.
-- [x] **RemovedLog** migrated (local shelf tombstones). `RealmRemovedLog` is now a Room
+- [x] **RemovedLog** migrated (local shelf tombstones). `RemovedLog` is now a Room
       `@Entity`; `RemovedLogDao` owns add/remove tombstone writes, bulk cleanup when resources or
       courses are re-added, and shelf merge filtering for removed resources/courses.
 - [x] **TeamTask** migrated (uploaded + synced task rows). `RealmTeamTask` is now a Room

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -96,8 +96,8 @@ wired through `di/RoomModule`.
       for its other models). NB: transient KSP `"Dao could not be resolved"` failures during this
       work were **corrupted incremental/daemon build state** from rapid iterative builds, not a
       real blocker — `./gradlew --stop` + a clean build clears them.
-- [x] **ApkLog** migrated through the new path (`RealmApkLog` now a Room `@Entity`, `ApkLogDao`,
-      `CrashLog` is a `RoomUploadConfig`, `MainApplication.saveLogToRealm` + crash-log sweep write
+- [x] **ApkLog** migrated through the new path (`ApkLog` now a Room `@Entity`, `ApkLogDao`,
+      `CrashLog` is a `RoomUploadConfig`, `MainApplication.saveLogToRoom` + crash-log sweep write
       via the DAO, `uploadCrashLog()` uses `uploadRoom`). First uploadable model on Room.
 - [x] **TeamNotification** migrated (single-id Room `@Entity`, `TeamNotificationDao`; converted
       3 sites across `NotificationsRepositoryImpl` + `VoicesRepositoryImpl`, both kept on

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -82,7 +82,7 @@ wired through `di/RoomModule`.
 - [x] **Retry** domain migrated end-to-end (`RealmRetryOperation` now a Room `@Entity`;
       Realm-based `createFromRetryFailure` factory replaced with a pure one; `RetryDao` with
       status-filtered queries/updates; `RetryRepositoryImpl` off `RealmRepository`; test ported).
-- [x] **Community** domain migrated (`RealmCommunity` now a Room `@Entity`; `CommunityDao` with a
+- [x] **Community** domain migrated (`Community` now a Room `@Entity`; `CommunityDao` with a
       `@Transaction replaceAll`; `CommunityRepositoryImpl` keeps `RealmRepository` only for the
       still-Realm `RealmMeetup` insert, using `CommunityDao` for community rows). First proven
       *coexistence-within-one-repo* template. Dropped a Realm-only `isValid` check in the sync UI.
@@ -102,7 +102,7 @@ wired through `di/RoomModule`.
 - [x] **TeamNotification** migrated (single-id Room `@Entity`, `TeamNotificationDao`; converted
       3 sites across `NotificationsRepositoryImpl` + `VoicesRepositoryImpl`, both kept on
       `RealmRepository` for their other models; test constructors updated).
-- [x] **Certification** migrated (`RealmCertification` Room `@Entity`, `CertificationDao` with a
+- [x] **Certification** migrated (`Certification` Room `@Entity`, `CertificationDao` with a
       LIKE-based `countByCourseId`; `isCourseCertified` + the sync bulk-insert converted). First
       proven **sync-bulk-insert** conversion: the per-table `insert` moves from the shared Realm
       `executeTransaction` dispatch in `TransactionSyncManager` to the outer suspend `when` +
@@ -167,12 +167,12 @@ wired through `di/RoomModule`.
 - [x] **NewsLog** migrated (uploaded-only activity log). `NewsLog` is now a Room
       `@Entity`; `NewsLogDao` owns pending lookup, inserts, and upload acknowledgements; upload
       config uses `RoomUploadConfig`.
-- [x] **TeamActivities / TeamLog** migrated (uploaded + synced team visit log). `RealmTeamLog` is
+- [x] **TeamActivities / TeamLog** migrated (uploaded + synced team visit log). `TeamLog` is
       now a Room `@Entity`; `TeamLogDao` owns visit counts, last-visit lookups, sync upserts,
       pending uploads, and upload acknowledgements; team activity sync now runs outside the legacy
       Realm transaction path and upload config uses `RoomUploadConfig`.
 - [x] **OfflineActivity / login activities** migrated (custom uploaded + synced login log).
-      `RealmOfflineActivity` is now a Room `@Entity`; `OfflineActivityDao` owns offline login
+      `OfflineActivity` is now a Room `@Entity`; `OfflineActivityDao` owns offline login
       counts/flows, last-login lookups, pending upload reads, upload acknowledgements, and sync
       upserts with the existing `_id` plus `loginTime`/`user` fallback dedupe behavior.
 - [x] **CourseProgress** migrated (uploaded + synced progress records). `RealmCourseProgress` is

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -107,7 +107,7 @@ wired through `di/RoomModule`.
       proven **sync-bulk-insert** conversion: the per-table `insert` moves from the shared Realm
       `executeTransaction` dispatch in `TransactionSyncManager` to the outer suspend `when` +
       a DAO upsert. Template for the remaining synced models.
-- [x] **Chat** migrated (`RealmChatHistory` Room `@Entity`, `ChatDao`; `ChatRepositoryImpl` off
+- [x] **Chat** migrated (`ChatHistory` Room `@Entity`, `ChatDao`; `ChatRepositoryImpl` off
       `RealmRepository` entirely). First proven **nested-relationship** pattern: `RealmConversation`
       (no independent identity, never queried alone) becomes a plain class stored as an embedded
       JSON `List<RealmConversation>` via a `Converters` type converter — the right mapping for
@@ -120,7 +120,7 @@ wired through `di/RoomModule`.
       `RealmRepository`; `Feedback` upload config -> `RoomUploadConfig` (markUploaded sets
       isUploaded via DAO). Sync path unchanged (already suspend/outer). Model test +
       repo test + UploadManager test updated.
-- [x] **Rating** migrated (uploaded + synced). `RealmRating` Room `@Entity` (@JvmField id/_id);
+- [x] **Rating** migrated (uploaded + synced). `Rating` Room `@Entity` (@JvmField id/_id);
       `RatingDao` (by-type, by-type-and-item, find-by-type-user-item, pending-uploads with the
       guest filter folded into the query, markUploaded); `RatingsRepositoryImpl` keeps
       `RealmRepository` only for still-Realm `RealmUser` lookups; upload config ->
@@ -192,7 +192,7 @@ wired through `di/RoomModule`.
       deletes, single-doc upserts, and sync bulk upserts. Notification sync now runs outside the
       legacy Realm transaction path.
 - [x] **Achievement** migrated (synced + custom uploaded profile achievement docs).
-      `RealmAchievement` is now a Room `@Entity` with JSON-backed `List<String>` fields;
+      `Achievement` is now a Room `@Entity` with JSON-backed `List<String>` fields;
       `AchievementDao` owns initialization, edits, pending-upload reads, upload acknowledgements,
       and sync bulk upserts. Achievement sync now runs outside the legacy Realm transaction path.
 - [x] **HealthExamination** migrated (synced + custom uploaded health records).

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -73,18 +73,18 @@ wired through `di/RoomModule`.
       `DictionaryActivity`; legacy `RealmDictionary` is now a plain compatibility DTO). First proven template (raw-Realm activity).
 - [x] Realm transition config: `DatabaseService` now uses `deleteRealmIfMigrationNeeded()` so a
       model leaving the Realm schema recreates the Realm file instead of crashing (drop-and-resync).
-- [x] **Life** domain migrated end-to-end (`RealmMyLife` is now a Room `@Entity`, `MyLifeDao`,
+- [x] **Life** domain migrated end-to-end (`MyLife` is now a Room `@Entity`, `MyLifeDao`,
       `LifeRepositoryImpl` off `RealmRepository`, both Life test files ported). First proven
       *repository* template (in-place model conversion, class name kept so UI is untouched).
-- [x] **Personals** domain migrated end-to-end (`RealmMyPersonal` now a Room `@Entity` with
+- [x] **Personals** domain migrated end-to-end (`Personal` now a Room `@Entity` with
       `@JvmField` on `id`/`_id` to avoid Room's ambiguous-accessor error, `PersonalDao` with a
       reactive `Flow` query, `PersonalsRepositoryImpl` off `RealmRepository`, test ported).
-- [x] **Retry** domain migrated end-to-end (`RealmRetryOperation` now a Room `@Entity`;
+- [x] **Retry** domain migrated end-to-end (`RetryOperation` now a Room `@Entity`;
       Realm-based `createFromRetryFailure` factory replaced with a pure one; `RetryDao` with
       status-filtered queries/updates; `RetryRepositoryImpl` off `RealmRepository`; test ported).
 - [x] **Community** domain migrated (`Community` now a Room `@Entity`; `CommunityDao` with a
       `@Transaction replaceAll`; `CommunityRepositoryImpl` keeps `RealmRepository` only for the
-      still-Realm `RealmMeetup` insert, using `CommunityDao` for community rows). First proven
+      still-Realm `Meetup` insert, using `CommunityDao` for community rows). First proven
       *coexistence-within-one-repo* template. Dropped a Realm-only `isValid` check in the sync UI.
 - [x] **Upload framework made Room-capable**: added `RoomUploadConfig<T: Any>` + a parallel
       `UploadCoordinator.uploadRoom()` path (DB-agnostic: `fetchPendingItems` + DAO `markUploaded`),
@@ -114,7 +114,7 @@ wired through `di/RoomModule`.
       value-object child lists. (Child types that ARE queried independently — courseSteps,
       answers, attachments, examQuestions — will instead need their own tables.) Both Chat test
       files ported to mock `ChatDao`.
-- [x] **Feedback** migrated (both uploaded AND synced). `RealmFeedback` Room `@Entity`
+- [x] **Feedback** migrated (both uploaded AND synced). `Feedback` Room `@Entity`
       (@JvmField id/_id; messages JSON string; @Ignore on computed messageList/message);
       `FeedbackDao` with two reactive `Flow` queries; `FeedbackRepositoryImpl` off
       `RealmRepository`; `Feedback` upload config -> `RoomUploadConfig` (markUploaded sets
@@ -135,7 +135,7 @@ wired through `di/RoomModule`.
       `CoursesRepositoryImpl.filterCourses` now resolves tag→course links via `TagDao` before the
       Realm course query (injects `tagDao`). First proven **`RealmList<String>` → JSON `List`**
       mapping. Repo test rewritten to mock `TagDao`; `CoursesRepositoryImplTest` constructor updated.
-- [x] **Meetup** migrated (synced + uploaded, cross-repo). `RealmMeetup` Room `@Entity`
+- [x] **Meetup** migrated (synced + uploaded, cross-repo). `Meetup` Room `@Entity`
       (non-null PK `id`; `@Index` on meetupId/teamId/userId; all-scalar fields, no converters);
       the Realm `insert`/`insertList`/`getMyMeetUpIds(realm,…)` companions replaced with pure
       `fromJson(...)` + `getMyMeetUpIds(List)`. `MeetupDao` (by-team/meetupId/id/user, members,
@@ -175,19 +175,19 @@ wired through `di/RoomModule`.
       `OfflineActivity` is now a Room `@Entity`; `OfflineActivityDao` owns offline login
       counts/flows, last-login lookups, pending upload reads, upload acknowledgements, and sync
       upserts with the existing `_id` plus `loginTime`/`user` fallback dedupe behavior.
-- [x] **CourseProgress** migrated (uploaded + synced progress records). `RealmCourseProgress` is
+- [x] **CourseProgress** migrated (uploaded + synced progress records). `CourseProgress` is
       now a Room `@Entity`; `CourseProgressDao` owns user/course progress reads, completion
       records, save/update paths, pending upload reads, upload acknowledgements, and sync upserts
       that preserve locally-passed steps when server progress lags.
 - [x] **RemovedLog** migrated (local shelf tombstones). `RemovedLog` is now a Room
       `@Entity`; `RemovedLogDao` owns add/remove tombstone writes, bulk cleanup when resources or
       courses are re-added, and shelf merge filtering for removed resources/courses.
-- [x] **TeamTask** migrated (uploaded + synced task rows). `RealmTeamTask` is now a Room
+- [x] **TeamTask** migrated (uploaded + synced task rows). `TeamTask` is now a Room
       `@Entity`; `TeamTaskDao` owns task flows, due-task notification lookups, title/id lookups,
       sync upserts, pending-upload reads, and upload acknowledgements; task repository and
       notification lookups use the DAO, and the upload config now uses `RoomUploadConfig`.
 - [ ] Migrate the remaining ~7 uploadable models to `RoomUploadConfig` + the synced-only domains.
-- [x] **Notification** migrated (synced local notification rows). `RealmNotification` is now a
+- [x] **Notification** migrated (synced local notification rows). `AppNotification` is now a
       Room `@Entity`; `NotificationDao` owns unread counts, read/sync marking, list filters,
       deletes, single-doc upserts, and sync bulk upserts. Notification sync now runs outside the
       legacy Realm transaction path.
@@ -196,7 +196,7 @@ wired through `di/RoomModule`.
       `AchievementDao` owns initialization, edits, pending-upload reads, upload acknowledgements,
       and sync bulk upserts. Achievement sync now runs outside the legacy Realm transaction path.
 - [x] **HealthExamination** migrated (synced + custom uploaded health records).
-      `RealmHealthExamination` is now a Room `@Entity`; `HealthExaminationDao` owns profile/id
+      `HealthExamination` is now a Room `@Entity`; `HealthExaminationDao` owns profile/id
       lookups, pending upload reads, upload acknowledgements, user-id fixes after user upload,
       and sync bulk upserts. Health sync now runs outside the legacy Realm transaction path.
 - [ ] Remaining ~28 model domains.


### PR DESCRIPTION
### Motivation
- Migrate startup and crash/ANR log persistence away from Realm to the Room-backed database as part of the Realm→Room transition.
- Avoid relying on the legacy `DatabaseService` / main-thread Realm warm-up during app initialization.
- Ensure logs continue to be persisted using the `ApkLogDao` Room DAO so crash/ANR reports survive process restarts.

### Description
- Replaced `DatabaseService`/Realm usages in `MainApplication` with an injected `AppDatabase` provider and removed the Realm dispatcher import.
- Removed the `mainThreadRealm` warm-up and explicit Realm lifecycle calls, and replaced the Realm connection check with a Room initialization that opens `appDatabase.openHelper.writableDatabase` on the IO dispatcher in `initializeDatabaseConnection`.
- Renamed `saveLogToRealm` to `saveLogToRoom` and updated uncaught-exception/ANR handling and pending-log sweep to insert `RealmApkLog` rows via `ApkLogDao.insert` instead of writing to Realm.
- Removed the now-unused `databaseService()` entry from the `CoreDependenciesEntryPoint` Hilt entry point.

### Testing
- `./gradlew :app:compileDefaultDebugKotlin` completed successfully and the project compiled (build succeeded with some Kotlin warnings reported).
- `./gradlew :app:compileDebugKotlin` failed due to an ambiguous task name in this multi-flavor project (task name collision), not due to the code changes.
- Changes were validated by re-running `./gradlew :app:compileDefaultDebugKotlin` after adjustments and the compilation remained successful.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b025b62f8832b877f7f881e5605b9)