### PR TITLE
sync: smoother realtime flow filtering (fixes #15098)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6209
+        versionName = "0.62.9"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.model.ChatHistory
@@ -61,11 +62,13 @@ class ChatViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            realtimeSyncManager.dataUpdateFlow.collect { update ->
-                if (update.table == "chats" && update.shouldRefreshUI) {
-                    _refreshChatSignal.emit(Unit)
+            realtimeSyncManager.dataUpdateFlow
+                .filter { it.table == "chats" }
+                .collect { update ->
+                    if (update.shouldRefreshUI) {
+                        _refreshChatSignal.emit(Unit)
+                    }
                 }
-            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
@@ -16,6 +16,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
@@ -440,8 +441,10 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
     }
 
     private fun setupRealtimeSync() {
-        collectWhenStarted(teamViewModel.getTeamUpdateFlow()) { update ->
-            if (update.table == "teams" && update.shouldRefreshUI) {
+        collectWhenStarted(
+            teamViewModel.getTeamUpdateFlow().filter { it.table == "teams" }
+        ) { update ->
+            if (update.shouldRefreshUI) {
                 refreshTeamDetails()
             }
         }


### PR DESCRIPTION
1. Modified `app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt` to apply table filtering (`chats`) on the `dataUpdateFlow` using `.filter { it.table == "chats" }` before collection.
2. Modified `app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt` to apply table filtering (`teams`) on `teamViewModel.getTeamUpdateFlow()` using `.filter { it.table == "teams" }` before passing it to `collectWhenStarted`.
3. Verified the changes using `git diff` and `git status`.
4. Successfully ran `./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.ui.chat.ChatViewModelTest" --no-daemon` and `./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.ui.teams.TeamViewModelTest" --no-daemon` to ensure regressions were avoided.

---
*PR created automatically by Jules for task [18352639545610116700](https://jules.google.com/task/18352639545610116700) started by @dogi*