### PR TITLE
🧪 Add test coverage for ConfigurationsRepository onError

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
@@ -92,4 +92,17 @@ class ConfigurationsRepositoryImplTest {
 
         io.mockk.verify(exactly = 1) { appDatabase.clearAllTables() }
     }
+
+    @Test
+    fun `checkVersion calls onError when baseUrl is empty`() = runTest(testDispatcher) {
+        val callback = mockk<ConfigurationsRepository.CheckVersionCallback>(relaxed = true)
+
+        every { sharedPrefManager.isAlternativeUrl() } returns false
+        every { sharedPrefManager.getCouchdbUrl() } returns ""
+        every { context.getString(R.string.server_url_not_configured) } returns "Server url not configured"
+
+        repository.checkVersion(callback, sharedPrefManager)
+
+        io.mockk.verify(exactly = 1) { callback.onError("Server url not configured", true) }
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `onError` function in `ConfigurationsRepository.CheckVersionCallback` was previously untested, primarily when the server URL configuration was empty.
📊 **Coverage:** Added test to `ConfigurationsRepositoryImplTest` to cover the scenario where `checkVersion` calls `onError` when `baseUrl` is empty. This verifies the caller behaves correctly rather than just testing an interface stub.
✨ **Result:** Improved test coverage by explicitly validating the error handling flow for empty configurations in `ConfigurationsRepositoryImpl`.

---
*PR created automatically by Jules for task [3874903826527264000](https://jules.google.com/task/3874903826527264000) started by @dogi*