### PR TITLE
teams: smoother repository admin querying (fixes #15089)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6198
+        versionName = "0.61.98"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
@@ -137,6 +137,7 @@ interface TeamDao {
     @Query("SELECT * FROM teams WHERE _id = :id LIMIT 1") suspend fun getById(id: String): MyTeam?
     @Query("SELECT * FROM teams WHERE userId = :userId") suspend fun getByUserId(userId: String): List<MyTeam>
     @Query("SELECT * FROM teams") suspend fun getAll(): List<MyTeam>
+    @Query("SELECT * FROM teams WHERE teamId = :teamId") suspend fun getAllByTeamId(teamId: String): List<MyTeam>
     @Query("SELECT * FROM teams") fun observeAll(): Flow<List<MyTeam>>
     @Query("SELECT * FROM teams WHERE docType = :docType") suspend fun getByDocType(docType: String): List<MyTeam>
     @Query("SELECT * FROM teams WHERE docType = :docType") fun observeByDocType(docType: String): Flow<List<MyTeam>>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -1049,7 +1049,7 @@ class TeamsRepositoryImpl @Inject constructor(
 
         if (communityLeadersJson.isNotEmpty()) {
             val adminUsers = userRepository.parseLeadersJson(communityLeadersJson)
-            val teamUserIds = teamDao.getAll().filter { it.teamId == teamId }.mapNotNull { it.userId }.toSet()
+            val teamUserIds = teamDao.getAllByTeamId(teamId).mapNotNull { it.userId }.toSet()
             val memberNames = members.mapTo(HashSet()) { it.name }
             val validAdmins = adminUsers.filter { admin ->
                 val adminFullId = "org.couchdb.user:${admin.name}"


### PR DESCRIPTION
Optimize TeamsRepositoryImpl admin lookup

Use a team-id-scoped DAO query instead of getAll().filter in TeamsRepository admin lookup.

- Added `getAllByTeamId(teamId: String)` query to `TeamDao`
- Replaced `teamDao.getAll().filter { it.teamId == teamId }` with `teamDao.getAllByTeamId(teamId)` in `TeamsRepositoryImpl`

Verified changes using `./gradlew compileDefaultDebugUnitTestKotlin --no-daemon`.

---
*PR created automatically by Jules for task [1440567828160742029](https://jules.google.com/task/1440567828160742029) started by @dogi*