### PR TITLE
all: less notification bell icon list item is more (fixes #14859)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6145
-        versionName = "0.61.45"
+        versionCode = 6158
+        versionName = "0.61.58"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapter.kt
@@ -112,7 +112,6 @@ class NotificationsAdapter(
             val notification = item.notification
             binding.title.text = Html.fromHtml(notification.formattedText.toString(), Html.FROM_HTML_MODE_LEGACY)
             binding.timestamp.text = formatRelativeTime(notification.createdAt)
-            binding.ivTypeIcon.setImageResource(iconResFor(notification.type))
             binding.root.alpha = if (notification.isRead) 0.6f else 1.0f
 
             if (item.isSelectionMode) {

--- a/app/src/main/res/layout/row_notifications.xml
+++ b/app/src/main/res/layout/row_notifications.xml
@@ -5,13 +5,7 @@
     android:orientation="horizontal"
     android:padding="@dimen/padding_small">
 
-    <ImageView
-        android:id="@+id/iv_type_icon"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_gravity="center_vertical"
-        android:layout_margin="@dimen/_4dp"
-        android:tint="@color/hint_color" />
+
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/row_notifications.xml
+++ b/app/src/main/res/layout/row_notifications.xml
@@ -5,7 +5,6 @@
     android:orientation="horizontal"
     android:padding="@dimen/padding_small">
 
-
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"


### PR DESCRIPTION
### Problem
In the notifications list view, every list item layout displayed a grey icon (iv_type_icon) corresponding to its type (which defaulted to the bell icon ic_notifications). Since the category headers (like "OTHER", "CHAT") already display a prominent blue version of these icons, repeating the grey icon on every single list item was redundant and cluttered the user interface.

### Solution
- Modified row_notifications.xml: Removed the iv_type_icon ImageView entirely, allowing the notification text and timestamp layouts to start cleanly from the left side
- Modified NotificationsAdapter.kt: Removed the line that sets the image resource on ivTypeIcon to avoid compilation errors and clean up unused bindings

[Screen_recording_20260721_205240.webm](https://github.com/user-attachments/assets/06ce6b9e-af50-4892-a33a-06829da4650d)

fixes (#14859)