### PR TITLE
all: smoother default dispatcher provider utils testing (fixes #14935)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6161
-        versionName = "0.61.61"
+        versionCode = 6168
+        versionName = "0.61.68"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/DefaultDispatcherProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/DefaultDispatcherProviderTest.kt
@@ -1,0 +1,30 @@
+package org.ole.planet.myplanet.utils
+
+import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DefaultDispatcherProviderTest {
+
+    private val dispatcherProvider = DefaultDispatcherProvider()
+
+    @Test
+    fun `test main returns Dispatchers Main`() {
+        assertEquals(Dispatchers.Main, dispatcherProvider.main)
+    }
+
+    @Test
+    fun `test io returns Dispatchers IO`() {
+        assertEquals(Dispatchers.IO, dispatcherProvider.io)
+    }
+
+    @Test
+    fun `test default returns Dispatchers Default`() {
+        assertEquals(Dispatchers.Default, dispatcherProvider.default)
+    }
+
+    @Test
+    fun `test unconfined returns Dispatchers Unconfined`() {
+        assertEquals(Dispatchers.Unconfined, dispatcherProvider.unconfined)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for DefaultDispatcherProvider is addressed. 
📊 **Coverage:** The test ensures that `main`, `io`, `default`, and `unconfined` properties return the correct standard dispatchers. 
✨ **Result:** Test coverage improved for dispatchers utils.

---
*PR created automatically by Jules for task [16941299550319948543](https://jules.google.com/task/16941299550319948543) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage verifying that coroutine dispatcher providers return the expected Main, IO, Default, and Unconfined dispatchers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->