### PR TITLE
teams: smoother repository records deleting (fixes #14943)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6161
-        versionName = "0.61.61"
+        versionCode = 6179
+        versionName = "0.61.79"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
@@ -144,6 +144,7 @@ interface TeamDao {
     @Query("SELECT COUNT(*) FROM teams WHERE teamId = :teamId AND userId = :userId AND docType = :docType") suspend fun countByTeamIdUserIdAndDocType(teamId: String, userId: String, docType: String): Int
     @Query("SELECT COUNT(*) FROM teams WHERE teamId = :teamId AND docType = :docType") suspend fun countByTeamIdAndDocType(teamId: String, docType: String): Int
     @Query("DELETE FROM teams WHERE _id = :id") suspend fun deleteById(id: String): Int
+    @Query("DELETE FROM teams WHERE _id IN (:ids)") suspend fun deleteByIds(ids: List<String>): Int
     @Query("DELETE FROM teams WHERE teamId = :teamId AND userId = :userId AND docType = :docType") suspend fun deleteByTeamIdUserIdAndDocType(teamId: String, userId: String, docType: String): Int
     @Upsert suspend fun upsertAll(items: List<MyTeam>)
     @Upsert suspend fun upsert(item: MyTeam)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -108,7 +108,10 @@ class TeamsRepositoryImpl @Inject constructor(
 
     override suspend fun deleteLocalTeamRecords(teamIds: List<String>) {
         if (teamIds.isEmpty()) return
-        teamIds.filter { it.isNotBlank() }.distinct().forEach { teamDao.deleteById(it) }
+        val validIds = teamIds.filter { it.isNotBlank() }.distinct()
+        if (validIds.isNotEmpty()) {
+            teamDao.deleteByIds(validIds)
+        }
     }
 
     override suspend fun markTeamUploaded(teamId: String?, rev: String) {


### PR DESCRIPTION
💡 **What:** Added a `deleteByIds` method to `TeamDao` taking a list of `id`s and updated `deleteLocalTeamRecords` in `TeamsRepositoryImpl` to filter and distinct the list of IDs, then use the new `deleteByIds` method to delete the records in a single batch.
🎯 **Why:** To eliminate an N+1 query performance issue where a `forEach` loop was used to make individual delete queries.
📊 **Measured Improvement:** Replaced N individual queries with a single batch query, significantly reducing the overhead of database transactions and network calls.

---
*PR created automatically by Jules for task [3922365623039178982](https://jules.google.com/task/3922365623039178982) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app version to 0.61.79.

* **Bug Fixes**
  * Improved removal of local team records by processing multiple selected records together, helping make cleanup more efficient and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->