### PR TITLE
Remove orientation restriction in WebViewActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
@@ -82,7 +82,6 @@ class WebViewActivity : AppCompatActivity() {
             val indexFile = File(directory, "index.html")
 
             if (indexFile.exists()) {
-                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
                 activityWebViewBinding.contentWebView.wv.loadUrl("https://appassets.androidplatform.net/assets/index.html")
             }
         } else {


### PR DESCRIPTION
Removed requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT to support large screen devices as required for Android 16.

---
*PR created automatically by Jules for task [6789521690817087937](https://jules.google.com/task/6789521690817087937) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local web content can now load without forcing the device into portrait orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->