### PR TITLE
Add offline submissions (list/detail/upload/export) to Flutter port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,11 @@
 
 ### Flutter port (in progress)
 A Flutter/Dart port lives in **`flutter/`**, alongside — not replacing — the Kotlin app. `app/`
-is unchanged and remains the shipping app. **12 of 28 UI packages** are ported, plus a durable
+is unchanged and remains the shipping app. **13 of 28 UI packages** are ported, plus a durable
 write-back path. The first vertical slice ran server configuration → login → resources list;
 since then the dashboard shell, courses, calendar, first-launch onboarding, the offline user
 profile, appearance settings, the dictionary, notifications, My life, references, personals, and
-ratings have landed. Everything below in this document describes the Kotlin app and still
+ratings, and the offline submissions flow with question-aware answer review have landed. Everything below in this document describes the Kotlin app and still
 applies to it.
 
 See **`docs/kotlin-to-flutter-migration.md`** for scope, the technology mapping (Hilt→Riverpod,

--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -5,8 +5,8 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 
 ## Status
 
-**Phase 13 complete.** The Flutter app builds (debug APK verified), analyzes clean, and passes its
-test suite. It is *not* yet a replacement for the Kotlin app: **12 of 28 UI packages** are ported.
+**Phase 14 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
+**13 of 28 UI packages** are ported.
 
 - **Phase 1** — skeleton plus the server configuration → login → resources slice.
 - **Phase 2** — dashboard shell (bottom-tab navigation) plus the courses list and detail.
@@ -23,6 +23,9 @@ test suite. It is *not* yet a replacement for the Kotlin app: **12 of 28 UI pack
 - **Phase 12** — offline course ratings, comments, aggregates, edits, and upload tracking.
 - **Phase 13** — durable write-back: an outbox replacing `RetryQueue`/`RetryQueueWorker`, drained
   on app resume, with personal-note upload as its first append-style path.
+- **Phase 14** — offline submission creation, durable upload, list, question-aware answer review, PDF export, and detail metadata, backed by a paginated,
+  reactive Drift cache with pull-to-refresh, status filters, progress reporting, and safe stale
+  cleanup.
 
 ## Strategy
 
@@ -76,6 +79,7 @@ test suite. It is *not* yet a replacement for the Kotlin app: **12 of 28 UI pack
 | Ratings (course UI/offline data) | `RatingsFragment`, `RatingsRepositoryImpl` | `ui/ratings/rating_dialog.dart`, `repository/ratings_repository.dart` |
 | Durable write-back queue | `services/retry/RetryQueue.kt`, `RetryQueueWorker`, `model/RetryOperation.kt` | `repository/outbox_repository.dart`, `repository/outbox_drainer.dart`, `ui/outbox_drain_scope.dart` |
 | Personal-note upload | `PersonalsRepositoryImpl.uploadPersonalDocument`, `Personal.serialize` | `repository/personals_uploader.dart` |
+| Submissions create/upload/list/detail/answers | `Submission`, `Answer`, `SubmissionDao`, `UploadConfigs.Submissions`, `SubmissionsFragment`, `SubmissionDetailFragment` | `repository/submissions_repository.dart`, `repository/submissions_uploader.dart`, `ui/submissions/submissions_screen.dart`, `ui/submissions/submission_detail_screen.dart` |
 
 `SharedPrefManager.getFirstLaunch()` is misleadingly named: it defaults to `false` and is set to
 `true` once onboarding finishes, so it actually means "onboarding already done". The port stores
@@ -238,7 +242,7 @@ Ordered by risk, highest first.
 
 `chat`, `community`, `components`, `enterprises`, `events`, `exam`,
 `feedback`, `health`, `maps`,
-`submissions`, `surveys`, `teams`, `viewer`, `voices` — plus personal attachments/upload,
+`surveys`, `teams`, `viewer`, `voices` — plus submission answers/create/export, personal attachments/upload,
 rating upload/sync, storage/retry, and the
 rest of `settings`, plus profile photo/upload, membership, and the rest of `user`, and the
 rest of `sync` and `dashboard` (the Kotlin dashboard's activity cards, surveys widget and drawer
@@ -302,4 +306,4 @@ succeeds, it just doesn't do what the Kotlin did.
 ---
 
 **Last updated**: 2026-08-03
-**Phase**: 13 of N (durable write-back)
+**Phase**: 14 of N (offline submissions list)

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -8,11 +8,12 @@ it covers scope, the technology mapping, what is deliberately not improved, and 
 
 ## Status
 
-Phases 1–13 provide server configuration, online/offline login, resources, courses, shelf
+Phases 1–14 provide server configuration, online/offline login, resources, courses, shelf
 write-back, the dashboard shell, calendar, first-launch onboarding, an offline-editable user
 profile, persisted appearance settings, safe server details, an offline dictionary, reactive
 notifications, personalized My life/reference navigation, offline personal items, and course
-ratings. **12 of 28 UI packages are ported**, offline-first, against the real CouchDB API.
+ratings, and offline submission creation/durable upload/list/detail/question-aware answer review/PDF export with paginated refresh and status filters.
+**13 of 28 UI packages are ported**, offline-first, against the real CouchDB API.
 
 Phase 13 added the durable write-back path — an `outbox` table replacing `RetryQueue`, drained
 on app resume by `OutboxDrainer` instead of by `WorkManager`. Writes made offline survive

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -33,6 +33,9 @@ part 'app_database.g.dart';
     PersonalEntries,
     Ratings,
     OutboxEntries,
+    Submissions,
+    SubmissionAnswers,
+    SubmissionQuestions,
   ],
   daos: [
     UserDao,
@@ -45,6 +48,7 @@ part 'app_database.g.dart';
     PersonalDao,
     RatingDao,
     OutboxDao,
+    SubmissionDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -57,7 +61,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.memory() : super(NativeDatabase.memory());
 
   @override
-  int get schemaVersion => 9;
+  int get schemaVersion => 12;
 
   /// Tables holding local intent the server cannot give back.
   ///
@@ -72,6 +76,9 @@ class AppDatabase extends _$AppDatabase {
     'my_personal',
     'removed_log',
     'my_life',
+    'submissions',
+    'submission_answers',
+    'submission_questions',
   };
 
   @override
@@ -831,4 +838,131 @@ class OutboxDao extends DatabaseAccessor<AppDatabase> with _$OutboxDaoMixin {
   Future<int> cleanup() => (delete(
     outboxEntries,
   )..where((row) => row.status.isIn([statusCompleted, statusAbandoned]))).go();
+}
+
+/// Port of `data/room/dao/SubmissionDao.kt` for the offline submissions list.
+@DriftAccessor(tables: [Submissions, SubmissionAnswers, SubmissionQuestions])
+class SubmissionDao extends DatabaseAccessor<AppDatabase>
+    with _$SubmissionDaoMixin {
+  SubmissionDao(super.db);
+
+  Stream<List<SubmissionRow>> watchForUser(String userId) =>
+      (select(submissions)
+            ..where((row) => row.userId.equals(userId))
+            ..orderBy([
+              (row) => OrderingTerm(
+                expression: row.lastUpdateTime,
+                mode: OrderingMode.desc,
+              ),
+            ]))
+          .watch();
+
+  Future<void> upsertAll(
+    List<SubmissionsCompanion> rows, {
+    Map<String, List<SubmissionAnswersCompanion>> answers = const {},
+    Map<String, List<SubmissionQuestionsCompanion>> questions = const {},
+  }) async {
+    await transaction(() async {
+      await batch(
+        (batch) => batch.insertAllOnConflictUpdate(submissions, rows),
+      );
+      for (final entry in answers.entries) {
+        await (delete(
+          submissionAnswers,
+        )..where((row) => row.submissionId.equals(entry.key))).go();
+        if (entry.value.isNotEmpty) {
+          await batch(
+            (batch) => batch.insertAll(submissionAnswers, entry.value),
+          );
+        }
+      }
+      for (final entry in questions.entries) {
+        await (delete(
+          submissionQuestions,
+        )..where((row) => row.submissionId.equals(entry.key))).go();
+        if (entry.value.isNotEmpty) {
+          await batch(
+            (batch) => batch.insertAll(submissionQuestions, entry.value),
+          );
+        }
+      }
+    });
+  }
+
+  Future<SubmissionRow?> getById(String id) =>
+      (select(submissions)
+            ..where((row) => row.id.equals(id) | row.couchId.equals(id))
+            ..limit(1))
+          .getSingleOrNull();
+
+  Stream<SubmissionRow?> watchById(String id) =>
+      (select(submissions)
+            ..where((row) => row.id.equals(id) | row.couchId.equals(id))
+            ..limit(1))
+          .watchSingleOrNull();
+
+  Stream<List<SubmissionAnswerRow>> watchAnswers(String submissionId) =>
+      (select(submissionAnswers)
+            ..where((row) => row.submissionId.equals(submissionId))
+            ..orderBy([(row) => OrderingTerm(expression: row.id)]))
+          .watch();
+
+  Stream<List<SubmissionQuestionRow>> watchQuestions(String submissionId) =>
+      (select(submissionQuestions)
+            ..where((row) => row.submissionId.equals(submissionId))
+            ..orderBy([(row) => OrderingTerm(expression: row.position)]))
+          .watch();
+
+  Future<int> count() async {
+    final count = submissions.id.count();
+    final row = await (selectOnly(
+      submissions,
+    )..addColumns([count])).getSingle();
+    return row.read(count) ?? 0;
+  }
+
+  Future<List<SubmissionRow>> pendingUploads(String userId) =>
+      (select(submissions)..where(
+            (row) => row.userId.equals(userId) & row.isUpdated.equals(true),
+          ))
+          .get();
+
+  Future<int> markUploaded(String id, String couchId, String rev) =>
+      (update(submissions)..where((row) => row.id.equals(id))).write(
+        SubmissionsCompanion(
+          couchId: Value(couchId),
+          rev: Value(rev),
+          uploaded: const Value(true),
+          isUpdated: const Value(false),
+        ),
+      );
+
+  /// Removes stale server-cache rows without binding an unbounded `NOT IN`.
+  Future<int> deleteNotIn(List<String> keepIds) async {
+    return transaction(() async {
+      final localIds =
+          await (selectOnly(submissions)
+                ..addColumns([submissions.id])
+                ..where(submissions.isUpdated.equals(false)))
+              .map((row) => row.read(submissions.id)!)
+              .get();
+      final keep = keepIds.toSet();
+      var deleted = 0;
+      for (final chunk in _chunked(
+        localIds.where((id) => !keep.contains(id)).toList(),
+        _sqliteVariableChunk,
+      )) {
+        await (delete(
+          submissionAnswers,
+        )..where((row) => row.submissionId.isIn(chunk))).go();
+        await (delete(
+          submissionQuestions,
+        )..where((row) => row.submissionId.isIn(chunk))).go();
+        deleted += await (delete(
+          submissions,
+        )..where((row) => row.id.isIn(chunk))).go();
+      }
+      return deleted;
+    });
+  }
 }

--- a/flutter/lib/data/local/tables.dart
+++ b/flutter/lib/data/local/tables.dart
@@ -352,3 +352,76 @@ class Ratings extends Table {
   @override
   Set<Column> get primaryKey => {id};
 }
+
+/// Port of `model/Submission.kt`.
+@DataClassName('SubmissionRow')
+@TableIndex(
+  name: 'submissions_user_updated',
+  columns: {#userId, #lastUpdateTime},
+)
+class Submissions extends Table {
+  TextColumn get id => text()();
+  TextColumn get couchId => text().named('_id').nullable()();
+  TextColumn get rev => text().named('_rev').nullable()();
+  TextColumn get parentId => text().nullable()();
+  TextColumn get type => text().nullable()();
+  TextColumn get userId => text().nullable()();
+  TextColumn get user => text().nullable()();
+  IntColumn get startTime => integer().withDefault(const Constant(0))();
+  IntColumn get lastUpdateTime => integer().withDefault(const Constant(0))();
+  IntColumn get grade => integer().withDefault(const Constant(0))();
+  TextColumn get status => text().nullable()();
+  BoolColumn get uploaded => boolean().withDefault(const Constant(false))();
+  TextColumn get sender => text().nullable()();
+  TextColumn get source => text().nullable()();
+  TextColumn get parentCode => text().nullable()();
+  TextColumn get parent => text().nullable()();
+  TextColumn get teamId => text().nullable()();
+  BoolColumn get isUpdated => boolean().withDefault(const Constant(false))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// Port of `model/Answer.kt`. Answers are authored with a submission and are
+/// cached separately, matching Room's `answers` table in the Kotlin app.
+@DataClassName('SubmissionAnswerRow')
+@TableIndex(name: 'submission_answers_submission', columns: {#submissionId})
+class SubmissionAnswers extends Table {
+  TextColumn get id => text()();
+  TextColumn get submissionId => text()();
+  TextColumn get examId => text().nullable()();
+  TextColumn get questionId => text().nullable()();
+  TextColumn get value => text().nullable()();
+  TextColumn get valueChoices => text()
+      .map(const StringListConverter())
+      .withDefault(const Constant('[]'))();
+  IntColumn get mistakes => integer().withDefault(const Constant(0))();
+  BoolColumn get isPassed => boolean().withDefault(const Constant(false))();
+  IntColumn get grade => integer().withDefault(const Constant(0))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// Embedded exam/survey question metadata from `model/ExamQuestion.kt`.
+@DataClassName('SubmissionQuestionRow')
+@TableIndex(name: 'submission_questions_submission', columns: {#submissionId})
+class SubmissionQuestions extends Table {
+  TextColumn get id => text()();
+  TextColumn get submissionId => text()();
+  TextColumn get header => text().nullable()();
+  TextColumn get body => text().nullable()();
+  TextColumn get type => text().nullable()();
+  TextColumn get correctChoices => text()
+      .map(const StringListConverter())
+      .withDefault(const Constant('[]'))();
+  TextColumn get choices => text()
+      .map(const StringListConverter())
+      .withDefault(const Constant('[]'))();
+  TextColumn get marks => text().nullable()();
+  IntColumn get position => integer()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -197,6 +197,48 @@
   "myHealth": "My health",
   "achievements": "Achievements",
   "submissions": "Submissions",
+  "submission": "Submission",
+  "submissionsUnavailable": "Submissions are unavailable",
+  "noSubmissions": "No submissions yet",
+  "pending": "Pending",
+  "submissionGrade": "Grade: {grade}",
+  "@submissionGrade": {
+    "placeholders": { "grade": { "type": "int" } }
+  },
+  "refresh": "Refresh",
+  "complete": "Complete",
+  "noMatchingSubmissions": "No submissions match this filter",
+  "submissionsSynced": "{count, plural, =0{Submissions are up to date} =1{1 submission synced} other{{count} submissions synced}}",
+  "@submissionsSynced": {
+    "placeholders": { "count": { "type": "int" } }
+  },
+  "submissionDetails": "Submission details",
+  "submissionNotFound": "Submission not found",
+  "unknown": "Unknown",
+  "status": "Status",
+  "lastUpdated": "Last updated",
+  "grade": "Grade",
+  "submittedBy": "Submitted by",
+  "submissionType": "Type",
+  "uploadStatus": "Upload status",
+  "uploaded": "Uploaded",
+  "answers": "Answers",
+  "answersUnavailable": "Answers are unavailable",
+  "noAnswers": "No answers were saved with this submission",
+  "noAnswer": "No answer",
+  "questionNumber": "Question {number}",
+  "@questionNumber": {
+    "placeholders": { "number": { "type": "int" } }
+  },
+  "newSubmission": "New submission",
+  "answer": "Answer",
+  "availableChoices": "Choices",
+  "exportPdf": "Export PDF",
+  "pdfExportFailed": "The PDF could not be created",
+  "pdfSaved": "PDF saved to {path}",
+  "@pdfSaved": {
+    "placeholders": { "path": { "type": "String" } }
+  },
   "mySurveys": "My surveys",
   "references": "References",
   "myPersonals": "My personals",

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -18,6 +18,9 @@ import '../repository/life_repository.dart';
 import '../repository/resources_repository.dart';
 import '../repository/shelf_repository.dart';
 import '../repository/user_repository.dart';
+import '../repository/submissions_repository.dart';
+import '../repository/submissions_uploader.dart';
+import '../repository/submissions_exporter.dart';
 
 /// The dependency graph, replacing the Hilt modules in `di/`.
 ///
@@ -74,6 +77,29 @@ final personalDaoProvider = Provider<PersonalDao>(
 
 final ratingDaoProvider = Provider<RatingDao>(
   (ref) => ref.watch(appDatabaseProvider).ratingDao,
+);
+
+final submissionDaoProvider = Provider<SubmissionDao>(
+  (ref) => ref.watch(appDatabaseProvider).submissionDao,
+);
+
+final submissionsRepositoryProvider = Provider<SubmissionsRepository>(
+  (ref) => SubmissionsRepository(
+    ref.watch(planetApiProvider),
+    ref.watch(submissionDaoProvider),
+  ),
+);
+
+final submissionsUploaderProvider = Provider<SubmissionsUploader>(
+  (ref) => SubmissionsUploader(
+    ref.watch(planetApiProvider),
+    ref.watch(submissionsRepositoryProvider),
+    ref.watch(outboxRepositoryProvider),
+  ),
+);
+
+final submissionsExporterProvider = Provider<SubmissionsExporter>(
+  (ref) => SubmissionsExporter(ref.watch(submissionsRepositoryProvider)),
 );
 
 /// Replaces `NetworkModule`.
@@ -158,14 +184,19 @@ final personalsUploaderProvider = Provider<PersonalsUploader>(
 /// verbatim from the stored payload.
 final outboxDrainerProvider = Provider<OutboxDrainer>((ref) {
   final uploader = ref.watch(personalsUploaderProvider);
+  final submissionsUploader = ref.watch(submissionsUploaderProvider);
   final config = ref.watch(serverConfigProvider);
   if (config != null) {
     uploader.authHeader = PersonalsUploader.authHeaderFor(config);
+    submissionsUploader.authHeader = PersonalsUploader.authHeaderFor(config);
   }
   return OutboxDrainer(
     ref.watch(planetApiProvider),
     ref.watch(outboxRepositoryProvider),
-    handlers: {PersonalsUploader.type: uploader.handler},
+    handlers: {
+      PersonalsUploader.type: uploader.handler,
+      SubmissionsUploader.type: submissionsUploader.handler,
+    },
   );
 });
 

--- a/flutter/lib/providers/submissions_provider.dart
+++ b/flutter/lib/providers/submissions_provider.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/local/app_database.dart';
+import 'app_providers.dart';
+import 'session_provider.dart';
+
+/// State for the port of `ui/submissions/SubmissionsFragment.kt`.
+final submissionsProvider = StreamProvider<List<SubmissionRow>>((ref) {
+  final user = ref.watch(sessionProvider).valueOrNull;
+  if (user == null) return Stream.value(const []);
+  return ref.watch(submissionsRepositoryProvider).watchForUser(user.id);
+});
+
+final submissionProvider = StreamProvider.family<SubmissionRow?, String>(
+  (ref, id) => ref.watch(submissionsRepositoryProvider).watchById(id),
+);
+
+final submissionAnswersProvider =
+    StreamProvider.family<List<SubmissionAnswerRow>, String>(
+      (ref, id) => ref.watch(submissionsRepositoryProvider).watchAnswers(id),
+    );
+
+final submissionQuestionsProvider =
+    StreamProvider.family<List<SubmissionQuestionRow>, String>(
+      (ref, id) => ref.watch(submissionsRepositoryProvider).watchQuestions(id),
+    );

--- a/flutter/lib/repository/submissions_exporter.dart
+++ b/flutter/lib/repository/submissions_exporter.dart
@@ -1,0 +1,142 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+
+import '../data/local/app_database.dart';
+import 'submissions_repository.dart';
+
+/// Dart port of `SubmissionsRepositoryExporter` using the cross-platform PDF
+/// package rather than Android's `PdfDocument` and `Canvas` APIs.
+class SubmissionsExporter {
+  const SubmissionsExporter(this._repository);
+
+  final SubmissionsRepository _repository;
+
+  Future<Uint8List?> generateBytes(String submissionId) async {
+    final submission = await _repository.getById(submissionId);
+    if (submission == null) return null;
+    final answers = await _repository.watchAnswers(submission.id).first;
+    final questions = await _repository.watchQuestions(submission.id).first;
+    final answersByQuestion = {
+      for (final answer in answers) answer.questionId: answer,
+    };
+    final document = pw.Document(
+      title: submission.parent ?? 'Submission report',
+      author: 'myPlanet',
+    );
+    document.addPage(
+      pw.MultiPage(
+        pageFormat: PdfPageFormat.a4,
+        margin: const pw.EdgeInsets.all(48),
+        build: (_) => [
+          pw.Header(
+            level: 0,
+            child: pw.Text(submission.parent ?? 'Submission report'),
+          ),
+          _metadata(submission),
+          pw.SizedBox(height: 20),
+          if (questions.isEmpty && answers.isEmpty)
+            pw.Text('No answers were saved with this submission.'),
+          for (var index = 0; index < questions.length; index++)
+            _question(
+              index,
+              questions[index],
+              answersByQuestion[_rawQuestionId(questions[index])],
+            ),
+          if (questions.isEmpty)
+            for (var index = 0; index < answers.length; index++)
+              _answerOnly(index, answers[index]),
+        ],
+        footer: (context) => pw.Align(
+          alignment: pw.Alignment.centerRight,
+          child: pw.Text('Page ${context.pageNumber} of ${context.pagesCount}'),
+        ),
+      ),
+    );
+    return document.save();
+  }
+
+  Future<File?> generateFile(
+    String submissionId, {
+    Directory? directory,
+  }) async {
+    final bytes = await generateBytes(submissionId);
+    if (bytes == null) return null;
+    final target = directory ?? await getApplicationDocumentsDirectory();
+    final folder = Directory(p.join(target.path, 'Submissions'));
+    await folder.create(recursive: true);
+    final safeId = submissionId.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), '_');
+    final file = File(
+      p.join(
+        folder.path,
+        'submission_${safeId}_${DateTime.now().millisecondsSinceEpoch}.pdf',
+      ),
+    );
+    await file.writeAsBytes(bytes, flush: true);
+    return file;
+  }
+
+  pw.Widget _metadata(SubmissionRow row) => pw.Table(
+    columnWidths: const {0: pw.FixedColumnWidth(90)},
+    children: [
+      _metadataRow('Status', row.status ?? 'Pending'),
+      _metadataRow('Submitted by', row.user ?? row.userId ?? 'Unknown'),
+      _metadataRow('Grade', '${row.grade}'),
+      _metadataRow(
+        'Updated',
+        row.lastUpdateTime == 0
+            ? 'Unknown'
+            : DateFormat.yMMMd().add_jm().format(
+                DateTime.fromMillisecondsSinceEpoch(row.lastUpdateTime),
+              ),
+      ),
+    ],
+  );
+
+  pw.TableRow _metadataRow(String label, String value) => pw.TableRow(
+    children: [
+      pw.Text(label, style: pw.TextStyle(fontWeight: pw.FontWeight.bold)),
+      pw.Text(value),
+    ],
+  );
+
+  pw.Widget _question(
+    int index,
+    SubmissionQuestionRow question,
+    SubmissionAnswerRow? answer,
+  ) => pw.Container(
+    margin: const pw.EdgeInsets.only(bottom: 16),
+    child: pw.Column(
+      crossAxisAlignment: pw.CrossAxisAlignment.start,
+      children: [
+        pw.Text(
+          'Q${index + 1}: ${question.header ?? question.body ?? ''}',
+          style: pw.TextStyle(fontWeight: pw.FontWeight.bold),
+        ),
+        if (question.body != null && question.header != null)
+          pw.Text(question.body!),
+        pw.SizedBox(height: 4),
+        pw.Text('A: ${answer == null ? 'No answer' : _answerValue(answer)}'),
+        if (question.marks != null) pw.Text('Marks: ${question.marks}'),
+      ],
+    ),
+  );
+
+  pw.Widget _answerOnly(int index, SubmissionAnswerRow answer) => pw.Paragraph(
+    text:
+        'Q${index + 1}: ${answer.questionId ?? ''}\nA: ${_answerValue(answer)}',
+  );
+
+  String _answerValue(SubmissionAnswerRow answer) =>
+      answer.valueChoices.isNotEmpty
+      ? answer.valueChoices.join(', ')
+      : answer.value ?? 'No answer';
+
+  String _rawQuestionId(SubmissionQuestionRow question) =>
+      question.id.substring(question.id.indexOf(':') + 1);
+}

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -1,0 +1,315 @@
+import 'package:drift/drift.dart';
+import 'package:crypto/crypto.dart';
+import 'dart:convert';
+
+import '../core/config/server_config.dart';
+import '../core/network/network_result.dart';
+import '../core/sync/adaptive_batch_processor.dart';
+import '../core/sync/sync_result.dart';
+import '../core/utils/json_utils.dart';
+import '../core/utils/url_utils.dart';
+import '../data/api/planet_api.dart';
+import '../data/local/app_database.dart';
+
+/// Offline list portion of `repository/SubmissionsRepositoryImpl.kt`.
+class SubmissionsRepository {
+  const SubmissionsRepository(this._api, this._dao);
+
+  static const int initialBatchSize = 100;
+
+  final PlanetApi _api;
+  final SubmissionDao _dao;
+
+  Stream<List<SubmissionRow>> watchForUser(String userId) =>
+      _dao.watchForUser(userId);
+
+  Stream<SubmissionRow?> watchById(String id) => _dao.watchById(id);
+  Stream<List<SubmissionAnswerRow>> watchAnswers(String submissionId) =>
+      _dao.watchAnswers(submissionId);
+  Stream<List<SubmissionQuestionRow>> watchQuestions(String submissionId) =>
+      _dao.watchQuestions(submissionId);
+  Future<SubmissionRow?> getById(String id) => _dao.getById(id);
+  Future<int> localCount() => _dao.count();
+
+  Future<String> createDraft({
+    required String userId,
+    required String type,
+    required String title,
+    required List<SubmissionDraftAnswer> answers,
+    DateTime? now,
+  }) async {
+    final timestamp = (now ?? DateTime.now()).millisecondsSinceEpoch;
+    final id = sha1
+        .convert(utf8.encode('$userId:$timestamp:$title'))
+        .toString();
+    await _dao.upsertAll(
+      [
+        SubmissionsCompanion.insert(
+          id: id,
+          userId: Value(userId),
+          type: Value(type),
+          parent: Value(title.trim()),
+          startTime: Value(timestamp),
+          lastUpdateTime: Value(timestamp),
+          status: const Value('pending'),
+          uploaded: const Value(false),
+          isUpdated: const Value(true),
+        ),
+      ],
+      answers: {
+        id: [
+          for (var index = 0; index < answers.length; index++)
+            SubmissionAnswersCompanion.insert(
+              id: '$id:${answers[index].questionId ?? index}',
+              submissionId: id,
+              questionId: Value(answers[index].questionId),
+              value: Value(answers[index].value),
+              valueChoices: Value(answers[index].choices),
+            ),
+        ],
+      },
+    );
+    return id;
+  }
+
+  Future<List<SubmissionRow>> pendingUploads(String userId) =>
+      _dao.pendingUploads(userId);
+
+  Future<void> markUploaded(String id, String couchId, String rev) async {
+    await _dao.markUploaded(id, couchId, rev);
+  }
+
+  Future<Map<String, dynamic>> serialize(SubmissionRow row) async {
+    final answers = await _dao.watchAnswers(row.id).first;
+    return {
+      'type': row.type,
+      'userId': row.userId,
+      'user': row.user,
+      'parentId': row.parentId,
+      'parent': row.parent,
+      'startTime': row.startTime,
+      'lastUpdateTime': row.lastUpdateTime,
+      'status': row.status,
+      'grade': row.grade,
+      'answers': [
+        for (final answer in answers)
+          {
+            if (answer.questionId != null) 'questionId': answer.questionId,
+            'value': answer.valueChoices.isNotEmpty
+                ? answer.valueChoices
+                : answer.value,
+            'mistakes': answer.mistakes,
+            'passed': answer.isPassed,
+          },
+      ],
+    };
+  }
+
+  /// Stores a CouchDB page. Answers and exam details remain with the later
+  /// surveys/exam slice; this preserves every field used by the list screen.
+  Future<void> upsertDocuments(Iterable<Map<String, dynamic>> documents) {
+    final rows = <SubmissionsCompanion>[];
+    final answers = <String, List<SubmissionAnswersCompanion>>{};
+    final questions = <String, List<SubmissionQuestionsCompanion>>{};
+    for (final json in documents) {
+      final id =
+          JsonUtils.getStringOrNull('id', json) ??
+          JsonUtils.getStringOrNull('_id', json);
+      if (id == null || id.isEmpty) {
+        throw const FormatException('Submission is missing an id');
+      }
+      rows.add(
+        SubmissionsCompanion.insert(
+          id: id,
+          couchId: Value(JsonUtils.getStringOrNull('_id', json)),
+          rev: Value(JsonUtils.getStringOrNull('_rev', json)),
+          parentId: Value(JsonUtils.getStringOrNull('parentId', json)),
+          type: Value(JsonUtils.getStringOrNull('type', json)),
+          userId: Value(JsonUtils.getStringOrNull('userId', json)),
+          user: Value(JsonUtils.getStringOrNull('user', json)),
+          startTime: Value(JsonUtils.getLong('startTime', json)),
+          lastUpdateTime: Value(JsonUtils.getLong('lastUpdateTime', json)),
+          grade: Value(JsonUtils.getLong('grade', json)),
+          status: Value(JsonUtils.getStringOrNull('status', json)),
+          uploaded: Value(JsonUtils.getBool('uploaded', json)),
+          sender: Value(JsonUtils.getStringOrNull('sender', json)),
+          source: Value(JsonUtils.getStringOrNull('source', json)),
+          parentCode: Value(JsonUtils.getStringOrNull('parentCode', json)),
+          parent: Value(JsonUtils.getStringOrNull('parent', json)),
+          teamId: Value(JsonUtils.getStringOrNull('teamId', json)),
+          isUpdated: Value(JsonUtils.getBool('isUpdated', json)),
+        ),
+      );
+      final rawAnswers = json['answers'];
+      answers[id] = [
+        if (rawAnswers is List)
+          for (var index = 0; index < rawAnswers.length; index++)
+            if (rawAnswers[index] is Map<String, dynamic>)
+              _answerFromJson(
+                rawAnswers[index] as Map<String, dynamic>,
+                submissionId: id,
+                index: index,
+                examId: JsonUtils.getStringOrNull(
+                  'parentId',
+                  json,
+                )?.split('@').first,
+              ),
+      ];
+      final parent = json['parent'];
+      final rawQuestions = parent is Map<String, dynamic>
+          ? parent['questions']
+          : null;
+      questions[id] = [
+        if (rawQuestions is List)
+          for (var index = 0; index < rawQuestions.length; index++)
+            if (rawQuestions[index] is Map<String, dynamic>)
+              _questionFromJson(
+                rawQuestions[index] as Map<String, dynamic>,
+                submissionId: id,
+                index: index,
+              ),
+      ];
+    }
+    return _dao.upsertAll(rows, answers: answers, questions: questions);
+  }
+
+  SubmissionQuestionsCompanion _questionFromJson(
+    Map<String, dynamic> json, {
+    required String submissionId,
+    required int index,
+  }) {
+    final questionId =
+        JsonUtils.getStringOrNull('id', json) ?? '$submissionId-q$index';
+    final rawChoices = json['choices'];
+    final choiceLabels = <String>[];
+    if (rawChoices is List) {
+      for (final choice in rawChoices) {
+        if (choice is Map<String, dynamic>) {
+          choiceLabels.add(JsonUtils.getString('res', choice));
+        } else if (choice != null) {
+          choiceLabels.add(choice.toString());
+        }
+      }
+    }
+    final correct = json['correctChoice'];
+    return SubmissionQuestionsCompanion.insert(
+      id: '$submissionId:$questionId',
+      submissionId: submissionId,
+      header: Value(
+        JsonUtils.getStringOrNull('title', json) ??
+            JsonUtils.getStringOrNull('header', json),
+      ),
+      body: Value(JsonUtils.getStringOrNull('body', json)),
+      type: Value(JsonUtils.getStringOrNull('type', json)),
+      correctChoices: Value(
+        correct is List
+            ? correct.map((e) => e.toString().toLowerCase()).toList()
+            : [if (correct != null) correct.toString().toLowerCase()],
+      ),
+      choices: Value(choiceLabels),
+      marks: Value(JsonUtils.getStringOrNull('marks', json)),
+      position: index,
+    );
+  }
+
+  SubmissionAnswersCompanion _answerFromJson(
+    Map<String, dynamic> json, {
+    required String submissionId,
+    required int index,
+    required String? examId,
+  }) {
+    final rawValue = json['value'];
+    final choices = rawValue is List
+        ? rawValue.map((value) => value.toString()).toList(growable: false)
+        : const <String>[];
+    final questionId = JsonUtils.getStringOrNull('questionId', json);
+    return SubmissionAnswersCompanion.insert(
+      id: '$submissionId:${questionId ?? index}',
+      submissionId: submissionId,
+      examId: Value(examId),
+      questionId: Value(questionId),
+      value: Value(rawValue is List ? null : rawValue?.toString()),
+      valueChoices: Value(choices),
+      mistakes: Value(JsonUtils.getInt('mistakes', json)),
+      isPassed: Value(JsonUtils.getBool('passed', json)),
+      grade: Value(JsonUtils.getInt('grade', json)),
+    );
+  }
+
+  /// Pulls the complete `submissions` CouchDB table into the offline cache.
+  /// Pages are committed independently, matching Kotlin's partial-sync rule.
+  Future<SyncResult> sync({
+    required ServerConfig config,
+    void Function(SyncProgress)? onProgress,
+  }) async {
+    final dbUrl = UrlUtils.dbUrl(config);
+    final authHeader = UrlUtils.basicAuthHeader('satellite', config.pin);
+    final countResult = await _api.getJsonObject(
+      '$dbUrl/submissions/_all_docs?limit=0',
+      authHeader: authHeader,
+    );
+    if (countResult is! NetworkSuccess<Map<String, dynamic>>) {
+      return SyncFailed(describeNetworkFailure(countResult));
+    }
+
+    final total = JsonUtils.getInt('total_rows', countResult.data);
+    if (total == 0) {
+      await _dao.deleteNotIn(const []);
+      onProgress?.call(const SyncProgress(completed: 0, total: 0));
+      return const SyncComplete(0);
+    }
+
+    final sizer = AdaptiveBatchProcessor(initialSize: initialBatchSize);
+    final savedIds = <String>[];
+    var skip = 0;
+    var walkedEveryPage = true;
+    while (skip < total) {
+      final limit = sizer.currentSize;
+      final stopwatch = Stopwatch()..start();
+      final pageResult = await _api.getJsonObject(
+        '$dbUrl/submissions/_all_docs?include_docs=true&limit=$limit&skip=$skip',
+        authHeader: authHeader,
+      );
+      stopwatch.stop();
+      if (pageResult is! NetworkSuccess<Map<String, dynamic>>) {
+        sizer.recordFailure();
+        return SyncFailed(describeNetworkFailure(pageResult));
+      }
+      sizer.recordSuccess(stopwatch.elapsedMilliseconds);
+
+      final rows = pageResult.data['rows'];
+      if (rows is! List || rows.isEmpty) {
+        walkedEveryPage = false;
+        break;
+      }
+      final docs = <Map<String, dynamic>>[];
+      for (final row in rows) {
+        if (row is! Map<String, dynamic>) continue;
+        final doc = JsonUtils.getObject('doc', row);
+        final id = JsonUtils.getString('_id', doc);
+        if (doc == null || id.isEmpty || id.startsWith('_design/')) continue;
+        docs.add(doc);
+        savedIds.add(id);
+      }
+      if (docs.isNotEmpty) await upsertDocuments(docs);
+      skip += rows.length;
+      onProgress?.call(
+        SyncProgress(completed: skip > total ? total : skip, total: total),
+      );
+    }
+
+    if (walkedEveryPage) await _dao.deleteNotIn(savedIds);
+    return SyncComplete(savedIds.length);
+  }
+}
+
+class SubmissionDraftAnswer {
+  const SubmissionDraftAnswer({
+    this.questionId,
+    this.value,
+    this.choices = const [],
+  });
+  final String? questionId;
+  final String? value;
+  final List<String> choices;
+}

--- a/flutter/lib/repository/submissions_uploader.dart
+++ b/flutter/lib/repository/submissions_uploader.dart
@@ -1,0 +1,54 @@
+import '../core/config/server_config.dart';
+import '../core/network/network_result.dart';
+import '../core/utils/url_utils.dart';
+import '../data/api/planet_api.dart';
+import 'outbox_drainer.dart';
+import 'outbox_repository.dart';
+import 'submissions_repository.dart';
+
+/// Durable append-style port of the submissions `UploadConfig`.
+class SubmissionsUploader {
+  SubmissionsUploader(this._api, this._submissions, this._outbox);
+
+  static const type = 'submissions';
+  final PlanetApi _api;
+  final SubmissionsRepository _submissions;
+  final OutboxRepository _outbox;
+  String? _authHeader;
+
+  static String endpointFor(ServerConfig config) =>
+      '${UrlUtils.dbUrl(config)}/submissions';
+
+  set authHeader(String? value) => _authHeader = value;
+
+  Future<int> queuePending({
+    required ServerConfig config,
+    required String userId,
+  }) async {
+    final rows = await _submissions.pendingUploads(userId);
+    for (final row in rows) {
+      await _outbox.enqueue(
+        uploadType: type,
+        itemId: row.id,
+        endpoint: endpointFor(config),
+        payload: await _submissions.serialize(row),
+        userId: userId,
+      );
+    }
+    return rows.length;
+  }
+
+  OutboxHandler get handler => (row, payload) async {
+    final result = await _api.postJsonObject(
+      row.endpoint,
+      payload,
+      authHeader: _authHeader,
+    );
+    if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
+      if (data case {'id': final String id, 'rev': final String rev}) {
+        await _submissions.markUploaded(row.itemId, id, rev);
+      }
+    }
+    return result;
+  };
+}

--- a/flutter/lib/ui/life/life_screen.dart
+++ b/flutter/lib/ui/life/life_screen.dart
@@ -107,6 +107,9 @@ void _openFeature(BuildContext context, String feature) {
     case 'personals':
       context.push(Routes.personals);
       return;
+    case 'submissions':
+      context.push(Routes.submissions);
+      return;
     default:
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(AppLocalizations.of(context).featureComingSoon)),

--- a/flutter/lib/ui/router.dart
+++ b/flutter/lib/ui/router.dart
@@ -19,6 +19,8 @@ import 'settings/settings_screen.dart';
 import 'sync/login_screen.dart';
 import 'sync/server_config_screen.dart';
 import 'user/profile_screen.dart';
+import 'submissions/submissions_screen.dart';
+import 'submissions/submission_detail_screen.dart';
 
 /// Replaces the Activity/Fragment navigation in `ui/components/FragmentNavigator`
 /// and the manual `Intent` hops between `SyncActivity` -> `LoginActivity` ->
@@ -44,6 +46,7 @@ class Routes {
   static const String life = '/life';
   static const String references = '/life/references';
   static const String personals = '/life/personals';
+  static const String submissions = '/life/submissions';
 }
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
@@ -170,6 +173,18 @@ final routerProvider = Provider<GoRouter>((ref) {
                   GoRoute(
                     path: 'personals',
                     builder: (context, state) => const PersonalsScreen(),
+                  ),
+                  GoRoute(
+                    path: 'submissions',
+                    builder: (context, state) => const SubmissionsScreen(),
+                    routes: [
+                      GoRoute(
+                        path: ':submissionId',
+                        builder: (context, state) => SubmissionDetailScreen(
+                          submissionId: state.pathParameters['submissionId']!,
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ),

--- a/flutter/lib/ui/submissions/submission_detail_screen.dart
+++ b/flutter/lib/ui/submissions/submission_detail_screen.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../data/local/app_database.dart';
+import '../../l10n/app_localizations.dart';
+import '../../providers/submissions_provider.dart';
+import '../../providers/app_providers.dart';
+
+/// Metadata portion of `ui/submissions/SubmissionDetailFragment.kt`.
+class SubmissionDetailScreen extends ConsumerWidget {
+  const SubmissionDetailScreen({required this.submissionId, super.key});
+
+  final String submissionId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final row = ref.watch(submissionProvider(submissionId));
+    final answers = ref.watch(submissionAnswersProvider(submissionId));
+    final questions = ref.watch(submissionQuestionsProvider(submissionId));
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.submissionDetails),
+        actions: [
+          IconButton(
+            tooltip: l10n.exportPdf,
+            icon: const Icon(Icons.picture_as_pdf_outlined),
+            onPressed: () => _export(context, ref),
+          ),
+        ],
+      ),
+      body: row.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => Center(child: Text(l10n.submissionsUnavailable)),
+        data: (submission) => submission == null
+            ? Center(child: Text(l10n.submissionNotFound))
+            : _Details(submission, answers: answers, questions: questions),
+      ),
+    );
+  }
+
+  Future<void> _export(BuildContext context, WidgetRef ref) async {
+    final l10n = AppLocalizations.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final file = await ref
+        .read(submissionsExporterProvider)
+        .generateFile(submissionId);
+    if (!context.mounted) return;
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          file == null ? l10n.pdfExportFailed : l10n.pdfSaved(file.path),
+        ),
+      ),
+    );
+  }
+}
+
+class _Details extends StatelessWidget {
+  const _Details(this.row, {required this.answers, required this.questions});
+  final SubmissionRow row;
+  final AsyncValue<List<SubmissionAnswerRow>> answers;
+  final AsyncValue<List<SubmissionQuestionRow>> questions;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final updated = row.lastUpdateTime == 0
+        ? l10n.unknown
+        : DateFormat.yMMMMd().add_jm().format(
+            DateTime.fromMillisecondsSinceEpoch(row.lastUpdateTime),
+          );
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text(
+          row.parent ?? row.type ?? l10n.submission,
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        const SizedBox(height: 16),
+        _Detail(label: l10n.status, value: row.status ?? l10n.pending),
+        _Detail(label: l10n.lastUpdated, value: updated),
+        _Detail(label: l10n.grade, value: '${row.grade}'),
+        _Detail(label: l10n.submittedBy, value: row.user ?? row.userId ?? '—'),
+        _Detail(label: l10n.submissionType, value: row.type ?? '—'),
+        _Detail(
+          label: l10n.uploadStatus,
+          value: row.uploaded ? l10n.uploaded : l10n.savedOffline,
+        ),
+        const Divider(height: 32),
+        Text(l10n.answers, style: Theme.of(context).textTheme.titleLarge),
+        const SizedBox(height: 8),
+        answers.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (_, _) => Text(l10n.answersUnavailable),
+          data: (rows) => rows.isEmpty
+              ? Text(l10n.noAnswers)
+              : Column(
+                  children: [
+                    for (var index = 0; index < rows.length; index++)
+                      _AnswerTile(
+                        answer: rows[index],
+                        question: questions.valueOrNull
+                            ?.where(
+                              (question) => question.id.endsWith(
+                                ':${rows[index].questionId}',
+                              ),
+                            )
+                            .firstOrNull,
+                        index: index,
+                      ),
+                  ],
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AnswerTile extends StatelessWidget {
+  const _AnswerTile({required this.answer, required this.index, this.question});
+  final SubmissionAnswerRow answer;
+  final SubmissionQuestionRow? question;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final value = answer.value?.trim().isNotEmpty == true
+        ? answer.value!
+        : answer.valueChoices.isNotEmpty
+        ? answer.valueChoices.join(', ')
+        : l10n.noAnswer;
+    final normalized = [
+      answer.value,
+      ...answer.valueChoices,
+    ].whereType<String>().map((value) => value.toLowerCase()).toSet();
+    final correct =
+        question != null &&
+        question!.correctChoices.isNotEmpty &&
+        question!.correctChoices.every(normalized.contains);
+    return Card(
+      child: ListTile(
+        leading: Icon(
+          answer.isPassed || correct ? Icons.check_circle : Icons.help_outline,
+          color: answer.isPassed || correct ? Colors.green : null,
+        ),
+        title: Text(
+          question?.header ??
+              question?.body ??
+              answer.questionId ??
+              l10n.questionNumber(index + 1),
+        ),
+        subtitle: Text(
+          question?.choices.isNotEmpty == true
+              ? '$value\n${l10n.availableChoices}: ${question!.choices.join(', ')}'
+              : value,
+        ),
+        trailing: answer.grade > 0 ? Text('${answer.grade}') : null,
+      ),
+    );
+  }
+}
+
+class _Detail extends StatelessWidget {
+  const _Detail({required this.label, required this.value});
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) => ListTile(
+    contentPadding: EdgeInsets.zero,
+    title: Text(label),
+    subtitle: Text(value),
+  );
+}

--- a/flutter/lib/ui/submissions/submissions_screen.dart
+++ b/flutter/lib/ui/submissions/submissions_screen.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+
+import '../../core/sync/sync_result.dart';
+import '../../data/local/app_database.dart';
+import '../../l10n/app_localizations.dart';
+import '../../providers/app_providers.dart';
+import '../../providers/submissions_provider.dart';
+import '../../providers/session_provider.dart';
+import '../../repository/personals_uploader.dart';
+import '../../repository/submissions_repository.dart';
+import '../router.dart';
+
+/// Port of `ui/submissions/SubmissionsFragment.kt` and `SubmissionsAdapter.kt`.
+class SubmissionsScreen extends ConsumerStatefulWidget {
+  const SubmissionsScreen({super.key});
+
+  @override
+  ConsumerState<SubmissionsScreen> createState() => _SubmissionsScreenState();
+}
+
+class _SubmissionsScreenState extends ConsumerState<SubmissionsScreen> {
+  String _filter = 'all';
+  bool _syncing = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final submissions = ref.watch(submissionsProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.submissions),
+        actions: [
+          IconButton(
+            tooltip: l10n.refresh,
+            onPressed: _syncing ? null : _sync,
+            icon: _syncing
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.sync),
+          ),
+        ],
+      ),
+      body: submissions.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => Center(child: Text(l10n.submissionsUnavailable)),
+        data: (rows) {
+          final filtered = switch (_filter) {
+            'pending' => rows.where((row) => !_isComplete(row)).toList(),
+            'complete' => rows.where(_isComplete).toList(),
+            _ => rows,
+          };
+          return Column(
+            children: [
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+                child: SegmentedButton<String>(
+                  segments: [
+                    ButtonSegment(value: 'all', label: Text(l10n.all)),
+                    ButtonSegment(value: 'pending', label: Text(l10n.pending)),
+                    ButtonSegment(
+                      value: 'complete',
+                      label: Text(l10n.complete),
+                    ),
+                  ],
+                  selected: {_filter},
+                  onSelectionChanged: (value) =>
+                      setState(() => _filter = value.single),
+                ),
+              ),
+              Expanded(
+                child: filtered.isEmpty
+                    ? Center(
+                        child: Text(
+                          rows.isEmpty
+                              ? l10n.noSubmissions
+                              : l10n.noMatchingSubmissions,
+                        ),
+                      )
+                    : RefreshIndicator(
+                        onRefresh: _sync,
+                        child: ListView.separated(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          itemCount: filtered.length,
+                          separatorBuilder: (_, _) => const Divider(height: 1),
+                          itemBuilder: (context, index) => _SubmissionTile(
+                            filtered[index],
+                            onTap: () => context.push(
+                              '${Routes.submissions}/${Uri.encodeComponent(filtered[index].id)}',
+                            ),
+                          ),
+                        ),
+                      ),
+              ),
+            ],
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _createDraft,
+        icon: const Icon(Icons.add),
+        label: Text(l10n.newSubmission),
+      ),
+    );
+  }
+
+  Future<void> _sync() async {
+    final config = ref.read(serverConfigProvider);
+    if (config == null || _syncing) return;
+    setState(() => _syncing = true);
+    final result = await ref
+        .read(submissionsRepositoryProvider)
+        .sync(config: config);
+    if (!mounted) return;
+    setState(() => _syncing = false);
+    final message = switch (result) {
+      SyncComplete(:final savedCount) => AppLocalizations.of(
+        context,
+      ).submissionsSynced(savedCount),
+      SyncFailed(:final message) => message,
+    };
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<void> _createDraft() async {
+    final l10n = AppLocalizations.of(context);
+    final title = TextEditingController();
+    final answer = TextEditingController();
+    final submitted = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.newSubmission),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: title,
+              autofocus: true,
+              decoration: InputDecoration(labelText: l10n.title),
+            ),
+            TextField(
+              controller: answer,
+              decoration: InputDecoration(labelText: l10n.answer),
+              minLines: 2,
+              maxLines: 4,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(l10n.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(l10n.save),
+          ),
+        ],
+      ),
+    );
+    if (submitted != true || title.text.trim().isEmpty || !mounted) return;
+    final user = ref.read(sessionProvider).valueOrNull;
+    if (user == null) return;
+    await ref
+        .read(submissionsRepositoryProvider)
+        .createDraft(
+          userId: user.id,
+          type: 'submission',
+          title: title.text,
+          answers: [
+            if (answer.text.trim().isNotEmpty)
+              SubmissionDraftAnswer(value: answer.text.trim()),
+          ],
+        );
+    final config = ref.read(serverConfigProvider);
+    if (config != null) {
+      await ref
+          .read(submissionsUploaderProvider)
+          .queuePending(config: config, userId: user.id);
+      await ref
+          .read(outboxDrainerProvider)
+          .drain(authHeader: PersonalsUploader.authHeaderFor(config));
+    }
+  }
+}
+
+bool _isComplete(SubmissionRow row) =>
+    row.uploaded ||
+    const {
+      'complete',
+      'completed',
+      'graded',
+    }.contains(row.status?.trim().toLowerCase());
+
+class _SubmissionTile extends StatelessWidget {
+  const _SubmissionTile(this.row, {required this.onTap});
+  final SubmissionRow row;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final title = row.parent?.trim().isNotEmpty == true
+        ? row.parent!
+        : row.type?.trim().isNotEmpty == true
+        ? row.type!
+        : l10n.submission;
+    final updated = row.lastUpdateTime == 0
+        ? null
+        : DateFormat.yMMMd().add_jm().format(
+            DateTime.fromMillisecondsSinceEpoch(row.lastUpdateTime),
+          );
+    return ListTile(
+      onTap: onTap,
+      leading: Icon(
+        row.uploaded ? Icons.assignment_turned_in : Icons.assignment_outlined,
+      ),
+      title: Text(title),
+      subtitle: Text(
+        [
+          row.status?.trim().isNotEmpty == true ? row.status! : l10n.pending,
+          ?updated,
+        ].join(' • '),
+      ),
+      trailing: row.grade > 0 ? Text(l10n.submissionGrade(row.grade)) : null,
+    );
+  }
+}

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.0.0"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -33,6 +41,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  barcode:
+    dependency: transitive
+    description:
+      name: barcode
+      sha256: "7b6729c37e3b7f34233e2318d866e8c48ddb46c1f7ad01ff7bb2a8de1da2b9f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.9"
+  bidi:
+    dependency: transitive
+    description:
+      name: bidi
+      sha256: "77f475165e94b261745cf1032c751e2032b8ed92ccb2bf5716036db79320637d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.13"
   boolean_selector:
     dependency: transitive
     description:
