### PR TITLE
Restrict Make Leader Action to Team Leaders

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersAdapter.kt
@@ -138,27 +138,26 @@ class MembersAdapter(
         if ((isLoggedInUserTeamLeader || isOwnCard) && itemCount > 1) {
             binding.icMore.visibility = View.VISIBLE
             binding.icMore.setOnClickListener {
-                val overflowMenuOptions = if (isOwnCard) {
-                    arrayOf(context.getString(R.string.leave))
-                } else {
-                    arrayOf(
-                        context.getString(R.string.remove),
-                        context.getString(R.string.make_leader)
-                    )
+                val overflowMenuOptions = mutableListOf<String>()
+                if (isOwnCard) {
+                    overflowMenuOptions.add(context.getString(R.string.leave))
+                } else if (isLoggedInUserTeamLeader) {
+                    overflowMenuOptions.add(context.getString(R.string.remove))
+                    overflowMenuOptions.add(context.getString(R.string.make_leader))
+                }
+
+                if (overflowMenuOptions.isEmpty()) {
+                    return@setOnClickListener
                 }
 
                 val builder = AlertDialog.Builder(context, R.style.AlertDialogTheme)
                 val adapter = MemberMenuAdapter(context, overflowMenuOptions.toList())
                 builder.setAdapter(adapter) { _, i ->
-                    if (isOwnCard) {
-                        when (i) {
-                            0 -> actionListener.onLeaveTeam()
-                        }
-                    } else {
-                        when (i) {
-                            0 -> actionListener.onRemoveMember(getItem(position), position)
-                            1 -> actionListener.onMakeLeader(getItem(position))
-                        }
+                    val selectedOption = overflowMenuOptions[i]
+                    when (selectedOption) {
+                        context.getString(R.string.leave) -> actionListener.onLeaveTeam()
+                        context.getString(R.string.remove) -> actionListener.onRemoveMember(getItem(position), position)
+                        context.getString(R.string.make_leader) -> actionListener.onMakeLeader(getItem(position))
                     }
                 }.setNegativeButton(R.string.dismiss, null).show()
             }


### PR DESCRIPTION
Updated MembersAdapter to dynamically build the overflow menu options so that non-leaders are not shown the "Make Leader" or "Remove" options. Refactored the options selection logic to use string comparisons instead of hardcoded index matching, preventing any array index mismatch bugs.

---
*PR created automatically by Jules for task [12389489629597052793](https://jules.google.com/task/12389489629597052793) started by @J-S-webskas*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overflow menu option handling for team members.
  * Ensured available actions are displayed and triggered correctly based on the member’s role and ownership status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->