### PR TITLE
Fix path traversal vulnerability in WebViewActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
@@ -78,10 +78,19 @@ class WebViewActivity : AppCompatActivity() {
         }
 
         if (resourceId != null) {
-            val directory = File(getExternalFilesDir(null), "ole/$resourceId")
+            val baseDir = File(getExternalFilesDir(null), "ole")
+            val directory = File(baseDir, resourceId)
             val indexFile = File(directory, "index.html")
 
-            if (indexFile.exists()) {
+            val isSafe = try {
+                val canonicalBase = baseDir.canonicalPath
+                val canonicalDir = directory.canonicalPath
+                canonicalDir.startsWith(canonicalBase + File.separator) || canonicalDir == canonicalBase
+            } catch (e: Exception) {
+                false
+            }
+
+            if (isSafe && indexFile.exists()) {
                 requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
                 activityWebViewBinding.contentWebView.wv.loadUrl("https://appassets.androidplatform.net/assets/index.html")
             }
@@ -153,7 +162,19 @@ class WebViewActivity : AppCompatActivity() {
 
     private fun setupAssetLoader(): WebViewAssetLoader? {
         val resourceId = intent.getStringExtra("RESOURCE_ID") ?: return null
-        val directory = File(getExternalFilesDir(null), "ole/$resourceId")
+        val baseDir = File(getExternalFilesDir(null), "ole")
+        val directory = File(baseDir, resourceId)
+
+        val isSafe = try {
+            val canonicalBase = baseDir.canonicalPath
+            val canonicalDir = directory.canonicalPath
+            canonicalDir.startsWith(canonicalBase + File.separator) || canonicalDir == canonicalBase
+        } catch (e: Exception) {
+            false
+        }
+
+        if (!isSafe) return null
+
         val externalPathHandler = WebViewAssetLoader.PathHandler { path ->
             try {
                 val file = File(directory, path)


### PR DESCRIPTION
Validate RESOURCE_ID input to prevent arbitrary file access.

---
*PR created automatically by Jules for task [11027085113857996427](https://jules.google.com/task/11027085113857996427) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection when loading offline web content from local storage.
  * Prevented access to files outside the intended content directory.
  * Local pages now load only when the expected entry file exists and the path is verified as safe.
  * Disabled asset loading when content paths fail safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->