### PR TITLE
teams: smoother repository task list handling (fixes #14882)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6166
-        versionName = "0.61.66"
+        versionCode = 6188
+        versionName = "0.61.88"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamTaskDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamTaskDao.kt
@@ -8,7 +8,7 @@ import org.ole.planet.myplanet.model.TeamTask
 
 @Dao
 interface TeamTaskDao {
-    @Query("SELECT * FROM team_tasks WHERE status != 'archived' AND completed = 0 AND assignee = :userId")
+    @Query("SELECT * FROM team_tasks WHERE (status IS NULL OR status != 'archived') AND completed = 0 AND assignee = :userId")
     fun getOpenTasksForUser(userId: String?): Flow<List<TeamTask>>
 
     @Query("SELECT * FROM team_tasks WHERE completed = 0 AND assignee = :userId AND isNotified = 0 AND deadline BETWEEN :start AND :end")
@@ -17,7 +17,7 @@ interface TeamTaskDao {
     @Query("UPDATE team_tasks SET isNotified = 1 WHERE id IN (:taskIds)")
     suspend fun markTasksNotified(taskIds: List<String>)
 
-    @Query("SELECT * FROM team_tasks WHERE teamId = :teamId AND status != 'archived'")
+    @Query("SELECT * FROM team_tasks WHERE teamId = :teamId AND (status IS NULL OR status != 'archived')")
     fun getTasksByTeamId(teamId: String): Flow<List<TeamTask>>
 
     @Query("SELECT * FROM team_tasks WHERE (_id IS NULL OR _id = '' OR isUpdated = 1)")

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -861,6 +861,7 @@ class TeamsRepositoryImpl @Inject constructor(
             this.teamId = teamId
             assignee = assigneeId
             isUpdated = true
+            status = "active"
         }
         upsertTask(teamTask)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
@@ -339,8 +339,9 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
                 adapterTask.updateAssignees(fetchedNames)
             }
 
-            adapterTask.submitList(taskList)
-            binding.rvTask.scrollToPosition(0)
+            adapterTask.submitList(taskList) {
+                binding.rvTask.scrollToPosition(0)
+            }
             showNoData(binding.tvNodata, taskList.size, "tasks")
         }
     }


### PR DESCRIPTION
Updated Room DAO queries to (status IS NULL OR status != 'archived'), and set status = "active" in createTask

[Screen_recording_20260723_212420.webm](https://github.com/user-attachments/assets/f9d09a20-4406-4a7f-b077-90e58ffe5e56)

fixes #14882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tasks with no status are now treated as active, so they correctly show up in open-task and team-task listings.
  * Newly created team tasks are explicitly set to an active status for consistent tracking.
  * Improved the tasks list behavior so the view scrolls to the top only after the updated list finishes rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->