### PR TITLE
all: smoother application time providing (fixes #14936)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6161
-        versionName = "0.61.61"
+        versionCode = 6170
+        versionName = "0.61.70"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -26,7 +26,6 @@ import dagger.hilt.android.HiltAndroidApp
 import java.lang.ref.WeakReference
 import java.net.HttpURLConnection
 import java.net.URL
-import java.util.Date
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -134,7 +133,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
 
         fun createLog(type: String, error: String = "") {
             applicationScope.launch {
-                saveLogToRoom(type, error, "${Date().time}")
+                saveLogToRoom(type, error, "${coreDependenciesEntryPoint.timeProvider().now()}")
             }
         }
 
@@ -255,7 +254,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
             val error = e.stackTraceToString()
             val pendingFile = CrashLogStore.save(context, ApkLog.ERROR_TYPE_CRASH, error)
             applicationScope.launch {
-                if (saveLogToRoom(ApkLog.ERROR_TYPE_CRASH, error, "${Date().time}")) {
+                if (saveLogToRoom(ApkLog.ERROR_TYPE_CRASH, error, "${coreDependenciesEntryPoint.timeProvider().now()}")) {
                     pendingFile?.delete()
                 }
             }
@@ -360,7 +359,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
                         val error = "ANR detected! Duration: ${duration}ms\n $message"
                         val pendingFile = CrashLogStore.save(context, ANR_LOG_TYPE, error)
                         applicationScope.launch {
-                            if (saveLogToRoom(ANR_LOG_TYPE, error, "${Date().time}")) {
+                            if (saveLogToRoom(ANR_LOG_TYPE, error, "${coreDependenciesEntryPoint.timeProvider().now()}")) {
                                 pendingFile?.delete()
                             }
                         }

--- a/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
@@ -9,6 +9,7 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TimeProvider
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
@@ -19,4 +20,5 @@ interface CoreDependenciesEntryPoint {
     fun serverUrlMapper(): ServerUrlMapper
     fun dispatcherProvider(): DispatcherProvider
     fun apkLogDao(): ApkLogDao
+    fun timeProvider(): TimeProvider
 }


### PR DESCRIPTION
🎯 **What:** Replaced the legacy `java.util.Date` with the injected `TimeProvider` in `MainApplication.kt` and `CoreDependenciesEntryPoint.kt`.
💡 **Why:** This improves maintainability, enables proper testing by avoiding `System.currentTimeMillis()` direct usage, and fixes the code health issue regarding the deprecated `Date()` usage.
✅ **Verification:** Verified by successfully running `./gradlew compileDefaultDebugUnitTestKotlin` to ensure there are no compilation errors.
✨ **Result:** Enhanced the codebase with injected, deterministic time fetching.

---
*PR created automatically by Jules for task [16469287610590752329](https://jules.google.com/task/16469287610590752329) started by @dogi*