### PR TITLE
chat: smoother message model callback diffing (fixes #15102)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6182
-        versionName = "0.61.82"
+        versionCode = 6214
+        versionName = "0.62.14"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/ChatMessage.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ChatMessage.kt
@@ -1,9 +1,12 @@
 package org.ole.planet.myplanet.model
 
+import java.util.UUID
+
 data class ChatMessage(
     val message: String,
     val viewType: Int,
-    val source: Int = 0
+    val source: Int = 0,
+    val id: String = UUID.randomUUID().toString()
 ) {
     companion object {
         const val QUERY = 1

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatAdapter.kt
@@ -24,8 +24,8 @@ class ChatAdapter(
     private val onAnimateTyping: (String, (String) -> Unit, () -> Unit) -> (() -> Unit)
 ) : ListAdapter<ChatMessage, RecyclerView.ViewHolder>(
     DiffUtils.itemCallback(
-        { old, new -> old.message == new.message && old.viewType == new.viewType },
-        { old, new -> old == new }
+        { old, new -> old.id == new.id },
+        { old, new -> old.message == new.message && old.viewType == new.viewType && old.source == new.source }
     )
 ) {
     val animatedMessages = HashMap<Int, Boolean>()


### PR DESCRIPTION
Fix ChatAdapter DiffUtil with proper ID

- Added unique `id` field to `ChatMessage` with `UUID.randomUUID().toString()` as the default.
- Updated `ChatAdapter`'s `DiffUtils.itemCallback` to compare items correctly. `areItemsTheSame` now compares `old.id == new.id`, and `areContentsTheSame` compares `message`, `viewType`, and `source` fields.
- Verified changes by running `./gradlew testDefaultDebugUnitTest --no-daemon`.

---
*PR created automatically by Jules for task [16738819957941399655](https://jules.google.com/task/16738819957941399655) started by @dogi*