### PR TITLE
resources: smoother view extensions utils hint spinning (fixes #14940)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6161
-        versionName = "0.61.61"
+        versionCode = 6174
+        versionName = "0.61.74"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -33,6 +33,7 @@ import org.ole.planet.myplanet.ui.components.CheckboxAdapter
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
 import org.ole.planet.myplanet.utils.Utilities.toast
+import org.ole.planet.myplanet.utils.setupHintSpinner
 
 @AndroidEntryPoint
 class AddResourceActivity : AppCompatActivity() {
@@ -103,10 +104,10 @@ class AddResourceActivity : AppCompatActivity() {
         binding.tvResourceFor.setOnClickListener { view: View ->
             showMultiSelectList(resources.getStringArray(R.array.array_resource_for), resourceFor, view,getString(R.string.resource_for))
         }
-        setupHintSpinner(binding.spnLang, getString(R.string.language), resources.getStringArray(R.array.language))
-        setupHintSpinner(binding.spnOpenWith, getString(R.string.select_open_with), resources.getStringArray(R.array.open_With))
-        setupHintSpinner(binding.spnMedia, getString(R.string.select_media), resources.getStringArray(R.array.media))
-        setupHintSpinner(binding.spnResourceType, getString(R.string.select_resource_type), resources.getStringArray(R.array.resource_type))
+        binding.spnLang.setupHintSpinner(getString(R.string.language), resources.getStringArray(R.array.language))
+        binding.spnOpenWith.setupHintSpinner(getString(R.string.select_open_with), resources.getStringArray(R.array.open_With))
+        binding.spnMedia.setupHintSpinner(getString(R.string.select_media), resources.getStringArray(R.array.media))
+        binding.spnResourceType.setupHintSpinner(getString(R.string.select_resource_type), resources.getStringArray(R.array.resource_type))
         binding.etTitle.setOnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
                 binding.tlTitle.error = null
@@ -124,35 +125,6 @@ class AddResourceActivity : AppCompatActivity() {
         }
         binding.btnSubmit.setOnClickListener { saveResource() }
         binding.btnCancel.setOnClickListener { finish() }
-    }
-
-    private fun setupHintSpinner(spinner: Spinner, hint: String, entries: Array<String>) {
-        val items = listOf(hint) + entries.toList()
-        val hintColor = ContextCompat.getColor(this, R.color.hint_color)
-        val textColor = ContextCompat.getColor(this, R.color.daynight_textColor)
-        val adapter = object : ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, items) {
-            override fun isEnabled(position: Int) = position != 0
-            override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
-                val view = super.getDropDownView(position, convertView, parent) as TextView
-                view.setTextColor(if (position == 0) hintColor else textColor)
-                return view
-            }
-            override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
-                val view = super.getView(position, convertView, parent) as TextView
-                view.isSingleLine = false
-                view.maxLines = 2
-                return view
-            }
-        }
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        spinner.adapter = adapter
-        spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
-                (view as? TextView)?.setTextColor(if (position == 0) hintColor else textColor)
-            }
-
-            override fun onNothingSelected(parent: AdapterView<*>) {}
-        }
     }
 
     private suspend fun prefillFields(resourceId: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceActivity.kt
@@ -5,15 +5,10 @@ import android.content.DialogInterface
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
-import android.widget.AdapterView
-import android.widget.ArrayAdapter
 import android.widget.EditText
-import android.widget.Spinner
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager

--- a/app/src/main/java/org/ole/planet/myplanet/utils/ViewExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ViewExtensions.kt
@@ -2,9 +2,17 @@ package org.ole.planet.myplanet.utils
 
 import android.text.Editable
 import android.text.TextWatcher
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import android.widget.EditText
+import android.widget.Spinner
+import android.widget.TextView
+import androidx.core.content.ContextCompat
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import org.ole.planet.myplanet.R
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.onStart
 
@@ -20,4 +28,33 @@ fun EditText.textChanges(): Flow<CharSequence?> {
         addTextChangedListener(listener)
         awaitClose { removeTextChangedListener(listener) }
     }.onStart { emit(text?.toString()) }
+}
+
+fun Spinner.setupHintSpinner(hint: String, entries: Array<String>) {
+    val items = listOf(hint) + entries.toList()
+    val hintColor = ContextCompat.getColor(context, R.color.hint_color)
+    val textColor = ContextCompat.getColor(context, R.color.daynight_textColor)
+    val adapter = object : ArrayAdapter<String>(context, android.R.layout.simple_spinner_item, items) {
+        override fun isEnabled(position: Int) = position != 0
+        override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+            val view = super.getDropDownView(position, convertView, parent) as TextView
+            view.setTextColor(if (position == 0) hintColor else textColor)
+            return view
+        }
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+            val view = super.getView(position, convertView, parent) as TextView
+            view.isSingleLine = false
+            view.maxLines = 2
+            return view
+        }
+    }
+    adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+    this.adapter = adapter
+    this.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
+            (view as? TextView)?.setTextColor(if (position == 0) hintColor else textColor)
+        }
+
+        override fun onNothingSelected(parent: AdapterView<*>) {}
+    }
 }


### PR DESCRIPTION
Moved setupHintSpinner from AddResourceActivity to ViewExtensions as a Spinner extension function to remove unused private method warning, improve reusability, and resolve the code health issue.

---
*PR created automatically by Jules for task [1474861127158432942](https://jules.google.com/task/1474861127158432942) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hint behavior and visual styling for resource selection fields.
  * Prevented placeholder hints from being selected as actual options.
  * Standardized dropdown and selected-item text colors across resource forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->