@@ -381,6 +405,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.1"
   intl:
     dependency: "direct main"
     description:
@@ -549,6 +581,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -597,6 +637,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdf:
+    dependency: "direct main"
+    description:
+      name: pdf
+      sha256: "517df47af468734a23c8b513c0c6a8a62357403ab1b8ab7fad1606576a9dbdd0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.13.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -621,6 +677,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.2"
   pub_semver:
     dependency: transitive
     description:
@@ -637,6 +701,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   recase:
     dependency: transitive
     description:
@@ -906,6 +978,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -45,6 +45,8 @@ dependencies:
   # Diacritic folding for titleNormal — stands in for java.text.Normalizer NFD,
   # which has no dart:core equivalent.
   diacritic: ^0.1.6
+  # Submission report generation — replaces Android PdfDocument.
+  pdf: ^3.11.3
 
 dev_dependencies:
   flutter_test:

--- a/flutter/test/repository/submissions_exporter_test.dart
+++ b/flutter/test/repository/submissions_exporter_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/submissions_exporter.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late AppDatabase db;
+  late SubmissionsRepository repository;
+  late SubmissionsExporter exporter;
+
+  setUp(() {
+    db = AppDatabase.memory();
+    repository = SubmissionsRepository(MockPlanetApi(), db.submissionDao);
+    exporter = SubmissionsExporter(repository);
+  });
+  tearDown(() => db.close());
+
+  test('generates a valid PDF containing submission questions', () async {
+    await repository.upsertDocuments([
+      {
+        '_id': 'report-1',
+        'userId': 'ada',
+        'status': 'graded',
+        'grade': 90,
+        'answers': [
+          {'questionId': 'q-1', 'value': 'Paris'},
+        ],
+        'parent': {
+          'name': 'Geography exam',
+          'questions': [
+            {'id': 'q-1', 'title': 'Capital city', 'marks': '10'},
+          ],
+        },
+      },
+    ]);
+
+    final bytes = await exporter.generateBytes('report-1');
+
+    expect(bytes, isNotNull);
+    expect(String.fromCharCodes(bytes!.take(5)), '%PDF-');
+    expect(bytes.length, greaterThan(500));
+  });
+
+  test('writes reports under the supplied directory', () async {
+    await repository.upsertDocuments([
+      {'_id': 'report:unsafe', 'status': 'complete'},
+    ]);
+    final directory = await Directory.systemTemp.createTemp('submission-pdf');
+    addTearDown(() => directory.delete(recursive: true));
+
+    final file = await exporter.generateFile(
+      'report:unsafe',
+      directory: directory,
+    );
+
+    expect(await file!.exists(), isTrue);
+    expect(file.path, contains('submission_report_unsafe_'));
+  });
+
+  test('returns null for an unknown submission', () async {
+    expect(await exporter.generateBytes('missing'), isNull);
+  });
+}

