### PR TITLE
courses: less next button binding is more (fixes #15080)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6194
-        versionName = "0.61.94"
+        versionCode = 6213
+        versionName = "0.62.13"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -277,7 +277,6 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
         } else {
             binding.nextStep.visibility = View.VISIBLE
             binding.nextStep.isClickable = true
-            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
         }
 
         updateStepDisplay(position)
@@ -293,22 +292,19 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
 
                 if (coursesRepository.isStepCompleted(stepId, userModel?.id)) {
                     isNextStepLocked = false
-                    binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
                 } else if (hasExam || hasSurvey) {
                     isNextStepLocked = true
                     lockedStepMessage = when {
                         hasExam -> getString(R.string.please_complete_test)
                         else -> getString(R.string.please_complete_survey)
                     }
-                    binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_grey_500))
+//                    binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_grey_500))
                 } else {
                     isNextStepLocked = false
-                    binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
                 }
             }
         } else {
             isNextStepLocked = false
-            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
         }
     }
     override fun onPageScrollStateChanged(state: Int) {}
@@ -316,11 +312,10 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     private fun onClickNext() {
         binding.tvStep.text = String.format(Locale.getDefault(), "${getString(R.string.step)} %d/%d", binding.viewPager2.currentItem, steps.size)
         if (binding.viewPager2.currentItem >= steps.size) {
-            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_grey_500))
+//            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_grey_500))
             binding.nextStep.visibility = View.GONE
             binding.finishStep.visibility = View.VISIBLE
         } else {
-            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
             binding.nextStep.visibility = View.VISIBLE
             binding.finishStep.visibility = View.GONE
         }
@@ -333,7 +328,6 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
             binding.nextStep.visibility = View.VISIBLE
             binding.finishStep.visibility = View.GONE
         }else{
-            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
             binding.nextStep.visibility = View.VISIBLE
             binding.finishStep.visibility = View.GONE
         }
@@ -417,7 +411,6 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
             }
         } else {
             binding.finishStep.isEnabled = true
-            binding.finishStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))
             binding.finishStep.setOnClickListener {
                 FragmentNavigator.popBackStack(requireActivity().supportFragmentManager)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -298,7 +298,6 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
                         hasExam -> getString(R.string.please_complete_test)
                         else -> getString(R.string.please_complete_survey)
                     }
-//                    binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_grey_500))
                 } else {
                     isNextStepLocked = false
                 }
@@ -312,7 +311,6 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     private fun onClickNext() {
         binding.tvStep.text = String.format(Locale.getDefault(), "${getString(R.string.step)} %d/%d", binding.viewPager2.currentItem, steps.size)
         if (binding.viewPager2.currentItem >= steps.size) {
-//            binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_grey_500))
             binding.nextStep.visibility = View.GONE
             binding.finishStep.visibility = View.VISIBLE
         } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -557,7 +557,7 @@
     <string name="send_survey_to">Send Survey to:</string>
     <string name="send_survey">Send Survey</string>
     <string name="previous">Previous</string>
-    <string name="next">Next</string>
+    <string name="next">next</string>
     <string name="submit_answer">Submit Answer</string>
     <string name="all_task">All Task</string>
     <string name="my_task">My task</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1344,5 +1344,4 @@
     <string name="save_changes">Save Changes</string>
     <string name="resource_updated">Resource updated</string>
     <string name="failed_to_update_resource">Failed to update resource</string>
-
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1344,4 +1344,7 @@
     <string name="save_changes">Save Changes</string>
     <string name="resource_updated">Resource updated</string>
     <string name="failed_to_update_resource">Failed to update resource</string>
+    <string name="join_team_first">Please join a Team to share this chat</string>
+    <string name="join_enterprise_first">Please join an Enterprise to share this chat</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -557,7 +557,7 @@
     <string name="send_survey_to">Send Survey to:</string>
     <string name="send_survey">Send Survey</string>
     <string name="previous">Previous</string>
-    <string name="next">next</string>
+    <string name="next">Next</string>
     <string name="submit_answer">Submit Answer</string>
     <string name="all_task">All Task</string>
     <string name="my_task">My task</string>


### PR DESCRIPTION
fix: #15080

Removed ```binding.finishStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))``` and ```binding.nextStep.setTextColor(ContextCompat.getColor(requireContext(), R.color.md_white_1000))``` seeing that the xml alrady implements daynight colors. The code is overriding the correct colors. 
Capitalized the Next button.



https://github.com/user-attachments/assets/7b2a0812-d293-421d-92bf-92ed70cbd11f




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual consistency in course navigation by preventing unintended text-color changes on Next/Finish and across page transitions.
  * Kept existing behavior for locked steps, enabled states, and survey/completion handling unchanged.
* **Documentation**
  * Updated the navigation label text for the Next action to use “Next” capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->