### PR TITLE
dashboard: smoother base loading (fixes #15091)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6200
+        versionName = "0.62.0"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
@@ -66,25 +66,28 @@ open class BaseDashboardFragment : DashboardPluginFragment(), OnSyncListener {
     lateinit var lifeRepository: LifeRepository
 
     fun onLoaded(v: View) {
+        val llPrompt = v.findViewById<LinearLayout>(R.id.ll_prompt)
+        val icClose = v.findViewById<ImageView>(R.id.ic_close)
+        val imageView = v.findViewById<ImageView>(R.id.imageView)
+
         viewLifecycleOwner.lifecycleScope.launch {
             model = userRepository.getUserProfile()
             fullName = model?.getFullName()
             if (fullName?.trim().isNullOrBlank()) {
                 fullName = model?.name
-                v.findViewById<LinearLayout>(R.id.ll_prompt).visibility = View.VISIBLE
-                v.findViewById<LinearLayout>(R.id.ll_prompt).setOnClickListener {
+                llPrompt.visibility = View.VISIBLE
+                llPrompt.setOnClickListener {
                     if (!childFragmentManager.isStateSaved) {
                         UserInformationFragment.getInstance("", "", false)
                             .show(childFragmentManager, "")
                     }
                 }
             } else {
-                v.findViewById<LinearLayout>(R.id.ll_prompt).visibility = View.GONE
+                llPrompt.visibility = View.GONE
             }
-            v.findViewById<ImageView>(R.id.ic_close).setOnClickListener {
-                v.findViewById<LinearLayout>(R.id.ll_prompt).visibility = View.GONE
+            icClose.setOnClickListener {
+                llPrompt.visibility = View.GONE
             }
-            val imageView = v.findViewById<ImageView>(R.id.imageView)
             if (!TextUtils.isEmpty(model?.userImage)) {
                 Glide.with(requireActivity())
                     .load(model?.userImage)


### PR DESCRIPTION
Cached findViewById calls for llPrompt, icClose, and imageView to local variables at the start of onLoaded method. Verified with ./gradlew compileDefaultDebugKotlin.

---
*PR created automatically by Jules for task [4352260156619664448](https://jules.google.com/task/4352260156619664448) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app release to version 0.62.0.

* **Bug Fixes**
  * Improved dashboard prompt handling while preserving existing visibility, close, image-loading, and role-display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->