### PR TITLE
⚡ Optimize user deletion with batch operation

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
@@ -23,6 +23,7 @@ interface UserDao {
     @Query("SELECT COUNT(*) FROM users") suspend fun count(): Int
     @Query("SELECT COUNT(*) FROM users WHERE planetCode = :planetCode") suspend fun countByPlanetCode(planetCode: String): Int
     @Query("DELETE FROM users WHERE id = :id") suspend fun deleteById(id: String): Int
+    @Query("DELETE FROM users WHERE id IN (:ids)") suspend fun deleteByIds(ids: List<String>): Int
     @Upsert suspend fun upsert(item: UserEntity)
     @Upsert suspend fun upsertAll(items: List<UserEntity>)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -1260,7 +1260,9 @@ class UserRepositoryImpl @Inject constructor(
             }
         }
 
-        usersToDelete.forEach { userDao.deleteById(it) }
+        if (usersToDelete.isNotEmpty()) {
+            userDao.deleteByIds(usersToDelete.toList())
+        }
         if (usersToUpsert.isNotEmpty()) {
             userDao.upsertAll(usersToUpsert)
         }


### PR DESCRIPTION
💡 **What:** Added `deleteByIds` method to `UserDao` to enable batch deletion and updated `UserRepositoryImpl.kt` to use it instead of looping over a list and calling `deleteById` for each user.

🎯 **Why:** The previous implementation executed an N+1 query pattern during the sync process (`usersToDelete.forEach { userDao.deleteById(it) }`), which is inefficient and scales poorly with the number of users to delete. Replacing it with a batch delete using the SQL `IN` clause significantly reduces the database overhead.

📊 **Measured Improvement:** Replaced N database calls with 1 batch call when processing user deletions during sync. Verified correctness by successfully running `UserRepositoryBulkInsertTest`.

---
*PR created automatically by Jules for task [219428901010654680](https://jules.google.com/task/219428901010654680) started by @dogi*