### PR TITLE
dashboard: smoother guest login warning (fixes #14955)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6184
+        versionName = "0.61.84"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -723,22 +723,14 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     private fun showVisitLimitWarning() {
         // Clear any existing banner first
         binding.bannerContainer.removeAllViews()
-        
+
         // Inflate the banner layout
         val bannerView = LayoutInflater.from(this).inflate(R.layout.banner_offline_visit_warning, binding.bannerContainer, true)
-        
+
         // Set up close button
         val closeButton = bannerView.findViewById<ImageButton>(R.id.banner_close)
         closeButton.setOnClickListener {
-            binding.bannerContainer.removeView(bannerView.parent as? View ?: bannerView)
-        }
-        
-        // Auto-dismiss after 10 seconds
-        lifecycleScope.launch {
-            delay(10000)
-            if (binding.bannerContainer.childCount > 0) {
-                binding.bannerContainer.removeAllViews()
-            }
+            binding.bannerContainer.removeAllViews()
         }
     }
 


### PR DESCRIPTION
- Removed the 10-second auto-dismiss coroutine inside showVisitLimitWarning() in DashboardActivity.kt
- The remaining guest login warning now persists on screen until the user explicitly dismisses it by clicking the close button (closeButton).

fixes #14955 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app version to 0.61.84.

* **Bug Fixes**
  * Improved the offline visit-limit warning banner so it remains visible until manually dismissed.
  * Ensured dismissing the warning reliably clears the banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->