### PR TITLE
all: smoother settings guest users handling (fixes #14959)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6185
+        versionName = "0.61.85"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -194,6 +194,7 @@ class SettingsActivity : AppCompatActivity() {
             setPreferencesFromResource(R.xml.pref, rootKey)
             lifecycleScope.launch {
                 user = profileDbHandler.getUserModel()
+                blockGuestSwitches()
             }
             dialog = DialogUtils.getCustomProgressDialog(requireActivity())
 
@@ -233,6 +234,30 @@ class SettingsActivity : AppCompatActivity() {
             clearDataButtonInit()
             initRetryQueueDebug()
             initStorageBreakdown()
+        }
+
+        private fun blockGuestSwitches() {
+            if (user?.id?.startsWith("guest") != true) return
+
+            fun processPreference(pref: Preference) {
+                when (pref) {
+                    is SwitchPreference -> {
+                        pref.onPreferenceChangeListener = OnPreferenceChangeListener { _, _ ->
+                            DialogUtils.guestDialog(requireContext())
+                            false
+                        }
+                    }
+                    is androidx.preference.PreferenceGroup -> {
+                        for (i in 0 until pref.preferenceCount) {
+                            processPreference(pref.getPreference(i))
+                        }
+                    }
+                }
+            }
+
+            for (i in 0 until preferenceScreen.preferenceCount) {
+                processPreference(preferenceScreen.getPreference(i))
+            }
         }
 
         private fun initStorageBreakdown() {


### PR DESCRIPTION
- Added blockGuestSwitches() in SettingFragment (SettingsActivity.kt).
- When a guest user views Settings, blockGuestSwitches() recursively scans all SwitchPreference items in the PreferenceScreen.
- Attaches an OnPreferenceChangeListener to every switch that pops up DialogUtils.guestDialog(requireContext()) (prompting them to become a member) and returns false to block the switch state from toggling.

[Screen_recording_20260724_214038.webm](https://github.com/user-attachments/assets/7cf38374-f838-4071-91cc-97aad8fc714a)

fixes #14959 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Settings**
  * Added guest-specific restrictions in Settings.
  * Guest users can no longer toggle switch-based preferences; attempts show an explanatory dialog and the change is blocked.
* **Release / Versioning**
  * Updated the app version (version code/name) for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->