--- a/flutter/test/repository/submissions_repository_test.dart
+++ b/flutter/test/repository/submissions_repository_test.dart
@@ -1,0 +1,258 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  late AppDatabase database;
+  late SubmissionsRepository repository;
+  late MockPlanetApi api;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  setUp(() {
+    database = AppDatabase.memory();
+    api = MockPlanetApi();
+    repository = SubmissionsRepository(api, database.submissionDao);
+  });
+
+  tearDown(() => database.close());
+
+  test('maps documents and watches newest submissions first', () async {
+    await repository.upsertDocuments([
+      {
+        '_id': 'older',
+        'userId': 'user-1',
+        'type': 'exam',
+        'lastUpdateTime': 10,
+        'status': 'complete',
+      },
+      {
+        '_id': 'newer',
+        'userId': 'user-1',
+        'lastUpdateTime': '20',
+        'uploaded': true,
+      },
+      {'_id': 'other-user', 'userId': 'user-2', 'lastUpdateTime': 30},
+    ]);
+
+    final rows = await repository.watchForUser('user-1').first;
+    expect(rows.map((row) => row.id), ['newer', 'older']);
+    expect(rows.first.uploaded, isTrue);
+    expect(rows.last.type, 'exam');
+  });
+
+  test('hydrates scalar and choice answers into the related cache', () async {
+    await repository.upsertDocuments([
+      {
+        '_id': 'answered',
+        'userId': 'user-1',
+        'parentId': 'exam-1@course-1',
+        'answers': [
+          {'questionId': 'q-1', 'value': 'written response', 'passed': true},
+          {
+            'questionId': 'q-2',
+            'value': ['choice-a', 'choice-b'],
+            'mistakes': 1,
+          },
+        ],
+      },
+    ]);
+
+    final answers = await repository.watchAnswers('answered').first;
+    expect(answers, hasLength(2));
+    expect(answers.first.value, 'written response');
+    expect(answers.first.isPassed, isTrue);
+    expect(answers.last.valueChoices, ['choice-a', 'choice-b']);
+    expect(answers.last.examId, 'exam-1');
+  });
+
+  test(
+    'hydrates embedded question text, choices, and correct answers',
+    () async {
+      await repository.upsertDocuments([
+        {
+          '_id': 'questions',
+          'parent': {
+            'questions': [
+              {
+                'id': 'q-1',
+                'title': 'Capital city',
+                'body': 'What is the capital?',
+                'type': 'selectOne',
+                'choices': [
+                  {'id': 'a', 'res': 'Paris'},
+                  {'id': 'b', 'res': 'Rome'},
+                ],
+                'correctChoice': ['paris'],
+                'marks': '10',
+              },
+            ],
+          },
+        },
+      ]);
+
+      final questions = await repository.watchQuestions('questions').first;
+      expect(questions.single.header, 'Capital city');
+      expect(questions.single.choices, ['Paris', 'Rome']);
+      expect(questions.single.correctChoices, ['paris']);
+      expect(questions.single.marks, '10');
+    },
+  );
+
+  test(
+    're-sync replaces removed answers instead of leaving stale rows',
+    () async {
+      await repository.upsertDocuments([
+        {
+          '_id': 'edited',
+          'answers': [
+            {'questionId': 'q-1', 'value': 'old'},
+          ],
+        },
+      ]);
+      await repository.upsertDocuments([
+        {'_id': 'edited', 'answers': <dynamic>[]},
+      ]);
+
+      expect(await repository.watchAnswers('edited').first, isEmpty);
+    },
+  );
+
+  test('rejects documents without an id', () {
+    expect(
+      () => repository.upsertDocuments([
+        {'userId': 'user-1'},
+      ]),
+      throwsFormatException,
+    );
+  });
+
+  test(
+    'creates a durable local draft with answers and serializes it',
+    () async {
+      final id = await repository.createDraft(
+        userId: 'user-1',
+        type: 'exam',
+        title: 'Offline exam',
+        answers: const [SubmissionDraftAnswer(questionId: 'q-1', value: '42')],
+        now: DateTime.fromMillisecondsSinceEpoch(1000),
+      );
+
+      final pending = await repository.pendingUploads('user-1');
+      expect(pending.single.id, id);
+      expect(pending.single.isUpdated, isTrue);
+      final payload = await repository.serialize(pending.single);
+      expect(payload['parent'], 'Offline exam');
+      expect((payload['answers'] as List).single, containsPair('value', '42'));
+    },
+  );
+
+  test(
+    'empty server sync does not delete an un-uploaded local draft',
+    () async {
+      await repository.createDraft(
+        userId: 'user-1',
+        type: 'exam',
+        title: 'Keep me',
+        answers: const [],
+      );
+      when(
+        () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({'total_rows': 0}),
+      );
+
+      await repository.sync(config: config);
+
+      expect(await repository.pendingUploads('user-1'), hasLength(1));
+    },
+  );
+
+  test('sync pulls pages, reports progress, and removes stale rows', () async {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/submissions/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({'total_rows': 2}),
+    );
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/submissions/_all_docs?include_docs=true&limit=100&skip=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          {
+            'doc': {'_id': 'one', 'userId': 'user-1'},
+          },
+          {
+            'doc': {'_id': 'two', 'userId': 'user-1'},
+          },
+        ],
+      }),
+    );
+    final progress = <int>[];
+
+    final result = await repository.sync(
+      config: config,
+      onProgress: (value) => progress.add(value.completed),
+    );
+
+    expect((result as SyncComplete).savedCount, 2);
+    expect(progress, [2]);
+    expect(await repository.localCount(), 2);
+  });
+
+  test('sync retains completed pages after a later network failure', () async {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/submissions/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({'total_rows': 101}),
+    );
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/submissions/_all_docs?include_docs=true&limit=100&skip=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': List.generate(
+          100,
+          (index) => {
+            'doc': {'_id': 'submission-$index', 'userId': 'user-1'},
+          },
+        ),
+      }),
+    );
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/submissions/_all_docs?include_docs=true&limit=100&skip=100',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          NetworkException<Map<String, dynamic>>(Exception('connection lost')),
+    );
+
+    expect(await repository.sync(config: config), isA<SyncFailed>());
+    expect(await repository.localCount(), 100);
+  });
+}

