### PR TITLE
courses: smoother progress grid lazy coloring (fixes #15088)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6197
+        versionName = "0.61.97"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/ProgressGridAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/ProgressGridAdapter.kt
@@ -18,6 +18,16 @@ class ProgressGridAdapter(private val context: Context) :
             areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
         )
     ) {
+    private val colorCompleted by lazy(LazyThreadSafetyMode.NONE) {
+        ContextCompat.getColor(context, R.color.md_green_500)
+    }
+    private val colorInProgress by lazy(LazyThreadSafetyMode.NONE) {
+        ContextCompat.getColor(context, R.color.md_yellow_500)
+    }
+    private val colorMain by lazy(LazyThreadSafetyMode.NONE) {
+        ContextCompat.getColor(context, R.color.mainColor)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderMyProgress {
         val rowMyProgressGridBinding =
             RowMyProgressGridBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -30,20 +40,12 @@ class ProgressGridAdapter(private val context: Context) :
             holder.tvProgress.text =
                 context.getString(R.string.percentage, item["percentage"].asString)
             if (item["completed"].asBoolean) {
-                holder.itemView.setBackgroundColor(
-                    ContextCompat.getColor(
-                        context, R.color.md_green_500
-                    )
-                )
+                holder.itemView.setBackgroundColor(colorCompleted)
             } else {
-                holder.itemView.setBackgroundColor(
-                    ContextCompat.getColor(
-                        context, R.color.md_yellow_500
-                    )
-                )
+                holder.itemView.setBackgroundColor(colorInProgress)
             }
         } else {
-            holder.itemView.setBackgroundColor(ContextCompat.getColor(context, R.color.mainColor))
+            holder.itemView.setBackgroundColor(colorMain)
         }
     }
 


### PR DESCRIPTION
Refactor ProgressGridAdapter to resolve colors via lazy properties

Replaced inline ContextCompat.getColor() calls in onBindViewHolder with lazy-initialized properties to avoid redundant context lookups during scrolling.

Tested by verifying no behavior change and codebase compiles via `./gradlew compileDefaultDebugKotlin`.

---
*PR created automatically by Jules for task [1134330030833374154](https://jules.google.com/task/1134330030833374154) started by @dogi*