### PR TITLE
resources: smoother web view pathing (fixes #14944)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6161
-        versionName = "0.61.61"
+        versionCode = 6181
+        versionName = "0.61.81"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
@@ -53,7 +53,7 @@ class WebViewActivity : AppCompatActivity() {
         fromDeepLink = !TextUtils.isEmpty(dataFromDeepLink)
         val title: String? = intent.getStringExtra("title")
         link = intent.getStringExtra("link") ?: ""
-        val resourceId = intent.getStringExtra("RESOURCE_ID")
+        val resourceDirectory = getLocalResourceDirectory(intent.getStringExtra("RESOURCE_ID"))
         clearCookie()
         if (!TextUtils.isEmpty(title)) {
             activityWebViewBinding.contentWebView.webTitle.text = title
@@ -77,9 +77,8 @@ class WebViewActivity : AppCompatActivity() {
             }
         }
 
-        if (resourceId != null) {
-            val directory = File(getExternalFilesDir(null), "ole/$resourceId")
-            val indexFile = File(directory, "index.html")
+        if (resourceDirectory != null) {
+            val indexFile = File(resourceDirectory, "index.html")
 
             if (indexFile.exists()) {
                 requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
@@ -93,7 +92,7 @@ class WebViewActivity : AppCompatActivity() {
     private fun setupWebView() {
         activityWebViewBinding.contentWebView.wv.settings.apply {
             // Only enable JavaScript for local resources that need it
-            val isLocalResource = intent.getStringExtra("RESOURCE_ID") != null
+            val isLocalResource = getLocalResourceDirectory(intent.getStringExtra("RESOURCE_ID")) != null
             javaScriptEnabled = isLocalResource
             javaScriptCanOpenWindowsAutomatically = false
             
@@ -152,12 +151,11 @@ class WebViewActivity : AppCompatActivity() {
     }
 
     private fun setupAssetLoader(): WebViewAssetLoader? {
-        val resourceId = intent.getStringExtra("RESOURCE_ID") ?: return null
-        val directory = File(getExternalFilesDir(null), "ole/$resourceId")
+        val directory = getLocalResourceDirectory(intent.getStringExtra("RESOURCE_ID")) ?: return null
         val externalPathHandler = WebViewAssetLoader.PathHandler { path ->
             try {
                 val file = File(directory, path)
-                if (file.exists() && file.canonicalPath.startsWith(directory.canonicalPath)) {
+                if (file.exists() && isWithinDirectory(file, directory)) {
                     val mimeType = URLConnection.guessContentTypeFromName(file.name) ?: "application/octet-stream"
                     return@PathHandler WebResourceResponse(mimeType, "utf-8", FileInputStream(file))
                 }
@@ -268,9 +266,36 @@ class WebViewActivity : AppCompatActivity() {
     }
     
     private fun checkUrlSafety(url: String): Boolean {
-        val resourceId = intent.getStringExtra("RESOURCE_ID")
+        val resourceId = getLocalResourceDirectory(intent.getStringExtra("RESOURCE_ID"))?.name
         val appDir = getExternalFilesDir(null)?.absolutePath ?: ""
         return WebViewSafety.isUrlSafe(url, trustedHosts, resourceId, appDir)
+    }
+
+    private fun getLocalResourceDirectory(resourceId: String?): File? {
+        if (resourceId.isNullOrBlank() || resourceId == "." || resourceId == "..") {
+            return null
+        }
+
+        if (resourceId.any { it == '/' || it == '\\' || it == File.separatorChar }) {
+            return null
+        }
+
+        val externalFilesDirectory = getExternalFilesDir(null) ?: return null
+
+        return try {
+            val oleDirectory = File(externalFilesDirectory, "ole").canonicalFile
+            val resourceDirectory = File(oleDirectory, resourceId).canonicalFile
+            resourceDirectory.takeIf { isWithinDirectory(it, oleDirectory) }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun isWithinDirectory(file: File, directory: File): Boolean {
+        val canonicalFile = file.canonicalFile
+        val canonicalDirectory = directory.canonicalFile
+        return canonicalFile.path == canonicalDirectory.path ||
+            canonicalFile.path.startsWith(canonicalDirectory.path + File.separator)
     }
 
     private fun setListeners() {


### PR DESCRIPTION
### Motivation
- Prevent a Path Traversal vulnerability where unsanitized `RESOURCE_ID` from `Intent.getStringExtra()` was interpolated into file paths used for `exists` and asset serving. 
- Ensure local WebView assets are only served from the app's `externalFilesDir/.../ole` directory and that JavaScript is only enabled for validated local resources.

### Description
- Replaced direct `intent.getStringExtra("RESOURCE_ID")` file interpolation with a canonicalized helper `getLocalResourceDirectory(resourceId: String?): File?` that rejects blank, single-dot, double-dot and separator-containing IDs. 
- Use `getLocalResourceDirectory(...)` for the `index.html` existence check, the WebViewAssetLoader directory, and the local-resource JavaScript enablement check. 
- Added `isWithinDirectory(file: File, directory: File): Boolean` and canonical path comparisons to ensure files served via the asset loader remain under the intended `ole` directory. 
- Wrapped filesystem resolution in safe `try/catch` and return `null` for invalid or unsafe resource IDs so the code falls back to remote URL loading.

### Testing
- Ran `./gradlew :app:compileDefaultDebugKotlin --no-daemon` which completed successfully. 
- Ran `./gradlew :app:testDefaultDebugUnitTest --no-daemon` which executed unit tests but many tests failed due to network/Robolectric Maven artifact fetch `java.net.SocketException` errors (716 tests executed, 39 failed). 
- An attempt to run `./gradlew testDebugUnitTest --no-daemon` was ambiguous in this project and was not used; explicit module-level test task above was executed instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a610e90de3c832b9c5f3d0502698b52)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of locally stored resources in the web viewer.
  * Blocked invalid or unsafe resource paths from being accessed.
  * Strengthened file and URL safety checks to prevent access outside the intended resource directory.
  * Ensured local content loads correctly while external links continue to open safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->