### PR TITLE
Remove redundant survey notification auto-navigation and unused getSurvey lookup

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
@@ -65,6 +65,7 @@ interface ExamDao {
     @Query("SELECT * FROM exams") suspend fun getAll(): List<StepExam>
     @Query("SELECT * FROM exams") fun observeAll(): Flow<List<StepExam>>
     @Query("SELECT * FROM exams WHERE type = :type") suspend fun getByType(type: String): List<StepExam>
+    @Query("SELECT * FROM exams WHERE type = :type AND name = :name LIMIT 1") suspend fun getByTypeAndName(type: String, name: String): StepExam?
     @Query("SELECT * FROM exams WHERE type = :type") fun observeByType(type: String): Flow<List<StepExam>>
     @Query("SELECT * FROM exams WHERE teamId = :teamId") suspend fun getByTeamId(teamId: String): List<StepExam>
     @Query("SELECT * FROM exams WHERE teamId = :teamId AND type = :type") suspend fun getByTeamIdAndType(teamId: String, type: String): List<StepExam>

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
@@ -65,7 +65,6 @@ interface ExamDao {
     @Query("SELECT * FROM exams") suspend fun getAll(): List<StepExam>
     @Query("SELECT * FROM exams") fun observeAll(): Flow<List<StepExam>>
     @Query("SELECT * FROM exams WHERE type = :type") suspend fun getByType(type: String): List<StepExam>
-    @Query("SELECT * FROM exams WHERE type = :type AND name = :name LIMIT 1") suspend fun getByTypeAndName(type: String, name: String): StepExam?
     @Query("SELECT * FROM exams WHERE type = :type") fun observeByType(type: String): Flow<List<StepExam>>
     @Query("SELECT * FROM exams WHERE teamId = :teamId") suspend fun getByTeamId(teamId: String): List<StepExam>
     @Query("SELECT * FROM exams WHERE teamId = :teamId AND type = :type") suspend fun getByTeamIdAndType(teamId: String, type: String): List<StepExam>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepository.kt
@@ -28,7 +28,6 @@ interface SurveysRepository {
     ): Map<String, SurveyFormState>
 
     suspend fun adoptSurvey(examId: String, userId: String?, teamId: String?, isTeam: Boolean)
-    suspend fun getSurvey(id: String): StepExam?
     suspend fun getSurveys(): List<StepExam>
     suspend fun getSurveys(ascending: Boolean = false): List<StepExam>
     suspend fun bulkInsertExamsFromSync(jsonArray: JsonArray)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
@@ -369,7 +369,7 @@ class SurveysRepositoryImpl @Inject constructor(
 
     override suspend fun getSurvey(id: String): StepExam? {
         return examDao.getById(id)
-            ?: examDao.getByType("surveys").firstOrNull { it.name == id }
+            ?: examDao.getByTypeAndName("surveys", id)
     }
 
     override suspend fun getSurveys(): List<StepExam> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
@@ -367,11 +367,6 @@ class SurveysRepositoryImpl @Inject constructor(
         return submissionDao.getPendingSurveys(userId).size
     }
 
-    override suspend fun getSurvey(id: String): StepExam? {
-        return examDao.getById(id)
-            ?: examDao.getByTypeAndName("surveys", id)
-    }
-
     override suspend fun getSurveys(): List<StepExam> {
         return examDao.getByType("surveys").map { it }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -204,10 +204,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             }
         }
 
-        collectWhenStarted(dashboardViewModel.surveyNavigationEvent) { surveyId ->
-            SubmissionsAdapter.openSurvey(this@DashboardActivity, surveyId, false, false, "")
-        }
-
         collectWhenStarted(dashboardViewModel.taskNavigationEvent) { teamData ->
             val f = TeamDetailFragment.newInstance(
                 teamId = teamData.first,
@@ -493,11 +489,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             val relatedId = intent.getStringExtra("related_id")
             
             when (notificationType) {
-                NotificationUtils.TYPE_SURVEY -> {
-                    lifecycleScope.launch {
-                        handleSurveyNavigation(relatedId)
-                    }
-                }
                 NotificationUtils.TYPE_TASK -> {
                     lifecycleScope.launch {
                         handleTaskNavigation(relatedId)
@@ -517,11 +508,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
     }
     
-    private suspend fun handleSurveyNavigation(surveyId: String?) {
-        if (surveyId != null) {
-            dashboardViewModel.handleSurveyNavigation(surveyId)
-        }
-    }
     
     private suspend fun handleTaskNavigation(taskId: String?) {
         if (taskId != null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -77,9 +77,6 @@ class DashboardViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(DashboardUiState())
     val uiState: StateFlow<DashboardUiState> = _uiState.asStateFlow()
 
-    private val _surveyNavigationEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
-    val surveyNavigationEvent: SharedFlow<String> = _surveyNavigationEvent.asSharedFlow()
-
     private val _taskNavigationEvent = MutableSharedFlow<Triple<String, String, String>>(extraBufferCapacity = 1)
     val taskNavigationEvent: SharedFlow<Triple<String, String, String>> = _taskNavigationEvent.asSharedFlow()
 
@@ -262,17 +259,6 @@ class DashboardViewModel @Inject constructor(
                 setUnreadNotifications(unreadCount)
             } catch (e: Exception) {
                 e.printStackTrace()
-            }
-        }
-    }
-
-    fun handleSurveyNavigation(surveyId: String) {
-        viewModelScope.launch {
-            val survey = withContext(dispatcherProvider.io) {
-                surveysRepository.getSurvey(surveyId)
-            }
-            survey?.id?.let { id ->
-                _surveyNavigationEvent.emit(id)
             }
         }
     }


### PR DESCRIPTION
Removes the duplicate survey-notification navigation path and the now-unused `getSurvey` lookup, consolidating survey-notification handling on the single `from_notification` → `SurveyFragment` path.

### Changes
- Removed `SurveysRepository.getSurvey(id)` and its implementation in `SurveysRepositoryImpl` (the `examDao.getById(id)` primary lookup with the `examDao.getByType("surveys").firstOrNull { it.name == id }` name fallback).
- Removed `DashboardViewModel.handleSurveyNavigation()` and the `surveyNavigationEvent` `SharedFlow` (and its `asSharedFlow()` exposure).
- Removed, in `DashboardActivity`: the `auto_navigate` `TYPE_SURVEY` branch in `handleNotificationIntent`, the `handleSurveyNavigation()` helper, and the `surveyNavigationEvent` collector.

Survey notifications tapped from the notification body continue to open `SurveyFragment` via the untouched `from_notification` path.

> **Note:** the previous title/description (“add a type+name survey DAO query for the getSurvey fallback”) did not match the diff — this PR *removes* `getSurvey` rather than adding a DAO query. Title and body corrected to reflect the actual change.

---
*PR created automatically by Jules for task [1370632456018352024](https://jules.google.com/task/1370632456018352024) started by @dogi*