--- a/flutter/test/repository/submissions_uploader_test.dart
+++ b/flutter/test/repository/submissions_uploader_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/outbox_repository.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/submissions_uploader.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  late AppDatabase db;
+  late MockPlanetApi api;
+  late SubmissionsRepository repository;
+  late OutboxRepository outbox;
+  late SubmissionsUploader uploader;
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+
+  setUp(() {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+    repository = SubmissionsRepository(api, db.submissionDao);
+    outbox = OutboxRepository(db.outboxDao);
+    uploader = SubmissionsUploader(api, repository, outbox);
+  });
+  tearDown(() => db.close());
+
+  test('queues a draft once and adopts CouchDB ids after upload', () async {
+    final id = await repository.createDraft(
+      userId: 'user-1',
+      type: 'exam',
+      title: 'Draft',
+      answers: const [],
+    );
+    expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
+    expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
+    final operation = (await outbox.due()).single;
+    when(
+      () => api.postJsonObject(
+        operation.endpoint,
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'id': 'server-id',
+        'rev': '1-rev',
+      }),
+    );
+
+    final result = await uploader.handler(operation, const {});
+
+    expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    expect(await repository.pendingUploads('user-1'), isEmpty);
+    expect((await repository.getById(id))?.couchId, 'server-id');
+  });
+}

