### PR TITLE
all: smoother notification spinner item sorting (fixes #14858)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6145
-        versionName = "0.61.45"
+        versionCode = 6157
+        versionName = "0.61.57"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsFragment.kt
@@ -61,7 +61,7 @@ class NotificationsFragment : Fragment() {
 
         val options = resources.getStringArray(status_options)
         val optionsList: MutableList<String?> = ArrayList(listOf(*options))
-        val spinnerAdapter = ArrayAdapter(requireContext(), R.layout.spinner_item, optionsList)
+        val spinnerAdapter = ArrayAdapter(requireContext(), R.layout.spinner_item_right, optionsList)
         spinnerAdapter.setDropDownViewResource(R.layout.spinner_item)
         binding.status.adapter = spinnerAdapter
         var isInitialSpinnerSelection = true

--- a/app/src/main/res/layout/fragment_notifications.xml
+++ b/app/src/main/res/layout/fragment_notifications.xml
@@ -13,6 +13,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/_4dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -27,20 +29,17 @@
             android:textColor="@color/bg_white"
             android:textAllCaps="false"
             app:layout_constraintEnd_toEndOf="parent" />
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_weight="1" />
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1" />
+
         <Spinner
             android:id="@+id/status"
-            android:layout_width="wrap_content"
+            android:layout_width="120dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
-            android:layout_weight="1"
             android:popupBackground="@color/secondary_bg"
             app:backgroundTint="@color/daynight_textColor" />
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_notifications.xml
+++ b/app/src/main/res/layout/fragment_notifications.xml
@@ -7,7 +7,6 @@
     android:background="@color/light_dark"
     tools:context=".ui.notifications.NotificationsFragment">
 
-    <!-- Normal filter bar -->
     <LinearLayout
         android:id="@+id/ltTopBar"
         android:layout_width="match_parent"
@@ -29,12 +28,10 @@
             android:textColor="@color/bg_white"
             android:textAllCaps="false"
             app:layout_constraintEnd_toEndOf="parent" />
-
         <View
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1" />
-
         <Spinner
             android:id="@+id/status"
             android:layout_width="120dp"
@@ -44,7 +41,6 @@
             app:backgroundTint="@color/daynight_textColor" />
     </LinearLayout>
 
-    <!-- Selection mode bar — overlays at same position as ltTopBar; only one visible at a time -->
     <LinearLayout
         android:id="@+id/ltBulkActionBar"
         android:layout_width="match_parent"
@@ -96,7 +92,6 @@
             android:contentDescription="@string/cancel_selection" />
     </LinearLayout>
 
-    <!-- Barrier sits below whichever bar is currently visible -->
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/headerBarrier"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/spinner_item_right.xml
+++ b/app/src/main/res/layout/spinner_item_right.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textColor="@color/daynight_textColor"
+    android:background="@color/secondary_bg"
+    android:gravity="end|center_vertical"
+    android:textAlignment="viewEnd"
+    android:padding="8dp" />


### PR DESCRIPTION
### Problem
- The spinner layout in ltTopBar had android:layout_weight="1" applied alongside two empty text view weights. This stretched the spinner box, creating a large, awkward click boundary and pushing the drop-down arrow far to the right.
- Using android:layout_width="wrap_content" on the spinner caused the container size to dynamically shift and resize depending on the length of the selected text ("All" vs "Unread").
- The selected option text inside the spinner defaulted to left-aligned, creating a gap between the text and the drop-down arrow.

### Solution
- Modified fragment_notifications.xml to remove the layout weight from the spinner and set a fixed width of 120dp to prevent dynamic container size shifts.
- Replaced the two empty TextView spacers with a single, clean View spacer (layout_width="0dp", layout_weight="1") to push the spinner cleanly to the right side of the screen.
- Added android:gravity="center_vertical" and android:orientation="horizontal" to the top bar layout to keep the button and the spinner vertically aligned.
- Created spinner_item_right.xml with android:gravity="end|center_vertical" and android:textAlignment="viewEnd".
- Updated NotificationsFragment.kt to use the new spinner_item_right layout for the selected spinner item. This aligns the selected text (e.g. "All", "Read", or "Unread") to the right, sitting right next to the drop-down arrow icon. The drop-down popup list remains left-aligned via the standard spinner_item layout.

[Screen_recording_20260721_203717.webm](https://github.com/user-attachments/assets/043bbd27-5056-4dbb-bed0-1606699f35c2)

fixes #14858 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the notification filter bar layout for cleaner horizontal alignment and spacing.
  * Updated the status filter selector area to simplify its spacing while keeping consistent sizing.
  * Changed the status spinner item to a new right-aligned, theme-aware (day/night) presentation with improved padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->