### PR TITLE
Move course step reads to Room

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
@@ -81,10 +81,12 @@ interface SubmissionDao {
     @Query("SELECT * FROM submissions WHERE userId = :userId AND parentId = :parentId AND status = 'pending' ORDER BY lastUpdateTime DESC LIMIT 1") suspend fun getLatestPendingByUserAndParent(userId: String?, parentId: String): RoomSubmissionEntity?
     @Query("SELECT * FROM submissions WHERE userId = :userId AND status = 'pending' ORDER BY startTime DESC LIMIT 1") suspend fun getLatestPendingByUser(userId: String?): RoomSubmissionEntity?
     @Query("SELECT * FROM submissions WHERE parentId LIKE '%' || :parentIdFragment || '%' LIMIT 1") suspend fun getFirstByParentIdContaining(parentIdFragment: String): RoomSubmissionEntity?
+    @Query("SELECT * FROM submissions WHERE parentId IN (:parentIds) AND type != 'survey' AND uploaded = 0") suspend fun getUnuploadedNonSurveyByParentIds(parentIds: List<String>): List<RoomSubmissionEntity>
     @Query("UPDATE submissions SET user = :userJson, status = 'complete', isUpdated = 1 WHERE id = :id") suspend fun markComplete(id: String, userJson: String): Int
     @Query("UPDATE submissions SET status = :status WHERE id = :id") suspend fun updateStatus(id: String, status: String): Int
     @Query("UPDATE submissions SET status = :status, lastUpdateTime = :lastUpdateTime WHERE id = :id") suspend fun updateStatusAndLastUpdate(id: String, status: String, lastUpdateTime: Long): Int
     @Query("DELETE FROM submissions WHERE parentId = :parentId AND userId = :userId") suspend fun deleteByParentAndUser(parentId: String, userId: String?): Int
+    @Query("DELETE FROM submissions WHERE id IN (:ids)") suspend fun deleteByIds(ids: List<String>): Int
     @Query("DELETE FROM submissions WHERE parentId = :parentId AND userId = :userId AND status = 'pending' AND type = 'survey' AND teamId IS NULL") suspend fun deletePendingSurveyOrphans(parentId: String?, userId: String?): Int
     @Query("SELECT * FROM submissions WHERE type = 'exam' AND parentId IS NOT NULL AND userId IS NOT NULL AND (_id IS NULL OR _id = '')") suspend fun getPendingExamResults(): List<RoomSubmissionEntity>
     @Query("SELECT * FROM submissions WHERE status = 'complete' AND (isUpdated = 1 OR _id = '')") suspend fun getPendingSubmissions(): List<RoomSubmissionEntity>

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.data.room.dao.legacy
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomAnswerEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomCourseEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomCourseStepEntity
@@ -66,7 +67,9 @@ interface SubmissionDao {
     @Query("SELECT * FROM submissions WHERE id = :id OR _id = :id LIMIT 1") suspend fun getByIdOrRemoteId(id: String): RoomSubmissionEntity?
     @Query("SELECT * FROM submissions WHERE id IN (:ids)") suspend fun getByIds(ids: List<String>): List<RoomSubmissionEntity>
     @Query("SELECT * FROM submissions WHERE userId = :userId") suspend fun getByUserId(userId: String): List<RoomSubmissionEntity>
+    @Query("SELECT * FROM submissions WHERE userId = :userId") fun observeByUserId(userId: String): Flow<List<RoomSubmissionEntity>>
     @Query("SELECT * FROM submissions WHERE userId = :userId AND status = 'pending' AND type = 'survey'") suspend fun getPendingSurveys(userId: String): List<RoomSubmissionEntity>
+    @Query("SELECT * FROM submissions WHERE userId = :userId AND LOWER(status) = 'pending' AND type = 'survey'") fun observePendingSurveys(userId: String?): Flow<List<RoomSubmissionEntity>>
     @Query("SELECT * FROM submissions WHERE userId = :userId AND status = 'pending' AND type = 'survey' AND teamId IS NULL") suspend fun getUniquePendingSurveyCandidates(userId: String): List<RoomSubmissionEntity>
     @Query("SELECT COUNT(*) FROM submissions WHERE (isUpdated = 1 OR _id = '')") suspend fun countPendingOfflineSubmissions(): Int
     @Query("SELECT COUNT(*) FROM submissions WHERE LOWER(status) = 'pending' AND id IN (SELECT submissionId FROM answers WHERE submissionId IS NOT NULL)") suspend fun countPendingExamResults(): Int
@@ -74,8 +77,10 @@ interface SubmissionDao {
     @Query("SELECT COUNT(*) FROM submissions WHERE userId = :userId AND parentId LIKE '%' || :examId || '%' AND status != 'pending'") suspend fun countCompletedByUserAndExamId(userId: String?, examId: String): Int
     @Query("SELECT * FROM submissions WHERE parentId = :parentId AND userId = :userId AND (:status IS NULL OR status = :status) ORDER BY startTime DESC") suspend fun getByParentUserAndStatus(parentId: String?, userId: String?, status: String?): List<RoomSubmissionEntity>
     @Query("SELECT * FROM submissions WHERE userId = :userId AND parentId = :parentId AND status = 'pending' ORDER BY lastUpdateTime DESC LIMIT 1") suspend fun getLatestPendingByUserAndParent(userId: String?, parentId: String): RoomSubmissionEntity?
+    @Query("SELECT * FROM submissions WHERE userId = :userId AND status = 'pending' ORDER BY startTime DESC LIMIT 1") suspend fun getLatestPendingByUser(userId: String?): RoomSubmissionEntity?
     @Query("SELECT * FROM submissions WHERE parentId LIKE '%' || :parentIdFragment || '%' LIMIT 1") suspend fun getFirstByParentIdContaining(parentIdFragment: String): RoomSubmissionEntity?
     @Query("UPDATE submissions SET user = :userJson, status = 'complete', isUpdated = 1 WHERE id = :id") suspend fun markComplete(id: String, userJson: String): Int
+    @Query("UPDATE submissions SET status = :status WHERE id = :id") suspend fun updateStatus(id: String, status: String): Int
     @Query("DELETE FROM submissions WHERE parentId = :parentId AND userId = :userId") suspend fun deleteByParentAndUser(parentId: String, userId: String?): Int
     @Query("SELECT * FROM submissions WHERE type = 'exam' AND parentId IS NOT NULL AND userId IS NOT NULL AND (_id IS NULL OR _id = '')") suspend fun getPendingExamResults(): List<RoomSubmissionEntity>
     @Query("SELECT * FROM submissions WHERE status = 'complete' AND (isUpdated = 1 OR _id = '')") suspend fun getPendingSubmissions(): List<RoomSubmissionEntity>

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
@@ -30,6 +30,8 @@ interface CourseDao {
 @Dao
 interface CourseStepDao {
     @Query("SELECT * FROM course_steps WHERE courseId = :courseId") suspend fun getByCourseId(courseId: String): List<RoomCourseStepEntity>
+    @Query("SELECT * FROM course_steps WHERE courseId IN (:courseIds)") suspend fun getByCourseIds(courseIds: List<String>): List<RoomCourseStepEntity>
+    @Query("SELECT * FROM course_steps WHERE id = :id LIMIT 1") suspend fun getById(id: String): RoomCourseStepEntity?
     @Upsert suspend fun upsertAll(items: List<RoomCourseStepEntity>)
     @Upsert fun upsertAllBlocking(items: List<RoomCourseStepEntity>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
@@ -81,7 +81,9 @@ interface SubmissionDao {
     @Query("SELECT * FROM submissions WHERE parentId LIKE '%' || :parentIdFragment || '%' LIMIT 1") suspend fun getFirstByParentIdContaining(parentIdFragment: String): RoomSubmissionEntity?
     @Query("UPDATE submissions SET user = :userJson, status = 'complete', isUpdated = 1 WHERE id = :id") suspend fun markComplete(id: String, userJson: String): Int
     @Query("UPDATE submissions SET status = :status WHERE id = :id") suspend fun updateStatus(id: String, status: String): Int
+    @Query("UPDATE submissions SET status = :status, lastUpdateTime = :lastUpdateTime WHERE id = :id") suspend fun updateStatusAndLastUpdate(id: String, status: String, lastUpdateTime: Long): Int
     @Query("DELETE FROM submissions WHERE parentId = :parentId AND userId = :userId") suspend fun deleteByParentAndUser(parentId: String, userId: String?): Int
+    @Query("DELETE FROM submissions WHERE parentId = :parentId AND userId = :userId AND status = 'pending' AND type = 'survey' AND teamId IS NULL") suspend fun deletePendingSurveyOrphans(parentId: String?, userId: String?): Int
     @Query("SELECT * FROM submissions WHERE type = 'exam' AND parentId IS NOT NULL AND userId IS NOT NULL AND (_id IS NULL OR _id = '')") suspend fun getPendingExamResults(): List<RoomSubmissionEntity>
     @Query("SELECT * FROM submissions WHERE status = 'complete' AND (isUpdated = 1 OR _id = '')") suspend fun getPendingSubmissions(): List<RoomSubmissionEntity>
     @Upsert suspend fun upsertAll(items: List<RoomSubmissionEntity>)
@@ -93,6 +95,7 @@ interface SubmissionDao {
 interface AnswerDao {
     @Query("SELECT * FROM answers WHERE submissionId = :submissionId") suspend fun getBySubmissionId(submissionId: String): List<RoomAnswerEntity>
     @Query("SELECT * FROM answers WHERE submissionId IN (:submissionIds)") suspend fun getBySubmissionIds(submissionIds: List<String>): List<RoomAnswerEntity>
+    @Query("SELECT * FROM answers WHERE submissionId = :submissionId AND questionId = :questionId LIMIT 1") suspend fun getBySubmissionAndQuestion(submissionId: String, questionId: String?): RoomAnswerEntity?
     @Query("DELETE FROM answers WHERE submissionId IN (:submissionIds)") suspend fun deleteBySubmissionIds(submissionIds: List<String>): Int
     @Upsert suspend fun upsertAll(items: List<RoomAnswerEntity>)
     @Upsert fun upsertAllBlocking(items: List<RoomAnswerEntity>)

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
@@ -55,6 +55,7 @@ interface ExamDao {
 
 @Dao
 interface QuestionDao {
+    @Query("SELECT * FROM exam_questions WHERE id IN (:ids)") suspend fun getByIds(ids: List<String>): List<RoomQuestionEntity>
     @Query("SELECT * FROM exam_questions WHERE examId = :examId") suspend fun getByExamId(examId: String): List<RoomQuestionEntity>
     @Query("SELECT * FROM exam_questions WHERE examId IN (:examIds)") suspend fun getByExamIds(examIds: List<String>): List<RoomQuestionEntity>
     @Query("SELECT COUNT(*) FROM exam_questions WHERE examId = :examId") suspend fun countByExamId(examId: String): Int
@@ -67,6 +68,7 @@ interface SubmissionDao {
     @Query("SELECT * FROM submissions WHERE id = :id OR _id = :id LIMIT 1") suspend fun getByIdOrRemoteId(id: String): RoomSubmissionEntity?
     @Query("SELECT * FROM submissions WHERE id IN (:ids)") suspend fun getByIds(ids: List<String>): List<RoomSubmissionEntity>
     @Query("SELECT * FROM submissions WHERE userId = :userId") suspend fun getByUserId(userId: String): List<RoomSubmissionEntity>
+    @Query("SELECT * FROM submissions WHERE userId = :userId AND type = 'exam'") suspend fun getExamSubmissionsByUser(userId: String?): List<RoomSubmissionEntity>
     @Query("SELECT * FROM submissions WHERE userId = :userId") fun observeByUserId(userId: String): Flow<List<RoomSubmissionEntity>>
     @Query("SELECT * FROM submissions WHERE userId = :userId AND status = 'pending' AND type = 'survey'") suspend fun getPendingSurveys(userId: String): List<RoomSubmissionEntity>
     @Query("SELECT * FROM submissions WHERE userId = :userId AND LOWER(status) = 'pending' AND type = 'survey'") fun observePendingSurveys(userId: String?): Flow<List<RoomSubmissionEntity>>

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
@@ -63,6 +63,17 @@ interface QuestionDao {
 
 @Dao
 interface SubmissionDao {
+    @Query("SELECT * FROM submissions WHERE id = :id OR _id = :id LIMIT 1") suspend fun getByIdOrRemoteId(id: String): RoomSubmissionEntity?
+    @Query("SELECT * FROM submissions WHERE id IN (:ids)") suspend fun getByIds(ids: List<String>): List<RoomSubmissionEntity>
+    @Query("SELECT * FROM submissions WHERE userId = :userId") suspend fun getByUserId(userId: String): List<RoomSubmissionEntity>
+    @Query("SELECT * FROM submissions WHERE userId = :userId AND status = 'pending' AND type = 'survey'") suspend fun getPendingSurveys(userId: String): List<RoomSubmissionEntity>
+    @Query("SELECT * FROM submissions WHERE userId = :userId AND status = 'pending' AND type = 'survey' AND teamId IS NULL") suspend fun getUniquePendingSurveyCandidates(userId: String): List<RoomSubmissionEntity>
+    @Query("SELECT COUNT(*) FROM submissions WHERE (isUpdated = 1 OR _id = '')") suspend fun countPendingOfflineSubmissions(): Int
+    @Query("SELECT COUNT(*) FROM submissions WHERE LOWER(status) = 'pending' AND id IN (SELECT submissionId FROM answers WHERE submissionId IS NOT NULL)") suspend fun countPendingExamResults(): Int
+    @Query("SELECT COUNT(*) FROM submissions WHERE userId = :userId AND parentId = :parentId AND type = :type") suspend fun countByUserParentAndType(userId: String?, parentId: String, type: String): Int
+    @Query("SELECT COUNT(*) FROM submissions WHERE userId = :userId AND parentId LIKE '%' || :examId || '%' AND status != 'pending'") suspend fun countCompletedByUserAndExamId(userId: String?, examId: String): Int
+    @Query("SELECT * FROM submissions WHERE parentId = :parentId AND userId = :userId AND (:status IS NULL OR status = :status) ORDER BY startTime DESC") suspend fun getByParentUserAndStatus(parentId: String?, userId: String?, status: String?): List<RoomSubmissionEntity>
+    @Query("SELECT * FROM submissions WHERE parentId LIKE '%' || :parentIdFragment || '%' LIMIT 1") suspend fun getFirstByParentIdContaining(parentIdFragment: String): RoomSubmissionEntity?
     @Query("SELECT * FROM submissions WHERE type = 'exam' AND parentId IS NOT NULL AND userId IS NOT NULL AND (_id IS NULL OR _id = '')") suspend fun getPendingExamResults(): List<RoomSubmissionEntity>
     @Query("SELECT * FROM submissions WHERE status = 'complete' AND (isUpdated = 1 OR _id = '')") suspend fun getPendingSubmissions(): List<RoomSubmissionEntity>
     @Upsert suspend fun upsertAll(items: List<RoomSubmissionEntity>)
@@ -73,6 +84,7 @@ interface SubmissionDao {
 @Dao
 interface AnswerDao {
     @Query("SELECT * FROM answers WHERE submissionId = :submissionId") suspend fun getBySubmissionId(submissionId: String): List<RoomAnswerEntity>
+    @Query("SELECT * FROM answers WHERE submissionId IN (:submissionIds)") suspend fun getBySubmissionIds(submissionIds: List<String>): List<RoomAnswerEntity>
     @Upsert suspend fun upsertAll(items: List<RoomAnswerEntity>)
     @Upsert fun upsertAllBlocking(items: List<RoomAnswerEntity>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
@@ -73,7 +73,10 @@ interface SubmissionDao {
     @Query("SELECT COUNT(*) FROM submissions WHERE userId = :userId AND parentId = :parentId AND type = :type") suspend fun countByUserParentAndType(userId: String?, parentId: String, type: String): Int
     @Query("SELECT COUNT(*) FROM submissions WHERE userId = :userId AND parentId LIKE '%' || :examId || '%' AND status != 'pending'") suspend fun countCompletedByUserAndExamId(userId: String?, examId: String): Int
     @Query("SELECT * FROM submissions WHERE parentId = :parentId AND userId = :userId AND (:status IS NULL OR status = :status) ORDER BY startTime DESC") suspend fun getByParentUserAndStatus(parentId: String?, userId: String?, status: String?): List<RoomSubmissionEntity>
+    @Query("SELECT * FROM submissions WHERE userId = :userId AND parentId = :parentId AND status = 'pending' ORDER BY lastUpdateTime DESC LIMIT 1") suspend fun getLatestPendingByUserAndParent(userId: String?, parentId: String): RoomSubmissionEntity?
     @Query("SELECT * FROM submissions WHERE parentId LIKE '%' || :parentIdFragment || '%' LIMIT 1") suspend fun getFirstByParentIdContaining(parentIdFragment: String): RoomSubmissionEntity?
+    @Query("UPDATE submissions SET user = :userJson, status = 'complete', isUpdated = 1 WHERE id = :id") suspend fun markComplete(id: String, userJson: String): Int
+    @Query("DELETE FROM submissions WHERE parentId = :parentId AND userId = :userId") suspend fun deleteByParentAndUser(parentId: String, userId: String?): Int
     @Query("SELECT * FROM submissions WHERE type = 'exam' AND parentId IS NOT NULL AND userId IS NOT NULL AND (_id IS NULL OR _id = '')") suspend fun getPendingExamResults(): List<RoomSubmissionEntity>
     @Query("SELECT * FROM submissions WHERE status = 'complete' AND (isUpdated = 1 OR _id = '')") suspend fun getPendingSubmissions(): List<RoomSubmissionEntity>
     @Upsert suspend fun upsertAll(items: List<RoomSubmissionEntity>)
@@ -85,6 +88,7 @@ interface SubmissionDao {
 interface AnswerDao {
     @Query("SELECT * FROM answers WHERE submissionId = :submissionId") suspend fun getBySubmissionId(submissionId: String): List<RoomAnswerEntity>
     @Query("SELECT * FROM answers WHERE submissionId IN (:submissionIds)") suspend fun getBySubmissionIds(submissionIds: List<String>): List<RoomAnswerEntity>
+    @Query("DELETE FROM answers WHERE submissionId IN (:submissionIds)") suspend fun deleteBySubmissionIds(submissionIds: List<String>): Int
     @Upsert suspend fun upsertAll(items: List<RoomAnswerEntity>)
     @Upsert fun upsertAllBlocking(items: List<RoomAnswerEntity>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
@@ -39,7 +39,11 @@ interface CourseStepDao {
 @Dao
 interface ExamDao {
     @Query("SELECT * FROM exams WHERE courseId = :courseId") suspend fun getByCourseId(courseId: String): List<RoomExamEntity>
+    @Query("SELECT * FROM exams WHERE courseId IN (:courseIds)") suspend fun getByCourseIds(courseIds: List<String>): List<RoomExamEntity>
+    @Query("SELECT * FROM exams WHERE courseId = :courseId AND type = :type") suspend fun getByCourseIdAndType(courseId: String, type: String): List<RoomExamEntity>
     @Query("SELECT * FROM exams WHERE stepId = :stepId") suspend fun getByStepId(stepId: String): List<RoomExamEntity>
+    @Query("SELECT * FROM exams WHERE stepId IN (:stepIds)") suspend fun getByStepIds(stepIds: List<String>): List<RoomExamEntity>
+    @Query("SELECT * FROM exams WHERE stepId = :stepId AND type = :type") suspend fun getByStepIdAndType(stepId: String, type: String): List<RoomExamEntity>
     @Query("SELECT * FROM exams WHERE sourceSurveyId IS NOT NULL AND _rev IS NULL") suspend fun getPendingAdoptedSurveys(): List<RoomExamEntity>
     @Upsert suspend fun upsertAll(items: List<RoomExamEntity>)
     @Upsert fun upsertAllBlocking(items: List<RoomExamEntity>)

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/legacy/LegacyEntityDaos.kt
@@ -38,6 +38,9 @@ interface CourseStepDao {
 
 @Dao
 interface ExamDao {
+    @Query("SELECT * FROM exams WHERE id IN (:ids)") suspend fun getByIds(ids: List<String>): List<RoomExamEntity>
+    @Query("SELECT * FROM exams WHERE id = :id LIMIT 1") suspend fun getById(id: String): RoomExamEntity?
+    @Query("SELECT * FROM exams WHERE stepId = :stepId LIMIT 1") suspend fun getFirstByStepId(stepId: String): RoomExamEntity?
     @Query("SELECT * FROM exams WHERE courseId = :courseId") suspend fun getByCourseId(courseId: String): List<RoomExamEntity>
     @Query("SELECT * FROM exams WHERE courseId IN (:courseIds)") suspend fun getByCourseIds(courseIds: List<String>): List<RoomExamEntity>
     @Query("SELECT * FROM exams WHERE courseId = :courseId AND type = :type") suspend fun getByCourseIdAndType(courseId: String, type: String): List<RoomExamEntity>
@@ -52,6 +55,8 @@ interface ExamDao {
 @Dao
 interface QuestionDao {
     @Query("SELECT * FROM exam_questions WHERE examId = :examId") suspend fun getByExamId(examId: String): List<RoomQuestionEntity>
+    @Query("SELECT * FROM exam_questions WHERE examId IN (:examIds)") suspend fun getByExamIds(examIds: List<String>): List<RoomQuestionEntity>
+    @Query("SELECT COUNT(*) FROM exam_questions WHERE examId = :examId") suspend fun countByExamId(examId: String): Int
     @Upsert suspend fun upsertAll(items: List<RoomQuestionEntity>)
     @Upsert fun upsertAllBlocking(items: List<RoomQuestionEntity>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/entity/legacy/LegacyRoomMappers.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/entity/legacy/LegacyRoomMappers.kt
@@ -134,6 +134,19 @@ fun RealmExamQuestion.toRoomEntity(): RoomQuestionEntity? {
     )
 }
 
+fun RoomQuestionEntity.toRealmModel(): RealmExamQuestion {
+    return RealmExamQuestion().apply {
+        id = this@toRealmModel.id
+        examId = this@toRealmModel.examId
+        type = this@toRealmModel.type
+        body = this@toRealmModel.question
+        header = this@toRealmModel.question
+        choices = this@toRealmModel.choices?.firstOrNull()
+        setCorrectChoices(this@toRealmModel.correctChoice)
+        marks = this@toRealmModel.grade.toString()
+    }
+}
+
 fun RealmSubmission.toRoomEntity(): RoomSubmissionEntity? {
     val localId = id ?: _id ?: return null
     return RoomSubmissionEntity(

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/entity/legacy/LegacyRoomMappers.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/entity/legacy/LegacyRoomMappers.kt
@@ -96,6 +96,30 @@ fun RealmStepExam.toRoomEntity(): RoomExamEntity? {
     )
 }
 
+fun RoomExamEntity.toRealmModel(): RealmStepExam {
+    return RealmStepExam().apply {
+        id = this@toRealmModel.id
+        _rev = this@toRealmModel._rev
+        createdDate = this@toRealmModel.createdDate
+        updatedDate = this@toRealmModel.updatedDate
+        adoptionDate = this@toRealmModel.adoptionDate
+        createdBy = this@toRealmModel.createdBy
+        totalMarks = this@toRealmModel.totalMarks
+        name = this@toRealmModel.name
+        description = this@toRealmModel.description
+        type = this@toRealmModel.type
+        stepId = this@toRealmModel.stepId
+        courseId = this@toRealmModel.courseId
+        sourcePlanet = this@toRealmModel.sourcePlanet
+        passingPercentage = this@toRealmModel.passingPercentage
+        noOfQuestions = this@toRealmModel.noOfQuestions
+        isFromNation = this@toRealmModel.isFromNation
+        teamId = this@toRealmModel.teamId
+        isTeamShareAllowed = this@toRealmModel.isTeamShareAllowed
+        sourceSurveyId = this@toRealmModel.sourceSurveyId
+    }
+}
+
 fun RealmExamQuestion.toRoomEntity(): RoomQuestionEntity? {
     val localId = id ?: return null
     return RoomQuestionEntity(

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/entity/legacy/LegacyRoomMappers.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/entity/legacy/LegacyRoomMappers.kt
@@ -1,8 +1,10 @@
 package org.ole.planet.myplanet.data.room.entity.legacy
 
+import io.realm.RealmList
 import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.model.RealmCourseStep
 import org.ole.planet.myplanet.model.RealmExamQuestion
+import org.ole.planet.myplanet.model.RealmMembershipDoc
 import org.ole.planet.myplanet.model.RealmMyCourse
 import org.ole.planet.myplanet.model.RealmMyTeam
 import org.ole.planet.myplanet.model.RealmStepExam
@@ -184,6 +186,46 @@ fun RealmAnswer.toRoomEntity(): RoomAnswerEntity? {
         questionId = questionId,
         submissionId = submissionId,
     )
+}
+
+fun RoomAnswerEntity.toRealmModel(): RealmAnswer {
+    return RealmAnswer().apply {
+        id = this@toRealmModel.id
+        value = this@toRealmModel.value
+        valueChoices = RealmList<String>().apply { addAll(this@toRealmModel.valueChoices.orEmpty()) }
+        mistakes = this@toRealmModel.mistakes
+        isPassed = this@toRealmModel.isPassed
+        grade = this@toRealmModel.grade
+        examId = this@toRealmModel.examId
+        questionId = this@toRealmModel.questionId
+        submissionId = this@toRealmModel.submissionId
+    }
+}
+
+fun RoomSubmissionEntity.toRealmModel(answers: List<RoomAnswerEntity> = emptyList()): RealmSubmission {
+    return RealmSubmission().apply {
+        id = this@toRealmModel.id
+        _id = this@toRealmModel._id
+        _rev = this@toRealmModel._rev
+        parentId = this@toRealmModel.parentId
+        type = this@toRealmModel.type
+        userId = this@toRealmModel.userId
+        user = this@toRealmModel.user
+        startTime = this@toRealmModel.startTime
+        lastUpdateTime = this@toRealmModel.lastUpdateTime
+        this.answers = RealmList<RealmAnswer>().apply { addAll(answers.map { it.toRealmModel() }) }
+        grade = this@toRealmModel.grade
+        status = this@toRealmModel.status
+        uploaded = this@toRealmModel.uploaded
+        sender = this@toRealmModel.sender
+        source = this@toRealmModel.source
+        parentCode = this@toRealmModel.parentCode
+        parent = this@toRealmModel.parent
+        isUpdated = this@toRealmModel.isUpdated
+        membershipDoc = this@toRealmModel.teamId?.let { teamId ->
+            RealmMembershipDoc().apply { this.teamId = teamId }
+        }
+    }
 }
 
 fun RealmMyTeam.toRoomEntity(): RoomTeamEntity? {

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/entity/legacy/LegacyRoomMappers.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/entity/legacy/LegacyRoomMappers.kt
@@ -61,6 +61,16 @@ fun RealmCourseStep.toRoomEntity(): RoomCourseStepEntity? {
     )
 }
 
+fun RoomCourseStepEntity.toRealmModel(): RealmCourseStep {
+    return RealmCourseStep().apply {
+        id = this@toRealmModel.id
+        courseId = this@toRealmModel.courseId
+        stepTitle = this@toRealmModel.stepTitle
+        description = this@toRealmModel.description
+        noOfResources = this@toRealmModel.noOfResources
+    }
+}
+
 fun RealmStepExam.toRoomEntity(): RoomExamEntity? {
     val localId = id ?: return null
     return RoomExamEntity(

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/entity/legacy/LegacyRoomMappers.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/entity/legacy/LegacyRoomMappers.kt
@@ -36,6 +36,23 @@ fun RealmUser.toRoomEntity(): RoomUserEntity? {
     )
 }
 
+fun RoomUserEntity.toRealmModel(): RealmUser {
+    return RealmUser().apply {
+        id = this@toRealmModel.id
+        _id = this@toRealmModel._id
+        _rev = this@toRealmModel._rev
+        name = this@toRealmModel.name
+        firstName = this@toRealmModel.firstName
+        lastName = this@toRealmModel.lastName
+        rolesList = RealmList<String?>().apply { addAll(this@toRealmModel.rolesList.orEmpty()) }
+        planetCode = this@toRealmModel.planetCode
+        parentCode = this@toRealmModel.parentCode
+        userAdmin = this@toRealmModel.isUserAdmin
+        joinDate = this@toRealmModel.joined
+        isUpdated = this@toRealmModel.updated > 0
+    }
+}
+
 fun RealmMyCourse.toRoomEntity(): RoomCourseEntity? {
     val localId = id ?: courseId ?: return null
     return RoomCourseEntity(

--- a/app/src/main/java/org/ole/planet/myplanet/model/RealmExamQuestion.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/RealmExamQuestion.kt
@@ -33,6 +33,12 @@ open class RealmExamQuestion : RealmObject() {
         return correctChoice
     }
 
+    fun setCorrectChoices(choices: List<String>?) {
+        correctChoice = RealmList<String>().apply {
+            choices.orEmpty().forEach { add(it) }
+        }
+    }
+
     val correctChoiceArray: JsonArray
         get() {
             val array = JsonArray()

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.data.room.entity.legacy.RoomCourseEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomCourseStepEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomExamEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomQuestionEntity
+import org.ole.planet.myplanet.data.room.entity.legacy.toRealmModel
 import org.ole.planet.myplanet.data.room.dao.MyLibraryDao
 import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
@@ -153,8 +154,7 @@ class CoursesRepositoryImpl @Inject constructor(
         if (courseId.isBlank()) {
             return emptyList()
         }
-        val course = getCourseById(courseId)
-        return course?.courseSteps?.toList() ?: emptyList()
+        return courseStepDao.getByCourseId(courseId).map { it.toRealmModel() }
     }
 
     override suspend fun markCoursesAdded(courseIds: List<String>, userId: String?): Result<Boolean> {
@@ -493,7 +493,7 @@ class CoursesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getCourseStepData(stepId: String, userId: String?): CourseStepData {
-        val step = findFirstCopy(RealmCourseStep::class.java) { equalTo("id", stepId) }
+        val step = courseStepDao.getById(stepId)?.toRealmModel()
             ?: throw IllegalStateException("Step not found")
         val resources = myLibraryDao.getByStepId(stepId)
         val intermediate = withRealm { realm ->

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -521,15 +521,13 @@ class CoursesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteCourseProgress(courseId: String?) {
-        val examIds = courseId?.let { examDao.getByCourseId(it).map { exam -> exam.id }.toTypedArray() } ?: emptyArray()
-        executeTransaction { realm ->
-            if (examIds.isNotEmpty()) {
-                realm.where(RealmSubmission::class.java)
-                    .`in`("parentId", examIds)
-                    .notEqualTo("type", "survey")
-                    .equalTo("uploaded", false)
-                    .findAll()
-                    .deleteAllFromRealm()
+        val examIds = courseId?.let { examDao.getByCourseId(it).map { exam -> exam.id } }.orEmpty()
+        if (examIds.isNotEmpty()) {
+            val submissions = submissionDao.getUnuploadedNonSurveyByParentIds(examIds.mapNotNull { it })
+            val submissionIds = submissions.map { it.id }
+            if (submissionIds.isNotEmpty()) {
+                answerDao.deleteBySubmissionIds(submissionIds)
+                submissionDao.deleteByIds(submissionIds)
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -145,9 +145,7 @@ class CoursesRepositoryImpl @Inject constructor(
         if (courseId.isNullOrEmpty()) {
             return 0
         }
-        return count(RealmStepExam::class.java) {
-            equalTo("courseId", courseId)
-        }.toInt()
+        return examDao.getByCourseIdAndType(courseId, "courses").size
     }
 
     override suspend fun getCourseSteps(courseId: String): List<RealmCourseStep> {
@@ -350,20 +348,11 @@ class CoursesRepositoryImpl @Inject constructor(
         val stepsList = getCourseSteps(courseId)
         val current = progressRepository.getCurrentProgress(stepsList, userId, courseId)
         val courseTitle = getCourseById(courseId)?.courseTitle
+        val stepIds = stepsList.mapNotNull { it.id }
+        val allExams = if (stepIds.isEmpty()) emptyList() else examDao.getByStepIds(stepIds).map { it.toRealmModel() }
         return withRealm { realm ->
             val max = stepsList.size
             val title = courseTitle
-
-            val stepIds = stepsList.mapNotNull { it.id }
-            val allExams = mutableListOf<RealmStepExam>()
-            if (stepIds.isNotEmpty()) {
-                stepIds.chunked(1000).forEach { chunk ->
-                    val chunkExams = realm.where(RealmStepExam::class.java)
-                        .`in`("stepId", chunk.toTypedArray())
-                        .findAll()
-                    allExams.addAll(chunkExams)
-                }
-            }
             val examsByStepId = allExams.groupBy { it.stepId }
 
             val examIds = allExams.mapNotNull { it.id }
@@ -496,19 +485,9 @@ class CoursesRepositoryImpl @Inject constructor(
         val step = courseStepDao.getById(stepId)?.toRealmModel()
             ?: throw IllegalStateException("Step not found")
         val resources = myLibraryDao.getByStepId(stepId)
-        val intermediate = withRealm { realm ->
-            val stepExams = realm.where(RealmStepExam::class.java)
-                .equalTo("stepId", stepId)
-                .equalTo("type", "courses")
-                .findAll()
-                .let { realm.copyFromRealm(it) }
-            val stepSurvey = realm.where(RealmStepExam::class.java)
-                .equalTo("stepId", stepId)
-                .equalTo("type", "surveys")
-                .findAll()
-                .let { realm.copyFromRealm(it) }
-            CourseStepData(step, resources, stepExams, stepSurvey, false)
-        }
+        val stepExams = examDao.getByStepIdAndType(stepId, "courses").map { it.toRealmModel() }
+        val stepSurvey = examDao.getByStepIdAndType(stepId, "surveys").map { it.toRealmModel() }
+        val intermediate = CourseStepData(step, resources, stepExams, stepSurvey, false)
         val userHasCourse = isMyCourse(userId, intermediate.step.courseId)
         return intermediate.copy(userHasCourse = userHasCourse)
     }
@@ -558,9 +537,8 @@ class CoursesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteCourseProgress(courseId: String?) {
+        val examIds = courseId?.let { examDao.getByCourseId(it).map { exam -> exam.id }.toTypedArray() } ?: emptyArray()
         executeTransaction { realm ->
-            val examList = realm.where(RealmStepExam::class.java).equalTo("courseId", courseId).findAll()
-            val examIds = examList.mapNotNull { it.id }.toTypedArray()
             if (examIds.isNotEmpty()) {
                 realm.where(RealmSubmission::class.java)
                     .`in`("parentId", examIds)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -24,6 +24,8 @@ import org.ole.planet.myplanet.data.room.dao.legacy.CourseDao
 import org.ole.planet.myplanet.data.room.dao.legacy.CourseStepDao
 import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
 import org.ole.planet.myplanet.data.room.dao.legacy.QuestionDao
+import org.ole.planet.myplanet.data.room.dao.legacy.AnswerDao
+import org.ole.planet.myplanet.data.room.dao.legacy.SubmissionDao
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomCourseEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomCourseStepEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomExamEntity
@@ -66,6 +68,8 @@ class CoursesRepositoryImpl @Inject constructor(
     private val courseStepDao: CourseStepDao,
     private val examDao: ExamDao,
     private val questionDao: QuestionDao,
+    private val submissionDao: SubmissionDao,
+    private val answerDao: AnswerDao,
     private val tagDao: TagDao,
     private val searchActivityDao: SearchActivityDao,
     private val courseProgressDao: CourseProgressDao,
@@ -350,72 +354,52 @@ class CoursesRepositoryImpl @Inject constructor(
         val courseTitle = getCourseById(courseId)?.courseTitle
         val stepIds = stepsList.mapNotNull { it.id }
         val allExams = if (stepIds.isEmpty()) emptyList() else examDao.getByStepIds(stepIds).map { it.toRealmModel() }
-        return withRealm { realm ->
-            val max = stepsList.size
-            val title = courseTitle
-            val examsByStepId = allExams.groupBy { it.stepId }
+        val max = stepsList.size
+        val title = courseTitle
+        val examsByStepId = allExams.groupBy { it.stepId }
 
-            val examIds = allExams.mapNotNull { it.id }
-            val questionsByExamId = if (examIds.isNotEmpty()) {
-                val allQuestions = mutableListOf<RealmExamQuestion>()
-                examIds.chunked(1000).forEach { chunk ->
-                    val chunkQuestions = realm.where(RealmExamQuestion::class.java)
-                        .`in`("examId", chunk.toTypedArray())
-                        .findAll()
-                    allQuestions.addAll(chunkQuestions)
-                }
-                allQuestions.groupBy { it.examId ?: "" }
-                    .filterKeys { it.isNotEmpty() }
-            } else {
-                emptyMap()
-            }
-
-            // To eliminate N+1 queries, we fetch all relevant submissions for the user upfront.
-            // We fetch all 'exam' submissions for the user and filter in memory to handle legacy formats
-            // and avoid doubling the query size with multiple ID variants.
-            val examIdsSet = examIds.toSet()
-            val userSubmissions = realm.where(RealmSubmission::class.java)
-                .equalTo("userId", userId)
-                .equalTo("type", "exam")
-                .findAll()
-
-            val relevantSubmissions = userSubmissions.filter { sub ->
-                val pId = sub.parentId
-                val basePId = if (pId?.contains("@") == true) pId.split("@")[0] else pId
-                examIdsSet.contains(basePId)
-            }
-
-            val submissionsByExamId = relevantSubmissions.groupBy { sub ->
-                val pId = sub.parentId
-                if (pId?.contains("@") == true) pId.split("@")[0] else pId ?: ""
-            }.filterKeys { it.isNotEmpty() }
-
-            val submissionIds = relevantSubmissions.mapNotNull { it.id }
-            val answersBySubmissionId = if (submissionIds.isNotEmpty()) {
-                // Realm IN query limit is around 1000 items, so we chunk the list to avoid query length limits.
-                val allAnswers = mutableListOf<RealmAnswer>()
-                submissionIds.chunked(1000).forEach { chunk ->
-                    val chunkAnswers = realm.where(RealmAnswer::class.java)
-                        .`in`("submissionId", chunk.toTypedArray())
-                        .findAll()
-                    allAnswers.addAll(chunkAnswers)
-                }
-                allAnswers.groupBy { it.submissionId ?: "" }
-                    .filterKeys { it.isNotEmpty() }
-            } else {
-                emptyMap()
-            }
-
-            val array = JsonArray()
-            stepsList.forEach { step ->
-                val ob = JsonObject()
-                ob.addProperty("stepId", step.id)
-                val exams = examsByStepId[step.id] ?: emptyList()
-                getExamObject(exams, ob, questionsByExamId, submissionsByExamId, answersBySubmissionId)
-                array.add(ob)
-            }
-            CourseProgressData(title, current, max, array)
+        val examIds = allExams.mapNotNull { it.id }
+        val questionsByExamId = if (examIds.isEmpty()) {
+            emptyMap()
+        } else {
+            questionDao.getByExamIds(examIds)
+                .map { it.toRealmModel() }
+                .groupBy { it.examId ?: "" }
+                .filterKeys { it.isNotEmpty() }
         }
+
+        val examIdsSet = examIds.toSet()
+        val relevantSubmissions = submissionDao.getExamSubmissionsByUser(userId)
+            .map { it.toRealmModel() }
+            .filter { sub -> examIdsSet.contains(getParentBaseId(sub.parentId)) }
+
+        val submissionsByExamId = relevantSubmissions.groupBy { sub ->
+            getParentBaseId(sub.parentId).orEmpty()
+        }.filterKeys { it.isNotEmpty() }
+
+        val submissionIds = relevantSubmissions.mapNotNull { it.id }
+        val answersBySubmissionId = if (submissionIds.isEmpty()) {
+            emptyMap()
+        } else {
+            answerDao.getBySubmissionIds(submissionIds)
+                .map { it.toRealmModel() }
+                .groupBy { it.submissionId ?: "" }
+                .filterKeys { it.isNotEmpty() }
+        }
+
+        val array = JsonArray()
+        stepsList.forEach { step ->
+            val ob = JsonObject()
+            ob.addProperty("stepId", step.id)
+            val exams = examsByStepId[step.id] ?: emptyList()
+            getExamObject(exams, ob, questionsByExamId, submissionsByExamId, answersBySubmissionId)
+            array.add(ob)
+        }
+        return CourseProgressData(title, current, max, array)
+    }
+
+    private fun getParentBaseId(parentId: String?): String? {
+        return if (parentId?.contains("@") == true) parentId.split("@")[0] else parentId
     }
 
     private fun getExamObject(

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
@@ -9,8 +9,11 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
+import org.ole.planet.myplanet.data.room.dao.legacy.AnswerDao
 import org.ole.planet.myplanet.data.room.dao.legacy.CourseStepDao
 import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
+import org.ole.planet.myplanet.data.room.dao.legacy.QuestionDao
+import org.ole.planet.myplanet.data.room.dao.legacy.SubmissionDao
 import org.ole.planet.myplanet.data.room.entity.legacy.toRealmModel
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CourseCompletion
@@ -31,7 +34,10 @@ class ProgressRepositoryImpl @Inject constructor(
     private val activitiesRepositoryLazy: dagger.Lazy<ActivitiesRepository>,
     private val courseProgressDao: CourseProgressDao,
     private val courseStepDao: CourseStepDao,
-    private val examDao: ExamDao
+    private val examDao: ExamDao,
+    private val submissionDao: SubmissionDao,
+    private val answerDao: AnswerDao,
+    private val questionDao: QuestionDao
 ) : RealmRepository(databaseService, realmDispatcher), ProgressRepository {
     override suspend fun getCourseProgress(courseIds: List<String>, userId: String?): HashMap<String?, JsonObject> {
         val allSteps = if (courseIds.isEmpty()) {
@@ -68,6 +74,9 @@ class ProgressRepositoryImpl @Inject constructor(
             examDao.getByCourseIds(courseIds).map { it.toRealmModel() }
         }
         val examsByCourseId = allExams.groupBy { it.courseId }
+        val submissionsByCourseId = submissionDao.getExamSubmissionsByUser(userId)
+            .map { it.toRealmModel() }
+            .groupBy { submission -> courseIds.firstOrNull { courseId -> submission.parentId?.contains(courseId) == true } }
 
         mycourses.forEach { course ->
             val obj = JsonObject()
@@ -75,13 +84,7 @@ class ProgressRepositoryImpl @Inject constructor(
             obj.addProperty("courseId", course.courseId)
             obj.add("progress", courseProgress[course.courseId])
 
-            val submissions = course.courseId?.let { courseId ->
-                queryList(RealmSubmission::class.java) {
-                    equalTo("userId", userId)
-                    equalTo("type", "exam")
-                    contains("parentId", courseId)
-                }
-            }
+            val submissions = submissionsByCourseId[course.courseId].orEmpty()
 
             val exams = examsByCourseId[course.courseId] ?: emptyList()
             val examIds: List<String> = exams.mapNotNull { it.id }
@@ -123,15 +126,11 @@ class ProgressRepositoryImpl @Inject constructor(
     private suspend fun submissionMap(
         submissions: List<RealmSubmission>, examIds: List<String>, obj: JsonObject
     ) {
-        val submissionIds = submissions.mapNotNull { it.id }.toTypedArray()
-        val allAnswers = if (submissionIds.isEmpty()) emptyList() else queryList(RealmAnswer::class.java) {
-            `in`("submissionId", submissionIds)
-        }
+        val submissionIds = submissions.mapNotNull { it.id }
+        val allAnswers = if (submissionIds.isEmpty()) emptyList() else answerDao.getBySubmissionIds(submissionIds).map { it.toRealmModel() }
 
-        val questionIds = allAnswers.mapNotNull { it.questionId }.distinct().toTypedArray()
-        val allQuestions = if (questionIds.isEmpty()) emptyList() else queryList(RealmExamQuestion::class.java) {
-            `in`("id", questionIds)
-        }
+        val questionIds = allAnswers.mapNotNull { it.questionId }.distinct()
+        val allQuestions = if (questionIds.isEmpty()) emptyList() else questionDao.getByIds(questionIds).map { it.toRealmModel() }
         val questionsMap = allQuestions.associateBy { it.id }
 
         val answersBySubmissionId = allAnswers.groupBy { it.submissionId }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.legacy.CourseStepDao
+import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
 import org.ole.planet.myplanet.data.room.entity.legacy.toRealmModel
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CourseCompletion
@@ -29,7 +30,8 @@ class ProgressRepositoryImpl @Inject constructor(
     private val coursesRepositoryLazy: dagger.Lazy<CoursesRepository>,
     private val activitiesRepositoryLazy: dagger.Lazy<ActivitiesRepository>,
     private val courseProgressDao: CourseProgressDao,
-    private val courseStepDao: CourseStepDao
+    private val courseStepDao: CourseStepDao,
+    private val examDao: ExamDao
 ) : RealmRepository(databaseService, realmDispatcher), ProgressRepository {
     override suspend fun getCourseProgress(courseIds: List<String>, userId: String?): HashMap<String?, JsonObject> {
         val allSteps = if (courseIds.isEmpty()) {
@@ -58,11 +60,12 @@ class ProgressRepositoryImpl @Inject constructor(
         val mycourses = coursesRepositoryLazy.get().getMyCourses(userId ?: "")
         val arr = JsonArray()
         val courseIds = mycourses.mapNotNull { it.courseId }
-        val courseIdsArray = courseIds.toTypedArray()
         val courseProgress = getCourseProgress(courseIds, userId)
 
-        val allExams = if (courseIdsArray.isEmpty()) emptyList() else queryList(RealmStepExam::class.java) {
-            `in`("courseId", courseIdsArray)
+        val allExams = if (courseIds.isEmpty()) {
+            emptyList()
+        } else {
+            examDao.getByCourseIds(courseIds).map { it.toRealmModel() }
         }
         val examsByCourseId = allExams.groupBy { it.courseId }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ProgressRepositoryImpl.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
+import org.ole.planet.myplanet.data.room.dao.legacy.CourseStepDao
+import org.ole.planet.myplanet.data.room.entity.legacy.toRealmModel
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CourseCompletion
 import org.ole.planet.myplanet.model.RealmAnswer
@@ -26,12 +28,14 @@ class ProgressRepositoryImpl @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val coursesRepositoryLazy: dagger.Lazy<CoursesRepository>,
     private val activitiesRepositoryLazy: dagger.Lazy<ActivitiesRepository>,
-    private val courseProgressDao: CourseProgressDao
+    private val courseProgressDao: CourseProgressDao,
+    private val courseStepDao: CourseStepDao
 ) : RealmRepository(databaseService, realmDispatcher), ProgressRepository {
     override suspend fun getCourseProgress(courseIds: List<String>, userId: String?): HashMap<String?, JsonObject> {
-        val courseIdsArray = courseIds.toTypedArray()
-        val allSteps = if (courseIdsArray.isEmpty()) emptyList() else queryList(RealmCourseStep::class.java) {
-            `in`("courseId", courseIdsArray)
+        val allSteps = if (courseIds.isEmpty()) {
+            emptyList()
+        } else {
+            courseStepDao.getByCourseIds(courseIds).map { it.toRealmModel() }
         }
         val allProgresses = if (courseIds.isEmpty()) emptyList() else courseProgressDao.getByUserAndCourseIds(userId, courseIds)
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
@@ -11,21 +11,23 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineDispatcher
-import org.ole.planet.myplanet.data.DatabaseService
-import org.ole.planet.myplanet.di.RealmDispatcher
+import org.ole.planet.myplanet.data.room.dao.legacy.AnswerDao
+import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
+import org.ole.planet.myplanet.data.room.dao.legacy.QuestionDao
+import org.ole.planet.myplanet.data.room.dao.legacy.SubmissionDao
+import org.ole.planet.myplanet.data.room.entity.legacy.toRealmModel
 import org.ole.planet.myplanet.model.RealmAnswer
-import org.ole.planet.myplanet.model.RealmExamQuestion
-import org.ole.planet.myplanet.model.RealmStepExam
 import org.ole.planet.myplanet.model.RealmSubmission
 import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils
 
 internal class SubmissionsRepositoryExporter @Inject constructor(
-    databaseService: DatabaseService,
-    @RealmDispatcher realmDispatcher: CoroutineDispatcher,
+    private val submissionDao: SubmissionDao,
+    private val answerDao: AnswerDao,
+    private val examDao: ExamDao,
+    private val questionDao: QuestionDao,
     private val timeProvider: TimeProvider
-) : RealmRepository(databaseService, realmDispatcher) {
+) {
 
     companion object {
         private const val PAGE_WIDTH = 595
@@ -37,10 +39,11 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
     suspend fun generateSubmissionPdf(
         context: Context,
         submissionId: String
-    ): File? = withRealmAsync { realm ->
-        try {
-            val submission = realm.where(RealmSubmission::class.java).equalTo("id", submissionId).findFirst()
-                ?: return@withRealmAsync null
+    ): File? {
+        return try {
+            val submissionEntity = submissionDao.getByIdOrRemoteId(submissionId) ?: return null
+            val answers = answerDao.getBySubmissionId(submissionEntity.id)
+            val submission = submissionEntity.toRealmModel(answers)
 
             val document = PdfDocument()
             try {
@@ -63,9 +66,7 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
                 }
 
                 val examId = getExamId(submission.parentId)
-                val exam = realm.where(RealmStepExam::class.java)
-                    .equalTo("id", examId)
-                    .findFirst()
+                val exam = examId?.let { examDao.getById(it)?.toRealmModel() }
 
                 canvas.drawText(exam?.name ?: "Submission Report", MARGIN, yPosition, titlePaint)
                 yPosition += LINE_HEIGHT * 2
@@ -75,9 +76,7 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
                 canvas.drawText("Date: ${TimeUtils.getFormattedDateWithTime(submission.lastUpdateTime)}", MARGIN, yPosition, normalPaint)
                 yPosition += LINE_HEIGHT * 2
 
-                val questions = realm.where(RealmExamQuestion::class.java)
-                    .equalTo("examId", examId)
-                    .findAll()
+                val questions = examId?.let { questionDao.getByExamId(it).map { question -> question.toRealmModel() } }.orEmpty()
 
                 val answersMap = submission.answers?.associateBy { it.questionId } ?: emptyMap()
 
@@ -128,13 +127,19 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
         context: Context,
         submissionIds: List<String>,
         examTitle: String
-    ): File? = withRealmAsync { realm ->
-        try {
-            val submissions = submissionIds.mapNotNull { id ->
-                realm.where(RealmSubmission::class.java).equalTo("id", id).findFirst()
+    ): File? {
+        return try {
+            val submissionEntities = if (submissionIds.isEmpty()) emptyList() else submissionDao.getByIds(submissionIds)
+            val answersBySubmissionId = if (submissionEntities.isEmpty()) {
+                emptyMap()
+            } else {
+                answerDao.getBySubmissionIds(submissionEntities.map { it.id }).groupBy { it.submissionId }
+            }
+            val submissions = submissionEntities.map { submission ->
+                submission.toRealmModel(answersBySubmissionId[submission.id].orEmpty())
             }
 
-            if (submissions.isEmpty()) return@withRealmAsync null
+            if (submissions.isEmpty()) return null
 
             val document = PdfDocument()
             try {
@@ -169,9 +174,7 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
                 yPosition += LINE_HEIGHT * 3
 
                 val examId = getExamId(submissions.firstOrNull()?.parentId)
-                val questions = realm.where(RealmExamQuestion::class.java)
-                    .equalTo("examId", examId)
-                    .findAll()
+                val questions = examId?.let { questionDao.getByExamId(it).map { question -> question.toRealmModel() } }.orEmpty()
 
                 submissions.forEachIndexed { submissionIndex, submission ->
                     if (yPosition > PAGE_HEIGHT - MARGIN - 100) {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -20,9 +20,12 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.legacy.AnswerDao
+import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
+import org.ole.planet.myplanet.data.room.dao.legacy.QuestionDao
 import org.ole.planet.myplanet.data.room.dao.legacy.SubmissionDao
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomAnswerEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomSubmissionEntity
+import org.ole.planet.myplanet.data.room.entity.legacy.toRealmModel
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CreateExamSubmissionRequest
 import org.ole.planet.myplanet.model.ExamAnswerData
@@ -52,7 +55,9 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     private val exporter: SubmissionsRepositoryExporter,
     private val submitPhotosDao: SubmitPhotosDao,
     private val submissionDao: SubmissionDao,
-    private val answerDao: AnswerDao
+    private val answerDao: AnswerDao,
+    private val examDao: ExamDao,
+    private val questionDao: QuestionDao
 ) : RealmRepository(databaseService, realmDispatcher), SubmissionsRepository {
 
     override suspend fun generateSubmissionPdf(submissionId: String): File? {
@@ -94,11 +99,9 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         }
     }
 
-private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
+    private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
         if (examIds.isEmpty()) return emptyList()
-        return queryList(RealmStepExam::class.java) {
-            `in`("id", examIds.toTypedArray())
-        }
+        return examDao.getByIds(examIds).map { it.toRealmModel() }
     }
 
     override suspend fun getUniquePendingSurveys(userId: String?): List<RealmSubmission> {
@@ -169,7 +172,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
     }
 
     override suspend fun getExamQuestionCount(stepId: String): Int {
-        return findByField(RealmStepExam::class.java, "stepId", stepId)?.noOfQuestions ?: 0
+        return examDao.getFirstByStepId(stepId)?.noOfQuestions ?: 0
     }
 
     override suspend fun getSubmissionById(id: String): RealmSubmission? {
@@ -200,19 +203,11 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
             return false
         }
 
-        val questions = queryList(RealmExamQuestion::class.java) {
-            equalTo("examId", stepExamId)
-        }
-        if (questions.isEmpty()) {
+        if (questionDao.countByExamId(stepExamId) == 0) {
             return false
         }
 
-        val examId = questions.firstOrNull()?.examId
-        if (examId.isNullOrBlank()) {
-            return false
-        }
-
-        val parentId = "$examId@$courseId"
+        val parentId = "$stepExamId@$courseId"
         return count(RealmSubmission::class.java) {
             equalTo("userId", userId)
             equalTo("parentId", parentId)
@@ -238,13 +233,11 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
     }
 
     override suspend fun createBulkSurveySubmissions(examId: String, userIds: List<String>) {
-        val parentId = withRealm { realm ->
-            val courseId = realm.where(RealmStepExam::class.java).equalTo("id", examId).findFirst()?.courseId
-            if (!courseId.isNullOrEmpty()) {
-                "$examId@$courseId"
-            } else {
-                examId
-            }
+        val courseId = examDao.getById(examId)?.courseId
+        val parentId = if (!courseId.isNullOrEmpty()) {
+            "$examId@$courseId"
+        } else {
+            examId
         }
         userIds.forEach { userId ->
             getOrCreateSubmission(userId, parentId)
@@ -289,9 +282,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
 
         val user = submission.userId?.let { findByField(RealmUser::class.java, "id", it) }
 
-        val questions = queryList(RealmExamQuestion::class.java) {
-            equalTo("examId", examId)
-        }
+        val questions = examId?.let { questionDao.getByExamId(it).map { question -> question.toRealmModel() } } ?: emptyList()
 
         val questionAnswers = questions.map { question ->
             val answer = submission.answers?.find { it.questionId == question.id }
@@ -403,7 +394,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
 
     override suspend fun isStepCompleted(stepId: String?, userId: String?): Boolean {
         if (stepId == null) return true
-        val exam = findByField(RealmStepExam::class.java, "stepId", stepId) ?: return true
+        val exam = examDao.getFirstByStepId(stepId) ?: return true
         return exam.id?.let {
             count(RealmSubmission::class.java) {
                 equalTo("userId", userId)
@@ -414,10 +405,7 @@ private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
     }
 
     private suspend fun getSurveysByCourseId(courseId: String): List<RealmStepExam> {
-        return queryList(RealmStepExam::class.java) {
-            equalTo("courseId", courseId)
-            equalTo("type", "survey")
-        }
+        return examDao.getByCourseIdAndType(courseId, "survey").map { it.toRealmModel() }
     }
 
     override suspend fun hasUnfinishedSurveys(courseId: String, userId: String?): Boolean {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -12,11 +12,9 @@ import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Provider
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.distinctUntilChanged
-import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.legacy.AnswerDao
 import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
@@ -27,7 +25,6 @@ import org.ole.planet.myplanet.data.room.entity.legacy.RoomAnswerEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomSubmissionEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.toRealmModel
 import org.ole.planet.myplanet.data.room.entity.legacy.toRoomEntity
-import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CreateExamSubmissionRequest
 import org.ole.planet.myplanet.model.ExamAnswerData
 import org.ole.planet.myplanet.model.QuestionAnswer
@@ -47,8 +44,6 @@ import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
 
 class SubmissionsRepositoryImpl @Inject internal constructor(
-    databaseService: DatabaseService,
-    @RealmDispatcher realmDispatcher: CoroutineDispatcher,
     private val teamsRepositoryProvider: Provider<TeamsRepository>,
     private val surveysRepositoryProvider: Provider<SurveysRepository>,
     @ApplicationContext private val context: Context,
@@ -60,7 +55,7 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     private val examDao: ExamDao,
     private val questionDao: QuestionDao,
     private val userDao: UserDao
-) : RealmRepository(databaseService, realmDispatcher), SubmissionsRepository {
+) : SubmissionsRepository {
 
     override suspend fun generateSubmissionPdf(submissionId: String): File? {
         return exporter.generateSubmissionPdf(context, submissionId)
@@ -250,7 +245,7 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         val examId = submission.parentId?.substringBefore('@')
         val exam = examId?.let { getExamById(it) }
 
-        val user = submission.userId?.let { findByField(RealmUser::class.java, "id", it) }
+        val user = submission.userId?.let { userDao.getById(it)?.toRealmModel() }
 
         val questions = examId?.let { questionDao.getByExamId(it).map { question -> question.toRealmModel() } } ?: emptyList()
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -6,7 +6,6 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.realm.Case
 import io.realm.RealmList
 import io.realm.Sort
 import java.io.File
@@ -16,6 +15,7 @@ import javax.inject.Inject
 import javax.inject.Provider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
@@ -84,17 +84,11 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     }
 
     override fun getPendingSurveysFlow(userId: String?): Flow<List<RealmSubmission>> {
-        return queryListFlow(RealmSubmission::class.java) {
-            equalTo("userId", userId)
-                .equalTo("type", "survey")
-                .equalTo("status", "pending", Case.INSENSITIVE)
-        }
+        return submissionDao.observePendingSurveys(userId).map { rows -> rows.map { it.toRealmModel() } }
     }
 
     override fun getSubmissionsFlow(userId: String): Flow<List<RealmSubmission>> {
-        return queryListFlow(RealmSubmission::class.java) {
-            equalTo("userId", userId)
-        }.distinctUntilChanged { old, new ->
+        return submissionDao.observeByUserId(userId).map { rows -> rows.map { it.toRealmModel() } }.distinctUntilChanged { old, new ->
             // Assuming any meaningful mutation bumps lastUpdateTime.
             old.size == new.size && old.zip(new).all { (o, n) -> o.id == n.id && o.lastUpdateTime == n.lastUpdateTime }
         }
@@ -410,70 +404,49 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
             null
         }
 
-        var detachedSub: RealmSubmission? = null
-        executeTransaction { r ->
-                val managedSub = createSubmissionInternal(null, r)
-
-                val parentId = when {
-                    !exam.id.isNullOrEmpty() -> if (!exam.courseId.isNullOrEmpty()) {
-                        "${exam.id}@${exam.courseId}"
-                    } else {
-                        exam.id
-                    }
-                    else -> managedSub.parentId
+        val now = Date().time
+        val submission = RealmSubmission().apply {
+            id = UUID.randomUUID().toString()
+            parentId = when {
+                !exam.id.isNullOrEmpty() -> if (!exam.courseId.isNullOrEmpty()) {
+                    "${exam.id}@${exam.courseId}"
+                } else {
+                    exam.id
                 }
-                managedSub.parentId = parentId
-
-                try {
-                    val parentJsonString = JsonObject().apply {
-                        addProperty("_id", exam.id ?: "")
-                        addProperty("name", exam.name ?: "")
-                        addProperty("courseId", exam.courseId ?: "")
-                        addProperty("sourcePlanet", exam.sourcePlanet ?: "")
-                        addProperty("teamShareAllowed", exam.isTeamShareAllowed)
-                        addProperty("noOfQuestions", exam.noOfQuestions)
-                        addProperty("isFromNation", exam.isFromNation)
-                    }.toString()
-                    managedSub.parent = parentJsonString
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-
-                managedSub.userId = userId
-                managedSub.status = "pending"
-                managedSub.type = type
-                managedSub.startTime = Date().time
-                managedSub.lastUpdateTime = Date().time
-                if (managedSub.answers == null) {
-                    managedSub.answers = RealmList()
-                }
-
-                if (team != null) {
-                    val teamRef = r.createObject(RealmTeamReference::class.java)
-                    teamRef._id = team._id
-                    teamRef.name = team.name
-                    teamRef.type = team.type ?: "team"
-                    managedSub.teamObject = teamRef
-
-                    val membershipDoc = r.createObject(RealmMembershipDoc::class.java)
-                    membershipDoc.teamId = teamId
-                    managedSub.membershipDoc = membershipDoc
-
-                    try {
-                        val userJson = JsonObject()
-                        userJson.addProperty("age", userDob ?: "")
-                        userJson.addProperty("gender", userGender ?: "")
-                        val membershipJson = JsonObject()
-                        membershipJson.addProperty("teamId", teamId)
-                        userJson.add("membershipDoc", membershipJson)
-                        managedSub.user = userJson.toString()
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                    }
-                }
-                detachedSub = r.copyFromRealm(managedSub)
+                else -> null
             }
-        return detachedSub
+            parent = JsonObject().apply {
+                addProperty("_id", exam.id ?: "")
+                addProperty("name", exam.name ?: "")
+                addProperty("courseId", exam.courseId ?: "")
+                addProperty("sourcePlanet", exam.sourcePlanet ?: "")
+                addProperty("teamShareAllowed", exam.isTeamShareAllowed)
+                addProperty("noOfQuestions", exam.noOfQuestions)
+                addProperty("isFromNation", exam.isFromNation)
+            }.toString()
+            this.userId = userId
+            status = "pending"
+            this.type = type
+            startTime = now
+            lastUpdateTime = now
+            answers = RealmList()
+
+            if (team != null) {
+                teamObject = RealmTeamReference().apply {
+                    _id = team._id
+                    name = team.name
+                    this.type = team.type ?: "team"
+                }
+                membershipDoc = RealmMembershipDoc().apply { this.teamId = teamId }
+                user = JsonObject().apply {
+                    addProperty("age", userDob ?: "")
+                    addProperty("gender", userGender ?: "")
+                    add("membershipDoc", JsonObject().apply { addProperty("teamId", teamId) })
+                }.toString()
+            }
+        }
+        saveSubmission(submission)
+        return submission
     }
 
     override suspend fun saveExamAnswer(answerData: ExamAnswerData): Boolean {
@@ -581,28 +554,20 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     }
 
     override suspend fun getLastPendingSubmission(userId: String?): RealmSubmission? {
-        return withRealm { realm ->
-            realm.where(RealmSubmission::class.java)
-                .equalTo("status", "pending")
-                .equalTo("userId", userId)
-                .sort("startTime", Sort.DESCENDING)
-                .findFirst()?.let { realm.copyFromRealm(it) }
-        }
+        return hydrateSubmission(submissionDao.getLatestPendingByUser(userId))
     }
 
     override suspend fun updateSubmissionStatus(submissionId: String?, status: String) {
         if (submissionId.isNullOrEmpty()) return
-        update(RealmSubmission::class.java, "id", submissionId) { submission ->
-            submission.status = status
-        }
+        submissionDao.updateStatus(submissionId, status)
     }
 
     override suspend fun getExamByStepId(stepId: String): RealmStepExam? {
-        return findByField(RealmStepExam::class.java, "stepId", stepId)
+        return examDao.getFirstByStepId(stepId)?.toRealmModel()
     }
 
     override suspend fun getExamById(id: String): RealmStepExam? {
-        return findByField(RealmStepExam::class.java, "id", id)
+        return examDao.getById(id)?.toRealmModel()
     }
 
     override suspend fun getUnuploadedPhotos(): List<Pair<String?, JsonObject>> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -599,17 +599,11 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
                 documentList.add(jsonDoc)
             }
         }
-        documentList.forEach { jsonDoc ->
-            insertSubmissionInternal(realm, jsonDoc)
-        }
         upsertRoomSubmissionsFromSync(documentList)
     }
 
     override suspend fun insertSubmission(submission: JsonObject) {
         if (submission.has("_attachments")) return
-        executeTransaction { mRealm ->
-            insertSubmissionInternal(mRealm, submission)
-        }
         upsertRoomSubmissionsFromSync(listOf(submission))
     }
 
@@ -676,10 +670,8 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
 
         if (submissions.isEmpty() && answers.isEmpty()) return
 
-        databaseService.room.runInTransaction {
-            if (submissions.isNotEmpty()) submissionDao.upsertAllBlocking(submissions)
-            if (answers.isNotEmpty()) answerDao.upsertAllBlocking(answers)
-        }
+        if (submissions.isNotEmpty()) submissionDao.upsertAllBlocking(submissions)
+        if (answers.isNotEmpty()) answerDao.upsertAllBlocking(answers)
     }
 
     private fun normalizeSubmissionUserId(userId: String): String {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -7,7 +7,6 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.realm.RealmList
-import io.realm.Sort
 import java.io.File
 import java.util.Date
 import java.util.UUID
@@ -581,16 +580,6 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         return submission
     }
 
-    private fun createSubmissionInternal(sub: RealmSubmission?, mRealm: io.realm.Realm): RealmSubmission {
-        val submission = if (sub == null || (sub.status == "complete" && (sub.type == "exam" || sub.type == "survey"))) {
-            mRealm.createObject(RealmSubmission::class.java, UUID.randomUUID().toString())
-        } else {
-            sub
-        }
-        submission.lastUpdateTime = Date().time
-        return submission
-    }
-
     override fun bulkInsertFromSync(realm: io.realm.Realm, jsonArray: JsonArray) {
         val documentList = ArrayList<JsonObject>(jsonArray.size())
         for (j in jsonArray) {
@@ -682,134 +671,6 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
             if (localUserId.startsWith("org.couchdb.user:")) localUserId else "org.couchdb.user:$localUserId"
         } else {
             userId
-        }
-    }
-
-    private fun insertSubmissionInternal(mRealm: io.realm.Realm, submission: JsonObject) {
-        if (submission.has("_attachments")) {
-            return
-        }
-
-        val id = JsonUtils.getString("_id", submission)
-
-        try {
-            var sub = mRealm.where(RealmSubmission::class.java).equalTo("_id", id).findFirst()
-            val isNewSubmission = sub == null
-            val hadLocalChanges = !isNewSubmission && sub.isUpdated
-            val serverStatus = JsonUtils.getString("status", submission)
-            val isStatusDowngrade = !isNewSubmission && serverStatus == "pending" &&
-                (sub.status == "complete" || sub.status == "requires grading")
-            val skipOverwrite = hadLocalChanges || isStatusDowngrade
-
-            if (sub == null) {
-                sub = mRealm.createObject(RealmSubmission::class.java, id)
-            }
-
-            updateBasicFields(sub, id, serverStatus, skipOverwrite, submission)
-            updateTeam(mRealm, sub, submission)
-            updateMembership(mRealm, sub, submission)
-            updateUserId(sub, submission)
-            updateAnswers(mRealm, sub, submission, skipOverwrite)
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
-    private fun updateBasicFields(
-        sub: RealmSubmission?,
-        id: String,
-        serverStatus: String,
-        skipOverwrite: Boolean,
-        submission: JsonObject
-    ) {
-        sub?._id = id
-        if (!skipOverwrite) {
-            sub?.status = serverStatus
-            sub?.isUpdated = false
-        }
-        sub?._rev = JsonUtils.getString("_rev", submission)
-        sub?.grade = JsonUtils.getLong("grade", submission)
-        sub?.type = JsonUtils.getString("type", submission)
-        sub?.uploaded = JsonUtils.getString("_rev", submission).isNotEmpty()
-        sub?.startTime = JsonUtils.getLong("startTime", submission)
-        sub?.lastUpdateTime = JsonUtils.getLong("lastUpdateTime", submission)
-        sub?.parentId = JsonUtils.getString("parentId", submission)
-        sub?.sender = JsonUtils.getString("sender", submission)
-        sub?.source = JsonUtils.getString("source", submission)
-        sub?.parentCode = JsonUtils.getString("parentCode", submission)
-        sub?.parent = JsonUtils.gson.toJson(JsonUtils.getJsonObject("parent", submission))
-        sub?.user = JsonUtils.gson.toJson(JsonUtils.getJsonObject("user", submission))
-    }
-
-    private fun updateTeam(mRealm: io.realm.Realm, sub: RealmSubmission?, submission: JsonObject) {
-        if (submission.has("team") && submission.get("team").isJsonObject) {
-            val teamJson = submission.getAsJsonObject("team")
-            val teamRef = mRealm.createObject(RealmTeamReference::class.java)
-            teamRef._id = JsonUtils.getString("_id", teamJson)
-            teamRef.name = JsonUtils.getString("name", teamJson)
-            teamRef.type = JsonUtils.getString("type", teamJson)
-            sub?.teamObject = teamRef
-        }
-    }
-
-    private fun updateMembership(mRealm: io.realm.Realm, sub: RealmSubmission?, submission: JsonObject) {
-        val userJson = JsonUtils.getJsonObject("user", submission)
-        if (userJson.has("membershipDoc")) {
-            val membershipJson = JsonUtils.getJsonObject("membershipDoc", userJson)
-            if (membershipJson.entrySet().isNotEmpty()) {
-                val membership = mRealm.createObject(RealmMembershipDoc::class.java)
-                membership.teamId = JsonUtils.getString("teamId", membershipJson)
-                sub?.membershipDoc = membership
-            }
-        }
-    }
-
-    private fun updateUserId(sub: RealmSubmission?, submission: JsonObject) {
-        val userId = JsonUtils.getString("_id", JsonUtils.getJsonObject("user", submission))
-        sub?.userId = if (userId.contains("@")) {
-            val us = userId.split("@".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-            if (us[0].startsWith("org.couchdb.user:")) us[0] else "org.couchdb.user:${us[0]}"
-        } else {
-            userId
-        }
-    }
-
-    private fun updateAnswers(
-        mRealm: io.realm.Realm,
-        sub: RealmSubmission?,
-        submission: JsonObject,
-        skipOverwrite: Boolean
-    ) {
-        if (!skipOverwrite && submission.has("answers")) {
-            val answersArray = submission.get("answers").asJsonArray
-            sub?.answers = io.realm.RealmList<RealmAnswer>()
-
-            val unmanagedAnswers = mutableListOf<RealmAnswer>()
-            for (i in 0 until answersArray.size()) {
-                val answerJson = answersArray[i].asJsonObject
-                val realmAnswer = RealmAnswer()
-                realmAnswer.id = UUID.randomUUID().toString()
-
-                realmAnswer.value = JsonUtils.getString("value", answerJson)
-                realmAnswer.mistakes = JsonUtils.getInt("mistakes", answerJson)
-                realmAnswer.isPassed = JsonUtils.getBoolean("passed", answerJson)
-                realmAnswer.submissionId = sub?._id
-                realmAnswer.examId = sub?.parentId
-
-                val examIdPart = sub?.parentId?.split("@")?.get(0) ?: sub?.parentId
-                realmAnswer.questionId = if (answerJson.has("questionId")) {
-                    JsonUtils.getString("questionId", answerJson)
-                } else {
-                    "$examIdPart-$i"
-                }
-
-                unmanagedAnswers.add(realmAnswer)
-            }
-
-            if (unmanagedAnswers.isNotEmpty()) {
-                val managedAnswers = mRealm.copyToRealmOrUpdate(unmanagedAnswers)
-                sub?.answers?.addAll(managedAnswers)
-            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -23,6 +23,7 @@ import org.ole.planet.myplanet.data.room.dao.legacy.AnswerDao
 import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
 import org.ole.planet.myplanet.data.room.dao.legacy.QuestionDao
 import org.ole.planet.myplanet.data.room.dao.legacy.SubmissionDao
+import org.ole.planet.myplanet.data.room.dao.legacy.UserDao
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomAnswerEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomSubmissionEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.toRealmModel
@@ -58,7 +59,8 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     private val submissionDao: SubmissionDao,
     private val answerDao: AnswerDao,
     private val examDao: ExamDao,
-    private val questionDao: QuestionDao
+    private val questionDao: QuestionDao,
+    private val userDao: UserDao
 ) : RealmRepository(databaseService, realmDispatcher), SubmissionsRepository {
 
     override suspend fun generateSubmissionPdf(submissionId: String): File? {
@@ -817,17 +819,17 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         val questions: List<RealmExamQuestion>
     )
 
-    private fun getPayloadData(mRealm: io.realm.Realm, submission: RealmSubmission): PayloadData {
-        val user = mRealm.where(RealmUser::class.java).equalTo("id", submission.userId).findFirst()
+    private suspend fun getPayloadData(submission: RealmSubmission): PayloadData {
+        val user = submission.userId?.let { userDao.getById(it)?.toRealmModel() }
         val examId = submission.examIdFromParentId()
-        val exam = examId?.let { mRealm.where(RealmStepExam::class.java).equalTo("id", it).findFirst() }
-        val questions = exam?.id?.let { mRealm.where(RealmExamQuestion::class.java).equalTo("examId", it).findAll() } ?: emptyList()
+        val exam = examId?.let { examDao.getById(it)?.toRealmModel() }
+        val questions = exam?.id?.let { questionDao.getByExamId(it).map { question -> question.toRealmModel() } } ?: emptyList()
         return PayloadData(user, exam, questions)
     }
 
-    override suspend fun getExamUploadPayload(submission: RealmSubmission): JsonObject = withRealmAsync { mRealm ->
+    override suspend fun getExamUploadPayload(submission: RealmSubmission): JsonObject {
         val `object` = JsonObject()
-        val payloadData = getPayloadData(mRealm, submission)
+        val payloadData = getPayloadData(submission)
         val user = payloadData.user
         val exam = payloadData.exam
 
@@ -870,14 +872,14 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         } else {
             `object`.add("user", JsonParser.parseString(submission.user))
         }
-        `object`
+        return `object`
     }
 
-    override suspend fun serializeSubmission(submission: RealmSubmission, context: Context, source: String, parentCode: String): JsonObject = withRealmAsync { mRealm ->
+    override suspend fun serializeSubmission(submission: RealmSubmission, context: Context, source: String, parentCode: String): JsonObject {
         val jsonObject = JsonObject()
 
         try {
-            val payloadData = getPayloadData(mRealm, submission)
+            val payloadData = getPayloadData(submission)
             val exam = payloadData.exam
 
             if (!submission._id.isNullOrEmpty()) {
@@ -918,6 +920,6 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         } catch (e: Exception) {
             e.printStackTrace()
         }
-        jsonObject
+        return jsonObject
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -72,6 +72,16 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         return parentId?.substringBefore("@")
     }
 
+    private suspend fun hydrateSubmissions(rows: List<RoomSubmissionEntity>): List<RealmSubmission> {
+        if (rows.isEmpty()) return emptyList()
+        val answersBySubmissionId = answerDao.getBySubmissionIds(rows.map { it.id }).groupBy { it.submissionId }
+        return rows.map { row -> row.toRealmModel(answersBySubmissionId[row.id].orEmpty()) }
+    }
+
+    private suspend fun hydrateSubmission(row: RoomSubmissionEntity?): RealmSubmission? {
+        return row?.let { hydrateSubmissions(listOf(it)).firstOrNull() }
+    }
+
     override fun getPendingSurveysFlow(userId: String?): Flow<List<RealmSubmission>> {
         return queryListFlow(RealmSubmission::class.java) {
             equalTo("userId", userId)
@@ -91,12 +101,7 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
 
     override suspend fun getPendingSurveys(userId: String?): List<RealmSubmission> {
         if (userId == null) return emptyList()
-
-        return queryList(RealmSubmission::class.java) {
-            equalTo("userId", userId)
-            equalTo("status", "pending")
-            equalTo("type", "survey")
-        }
+        return hydrateSubmissions(submissionDao.getPendingSurveys(userId))
     }
 
     private suspend fun getExamsByIds(examIds: List<String>): List<RealmStepExam> {
@@ -107,12 +112,7 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     override suspend fun getUniquePendingSurveys(userId: String?): List<RealmSubmission> {
         if (userId == null) return emptyList()
 
-        val pendingSurveys = queryList(RealmSubmission::class.java) {
-            equalTo("userId", userId)
-            equalTo("status", "pending")
-            equalTo("type", "survey")
-            isNull("membershipDoc")
-        }
+        val pendingSurveys = hydrateSubmissions(submissionDao.getUniquePendingSurveyCandidates(userId))
 
         if (pendingSurveys.isEmpty()) {
             return emptyList()
@@ -176,21 +176,17 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     }
 
     override suspend fun getSubmissionById(id: String): RealmSubmission? {
-        return findByField(RealmSubmission::class.java, "id", id)
+        return hydrateSubmission(submissionDao.getByIdOrRemoteId(id))
     }
 
     override suspend fun getSubmissionsByIds(ids: List<String>): List<RealmSubmission> {
         if (ids.isEmpty()) return emptyList()
 
-        return queryList(RealmSubmission::class.java) {
-            `in`("id", ids.toTypedArray())
-        }
+        return hydrateSubmissions(submissionDao.getByIds(ids))
     }
 
     override suspend fun getSubmissionsByUserId(userId: String): List<RealmSubmission> {
-        return queryList(RealmSubmission::class.java, ensureLatest = true) {
-            equalTo("userId", userId)
-        }
+        return hydrateSubmissions(submissionDao.getByUserId(userId))
     }
 
     override suspend fun hasSubmission(
@@ -208,28 +204,15 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         }
 
         val parentId = "$stepExamId@$courseId"
-        return count(RealmSubmission::class.java) {
-            equalTo("userId", userId)
-            equalTo("parentId", parentId)
-            equalTo("type", type)
-        } > 0
+        return submissionDao.countByUserParentAndType(userId, parentId, type) > 0
     }
 
     override suspend fun hasPendingOfflineSubmissions(): Boolean {
-        return count(RealmSubmission::class.java) {
-            beginGroup()
-            equalTo("isUpdated", true)
-            or()
-            isEmpty("_id")
-            endGroup()
-        } > 0
+        return submissionDao.countPendingOfflineSubmissions() > 0
     }
 
     override suspend fun hasPendingExamResults(): Boolean {
-        return count(RealmSubmission::class.java) {
-            equalTo("status", "pending", Case.INSENSITIVE)
-            isNotEmpty("answers")
-        } > 0
+        return submissionDao.countPendingExamResults() > 0
     }
 
     override suspend fun createBulkSurveySubmissions(examId: String, userIds: List<String>) {
@@ -261,16 +244,10 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     }
 
     override suspend fun getSubmissionDetail(submissionId: String): SubmissionDetail? {
-        var submission = findFirstCopy(RealmSubmission::class.java) {
-            equalTo("id", submissionId)
-                .or()
-                .equalTo("_id", submissionId)
-        }
+        var submission = hydrateSubmission(submissionDao.getByIdOrRemoteId(submissionId))
 
         if (submission == null) {
-            submission = findFirstCopy(RealmSubmission::class.java) {
-                contains("parentId", submissionId)
-            }
+            submission = hydrateSubmission(submissionDao.getFirstByParentIdContaining(submissionId))
         }
 
         if (submission == null) {
@@ -345,24 +322,11 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     }
 
     override suspend fun getSubmissionsByParentId(parentId: String?, userId: String?, status: String?): List<RealmSubmission> {
-        return queryList(RealmSubmission::class.java) {
-            equalTo("parentId", parentId)
-                .equalTo("userId", userId)
-                .apply {
-                    if (status != null) {
-                        equalTo("status", status)
-                    }
-                }
-                .sort("startTime", Sort.DESCENDING)
-        }
+        return hydrateSubmissions(submissionDao.getByParentUserAndStatus(parentId, userId, status))
     }
 
     override suspend fun getSubmissionItems(parentId: String?, userId: String?): List<SubmissionItem> {
-        return queryList(RealmSubmission::class.java, maxDepth = 0) {
-            equalTo("parentId", parentId)
-                .equalTo("userId", userId)
-                .sort("startTime", Sort.DESCENDING)
-        }.map {
+        return submissionDao.getByParentUserAndStatus(parentId, userId, null).map {
             SubmissionItem(
                 id = it.id,
                 lastUpdateTime = it.lastUpdateTime,
@@ -396,11 +360,7 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         if (stepId == null) return true
         val exam = examDao.getFirstByStepId(stepId) ?: return true
         return exam.id?.let {
-            count(RealmSubmission::class.java) {
-                equalTo("userId", userId)
-                    .contains("parentId", it)
-                    .notEqualTo("status", "pending")
-            } > 0
+            submissionDao.countCompletedByUserAndExamId(userId, it) > 0
         } ?: false
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -451,98 +451,72 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
 
     override suspend fun saveExamAnswer(answerData: ExamAnswerData): Boolean {
         val (submission, question, ans, listAns, otherText, otherVisible, type, index, total, isExplicitSubmission) = answerData
-        val submissionId = submission?.id
+        val submissionRow = submission?.id?.let { submissionDao.getByIdOrRemoteId(it) }
+            ?: submission?.toRoomEntity()
+            ?: submissionDao.getLatestPendingByUser(submission?.userId)
+        val submissionId = submissionRow?.id
         val questionId = question.id
 
-        executeTransaction { r ->
-            val realmSubmission = if (submissionId != null) {
-                r.where(RealmSubmission::class.java).equalTo("id", submissionId).findFirst()
+        if (submissionRow != null && !questionId.isNullOrBlank()) {
+            val existing = answerDao.getBySubmissionAndQuestion(submissionRow.id, questionId)
+            val valueChoices: List<String>?
+            val value: String?
+
+            if (question.type.equals("select", ignoreCase = true)) {
+                if (otherVisible && !otherText.isNullOrEmpty()) {
+                    value = otherText
+                    valueChoices = listOf("""{"id":"other","text":"$otherText"}""")
+                } else {
+                    val choiceText = ExamAnswerUtils.getChoiceTextById(question, ans)
+                    value = choiceText
+                    valueChoices = if (ans.isNotEmpty()) {
+                        listOf("""{"id":"$ans","text":"$choiceText"}""")
+                    } else {
+                        emptyList()
+                    }
+                }
+            } else if (question.type.equals("selectMultiple", ignoreCase = true)) {
+                value = ""
+                valueChoices = listAns?.map { (text, id) ->
+                    if (id == "other" && otherVisible && !otherText.isNullOrEmpty()) {
+                        """{"id":"other","text":"$otherText"}"""
+                    } else {
+                        """{"id":"$id","text":"$text"}"""
+                    }
+                }
             } else {
-                r.where(RealmSubmission::class.java)
-                    .equalTo("status", "pending")
-                    .sort("startTime", Sort.DESCENDING)
-                    .findFirst()
+                value = if (otherVisible && !otherText.isNullOrEmpty()) otherText else ans
+                valueChoices = null
             }
 
-            val realmQuestion = r.where(RealmExamQuestion::class.java).equalTo("id", questionId).findFirst()
+            val isCorrect = if (type == "exam") {
+                ExamAnswerUtils.checkCorrectAnswer(ans, listAns, question)
+            } else {
+                true
+            }
+            val isFinal = index == total - 1
+            val newStatus = when {
+                isFinal && isExplicitSubmission && type == "survey" -> "complete"
+                isFinal && isExplicitSubmission -> "requires grading"
+                else -> "pending"
+            }
+            val now = Date().time
+            val answer = RoomAnswerEntity(
+                id = existing?.id ?: UUID.randomUUID().toString(),
+                value = value,
+                valueChoices = valueChoices,
+                mistakes = if (type == "exam" && !isCorrect) (existing?.mistakes ?: 0) + 1 else existing?.mistakes ?: 0,
+                isPassed = if (type == "exam") isCorrect else existing?.isPassed ?: false,
+                grade = if (type == "exam") 1 else existing?.grade ?: 0,
+                examId = question.examId,
+                questionId = questionId,
+                submissionId = submissionId,
+            )
+            answerDao.upsertAll(listOf(answer))
+            submissionDao.updateStatusAndLastUpdate(submissionRow.id, newStatus, now)
 
-            if (realmSubmission != null && realmQuestion != null) {
-                val existing = realmSubmission.answers?.find { it.questionId == realmQuestion.id }
-                val ansObj = if (existing != null) {
-                    existing
-                } else {
-                    val newAnswerId = UUID.randomUUID().toString()
-                    val newAnswer = r.createObject(RealmAnswer::class.java, newAnswerId)
-                    realmSubmission.answers?.add(newAnswer)
-                    newAnswer
-                }
-                ansObj.questionId = realmQuestion.id
-                ansObj.submissionId = realmSubmission.id
-                ansObj.examId = realmQuestion.examId
-
-                if (realmQuestion.type.equals("select", ignoreCase = true)) {
-                    if (otherVisible && !otherText.isNullOrEmpty()) {
-                        ansObj.value = otherText
-                        ansObj.valueChoices = RealmList<String>().apply {
-                            add("""{"id":"other","text":"$otherText"}""")
-                        }
-                    } else {
-                        val choiceText = ExamAnswerUtils.getChoiceTextById(realmQuestion, ans)
-                        ansObj.value = choiceText
-                        ansObj.valueChoices = RealmList<String>().apply {
-                            if (ans.isNotEmpty()) {
-                                add("""{"id":"$ans","text":"$choiceText"}""")
-                            }
-                        }
-                    }
-                } else if (realmQuestion.type.equals("selectMultiple", ignoreCase = true)) {
-                    ansObj.value = ""
-                    ansObj.valueChoices = RealmList<String>().apply {
-                        listAns?.forEach { (text, id) ->
-                            if (id == "other" && otherVisible && !otherText.isNullOrEmpty()) {
-                                add("""{"id":"other","text":"$otherText"}""")
-                            } else {
-                                add("""{"id":"$id","text":"$text"}""")
-                            }
-                        }
-                    }
-                } else {
-                    val textValue = if (otherVisible && !otherText.isNullOrEmpty()) {
-                        otherText
-                    } else {
-                        ans
-                    }
-                    ansObj.value = textValue
-                    ansObj.valueChoices = null
-                }
-
-                if (type == "exam") {
-                    val isCorrect = ExamAnswerUtils.checkCorrectAnswer(ans, listAns, realmQuestion)
-                    ansObj.isPassed = isCorrect
-                    ansObj.grade = 1
-                    if (!isCorrect) {
-                        ansObj.mistakes += 1
-                    }
-                }
-
-                val isFinal = index == total - 1
-                realmSubmission.lastUpdateTime = Date().time
-                realmSubmission.status = when {
-                    isFinal && isExplicitSubmission && type == "survey" -> "complete"
-                    isFinal && isExplicitSubmission -> "requires grading"
-                    else -> "pending"
-                }
-
-                if (realmSubmission.status == "complete" && type == "survey") {
-                    val orphans = r.where(RealmSubmission::class.java)
-                        .equalTo("parentId", realmSubmission.parentId)
-                        .equalTo("userId", realmSubmission.userId)
-                        .equalTo("status", "pending")
-                        .equalTo("type", "survey")
-                        .isNull("membershipDoc")
-                        .findAll()
-                    orphans.deleteAllFromRealm()
-                }
+            if (newStatus == "complete" && type == "survey") {
+                submissionDao.deletePendingSurveyOrphans(submissionRow.parentId, submissionRow.userId)
             }
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -26,6 +26,7 @@ import org.ole.planet.myplanet.data.room.dao.legacy.SubmissionDao
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomAnswerEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomSubmissionEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.toRealmModel
+import org.ole.planet.myplanet.data.room.entity.legacy.toRoomEntity
 import org.ole.planet.myplanet.di.RealmDispatcher
 import org.ole.planet.myplanet.model.CreateExamSubmissionRequest
 import org.ole.planet.myplanet.model.ExamAnswerData
@@ -228,19 +229,16 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     }
 
     override suspend fun saveSubmission(submission: RealmSubmission) {
-        try {
-            save(submission)
-        } catch (e: Exception) {
-            throw e
+        val submissionEntity = submission.toRoomEntity() ?: return
+        val answerEntities = submission.answers?.mapNotNull { it.toRoomEntity() }.orEmpty()
+        submissionDao.upsertAll(listOf(submissionEntity))
+        if (answerEntities.isNotEmpty()) {
+            answerDao.upsertAll(answerEntities)
         }
     }
 
     override suspend fun markSubmissionComplete(id: String, payload: JsonObject) {
-        update(RealmSubmission::class.java, "id", id) { sub ->
-            sub.user = payload.toString()
-            sub.status = "complete"
-            sub.isUpdated = true // Mark for upload
-        }
+        submissionDao.markComplete(id, payload.toString())
     }
 
     override suspend fun getSubmissionDetail(submissionId: String): SubmissionDetail? {
@@ -337,23 +335,17 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     }
 
     override suspend fun deleteExamSubmissions(examId: String, courseId: String?, userId: String?) {
-        executeTransaction { realm ->
-            val parentIdToSearch = if (!courseId.isNullOrEmpty()) {
-                "${examId}@${courseId}"
-            } else {
-                examId
-            }
-
-            val allSubmissions = realm.where(RealmSubmission::class.java)
-                .equalTo("userId", userId)
-                .equalTo("parentId", parentIdToSearch)
-                .findAll()
-
-            allSubmissions.forEach { submission ->
-                submission.answers?.deleteAllFromRealm()
-                submission.deleteFromRealm()
-            }
+        val parentIdToSearch = if (!courseId.isNullOrEmpty()) {
+            "${examId}@${courseId}"
+        } else {
+            examId
         }
+        val submissions = submissionDao.getByParentUserAndStatus(parentIdToSearch, userId, null)
+        val submissionIds = submissions.map { it.id }
+        if (submissionIds.isNotEmpty()) {
+            answerDao.deleteBySubmissionIds(submissionIds)
+        }
+        submissionDao.deleteByParentAndUser(parentIdToSearch, userId)
     }
 
     override suspend fun isStepCompleted(stepId: String?, userId: String?): Boolean {
@@ -629,25 +621,23 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     }
 
     override suspend fun getOrCreateSubmission(userId: String?, parentId: String): RealmSubmission {
-        var detachedSub: RealmSubmission? = null
-        executeTransaction { r ->
-            val sub = r.where(RealmSubmission::class.java)
-                .equalTo("userId", userId)
-                .equalTo("parentId", parentId)
-                .sort("lastUpdateTime", Sort.DESCENDING)
-                .equalTo("status", "pending")
-                .findFirst()
-
-            val managedSub = createSubmissionInternal(sub, r)
-            if (managedSub.userId.isNullOrEmpty()) managedSub.userId = userId
-            if (managedSub.parentId.isNullOrEmpty()) managedSub.parentId = parentId
-            if (managedSub.status.isNullOrEmpty()) managedSub.status = "pending"
-            if (managedSub.type.isNullOrEmpty()) managedSub.type = "survey"
-            if (managedSub.startTime == 0L) managedSub.startTime = Date().time
-
-            detachedSub = r.copyFromRealm(managedSub)
+        val existing = hydrateSubmission(submissionDao.getLatestPendingByUserAndParent(userId, parentId))
+        if (existing != null) {
+            return existing
         }
-        return detachedSub ?: error("Failed to create or retrieve submission")
+
+        val submission = RealmSubmission().apply {
+            id = UUID.randomUUID().toString()
+            this.userId = userId
+            this.parentId = parentId
+            status = "pending"
+            type = "survey"
+            startTime = Date().time
+            lastUpdateTime = startTime
+            answers = RealmList()
+        }
+        saveSubmission(submission)
+        return submission
     }
 
     private fun createSubmissionInternal(sub: RealmSubmission?, mRealm: io.realm.Realm): RealmSubmission {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -67,6 +67,8 @@ class CoursesRepositoryImplTest {
             mockk(relaxed = true),
             mockk(relaxed = true),
             mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
             searchActivityDao,
             courseProgressDao,
             mockk(relaxed = true),

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
@@ -21,6 +21,8 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
+import org.ole.planet.myplanet.data.room.dao.legacy.CourseStepDao
+import org.ole.planet.myplanet.data.room.entity.legacy.RoomCourseStepEntity
 import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.model.CourseProgress
 import org.ole.planet.myplanet.model.RealmCourseStep
@@ -40,6 +42,7 @@ class ProgressRepositoryImplTest {
     private val databaseService: DatabaseService = mockk(relaxed = true)
     private lateinit var mockCoursesRepository: CoursesRepository
     private val courseProgressDao: CourseProgressDao = mockk(relaxed = true)
+    private val courseStepDao: CourseStepDao = mockk(relaxed = true)
 
     @Before
     fun setUp() {
@@ -52,7 +55,8 @@ class ProgressRepositoryImplTest {
             dispatcherProvider,
             { mockCoursesRepository },
             { mockk(relaxed = true) },
-            courseProgressDao
+            courseProgressDao,
+            courseStepDao
         ), recordPrivateCalls = true)
     }
 
@@ -183,9 +187,9 @@ class ProgressRepositoryImplTest {
 
         coEvery { mockCoursesRepository.getMyCourses(any()) } returns myCourses
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseStep::class.java, any<Function1<RealmQuery<RealmCourseStep>, Unit>>())
-        } returns steps
+        coEvery { courseStepDao.getByCourseIds(listOf("course1")) } returns steps.mapIndexed { index, step ->
+            RoomCourseStepEntity(id = step.id ?: "step$index", courseId = step.courseId)
+        }
 
         coEvery { courseProgressDao.getByUserAndCourseIds("user1", listOf("course1")) } returns listOf(CourseProgress().apply {
             stepNum = 1
@@ -234,9 +238,9 @@ class ProgressRepositoryImplTest {
 
         val progresses1 = listOf(CourseProgress().apply { courseId = "course1"; stepNum = 1 })
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmCourseStep::class.java, any<Function1<RealmQuery<RealmCourseStep>, Unit>>())
-        } returns steps1 + steps2
+        coEvery { courseStepDao.getByCourseIds(courseIds) } returns (steps1 + steps2).mapIndexed { index, step ->
+            RoomCourseStepEntity(id = step.id ?: "step$index", courseId = step.courseId)
+        }
 
         coEvery { courseProgressDao.getByUserAndCourseIds("user1", courseIds) } returns progresses1
 
@@ -307,7 +311,8 @@ class ProgressRepositoryImplTest {
             dispatcherProvider,
             { mockCoursesRepository },
             { activitiesRepo },
-            courseProgressDao
+            courseProgressDao,
+            courseStepDao
         )
 
         coEvery { activitiesRepo.hasUserCompletedSync("user1") } returns true

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
@@ -22,6 +22,8 @@ import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
 import org.ole.planet.myplanet.data.room.dao.legacy.CourseStepDao
+import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
+import org.ole.planet.myplanet.data.room.entity.legacy.RoomExamEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomCourseStepEntity
 import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.model.CourseProgress
@@ -43,6 +45,7 @@ class ProgressRepositoryImplTest {
     private lateinit var mockCoursesRepository: CoursesRepository
     private val courseProgressDao: CourseProgressDao = mockk(relaxed = true)
     private val courseStepDao: CourseStepDao = mockk(relaxed = true)
+    private val examDao: ExamDao = mockk(relaxed = true)
 
     @Before
     fun setUp() {
@@ -56,7 +59,8 @@ class ProgressRepositoryImplTest {
             { mockCoursesRepository },
             { mockk(relaxed = true) },
             courseProgressDao,
-            courseStepDao
+            courseStepDao,
+            examDao
         ), recordPrivateCalls = true)
     }
 
@@ -200,9 +204,9 @@ class ProgressRepositoryImplTest {
             repository invoke "queryList" withArguments listOf(RealmSubmission::class.java, any<Function1<RealmQuery<RealmSubmission>, Unit>>())
         } returns submissions
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmStepExam::class.java, any<Function1<RealmQuery<RealmStepExam>, Unit>>())
-        } returns exams
+        coEvery { examDao.getByCourseIds(listOf("course1")) } returns exams.map { exam ->
+            RoomExamEntity(id = exam.id ?: "exam", courseId = exam.courseId, stepId = exam.stepId, type = exam.type)
+        }
 
         coEvery {
             repository invoke "queryList" withArguments listOf(RealmAnswer::class.java, any<Function1<RealmQuery<RealmAnswer>, Unit>>())
@@ -312,7 +316,8 @@ class ProgressRepositoryImplTest {
             { mockCoursesRepository },
             { activitiesRepo },
             courseProgressDao,
-            courseStepDao
+            courseStepDao,
+            examDao
         )
 
         coEvery { activitiesRepo.hasUserCompletedSync("user1") } returns true

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ProgressRepositoryImplTest.kt
@@ -8,7 +8,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.unmockkAll
-import io.realm.RealmQuery
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -21,9 +20,13 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.CourseProgressDao
+import org.ole.planet.myplanet.data.room.dao.legacy.AnswerDao
 import org.ole.planet.myplanet.data.room.dao.legacy.CourseStepDao
 import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
+import org.ole.planet.myplanet.data.room.dao.legacy.QuestionDao
+import org.ole.planet.myplanet.data.room.dao.legacy.SubmissionDao
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomExamEntity
+import org.ole.planet.myplanet.data.room.entity.legacy.RoomSubmissionEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomCourseStepEntity
 import org.ole.planet.myplanet.model.RealmAnswer
 import org.ole.planet.myplanet.model.CourseProgress
@@ -46,6 +49,9 @@ class ProgressRepositoryImplTest {
     private val courseProgressDao: CourseProgressDao = mockk(relaxed = true)
     private val courseStepDao: CourseStepDao = mockk(relaxed = true)
     private val examDao: ExamDao = mockk(relaxed = true)
+    private val submissionDao: SubmissionDao = mockk(relaxed = true)
+    private val answerDao: AnswerDao = mockk(relaxed = true)
+    private val questionDao: QuestionDao = mockk(relaxed = true)
 
     @Before
     fun setUp() {
@@ -60,7 +66,10 @@ class ProgressRepositoryImplTest {
             { mockk(relaxed = true) },
             courseProgressDao,
             courseStepDao,
-            examDao
+            examDao,
+            submissionDao,
+            answerDao,
+            questionDao
         ), recordPrivateCalls = true)
     }
 
@@ -71,9 +80,7 @@ class ProgressRepositoryImplTest {
 
     @Test
     fun fetchCourseData_executes_successfully() = runTest(testDispatcher) {
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmSubmission::class.java, any<Function1<RealmQuery<RealmSubmission>, Unit>>())
-        } returns emptyList<RealmSubmission>()
+        coEvery { submissionDao.getExamSubmissionsByUser("user123") } returns emptyList()
         val result = repository.fetchCourseData("user123")
         assertEquals(JsonArray(), result)
     }
@@ -200,21 +207,26 @@ class ProgressRepositoryImplTest {
             courseId = "course1"
         })
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmSubmission::class.java, any<Function1<RealmQuery<RealmSubmission>, Unit>>())
-        } returns submissions
+        coEvery { submissionDao.getExamSubmissionsByUser("user1") } returns submissions.map { submission ->
+            RoomSubmissionEntity(id = submission.id ?: "submission", parentId = submission.parentId, userId = submission.userId, type = submission.type)
+        }
 
         coEvery { examDao.getByCourseIds(listOf("course1")) } returns exams.map { exam ->
             RoomExamEntity(id = exam.id ?: "exam", courseId = exam.courseId, stepId = exam.stepId, type = exam.type)
         }
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmAnswer::class.java, any<Function1<RealmQuery<RealmAnswer>, Unit>>())
-        } returns answers
+        coEvery { answerDao.getBySubmissionIds(listOf("sub1")) } returns answers.map { answer ->
+            org.ole.planet.myplanet.data.room.entity.legacy.RoomAnswerEntity(
+                id = answer.id ?: "answer",
+                questionId = answer.questionId,
+                submissionId = answer.submissionId,
+                mistakes = answer.mistakes,
+            )
+        }
 
-        coEvery {
-            repository invoke "queryList" withArguments listOf(RealmExamQuestion::class.java, any<Function1<RealmQuery<RealmExamQuestion>, Unit>>())
-        } returns listOf(question)
+        coEvery { questionDao.getByIds(listOf("q1")) } returns listOf(
+            org.ole.planet.myplanet.data.room.entity.legacy.RoomQuestionEntity(id = "q1", examId = "exam1")
+        )
 
         val data = repository.fetchCourseData("user1")
         advanceUntilIdle()
@@ -317,7 +329,10 @@ class ProgressRepositoryImplTest {
             { activitiesRepo },
             courseProgressDao,
             courseStepDao,
-            examDao
+            examDao,
+            submissionDao,
+            answerDao,
+            questionDao
         )
 
         coEvery { activitiesRepo.hasUserCompletedSync("user1") } returns true

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -100,10 +100,7 @@ class SubmissionsRepositoryImplTest {
 
     @Test
     fun `getPendingSurveysFlow queries correctly`() = runTest {
-        val mockList = listOf(mockk<RealmSubmission>())
-        coEvery {
-            repository["queryListFlow"](RealmSubmission::class.java, any<Function1<RealmQuery<RealmSubmission>, Unit>>())
-        } returns kotlinx.coroutines.flow.flowOf(mockList)
+        every { submissionDao.observePendingSurveys("user_123") } returns kotlinx.coroutines.flow.flowOf(listOf(RoomSubmissionEntity(id = "submission1")))
 
         val result = repository.getPendingSurveysFlow("user_123").first()
         assertEquals(1, result.size)
@@ -111,10 +108,7 @@ class SubmissionsRepositoryImplTest {
 
     @Test
     fun `getSubmissionsFlow queries correctly`() = runTest {
-        val mockList = listOf(mockk<RealmSubmission>())
-        coEvery {
-            repository["queryListFlow"](RealmSubmission::class.java, any<Function1<RealmQuery<RealmSubmission>, Unit>>())
-        } returns kotlinx.coroutines.flow.flowOf(mockList)
+        every { submissionDao.observeByUserId("user_123") } returns kotlinx.coroutines.flow.flowOf(listOf(RoomSubmissionEntity(id = "submission1")))
 
         val result = repository.getSubmissionsFlow("user_123").first()
         assertEquals(1, result.size)
@@ -122,22 +116,11 @@ class SubmissionsRepositoryImplTest {
 
     @Test
     fun `getSubmissionsFlow suppresses equivalent emissions`() = runTest {
-        val s1 = mockk<RealmSubmission>(relaxed = true).apply {
-            every { id } returns "1"
-            every { lastUpdateTime } returns 100L
-        }
-        val s1_dup = mockk<RealmSubmission>(relaxed = true).apply {
-            every { id } returns "1"
-            every { lastUpdateTime } returns 100L
-        }
-        val subList = listOf(s1)
-        val subListDup = listOf(s1_dup)
+        val subList = listOf(RoomSubmissionEntity(id = "1", lastUpdateTime = 100L))
+        val subListDup = listOf(RoomSubmissionEntity(id = "1", lastUpdateTime = 100L))
 
-        val flowEmitter = kotlinx.coroutines.flow.MutableSharedFlow<List<RealmSubmission>>(replay = 1)
-
-        coEvery {
-            repository["queryListFlow"](RealmSubmission::class.java, any<Function1<RealmQuery<RealmSubmission>, Unit>>())
-        } returns flowEmitter
+        val flowEmitter = kotlinx.coroutines.flow.MutableSharedFlow<List<RoomSubmissionEntity>>(replay = 1)
+        every { submissionDao.observeByUserId("user_123") } returns flowEmitter
 
         var emissions = 0
         val job = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined).launch {
@@ -319,19 +302,12 @@ class SubmissionsRepositoryImplTest {
         every { exam.courseId } returns "course_id"
         every { exam.id } returns "exam_id"
 
-        val realm = mockk<Realm>(relaxed = true)
-
-        val transactionSlot = slot<Function1<Realm, Unit>>()
-        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
-            // Empty to skip lambda execution to prevent Realm type issues when testing createObject
-        }
-
         val result = repository.createExamSubmission(
-            CreateExamSubmissionRequest("user", "dob", "gender", exam, "type", "team")
+            CreateExamSubmissionRequest("user", "dob", "gender", exam, "type", null)
         )
-        // Function executeTransaction wrapper does not execute anything, so result can be null.
-        // We verify the interaction.
-        coVerify { databaseService.executeTransactionAsync(any()) }
+
+        assertEquals("exam_id@course_id", result?.parentId)
+        coVerify { submissionDao.upsertAll(match { it.single().parentId == "exam_id@course_id" }) }
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -29,6 +29,7 @@ import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
 import org.ole.planet.myplanet.data.room.dao.legacy.QuestionDao
 import org.ole.planet.myplanet.data.room.dao.legacy.SubmissionDao
+import org.ole.planet.myplanet.data.room.dao.legacy.UserDao
 import org.ole.planet.myplanet.data.room.dao.legacy.AnswerDao
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomExamEntity
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomSubmissionEntity
@@ -56,6 +57,7 @@ class SubmissionsRepositoryImplTest {
     private val answerDao: AnswerDao = mockk(relaxed = true)
     private val examDao: ExamDao = mockk(relaxed = true)
     private val questionDao: QuestionDao = mockk(relaxed = true)
+    private val userDao: UserDao = mockk(relaxed = true)
     private lateinit var repository: SubmissionsRepositoryImpl
 
     @Before
@@ -89,7 +91,8 @@ class SubmissionsRepositoryImplTest {
             submissionDao,
             answerDao,
             examDao,
-            questionDao
+            questionDao,
+            userDao
         ), recordPrivateCalls = true)
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -28,7 +28,10 @@ import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
 import org.ole.planet.myplanet.data.room.dao.legacy.QuestionDao
+import org.ole.planet.myplanet.data.room.dao.legacy.SubmissionDao
+import org.ole.planet.myplanet.data.room.dao.legacy.AnswerDao
 import org.ole.planet.myplanet.data.room.entity.legacy.RoomExamEntity
+import org.ole.planet.myplanet.data.room.entity.legacy.RoomSubmissionEntity
 import org.ole.planet.myplanet.model.CreateExamSubmissionRequest
 import org.ole.planet.myplanet.model.ExamAnswerData
 import org.ole.planet.myplanet.model.RealmAnswer
@@ -49,6 +52,8 @@ class SubmissionsRepositoryImplTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private val submitPhotosDao: SubmitPhotosDao = mockk(relaxed = true)
+    private val submissionDao: SubmissionDao = mockk(relaxed = true)
+    private val answerDao: AnswerDao = mockk(relaxed = true)
     private val examDao: ExamDao = mockk(relaxed = true)
     private val questionDao: QuestionDao = mockk(relaxed = true)
     private lateinit var repository: SubmissionsRepositoryImpl
@@ -81,8 +86,8 @@ class SubmissionsRepositoryImplTest {
             sharedPrefManager,
             exporter,
             submitPhotosDao,
-            mockk(relaxed = true),
-            mockk(relaxed = true),
+            submissionDao,
+            answerDao,
             examDao,
             questionDao
         ), recordPrivateCalls = true)
@@ -198,10 +203,8 @@ class SubmissionsRepositoryImplTest {
 
     @Test
     fun `getSubmissionsByUserId returns correctly`() = runTest {
-        val mockList = listOf(mockk<RealmSubmission>())
-        coEvery {
-            repository["queryList"](RealmSubmission::class.java, true, any<Function1<RealmQuery<RealmSubmission>, Unit>>())
-        } returns mockList
+        coEvery { submissionDao.getByUserId("test") } returns listOf(RoomSubmissionEntity(id = "submission1", userId = "test"))
+        coEvery { answerDao.getBySubmissionIds(listOf("submission1")) } returns emptyList()
 
         val result = repository.getSubmissionsByUserId("test")
         assertEquals(1, result.size)
@@ -317,9 +320,7 @@ class SubmissionsRepositoryImplTest {
     fun `hasSubmission returns true when match found`() = runTest {
         coEvery { questionDao.countByExamId("stepExamId") } returns 1
 
-        coEvery {
-            repository["count"](RealmSubmission::class.java, any<Function1<RealmQuery<RealmSubmission>, Unit>>())
-        } returns 1L
+        coEvery { submissionDao.countByUserParentAndType("userId", "stepExamId@courseId", "type") } returns 1
 
         val result = repository.hasSubmission("stepExamId", "courseId", "userId", "type")
         assertTrue(result)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -225,18 +225,12 @@ class SubmissionsRepositoryImplTest {
     }
 
     @Test
-    fun `saveSubmission performs transaction`() = runTest {
-        val sub = mockk<RealmSubmission>(relaxed = true)
-
-        val transactionSlot = slot<Function1<Realm, Unit>>()
-        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
-            val realm = mockk<Realm>(relaxed = true)
-            transactionSlot.captured.invoke(realm)
-        }
+    fun `saveSubmission upserts submission through Room`() = runTest {
+        val sub = RealmSubmission().apply { id = "submission1" }
 
         repository.saveSubmission(sub)
 
-        coVerify { databaseService.executeTransactionAsync(any()) }
+        coVerify { submissionDao.upsertAll(match { it.single().id == "submission1" }) }
     }
 
     @Test
@@ -300,20 +294,13 @@ class SubmissionsRepositoryImplTest {
     }
 
     @Test
-    fun `deleteExamSubmissions queries and deletes correctly`() = runTest {
-        val transactionSlot = slot<Function1<Realm, Unit>>()
-        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
-            val realm = mockk<Realm>(relaxed = true)
-            val query = mockk<RealmQuery<RealmSubmission>>(relaxed = true)
-            every { realm.where(RealmSubmission::class.java) } returns query
-            every { query.equalTo(any<String>(), any<String>()) } returns query
-            every { query.findAll() } returns mockk(relaxed = true)
-
-            transactionSlot.captured.invoke(realm)
-        }
+    fun `deleteExamSubmissions deletes answers and submissions through Room`() = runTest {
+        coEvery { submissionDao.getByParentUserAndStatus("exam@course", "user", null) } returns listOf(RoomSubmissionEntity(id = "submission1"))
 
         repository.deleteExamSubmissions("exam", "course", "user")
-        coVerify { databaseService.executeTransactionAsync(any()) }
+
+        coVerify { answerDao.deleteBySubmissionIds(listOf("submission1")) }
+        coVerify { submissionDao.deleteByParentAndUser("exam@course", "user") }
     }
 
     @Test
@@ -374,17 +361,11 @@ class SubmissionsRepositoryImplTest {
     }
 
     @Test
-    fun `markSubmissionComplete executes transaction`() = runTest {
-        val mockSub = mockk<RealmSubmission>(relaxed = true)
-        coEvery {
-            repository["update"](RealmSubmission::class.java, "id", "test_id", any<Function1<RealmSubmission, Unit>>())
-        } answers {
-            val updater = it.invocation.args[3] as (RealmSubmission) -> Unit
-            updater.invoke(mockSub)
-        }
+    fun `markSubmissionComplete updates submission through Room`() = runTest {
+        val payload = JsonObject().apply { addProperty("name", "Learner") }
 
-        repository.markSubmissionComplete("test_id", JsonObject())
+        repository.markSubmissionComplete("test_id", payload)
 
-        verify { mockSub.status = "complete" }
+        coVerify { submissionDao.markComplete("test_id", payload.toString()) }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -26,6 +26,9 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
+import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
+import org.ole.planet.myplanet.data.room.dao.legacy.QuestionDao
+import org.ole.planet.myplanet.data.room.entity.legacy.RoomExamEntity
 import org.ole.planet.myplanet.model.CreateExamSubmissionRequest
 import org.ole.planet.myplanet.model.ExamAnswerData
 import org.ole.planet.myplanet.model.RealmAnswer
@@ -46,6 +49,8 @@ class SubmissionsRepositoryImplTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private val submitPhotosDao: SubmitPhotosDao = mockk(relaxed = true)
+    private val examDao: ExamDao = mockk(relaxed = true)
+    private val questionDao: QuestionDao = mockk(relaxed = true)
     private lateinit var repository: SubmissionsRepositoryImpl
 
     @Before
@@ -77,7 +82,9 @@ class SubmissionsRepositoryImplTest {
             exporter,
             submitPhotosDao,
             mockk(relaxed = true),
-            mockk(relaxed = true)
+            mockk(relaxed = true),
+            examDao,
+            questionDao
         ), recordPrivateCalls = true)
     }
 
@@ -204,19 +211,7 @@ class SubmissionsRepositoryImplTest {
     fun `createBulkSurveySubmissions calls getOrCreateSubmission for all users`() = runTest {
         val examId = "examId"
         val userIds = listOf("user1", "user2")
-        val realm = mockk<Realm>(relaxed = true)
-        val query = mockk<RealmQuery<RealmStepExam>>(relaxed = true)
-        val exam = mockk<RealmStepExam>(relaxed = true)
-
-        every { realm.where(RealmStepExam::class.java) } returns query
-        every { query.equalTo("id", examId) } returns query
-        every { query.findFirst() } returns exam
-        every { exam.courseId } returns "courseId"
-
-        coEvery { repository["withRealm"](any<Boolean>(), any<Function1<Realm, Any>>()) } answers {
-            val action = arg<Function1<Realm, Any>>(1)
-            action.invoke(realm)
-        }
+        coEvery { examDao.getById(examId) } returns RoomExamEntity(id = examId, courseId = "courseId")
 
         coEvery { repository.getOrCreateSubmission(any(), any()) } returns mockk()
 
@@ -320,13 +315,7 @@ class SubmissionsRepositoryImplTest {
 
     @Test
     fun `hasSubmission returns true when match found`() = runTest {
-        val mockQuestionList = listOf(mockk<RealmExamQuestion>(relaxed = true).apply {
-            every { examId } returns "stepExamId"
-        })
-
-        coEvery {
-            repository["queryList"](RealmExamQuestion::class.java, false, any<Function1<RealmQuery<RealmExamQuestion>, Unit>>())
-        } answers { mockQuestionList }
+        coEvery { questionDao.countByExamId("stepExamId") } returns 1
 
         coEvery {
             repository["count"](RealmSubmission::class.java, any<Function1<RealmQuery<RealmSubmission>, Unit>>())

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -311,29 +311,28 @@ class SubmissionsRepositoryImplTest {
     }
 
     @Test
-    fun `saveExamAnswer executes without exceptions`() = runTest {
+    fun `saveExamAnswer upserts answer through Room`() = runTest {
         val answerData = mockk<ExamAnswerData>(relaxed = true)
-        val mockAnswer = RealmAnswer()
-        val mockExam = mockk<RealmStepExam>(relaxed = true)
-        val mockQuestion = mockk<RealmExamQuestion>(relaxed = true)
-        val mockSubmission = mockk<RealmSubmission>(relaxed = true)
+        val question = RealmExamQuestion().apply { id = "question1"; examId = "exam1"; type = "text" }
+        val submission = RealmSubmission().apply { id = "submission1"; userId = "user1"; parentId = "exam1@course1" }
 
-        every { answerData.component1() } returns mockSubmission
-        every { answerData.component2() } returns mockQuestion
-
-        coEvery { repository.getSubmissionById(any()) } returns mockSubmission
-        coEvery { repository.getExamById(any()) } returns mockExam
-
-        val transactionSlot = slot<Function1<Realm, Unit>>()
-        coEvery {
-            databaseService.executeTransactionAsync(capture(transactionSlot))
-        } answers {
-            // Empty to prevent internal query cast exceptions. We just verify the interaction.
-        }
+        every { answerData.component1() } returns submission
+        every { answerData.component2() } returns question
+        every { answerData.component3() } returns "answer text"
+        every { answerData.component4() } returns null
+        every { answerData.component5() } returns null
+        every { answerData.component6() } returns false
+        every { answerData.component7() } returns "survey"
+        every { answerData.component8() } returns 0
+        every { answerData.component9() } returns 1
+        every { answerData.component10() } returns true
+        coEvery { submissionDao.getByIdOrRemoteId("submission1") } returns RoomSubmissionEntity(id = "submission1", parentId = "exam1@course1", userId = "user1")
 
         val result = repository.saveExamAnswer(answerData)
+
         assertTrue(result)
-        coVerify { databaseService.executeTransactionAsync(any()) }
+        coVerify { answerDao.upsertAll(match { it.single().submissionId == "submission1" && it.single().value == "answer text" }) }
+        coVerify { submissionDao.updateStatusAndLastUpdate("submission1", "complete", any()) }
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -232,11 +232,9 @@ class SubmissionsRepositoryImplTest {
             })
         }
 
-        // Since insertSubmissionInternal is called on `this`, spyk can track it
-        every { repository["insertSubmissionInternal"](any<Realm>(), any<JsonObject>()) } answers { }
-
         repository.bulkInsertFromSync(realm, jsonArray)
-        verify(exactly = 1) { repository["insertSubmissionInternal"](realm, any<JsonObject>()) }
+
+        verify { submissionDao.upsertAllBlocking(match { it.single().id == "test_id" }) }
     }
 
     @Test
@@ -247,33 +245,15 @@ class SubmissionsRepositoryImplTest {
     }
 
     @Test
-    fun `insertSubmission performs happy path creation`() = runTest {
-        val realm = mockk<Realm>(relaxed = true)
-        val transactionSlot = slot<Function1<Realm, Unit>>()
-        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
-            transactionSlot.captured.invoke(realm)
-        }
-
-        val query = mockk<RealmQuery<RealmSubmission>>(relaxed = true)
-        every { realm.where(RealmSubmission::class.java) } returns query
-        every { query.equalTo(any<String>(), any<String>()) } returns query
-        every { query.findFirst() } returns null
-        every { realm.createObject(RealmSubmission::class.java, any<String>()) } returns mockk<RealmSubmission>(relaxed = true)
-
+    fun `insertSubmission upserts synced submission through Room`() = runTest {
         val submission = JsonObject().apply {
             addProperty("_id", "test_id")
             addProperty("status", "pending")
         }
 
-        every { repository["updateBasicFields"](any<RealmSubmission>(), any<String>(), any<String>(), any<Boolean>(), any<JsonObject>()) } answers { }
-        every { repository["updateTeam"](any<Realm>(), any<RealmSubmission>(), any<JsonObject>()) } answers { }
-        every { repository["updateMembership"](any<Realm>(), any<RealmSubmission>(), any<JsonObject>()) } answers { }
-        every { repository["updateUserId"](any<RealmSubmission>(), any<JsonObject>()) } answers { }
-        every { repository["updateAnswers"](any<Realm>(), any<RealmSubmission>(), any<JsonObject>(), any<Boolean>()) } answers { }
-
         repository.insertSubmission(submission)
 
-        verify(exactly = 1) { realm.createObject(RealmSubmission::class.java, "test_id") }
+        verify { submissionDao.upsertAllBlocking(match { it.single().id == "test_id" }) }
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -7,24 +7,20 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import io.realm.Realm
-import io.realm.RealmQuery
 import javax.inject.Provider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.ole.planet.myplanet.data.DatabaseService
 import org.ole.planet.myplanet.data.room.dao.SubmitPhotosDao
 import org.ole.planet.myplanet.data.room.dao.legacy.ExamDao
 import org.ole.planet.myplanet.data.room.dao.legacy.QuestionDao
@@ -44,13 +40,11 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 @ExperimentalCoroutinesApi
 class SubmissionsRepositoryImplTest {
 
-    private lateinit var databaseService: DatabaseService
     private lateinit var teamsRepositoryProvider: Provider<TeamsRepository>
     private lateinit var surveysRepositoryProvider: Provider<SurveysRepository>
     private lateinit var context: Context
     private lateinit var sharedPrefManager: SharedPrefManager
     private lateinit var exporter: SubmissionsRepositoryExporter
-    private val testDispatcher = UnconfinedTestDispatcher()
 
     private val submitPhotosDao: SubmitPhotosDao = mockk(relaxed = true)
     private val submissionDao: SubmissionDao = mockk(relaxed = true)
@@ -62,7 +56,6 @@ class SubmissionsRepositoryImplTest {
 
     @Before
     fun setUp() {
-        databaseService = mockk(relaxed = true)
         val teamsRepo = mockk<TeamsRepository>(relaxed = true)
         teamsRepositoryProvider = mockk(relaxed = true)
         every { teamsRepositoryProvider.get() } returns teamsRepo
@@ -71,17 +64,7 @@ class SubmissionsRepositoryImplTest {
         sharedPrefManager = mockk(relaxed = true)
         exporter = mockk(relaxed = true)
 
-        every { databaseService.ioDispatcher } returns testDispatcher
-
-        val transactionSlot = slot<Function1<Realm, Unit>>()
-        coEvery { databaseService.executeTransactionAsync(capture(transactionSlot)) } answers {
-            val realm = mockk<Realm>(relaxed = true)
-            transactionSlot.captured.invoke(realm)
-        }
-
         repository = spyk(SubmissionsRepositoryImpl(
-            databaseService,
-            testDispatcher,
             teamsRepositoryProvider,
             surveysRepositoryProvider,
             context,
@@ -156,20 +139,12 @@ class SubmissionsRepositoryImplTest {
 
     @Test
     fun `getUniquePendingSurveys returns list when exams exist`() = runTest {
-        val mockSub1 = mockk<RealmSubmission>(relaxed = true).apply {
-            every { parentId } returns "exam1@course1"
-        }
-        val mockSub2 = mockk<RealmSubmission>(relaxed = true).apply {
-            every { parentId } returns "exam2@course1"
-        }
-
-        coEvery {
-            repository["queryList"](RealmSubmission::class.java, false, any<Function1<RealmQuery<RealmSubmission>, Unit>>())
-        } returns listOf(mockSub1, mockSub2)
-
-        coEvery {
-            repository["getExamsByIds"](any<List<String>>())
-        } returns emptyList<RealmStepExam>()
+        coEvery { submissionDao.getUniquePendingSurveyCandidates("user") } returns listOf(
+            RoomSubmissionEntity(id = "sub1", parentId = "exam1@course1"),
+            RoomSubmissionEntity(id = "sub2", parentId = "exam2@course1"),
+        )
+        coEvery { answerDao.getBySubmissionIds(listOf("sub1", "sub2")) } returns emptyList()
+        coEvery { examDao.getByIds(listOf("exam1", "exam2")) } returns emptyList()
 
         val result = repository.getUniquePendingSurveys("user")
         assertEquals(0, result.size)
@@ -244,7 +219,7 @@ class SubmissionsRepositoryImplTest {
     fun `insertSubmission skips if _attachments present`() = runTest {
         val submission = JsonObject().apply { addProperty("_attachments", "test") }
         repository.insertSubmission(submission)
-        coVerify(exactly = 0) { databaseService.executeTransactionAsync(any()) }
+        verify(exactly = 0) { submissionDao.upsertAllBlocking(any()) }
     }
 
     @Test

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -282,6 +282,9 @@ wired through `di/RoomModule`.
       now reads exam submissions, answers, and questions through `SubmissionDao`, `AnswerDao`, and
       `QuestionDao` instead of querying Realm inside the per-course loop. This removes the remaining
       Realm submission/answer/question reads from progress reporting.
+- [x] **Submission PDF export moved to Room**: `SubmissionsRepositoryExporter` now reads submissions,
+      answers, exams, and questions through `SubmissionDao`, `AnswerDao`, `ExamDao`, and `QuestionDao`
+      instead of opening Realm while rendering single-submission and bulk-submission PDFs.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -248,6 +248,11 @@ wired through `di/RoomModule`.
       unfinished/pending survey metadata, and submission-detail question rows through `ExamDao` and
       `QuestionDao` instead of Realm queries. `RoomQuestionEntity` hydrates legacy
       `RealmExamQuestion` compatibility objects, including correct-choice data for grading display.
+- [x] **Submission list/detail reads moved to Room**: `SubmissionDao` and `AnswerDao` now back
+      submission lookup by id/user/ids, pending-survey lists, pending-offline counts, pending exam
+      result counts, parent/status submission lists, submission item summaries, and completion checks.
+      `RoomSubmissionEntity` and `RoomAnswerEntity` hydrate legacy `RealmSubmission`/`RealmAnswer`
+      compatibility objects with child answers grouped in one DAO batch per submission list.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -270,6 +270,10 @@ wired through `di/RoomModule`.
       now upsert CouchDB submission docs directly into `SubmissionDao`/`AnswerDao` and no longer
       mirror synced submission payloads into Realm. The old Realm parsing helpers remain only as
       dead legacy code until the final Realm deletion pass.
+- [x] **Submission upload serialization reads moved to Room**: `getExamUploadPayload` and
+      `serializeSubmission` now resolve users, exams, and questions through `UserDao`, `ExamDao`, and
+      `QuestionDao` rather than opening Realm. Submission upload payload generation now uses Room for
+      all migrated metadata dependencies.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -265,7 +265,11 @@ wired through `di/RoomModule`.
 - [x] **Exam answer saves moved to Room**: `saveExamAnswer` now reads/upserts answers through
       `AnswerDao`, updates submission status/timestamps through `SubmissionDao`, and removes pending
       survey orphans through Room when a survey is completed. Realm remains only in deeper legacy
-      sync/upload serialization paths for submissions.
+      upload serialization paths for submissions.
+- [x] **Submission sync inserts moved to Room-only**: `bulkInsertFromSync` and `insertSubmission`
+      now upsert CouchDB submission docs directly into `SubmissionDao`/`AnswerDao` and no longer
+      mirror synced submission payloads into Realm. The old Realm parsing helpers remain only as
+      dead legacy code until the final Realm deletion pass.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -243,6 +243,11 @@ wired through `di/RoomModule`.
       survey reads for course progress, course-step detail, exam counts, and local-progress cleanup,
       hydrating legacy `RealmStepExam` compatibility objects from `RoomExamEntity`. Sync writes for
       both tables were already landing in Room.
+- [x] **Submission survey/exam metadata reads moved to Room**: `SubmissionsRepositoryImpl` now
+      resolves survey titles/maps, exam question counts, bulk-survey parent ids, step completion,
+      unfinished/pending survey metadata, and submission-detail question rows through `ExamDao` and
+      `QuestionDao` instead of Realm queries. `RoomQuestionEntity` hydrates legacy
+      `RealmExamQuestion` compatibility objects, including correct-choice data for grading display.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -257,6 +257,11 @@ wired through `di/RoomModule`.
       `deleteExamSubmissions`, and `getOrCreateSubmission` now use `SubmissionDao`/`AnswerDao`
       instead of Realm transactions. This keeps survey-response creation, completion marking, and
       local exam-submission cleanup on the same Room tables used by the read paths.
+- [x] **Submission flows and creation moved to Room**: pending-survey and all-submission `Flow`
+      streams now come from `SubmissionDao` `Flow`s, `createExamSubmission` builds unmanaged
+      compatibility submissions and persists through Room, and simple status/exam lookup helpers
+      (`getLastPendingSubmission`, `updateSubmissionStatus`, `getExamByStepId`, `getExamById`) now
+      use Room DAOs.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -268,8 +268,8 @@ wired through `di/RoomModule`.
       upload serialization paths for submissions.
 - [x] **Submission sync inserts moved to Room-only**: `bulkInsertFromSync` and `insertSubmission`
       now upsert CouchDB submission docs directly into `SubmissionDao`/`AnswerDao` and no longer
-      mirror synced submission payloads into Realm. The old Realm parsing helpers remain only as
-      dead legacy code until the final Realm deletion pass.
+      mirror synced submission payloads into Realm. The old Realm parsing helpers for synced
+      submission inserts have been deleted.
 - [x] **Submission upload serialization reads moved to Room**: `getExamUploadPayload` and
       `serializeSubmission` now resolve users, exams, and questions through `UserDao`, `ExamDao`, and
       `QuestionDao` rather than opening Realm. Submission upload payload generation now uses Room for

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -253,6 +253,10 @@ wired through `di/RoomModule`.
       result counts, parent/status submission lists, submission item summaries, and completion checks.
       `RoomSubmissionEntity` and `RoomAnswerEntity` hydrate legacy `RealmSubmission`/`RealmAnswer`
       compatibility objects with child answers grouped in one DAO batch per submission list.
+- [x] **Submission write helpers moved to Room**: `saveSubmission`, `markSubmissionComplete`,
+      `deleteExamSubmissions`, and `getOrCreateSubmission` now use `SubmissionDao`/`AnswerDao`
+      instead of Realm transactions. This keeps survey-response creation, completion marking, and
+      local exam-submission cleanup on the same Room tables used by the read paths.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -288,6 +288,9 @@ wired through `di/RoomModule`.
 - [x] **Per-course step progress details moved to Room**: `CoursesRepositoryImpl.getCourseProgress`
       now builds step-level exam completion data from `ExamDao`, `QuestionDao`, `SubmissionDao`, and
       `AnswerDao` instead of opening Realm for exam questions, submissions, and answers.
+- [x] **Course progress deletion moved to Room**: `CoursesRepositoryImpl.deleteCourseProgress`
+      now resolves course exams through `ExamDao` and deletes matching local exam submissions plus
+      answers through `SubmissionDao`/`AnswerDao` instead of a Realm transaction.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -274,6 +274,10 @@ wired through `di/RoomModule`.
       `serializeSubmission` now resolve users, exams, and questions through `UserDao`, `ExamDao`, and
       `QuestionDao` rather than opening Realm. Submission upload payload generation now uses Room for
       all migrated metadata dependencies.
+- [x] **Submissions repository detached from `RealmRepository`**: the remaining submission-detail
+      user lookup now uses `UserDao`, and `SubmissionsRepositoryImpl` no longer extends the Realm
+      repository base or injects a Realm dispatcher. Submission code still accepts legacy model types at
+      its public boundary, but its migrated data access no longer depends on the generic Realm helpers.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -236,6 +236,10 @@ wired through `di/RoomModule`.
       `markResourceUploaded`, which updates the library via the DAO then does the team write in a
       Realm transaction. `BaseRecyclerFragment`/`BaseResourceFragment` type checks updated (library
       is no longer a `RealmObject`). Resource/upload/repo tests rewritten to mock `MyLibraryDao`.
+- [x] **CourseStep read paths moved to Room**: `CourseStepDao` now serves per-course, batched
+      course-id, and single-step lookups; course step progress and course-step detail screens hydrate
+      legacy `RealmCourseStep` compatibility objects from `RoomCourseStepEntity` instead of querying
+      Realm. Sync writes were already landing in the Room course-step table.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -236,10 +236,13 @@ wired through `di/RoomModule`.
       `markResourceUploaded`, which updates the library via the DAO then does the team write in a
       Realm transaction. `BaseRecyclerFragment`/`BaseResourceFragment` type checks updated (library
       is no longer a `RealmObject`). Resource/upload/repo tests rewritten to mock `MyLibraryDao`.
-- [x] **CourseStep read paths moved to Room**: `CourseStepDao` now serves per-course, batched
-      course-id, and single-step lookups; course step progress and course-step detail screens hydrate
-      legacy `RealmCourseStep` compatibility objects from `RoomCourseStepEntity` instead of querying
-      Realm. Sync writes were already landing in the Room course-step table.
+- [x] **CourseStep + course exam read paths moved to Room**: `CourseStepDao` now serves
+      per-course, batched course-id, and single-step lookups; course step progress and course-step
+      detail screens hydrate legacy `RealmCourseStep` compatibility objects from
+      `RoomCourseStepEntity` instead of querying Realm. `ExamDao` now serves course/step exam and
+      survey reads for course progress, course-step detail, exam counts, and local-progress cleanup,
+      hydrating legacy `RealmStepExam` compatibility objects from `RoomExamEntity`. Sync writes for
+      both tables were already landing in Room.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -278,6 +278,10 @@ wired through `di/RoomModule`.
       user lookup now uses `UserDao`, and `SubmissionsRepositoryImpl` no longer extends the Realm
       repository base or injects a Realm dispatcher. Submission code still accepts legacy model types at
       its public boundary, but its migrated data access no longer depends on the generic Realm helpers.
+- [x] **Progress submission mistake aggregation moved to Room**: `ProgressRepositoryImpl.fetchCourseData`
+      now reads exam submissions, answers, and questions through `SubmissionDao`, `AnswerDao`, and
+      `QuestionDao` instead of querying Realm inside the per-course loop. This removes the remaining
+      Realm submission/answer/question reads from progress reporting.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -285,6 +285,9 @@ wired through `di/RoomModule`.
 - [x] **Submission PDF export moved to Room**: `SubmissionsRepositoryExporter` now reads submissions,
       answers, exams, and questions through `SubmissionDao`, `AnswerDao`, `ExamDao`, and `QuestionDao`
       instead of opening Realm while rendering single-submission and bulk-submission PDFs.
+- [x] **Per-course step progress details moved to Room**: `CoursesRepositoryImpl.getCourseProgress`
+      now builds step-level exam completion data from `ExamDao`, `QuestionDao`, `SubmissionDao`, and
+      `AnswerDao` instead of opening Realm for exam questions, submissions, and answers.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.

--- a/docs/realm-to-room-migration.md
+++ b/docs/realm-to-room-migration.md
@@ -262,6 +262,10 @@ wired through `di/RoomModule`.
       compatibility submissions and persists through Room, and simple status/exam lookup helpers
       (`getLastPendingSubmission`, `updateSubmissionStatus`, `getExamByStepId`, `getExamById`) now
       use Room DAOs.
+- [x] **Exam answer saves moved to Room**: `saveExamAnswer` now reads/upserts answers through
+      `AnswerDao`, updates submission status/timestamps through `SubmissionDao`, and removes pending
+      survey orphans through Room when a survey is completed. Realm remains only in deeper legacy
+      sync/upload serialization paths for submissions.
 - [ ] Remaining ~26 model domains.
 - [ ] Migrate 39 Realm-based test files.
 - [ ] Remove Realm; full `assembleDefaultDebug` + `testDefaultDebugUnitTest` green.


### PR DESCRIPTION
### Motivation

- Migrate course-step read paths from Realm to Room as part of the ongoing Realm→Room transition so UI and repositories can read course-step data from the Room schema while preserving compatibility with existing Realm-based surfaces.

### Description

- Add `CourseStepDao` query methods for per-course (`getByCourseId`), batched course-id (`getByCourseIds`) and single-step (`getById`) lookups in `app/src/main/java/.../LegacyEntityDaos.kt`.
- Add a compatibility mapper `RoomCourseStepEntity.toRealmModel()` so repositories and UI code can continue to work with `RealmCourseStep` objects while data is served from Room in `app/src/main/java/.../LegacyRoomMappers.kt`.
- Replace Realm-backed course-step reads with Room DAO reads in `CoursesRepositoryImpl` for `getCourseSteps` and `getCourseStepData` and in `ProgressRepositoryImpl` for progress calculations, wiring in `CourseStepDao` and mapping entities to legacy models.
- Update `ProgressRepositoryImpl` unit tests to mock `CourseStepDao` and adjust the migration tracker documentation in `docs/realm-to-room-migration.md`.

### Testing

- Ran `./gradlew compileDefaultDebugKotlin` which completed successfully (Kotlin compile OK).
- Ran the full unit test task `./gradlew compileDefaultDebugKotlin testDefaultDebugUnitTest` which failed due to widespread Robolectric/Maven artifact socket errors unrelated to these changes (network artifact fetch errors), not code regressions in the modified logic.
- Ran the focused test `./gradlew testDefaultDebugUnitTest --tests org.ole.planet.myplanet.repository.ProgressRepositoryImplTest` which completed successfully and validated the adjusted progress/course-step read logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b5023d7dc832b9569b6be53208cfe)