### PR TITLE
chat: smoother primary url checking (fixes #14866)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6141
-        versionName = "0.61.41"
+        versionCode = 6154
+        versionName = "0.61.54"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -214,6 +214,14 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
             return reachable
         }
 
+        suspend fun isPrimaryServerReachable(
+            urlString: String,
+            ioDispatcher: CoroutineDispatcher = coreDependenciesEntryPoint.dispatcherProvider().io
+        ): Boolean {
+            if (urlString.isBlank()) return false
+            return tryConnect(urlString, ioDispatcher)
+        }
+
         private suspend fun tryConnect(
             urlString: String,
             ioDispatcher: CoroutineDispatcher

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication
+import org.ole.planet.myplanet.MainApplication.Companion.isPrimaryServerReachable
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentChatDetailBinding
@@ -709,11 +710,12 @@ class ChatDetailFragment : Fragment() {
     private fun clearAlternativeUrlIfPrimaryRestored() {
         if (!sharedPrefManager.isAlternativeUrl()) return
         val primaryUrl = serverUrl
+        val prefManager = sharedPrefManager
         MainApplication.applicationScope.launch(dispatcherProvider.io) {
-            if (isServerReachable(primaryUrl)) {
-                sharedPrefManager.setAlternativeUrl("")
-                sharedPrefManager.setProcessedAlternativeUrl("")
-                sharedPrefManager.setIsAlternativeUrl(false)
+            if (isPrimaryServerReachable(primaryUrl)) {
+                prefManager.setAlternativeUrl("")
+                prefManager.setProcessedAlternativeUrl("")
+                prefManager.setIsAlternativeUrl(false)
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -33,6 +33,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.isServerReachable
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentChatDetailBinding
@@ -698,15 +699,23 @@ class ChatDetailFragment : Fragment() {
         if (this::messageTextWatcher.isInitialized) {
             binding.editGchatMessage.removeTextChangedListener(messageTextWatcher)
         }
-        if (sharedPrefManager.isAlternativeUrl()) {
-            sharedPrefManager.setAlternativeUrl("")
-            sharedPrefManager.setProcessedAlternativeUrl("")
-            sharedPrefManager.setIsAlternativeUrl(false)
-        }
+        clearAlternativeUrlIfPrimaryRestored()
         loadingJob?.cancel()
         speechRecognizer?.destroy()
         _binding = null
         super.onDestroyView()
+    }
+
+    private fun clearAlternativeUrlIfPrimaryRestored() {
+        if (!sharedPrefManager.isAlternativeUrl()) return
+        val primaryUrl = serverUrl
+        MainApplication.applicationScope.launch(dispatcherProvider.io) {
+            if (isServerReachable(primaryUrl)) {
+                sharedPrefManager.setAlternativeUrl("")
+                sharedPrefManager.setProcessedAlternativeUrl("")
+                sharedPrefManager.setIsAlternativeUrl(false)
+            }
+        }
     }
 
     private fun buildContextPrefix(): String {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -712,7 +712,7 @@ class ChatDetailFragment : Fragment() {
         val primaryUrl = serverUrl
         val prefManager = sharedPrefManager
         MainApplication.applicationScope.launch(dispatcherProvider.io) {
-            if (isPrimaryServerReachable(primaryUrl)) {
+            if (isPrimaryServerReachable(primaryUrl, dispatcherProvider.io)) {
                 prefManager.setAlternativeUrl("")
                 prefManager.setProcessedAlternativeUrl("")
                 prefManager.setIsAlternativeUrl(false)

--- a/app/src/test/java/org/ole/planet/myplanet/MainApplicationTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/MainApplicationTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -20,7 +21,6 @@ import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainApplicationTest {
-
     private lateinit var mockContext: Context
     private lateinit var mockEntryPoint: CoreDependenciesEntryPoint
     private lateinit var mockServerUrlMapper: ServerUrlMapper
@@ -66,5 +66,33 @@ class MainApplicationTest {
 
         // Since invalid_url will throw an exception or return false
         assertFalse(result == true)
+    }
+
+    @Test
+    fun `isPrimaryServerReachable returns false for invalid URL`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+
+        var result: Boolean? = null
+
+        launch(testDispatcher) {
+            result = MainApplication.isPrimaryServerReachable("invalid_url", testDispatcher)
+        }
+
+        advanceUntilIdle()
+
+        assertFalse(result == true)
+    }
+
+    @Test
+    fun `isPrimaryServerReachable never consults the alternative URL mapping`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+
+        launch(testDispatcher) {
+            MainApplication.isPrimaryServerReachable("invalid_url", testDispatcher)
+        }
+
+        advanceUntilIdle()
+
+        verify(exactly = 0) { mockServerUrlMapper.processUrl(any()) }
     }
 }


### PR DESCRIPTION
fixes #14866
Instead of unconditionally clearing the alternative URL on fragment destroy, only clear it if the primary server is reachable. This prevents losing the alternative URL when the primary is still down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server URL handling when leaving a chat screen by deferring alternative URL cleanup until the primary server is confirmed reachable.
  * Added validation to prevent connectivity checks for blank/invalid URLs.
* **Tests**
  * Added coroutine unit tests covering primary server reachability validation and ensuring invalid inputs don’t trigger alternative URL mapping.
* **Chores**
  * Updated the app release version metadata to 0.61.54 (code 6154).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->