### PR TITLE
Remove duplicate/unused API and repository methods

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
@@ -350,7 +350,7 @@ open class BaseDashboardFragment : DashboardPluginFragment(), OnSyncListener {
                         val adapter = HealthUsersAdapter { selected ->
                             selected._id?.let { userId ->
                                 viewLifecycleOwner.lifecycleScope.launch {
-                                    val libraryList = viewModel.getLibraryForSelectedUser(userId)
+                                    val libraryList = viewModel.getLibraryListForUser(userId)
                                     showDownloadDialog(libraryList)
                                 }
                             }

--- a/app/src/main/java/org/ole/planet/myplanet/data/api/ApiInterface.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/api/ApiInterface.kt
@@ -28,9 +28,6 @@ interface ApiInterface {
     suspend fun getJsonObject(@Header("Authorization") header: String?, @Url url: String?): Response<JsonObject>
 
     @POST
-    suspend fun findDocs(@Header("Authorization") header: String?, @Header("Content-Type") c: String?, @Url url: String?, @Body s: JsonObject?): Response<JsonObject>
-
-    @POST
     suspend fun postDoc(@Header("Authorization") header: String?, @Header("Content-Type") c: String?, @Url url: String?, @Body s: JsonObject?): Response<JsonObject>
 
     @POST

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -42,7 +42,6 @@ interface ResourcesRepository {
     suspend fun getLibraryItemsByIds(ids: Collection<String>): List<MyLibrary>
     suspend fun getLibraryItemsByLocalAddress(localAddress: String): List<MyLibrary>
     suspend fun getLibraryListForUser(userId: String?): List<MyLibrary>
-    suspend fun getLibraryForSelectedUser(userId: String): List<MyLibrary>
     suspend fun getMyLibrary(userId: String?): List<MyLibrary>
     suspend fun getAllStepResources(stepId: String?): List<MyLibrary>
     fun getRecentResources(userId: String): Flow<List<MyLibrary>>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -185,10 +185,6 @@ class ResourcesRepositoryImpl @Inject constructor(
             .filter { it.needToUpdate() }
     }
 
-    override suspend fun getLibraryForSelectedUser(userId: String): List<MyLibrary> {
-        return getLibraryListForUser(userId)
-    }
-
     override suspend fun getMyLibrary(userId: String?): List<MyLibrary> {
         if (userId.isNullOrBlank()) return emptyList()
         return myLibraryDao.getForUserPattern(userIdPattern(userId))

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepository.kt
@@ -29,7 +29,6 @@ interface SurveysRepository {
 
     suspend fun adoptSurvey(examId: String, userId: String?, teamId: String?, isTeam: Boolean)
     suspend fun getSurvey(id: String): StepExam?
-    suspend fun getSurveys(): List<StepExam>
     suspend fun getSurveys(ascending: Boolean = false): List<StepExam>
     suspend fun bulkInsertExamsFromSync(jsonArray: JsonArray)
     fun dueRemindersFlow(): Flow<List<String>>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
@@ -372,10 +372,6 @@ class SurveysRepositoryImpl @Inject constructor(
             ?: examDao.getByType("surveys").firstOrNull { it.name == id }
     }
 
-    override suspend fun getSurveys(): List<StepExam> {
-        return examDao.getByType("surveys").map { it }
-    }
-
     override suspend fun getSurveys(ascending: Boolean): List<StepExam> {
         val entities = examDao.getByType("surveys").sortedBy { it.createdDate }
         return (if (ascending) entities else entities.asReversed()).map { it }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -1331,7 +1331,7 @@ class UserRepositoryImpl @Inject constructor(
         }
 
         val response = org.ole.planet.myplanet.data.api.ApiClient.executeWithRetryAndWrap {
-            apiInterface.findDocs(org.ole.planet.myplanet.utils.UrlUtils.header, "application/json", "${org.ole.planet.myplanet.utils.UrlUtils.getUrl()}/shelf/_all_docs?include_docs=true", keysObject)
+            apiInterface.postDoc(org.ole.planet.myplanet.utils.UrlUtils.header, "application/json", "${org.ole.planet.myplanet.utils.UrlUtils.getUrl()}/shelf/_all_docs?include_docs=true", keysObject)
         }?.body()
 
         response?.let { responseBody ->

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/LoginSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/LoginSyncManager.kt
@@ -144,7 +144,7 @@ class LoginSyncManager @Inject constructor(
                 }
 
                 try {
-                    val response = apiInterface.findDocs(header, "application/json", url, `object`)
+                    val response = apiInterface.postDoc(header, "application/json", url, `object`)
                     if (response.isSuccessful && response.body() != null) {
                         val responseBody = response.body()
                         sharedPrefManager.setCommunityLeaders("$responseBody")

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -637,7 +637,7 @@ class SyncManager @Inject constructor(
                 val apiStartTime = SystemClock.elapsedRealtime()
                 var response: JsonObject? = null
                 ApiClient.executeWithRetryAndWrap {
-                    apiInterface.findDocs(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject)
+                    apiInterface.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject)
                 }?.let {
                     response = it.body()
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/TransactionSyncManager.kt
@@ -222,7 +222,7 @@ class TransactionSyncManager @Inject constructor(
                 }
                 val batchStartTime = SystemClock.elapsedRealtime()
                 val batchApiStartTime = SystemClock.elapsedRealtime()
-                val response = apiInterface.findDocs(
+                val response = apiInterface.postDoc(
                     authHeader,
                     "application/json",
                     "$url/$table/_all_docs?include_docs=true&limit=$pageSize&skip=$skip",

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -169,10 +169,6 @@ class DashboardViewModel @Inject constructor(
         return teamsRepository.getTeamType(teamId)
     }
 
-    suspend fun getLibraryForSelectedUser(userId: String): List<MyLibrary> {
-        return resourcesRepository.getLibraryForSelectedUser(userId)
-    }
-
     suspend fun getLibraryListForUser(userId: String?): List<MyLibrary> {
         return resourcesRepository.getLibraryListForUser(userId)
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/TransactionSyncManagerCheckpointTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/TransactionSyncManagerCheckpointTest.kt
@@ -142,7 +142,7 @@ class TransactionSyncManagerCheckpointTest {
 
     @Test
     fun `checkpoint persists the committed batch boundary`() = runBlocking {
-        coEvery { apiInterface.findDocs(any(), any(), any(), any()) } returnsMany
+        coEvery { apiInterface.postDoc(any(), any(), any(), any()) } returnsMany
             listOf(rowsResponse(20), rowsResponse(0))
         coEvery { ratingsRepository.insertRatingsFromSync(any()) } returns Unit
 
@@ -158,7 +158,7 @@ class TransactionSyncManagerCheckpointTest {
     // re-flagged by runTest's uncaught-exception detection as it unwinds the withContext child.
     @Test
     fun `checkpoint does not advance past a batch that failed to commit`() = runBlocking {
-        coEvery { apiInterface.findDocs(any(), any(), any(), any()) } returns rowsResponse(20)
+        coEvery { apiInterface.postDoc(any(), any(), any(), any()) } returns rowsResponse(20)
         coEvery { ratingsRepository.insertRatingsFromSync(any()) } throws RuntimeException("insert boom")
 
         val total = transactionSyncManager.syncDb("ratings", useCheckpoint = true)
@@ -174,7 +174,7 @@ class TransactionSyncManagerCheckpointTest {
     // withContext boundary isn't misread by runTest's uncaught-exception detection.
     @Test
     fun `cancellation propagates instead of being swallowed`() = runBlocking {
-        coEvery { apiInterface.findDocs(any(), any(), any(), any()) } throws
+        coEvery { apiInterface.postDoc(any(), any(), any(), any()) } throws
             CancellationException("worker stopped")
 
         try {


### PR DESCRIPTION
## Summary
This PR removes redundant method overloads and unused API endpoints that were superseded by more general implementations. The changes consolidate duplicate functionality and clean up the codebase.

## Key Changes

- **API Interface (`ApiInterface.kt`)**: Removed the `findDocs()` method which was a duplicate POST endpoint; all call sites now use the more appropriately named `postDoc()` method instead.

- **Repository Interfaces & Implementations**:
  - Removed `getLibraryForSelectedUser()` from `ResourcesRepository` and `ResourcesRepositoryImpl` — this was a simple wrapper around `getLibraryListForUser()` with identical behavior
  - Removed parameterless `getSurveys()` from `SurveysRepository` and `SurveysRepositoryImpl` — the overloaded version with `ascending` parameter provides the same functionality with more control

- **ViewModel**: Removed `getLibraryForSelectedUser()` from `DashboardViewModel` which only delegated to the repository method being removed

- **UI & Service Updates**: Updated all call sites to use the consolidated methods:
  - `BaseDashboardFragment.kt`: Changed `getLibraryForSelectedUser()` → `getLibraryListForUser()`
  - `UserRepositoryImpl.kt`, `LoginSyncManager.kt`, `SyncManager.kt`, `TransactionSyncManager.kt`: Changed `findDocs()` → `postDoc()`

- **Tests**: Updated mock expectations in `TransactionSyncManagerCheckpointTest.kt` to use `postDoc()` instead of `findDocs()`

## Implementation Details
All removed methods were either:
1. Simple wrappers with no additional logic
2. Duplicate endpoints with confusing naming (`findDocs` vs `postDoc` for the same POST operation)
3. Superseded by more flexible overloaded versions

The changes maintain full backward compatibility in behavior while reducing code duplication and improving API clarity.

https://claude.ai/code/session_01HwwoC8uH1px6BBSjGjgsdg