### PR TITLE
Fix team member three dots refresh/UI update issue

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersAdapter.kt
@@ -69,6 +69,7 @@ class MembersAdapter(
                     holder.binding.tvIsLeader.text = context.getString(R.string.team_leader)
                 }
             }
+            checkUserAndShowOverflowMenu(holder.binding, position)
         } else {
             super.onBindViewHolder(holder, position, payloads)
         }
@@ -168,8 +169,13 @@ class MembersAdapter(
     }
 
     fun updateData(newList: List<JoinedMemberData>, isLoggedInUserTeamLeader: Boolean) {
+        val leaderChanged = this.isLoggedInUserTeamLeader != isLoggedInUserTeamLeader
         this.isLoggedInUserTeamLeader = isLoggedInUserTeamLeader
-        submitList(newList)
+        submitList(newList) {
+            if (leaderChanged) {
+                notifyDataSetChanged()
+            }
+        }
     }
 
     class MembersViewHolder(val binding: RowJoinedUserBinding) :


### PR DESCRIPTION
Fixed an issue where transferring team leadership would not properly refresh the three-dots overflow menu visibility until navigating away and back.
We now track whether the logged-in user's leadership status changes in `MembersAdapter.updateData()` and trigger `notifyDataSetChanged()` inside the `submitList` callback to ensure a complete and immediate UI update of all list items. Additionally, we make sure that partial updates handled in `onBindViewHolder(holder, position, payloads)` also refresh the overflow menu's visibility.

---
*PR created automatically by Jules for task [16386855065134134968](https://jules.google.com/task/16386855065134134968) started by @J-S-webskas*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed team member overflow menus so leader-related updates display consistently.
  * Updated member listings immediately when the signed-in user’s team leader status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->