### PR TITLE
sync: smoother transaction manager attachment downloading (fixes #14937)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6161
-        versionName = "0.61.61"
+        versionCode = 6171
+        versionName = "0.61.71"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.coroutineScope
 import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.ApplicationScope
@@ -378,7 +379,7 @@ class TransactionSyncManager @Inject constructor(
         return docs
     }
 
-    private suspend fun downloadCvAttachmentsFromBatch(arr: JsonArray) {
+    private suspend fun downloadCvAttachmentsFromBatch(arr: JsonArray) = coroutineScope {
         for (j in arr) {
             val jsonDoc = getJsonObject("doc", j.asJsonObject)
             val docId = getString("_id", jsonDoc)
@@ -390,13 +391,13 @@ class TransactionSyncManager @Inject constructor(
                     FileUtils.getOlePath(context) + "cv/$resumeFileName"
                 )
                 if (!destFile.exists()) {
-                    downloadCvAttachment(docId, destFile)
+                    launch { downloadCvAttachment(docId, destFile) }
                 }
             }
         }
     }
 
-    private suspend fun downloadTeamAttachmentsFromBatch(arr: JsonArray) {
+    private suspend fun downloadTeamAttachmentsFromBatch(arr: JsonArray) = coroutineScope {
         for (j in arr) {
             val jsonDoc = getJsonObject("doc", j.asJsonObject)
             val docId = getString("_id", jsonDoc)
@@ -406,12 +407,12 @@ class TransactionSyncManager @Inject constructor(
             val destFile = MyTeam
                 .getAttachmentFile(context, docId, attachmentName) ?: continue
             if (!destFile.exists()) {
-                downloadTeamAttachment(docId, attachmentName, destFile)
+                launch { downloadTeamAttachment(docId, attachmentName, destFile) }
             }
         }
     }
 
-    private suspend fun downloadCourseCoversFromBatch(arr: JsonArray) {
+    private suspend fun downloadCourseCoversFromBatch(arr: JsonArray) = coroutineScope {
         for (j in arr) {
             val jsonDoc = getJsonObject("doc", j.asJsonObject)
             val docId = getString("_id", jsonDoc)
@@ -422,7 +423,7 @@ class TransactionSyncManager @Inject constructor(
                 val destFile = MyCourse
                     .getCoverImageFile(context, docId, coverFileName) ?: continue
                 if (!destFile.exists()) {
-                    downloadCourseCover(docId, coverFileName, destFile)
+                    launch { downloadCourseCover(docId, coverFileName, destFile) }
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -380,6 +380,7 @@ class TransactionSyncManager @Inject constructor(
     }
 
     private suspend fun downloadCvAttachmentsFromBatch(arr: JsonArray) = coroutineScope {
+        val inProgress = mutableSetOf<String>()
         for (j in arr) {
             val jsonDoc = getJsonObject("doc", j.asJsonObject)
             val docId = getString("_id", jsonDoc)
@@ -390,7 +391,7 @@ class TransactionSyncManager @Inject constructor(
                 val destFile = File(
                     FileUtils.getOlePath(context) + "cv/$resumeFileName"
                 )
-                if (!destFile.exists()) {
+                if (!destFile.exists() && inProgress.add(resumeFileName)) {
                     launch { downloadCvAttachment(docId, destFile) }
                 }
             }


### PR DESCRIPTION
💡 **What:** Refactored sequential loops in `downloadCvAttachmentsFromBatch`, `downloadTeamAttachmentsFromBatch`, and `downloadCourseCoversFromBatch` to use `coroutineScope` and `launch`.\n🎯 **Why:** Speeds up large batch processing by downloading all attachments concurrently rather than sequentially awaiting each download.\n📊 **Measured Improvement:** The methods were optimized without altering behavior; formal benchmarking was omitted in favor of structural improvements which logically improve total wait time for network requests.

---
*PR created automatically by Jules for task [17427158765388855379](https://jules.google.com/task/17427158765388855379) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Attachment downloads for CV resumes, team attachments, and course cover images now run concurrently to reduce overall synchronization time.
  * Download behavior and error handling remain unchanged.

* **Build Version Update**
  * Updated the app version code and version name to the next release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->