### PR TITLE
dashboard: smoother window edge handling (fixes #14825)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6141
-        versionName = "0.61.41"
+        versionCode = 6153
+        versionName = "0.61.53"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -82,6 +82,7 @@ import org.ole.planet.myplanet.ui.teams.TeamPageConfig.TasksPage
 import org.ole.planet.myplanet.ui.user.BecomeMemberActivity
 import org.ole.planet.myplanet.utils.DialogUtils.guestDialog
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utils.LocaleUtils
 import org.ole.planet.myplanet.utils.NotificationUtils
@@ -243,18 +244,9 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     }
 
     private fun initViews() {
-        WindowCompat.setDecorFitsSystemWindows(window, false)
         binding = ActivityDashboardBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        val insetsController = WindowCompat.getInsetsController(window, binding.root)
-        insetsController.isAppearanceLightStatusBars = true
-        insetsController.isAppearanceLightNavigationBars = true
-        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, windowInsets ->
-            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-            binding.myToolbar.updatePadding(top = insets.top)
-            view.updatePadding(left = insets.left, right = insets.right, bottom = insets.bottom)
-            WindowInsetsCompat.CONSUMED
-        }
+        EdgeToEdgeUtils.setupEdgeToEdge(this, window.decorView)
         setupUI(binding.activityDashboardParentLayout, this@DashboardActivity)
         setSupportActionBar(binding.myToolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(false)


### PR DESCRIPTION
### Problem
- In DashboardActivity.kt, the custom window insets listener was attached directly to binding.root
- When the navigation drawer was initialized or when other activities (like SettingsActivity) were closed and the dashboard resumed, the wrapped DrawerLayout intercepted/consumed the insets, or did not propagate layout updates correctly, resulting in the toolbar padding being reset to 0 and causing it to slide under the status bar

### Solution
- Cleaned up the custom insets listener and manual status bar configuration in initViews().
- Replaced it with a single call to the project's utility method: EdgeToEdgeUtils.setupEdgeToEdge(this, window.decorView)
- Applying setupEdgeToEdge directly to the window.decorView ensures window padding is handled at the topmost window container. This isolates the padding logic from MaterialDrawer's hierarchy modifications and guarantees that the UI will not slide beneath the status bar upon resume or menu actions

[Screen_recording_20260720_221434.webm](https://github.com/user-attachments/assets/42f9755c-c659-4cb9-ab0a-165d9a5cba3b)

fixes #14825 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard layout handling for system bars and window insets to better support edge-to-edge screen configurations.
* **Chores**
  * Updated the Android app version to **0.61.53** (version code **6153**) to reflect this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->