### PR TITLE
🧪 [Add test for onCheckingVersion in ConfigurationsRepository]

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryTest.kt
@@ -1,0 +1,18 @@
+package org.ole.planet.myplanet.repository
+
+import org.junit.Test
+import org.ole.planet.myplanet.model.MyPlanet
+
+class ConfigurationsRepositoryTest {
+
+    @Test
+    fun `CheckVersionCallback default onCheckingVersion does not throw exception`() {
+        val callback = object : ConfigurationsRepository.CheckVersionCallback {
+            override fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean) {}
+            override fun onError(msg: String, blockSync: Boolean) {}
+        }
+
+        // This should run without throwing any exceptions since the default implementation is empty.
+        callback.onCheckingVersion()
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Added a unit test to verify the default implementation of `onCheckingVersion` in `ConfigurationsRepository.CheckVersionCallback` does not throw an exception when called.
📊 **Coverage:** What scenarios are now tested: Calling `onCheckingVersion` on a `CheckVersionCallback` instance that uses the default interface implementation.
✨ **Result:** The improvement in test coverage: Improved test coverage for `ConfigurationsRepository.kt`.

---
*PR created automatically by Jules for task [14242956507886853491](https://jules.google.com/task/14242956507886853491) started by @dogi*