### PR TITLE
Fix coroutine leaks in ViewModels

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseDetailViewModel.kt
@@ -107,4 +107,9 @@ class CourseDetailViewModel @Inject constructor(
             }
         }
     }
+
+    override fun onCleared() {
+        super.onCleared()
+        loadJob?.cancel()
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -369,4 +369,12 @@ class DashboardViewModel @Inject constructor(
     fun clearNewNotifications() {
         _uiState.update { it.copy(newNotifications = emptyList()) }
     }
+
+    override fun onCleared() {
+        super.onCleared()
+        libraryJob?.cancel()
+        coursesJob?.cancel()
+        teamsJob?.cancel()
+        profileJob?.cancel()
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesViewModel.kt
@@ -41,4 +41,9 @@ class EnterprisesFinancesViewModel @Inject constructor(
             }
         }
     }
+
+    override fun onCleared() {
+        super.onCleared()
+        transactionsJob?.cancel()
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListViewModel.kt
@@ -41,4 +41,9 @@ class FeedbackListViewModel @Inject constructor(
     fun refreshFeedback() {
         loadFeedback()
     }
+
+    override fun onCleared() {
+        super.onCleared()
+        fetchJob?.cancel()
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
@@ -72,4 +72,9 @@ class ResourcesViewModel @Inject constructor(
             ResourceListModel(library, item, rating, tags)
         }
     }
+
+    override fun onCleared() {
+        super.onCleared()
+        observeOpenedResourcesJob?.cancel()
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
@@ -173,4 +173,10 @@ class TeamViewModel @Inject constructor(
                 onFailure = { TeamActionResult.Failure(it.message) }
             )
     }
+
+    override fun onCleared() {
+        super.onCleared()
+        loadJob?.cancel()
+        loadTaskJob?.cancel()
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesViewModel.kt
@@ -107,4 +107,8 @@ class TeamsVoicesViewModel @Inject constructor(
         return voicesRepository.getLibraryResource(resourceId)
     }
 
+    override fun onCleared() {
+        super.onCleared()
+        observeJob?.cancel()
+    }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesViewModel.kt
@@ -208,4 +208,8 @@ class VoicesViewModel @Inject constructor(
         allLabels.sorted()
     }
 
+    override fun onCleared() {
+        super.onCleared()
+        observeJob?.cancel()
+    }
 }


### PR DESCRIPTION
Fixes coroutine leaks by properly overriding `onCleared()` and manually cancelling stored `Job` instances across ViewModels, as requested by the user. 
Tested with:
`./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.ui.resources.ResourcesViewModelTest" --no-daemon`
`./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.ui.dashboard.DashboardViewModelTest" --no-daemon`
`./gradlew compileDefaultDebugKotlin --no-daemon`

---
*PR created automatically by Jules for task [11068429229460876883](https://jules.google.com/task/11068429229460876883) started by @dogi*