### PR TITLE
all: smoother markdown image loading (fixes #14939)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -216,6 +216,7 @@ dependencies {
     implementation(libs.pbkdf2)
     implementation(libs.markwon.editor)
     implementation(libs.markwon.image)
+    implementation(libs.markwon.image.glide)
     implementation(libs.markwon.html)
     implementation(libs.markwon.ext.tables)
     implementation(libs.osmdroid.android)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6161
-        versionName = "0.61.61"
+        versionCode = 6173
+        versionName = "0.61.73"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/MarkdownUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/MarkdownUtils.kt
@@ -21,7 +21,6 @@ import com.github.chrisbanes.photoview.PhotoView
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonConfiguration
-import io.noties.markwon.MarkwonPlugin
 import io.noties.markwon.MarkwonSpansFactory
 import io.noties.markwon.RenderProps
 import io.noties.markwon.core.MarkwonTheme
@@ -31,9 +30,7 @@ import io.noties.markwon.html.HtmlTag
 import io.noties.markwon.html.tag.SimpleTagHandler
 import io.noties.markwon.image.ImageProps
 import io.noties.markwon.image.ImagesPlugin
-import io.noties.markwon.image.file.FileSchemeHandler
-import io.noties.markwon.image.network.NetworkSchemeHandler
-import io.noties.markwon.image.network.OkHttpNetworkSchemeHandler
+import io.noties.markwon.image.glide.GlideImagesPlugin
 import io.noties.markwon.movement.MovementMethodPlugin
 import java.util.regex.Pattern
 import org.commonmark.node.Image
@@ -60,18 +57,11 @@ object MarkdownUtils {
         return Markwon.builder(context)
             .usePlugin(HtmlPlugin.create())
             .usePlugin(ImagesPlugin.create())
+            .usePlugin(GlideImagesPlugin.create(Glide.with(context)))
             .usePlugin(MovementMethodPlugin.create(LinkMovementMethod.getInstance()))
             .usePlugin(TablePlugin.create(context))
             .usePlugin(HtmlPlugin.create { plugin: HtmlPlugin -> plugin.addHandler(AlignTagHandler()) })
             .usePlugin(object : AbstractMarkwonPlugin() {
-                override fun configure(registry: MarkwonPlugin.Registry) {
-                    registry.require(ImagesPlugin::class.java) { imagesPlugin ->
-                        imagesPlugin.addSchemeHandler(FileSchemeHandler.createWithAssets(context.assets))
-                        imagesPlugin.addSchemeHandler(NetworkSchemeHandler.create())
-                        imagesPlugin.addSchemeHandler(OkHttpNetworkSchemeHandler.create())
-                    }
-                }
-
                 override fun configureSpansFactory(builder: MarkwonSpansFactory.Builder) {
                     builder.appendFactory(Image::class.java) { configuration, props ->
                         val url = ImageProps.DESTINATION.require(props)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,6 +118,7 @@ circleimageview = { module = "de.hdodenhof:circleimageview", version.ref = "circ
 pbkdf2 = { module = "de.rtner:PBKDF2", version.ref = "pbkdf2" }
 markwon-editor = { module = "io.noties.markwon:editor", version.ref = "markwon" }
 markwon-image = { module = "io.noties.markwon:image", version.ref = "markwon" }
+markwon-image-glide = { module = "io.noties.markwon:image-glide", version.ref = "markwon" }
 markwon-html = { module = "io.noties.markwon:html", version.ref = "markwon" }
 markwon-ext-tables = { module = "io.noties.markwon:ext-tables", version.ref = "markwon" }
 osmdroid-android = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroidAndroid" }


### PR DESCRIPTION
### Motivation
- Reduce memory usage and avoid excessive bitmap decoding by delegating markdown image loading/decoding to Glide so downsampling, caching and memory management are handled by a proven image loader.
- Replace the code path that relied on Markwon's direct network/file scheme handlers (which can trigger manual decoding) with the Markwon–Glide integration to improve performance and stability.

### Description
- Add `markwon-image-glide` to `gradle/libs.versions.toml` and include `implementation(libs.markwon.image.glide)` in `app/build.gradle` to bring in the Markwon Glide integration.
- Update `MarkdownUtils.buildMarkwon` to register `GlideImagesPlugin.create(Glide.with(context))` alongside `ImagesPlugin` so markdown image loading uses Glide’s pipeline.
- Remove the previous explicit network/file scheme handler registrations and preserve the custom clickable `CustomImageSpan` and zoomable-image dialog behavior so UX is unchanged.

### Testing
- Ran `./gradlew :app:compileDefaultDebugKotlin` and the build completed successfully (compilation succeeded; Kotlin compiler warnings were reported but did not fail the build).
- Attempting `./gradlew :app:compileDebugKotlin` produced an ambiguous-task warning due to multiple build variants; using the explicit variant task (`:app:compileDefaultDebugKotlin`) succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a610af0ac2c832b85291f2d3a9b6c85)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved image handling in Markdown content using Glide-based rendering.
  * Images now load more reliably from supported sources while preserving existing clickable and zoomable behavior.
* **Build & Release**
  * Updated the app version metadata (version code/name).
  * Added the Glide-based Markwon image dependency to the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->