### PR TITLE
Add QR code scanning for server configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -196,6 +196,7 @@ dependencies {
     implementation(libs.glide)
     ksp(libs.glide.ksp)
     implementation(libs.photoView)
+    implementation(libs.zxing.embedded)
     implementation(libs.fab)
     implementation(libs.mpAndroidChart)
     implementation(libs.circular.progress.view)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -3,10 +3,13 @@ package org.ole.planet.myplanet.ui.sync
 import android.Manifest
 import android.content.DialogInterface
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.res.ColorStateList
 import android.graphics.drawable.AnimationDrawable
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.text.TextUtils
 import android.util.Log
 import android.view.ContextThemeWrapper
@@ -21,13 +24,18 @@ import android.widget.RadioGroup
 import android.widget.Spinner
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SwitchCompat
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanIntentResult
+import com.journeyapps.barcodescanner.ScanOptions
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
 import java.util.Date
@@ -37,6 +45,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.context
@@ -139,6 +148,32 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
 
     @Inject
     open lateinit var broadcastService: BroadcastService
+
+    private val qrScanLauncher = registerForActivityResult(ScanContract()) { result ->
+        handleQrScanResult(result)
+    }
+
+    private val requestQrCameraPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            startQrScan()
+        } else if (!shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)) {
+            AlertDialog.Builder(this, R.style.AlertDialogTheme)
+                .setTitle(R.string.permission_required)
+                .setMessage(R.string.camera_permission_required)
+                .setPositiveButton(R.string.settings) { dialog, _ ->
+                    dialog.dismiss()
+                    startActivity(
+                        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.fromParts("package", packageName, null))
+                    )
+                }
+                .setNegativeButton(R.string.cancel) { dialog, _ -> dialog.dismiss() }
+                .show()
+        } else {
+            Utilities.toast(this, getString(R.string.camera_permission_required))
+        }
+    }
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -681,6 +716,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         binding.clearData.setOnClickListener {
             clearDataDialog(getString(R.string.are_you_sure_you_want_to_clear_data), false)
         }
+        binding.btnScanQr.setOnClickListener { launchQrScanner() }
 
         showAdditionalServers = false
         if (serverListAddresses.isNotEmpty() && prefData.getServerUrl().isNotEmpty()) {
@@ -689,12 +725,76 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
 
         neutralAction.setOnClickListener { onNeutralButtonClick(dialog) }
 
-        dialog.setOnDismissListener { serverDialogBinding = null }
+        currentDialog = dialog
+        dialog.setOnDismissListener {
+            serverDialogBinding = null
+            currentDialog = null
+        }
         dialog.show()
         sync(binding)
         if (!prefData.getManualConfig()) {
             dialog.getActionButton(DialogAction.NEUTRAL).text = getString(R.string.show_more)
         }
+    }
+
+    private fun launchQrScanner() {
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
+            startQrScan()
+        } else {
+            requestQrCameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    private fun startQrScan() {
+        qrScanLauncher.launch(
+            ScanOptions()
+                .setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+                .setPrompt(getString(R.string.scan_server_qr_prompt))
+                .setBeepEnabled(true)
+                .setOrientationLocked(false)
+        )
+    }
+
+    private fun handleQrScanResult(result: ScanIntentResult) {
+        val contents = result.contents ?: return
+        val payload = try {
+            Json.decodeFromString<ServerQrPayload>(contents)
+        } catch (e: Exception) {
+            Utilities.toast(this, getString(R.string.qr_scan_invalid))
+            return
+        }
+        val rawUrl = payload.url.trim()
+        val pin = payload.pin.trim()
+        if (rawUrl.isEmpty() || pin.isEmpty()) {
+            Utilities.toast(this, getString(R.string.qr_scan_invalid))
+            return
+        }
+
+        val binding = serverDialogBinding
+        val dialog = currentDialog
+        if (binding == null || dialog == null) {
+            Utilities.toast(this, getString(R.string.qr_scan_invalid))
+            return
+        }
+
+        if (!binding.manualConfiguration.isChecked) {
+            binding.manualConfiguration.isChecked = true
+            prefData.setManualConfig(true)
+            showConfigurationUIElements(binding, true, dialog)
+        }
+
+        val useHttps = when {
+            rawUrl.startsWith("http://", ignoreCase = true) -> false
+            rawUrl.startsWith("https://", ignoreCase = true) -> true
+            else -> !payload.protocol.equals("http", ignoreCase = true)
+        }
+        binding.radioHttps.isChecked = useHttps
+        binding.radioHttp.isChecked = !useHttps
+        prefData.setServerProtocol(getString(if (useHttps) R.string.https_protocol else R.string.http_protocol))
+
+        serverUrl.setText(ServerConfigUtils.removeProtocol(rawUrl))
+        serverPassword.setText(pin)
+        Utilities.toast(this, getString(R.string.qr_scan_success))
     }
     fun continueSync(dialog: MaterialDialog, url: String, isAlternativeUrl: Boolean, defaultUrl: String) {
         runOnUiThread {
@@ -817,3 +917,10 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         }
     }
 }
