### PR TITLE
all: less pager adapter diff utils is more (fixes #15099)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6210
+        versionName = "0.62.10"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesPagerAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesPagerAdapter.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import org.ole.planet.myplanet.utils.DiffUtils
 
 class CoursesPagerAdapter(fm: Fragment, private val courseId: String?) : FragmentStateAdapter(fm) {
     private val steps = mutableListOf<String>()
@@ -15,21 +14,7 @@ class CoursesPagerAdapter(fm: Fragment, private val courseId: String?) : Fragmen
         private const val COURSE_DETAIL_ID = 0L
     }
 
-    private sealed interface StepItem
-    private object HeaderItem : StepItem
-    private data class StepEntry(val id: String) : StepItem
-
     fun submitList(newSteps: List<String>) {
-        val oldWithHeader: List<StepItem> = listOf(HeaderItem) + steps.map(::StepEntry)
-        val newWithHeader: List<StepItem> = listOf(HeaderItem) + newSteps.map(::StepEntry)
-
-        val diffResult = DiffUtils.calculateDiff(
-            oldWithHeader,
-            newWithHeader,
-            areItemsTheSame = { a, b -> a == b },
-            areContentsTheSame = { a, b -> a == b }
-        )
-
         newSteps.forEach { stepId ->
             if (!itemIds.containsKey(stepId)) {
                 itemIds[stepId] = nextId++
@@ -38,7 +23,7 @@ class CoursesPagerAdapter(fm: Fragment, private val courseId: String?) : Fragmen
 
         steps.clear()
         steps.addAll(newSteps)
-        diffResult.dispatchUpdatesTo(this)
+        notifyDataSetChanged()
     }
 
     override fun createFragment(position: Int): Fragment {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamPagerAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamPagerAdapter.kt
@@ -18,7 +18,6 @@ import org.ole.planet.myplanet.ui.teams.courses.TeamCoursesFragment
 import org.ole.planet.myplanet.ui.teams.members.MembersFragment
 import org.ole.planet.myplanet.ui.teams.members.RequestsFragment
 import org.ole.planet.myplanet.ui.teams.resources.TeamResourcesFragment
-import org.ole.planet.myplanet.utils.DiffUtils
 
 class TeamPagerAdapter(
     private val parentFragment: Fragment,
@@ -29,14 +28,8 @@ class TeamPagerAdapter(
 ) : FragmentStateAdapter(parentFragment) {
 
     fun updatePages(newPages: List<TeamPageConfig>) {
-        val diffResult = DiffUtils.calculateDiff(
-            pages,
-            newPages,
-            areItemsTheSame = { a, b -> a.id == b.id },
-            areContentsTheSame = { a, b -> a == b }
-        )
         pages = newPages.toList()
-        diffResult.dispatchUpdatesTo(this)
+        notifyDataSetChanged()
     }
 
     override fun getItemCount(): Int = pages.size


### PR DESCRIPTION
Modified `CoursesPagerAdapter` and `TeamPagerAdapter` to remove custom `DiffUtils.calculateDiff` calls for updating pages/steps. They now directly reassign the dataset and call `notifyDataSetChanged()`.
Compiled and verified changes with:
`./gradlew compileDefaultDebugKotlin --no-daemon > compile_log.txt 2>&1 &`

---
*PR created automatically by Jules for task [14474775003556453290](https://jules.google.com/task/14474775003556453290) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when refreshing course page lists.
  * Improved reliability when refreshing team page lists.
  * Ensured the UI consistently reflects updated items after list changes, reducing the chance of stale or incorrectly rendered content.
* **Chores**
  * Bumped app version to **0.62.10** (versionCode **6210**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->