### PR TITLE
courses: smoother filter controller debouncing (fixes #15084)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6194
+        versionName = "0.61.94"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
@@ -8,10 +8,16 @@ import android.widget.ArrayAdapter
 import android.widget.EditText
 import android.widget.Spinner
 import android.widget.TextView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.utils.DefaultDispatcherProvider
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.model.TagEntity
 
 data class FilterState(
@@ -40,6 +46,9 @@ class CourseFilterController(
     val searchTags: MutableList<TagEntity> = ArrayList()
     private var searchTextWatcher: TextWatcher? = null
     private var spinnerListener: AdapterView.OnItemSelectedListener? = null
+    private var searchJob: Job? = null
+    private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider()
+    private val coroutineScope = CoroutineScope(dispatcherProvider.main)
 
     fun setup() {
         etSearch = rootView.findViewById(R.id.et_search)
@@ -84,7 +93,11 @@ class CourseFilterController(
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 if (!etSearch.isFocused) return
-                _filterState.value = currentState()
+                searchJob?.cancel()
+                searchJob = coroutineScope.launch {
+                    delay(300)
+                    _filterState.value = currentState()
+                }
             }
             override fun afterTextChanged(s: Editable) {}
         }
@@ -158,6 +171,7 @@ class CourseFilterController(
     }
 
     fun detach() {
+        searchJob?.cancel()
         searchTextWatcher?.let { etSearch.removeTextChangedListener(it) }
         searchTextWatcher = null
         spnGrade.onItemSelectedListener = null


### PR DESCRIPTION
Added debounce to CourseFilterController search watcher using CoroutineScope and Job to track it with a 300ms delay. Safe usage of `dispatcherProvider.main` applied. Checked for regressions running compilation tasks.

---
*PR created automatically by Jules for task [11728037400533417150](https://jules.google.com/task/11728037400533417150) started by @dogi*