### PR TITLE
life: smoother health repository examination marking (fixes #15085)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6195
+        versionName = "0.61.95"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/HealthExaminationDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/HealthExaminationDao.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.data.room.dao
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Upsert
 import org.ole.planet.myplanet.model.HealthExamination
 
@@ -27,6 +28,13 @@ interface HealthExaminationDao {
 
     @Query("UPDATE health_examinations SET _rev = :rev, isUpdated = 0 WHERE _id = :id")
     suspend fun markUploaded(id: String, rev: String?)
+
+    @Transaction
+    suspend fun markUploaded(idToRevMap: Map<String, String?>) {
+        idToRevMap.forEach { (id, rev) ->
+            markUploaded(id, rev)
+        }
+    }
 
     @Query("UPDATE health_examinations SET userId = :userId WHERE _id = :id")
     suspend fun updateUserId(id: String, userId: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -59,9 +59,7 @@ class HealthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markHealthExaminationsUploaded(idToRevMap: Map<String, String?>) {
-        idToRevMap.forEach { (id, rev) ->
-            healthExaminationDao.markUploaded(id, rev)
-        }
+        healthExaminationDao.markUploaded(idToRevMap)
     }
 
     override suspend fun saveExamination(examination: HealthExamination?, pojo: HealthExamination?, user: UserEntity?) {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/HealthRepositoryImplTest.kt
@@ -146,8 +146,7 @@ class HealthRepositoryImplTest {
         repository.markHealthExaminationsUploaded(idToRevMap)
         advanceUntilIdle()
 
-        coVerify { healthExaminationDao.markUploaded("exam1", "rev1") }
-        coVerify { healthExaminationDao.markUploaded("exam2", "rev2") }
+        coVerify { healthExaminationDao.markUploaded(idToRevMap) }
     }
 
     @Test


### PR DESCRIPTION
Wraps the per-id markUploaded loop in a single Room transaction to ensure atomicity and improve database performance.

Test execution step:
```bash
./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.repository.HealthRepositoryImplTest" --no-daemon > test_output.log 2>&1 &
```

---
*PR created automatically by Jules for task [6626593740641045922](https://jules.google.com/task/6626593740641045922) started by @dogi*