+
+@Serializable
+private data class ServerQrPayload(
+    val url: String,
+    val pin: String,
+    val protocol: String = "https"
+)

--- a/app/src/main/res/layout/dialog_server_url.xml
+++ b/app/src/main/res/layout/dialog_server_url.xml
@@ -16,6 +16,18 @@
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+    <Button
+        android:id="@+id/btnScanQr"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@color/mainColor"
+        android:text="@string/scan_qr_code"
+        android:textAllCaps="false"
+        android:textColor="@android:color/white"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView2" />
+
     <TextView
         android:id="@+id/syncToServerText"
         android:layout_width="wrap_content"
@@ -26,7 +38,7 @@
         android:textSize="18sp"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView2" />
+        app:layout_constraintTop_toBottomOf="@+id/btnScanQr" />
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/serverUrls"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,10 @@
     <string name="err_msg_login">Username and/or password do not match</string>
     <string name="hint_serverURL">planet ip</string>
     <string name="hint_serverPin">server pin</string>
+    <string name="scan_qr_code">Scan QR Code</string>
+    <string name="scan_server_qr_prompt">Point your camera at the server QR code</string>
+    <string name="qr_scan_invalid">Invalid QR code. Please check the details manually.</string>
+    <string name="qr_scan_success">Server details filled in from QR code. Review and tap Sync or Save.</string>
     <string name="radio_http">http</string>
     <string name="radio_https">https</string>
     <string name="title_activity_dashboard">Dashboard</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ materialDialogs = "0.9.6.0"
 materialCalendarView = "1.9.2"
 glide = "5.0.9"
 photoView = "2.3.0"
+zxingEmbedded = "4.3.0"
 fab = "1.6.4"
 mpAndroidChart = "v3.1.0"
 circularProgressView = "0.1.2"
@@ -101,6 +102,7 @@ material-calendar-view = { module = "com.applandeo:material-calendar-view", vers
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 glide-ksp = { module = "com.github.bumptech.glide:ksp", version.ref = "glide" }
 photoView = { module = "com.github.chrisbanes:PhotoView", version.ref = "photoView" }
+zxing-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxingEmbedded" }
 fab = { module = "com.github.clans:fab", version.ref = "fab" }
 mpAndroidChart = { module = "com.github.PhilJay:MPAndroidChart", version.ref = "mpAndroidChart" }
 circular-progress-view = { module = "com.github.VaibhavLakhera:Circular-Progress-View", version.ref = "circularProgressView" }


### PR DESCRIPTION
Integrate zxing-android-embedded to allow users to scan a QR code containing server URL, PIN, and protocol to auto-fill the server configuration dialog.

https://github.com/user-attachments/assets/d8d07e51-b74f-4c1b-b203-15f1e95bed32



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QR code scanning to server configuration.
  * Automatically fills server protocol, address, and password from valid QR codes.
  * Added camera permission handling and guidance when access is unavailable.
  * Added clear success and error messages for QR scanning results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->