### PR TITLE
all: smoother item reorder helper utils testing (fixes #14934)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6161
-        versionName = "0.61.61"
+        versionCode = 6167
+        versionName = "0.61.67"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ItemReorderHelperTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ItemReorderHelperTest.kt
@@ -1,0 +1,137 @@
+package org.ole.planet.myplanet.utils
+
+import android.view.View
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.callback.OnItemDragStateListener
+import org.ole.planet.myplanet.callback.OnItemMoveListener
+
+class ItemReorderHelperTest {
+
+    private lateinit var adapter: OnItemMoveListener
+    private lateinit var itemReorderHelper: ItemReorderHelper
+
+    @Before
+    fun setUp() {
+        adapter = mockk(relaxed = true)
+        itemReorderHelper = ItemReorderHelper(adapter)
+    }
+
+    @Test
+    fun `isLongPressDragEnabled should return true`() {
+        assertTrue(itemReorderHelper.isLongPressDragEnabled)
+    }
+
+    @Test
+    fun `isItemViewSwipeEnabled should return false`() {
+        assertFalse(itemReorderHelper.isItemViewSwipeEnabled)
+    }
+
+    @Test
+    fun `getMovementFlags with GridLayoutManager should return proper flags`() {
+        val recyclerView: RecyclerView = mockk()
+        val layoutManager: GridLayoutManager = mockk()
+        val viewHolder: RecyclerView.ViewHolder = mockk()
+
+        every { recyclerView.layoutManager } returns layoutManager
+
+        val flags = itemReorderHelper.getMovementFlags(recyclerView, viewHolder)
+
+        val expectedDragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN or ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
+        val expectedFlags = ItemTouchHelper.Callback.makeMovementFlags(expectedDragFlags, 0)
+        assertEquals(expectedFlags, flags)
+    }
+
+    @Test
+    fun `getMovementFlags with LinearLayoutManager should return proper flags`() {
+        val recyclerView: RecyclerView = mockk()
+        val layoutManager: LinearLayoutManager = mockk()
+        val viewHolder: RecyclerView.ViewHolder = mockk()
+
+        every { recyclerView.layoutManager } returns layoutManager
+
+        val flags = itemReorderHelper.getMovementFlags(recyclerView, viewHolder)
+
+        val expectedDragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN
+        val expectedSwipeFlags = ItemTouchHelper.START or ItemTouchHelper.END
+        val expectedFlags = ItemTouchHelper.Callback.makeMovementFlags(expectedDragFlags, expectedSwipeFlags)
+        assertEquals(expectedFlags, flags)
+    }
+
+    @Test
+    fun `onMove should return false if itemViewTypes are different`() {
+        val recyclerView: RecyclerView = mockk()
+        val source: RecyclerView.ViewHolder = mockk()
+        val target: RecyclerView.ViewHolder = mockk()
+
+        every { source.itemViewType } returns 1
+        every { target.itemViewType } returns 2
+
+        val result = itemReorderHelper.onMove(recyclerView, source, target)
+
+        assertFalse(result)
+        verify(exactly = 0) { adapter.onItemMove(any(), any()) }
+    }
+
+    @Test
+    fun `onMove should notify adapter and return true if itemViewTypes are same`() {
+        val recyclerView: RecyclerView = mockk()
+        val source: RecyclerView.ViewHolder = mockk()
+        val target: RecyclerView.ViewHolder = mockk()
+
+        every { source.itemViewType } returns 1
+        every { target.itemViewType } returns 1
+        every { source.bindingAdapterPosition } returns 0
+        every { target.bindingAdapterPosition } returns 1
+        every { adapter.onItemMove(0, 1) } returns true
+
+        val result = itemReorderHelper.onMove(recyclerView, source, target)
+
+        assertTrue(result)
+        verify(exactly = 1) { adapter.onItemMove(0, 1) }
+    }
+
+    @Test
+    fun `onSelectedChanged should call onItemSelected when actionState is not idle and viewHolder is OnItemDragStateListener`() {
+        val itemView: View = mockk(relaxed = true)
+        val viewHolder = object : RecyclerView.ViewHolder(itemView), OnItemDragStateListener {
+            var selectedCalled = false
+            override fun onItemSelected() {
+                selectedCalled = true
+            }
+            override fun onItemClear(viewHolder: RecyclerView.ViewHolder?) {}
+        }
+
+        itemReorderHelper.onSelectedChanged(viewHolder, ItemTouchHelper.ACTION_STATE_DRAG)
+
+        assertTrue(viewHolder.selectedCalled)
+    }
+
+    @Test
+    fun `clearView should call onItemClear and restore alpha`() {
+        val itemView: View = mockk(relaxed = true)
+        val viewHolder = object : RecyclerView.ViewHolder(itemView), OnItemDragStateListener {
+            var clearCalled = false
+            override fun onItemSelected() {}
+            override fun onItemClear(viewHolder: RecyclerView.ViewHolder?) {
+                clearCalled = true
+            }
+        }
+        val recyclerView: RecyclerView = mockk()
+
+        itemReorderHelper.clearView(recyclerView, viewHolder)
+
+        verify(exactly = 1) { itemView.alpha = ItemReorderHelper.ALPHA_FULL }
+        assertTrue(viewHolder.clearCalled)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Missing tests for ItemReorderHelper class in RecyclerView drag-and-drop are addressed.\n📊 **Coverage:** Covered long press dragging, swipe enabling, movement flags computation based on layout managers, row moving (both same and different item types), selection changing, and view clearing interactions.\n✨ **Result:** Increased test coverage and confidence in UI helper.

---
*PR created automatically by Jules for task [108517644599070119](https://jules.google.com/task/108517644599070119) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests covering item drag-and-drop behavior.
  * Verified movement rules for both grid and list layouts.
  * Added coverage for compatible vs. incompatible item types.
  * Confirmed drag-state callbacks trigger correctly and that item appearance is restored after interactions.
* **Chores**
  * Bumped the app version code and version name for the next release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->