### PR TITLE
chat: smoother share target coloring (fixes #15101)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6212
+        versionName = "0.62.12"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatShareTargetAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatShareTargetAdapter.kt
@@ -45,11 +45,12 @@ class ChatShareTargetAdapter(
     class GroupViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         private val listTitleTextView: TextView = view.findViewById(R.id.listTitle)
         private val arrowIcon: ImageView = view.findViewById(R.id.arrowIcon)
+        private val textColor = ContextCompat.getColor(view.context, R.color.daynight_textColor)
 
         fun bind(item: ChatShareTargetItem) {
             listTitleTextView.setTypeface(null, Typeface.BOLD)
             listTitleTextView.text = item.title
-            listTitleTextView.setTextColor(ContextCompat.getColor(itemView.context, R.color.daynight_textColor))
+            listTitleTextView.setTextColor(textColor)
             arrowIcon.rotation = if (item.isExpanded) 180f else 0f
         }
     }
@@ -57,11 +58,13 @@ class ChatShareTargetAdapter(
     class ChildViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         private val expandedListTextView: TextView = view.findViewById(R.id.expandedListItem)
         private val sharedIcon: ImageView = view.findViewById(R.id.sharedIcon)
+        private val textColor = ContextCompat.getColor(view.context, R.color.daynight_textColor)
+        private val backgroundColor = ContextCompat.getColor(view.context, R.color.multi_select_grey)
 
         fun bind(item: ChatShareTargetItem) {
             expandedListTextView.text = item.title
-            itemView.setBackgroundColor(ContextCompat.getColor(itemView.context, R.color.multi_select_grey))
-            expandedListTextView.setTextColor(ContextCompat.getColor(itemView.context, R.color.daynight_textColor))
+            itemView.setBackgroundColor(backgroundColor)
+            expandedListTextView.setTextColor(textColor)
             sharedIcon.visibility = if (item.isShared) View.VISIBLE else View.GONE
         }
     }


### PR DESCRIPTION
1. Resolved the `daynight_textColor` and `multi_select_grey` colors once by defining them as properties in `GroupViewHolder` and `ChildViewHolder`.
2. Updated the `bind()` methods to use these cached properties instead of repeatedly calling `ContextCompat.getColor(itemView.context, ...)`.
3. Verified the codebase cleanly compiles and tests pass by running `./gradlew testDefaultDebugUnitTest --no-daemon`.

---
*PR created automatically by Jules for task [15582314665282591371](https://jules.google.com/task/15582314665282591371) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app to version 0.62.12.

* **Performance Improvements**
  * Improved chat sharing screen rendering for smoother, more efficient display of share targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->