### PR TITLE
courses: smoother inline resources caching (fixes #15083)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6193
+        versionName = "0.61.93"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -83,8 +83,18 @@ class InlineResourceAdapter(
 
     override fun onCurrentListChanged(previousList: MutableList<MyLibrary>, currentList: MutableList<MyLibrary>) {
         super.onCurrentListChanged(previousList, currentList)
-        textCache.clear()
-        bitmapCache.evictAll()
+        val dir = externalFilesDir ?: return
+        val currentMap = currentList.associateBy { it.id }
+
+        previousList.forEach { prev ->
+            val current = currentMap[prev.id]
+            if (current == null || current.resourceLocalAddress != prev.resourceLocalAddress) {
+                val file = File(dir, "ole/${prev.id}/${prev.resourceLocalAddress}")
+                val prefix = file.absolutePath
+                textCache.keys.filter { it.startsWith(prefix) }.forEach { textCache.remove(it) }
+                bitmapCache.snapshot().keys.filter { it.startsWith(prefix) }.forEach { bitmapCache.remove(it) }
+            }
+        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {


### PR DESCRIPTION
Optimized `InlineResourceAdapter` cache eviction strategy in `onCurrentListChanged`.

Currently, the adapter clears the entire `textCache` and `bitmapCache` whenever the list updates. This change refines the process:
1. It compares `previousList` against `currentList` by their resource IDs.
2. If a resource from the previous list is absent in the new list, or if its local file address has changed, the adapter derives the corresponding absolute file path.
3. Using this path as a prefix, it selectively filters and removes only those specific entries from the caches.

For `LruCache`, `bitmapCache.snapshot().keys` is used to safely iterate over and filter the keys before removal, avoiding concurrent modification issues and preserving other valid cache entries.

Tested compilation by executing `./gradlew compileDefaultDebugKotlin --no-daemon > build_log.txt 2>&1 &` in the background, verified success via `sleep X && cat build_log.txt | grep -E "BUILD SUCCESSFUL|BUILD FAILED"`. Cleaned workspace afterward.

---
*PR created automatically by Jules for task [6457234908203870475](https://jules.google.com/task/6457234908203870475) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app version to 0.61.93.

* **Bug Fixes**
  * Improved inline course resource preview caching.
  * Updated resources now refresh affected previews while preserving unchanged cached content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->