### PR TITLE
all: smoother notifications text caching (fixes #15093)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6202
+        versionName = "0.62.2"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/NotificationListItem.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/NotificationListItem.kt
@@ -1,5 +1,7 @@
 package org.ole.planet.myplanet.model
 
+import android.text.Html
+
 sealed class NotificationListItem {
     data class Header(
         val type: String,
@@ -12,5 +14,9 @@ sealed class NotificationListItem {
         val notification: Notification,
         val isSelected: Boolean = false,
         val isSelectionMode: Boolean = false
-    ) : NotificationListItem()
+    ) : NotificationListItem() {
+        val parsedText: CharSequence by lazy(LazyThreadSafetyMode.NONE) {
+            Html.fromHtml(notification.formattedText.toString(), Html.FROM_HTML_MODE_LEGACY)
+        }
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapter.kt
@@ -110,7 +110,7 @@ class NotificationsAdapter(
 
         fun bind(item: NotificationListItem.Item) {
             val notification = item.notification
-            binding.title.text = Html.fromHtml(notification.formattedText.toString(), Html.FROM_HTML_MODE_LEGACY)
+            binding.title.text = item.parsedText
             binding.timestamp.text = formatRelativeTime(notification.createdAt)
             binding.root.alpha = if (notification.isRead) 0.6f else 1.0f
 


### PR DESCRIPTION
Cache parsed notification text so Html.fromHtml runs once per item, not per bind, by creating a parsedText property in NotificationListItem.Item that is lazily initialized and replacing the call to Html.fromHtml in NotificationsAdapter with a reference to parsedText

---
*PR created automatically by Jules for task [1280115946665825524](https://jules.google.com/task/1280115946665825524) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification title rendering by correctly parsing and displaying formatted notification text.
  - Ensures existing timestamps and selection/read UI behavior remain unchanged while preserving styling in titles.
- **Chores**
  - Updated the app version (version code and version name) for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->