--- a/flutter/test/ui/submissions_screen_test.dart
+++ b/flutter/test/ui/submissions_screen_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/submissions_provider.dart';
+import 'package:myplanet/ui/submissions/submissions_screen.dart';
+import 'package:myplanet/ui/submissions/submission_detail_screen.dart';
+
+import '../support/widget_harness.dart';
+
+void main() {
+  testWidgets('renders cached submission status and grade', (tester) async {
+    final row = SubmissionRow(
+      id: 'submission-1',
+      startTime: 0,
+      parent: 'Safety exam',
+      userId: 'user-1',
+      lastUpdateTime: DateTime(2026, 8, 3).millisecondsSinceEpoch,
+      grade: 85,
+      status: 'complete',
+      uploaded: true,
+      isUpdated: false,
+    );
+    await tester.pumpWidget(
+      wrapScreen(
+        const SubmissionsScreen(),
+        overrides: [
+          submissionsProvider.overrideWith((ref) => Stream.value([row])),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Submissions'), findsOneWidget);
+    expect(find.text('Safety exam'), findsOneWidget);
+    expect(find.textContaining('complete'), findsOneWidget);
+    expect(find.text('Grade: 85'), findsOneWidget);
+    expect(find.byIcon(Icons.assignment_turned_in), findsOneWidget);
+  });
+
+  testWidgets('filters pending and complete submissions', (tester) async {
+    final pending = SubmissionRow(
+      id: 'pending',
+      type: 'survey',
+      startTime: 0,
+      lastUpdateTime: 1,
+      grade: 0,
+      uploaded: false,
+      isUpdated: true,
+    );
+    final complete = SubmissionRow(
+      id: 'complete',
+      type: 'exam',
+      startTime: 0,
+      lastUpdateTime: 2,
+      grade: 70,
+      status: 'complete',
+      uploaded: true,
+      isUpdated: false,
+    );
+    await tester.pumpWidget(
+      wrapScreen(
+        const SubmissionsScreen(),
+        overrides: [
+          submissionsProvider.overrideWith(
+            (ref) => Stream.value([pending, complete]),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('survey'), findsOneWidget);
+    expect(find.text('exam'), findsOneWidget);
+    await tester.tap(find.text('Pending'));
+    await tester.pumpAndSettle();
+    expect(find.text('survey'), findsOneWidget);
+    expect(find.text('exam'), findsNothing);
+  });
+
+  testWidgets('renders submission details from the offline cache', (
+    tester,
+  ) async {
+    final row = SubmissionRow(
+      id: 'submission-2',
+      type: 'exam',
+      user: 'Ada Learner',
+      startTime: 0,
+      lastUpdateTime: 0,
+      grade: 92,
+      status: 'graded',
+      uploaded: true,
+      isUpdated: false,
+    );
+    await tester.pumpWidget(
+      wrapScreen(
+        const SubmissionDetailScreen(submissionId: 'submission-2'),
+        overrides: [
+          submissionProvider(
+            'submission-2',
+          ).overrideWith((ref) => Stream.value(row)),
+          submissionAnswersProvider('submission-2').overrideWith(
+            (ref) => Stream.value([
+              const SubmissionAnswerRow(
+                id: 'submission-2:q-1',
+                submissionId: 'submission-2',
+                questionId: 'q-1',
+                value: 'Paris',
+                valueChoices: [],
+                mistakes: 0,
+                isPassed: true,
+                grade: 10,
+              ),
+            ]),
+          ),
+          submissionQuestionsProvider('submission-2').overrideWith(
+            (ref) => Stream.value([
+              const SubmissionQuestionRow(
+                id: 'submission-2:q-1',
+                submissionId: 'submission-2',
+                header: 'Capital city',
+                body: 'What is the capital?',
+                type: 'selectOne',
+                correctChoices: ['paris'],
+                choices: ['Paris', 'Rome'],
+                marks: '10',
+                position: 0,
+              ),
+            ]),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Submission details'), findsOneWidget);
+    expect(find.text('Ada Learner'), findsOneWidget);
+    expect(find.text('92'), findsOneWidget);
+    expect(find.text('Uploaded'), findsOneWidget);
+    await tester.drag(find.byType(ListView), const Offset(0, -500));
+    await tester.pumpAndSettle();
+    expect(find.text('Answers'), findsOneWidget);
+    expect(find.text('Capital city'), findsOneWidget);
+    expect(find.textContaining('Choices: Paris, Rome'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+}


### PR DESCRIPTION
### Motivation
- Implement the offline submissions vertical slice in the Flutter port so submissions can be created, cached, listed, viewed, and durably uploaded matching the Kotlin app behaviour.
- Provide PDF export for submission reports and integrate submissions into the existing outbox/drain durability model.
- Expose submissions in the UI and navigation so users can create drafts and review answers offline.

### Description
- Added Drift schema tables `Submissions`, `SubmissionAnswers`, and `SubmissionQuestions`, bumped `schemaVersion` to `12`, and marked them as local-authority tables to preserve drafts across resyncs in `AppDatabase`.
- Implemented `SubmissionDao` with watch, upsert, delete, pending upload, and cleanup helpers and wired it into the provider graph via `submissionDaoProvider`.
- Added `SubmissionsRepository` implementing local draft creation (`createDraft`), serialization, page-based CouchDB sync (`sync`), and helpers to watch rows/answers/questions; and `SubmissionsUploader` that queues drafts to the `outbox` and provides an upload handler integrated into `OutboxDrainer`.
- Added `SubmissionsExporter` to generate and write PDF reports using the `pdf` package and wired an exporter provider; updated `pubspec.yaml`/`pubspec.lock` to include `pdf` and other transitive packages.
- Added UI: `SubmissionsScreen` (list, filters, create draft, refresh), `SubmissionDetailScreen` (metadata, answers, export), routes in `router.dart`, and `life_screen` integration; with localized strings added to `app_en.arb`.
- Added Riverpod providers in `submissions_provider.dart` and `app_providers.dart` to expose repository streams and uploader/exporter instances.
- Tests: added unit/widget tests under `flutter/test/` for `SubmissionsRepository`, `SubmissionsUploader`, `SubmissionsExporter`, and UI screens; included an in-memory `AppDatabase` test setup and mock `PlanetApi` usage.

### Testing
- Ran `flutter test` for the new tests covering `SubmissionsRepository`, `SubmissionsUploader`, and `SubmissionsExporter`, and all tests passed.
- Ran widget tests for `SubmissionsScreen` and `SubmissionDetailScreen` under the test harness and they passed.
- Verified PDF bytes generation in `SubmissionsExporter` tests and file write behavior in a temporary directory test; both assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fe1aff2bc832b8e015f016f6c3682)