### PR TITLE
Cleanup Realm in StorageCategoryDetailFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
@@ -171,7 +171,7 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
         val oleDir = File(FileUtils.getOlePath(requireContext()))
         if (!oleDir.exists() || !oleDir.isDirectory) return emptyList()
 
-        // Build a map of resourceId → title from Realm (one query)
+        // Build a map of resourceId → title from Room database (one query)
         val titleMap = resourcesRepository.getResourceTitlesMap()
 
         // Group files by resourceId directory
@@ -239,7 +239,7 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
                     }
                 }
 
-                // Sync Realm: mark deleted resources as not offline
+                // Sync database: mark deleted resources as not offline
                 val deletedIds = toDelete.map { it.resourceId }.toSet()
                 resourcesRepository.markResourcesAsNotOffline(deletedIds)
             }


### PR DESCRIPTION
Removed legacy Realm references in comments within `StorageCategoryDetailFragment`. The actual code was already utilizing the correct Room-backed `resourcesRepository`. Tested successfully.

---
*PR created automatically by Jules for task [7904950987197951098](https://jules.google.com/task/7904950987197951098) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated inline comments to accurately reference the current Room database terminology.
  * Clarified that deleted resources are marked as no longer available offline during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->