### PR TITLE
⚡ Optimize team attachments batch download

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
@@ -396,19 +397,21 @@ class TransactionSyncManager @Inject constructor(
         }
     }
 
-    private suspend fun downloadTeamAttachmentsFromBatch(arr: JsonArray) {
-        for (j in arr) {
+    private suspend fun downloadTeamAttachmentsFromBatch(arr: JsonArray) = coroutineScope {
+        arr.mapNotNull { j ->
             val jsonDoc = getJsonObject("doc", j.asJsonObject)
             val docId = getString("_id", jsonDoc)
-            if (docId.startsWith("_design")) continue
+            if (docId.startsWith("_design")) return@mapNotNull null
             val attachmentName = MyTeam
-                .getFirstAttachmentName(jsonDoc) ?: continue
+                .getFirstAttachmentName(jsonDoc) ?: return@mapNotNull null
             val destFile = MyTeam
-                .getAttachmentFile(context, docId, attachmentName) ?: continue
+                .getAttachmentFile(context, docId, attachmentName) ?: return@mapNotNull null
             if (!destFile.exists()) {
-                downloadTeamAttachment(docId, attachmentName, destFile)
+                async { downloadTeamAttachment(docId, attachmentName, destFile) }
+            } else {
+                null
             }
-        }
+        }.awaitAll()
     }
 
     private suspend fun downloadCourseCoversFromBatch(arr: JsonArray) {


### PR DESCRIPTION
💡 **What:** Refactored downloadTeamAttachmentsFromBatch to download attachments concurrently using async/awaitAll.\n🎯 **Why:** Previously, attachments were downloaded sequentially in a loop, which caused high latency when processing many files in a single batch.\n📊 **Measured Improvement:** Improves batch sync time for team attachments by utilizing concurrent requests instead of sequential blocking.

---
*PR created automatically by Jules for task [12883944686116559126](https://jules.google.com/task/12883944686116559126) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved synchronization speed by downloading missing team attachments concurrently.
  * Existing local attachments are skipped during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->