### PR TITLE
Add text size localization strings for ar, es, fr, ne, so

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1014,6 +1014,11 @@
     <string name="dark_mode_follow_system">اتباع النظام</string>
     <string name="theme_mode_light">فاتح</string>
     <string name="theme_mode_dark">داكن</string>
+    <string name="text_size">حجم النص</string>
+    <string name="select_text_size">اختر حجم النص</string>
+    <string name="text_size_small">صغير</string>
+    <string name="text_size_medium">متوسط</string>
+    <string name="text_size_large">كبير</string>
     <string name="are_you_sure_you_want_to_archive_these_courses">هل أنت متأكد أنك تريد أرشفة هذه الدورات؟</string>
     <string name="are_you_sure_you_want_to_archive_this_course">هل أنت متأكد أنك تريد أرشفة هذه الدورة؟</string>
     <string name="manual">يدوي</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1010,6 +1010,11 @@
     <string name="dark_mode_follow_system">Seguir el sistema</string>
     <string name="theme_mode_light">Claro</string>
     <string name="theme_mode_dark">Oscuro</string>
+    <string name="text_size">tamaño del texto</string>
+    <string name="select_text_size">Seleccionar tamaño de texto</string>
+    <string name="text_size_small">Pequeño</string>
+    <string name="text_size_medium">Mediano</string>
+    <string name="text_size_large">Grande</string>
     <string name="are_you_sure_you_want_to_archive_these_courses">¿Estás seguro de que deseas archivar estos cursos?</string>
     <string name="are_you_sure_you_want_to_archive_this_course">¿Estás seguro de que deseas archivar este curso?</string>
     <string name="manual">manual</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1011,6 +1011,11 @@
     <string name="dark_mode_follow_system">Suivre le système</string>
     <string name="theme_mode_light">Clair</string>
     <string name="theme_mode_dark">Sombre</string>
+    <string name="text_size">taille du texte</string>
+    <string name="select_text_size">Sélectionner la taille du texte</string>
+    <string name="text_size_small">Petit</string>
+    <string name="text_size_medium">Moyen</string>
+    <string name="text_size_large">Grand</string>
     <string name="are_you_sure_you_want_to_archive_these_courses">Etes-vous sûr de vouloir archiver ces cours ?</string>
     <string name="are_you_sure_you_want_to_archive_this_course">Êtes-vous sûr de vouloir archiver ce cours ?</string>
     <string name="manual">manuel</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -1010,6 +1010,11 @@
     <string name="dark_mode_follow_system">प्रणालीको पालना गर्नुहोस्</string>
     <string name="theme_mode_light">उज्यालो</string>
     <string name="theme_mode_dark">अँध्यारो</string>
+    <string name="text_size">पाठको आकार</string>
+    <string name="select_text_size">पाठको आकार छान्नुहोस्</string>
+    <string name="text_size_small">सानो</string>
+    <string name="text_size_medium">मध्यम</string>
+    <string name="text_size_large">ठूलो</string>
     <string name="are_you_sure_you_want_to_archive_these_courses">के तपाइँ यी पाठ्यक्रमहरू संग्रह गर्न निश्चित हुनुहुन्छ?</string>
     <string name="are_you_sure_you_want_to_archive_this_course">के तपाइँ निश्चित हुनुहुन्छ कि तपाइँ यो पाठ्यक्रम संग्रह गर्न चाहनुहुन्छ?</string>
     <string name="manual">हस्तपुस्तिका</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -1010,6 +1010,11 @@
     <string name="dark_mode_follow_system">Raac Nidaamka</string>
     <string name="theme_mode_light">Iftiin</string>
     <string name="theme_mode_dark">Madow</string>
+    <string name="text_size">cabbirka qoraalka</string>
+    <string name="select_text_size">Dooro Cabbirka Qoraalka</string>
+    <string name="text_size_small">Yar</string>
+    <string name="text_size_medium">Dhexdhexaad</string>
+    <string name="text_size_large">Weyn</string>
     <string name="are_you_sure_you_want_to_archive_these_courses">Ma hubtaa inaad rabto inaad kaydiso koorsooyinkan?</string>
     <string name="are_you_sure_you_want_to_archive_this_course">Ma hubtaa inaad rabto inaad kaydiso koorsadan?</string>
     <string name="manual">buug</string>


### PR DESCRIPTION
## Summary
Add localized string resources for text size customization feature across five supported languages (Arabic, Spanish, French, Nepali, and Somali).

## Changes
- Added 5 new string resources to each language file:
  - `text_size`: Label for the text size setting
  - `select_text_size`: Prompt to select text size
  - `text_size_small`: Small size option
  - `text_size_medium`: Medium size option
  - `text_size_large`: Large size option

- Updated language files:
  - `app/src/main/res/values-ar/strings.xml` (Arabic)
  - `app/src/main/res/values-es/strings.xml` (Spanish)
  - `app/src/main/res/values-fr/strings.xml` (French)
  - `app/src/main/res/values-ne/strings.xml` (Nepali)
  - `app/src/main/res/values-so/strings.xml` (Somali)

## Implementation Details
- Strings are inserted after theme mode settings and before archive confirmation dialogs, maintaining consistent organization
- All translations follow the existing naming convention and formatting patterns in each language file
- This enables UI implementation of text size preferences with proper localization support

https://claude.ai/code/session_01UNQkYcoftSfXtZi3oTwGZ5