### PR TITLE
Add change detection before submitList in TeamFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
@@ -311,12 +311,7 @@ class TeamFragment : Fragment() {
 
     private fun observeTeamData() {
         collectLatestWhenStarted(viewModel.teamData) { teamDataList ->
-            val isMeaningfulChange = previousTeamDataList == null ||
-                previousTeamDataList?.size != teamDataList.size ||
-                previousTeamDataList?.firstOrNull()?._id != teamDataList.firstOrNull()?._id ||
-                previousTeamDataList?.lastOrNull()?._id != teamDataList.lastOrNull()?._id
-
-            if (isMeaningfulChange) {
+            if (previousTeamDataList != teamDataList) {
                 teamListAdapter.submitList(teamDataList)
                 previousTeamDataList = teamDataList
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
@@ -365,6 +365,7 @@ class TeamFragment : Fragment() {
 
     override fun onDestroyView() {
         _binding = null
+        previousTeamDataList = null
         super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
@@ -51,6 +51,7 @@ class TeamFragment : Fragment() {
     var user: UserEntity? = null
     private lateinit var teamListAdapter: TeamsAdapter
     private var conditionApplied: Boolean = false
+    private var previousTeamDataList: List<TeamDetails>? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -310,7 +311,15 @@ class TeamFragment : Fragment() {
 
     private fun observeTeamData() {
         collectLatestWhenStarted(viewModel.teamData) { teamDataList ->
-            teamListAdapter.submitList(teamDataList)
+            val isMeaningfulChange = previousTeamDataList == null ||
+                previousTeamDataList?.size != teamDataList.size ||
+                previousTeamDataList?.firstOrNull()?._id != teamDataList.firstOrNull()?._id ||
+                previousTeamDataList?.lastOrNull()?._id != teamDataList.lastOrNull()?._id
+
+            if (isMeaningfulChange) {
+                teamListAdapter.submitList(teamDataList)
+                previousTeamDataList = teamDataList
+            }
             showNoResultsMessage(teamDataList.isEmpty())
             listContentDescription(conditionApplied)
         }

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,5 @@
+Fix TeamFragment list submission caching logic
+
+* Used full structural equality check (`!=`) instead of a lossy heuristic to avoid stale UI updates.
+* Reset `previousTeamDataList` to `null` in `onDestroyView()` so that when the view and adapter are recreated, the initial list submission is not improperly skipped.
+* Documented unfeasibility of Robolectric UI tests due to Hilt binding complexity.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,5 +1,0 @@
-Fix TeamFragment list submission caching logic
-
-* Used full structural equality check (`!=`) instead of a lossy heuristic to avoid stale UI updates.
-* Reset `previousTeamDataList` to `null` in `onDestroyView()` so that when the view and adapter are recreated, the initial list submission is not improperly skipped.
-* Documented unfeasibility of Robolectric UI tests due to Hilt binding complexity.


### PR DESCRIPTION
Added heuristic change detection logic before calling `submitList` in `TeamFragment`.
Verified functionality compilation using `./gradlew compileDefaultDebugKotlin --no-daemon` and tested for regressions using `./gradlew testDefaultDebugUnitTest --no-daemon`.

---
*PR created automatically by Jules for task [5860650445359497477](https://jules.google.com/task/5860650445359497477) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved team list updates by refreshing the display only when the received team data changes, reducing unnecessary updates during live emissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->