### PR TITLE
Fix edge-to-edge display for Android 15

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -178,6 +178,8 @@ dependencies {
     implementation platform(libs.kotlin.bom)
     implementation(libs.annotation)
     implementation(libs.appcompat)
+    implementation("androidx.activity:activity-ktx:1.9.0")
+    implementation("androidx.activity:activity:1.9.0")
     implementation(libs.cardview)
     implementation(libs.constraintlayout)
     implementation(libs.core.ktx)

--- a/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BasePermissionActivity.kt
@@ -8,6 +8,8 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.os.Process
 import android.provider.Settings
 import android.util.Log
@@ -28,6 +30,11 @@ import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.Utilities
 
 abstract class BasePermissionActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+    }
     @Inject
     open lateinit var sharedPrefManager: SharedPrefManager
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -1041,7 +1041,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         updateLastSyncStatus()
     }
 
-    override fun onNewIntent(intent: Intent?) {
+    override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
         handleNotificationIntent(intent)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackDetailActivity.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.ui.feedback
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.text.TextUtils
 import android.view.MenuItem
 import android.view.View
@@ -39,6 +40,7 @@ class FeedbackDetailActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         activityFeedbackDetailBinding = ActivityFeedbackDetailBinding.inflate(layoutInflater)
         setContentView(activityFeedbackDetailBinding.root)
         EdgeToEdgeUtils.setupEdgeToEdgeWithKeyboard(this, activityFeedbackDetailBinding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/AddHealthActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/AddHealthActivity.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.ui.health
 
 import android.app.DatePickerDialog
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.view.MenuItem
 import android.view.View
 import android.widget.ArrayAdapter
@@ -30,6 +31,7 @@ class AddHealthActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = ActivityAddHealthBinding.inflate(layoutInflater)
         setContentView(binding.root)
         EdgeToEdgeUtils.setupEdgeToEdgeWithKeyboard(this, binding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthExaminationActivity.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.ui.health
 
 import android.content.DialogInterface
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.text.TextUtils
 import android.view.MenuItem
 import android.view.View
@@ -72,6 +73,7 @@ class HealthExaminationActivity : AppCompatActivity(), CompoundButton.OnCheckedC
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = ActivityHealthExaminationBinding.inflate(layoutInflater)
         setContentView(binding.root)
         EdgeToEdgeUtils.setupEdgeToEdgeWithKeyboard(this, binding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/maps/OfflineMapsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/maps/OfflineMapsActivity.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.ui.maps
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.PreferenceManager
 import org.ole.planet.myplanet.databinding.ActivityOfflineMapsBinding
@@ -14,6 +15,7 @@ class OfflineMapsActivity : AppCompatActivity() {
     private lateinit var activityOfflineMapsBinding: ActivityOfflineMapsBinding
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         Configuration.getInstance().load(this, PreferenceManager.getDefaultSharedPreferences(this))
         activityOfflineMapsBinding = ActivityOfflineMapsBinding.inflate(layoutInflater)
         setContentView(activityOfflineMapsBinding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/onboarding/OnboardingActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -44,6 +45,7 @@ class OnboardingActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         if (!isTaskRoot) {
             val chooserUri = webLinkForAppChooser(intent)
             if (chooserUri != null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.ui.resources
 import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
@@ -56,6 +57,7 @@ class AddResourceActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         binding = ActivityAddResourceBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -209,7 +209,7 @@ class AddResourceFragment : BottomSheetDialogFragment() {
         val takeVideoIntent = Intent(MediaStore.ACTION_VIDEO_CAPTURE)
         videoUri = createVideoFileUri()
         takeVideoIntent.putExtra(MediaStore.EXTRA_OUTPUT, videoUri)
-        captureVideoLauncher.launch(videoUri)
+        videoUri?.let { captureVideoLauncher.launch(it) }
     }
 
     private fun createVideoFileUri(): Uri? {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -6,6 +6,7 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
@@ -61,6 +62,7 @@ class SettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         EdgeToEdgeUtils.setupEdgeToEdge(this, window.decorView)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         FragmentNavigator.replaceFragment(supportFragmentManager, android.R.id.content, SettingFragment())

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/PublicSurveyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/PublicSurveyActivity.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.ui.surveys
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.util.Log
 import android.view.View
 import android.widget.Toast
@@ -56,6 +57,7 @@ class PublicSurveyActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = ActivityPublicSurveyBinding.inflate(layoutInflater)
         setContentView(binding.root)
         EdgeToEdgeUtils.setupEdgeToEdge(this, binding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ResourceViewerActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ResourceViewerActivity.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.ui.viewer
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.os.Environment
 import android.util.Log
 import android.view.MenuItem
@@ -17,6 +18,7 @@ class ResourceViewerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = ActivityResourceViewerBinding.inflate(layoutInflater)
         setContentView(binding.root)
         EdgeToEdgeUtils.setupEdgeToEdge(this, binding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/WebViewActivity.kt
@@ -6,6 +6,7 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.text.TextUtils
 import android.view.View
 import android.webkit.ConsoleMessage
@@ -46,6 +47,7 @@ class WebViewActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         activityWebViewBinding = ActivityWebViewBinding.inflate(layoutInflater)
         setContentView(activityWebViewBinding.root)
         EdgeToEdgeUtils.setupEdgeToEdge(this, activityWebViewBinding.root)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.MenuItem
@@ -77,6 +78,7 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         activityReplyBinding = ActivityReplyBinding.inflate(layoutInflater)
         setContentView(activityReplyBinding.root)
         EdgeToEdgeUtils.setupEdgeToEdgeWithKeyboard(this, activityReplyBinding.root)


### PR DESCRIPTION
Add enableEdgeToEdge to activities to support Edge-to-edge display on Android 15

---
*PR created automatically by Jules for task [16843062098231629900](https://jules.google.com/task/16843062098231629900) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated screens to support edge-to-edge display, improving use of available screen space and modern Android system-bar behavior.
* **Bug Fixes**
  * Prevented video capture from starting when no valid output location is available.
* **Improvements**
  * Improved notification intent handling and badge refresh behavior in the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->