### PR TITLE
courses: smoother steps exams border spacing (fixes #14826)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6141
-        versionName = "0.61.41"
+        versionCode = 6152
+        versionName = "0.61.52"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/res/layout/fragment_course_detail.xml
+++ b/app/src/main/res/layout/fragment_course_detail.xml
@@ -9,7 +9,7 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/card_bg"
+        android:background="@color/secondary_bg"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">

--- a/app/src/main/res/layout/fragment_exam_taking.xml
+++ b/app/src/main/res/layout/fragment_exam_taking.xml
@@ -11,12 +11,10 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <androidx.cardview.widget.CardView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:cardCornerRadius="8dp"
-            app:cardElevation="16dp"
-            app:cardUseCompatPadding="true">
+            android:orientation="vertical">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -184,6 +182,6 @@
                         android:text="@string/submit_answer" />
                 </LinearLayout>
             </LinearLayout>
-        </androidx.cardview.widget.CardView>
+        </LinearLayout>
     </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_take_course.xml
+++ b/app/src/main/res/layout/fragment_take_course.xml
@@ -12,18 +12,19 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:visibility="gone" />
-
     <LinearLayout
         android:id="@+id/content_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center_vertical"
             android:padding="8dp">
+
             <ImageView
                 android:id="@+id/backButton"
                 android:layout_width="wrap_content"
@@ -48,11 +49,13 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:orientation="vertical">
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
                     android:background="@color/colorPrimary"
                     android:padding="8dp">
+
                     <TextView
                         android:id="@+id/tv_step"
                         android:layout_width="wrap_content"
@@ -80,7 +83,6 @@
                     android:layout_height="4dp"
                     android:progress="0"
                     android:progressTint="@color/colorAccent" />
-
                 <androidx.viewpager2.widget.ViewPager2
                     android:id="@+id/viewPager2"
                     android:layout_width="match_parent"
@@ -137,6 +139,7 @@
                         android:drawableTint="@color/daynight_textColor"
                         android:visibility="gone" />
                 </LinearLayout>
+
                 <LinearLayout
                     android:id="@+id/ll_progress"
                     android:layout_width="match_parent"
@@ -144,6 +147,7 @@
                     android:background="@color/colorPrimary"
                     android:padding="8dp"
                     android:visibility="gone">
+
                     <androidx.appcompat.widget.AppCompatSeekBar
                         android:id="@+id/course_progress"
                         style="@style/Seekbar"

--- a/app/src/main/res/layout/fragment_take_course.xml
+++ b/app/src/main/res/layout/fragment_take_course.xml
@@ -50,124 +50,124 @@
             android:layout_weight="1"
             android:orientation="vertical">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize"
-                    android:background="@color/colorPrimary"
-                    android:padding="8dp">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="@color/colorPrimary"
+                android:padding="8dp">
 
-                    <TextView
-                        android:id="@+id/tv_step"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_vertical"
-                        android:layout_weight="1"
-                        android:text="@string/step"
-                        android:textAllCaps="true"
-                        android:textColor="@color/md_white_1000"
-                        android:textSize="@dimen/text_size_mid"
-                        android:textStyle="bold" />
-                    <Button
-                        android:id="@+id/btn_remove"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:background="@drawable/buttonyellow"
-                        android:minHeight="@dimen/_40dp"
-                        android:text="@string/remove" />
-                </LinearLayout>
-
-                <ProgressBar
-                    android:id="@+id/course_step_progress_bar"
-                    style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-                    android:layout_width="match_parent"
-                    android:layout_height="4dp"
-                    android:progress="0"
-                    android:progressTint="@color/colorAccent" />
-                <androidx.viewpager2.widget.ViewPager2
-                    android:id="@+id/viewPager2"
-                    android:layout_width="match_parent"
-                    android:layout_height="0dp"
+                <TextView
+                    android:id="@+id/tv_step"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
                     android:layout_weight="1"
-                    android:background="@color/secondary_bg" />
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize"
-                    android:background="@color/secondary_bg"
-                    android:orientation="horizontal"
-                    android:padding="8dp">
+                    android:text="@string/step"
+                    android:textAllCaps="true"
+                    android:textColor="@color/md_white_1000"
+                    android:textSize="@dimen/text_size_mid"
+                    android:textStyle="bold" />
+                <Button
+                    android:id="@+id/btn_remove"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/buttonyellow"
+                    android:minHeight="@dimen/_40dp"
+                    android:text="@string/remove" />
+            </LinearLayout>
 
-                    <TextView
-                        android:id="@+id/previous_step"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:background="?attr/selectableItemBackground"
-                        android:gravity="center"
-                        android:minWidth="100dp"
-                        android:text="@string/previous"
-                        android:textColor="@color/daynight_textColor"
-                        android:drawableTint="@color/daynight_textColor"
-                        app:drawableLeftCompat="@drawable/ic_left_arrow" />
-                    <View
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1" />
-                    <TextView
-                        android:id="@+id/next_step"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_marginStart="@dimen/padding_normal"
-                        android:background="?attr/selectableItemBackground"
-                        android:gravity="center"
-                        android:minWidth="100dp"
-                        android:text="@string/next"
-                        android:textColor="@color/daynight_textColor"
-                        android:drawableTint="@color/daynight_textColor"
-                        app:drawableRightCompat="@drawable/ic_right_arrow" />
-                    <TextView
-                        android:id="@+id/finish_step"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_marginStart="@dimen/padding_normal"
-                        android:background="?attr/selectableItemBackground"
-                        android:gravity="center"
-                        android:minWidth="100dp"
-                        android:text="@string/finish"
-                        android:textColor="@color/daynight_textColor"
-                        android:drawableTint="@color/daynight_textColor"
-                        android:visibility="gone" />
-                </LinearLayout>
+            <ProgressBar
+                android:id="@+id/course_step_progress_bar"
+                style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                android:progress="0"
+                android:progressTint="@color/colorAccent" />
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/viewPager2"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:background="@color/secondary_bg" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="@color/secondary_bg"
+                android:orientation="horizontal"
+                android:padding="8dp">
 
-                <LinearLayout
-                    android:id="@+id/ll_progress"
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize"
-                    android:background="@color/colorPrimary"
-                    android:padding="8dp"
-                    android:visibility="gone">
+                <TextView
+                    android:id="@+id/previous_step"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:background="?attr/selectableItemBackground"
+                    android:gravity="center"
+                    android:minWidth="100dp"
+                    android:text="@string/previous"
+                    android:textColor="@color/daynight_textColor"
+                    android:drawableTint="@color/daynight_textColor"
+                    app:drawableLeftCompat="@drawable/ic_left_arrow" />
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+                <TextView
+                    android:id="@+id/next_step"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="@dimen/padding_normal"
+                    android:background="?attr/selectableItemBackground"
+                    android:gravity="center"
+                    android:minWidth="100dp"
+                    android:text="@string/next"
+                    android:textColor="@color/daynight_textColor"
+                    android:drawableTint="@color/daynight_textColor"
+                    app:drawableRightCompat="@drawable/ic_right_arrow" />
+                <TextView
+                    android:id="@+id/finish_step"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="@dimen/padding_normal"
+                    android:background="?attr/selectableItemBackground"
+                    android:gravity="center"
+                    android:minWidth="100dp"
+                    android:text="@string/finish"
+                    android:textColor="@color/daynight_textColor"
+                    android:drawableTint="@color/daynight_textColor"
+                    android:visibility="gone" />
+            </LinearLayout>
 
-                    <androidx.appcompat.widget.AppCompatSeekBar
-                        android:id="@+id/course_progress"
-                        style="@style/Seekbar"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_weight="1"
-                        android:background="@color/bg_white"
-                        android:padding="8dp" />
-                    <TextView
-                        android:id="@+id/tv_percentage_complete"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:gravity="center"
-                        android:padding="@dimen/padding_normal"
-                        android:textColor="@color/md_white_1000"
-                        android:textSize="@dimen/text_size_mid"
-                        android:visibility="gone" />
-                </LinearLayout>
+            <LinearLayout
+                android:id="@+id/ll_progress"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="@color/colorPrimary"
+                android:padding="8dp"
+                android:visibility="gone">
+
+                <androidx.appcompat.widget.AppCompatSeekBar
+                    android:id="@+id/course_progress"
+                    style="@style/Seekbar"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_weight="1"
+                    android:background="@color/bg_white"
+                    android:padding="8dp" />
+                <TextView
+                    android:id="@+id/tv_percentage_complete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:padding="@dimen/padding_normal"
+                    android:textColor="@color/md_white_1000"
+                    android:textSize="@dimen/text_size_mid"
+                    android:visibility="gone" />
+            </LinearLayout>
         </LinearLayout>
     </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_take_course.xml
+++ b/app/src/main/res/layout/fragment_take_course.xml
@@ -43,17 +43,11 @@
                 android:textStyle="bold" />
         </LinearLayout>
 
-        <androidx.cardview.widget.CardView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            app:cardCornerRadius="8dp"
-            app:cardElevation="2dp"
-            app:cardUseCompatPadding="true">
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical">
+            android:orientation="vertical">
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
@@ -92,11 +86,11 @@
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
                     android:layout_weight="1"
-                    android:background="@color/card_bg" />
+                    android:background="@color/secondary_bg" />
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
-                    android:background="@color/colorPrimary"
+                    android:background="@color/secondary_bg"
                     android:orientation="horizontal"
                     android:padding="8dp">
 
@@ -109,7 +103,8 @@
                         android:gravity="center"
                         android:minWidth="100dp"
                         android:text="@string/previous"
-                        android:textColor="@color/md_white_1000"
+                        android:textColor="@color/daynight_textColor"
+                        android:drawableTint="@color/daynight_textColor"
                         app:drawableLeftCompat="@drawable/ic_left_arrow" />
                     <View
                         android:layout_width="0dp"
@@ -125,7 +120,8 @@
                         android:gravity="center"
                         android:minWidth="100dp"
                         android:text="@string/next"
-                        android:textColor="@color/md_white_1000"
+                        android:textColor="@color/daynight_textColor"
+                        android:drawableTint="@color/daynight_textColor"
                         app:drawableRightCompat="@drawable/ic_right_arrow" />
                     <TextView
                         android:id="@+id/finish_step"
@@ -137,7 +133,8 @@
                         android:gravity="center"
                         android:minWidth="100dp"
                         android:text="@string/finish"
-                        android:textColor="@color/md_white_1000"
+                        android:textColor="@color/daynight_textColor"
+                        android:drawableTint="@color/daynight_textColor"
                         android:visibility="gone" />
                 </LinearLayout>
                 <LinearLayout
@@ -167,7 +164,6 @@
                         android:textSize="@dimen/text_size_mid"
                         android:visibility="gone" />
                 </LinearLayout>
-            </LinearLayout>
-        </androidx.cardview.widget.CardView>
+        </LinearLayout>
     </LinearLayout>
 </FrameLayout>


### PR DESCRIPTION
### Problem
- The main containers for the course-taking and exam-taking layouts used CardView elements with app:cardUseCompatPadding="true" and rounded corners. This padding caused the parent background color (colorPrimaryDark) to bleed around the edges, forming an unwanted border
- The bottom navigation bar in the course taker screen used colorPrimary as its background, causing a visual split
- When course details inside the view pager were long enough to scroll, the CourseDetailFragment's NestedScrollView stretched and filled the screen with its @color/card_bg background (light gray #3a3b3c in dark mode). This met the bottom navigation bar (@color/secondary_bg / dark gray #242526 in dark mode), creating an unwanted color-split border at the bottom.

### Solution
- Replaced CardView wrapping in fragment_take_course.xml with a standard flat LinearLayout
- Replaced CardView wrapping in fragment_exam_taking.xml with a standard flat LinearLayout
- Updated the backgrounds of ViewPager2 and the bottom navigation bar in fragment_take_course.xml to @color/secondary_bg. This resolves to white (#FFFFFF) in light mode and dark-gray (#242526) in dark mode
- Changed the background of the NestedScrollView in fragment_course_detail.xml from @color/card_bg to @color/secondary_bg. This unifies the entire course details view with the bottom navigation bar, removing the color-split border when details are scrollable
- Updated the bottom navigation action texts to @color/daynight_textColor and added android:drawableTint="@color/daynight_textColor" to the navigation arrow drawables so they remain high-contrast and readable in both light and dark themes

[Screen_recording_20260720_203144.webm](https://github.com/user-attachments/assets/f749511f-9bab-49bc-aa63-bfc9066b525e)

fixes #14826 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background consistency across course detail, course-taking, and exam-taking screens by aligning fragment container backgrounds.
  * Updated the course-taking step/viewpager layout structure to improve sizing and reliability.
  * Enhanced day/night theme support for step navigation buttons, including arrow tinting for better contrast.
* **Style**
  * Simplified visual container structure on course-taking and exam-taking screens by removing card-style wrappers in favor of cleaner layout containers.
* **Chores**
  * Bumped app version to **0.61.52** (versionCode **6152**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->