### PR TITLE
enterprises: smoother finances initializing (fixes #15090)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6199
+        versionName = "0.61.99"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesFragment.kt
@@ -32,6 +32,7 @@ import org.ole.planet.myplanet.model.Transaction
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.TimeUtils.formatDateTZ
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class EnterprisesFinancesFragment : BaseTeamFragment() {
@@ -226,20 +227,14 @@ class EnterprisesFinancesFragment : BaseTeamFragment() {
         binding.rvFinance.layoutManager = LinearLayoutManager(activity)
         binding.rvFinance.adapter = financeAdapter
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            launch {
-                isMemberFlow.collectLatest { isMember ->
-                    val canManage = if (fromCommunity) user?.isManager() == true else isMember
-                    binding.addTransaction.visibility = if (canManage) View.VISIBLE else View.GONE
-                }
-            }
-            launch {
-                viewModel.transactions.collectLatest { results ->
-                    transactions = results
-                    updatedFinanceList(results)
-                    showNoData(binding.tvNodata, transactions.size, "finances")
-                }
-            }
+        collectLatestWhenStarted(isMemberFlow) { isMember ->
+            val canManage = if (fromCommunity) user?.isManager() == true else isMember
+            binding.addTransaction.visibility = if (canManage) View.VISIBLE else View.GONE
+        }
+        collectLatestWhenStarted(viewModel.transactions) { results ->
+            transactions = results
+            updatedFinanceList(results)
+            showNoData(binding.tvNodata, transactions.size, "finances")
         }
 
         observeTransactions()


### PR DESCRIPTION
Refactored EnterprisesFinancesFragment to use collectLatestWhenStarted instead of viewLifecycleOwner.lifecycleScope.launch for isMemberFlow and viewModel.transactions flows.

---
*PR created automatically by Jules for task [1266444612064009616](https://jules.google.com/task/1266444612064009616) started by @dogi*