### PR TITLE
all: smoother time utils providing (fixes #15096)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6207
+        versionName = "0.62.7"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -86,6 +86,7 @@ import org.ole.planet.myplanet.utils.KeyboardUtils.setupUI
 import org.ole.planet.myplanet.utils.LocaleUtils
 import org.ole.planet.myplanet.utils.NotificationUtils
 import org.ole.planet.myplanet.utils.ServerConfigUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities.toast
 import org.ole.planet.myplanet.utils.collectWhenStarted
@@ -107,6 +108,8 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     override lateinit var dispatcherProvider: DispatcherProvider
     @Inject
     lateinit var userSessionManager: UserSessionManager
+    @Inject
+    override lateinit var timeProvider: TimeProvider
 
     @Inject
     override lateinit var resourcesRepository: ResourcesRepository
@@ -556,7 +559,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         val statusText = if (lastSyncMillis <= 0L) {
             getString(R.string.last_synced_colon) + getString(R.string.last_synced_never)
         } else {
-            getString(R.string.last_synced_colon) + TimeUtils.getRelativeTime(lastSyncMillis)
+            getString(R.string.last_synced_colon) + TimeUtils.getRelativeTime(lastSyncMillis, timeProvider)
         }
         binding.dashboardLastSyncStatus.text = statusText
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -48,6 +48,7 @@ import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
@@ -95,6 +96,8 @@ class SettingsActivity : AppCompatActivity() {
         lateinit var defaultPref: SharedPreferences
         @Inject
         lateinit var sharedPrefManager: SharedPrefManager
+        @Inject
+        lateinit var timeProvider: TimeProvider
         var user: UserEntity? = null
         private var libraryList: List<MyLibrary>? = null
         private lateinit var dialog: DialogUtils.CustomProgressDialog
@@ -353,7 +356,7 @@ class SettingsActivity : AppCompatActivity() {
             if (lastSynced == 0L) {
                 lastSyncDate?.setTitle(R.string.last_synced_never)
             } else if (lastSyncDate != null) {
-                lastSyncDate.title = getString(R.string.last_synced_colon) + TimeUtils.getRelativeTime(lastSynced)
+                lastSyncDate.title = getString(R.string.last_synced_colon) + TimeUtils.getRelativeTime(lastSynced, timeProvider)
             }
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -69,6 +69,7 @@ import org.ole.planet.myplanet.utils.NetworkUtils.getCustomDeviceName
 import org.ole.planet.myplanet.utils.NetworkUtils.isNetworkConnectedFlow
 import org.ole.planet.myplanet.utils.NotificationUtils.cancelAll
 import org.ole.planet.myplanet.utils.ServerConfigUtils
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
@@ -133,6 +134,8 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
 
     @Inject
     lateinit var syncManager: SyncManager
+    @Inject
+    override lateinit var timeProvider: TimeProvider
 
     @Inject
     lateinit var transactionSyncManager: TransactionSyncManager
@@ -367,7 +370,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         return if (lastSynced == 0L) {
             " Never Synced"
         } else {
-            TimeUtils.getRelativeTime(lastSynced)
+            TimeUtils.getRelativeTime(lastSynced, timeProvider)
         }
     }
 
@@ -593,7 +596,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
                 dotSync?.backgroundTintList = ColorStateList.valueOf(0xFFEF4444.toInt())
             } else {
                 val lastSyncMillis = prefData.getLastSync()
-                var relativeTime = TimeUtils.getRelativeTime(lastSyncMillis)
+                var relativeTime = TimeUtils.getRelativeTime(lastSyncMillis, timeProvider)
 
                 if (relativeTime.matches(secondsAgoRegex)) {
                     relativeTime = getString(R.string.a_few_seconds_ago)
@@ -737,7 +740,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
         }
         prefData.setLastUsageUploaded(Date().time)
         if (::lblLastSyncDate.isInitialized) {
-            lblLastSyncDate.text = getString(R.string.message_placeholder, "${getString(R.string.last_sync, TimeUtils.getRelativeTime(Date().time))} >>")
+            lblLastSyncDate.text = getString(R.string.message_placeholder, "${getString(R.string.last_sync, TimeUtils.getRelativeTime(Date().time, timeProvider))} >>")
         }
         syncFailed = false
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/UserProfileFragment.kt
@@ -58,6 +58,7 @@ import org.ole.planet.myplanet.databinding.EditProfileDialogBinding
 import org.ole.planet.myplanet.databinding.FragmentUserProfileBinding
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
@@ -69,6 +70,8 @@ class UserProfileFragment : Fragment() {
     private val viewModel: UserProfileViewModel by viewModels()
     @Inject
     lateinit var userSessionManager: UserSessionManager
+    @Inject
+    lateinit var timeProvider: TimeProvider
     private var model: UserEntity? = null
     private var editProfileDialog: Dialog? = null
     private lateinit var pickImageLauncher: ActivityResultLauncher<Intent>
@@ -452,7 +455,7 @@ class UserProfileFragment : Fragment() {
     private fun createStatsMap(): LinkedHashMap<String, String?> {
         return linkedMapOf(
             getString(R.string.community_name) to Utilities.checkNA(model?.planetCode),
-            getString(R.string.last_login) to viewModel.lastVisit.value?.let { TimeUtils.getRelativeTime(it) },
+            getString(R.string.last_login) to viewModel.lastVisit.value?.let { TimeUtils.getRelativeTime(it, timeProvider) },
             getString(R.string.total_visits_overall) to viewModel.offlineVisits.value.toString(),
             getString(R.string.most_opened_resource) to Utilities.checkNA(viewModel.maxOpenedResource.value),
             getString(R.string.number_of_resources_opened) to Utilities.checkNA(viewModel.numberOfResourceOpen.value)

--- a/app/src/main/java/org/ole/planet/myplanet/utils/TimeUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/TimeUtils.kt
@@ -44,8 +44,8 @@ object TimeUtils {
         DateTimeFormatter.ofPattern("EEE MMM dd yyyy HH:mm:ss 'GMT'Z (z)", Locale.US).withZone(ZoneId.systemDefault())
     }
 
-    fun getRelativeTime(timestamp: Long): String {
-        val timeNow = System.currentTimeMillis()
+    fun getRelativeTime(timestamp: Long, timeProvider: TimeProvider? = null): String {
+        val timeNow = timeProvider?.now() ?: System.currentTimeMillis()
         return if (timestamp < timeNow) {
             DateUtils.getRelativeTimeSpanString(timestamp, timeNow, 0).toString()
         } else "Just now"


### PR DESCRIPTION
Replaced `System.currentTimeMillis()` in `TimeUtils.kt` with an injectable `TimeProvider`. To avoid converting the `TimeUtils` object to a class and breaking over 25 static call sites, the `TimeProvider` was injected into the caller UI components (`DashboardActivity`, `SettingsActivity`, `SyncActivity`, and `UserProfileFragment`) and passed as an argument to `TimeUtils.getRelativeTime()`.

Tested with `./gradlew compileDefaultDebugKotlin --no-daemon > test_output.log 2>&1 &` and `./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.utils.TimeUtilsTest" --no-daemon`.

---
*PR created automatically by Jules for task [4857534733444615853](https://jules.google.com/task/4857534733444615853) started by @dogi*