### PR TITLE
all: smoother text view extensions utils coloring (fixes #14831)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6141
-        versionName = "0.61.41"
+        versionCode = 6150
+        versionName = "0.61.50"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/TextViewExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/TextViewExtensions.kt
@@ -16,6 +16,7 @@ fun TextView.makeExpandable(
     collapseLabel: String = context.getString(R.string.show_less)
 ) {
     var isExpanded = false
+    setLinkTextColor(androidx.core.content.ContextCompat.getColor(context, R.color.mainColor))
 
     fun refresh() {
         text = fullText


### PR DESCRIPTION
1. No color was defined in the code before: Inside TextViewExtensions.kt, the code only created the clickable "show more" link, but it never specified a text color for it.
2. Because no color was set explicitly, the text implicitly inherited the app's default link/accent color (colorAccent), which is defined globally as red in the theme settings.
3. Overriding the default: To change this behavior specifically for expandable text views, we had to introduce a new line: setLinkTextColor(androidx.core.content.ContextCompat.getColor(context, R.color.mainColor))                                                                                                                                       
This explicitly tells the TextView to override the inherited red color and render its links in blue.

[Screen_recording_20260720_181249.webm](https://github.com/user-attachments/assets/6a2bd39b-612e-4a6b-89e1-564b3a7675c8)

fixes #14831 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expandable text links now use the app’s main color for improved visibility and consistency.

* **Chores**
  * Updated the app version to 0.61.50.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->