### PR TITLE
courses: smoother joining (fixes #14879)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6166
-        versionName = "0.61.66"
+        versionCode = 6177
+        versionName = "0.61.77"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -110,11 +110,17 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         }
     }
 
-    open fun addToMyList() {
-        if (isAddInProgress) return
+    open fun addToMyList(onComplete: (() -> Unit)? = null) {
+        if (isAddInProgress) {
+            onComplete?.invoke()
+            return
+        }
 
         val itemsToAdd = selectedItems?.toList() ?: emptyList()
-        if (itemsToAdd.isEmpty()) return
+        if (itemsToAdd.isEmpty()) {
+            onComplete?.invoke()
+            return
+        }
 
         val resourceIds = mutableListOf<String>()
         val courseIds = mutableListOf<String>()
@@ -127,52 +133,58 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
             }
         }
 
-        if (resourceIds.isEmpty() && courseIds.isEmpty()) return
+        if (resourceIds.isEmpty() && courseIds.isEmpty()) {
+            onComplete?.invoke()
+            return
+        }
 
         isAddInProgress = true
         setJoinInProgress(true)
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val userId = profileDbHandler.getUserModel()?.id ?: return@launch
-            var libraryAdded = false
-            var courseAdded = false
-            var errorOccurred: Throwable? = null
+            try {
+                val userId = profileDbHandler.getUserModel()?.id ?: return@launch
+                var libraryAdded = false
+                var courseAdded = false
+                var errorOccurred: Throwable? = null
 
-            if (resourceIds.isNotEmpty()) {
-                val libraryResult = resourcesRepository.addResourcesToUserLibrary(resourceIds, userId)
-                libraryResult.onSuccess {
-                    libraryAdded = true
-                }.onFailure {
-                    errorOccurred = it
-                }
-            }
-
-            if (courseIds.isNotEmpty()) {
-                val courseResult = coursesRepository.markCoursesAdded(courseIds, userId)
-                courseResult.onSuccess { added ->
-                    if (added) {
-                        courseAdded = true
+                if (resourceIds.isNotEmpty()) {
+                    val libraryResult = resourcesRepository.addResourcesToUserLibrary(resourceIds, userId)
+                    libraryResult.onSuccess {
+                        libraryAdded = true
+                    }.onFailure {
+                        errorOccurred = it
                     }
-                }.onFailure {
-                    errorOccurred = it
                 }
+
+                if (courseIds.isNotEmpty()) {
+                    val courseResult = coursesRepository.markCoursesAdded(courseIds, userId)
+                    courseResult.onSuccess { added ->
+                        if (added) {
+                            courseAdded = true
+                        }
+                    }.onFailure {
+                        errorOccurred = it
+                    }
+                }
+
+                if (view == null || !isAdded || requireActivity().isFinishing) return@launch
+
+                postAddRefresh()
+
+                errorOccurred?.let {
+                    it.printStackTrace()
+                    toast(activity, "An error occurred: ${it.message}")
+                    return@launch
+                }
+
+                if (libraryAdded) toast(activity, getString(R.string.added_to_my_library))
+                if (courseAdded) toast(activity, getString(R.string.added_to_my_courses))
+            } finally {
+                isAddInProgress = false
+                setJoinInProgress(false)
+                onComplete?.invoke()
             }
-
-            isAddInProgress = false
-            setJoinInProgress(false)
-
-            if (view == null || !isAdded || requireActivity().isFinishing) return@launch
-
-            postAddRefresh()
-
-            errorOccurred?.let {
-                it.printStackTrace()
-                toast(activity, "An error occurred: ${it.message}")
-                return@launch
-            }
-
-            if (libraryAdded) toast(activity, getString(R.string.added_to_my_library))
-            if (courseAdded) toast(activity, getString(R.string.added_to_my_courses))
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -360,6 +360,7 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
     }
 
     private fun createAlertDialog(): AlertDialog {
+        var hasAdded = false
         val builder = AlertDialog.Builder(requireContext(), R.style.CustomAlertDialog)
         val msg = buildString {
             append(getString(R.string.success_you_have_added_the_following_courses))
@@ -381,18 +382,25 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
                 if (userModel?.id?.startsWith("guest") == true) {
                     DialogUtils.guestDialog(requireContext())
                 } else {
-                    addToMyList()
-                    val fragment = CoursesFragment().apply {
-                        arguments = Bundle().apply { putBoolean("isMyCourseLib", true) }
+                    hasAdded = true
+                    addToMyList {
+                        val fragment = CoursesFragment().apply {
+                            arguments = Bundle().apply { putBoolean("isMyCourseLib", true) }
+                        }
+                        homeItemClickListener?.openMyFragment(fragment)
                     }
-                    homeItemClickListener?.openMyFragment(fragment)
                 }
             }
             .setNegativeButton(R.string.ok) { dialog: DialogInterface, _: Int ->
+                hasAdded = true
                 addToMyList()
                 dialog.cancel()
-    }
-            .setOnDismissListener { addToMyList() }
+            }
+            .setOnDismissListener {
+                if (!hasAdded) {
+                    addToMyList()
+                }
+            }
 
         return builder.create()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -417,6 +417,7 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
     }
 
     private fun createAlertDialog(): AlertDialog {
+        var hasAdded = false
         val builder = AlertDialog.Builder(requireContext(), R.style.CustomAlertDialog)
         builder.setMessage(buildAlertMessage())
         builder.setCancelable(true)
@@ -424,19 +425,26 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
                 if (userModel?.id?.startsWith("guest") == true) {
                     guestDialog(requireContext())
                 } else {
-                    val fragment = ResourcesFragment().apply {
-                        arguments = Bundle().apply {
-                            putBoolean("isMyCourseLib", true)
+                    hasAdded = true
+                    addToMyList {
+                        val fragment = ResourcesFragment().apply {
+                            arguments = Bundle().apply {
+                                putBoolean("isMyCourseLib", true)
+                            }
                         }
+                        homeItemClickListener?.openMyFragment(fragment)
                     }
-                    homeItemClickListener?.openMyFragment(fragment)
                 }
             }
         builder.setNegativeButton(getString(R.string.ok)) { dialog: DialogInterface, _: Int ->
+            hasAdded = true
+            addToMyList()
             dialog.cancel()
         }
         builder.setOnDismissListener {
-            addToMyList()
+            if (!hasAdded) {
+                addToMyList()
+            }
         }
         return builder.create()
     }
@@ -724,26 +732,32 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         }
     }
 
-    override fun addToMyList() {
+    override fun addToMyList(onComplete: (() -> Unit)?) {
         val userId = userModel?.id
         val itemsToAdd = selectedItems?.mapNotNull { it?.resourceId } ?: emptyList()
 
         if (userId != null && itemsToAdd.isNotEmpty()) {
             lifecycleScope.launch {
-                viewModel.addResourcesToUserLibrary(itemsToAdd, userId)
-                    .onSuccess {
-                        _binding ?: return@onSuccess
-                        Utilities.toast(activity, getString(R.string.added_to_my_library))
-                        refreshResourcesData()
-                        selectedItems?.clear()
-                        changeButtonStatus()
-                        hideButton()
-                    }
-                    .onFailure {
-                        _binding ?: return@onFailure
-                        Utilities.toast(activity, getString(R.string.error, it.message))
-                    }
+                try {
+                    viewModel.addResourcesToUserLibrary(itemsToAdd, userId)
+                        .onSuccess {
+                            _binding ?: return@onSuccess
+                            Utilities.toast(activity, getString(R.string.added_to_my_library))
+                            refreshResourcesData()
+                            selectedItems?.clear()
+                            changeButtonStatus()
+                            hideButton()
+                        }
+                        .onFailure {
+                            _binding ?: return@onFailure
+                            Utilities.toast(activity, getString(R.string.error, it.message))
+                        }
+                } finally {
+                    onComplete?.invoke()
+                }
             }
+        } else {
+            onComplete?.invoke()
         }
     }
 }


### PR DESCRIPTION
- Updated addToMyList(onComplete: (() -> Unit)?) in BaseRecyclerFragment.kt, ResourcesFragment.kt, and CoursesFragment.kt to accept a completion callback that fires in a finally block once Room DB writes finish
- Updated createAlertDialog so that tapping "Go to myLibrary" / "Go to myCourses" awaits completion of addToMyList before performing openMyFragment
- Added a hasAdded flag to ensure addToMyList is called exactly once per dialog interaction

[Screen_recording_20260723_214137.webm](https://github.com/user-attachments/assets/8a5821b9-c876-4fe6-af6e-bec50d93c982)

fixes #14879


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate additions when confirming course or resource selections.
  * Improved reliability when adding items to My Courses or My Library, including handling incomplete or unsuccessful operations.
  * Ensured loading indicators, controls, and selection states are restored after the operation finishes.

* **Improvements**
  * Navigation to My Library now occurs only after items are successfully processed.
  * Existing success notifications and error handling remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->