### PR TITLE
courses: smoother progress status view modelling (fixes #14797)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6145
-        versionName = "0.61.45"
+        versionCode = 6156
+        versionName = "0.61.56"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -532,7 +532,7 @@ class CoursesAdapter(
         private fun updateProgressViews(position: Int) {
             val course = getItem(position) ?: return
             val progress = progressMap?.get(course.courseId)
-            if (progress != null) {
+            if (progress != null && course.isMyCourse) {
                 rowCourseBinding.courseProgress.max = getInt("max", progress)
                 val currentProgress = getInt("current", progress)
                 rowCourseBinding.courseProgress.progress = currentProgress

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
@@ -74,11 +74,7 @@ class CoursesViewModel @Inject constructor(
                     val (map, progressMap) = coroutineScope {
                         val ratingsDeferred = async { coursesRepository.getCourseRatings(userId) }
                         val progressDeferred = async {
-                            if (isMyCourseLib) {
-                                coursesRepository.getCourseProgress(userId, allCourseIds)
-                            } else {
-                                null
-                            }
+                            coursesRepository.getCourseProgress(userId, allCourseIds)
                         }
                         Pair(ratingsDeferred.await(), progressDeferred.await())
                     }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesViewModelTest.kt
@@ -63,8 +63,8 @@ class CoursesViewModelTest {
     }
 
     @Test
-    fun testLoadCourses_NotMyCoursesLib_SkipsGetCourseProgress() = runTest {
+    fun testLoadCourses_NotMyCoursesLib_StillCallsGetCourseProgress() = runTest {
         viewModel.loadCourses(false, "u1")
-        coVerify(exactly = 0) { coursesRepository.getCourseProgress(any<String>(), any<List<String>>()) }
+        coVerify { coursesRepository.getCourseProgress("u1", any<List<String>>()) }
     }
 }


### PR DESCRIPTION
### What Was the Cause
In CoursesViewModel.kt, the user's progress mapping was only loaded when isMyCourseLib was true (i.e. only when viewing the "My Courses" shelf). Catalog Fallback: When viewing the general course catalog ("Our Courses" search tab), isMyCourseLib is false, so progress mapping was passed as null. Because progress was always null for catalog courses, CoursesAdapter.kt fell back to displaying the "Not Started" status badge for every course

### Solution
- Modified CoursesViewModel.kt: Removed the conditional isMyCourseLib check so that course progress is always fetched from the database for all loaded courses.
- Modified CoursesAdapter.kt: Updated updateProgressViews to only show the horizontal progress bar if the user is enrolled in the course (course.isMyCourse == true). This ensures we don't display 0% progress bars for catalog courses the user hasn't joined, while correctly showing the progress status badge (e.g. "Completed" or "In Progress") everywhere the course is found.

[Screen_recording_20260721_195101.webm](https://github.com/user-attachments/assets/8b00e4d0-8656-4dd9-be32-7fbe754e04eb)

fixes #14797 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated course progress UI so progress indicators (bars/badges) show only for courses owned by the current user.
  * Adjusted course list progress loading so progress data is prepared consistently, including non-“My Courses” library views.
  * Ensured courses not associated with the current user follow the “no progress” UI state.

* **Chores**
  * Bumped app version to **0.61.56** (**6156**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->