### PR TITLE
feat: optimize markwon image loading with glide

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/MarkdownUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/MarkdownUtils.kt
@@ -30,10 +30,7 @@ import io.noties.markwon.html.HtmlPlugin
 import io.noties.markwon.html.HtmlTag
 import io.noties.markwon.html.tag.SimpleTagHandler
 import io.noties.markwon.image.ImageProps
-import io.noties.markwon.image.ImagesPlugin
-import io.noties.markwon.image.file.FileSchemeHandler
-import io.noties.markwon.image.network.NetworkSchemeHandler
-import io.noties.markwon.image.network.OkHttpNetworkSchemeHandler
+import io.noties.markwon.image.glide.GlideImagesPlugin
 import io.noties.markwon.movement.MovementMethodPlugin
 import java.util.regex.Pattern
 import org.commonmark.node.Image
@@ -59,19 +56,11 @@ object MarkdownUtils {
     private fun buildMarkwon(context: Context): Markwon {
         return Markwon.builder(context)
             .usePlugin(HtmlPlugin.create())
-            .usePlugin(ImagesPlugin.create())
+            .usePlugin(GlideImagesPlugin.create(context))
             .usePlugin(MovementMethodPlugin.create(LinkMovementMethod.getInstance()))
             .usePlugin(TablePlugin.create(context))
             .usePlugin(HtmlPlugin.create { plugin: HtmlPlugin -> plugin.addHandler(AlignTagHandler()) })
             .usePlugin(object : AbstractMarkwonPlugin() {
-                override fun configure(registry: MarkwonPlugin.Registry) {
-                    registry.require(ImagesPlugin::class.java) { imagesPlugin ->
-                        imagesPlugin.addSchemeHandler(FileSchemeHandler.createWithAssets(context.assets))
-                        imagesPlugin.addSchemeHandler(NetworkSchemeHandler.create())
-                        imagesPlugin.addSchemeHandler(OkHttpNetworkSchemeHandler.create())
-                    }
-                }
-
                 override fun configureSpansFactory(builder: MarkwonSpansFactory.Builder) {
                     builder.appendFactory(Image::class.java) { configuration, props ->
                         val url = ImageProps.DESTINATION.require(props)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,7 +117,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 circleimageview = { module = "de.hdodenhof:circleimageview", version.ref = "circleimageview" }
 pbkdf2 = { module = "de.rtner:PBKDF2", version.ref = "pbkdf2" }
 markwon-editor = { module = "io.noties.markwon:editor", version.ref = "markwon" }
-markwon-image = { module = "io.noties.markwon:image", version.ref = "markwon" }
+markwon-image = { module = "io.noties.markwon:image-glide", version.ref = "markwon" }
 markwon-html = { module = "io.noties.markwon:html", version.ref = "markwon" }
 markwon-ext-tables = { module = "io.noties.markwon:ext-tables", version.ref = "markwon" }
 osmdroid-android = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroidAndroid" }


### PR DESCRIPTION
Migrate Markwon image loading from ImagesPlugin to GlideImagesPlugin to automate downsampling and caching.

---
*PR created automatically by Jules for task [7154375116950878444](https://jules.google.com/task/7154375116950878444) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image rendering in Markdown content for more reliable loading and display.
  * Enhanced support for remote and locally cached images within rendered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->