### PR TITLE
🧹 [Code Health] Remove unused setupPrivateResourceCheckbox

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -77,16 +77,12 @@ class AddResourceActivity : AppCompatActivity() {
                 prefillFields(resourceId)
             }
         }
-        setupPrivateResourceCheckbox()
+        binding.cbPrivateResource.isVisible = teamId != null
+        binding.cbPrivateResource.isChecked = teamId != null
         lifecycleScope.launch {
             userModel = userSessionManager.getUserModel()
             binding.tvAddedBy.text = userModel?.name
         }
-    }
-
-    private fun setupPrivateResourceCheckbox() {
-        binding.cbPrivateResource.isVisible = teamId != null
-        binding.cbPrivateResource.isChecked = teamId != null
     }
 
     private fun initializeViews() {


### PR DESCRIPTION
🎯 **What:** Inlined and removed the unused private method `setupPrivateResourceCheckbox` in `AddResourceActivity.kt`.
💡 **Why:** Private methods with only one usage can be safely inlined to reduce unnecessary indirection.
✅ **Verification:** Ensured tests ran correctly and `AddResourceActivity.kt` compiled properly. Code review gave a Correct rating for this functional equivalency.
✨ **Result:** A more concise and maintainable `AddResourceActivity` class.

---
*PR created automatically by Jules for task [13394558088542523750](https://jules.google.com/task/13394558088542523750) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the private resource option’s visibility and selection state based on the selected team.
  * Ensured the resource attribution text continues loading correctly when adding a resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->