### PR TITLE
resources: less web view orientation lock is more (fixes #14945)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6161
-        versionName = "0.61.61"
+        versionCode = 6182
+        versionName = "0.61.82"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.ui.viewer
 
-import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.net.Uri
@@ -82,7 +81,6 @@ class WebViewActivity : AppCompatActivity() {
             val indexFile = File(directory, "index.html")
 
             if (indexFile.exists()) {
-                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
                 activityWebViewBinding.contentWebView.wv.loadUrl("https://appassets.androidplatform.net/assets/index.html")
             }
         } else {


### PR DESCRIPTION
### Motivation
- Android 16+ may ignore resizability and orientation restrictions on large-screen devices, so explicit orientation locks can cause layout/usability issues on foldables and tablets.
- `WebViewActivity` previously forced portrait when loading local packaged web resources, which could prevent proper resizing and rotation on large screens.

### Description
- Removed the `requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT` call from `app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt` so the activity no longer forces portrait for local content.
- Removed the now-unused `ActivityInfo` import from the same file; no other behavior or security-related WebView settings were changed.

### Testing
- Ran `./gradlew :app:compileDefaultDebugKotlin --no-daemon`, which completed successfully.
- Attempted `./gradlew testDebugUnitTest --no-daemon`, which failed due to an ambiguous Gradle task name (candidates `testDefaultDebugUnitTest` and `testLiteDebugUnitTest`).
- Verified the Kotlin source file compiles and the project build tasks for the app module completed without errors for the compile step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a610a713d08832bb4fd0f3fa6f64d5c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of locally hosted directory content without enforcing portrait orientation.
  * Preserved existing WebView behavior, safety checks, progress handling, and night-mode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->