### PR TITLE
Refactor ResourcesRepositoryImpl to depend on UserRepository instead of UserDao

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -17,7 +17,6 @@ import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TeamDao
-import org.ole.planet.myplanet.data.room.dao.UserDao
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.MyTeam
 import org.ole.planet.myplanet.model.SearchActivity
@@ -40,7 +39,7 @@ class ResourcesRepositoryImpl @Inject constructor(
     private val removedLogDao: RemovedLogDao,
     private val teamsSyncRepositoryLazy: dagger.Lazy<TeamsSyncRepository>,
     private val myLibraryDao: MyLibraryDao,
-    private val userDao: UserDao,
+    private val userRepository: UserRepository,
     private val teamDao: TeamDao
 ) : ResourcesRepository {
 
@@ -385,7 +384,7 @@ class ResourcesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun observeOpenedResourceIds(userId: String): Flow<Set<String>> {
-        val userName = userDao.getById(userId)?.name ?: return flowOf(emptySet())
+        val userName = userRepository.getUserById(userId)?.name ?: return flowOf(emptySet())
 
         return resourceActivityDao.observeByUserAndType(userName, "resource_opened")
             .map { activities -> activities.mapNotNull { it.resourceId }.toSet() }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryBenchmarkTest.kt
@@ -15,7 +15,6 @@ import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TeamDao
-import org.ole.planet.myplanet.data.room.dao.UserDao
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.services.SharedPrefManager
 
@@ -32,7 +31,7 @@ class ResourcesRepositoryBenchmarkTest {
     private val removedLogDao: RemovedLogDao = mockk(relaxed = true)
     private val teamsSyncRepositoryLazy: dagger.Lazy<TeamsSyncRepository> = mockk(relaxed = true)
     private val myLibraryDao: MyLibraryDao = mockk(relaxed = true)
-    private val userDao: UserDao = mockk(relaxed = true)
+    private val userRepository: UserRepository = mockk(relaxed = true)
     private val teamDao: TeamDao = mockk(relaxed = true)
 
     @Before
@@ -48,7 +47,7 @@ class ResourcesRepositoryBenchmarkTest {
             removedLogDao,
             teamsSyncRepositoryLazy,
             myLibraryDao,
-            userDao,
+            userRepository,
             teamDao
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -21,7 +21,6 @@ import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TeamDao
-import org.ole.planet.myplanet.data.room.dao.UserDao
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.SearchActivity
 import org.ole.planet.myplanet.services.SharedPrefManager
@@ -42,7 +41,7 @@ class ResourcesRepositoryImplTest {
     private val teamsRepositoryLazy: Lazy<TeamsRepository> = mockk(relaxed = true)
     private val teamsSyncRepositoryLazy: Lazy<TeamsSyncRepository> = mockk(relaxed = true)
     private val myLibraryDao: MyLibraryDao = mockk(relaxed = true)
-    private val userDao: UserDao = mockk(relaxed = true)
+    private val userRepository: UserRepository = mockk(relaxed = true)
     private val teamDao: TeamDao = mockk(relaxed = true)
 
     private lateinit var repository: ResourcesRepositoryImpl
@@ -62,7 +61,7 @@ class ResourcesRepositoryImplTest {
             removedLogDao,
             teamsSyncRepositoryLazy,
             myLibraryDao,
-            userDao,
+            userRepository,
             teamDao,
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryLibrarySyncTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryLibrarySyncTest.kt
@@ -20,7 +20,6 @@ import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TeamDao
-import org.ole.planet.myplanet.data.room.dao.UserDao
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
@@ -70,7 +69,7 @@ class ResourcesRepositoryLibrarySyncTest {
             mockk<RemovedLogDao>(relaxed = true),
             mockk<dagger.Lazy<TeamsSyncRepository>>(relaxed = true),
             myLibraryDao,
-            mockk<UserDao>(relaxed = true),
+            mockk<UserRepository>(relaxed = true),
             mockk<TeamDao>(relaxed = true),
         )
     }


### PR DESCRIPTION
This change updates `ResourcesRepositoryImpl` to use `UserRepository` instead of the direct `UserDao` dependency. The constructor parameter and internal usages have been updated accordingly, along with all associated unit tests.

---
*PR created automatically by OpenHands for task [9970497506675911433](https://jules.google.com/task/9970497506675911433) started by @dogi*

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b24c422a-4997-4eb4-823c-bec5a8d5d5e4)