### PR TITLE
login: smoother settings resetting (fixes #14957)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6166
-        versionName = "0.61.66"
+        versionCode = 6203
+        versionName = "0.62.3"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -261,7 +261,7 @@ class SettingsActivity : AppCompatActivity() {
                     lifecycleScope.launch {
                         val userModel = profileDbHandler.getUserModel()
                         if (userModel?.id?.startsWith("guest") == true) {
-                            org.ole.planet.myplanet.utils.DialogUtils.guestDialog(requireActivity())
+                            guestDialog(requireActivity())
                             return@launch
                         }
                         AlertDialog.Builder(requireActivity())

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -258,10 +258,20 @@ class SettingsActivity : AppCompatActivity() {
             val preference = findPreference<Preference>("reset_app")
             if (preference != null) {
                 preference.onPreferenceClickListener = OnPreferenceClickListener {
-                    AlertDialog.Builder(requireActivity()).setTitle(R.string.are_you_sure)
-                        .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
-                            viewModel.clearAllData()
-                        }.setNegativeButton(R.string.no, null).show()
+                    lifecycleScope.launch {
+                        val userModel = profileDbHandler.getUserModel()
+                        if (userModel?.id?.startsWith("guest") == true) {
+                            org.ole.planet.myplanet.utils.DialogUtils.guestDialog(requireActivity())
+                            return@launch
+                        }
+                        AlertDialog.Builder(requireActivity())
+                            .setTitle(R.string.are_you_sure)
+                            .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
+                                viewModel.clearAllData()
+                            }
+                            .setNegativeButton(R.string.no, null)
+                            .show()
+                    }
                     false
                 }
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -261,7 +261,7 @@ class SettingsActivity : AppCompatActivity() {
                     viewLifecycleOwner.lifecycleScope.launch {
                         val userModel = profileDbHandler.getUserModel()
                         if (userModel?.id?.startsWith("guest") == true) {
-                            guestDialog(requireActivity())
+                            DialogUtils.guestDialog(requireActivity())
                             return@launch
                         }
                         AlertDialog.Builder(requireActivity())

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -258,7 +258,7 @@ class SettingsActivity : AppCompatActivity() {
             val preference = findPreference<Preference>("reset_app")
             if (preference != null) {
                 preference.onPreferenceClickListener = OnPreferenceClickListener {
-                    lifecycleScope.launch {
+                    viewLifecycleOwner.lifecycleScope.launch {
                         val userModel = profileDbHandler.getUserModel()
                         if (userModel?.id?.startsWith("guest") == true) {
                             guestDialog(requireActivity())


### PR DESCRIPTION
fixes: #14957

https://github.com/user-attachments/assets/627c2d9e-7b4b-4508-9967-0cd697bc04bd




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the app reset flow by loading the current user details before showing the confirmation step.
  * Guest accounts now see a guest-specific message, and the reset action is blocked to prevent clearing app data.
  * Regular accounts still see the standard confirmation, and confirming clears all app data.
* **Chores**
  * Updated the app version to **0.62.3**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->