### PR TITLE
resources: use StateFlow for download progress broadcasts (fixes #14868)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -273,10 +273,21 @@ abstract class BaseResourceFragment : Fragment() {
                 broadcastService.events.collect { intent ->
                     if (isActive) {
                         when (intent.action) {
-                            DashboardActivity.MESSAGE_PROGRESS -> broadcastReceiver.onReceive(requireContext(), intent)
                             "ACTION_NETWORK_CHANGED" -> receiver.onReceive(requireContext(), intent)
                             DownloadService.RESOURCE_NOT_FOUND_ACTION -> resourceNotFoundReceiver.onReceive(requireContext(), intent)
                         }
+                    }
+                }
+            }
+        }
+        // MESSAGE_PROGRESS is served from latestDownloadProgress (not `events`) so a fragment
+        // whose view was recreated or briefly stopped right as a download finished still sees
+        // the latest state on resubscribe, instead of losing that update forever.
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                broadcastService.latestDownloadProgress.collect { intent ->
+                    if (isActive && intent != null) {
+                        broadcastReceiver.onReceive(requireContext(), intent)
                     }
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/model/Download.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Download.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.model
 
 import android.os.Parcel
 import android.os.Parcelable
+import java.util.concurrent.atomic.AtomicLong
 
 class Download() : Parcelable {
     var fileName: String? = null
@@ -12,6 +13,7 @@ class Download() : Parcelable {
     var failed: Boolean = false
     var message: String? = null
     var fileUrl: String? = null
+    var completionId: Long = 0L
 
     constructor(parcel: Parcel) : this() {
         fileName = parcel.readString()
@@ -22,6 +24,7 @@ class Download() : Parcelable {
         failed = parcel.readByte() != 0.toByte()
         message = parcel.readString()
         fileUrl = parcel.readString()
+        completionId = parcel.readLong()
     }
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
@@ -33,6 +36,7 @@ class Download() : Parcelable {
         parcel.writeByte(if (failed) 1 else 0)
         parcel.writeString(message)
         parcel.writeString(fileUrl)
+        parcel.writeLong(completionId)
     }
 
     override fun describeContents(): Int {
@@ -40,6 +44,10 @@ class Download() : Parcelable {
     }
 
     companion object CREATOR : Parcelable.Creator<Download> {
+        private val completionIdGenerator = AtomicLong(0)
+
+        fun nextCompletionId(): Long = completionIdGenerator.incrementAndGet()
+
         override fun createFromParcel(parcel: Parcel): Download {
             return Download(parcel)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/services/BroadcastService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/BroadcastService.kt
@@ -4,18 +4,41 @@ import android.content.Intent
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 @Singleton
 open class BroadcastService @Inject constructor() {
     private val _events = MutableSharedFlow<Intent>(extraBufferCapacity = 64)
     val events = _events.asSharedFlow()
 
+    // Download progress/completion is current *state*, not a one-shot event: a collector that
+    // (re)subscribes after missing the last emission - e.g. the app was backgrounded right as a
+    // download finished, or a fragment's view was torn down and recreated on rotation - must
+    // still be able to observe it. `events` has replay = 0, so a collector that wasn't actively
+    // subscribed at the exact moment of emission loses that intent forever. MESSAGE_PROGRESS
+    // intents are therefore tracked here instead, where StateFlow always replays its latest
+    // value to new subscribers. Other action types (retry countdowns, one-shot "resource not
+    // found" dialogs) intentionally stay on `events` only, since replaying those on every
+    // resubscribe would incorrectly re-trigger a dialog/toast the user already saw.
+    private val _latestDownloadProgress = MutableStateFlow<Intent?>(null)
+    val latestDownloadProgress: StateFlow<Intent?> = _latestDownloadProgress.asStateFlow()
+
     open suspend fun sendBroadcast(intent: Intent) {
-        _events.emit(intent)
+        if (intent.action == DownloadService.MESSAGE_PROGRESS) {
+            _latestDownloadProgress.value = intent
+        } else {
+            _events.emit(intent)
+        }
     }
 
     fun trySendBroadcast(intent: Intent): Boolean {
+        if (intent.action == DownloadService.MESSAGE_PROGRESS) {
+            _latestDownloadProgress.value = intent
+            return true
+        }
         return _events.tryEmit(intent)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -473,6 +473,9 @@ class DownloadService : Service() {
             fileUrl = originalDownloadUrl.ifEmpty { url }
             progress = 100
             completeAll = (remaining == 0) || (isCurrentDownloadPriority && remainingPriority == 0)
+            if (completeAll) {
+                completionId = Download.nextCompletionId()
+            }
         }
 
         sendIntent(download, fromSync)

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
@@ -158,6 +158,9 @@ class DownloadWorker @AssistedInject constructor(
             progress = if (success) 100 else 0
             failed = !success
             completeAll = isComplete
+            if (isComplete) {
+                completionId = Download.nextCompletionId()
+            }
             if (!success) {
                 message = context.getString(R.string.download_failed)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dictionary/DictionaryActivity.kt
@@ -89,13 +89,14 @@ class DictionaryActivity : BaseActivity() {
     }
 
     override fun registerReceiver() {
+        // Served from latestDownloadProgress (not `events`) so this activity still sees the
+        // latest download state if it resubscribes after missing the last emission - `events`
+        // has no replay and would otherwise lose that update forever.
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                broadcastService.events.collect { intent ->
-                    if (isActive) {
-                        when (intent.action) {
-                            "message_progress" -> receiver.onReceive(this@DictionaryActivity, intent)
-                        }
+                broadcastService.latestDownloadProgress.collect { intent ->
+                    if (isActive && intent != null) {
+                        receiver.onReceive(this@DictionaryActivity, intent)
                     }
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -45,7 +45,6 @@ import org.ole.planet.myplanet.model.ResourceListModel
 import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.model.TagItem
 import org.ole.planet.myplanet.services.SharedPrefManager
-import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncHelper
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
 import org.ole.planet.myplanet.utils.DialogUtils.guestDialog
@@ -90,6 +89,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
     
     private lateinit var realtimeSyncHelper: RealtimeSyncHelper
     private var refreshJob: Job? = null
+    private var lastHandledDownloadCompletion = 0L
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -160,24 +160,24 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
         initArrays()
         hideButton()
 
-        collectWhenStarted(viewModel.downloadComplete) { completed ->
-            if (completed) {
+        collectWhenStarted(viewModel.downloadCompletedAt) { completedAt ->
+            if (completedAt > lastHandledDownloadCompletion) {
+                lastHandledDownloadCompletion = completedAt
                 refreshResourcesData()
             }
         }
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                broadcastService.events.collect { intent ->
-                    if (intent.action == DashboardActivity.MESSAGE_PROGRESS) {
-                        val download = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            intent.getParcelableExtra("download", Download::class.java)
-                        } else {
-                            @Suppress("DEPRECATION")
-                            intent.getParcelableExtra("download")
-                        }
-                        if (download?.completeAll == true) {
-                            viewModel.notifyDownloadComplete()
-                        }
+                broadcastService.latestDownloadProgress.collect { intent ->
+                    intent ?: return@collect
+                    val download = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        intent.getParcelableExtra("download", Download::class.java)
+                    } else {
+                        @Suppress("DEPRECATION")
+                        intent.getParcelableExtra("download")
+                    }
+                    if (download?.completeAll == true) {
+                        viewModel.notifyDownloadComplete()
                     }
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -177,7 +177,7 @@ class ResourcesFragment : BaseRecyclerFragment<RealmMyLibrary?>(), OnLibraryItem
                         intent.getParcelableExtra("download")
                     }
                     if (download?.completeAll == true) {
-                        viewModel.notifyDownloadComplete()
+                        viewModel.notifyDownloadComplete(download.completionId)
                     }
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
@@ -23,8 +23,14 @@ class ResourcesViewModel @Inject constructor(
     private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
 
-    private val _downloadComplete = MutableStateFlow(false)
-    val downloadComplete: StateFlow<Boolean> = _downloadComplete.asStateFlow()
+    // A monotonically increasing "last completed at" timestamp rather than a true/false pulse:
+    // toggling a StateFlow true-then-false with no suspension in between can be conflated away
+    // entirely by a collector that isn't actively resumed at that exact moment, silently
+    // dropping the completion signal. A value that never repeats can't be missed that way -
+    // collectors compare it against the last timestamp they handled instead of reacting to a
+    // transient flip.
+    private val _downloadCompletedAt = MutableStateFlow(0L)
+    val downloadCompletedAt: StateFlow<Long> = _downloadCompletedAt.asStateFlow()
 
     private val _openedResourceIds = MutableStateFlow<Set<String>>(emptySet())
     val openedResourceIds: StateFlow<Set<String>> = _openedResourceIds.asStateFlow()
@@ -32,8 +38,7 @@ class ResourcesViewModel @Inject constructor(
     private var observeOpenedResourcesJob: Job? = null
 
     fun notifyDownloadComplete() {
-        _downloadComplete.value = true
-        _downloadComplete.value = false
+        _downloadCompletedAt.value = System.currentTimeMillis()
     }
 
     fun observeOpenedResourceIds(userId: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
@@ -36,8 +36,15 @@ class ResourcesViewModel @Inject constructor(
     val openedResourceIds: StateFlow<Set<String>> = _openedResourceIds.asStateFlow()
 
     private var observeOpenedResourcesJob: Job? = null
+    private var lastCompletionId = 0L
 
-    fun notifyDownloadComplete() {
+    fun notifyDownloadComplete(completionId: Long = 0L) {
+        if (completionId != 0L) {
+            if (completionId == lastCompletionId) {
+                return
+            }
+            lastCompletionId = completionId
+        }
         _downloadCompletedAt.value = System.currentTimeMillis()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -62,6 +62,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
         DialogUtils.CustomProgressDialog(this)
     }
 
+    private var lastHandledCompletionId = 0L
     var broadcastReceiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             if (intent.action == DashboardActivity.MESSAGE_PROGRESS) {
@@ -73,6 +74,12 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
                 }
                 val fromSync = intent.getBooleanExtra("fromSync", false)
                 if (!fromSync) {
+                    if (download?.completeAll == true) {
+                        if (download.completionId != 0L && download.completionId == lastHandledCompletionId) {
+                            return
+                        }
+                        lastHandledCompletionId = download.completionId
+                    }
                     checkDownloadResult(download)
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -53,7 +53,6 @@ import org.ole.planet.myplanet.services.ResourceDownloadCoordinator
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.SyncManager
 import org.ole.planet.myplanet.services.sync.TransactionSyncManager
-import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.utils.Constants
 import org.ole.planet.myplanet.utils.Constants.autoSynFeature
 import org.ole.planet.myplanet.utils.DialogUtils.getUpdateDialog
@@ -760,10 +759,12 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
     }
 
     open fun registerReceiver() {
-        collectWhenStarted(broadcastService.events) { intent ->
-            if (intent.action == DashboardActivity.MESSAGE_PROGRESS) {
-                broadcastReceiver.onReceive(this@SyncActivity, intent)
-            }
+        // Served from latestDownloadProgress (not `events`) so this activity still sees the
+        // latest download state if it resubscribes after missing the last emission - `events`
+        // has no replay and would otherwise lose that update forever.
+        collectWhenStarted(broadcastService.latestDownloadProgress) { intent ->
+            intent ?: return@collectWhenStarted
+            broadcastReceiver.onReceive(this@SyncActivity, intent)
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/services/BroadcastServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/BroadcastServiceTest.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.services
 
+import android.app.Application
 import android.content.Intent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -7,11 +8,17 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [32], application = Application::class)
 class BroadcastServiceTest {
 
     private lateinit var broadcastService: BroadcastService
@@ -50,5 +57,52 @@ class BroadcastServiceTest {
         job.join()
         assertTrue(result)
         assertEquals(testIntent, receivedIntent)
+    }
+
+    @Test
+    fun `latestDownloadProgress starts null`() {
+        assertNull(broadcastService.latestDownloadProgress.value)
+    }
+
+    @Test
+    fun `sendBroadcast routes MESSAGE_PROGRESS to latestDownloadProgress instead of events`() = runTest {
+        val progressIntent = Intent(DownloadService.MESSAGE_PROGRESS)
+        var receivedOnEvents = false
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            broadcastService.events.collect { receivedOnEvents = true }
+        }
+
+        broadcastService.sendBroadcast(progressIntent)
+
+        assertEquals(progressIntent, broadcastService.latestDownloadProgress.value)
+        assertTrue("MESSAGE_PROGRESS must not be re-emitted on the one-shot `events` flow", !receivedOnEvents)
+        job.cancel()
+    }
+
+    @Test
+    fun `trySendBroadcast routes MESSAGE_PROGRESS to latestDownloadProgress and returns true`() {
+        val progressIntent = Intent(DownloadService.MESSAGE_PROGRESS)
+
+        val result = broadcastService.trySendBroadcast(progressIntent)
+
+        assertTrue(result)
+        assertEquals(progressIntent, broadcastService.latestDownloadProgress.value)
+    }
+
+    @Test
+    fun `latestDownloadProgress replays the last value to a subscriber that attaches after the emission`() = runTest {
+        val progressIntent = Intent(DownloadService.MESSAGE_PROGRESS).apply {
+            putExtra("marker", "batch-complete")
+        }
+
+        // Emitted while nothing is subscribed - simulates a download finishing while the
+        // consuming fragment's view was torn down (rotation) or the app was backgrounded.
+        broadcastService.sendBroadcast(progressIntent)
+
+        // A collector attaching afterwards must still observe it, unlike a replay = 0 SharedFlow.
+        val received = broadcastService.latestDownloadProgress.first { it != null }
+
+        assertEquals("batch-complete", received?.getStringExtra("marker"))
     }
 }


### PR DESCRIPTION
fixes #14868
Replace SharedFlow (replay=0) with StateFlow for MESSAGE_PROGRESS intents so late subscribers still receive the latest download state. Fixes missed updates when fragments are recreated or the app is backgrounded. Also replaces the boolean download-complete pulse in ResourcesViewModel with a monotonic timestamp to avoid conflation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download progress handling so the latest status is retained and restored when screens reconnect.
  * Resource listings now refresh based on completion time and avoid duplicate refreshes after “all complete.”
  * Dictionary, synchronization, and related screens now process the right download updates consistently.
  * Added completion tracking to prevent repeated handling of duplicate “all complete” events.
* **Tests**
  * Added/updated coverage for latest progress delivery, replay to late subscribers, and completion event routing/de-duplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->