### PR TITLE
Remove duplicate postUploadArray method from UploadRepositoryImpl

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
@@ -64,13 +64,6 @@ class UploadRepositoryImpl @Inject constructor(
         return apiInterface.postDocArray(UrlUtils.header, "application/json", url, serializedData)
     }
 
-    override suspend fun postUploadArray(
-        url: String,
-        serializedData: JsonObject
-    ): Response<com.google.gson.JsonArray> {
-        return apiInterface.postDocArray(UrlUtils.header, "application/json", url, serializedData)
-    }
-
     override suspend fun putUpload(
         url: String,
         serializedData: JsonObject


### PR DESCRIPTION
## Summary
Removed a duplicate `postUploadArray` method from `UploadRepositoryImpl` that was identical to the existing `postDocArray` method, reducing code duplication in the repository layer.

## Changes
- **Removed**: Duplicate `postUploadArray` suspend function override that delegated to `apiInterface.postDocArray()` with identical parameters and return type as the existing `postDocArray` method

## Details
The removed method was a redundant override that served no distinct purpose—it simply forwarded calls to the same underlying API method as `postDocArray`. This cleanup improves code maintainability by eliminating unnecessary duplication in the repository pattern implementation.

https://claude.ai/code/session_01F3hJgLyA7BAKfirKxfzjKh