### PR TITLE
dashboard: fix ui cropping and logo stretching in landscape orientation (fixes #14891)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -22,6 +22,7 @@ import android.widget.ImageButton
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
+import android.widget.ImageView
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
@@ -788,22 +789,12 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     private val accountHeader: AccountHeader
         get() {
             val displayMetrics = resources.displayMetrics
-            val screenWidth = displayMetrics.widthPixels
-            val screenHeight = displayMetrics.heightPixels
             val density = displayMetrics.density
-
-            var paddingVerticalPx = screenHeight * 0.15
-            var paddingHorizontalPx = screenWidth * 0.15
-            if(screenWidth > screenHeight){ //sizing for tablets
-                paddingVerticalPx = screenHeight * 0.05
-                paddingHorizontalPx = screenWidth * 0.05
-            }
-
-            val paddingVerticalDp = (paddingVerticalPx / density).toInt()
-            val paddingHorizontalDp = (paddingHorizontalPx / density).toInt()
             val statusBarHeight = ViewCompat.getRootWindowInsets(binding.root)
                 ?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
                 ?: ceil(25 * density).toInt()
+
+            val headerHeightDp = (resources.getDimension(R.dimen.drawer_header_height) / density).toInt()
 
             val header = AccountHeaderBuilder()
                 .withActivity(this@DashboardActivity)
@@ -811,13 +802,11 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
                 .withHeaderBackground(R.drawable.ole_logo)
                 .withDividerBelowHeader(false)
                 .withTranslucentStatusBar(false)
-                .withHeightDp(paddingVerticalDp + 20 * 2 + (statusBarHeight / density).toInt())
+                .withHeightDp(headerHeightDp + (statusBarHeight / density).toInt())
                 .build()
             val headerBackground = header.headerBackgroundView
-            headerBackground.setPadding(
-                paddingHorizontalDp, paddingVerticalDp + statusBarHeight + 25,
-                paddingHorizontalDp, paddingVerticalDp + 50
-            )
+            headerBackground.scaleType = ImageView.ScaleType.FIT_CENTER
+            headerBackground.setPadding(0, 0, 0, 0)
 
             val currentNightMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
             if (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_NO ||
@@ -835,7 +824,8 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             ?.getInsets(WindowInsetsCompat.Type.systemBars())?.top
             ?: ceil(25 * resources.displayMetrics.density).toInt()
 
-        val headerHeight = 160 + (statusBarHeight / resources.displayMetrics.density).toInt()
+        val headerHeightDp = (resources.getDimension(R.dimen.drawer_header_height) / resources.displayMetrics.density).toInt()
+        val headerHeight = headerHeightDp + (statusBarHeight / resources.displayMetrics.density).toInt()
         val dimenHolder = DimenHolder.fromDp(headerHeight)
 
         result = headerResult?.let {

--- a/app/src/main/res/layout/home_card_courses.xml
+++ b/app/src/main/res/layout/home_card_courses.xml
@@ -24,7 +24,7 @@
                 android:background="@color/md_amber_700"
                 android:gravity="center"
                 android:orientation="vertical"
-                android:padding="@dimen/padding_normal">
+                android:padding="@dimen/home_card_padding">
 
                 <ImageView
                     android:layout_width="@dimen/image_size_home_card"
@@ -34,29 +34,28 @@
                     app:srcCompat="@drawable/mycourses"
                     android:contentDescription="@string/txt_myCourses" />
 
-
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:gravity="center"
                     android:text="@string/txt_myCourses"
-                    android:textColor="@color/md_white_1000" />
-
+                    android:textColor="@color/md_white_1000"
+                    android:textSize="@dimen/home_card_title_text_size" />
 
             </LinearLayout>
 
             <TextView
                 android:id="@+id/count_course"
-                android:layout_width="35dp"
-                android:layout_height="35dp"
+                android:layout_width="@dimen/home_card_badge_size"
+                android:layout_height="@dimen/home_card_badge_size"
                 android:layout_gravity="end"
                 android:layout_margin="@dimen/padding_small"
                 android:background="@drawable/oval_white"
                 android:gravity="center"
                 android:padding="@dimen/padding_small"
                 android:textColor="@color/daynight_textColor"
-                android:textSize="18sp"
+                android:textSize="@dimen/home_card_badge_text_size"
                 android:textStyle="bold" />
 
         </FrameLayout>

--- a/app/src/main/res/layout/home_card_library.xml
+++ b/app/src/main/res/layout/home_card_library.xml
@@ -24,7 +24,7 @@
                 android:background="@color/md_red_700"
                 android:gravity="center"
                 android:orientation="vertical"
-                android:padding="@dimen/padding_normal">
+                android:padding="@dimen/home_card_padding">
 
                 <ImageView
                     android:layout_width="@dimen/image_size_home_card"
@@ -40,14 +40,15 @@
                     android:layout_gravity="center"
                     android:gravity="center"
                     android:text="@string/txt_myLibrary"
-                    android:textColor="@color/md_white_1000" />
+                    android:textColor="@color/md_white_1000"
+                    android:textSize="@dimen/home_card_title_text_size" />
 
             </LinearLayout>
 
             <TextView
                 android:id="@+id/count_library"
-                android:layout_width="35dp"
-                android:layout_height="35dp"
+                android:layout_width="@dimen/home_card_badge_size"
+                android:layout_height="@dimen/home_card_badge_size"
                 android:layout_gravity="end"
                 android:layout_margin="@dimen/padding_small"
                 android:background="@drawable/oval_white"
@@ -55,7 +56,7 @@
                 android:padding="@dimen/padding_small"
                 android:text="12"
                 android:textColor="@color/daynight_textColor"
-                android:textSize="18sp"
+                android:textSize="@dimen/home_card_badge_text_size"
                 android:textStyle="bold" />
 
         </FrameLayout>

--- a/app/src/main/res/layout/home_card_mylife.xml
+++ b/app/src/main/res/layout/home_card_mylife.xml
@@ -26,7 +26,7 @@
                 android:background="@color/md_purple_700"
                 android:gravity="center"
                 android:orientation="vertical"
-                android:padding="@dimen/padding_normal">
+                android:padding="@dimen/home_card_padding">
 
                 <ImageView
                     android:layout_width="@dimen/image_size_home_card"
@@ -42,7 +42,8 @@
                     android:layout_gravity="center"
                     android:gravity="center"
                     android:text="@string/txt_myLife"
-                    android:textColor="@color/md_white_1000" />
+                    android:textColor="@color/md_white_1000"
+                    android:textSize="@dimen/home_card_title_text_size" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/home_card_teams.xml
+++ b/app/src/main/res/layout/home_card_teams.xml
@@ -25,7 +25,7 @@
                 android:background="@color/md_green_700"
                 android:gravity="center"
                 android:orientation="vertical"
-                android:padding="@dimen/padding_normal">
+                android:padding="@dimen/home_card_padding">
 
                 <ImageView
                     android:layout_width="@dimen/image_size_home_card"
@@ -41,14 +41,15 @@
                     android:layout_gravity="center"
                     android:gravity="center"
                     android:text="@string/txt_myTeams"
-                    android:textColor="@color/md_white_1000" />
+                    android:textColor="@color/md_white_1000"
+                    android:textSize="@dimen/home_card_title_text_size" />
 
             </LinearLayout>
 
             <TextView
                 android:id="@+id/count_team"
-                android:layout_width="35dp"
-                android:layout_height="34dp"
+                android:layout_width="@dimen/home_card_badge_size"
+                android:layout_height="@dimen/home_card_badge_size"
                 android:layout_gravity="end"
                 android:layout_margin="@dimen/padding_small"
                 android:background="@drawable/oval_white"
@@ -56,7 +57,7 @@
                 android:padding="@dimen/padding_small"
                 android:text="12"
                 android:textColor="@color/daynight_textColor"
-                android:textSize="18sp"
+                android:textSize="@dimen/home_card_badge_text_size"
                 android:textStyle="bold" />
 
         </FrameLayout>

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,0 +1,9 @@
+<resources>
+    <dimen name="image_size_home_card">20dp</dimen>
+    <dimen name="dashboard_card_title">75dp</dimen>
+    <dimen name="home_card_badge_size">20dp</dimen>
+    <dimen name="home_card_badge_text_size">11sp</dimen>
+    <dimen name="home_card_padding">4dp</dimen>
+    <dimen name="home_card_title_text_size">11sp</dimen>
+    <dimen name="drawer_header_height">120dp</dimen>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,6 +11,11 @@
     <dimen name="padding_small">4dp</dimen>
     <dimen name="image_size_home_card">40dp</dimen>
     <dimen name="dashboard_card_title">90dp</dimen>
+    <dimen name="home_card_badge_size">30dp</dimen>
+    <dimen name="home_card_badge_text_size">14sp</dimen>
+    <dimen name="home_card_padding">8dp</dimen>
+    <dimen name="home_card_title_text_size">14sp</dimen>
+    <dimen name="drawer_header_height">180dp</dimen>
     <dimen name="_80dp">80dp</dimen>
     <dimen name="_60dp">60dp</dimen>
     <dimen name="_40dp">40dp</dimen>


### PR DESCRIPTION
Landscape-specific overrides using values-land/dimens.xml and synchronizing the sidebar header heights using the new drawer_header_height token

<img width="2400" height="1080" alt="Screenshot_20260722_211606" src="https://github.com/user-attachments/assets/f6ce9bb1-9407-4fd1-bc3d-fe98f767c025" />

<img width="2400" height="1080" alt="Screenshot_20260722_211553" src="https://github.com/user-attachments/assets/d54b2e11-de80-4ed5-8454-2e2457b85307" />

fixes #14891 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized dashboard card padding, title styling, and count badge sizing across Courses, Library, My Life, and Teams.
  * Added responsive dimension values for landscape layouts to improve card and dashboard presentation across screen sizes.
  * Updated the navigation drawer header sizing and image rendering for more consistent display, including status bar spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->