### PR TITLE
all: smoother file utils time providing (fixes #15103)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6215
+        versionName = "0.62.15"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -44,9 +44,13 @@ import org.ole.planet.myplanet.utils.DialogUtils
 import org.ole.planet.myplanet.utils.DialogUtils.getProgressDialog
 import org.ole.planet.myplanet.utils.DialogUtils.showError
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.TimeProvider
 
 @AndroidEntryPoint
 abstract class BaseResourceFragment : Fragment() {
+    @Inject
+    lateinit var timeProvider: TimeProvider
+
     var homeItemClickListener: OnHomeItemClickListener? = null
     var model: UserEntity? = null
     var lv: RecyclerView? = null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -54,9 +54,6 @@ class BellDashboardFragment : BaseDashboardFragment() {
     @Inject
     lateinit var serverUrlMapper: ServerUrlMapper
 
-    @Inject
-    lateinit var timeProvider: TimeProvider
-
     companion object {
         private val SURVEY_DIALOG_INTERVAL_MS = TimeUnit.HOURS.toMillis(1)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesFragment.kt
@@ -287,7 +287,7 @@ class EnterprisesFinancesFragment : BaseTeamFragment() {
                         return@setPositiveButton
                     }
                     val imageUri = selectedImageUri
-                    val imageName = imageUri?.let { FileUtils.getDisplayName(requireContext(), it) }
+                    val imageName = imageUri?.let { FileUtils.getDisplayName(requireContext(), it, timeProvider) }
                     val imageData = imageUri?.let { FileUtils.readBytesFromUri(requireContext(), it) }
                     viewLifecycleOwner.lifecycleScope.launch {
                         val capturedDate = date ?: return@launch

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsFragment.kt
@@ -195,7 +195,7 @@ class EnterprisesReportsFragment : BaseTeamFragment() {
         submit?.setOnClickListener {
             if (isValidReportForm(dialogAddReportBinding)) {
                 val imageUri = selectedImageUri
-                val imageName = imageUri?.let { FileUtils.getDisplayName(requireContext(), it) }
+                val imageName = imageUri?.let { FileUtils.getDisplayName(requireContext(), it, timeProvider) }
                 val imageData = imageUri?.let { FileUtils.readBytesFromUri(requireContext(), it) }
                 viewModel.addReport(
                     description = dialogAddReportBinding.summary.text.toString(),
@@ -278,7 +278,7 @@ class EnterprisesReportsFragment : BaseTeamFragment() {
                 }
 
                 val imageUri = selectedImageUri
-                val imageName = imageUri?.let { FileUtils.getDisplayName(requireContext(), it) }
+                val imageName = imageUri?.let { FileUtils.getDisplayName(requireContext(), it, timeProvider) }
                 val imageData = imageUri?.let { FileUtils.readBytesFromUri(requireContext(), it) }
                 viewModel.updateReport(
                     reportId = reportId,

--- a/app/src/main/java/org/ole/planet/myplanet/utils/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/FileUtils.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.utils
 
 import android.app.PendingIntent
 import android.app.usage.StorageStatsManager
+import org.ole.planet.myplanet.utils.TimeProvider
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInstaller
@@ -174,7 +175,7 @@ object FileUtils {
         }
     }
 
-    fun getDisplayName(context: Context, uri: Uri): String {
+    fun getDisplayName(context: Context, uri: Uri, timeProvider: TimeProvider): String {
         var name: String? = null
         if (uri.scheme == "content") {
             context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
@@ -184,7 +185,7 @@ object FileUtils {
                 }
             }
         }
-        return name ?: uri.lastPathSegment ?: "image_${System.currentTimeMillis()}.jpg"
+        return name ?: uri.lastPathSegment ?: "image_${timeProvider.now()}.jpg"
     }
 
     fun readBytesFromUri(context: Context, uri: Uri): ByteArray? {


### PR DESCRIPTION
Replaced hardcoded `System.currentTimeMillis()` with injected `TimeProvider` in `FileUtils.getDisplayName()` to improve consistency and testability.

Modified:
1. `FileUtils.kt`: Added `timeProvider: TimeProvider` to `getDisplayName`.
2. `BaseResourceFragment.kt`: Added `@Inject lateinit var timeProvider: TimeProvider`.
3. `BellDashboardFragment.kt`: Removed redundant `@Inject lateinit var timeProvider` which hid the supertype member.
4. `EnterprisesFinancesFragment.kt` & `EnterprisesReportsFragment.kt`: Updated `getDisplayName` calls to use the injected `timeProvider`.

Verified changes by compiling with `./gradlew compileDefaultDebugKotlin` and running targeted tests with `./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.utils.FileUtilsTest"`.

---
*PR created automatically by Jules for task [17454510487301705021](https://jules.google.com/task/17454510487301705021) started by @dogi*