### PR TITLE
Add offline events/meetups (Phase 15): DB, repo, uploader, UI and tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,12 @@
 
 ### Flutter port (in progress)
 A Flutter/Dart port lives in **`flutter/`**, alongside — not replacing — the Kotlin app. `app/`
-is unchanged and remains the shipping app. **13 of 28 UI packages** are ported, plus a durable
+is unchanged and remains the shipping app. **15 of 28 UI packages** are ported, plus a durable
 write-back path. The first vertical slice ran server configuration → login → resources list;
 since then the dashboard shell, courses, calendar, first-launch onboarding, the offline user
 profile, appearance settings, the dictionary, notifications, My life, references, personals, and
-ratings, and the offline submissions flow with question-aware answer review have landed. Everything below in this document describes the Kotlin app and still
+ratings, offline submissions with question-aware answer review, events/meetups, and individual
+surveys have landed. Everything below in this document describes the Kotlin app and still
 applies to it.
 
 See **`docs/kotlin-to-flutter-migration.md`** for scope, the technology mapping (Hilt→Riverpod,

--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -5,8 +5,8 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 
 ## Status
 
-**Phase 14 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
-**13 of 28 UI packages** are ported.
+**Phase 15 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
+**14 of 28 UI packages** are ported.
 
 - **Phase 1** — skeleton plus the server configuration → login → resources slice.
 - **Phase 2** — dashboard shell (bottom-tab navigation) plus the courses list and detail.
@@ -26,6 +26,8 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 - **Phase 14** — offline submission creation, durable upload, list, question-aware answer review, PDF export, and detail metadata, backed by a paginated,
   reactive Drift cache with pull-to-refresh, status filters, progress reporting, and safe stale
   cleanup.
+- **Phase 15** — offline meetups list/detail/create/edit, join/leave shelf state, CouchDB mapping,
+  reactive Drift persistence, and durable outbox upload.
 
 ## Strategy
 
@@ -80,6 +82,7 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 | Durable write-back queue | `services/retry/RetryQueue.kt`, `RetryQueueWorker`, `model/RetryOperation.kt` | `repository/outbox_repository.dart`, `repository/outbox_drainer.dart`, `ui/outbox_drain_scope.dart` |
 | Personal-note upload | `PersonalsRepositoryImpl.uploadPersonalDocument`, `Personal.serialize` | `repository/personals_uploader.dart` |
 | Submissions create/upload/list/detail/answers | `Submission`, `Answer`, `SubmissionDao`, `UploadConfigs.Submissions`, `SubmissionsFragment`, `SubmissionDetailFragment` | `repository/submissions_repository.dart`, `repository/submissions_uploader.dart`, `ui/submissions/submissions_screen.dart`, `ui/submissions/submission_detail_screen.dart` |
+| Events/meetups | `Meetup`, `MeetupDao`, `EventsRepositoryImpl`, `EventsDetailFragment`, meetup upload config | `data/local/meetup_mapper.dart`, `repository/events_repository.dart`, `repository/events_uploader.dart`, `ui/events/` |
 
 `SharedPrefManager.getFirstLaunch()` is misleadingly named: it defaults to `false` and is set to
 `true` once onboarding finishes, so it actually means "onboarding already done". The port stores
@@ -238,9 +241,9 @@ Ordered by risk, highest first.
    defects in `strings.xml`; fixing them in Crowdin corrects the Kotlin and Flutter apps together,
    whereas diverging here would make the two apps disagree.
 
-## Remaining UI packages (16 of 28)
+## Remaining UI packages (14 of 28)
 
-`chat`, `community`, `components`, `enterprises`, `events`, `exam`,
+`chat`, `community`, `components`, `enterprises`, `exam`,
 `feedback`, `health`, `maps`,
 `surveys`, `teams`, `viewer`, `voices` — plus submission answers/create/export, personal attachments/upload,
 rating upload/sync, storage/retry, and the
@@ -315,4 +318,4 @@ succeeds, it just doesn't do what the Kotlin did.
 ---
 
 **Last updated**: 2026-08-03
-**Phase**: 14 of N (offline submissions list)
+**Phase**: 15 of N (offline events/meetups)

--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -26,8 +26,9 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 - **Phase 14** — offline submission creation, durable upload, list, question-aware answer review, PDF export, and detail metadata, backed by a paginated,
   reactive Drift cache with pull-to-refresh, status filters, progress reporting, and safe stale
   cleanup.
-- **Phase 15** — offline meetups list/detail/create/edit, join/leave shelf state, CouchDB mapping,
-  reactive Drift persistence, and durable outbox upload.
+- **Phase 15** — offline meetups list/detail/create/edit, date/time and recurrence editing,
+  search/sort, paginated pull-to-refresh, join/leave shelf write-back, CouchDB mapping, reactive
+  Drift persistence, and durable outbox upload.
 
 ## Strategy
 

--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -5,8 +5,8 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 
 ## Status
 
-**Phase 15 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
-**14 of 28 UI packages** are ported.
+**Phase 16 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
+**15 of 28 UI packages** are ported.
 
 - **Phase 1** — skeleton plus the server configuration → login → resources slice.
 - **Phase 2** — dashboard shell (bottom-tab navigation) plus the courses list and detail.
@@ -29,6 +29,8 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 - **Phase 15** — offline meetups list/detail/create/edit, date/time and recurrence editing,
   search/sort, paginated pull-to-refresh, join/leave shelf write-back, CouchDB mapping, reactive
   Drift persistence, and durable outbox upload.
+- **Phase 16** — offline individual-survey catalog, search/sort and paginated sync, question
+  forms for text and single/multiple choice, required-answer validation, and durable submission.
 
 ## Strategy
 
@@ -84,6 +86,7 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 | Personal-note upload | `PersonalsRepositoryImpl.uploadPersonalDocument`, `Personal.serialize` | `repository/personals_uploader.dart` |
 | Submissions create/upload/list/detail/answers | `Submission`, `Answer`, `SubmissionDao`, `UploadConfigs.Submissions`, `SubmissionsFragment`, `SubmissionDetailFragment` | `repository/submissions_repository.dart`, `repository/submissions_uploader.dart`, `ui/submissions/submissions_screen.dart`, `ui/submissions/submission_detail_screen.dart` |
 | Events/meetups | `Meetup`, `MeetupDao`, `EventsRepositoryImpl`, `EventsDetailFragment`, meetup upload config | `data/local/meetup_mapper.dart`, `repository/events_repository.dart`, `repository/events_uploader.dart`, `ui/events/` |
+| Individual surveys | `StepExam`, `ExamQuestion`, `SurveysRepositoryImpl`, `SurveyFragment`, survey mode of `ExamTakingFragment` | `data/local/survey_mapper.dart`, `repository/surveys_repository.dart`, `ui/surveys/` |
 
 `SharedPrefManager.getFirstLaunch()` is misleadingly named: it defaults to `false` and is set to
 `true` once onboarding finishes, so it actually means "onboarding already done". The port stores
@@ -242,11 +245,11 @@ Ordered by risk, highest first.
    defects in `strings.xml`; fixing them in Crowdin corrects the Kotlin and Flutter apps together,
    whereas diverging here would make the two apps disagree.
 
-## Remaining UI packages (14 of 28)
+## Remaining UI packages (13 of 28)
 
 `chat`, `community`, `components`, `enterprises`, `exam`,
 `feedback`, `health`, `maps`,
-`surveys`, `teams`, `viewer`, `voices` — plus submission answers/create/export, personal attachments/upload,
+`teams`, `viewer`, `voices` — plus team/public survey sharing, personal attachments/upload,
 rating upload/sync, storage/retry, and the
 rest of `settings`, plus profile photo/upload, membership, and the rest of `user`, and the
 rest of `sync` and `dashboard` (the Kotlin dashboard's activity cards, surveys widget and drawer
@@ -319,4 +322,4 @@ succeeds, it just doesn't do what the Kotlin did.
 ---
 
 **Last updated**: 2026-08-03
-**Phase**: 15 of N (offline events/meetups)
+**Phase**: 16 of N (offline individual surveys)

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -13,13 +13,16 @@ write-back, the dashboard shell, calendar, first-launch onboarding, an offline-e
 profile, persisted appearance settings, safe server details, an offline dictionary, reactive
 notifications, personalized My life/reference navigation, offline personal items, and course
 ratings, and offline submission creation/durable upload/list/detail/question-aware answer review/PDF export with paginated refresh and status filters.
-**13 of 28 UI packages are ported**, offline-first, against the real CouchDB API.
+**14 of 28 UI packages are ported**, offline-first, against the real CouchDB API.
 
 Phase 13 added the durable write-back path — an `outbox` table replacing `RetryQueue`, drained
 on app resume by `OutboxDrainer` instead of by `WorkManager`. Writes made offline survive
 process death and go out on the next launch; what they do *not* do is send while the app is
 closed. See [the migration tracker](../docs/kotlin-to-flutter-migration.md) for why that trade is
 the right one here and what is still open.
+
+Phase 15 completes offline events: meetup persistence and CouchDB mapping, list/detail/create/edit
+screens, join/leave shelf state, and durable outbox uploads are now Dart/Drift code.
 
 ## Getting started
 

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -8,12 +8,12 @@ it covers scope, the technology mapping, what is deliberately not improved, and 
 
 ## Status
 
-Phases 1–14 provide server configuration, online/offline login, resources, courses, shelf
+Phases 1–16 provide server configuration, online/offline login, resources, courses, shelf
 write-back, the dashboard shell, calendar, first-launch onboarding, an offline-editable user
 profile, persisted appearance settings, safe server details, an offline dictionary, reactive
 notifications, personalized My life/reference navigation, offline personal items, and course
 ratings, and offline submission creation/durable upload/list/detail/question-aware answer review/PDF export with paginated refresh and status filters.
-**14 of 28 UI packages are ported**, offline-first, against the real CouchDB API.
+**15 of 28 UI packages are ported**, offline-first, against the real CouchDB API.
 
 Phase 13 added the durable write-back path — an `outbox` table replacing `RetryQueue`, drained
 on app resume by `OutboxDrainer` instead of by `WorkManager`. Writes made offline survive
@@ -24,6 +24,10 @@ the right one here and what is still open.
 Phase 15 completes offline events: meetup persistence and paginated CouchDB sync,
 list/detail/create/edit and date/time screens, search/sort, join/leave shelf write-back, and
 durable outbox uploads are now Dart/Drift code.
+
+Phase 16 adds individual surveys: the exams catalog and embedded questions sync into Drift,
+users can search, sort, answer text and choice questions offline, and completed responses enter
+the durable submissions outbox.
 
 ## Getting started
 

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -21,8 +21,9 @@ process death and go out on the next launch; what they do *not* do is send while
 closed. See [the migration tracker](../docs/kotlin-to-flutter-migration.md) for why that trade is
 the right one here and what is still open.
 
-Phase 15 completes offline events: meetup persistence and CouchDB mapping, list/detail/create/edit
-screens, join/leave shelf state, and durable outbox uploads are now Dart/Drift code.
+Phase 15 completes offline events: meetup persistence and paginated CouchDB sync,
+list/detail/create/edit and date/time screens, search/sort, join/leave shelf write-back, and
+durable outbox uploads are now Dart/Drift code.
 
 ## Getting started
 

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -37,6 +37,8 @@ part 'app_database.g.dart';
     SubmissionAnswers,
     SubmissionQuestions,
     Meetups,
+    Surveys,
+    SurveyQuestions,
   ],
   daos: [
     UserDao,
@@ -51,6 +53,7 @@ part 'app_database.g.dart';
     OutboxDao,
     SubmissionDao,
     MeetupDao,
+    SurveyDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -63,7 +66,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.memory() : super(NativeDatabase.memory());
 
   @override
-  int get schemaVersion => 13;
+  int get schemaVersion => 14;
 
   /// Tables holding local intent the server cannot give back.
   ///
@@ -1038,4 +1041,60 @@ class MeetupDao extends DatabaseAccessor<AppDatabase> with _$MeetupDaoMixin {
           updated: const Value(false),
         ),
       );
+}
+
+/// Port of the survey subset of `ExamDao` and `QuestionDao`.
+@DriftAccessor(tables: [Surveys, SurveyQuestions])
+class SurveyDao extends DatabaseAccessor<AppDatabase> with _$SurveyDaoMixin {
+  SurveyDao(super.db);
+
+  Stream<List<SurveyRow>> watchAll() =>
+      (select(surveys)..orderBy([
+            (row) => OrderingTerm(
+              expression: row.createdDate,
+              mode: OrderingMode.desc,
+            ),
+          ]))
+          .watch();
+
+  Future<SurveyRow?> getById(String id) =>
+      (select(surveys)..where((row) => row.id.equals(id))).getSingleOrNull();
+
+  Future<List<SurveyQuestionRow>> questionsFor(String surveyId) =>
+      (select(surveyQuestions)
+            ..where((row) => row.surveyId.equals(surveyId))
+            ..orderBy([(row) => OrderingTerm(expression: row.position)]))
+          .get();
+
+  Future<void> upsertAll(
+    List<SurveysCompanion> rows,
+    Map<String, List<SurveyQuestionsCompanion>> questions,
+  ) => transaction(() async {
+    if (rows.isNotEmpty) {
+      await batch((batch) => batch.insertAllOnConflictUpdate(surveys, rows));
+    }
+    for (final entry in questions.entries) {
+      await (delete(
+        surveyQuestions,
+      )..where((row) => row.surveyId.equals(entry.key))).go();
+      if (entry.value.isNotEmpty) {
+        await batch((batch) => batch.insertAll(surveyQuestions, entry.value));
+      }
+    }
+  });
+
+  Future<int> deleteNotIn(List<String> ids) => transaction(() async {
+    final stale =
+        await (selectOnly(surveys)
+              ..addColumns([surveys.id])
+              ..where(surveys.id.isNotIn(ids)))
+            .map((row) => row.read(surveys.id)!)
+            .get();
+    if (stale.isNotEmpty) {
+      await (delete(
+        surveyQuestions,
+      )..where((row) => row.surveyId.isIn(stale))).go();
+    }
+    return (delete(surveys)..where((row) => row.id.isIn(stale))).go();
+  });
 }

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -36,6 +36,7 @@ part 'app_database.g.dart';
     Submissions,
     SubmissionAnswers,
     SubmissionQuestions,
+    Meetups,
   ],
   daos: [
     UserDao,
@@ -49,6 +50,7 @@ part 'app_database.g.dart';
     RatingDao,
     OutboxDao,
     SubmissionDao,
+    MeetupDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -61,7 +63,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.memory() : super(NativeDatabase.memory());
 
   @override
-  int get schemaVersion => 12;
+  int get schemaVersion => 13;
 
   /// Tables holding local intent the server cannot give back.
   ///
@@ -974,4 +976,55 @@ class SubmissionDao extends DatabaseAccessor<AppDatabase>
       return deleted;
     });
   }
+}
+
+/// Port of `data/room/dao/MeetupDao.kt`.
+@DriftAccessor(tables: [Meetups])
+class MeetupDao extends DatabaseAccessor<AppDatabase> with _$MeetupDaoMixin {
+  MeetupDao(super.db);
+
+  Future<void> upsert(MeetupsCompanion row) =>
+      into(meetups).insertOnConflictUpdate(row);
+
+  Future<void> upsertAll(List<MeetupsCompanion> rows) async {
+    if (rows.isEmpty) return;
+    await batch((batch) => batch.insertAllOnConflictUpdate(meetups, rows));
+  }
+
+  Future<MeetupRow?> getById(String id) =>
+      (select(meetups)..where((row) => row.id.equals(id))).getSingleOrNull();
+
+  Future<MeetupRow?> getByMeetupId(String id) =>
+      (select(meetups)
+            ..where((row) => row.meetupId.equals(id))
+            ..limit(1))
+          .getSingleOrNull();
+
+  Future<List<MeetupRow>> getByMeetupIds(List<String> ids) =>
+      (select(meetups)..where((row) => row.meetupId.isIn(ids))).get();
+
+  Stream<List<MeetupRow>> watchForTeam(String teamId) =>
+      (select(meetups)
+            ..where((row) => row.teamId.equals(teamId))
+            ..orderBy([(row) => OrderingTerm(expression: row.startDate)]))
+          .watch();
+
+  Stream<List<MeetupRow>> watchAll() => (select(
+    meetups,
+  )..orderBy([(row) => OrderingTerm(expression: row.startDate)])).watch();
+
+  Future<List<MeetupRow>> meetupsOnShelf(String userId) =>
+      (select(meetups)..where((row) => row.userId.equals(userId))).get();
+
+  Future<List<MeetupRow>> pendingUploads() =>
+      (select(meetups)..where((row) => row.updated.equals(true))).get();
+
+  Future<int> markUploaded(String id, String remoteId, String remoteRev) =>
+      (update(meetups)..where((row) => row.id.equals(id))).write(
+        MeetupsCompanion(
+          meetupId: Value(remoteId),
+          meetupIdRev: Value(remoteRev),
+          updated: const Value(false),
+        ),
+      );
 }

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1019,6 +1019,17 @@ class MeetupDao extends DatabaseAccessor<AppDatabase> with _$MeetupDaoMixin {
   Future<List<MeetupRow>> pendingUploads() =>
       (select(meetups)..where((row) => row.updated.equals(true))).get();
 
+  Future<int> count() async {
+    final count = meetups.id.count();
+    final row = await (selectOnly(meetups)..addColumns([count])).getSingle();
+    return row.read(count) ?? 0;
+  }
+
+  /// Removes stale server rows without discarding locally edited meetups.
+  Future<int> deleteNotIn(List<String> keepIds) => (delete(
+    meetups,
+  )..where((row) => row.updated.equals(false) & row.id.isNotIn(keepIds))).go();
+
   Future<int> markUploaded(String id, String remoteId, String remoteRev) =>
       (update(meetups)..where((row) => row.id.equals(id))).write(
         MeetupsCompanion(

--- a/flutter/lib/data/local/meetup_mapper.dart
+++ b/flutter/lib/data/local/meetup_mapper.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+import '../../core/utils/json_utils.dart';
+import 'app_database.dart';
+
+/// Port of `Meetup.fromJson` in `model/Meetup.kt`.
+class MeetupMapper {
+  const MeetupMapper._();
+
+  static MeetupsCompanion? fromDoc(
+    Map<String, dynamic> doc, {
+    MeetupRow? existing,
+    String? userId,
+  }) {
+    final id = JsonUtils.getString('_id', doc);
+    if (id.isEmpty || id.startsWith('_design/')) return null;
+    final link = JsonUtils.getObject('link', doc);
+    return MeetupsCompanion(
+      id: Value(id),
+      userId: Value(userId),
+      meetupId: Value(id),
+      meetupIdRev: Value(JsonUtils.getStringOrNull('_rev', doc)),
+      title: Value(JsonUtils.getStringOrNull('title', doc)),
+      description: Value(JsonUtils.getStringOrNull('description', doc)),
+      startDate: Value(JsonUtils.getLong('startDate', doc)),
+      endDate: Value(JsonUtils.getLong('endDate', doc)),
+      recurring: Value(JsonUtils.getStringOrNull('recurring', doc)),
+      day: Value(_encoded(doc['day'])),
+      startTime: Value(JsonUtils.getStringOrNull('startTime', doc)),
+      endTime: Value(JsonUtils.getStringOrNull('endTime', doc)),
+      category: Value(JsonUtils.getStringOrNull('category', doc)),
+      meetupLocation: Value(JsonUtils.getStringOrNull('meetupLocation', doc)),
+      meetupLink: Value(JsonUtils.getStringOrNull('meetupLink', doc)),
+      creator: Value(JsonUtils.getStringOrNull('createdBy', doc)),
+      link: Value(link == null ? null : jsonEncode(link)),
+      teamId: Value(
+        link == null ? null : JsonUtils.getStringOrNull('teams', link),
+      ),
+      createdDate: Value(existing?.createdDate ?? 0),
+      recurringNumber: Value(existing?.recurringNumber ?? 10),
+      sync: Value(existing?.sync),
+      sourcePlanet: Value(existing?.sourcePlanet),
+      updated: Value(existing?.updated ?? false),
+    );
+  }
+
+  static String? _encoded(Object? value) =>
+      value == null ? null : jsonEncode(value);
+}

--- a/flutter/lib/data/local/survey_mapper.dart
+++ b/flutter/lib/data/local/survey_mapper.dart
@@ -1,0 +1,68 @@
+import 'package:drift/drift.dart';
+
+import '../../core/utils/json_utils.dart';
+import 'app_database.dart';
+
+/// Port of `StepExam.insertCourseStepsExams` and
+/// `ExamQuestion.insertExamQuestions` for survey documents.
+class SurveyMapper {
+  const SurveyMapper._();
+
+  static SurveyMapping? fromDoc(Map<String, dynamic> doc) {
+    final id = JsonUtils.getString('_id', doc);
+    final type = JsonUtils.getString('type', doc);
+    if (id.isEmpty || id.startsWith('_design/') || type != 'surveys') {
+      return null;
+    }
+    final rawQuestions = doc['questions'];
+    final questions = <SurveyQuestionsCompanion>[];
+    if (rawQuestions is List) {
+      for (var index = 0; index < rawQuestions.length; index++) {
+        final question = rawQuestions[index];
+        if (question is! Map<String, dynamic>) continue;
+        final remoteId = JsonUtils.getString('_id', question);
+        questions.add(
+          SurveyQuestionsCompanion.insert(
+            id: remoteId.isEmpty ? '$id:$index' : '$id:$remoteId',
+            surveyId: id,
+            questionId: Value(remoteId.isEmpty ? null : remoteId),
+            header: Value(JsonUtils.getStringOrNull('header', question)),
+            body: Value(JsonUtils.getStringOrNull('body', question)),
+            type: Value(JsonUtils.getStringOrNull('type', question)),
+            choices: Value(JsonUtils.getStringList('choices', question)),
+            required: Value(JsonUtils.getBool('required', question)),
+            position: index,
+          ),
+        );
+      }
+    }
+    return SurveyMapping(
+      survey: SurveysCompanion.insert(
+        id: id,
+        rev: Value(JsonUtils.getStringOrNull('_rev', doc)),
+        name: Value(JsonUtils.getStringOrNull('name', doc)),
+        description: Value(JsonUtils.getStringOrNull('description', doc)),
+        createdDate: Value(JsonUtils.getLong('createdDate', doc)),
+        updatedDate: Value(JsonUtils.getLong('updatedDate', doc)),
+        adoptionDate: Value(JsonUtils.getLong('adoptionDate', doc)),
+        createdBy: Value(JsonUtils.getStringOrNull('createdBy', doc)),
+        totalMarks: Value(JsonUtils.getInt('totalMarks', doc)),
+        passingPercentage: Value(
+          JsonUtils.getStringOrNull('passingPercentage', doc),
+        ),
+        sourcePlanet: Value(JsonUtils.getStringOrNull('sourcePlanet', doc)),
+        isFromNation: Value(JsonUtils.getBool('isFromNation', doc)),
+        teamId: Value(JsonUtils.getStringOrNull('teamId', doc)),
+        teamShareAllowed: Value(JsonUtils.getBool('teamShareAllowed', doc)),
+        sourceSurveyId: Value(JsonUtils.getStringOrNull('sourceSurveyId', doc)),
+      ),
+      questions: questions,
+    );
+  }
+}
+
+class SurveyMapping {
+  const SurveyMapping({required this.survey, required this.questions});
+  final SurveysCompanion survey;
+  final List<SurveyQuestionsCompanion> questions;
+}

--- a/flutter/lib/data/local/tables.dart
+++ b/flutter/lib/data/local/tables.dart
@@ -461,3 +461,48 @@ class Meetups extends Table {
   @override
   Set<Column> get primaryKey => {id};
 }
+
+/// Port of survey-shaped rows from `model/StepExam.kt` (`exams` database).
+@DataClassName('SurveyRow')
+@TableIndex(name: 'surveys_created_date', columns: {#createdDate})
+class Surveys extends Table {
+  TextColumn get id => text()();
+  TextColumn get rev => text().named('_rev').nullable()();
+  TextColumn get name => text().nullable()();
+  TextColumn get description => text().nullable()();
+  IntColumn get createdDate => integer().withDefault(const Constant(0))();
+  IntColumn get updatedDate => integer().withDefault(const Constant(0))();
+  IntColumn get adoptionDate => integer().withDefault(const Constant(0))();
+  TextColumn get createdBy => text().nullable()();
+  IntColumn get totalMarks => integer().withDefault(const Constant(0))();
+  TextColumn get passingPercentage => text().nullable()();
+  TextColumn get sourcePlanet => text().nullable()();
+  BoolColumn get isFromNation => boolean().withDefault(const Constant(false))();
+  TextColumn get teamId => text().nullable()();
+  BoolColumn get teamShareAllowed =>
+      boolean().withDefault(const Constant(false))();
+  TextColumn get sourceSurveyId => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// Questions embedded in an `exams` CouchDB survey document.
+@DataClassName('SurveyQuestionRow')
+@TableIndex(name: 'survey_questions_survey', columns: {#surveyId, #position})
+class SurveyQuestions extends Table {
+  TextColumn get id => text()();
+  TextColumn get surveyId => text()();
+  TextColumn get questionId => text().nullable()();
+  TextColumn get header => text().nullable()();
+  TextColumn get body => text().nullable()();
+  TextColumn get type => text().nullable()();
+  TextColumn get choices => text()
+      .map(const StringListConverter())
+      .withDefault(const Constant('[]'))();
+  BoolColumn get required => boolean().withDefault(const Constant(false))();
+  IntColumn get position => integer()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/flutter/lib/data/local/tables.dart
+++ b/flutter/lib/data/local/tables.dart
@@ -425,3 +425,39 @@ class SubmissionQuestions extends Table {
   @override
   Set<Column> get primaryKey => {id};
 }
+
+/// Port of `model/Meetup.kt`. Meetups are server-cached documents that may
+/// also carry local edits until the generic meetup uploader is ported.
+@DataClassName('MeetupRow')
+@TableIndex(name: 'meetup_remote_id', columns: {#meetupId})
+@TableIndex(name: 'meetup_team_id', columns: {#teamId})
+@TableIndex(name: 'meetup_user_id', columns: {#userId})
+class Meetups extends Table {
+  TextColumn get id => text()();
+  TextColumn get userId => text().nullable()();
+  TextColumn get meetupId => text().nullable()();
+  TextColumn get meetupIdRev => text().nullable()();
+  TextColumn get title => text().nullable()();
+  TextColumn get description => text().nullable()();
+  IntColumn get startDate => integer().withDefault(const Constant(0))();
+  IntColumn get endDate => integer().withDefault(const Constant(0))();
+  TextColumn get recurring =>
+      text().nullable().withDefault(const Constant('none'))();
+  TextColumn get day => text().nullable()();
+  TextColumn get startTime => text().nullable()();
+  TextColumn get endTime => text().nullable()();
+  TextColumn get category => text().nullable()();
+  TextColumn get meetupLocation => text().nullable()();
+  TextColumn get meetupLink => text().nullable()();
+  TextColumn get creator => text().nullable()();
+  TextColumn get link => text().nullable()();
+  TextColumn get teamId => text().nullable()();
+  IntColumn get createdDate => integer().withDefault(const Constant(0))();
+  IntColumn get recurringNumber => integer().withDefault(const Constant(10))();
+  TextColumn get sync => text().nullable()();
+  TextColumn get sourcePlanet => text().nullable()();
+  BoolColumn get updated => boolean().withDefault(const Constant(false))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -333,5 +333,15 @@
   "endTime": "End time",
   "none": "None",
   "daily": "Daily",
-  "weekly": "Weekly"
+  "weekly": "Weekly",
+  "syncMeetups": "Sync meetups",
+  "searchMeetups": "Search meetups",
+  "sortMeetups": "Sort meetups",
+  "newestFirst": "Newest first",
+  "oldestFirst": "Oldest first",
+  "titleAscending": "Title A–Z",
+  "titleDescending": "Title Z–A",
+  "startDate": "Start date",
+  "endDate": "End date",
+  "timeNotSet": "Time not set"
 }

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -343,5 +343,16 @@
   "titleDescending": "Title Z–A",
   "startDate": "Start date",
   "endDate": "End date",
-  "timeNotSet": "Time not set"
+  "timeNotSet": "Time not set",
+  "syncSurveys": "Sync surveys",
+  "searchSurveys": "Search surveys",
+  "sortSurveys": "Sort surveys",
+  "surveysUnavailable": "Surveys are unavailable",
+  "noSurveys": "No surveys available",
+  "untitledSurvey": "Untitled survey",
+  "takeSurvey": "Take survey",
+  "surveyLoadFailed": "Survey could not be loaded",
+  "surveyHasNoQuestions": "This survey has no questions",
+  "submitSurvey": "Submit survey",
+  "answerRequiredQuestions": "Answer all required questions"
 }

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -259,7 +259,6 @@
   "savedOffline": "Saved offline — pending upload",
   "edit": "Edit",
   "title": "Title",
-  "description": "Description",
   "titleRequired": "Enter a title",
   "rateCourse": "Rate course",
   "rateTitle": "Rate {title}",
@@ -311,5 +310,28 @@
       "current": { "type": "int" },
       "total": { "type": "int" }
     }
-  }
+  },
+  "meetups": "Meetups",
+  "syncPendingMeetups": "Sync pending meetups",
+  "meetupsUnavailable": "Meetups are unavailable",
+  "noMeetups": "No meetups yet",
+  "dateNotSet": "Date not set",
+  "untitledMeetup": "Untitled meetup",
+  "addMeetup": "Add meetup",
+  "meetupDetails": "Meetup details",
+  "meetupNotFound": "Meetup not found",
+  "createdBy": "Created by",
+  "category": "Category",
+  "location": "Location",
+  "link": "Link",
+  "recurring": "Recurring",
+  "description": "Description",
+  "leaveMeetup": "Leave meetup",
+  "joinMeetup": "Join meetup",
+  "editMeetup": "Edit meetup",
+  "startTime": "Start time",
+  "endTime": "End time",
+  "none": "None",
+  "daily": "Daily",
+  "weekly": "Weekly"
 }

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -23,6 +23,7 @@ import '../repository/user_repository.dart';
 import '../repository/submissions_repository.dart';
 import '../repository/submissions_uploader.dart';
 import '../repository/submissions_exporter.dart';
+import '../repository/surveys_repository.dart';
 
 /// The dependency graph, replacing the Hilt modules in `di/`.
 ///
@@ -104,10 +105,22 @@ final submissionDaoProvider = Provider<SubmissionDao>(
   (ref) => ref.watch(appDatabaseProvider).submissionDao,
 );
 
+final surveyDaoProvider = Provider<SurveyDao>(
+  (ref) => ref.watch(appDatabaseProvider).surveyDao,
+);
+
 final submissionsRepositoryProvider = Provider<SubmissionsRepository>(
   (ref) => SubmissionsRepository(
     ref.watch(planetApiProvider),
     ref.watch(submissionDaoProvider),
+  ),
+);
+
+final surveysRepositoryProvider = Provider<SurveysRepository>(
+  (ref) => SurveysRepository(
+    ref.watch(planetApiProvider),
+    ref.watch(surveyDaoProvider),
+    ref.watch(submissionsRepositoryProvider),
   ),
 );
 

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -8,6 +8,8 @@ import '../data/local/app_database.dart';
 import '../repository/configurations_repository.dart';
 import '../repository/courses_repository.dart';
 import '../repository/dictionary_repository.dart';
+import '../repository/events_repository.dart';
+import '../repository/events_uploader.dart';
 import '../repository/notifications_repository.dart';
 import '../repository/outbox_drainer.dart';
 import '../repository/outbox_repository.dart';
@@ -65,6 +67,22 @@ final dictionaryDaoProvider = Provider<DictionaryDao>(
 
 final notificationDaoProvider = Provider<NotificationDao>(
   (ref) => ref.watch(appDatabaseProvider).notificationDao,
+);
+
+final meetupDaoProvider = Provider<MeetupDao>(
+  (ref) => ref.watch(appDatabaseProvider).meetupDao,
+);
+
+final eventsRepositoryProvider = Provider<EventsRepository>(
+  (ref) => EventsRepository(ref.watch(meetupDaoProvider)),
+);
+
+final eventsUploaderProvider = Provider<EventsUploader>(
+  (ref) => EventsUploader(
+    ref.watch(planetApiProvider),
+    ref.watch(eventsRepositoryProvider),
+    ref.watch(outboxRepositoryProvider),
+  ),
 );
 
 final myLifeDaoProvider = Provider<MyLifeDao>(
@@ -185,10 +203,12 @@ final personalsUploaderProvider = Provider<PersonalsUploader>(
 final outboxDrainerProvider = Provider<OutboxDrainer>((ref) {
   final uploader = ref.watch(personalsUploaderProvider);
   final submissionsUploader = ref.watch(submissionsUploaderProvider);
+  final eventsUploader = ref.watch(eventsUploaderProvider);
   final config = ref.watch(serverConfigProvider);
   if (config != null) {
     uploader.authHeader = PersonalsUploader.authHeaderFor(config);
     submissionsUploader.authHeader = PersonalsUploader.authHeaderFor(config);
+    eventsUploader.authHeader = PersonalsUploader.authHeaderFor(config);
   }
   return OutboxDrainer(
     ref.watch(planetApiProvider),
@@ -196,6 +216,7 @@ final outboxDrainerProvider = Provider<OutboxDrainer>((ref) {
     handlers: {
       PersonalsUploader.type: uploader.handler,
       SubmissionsUploader.type: submissionsUploader.handler,
+      EventsUploader.type: eventsUploader.handler,
     },
   );
 });
@@ -211,6 +232,7 @@ final shelfRepositoryProvider = Provider<ShelfRepository>(
     ref.watch(courseDaoProvider),
     ref.watch(myLibraryDaoProvider),
     ref.watch(removedLogDaoProvider),
+    ref.watch(meetupDaoProvider),
   ),
 );
 

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -74,7 +74,10 @@ final meetupDaoProvider = Provider<MeetupDao>(
 );
 
 final eventsRepositoryProvider = Provider<EventsRepository>(
-  (ref) => EventsRepository(ref.watch(meetupDaoProvider)),
+  (ref) => EventsRepository(
+    ref.watch(planetApiProvider),
+    ref.watch(meetupDaoProvider),
+  ),
 );
 
 final eventsUploaderProvider = Provider<EventsUploader>(

--- a/flutter/lib/providers/events_provider.dart
+++ b/flutter/lib/providers/events_provider.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/local/app_database.dart';
+import 'app_providers.dart';
+import 'session_provider.dart';
+
+final eventsProvider = StreamProvider<List<MeetupRow>>(
+  (ref) => ref.watch(eventsRepositoryProvider).watchAll(),
+);
+
+final meetupProvider = FutureProvider.family<MeetupRow?, String>(
+  (ref, id) => ref.watch(eventsRepositoryProvider).getById(id),
+);
+
+class EventsActions {
+  EventsActions(this.ref);
+  final Ref ref;
+
+  Future<String?> save({
+    String? id,
+    required String title,
+    required String description,
+    required int startDate,
+    required int endDate,
+    required String startTime,
+    required String endTime,
+    required String location,
+    required String link,
+    required String recurring,
+  }) async {
+    final repository = ref.read(eventsRepositoryProvider);
+    String? savedId = id;
+    if (id == null) {
+      final user = ref.read(sessionProvider).valueOrNull;
+      savedId = await repository.create(
+        title: title,
+        description: description,
+        startDate: startDate,
+        endDate: endDate,
+        startTime: startTime,
+        endTime: endTime,
+        location: location,
+        link: link,
+        recurring: recurring,
+        creator: user?.name ?? user?.id ?? '',
+        sourcePlanet: user?.planetCode,
+      );
+    } else {
+      final success = await repository.update(
+        id,
+        title: title,
+        description: description,
+        startDate: startDate,
+        endDate: endDate,
+        startTime: startTime,
+        endTime: endTime,
+        location: location,
+        link: link,
+        recurring: recurring,
+      );
+      if (!success) return null;
+    }
+    await queuePending();
+    if (savedId != null) ref.invalidate(meetupProvider(savedId));
+    return savedId;
+  }
+
+  Future<void> toggleAttendance(MeetupRow row) async {
+    final user = ref.read(sessionProvider).valueOrNull;
+    await ref
+        .read(eventsRepositoryProvider)
+        .toggleAttendance(row.meetupId ?? row.id, user?.id);
+    ref.invalidate(meetupProvider(row.id));
+  }
+
+  Future<int> queuePending() async {
+    final config = ref.read(serverConfigProvider);
+    if (config == null) return 0;
+    return ref
+        .read(eventsUploaderProvider)
+        .queuePending(
+          config: config,
+          userId: ref.read(sessionProvider).valueOrNull?.id,
+        );
+  }
+}
+
+final eventsActionsProvider = Provider<EventsActions>(EventsActions.new);

--- a/flutter/lib/providers/events_provider.dart
+++ b/flutter/lib/providers/events_provider.dart
@@ -1,12 +1,51 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/local/app_database.dart';
+import '../core/sync/sync_result.dart';
 import 'app_providers.dart';
 import 'session_provider.dart';
+import 'sync_state.dart';
 
-final eventsProvider = StreamProvider<List<MeetupRow>>(
-  (ref) => ref.watch(eventsRepositoryProvider).watchAll(),
+enum EventsSort {
+  dateAscending,
+  dateDescending,
+  titleAscending,
+  titleDescending,
+}
+
+final eventsSearchProvider = StateProvider<String>((ref) => '');
+final eventsSortProvider = StateProvider<EventsSort>(
+  (ref) => EventsSort.dateDescending,
 );
+
+final eventsProvider = StreamProvider<List<MeetupRow>>((ref) async* {
+  final query = ref.watch(eventsSearchProvider).trim().toLowerCase();
+  final sort = ref.watch(eventsSortProvider);
+  await for (final cached in ref.watch(eventsRepositoryProvider).watchAll()) {
+    final rows = cached
+        .where(
+          (row) =>
+              query.isEmpty ||
+              (row.title ?? '').toLowerCase().contains(query) ||
+              (row.description ?? '').toLowerCase().contains(query) ||
+              (row.meetupLocation ?? '').toLowerCase().contains(query),
+        )
+        .toList();
+    rows.sort(switch (sort) {
+      EventsSort.dateAscending => (a, b) => a.startDate.compareTo(b.startDate),
+      EventsSort.dateDescending => (a, b) => b.startDate.compareTo(a.startDate),
+      EventsSort.titleAscending =>
+        (a, b) => (a.title ?? '').toLowerCase().compareTo(
+          (b.title ?? '').toLowerCase(),
+        ),
+      EventsSort.titleDescending =>
+        (a, b) => (b.title ?? '').toLowerCase().compareTo(
+          (a.title ?? '').toLowerCase(),
+        ),
+    });
+    yield rows;
+  }
+});
 
 final meetupProvider = FutureProvider.family<MeetupRow?, String>(
   (ref, id) => ref.watch(eventsRepositoryProvider).getById(id),
@@ -70,6 +109,12 @@ class EventsActions {
     await ref
         .read(eventsRepositoryProvider)
         .toggleAttendance(row.meetupId ?? row.id, user?.id);
+    final config = ref.read(serverConfigProvider);
+    if (config != null && user?.couchId?.isNotEmpty == true) {
+      await ref
+          .read(shelfRepositoryProvider)
+          .upload(config: config, userId: user!.id, shelfDocId: user.couchId!);
+    }
     ref.invalidate(meetupProvider(row.id));
   }
 
@@ -86,3 +131,15 @@ class EventsActions {
 }
 
 final eventsActionsProvider = Provider<EventsActions>(EventsActions.new);
+
+class EventsSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncResult> runSync(config, void Function(SyncProgress) onProgress) =>
+      ref
+          .read(eventsRepositoryProvider)
+          .sync(config: config, onProgress: onProgress);
+}
+
+final eventsSyncProvider = NotifierProvider<EventsSyncNotifier, SyncUiState>(
+  EventsSyncNotifier.new,
+);

--- a/flutter/lib/providers/surveys_provider.dart
+++ b/flutter/lib/providers/surveys_provider.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/config/server_config.dart';
+import '../core/sync/sync_result.dart';
+import '../data/local/app_database.dart';
+import 'app_providers.dart';
+import 'sync_state.dart';
+
+enum SurveySort { newest, oldest, titleAscending, titleDescending }
+
+final surveySearchProvider = StateProvider<String>((ref) => '');
+final surveySortProvider = StateProvider<SurveySort>(
+  (ref) => SurveySort.newest,
+);
+
+final surveysProvider = StreamProvider<List<SurveyRow>>((ref) async* {
+  final query = ref.watch(surveySearchProvider).trim().toLowerCase();
+  final sort = ref.watch(surveySortProvider);
+  await for (final cached in ref.watch(surveysRepositoryProvider).watchAll()) {
+    final rows = cached
+        .where(
+          (row) =>
+              !row.teamShareAllowed &&
+              (row.teamId == null || row.teamId!.isEmpty) &&
+              (query.isEmpty ||
+                  (row.name ?? '').toLowerCase().contains(query) ||
+                  (row.description ?? '').toLowerCase().contains(query)),
+        )
+        .toList();
+    rows.sort(switch (sort) {
+      SurveySort.newest => (a, b) => b.createdDate.compareTo(a.createdDate),
+      SurveySort.oldest => (a, b) => a.createdDate.compareTo(b.createdDate),
+      SurveySort.titleAscending => (a, b) => (a.name ?? '').compareTo(
+        b.name ?? '',
+      ),
+      SurveySort.titleDescending => (a, b) => (b.name ?? '').compareTo(
+        a.name ?? '',
+      ),
+    });
+    yield rows;
+  }
+});
+
+final surveyProvider = FutureProvider.family<SurveyRow?, String>(
+  (ref, id) => ref.watch(surveysRepositoryProvider).getById(id),
+);
+final surveyQuestionsProvider =
+    FutureProvider.family<List<SurveyQuestionRow>, String>(
+      (ref, id) => ref.watch(surveysRepositoryProvider).questionsFor(id),
+    );
+
+class SurveysSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncResult> runSync(
+    ServerConfig config,
+    void Function(SyncProgress) onProgress,
+  ) => ref
+      .read(surveysRepositoryProvider)
+      .sync(config: config, onProgress: onProgress);
+}
+
+final surveysSyncProvider = NotifierProvider<SurveysSyncNotifier, SyncUiState>(
+  SurveysSyncNotifier.new,
+);

--- a/flutter/lib/repository/events_repository.dart
+++ b/flutter/lib/repository/events_repository.dart
@@ -2,12 +2,20 @@ import 'dart:convert';
 
 import 'package:drift/drift.dart';
 
+import '../core/config/server_config.dart';
+import '../core/network/network_result.dart';
+import '../core/sync/adaptive_batch_processor.dart';
+import '../core/sync/sync_result.dart';
+import '../core/utils/json_utils.dart';
+import '../core/utils/url_utils.dart';
+import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
 import '../data/local/meetup_mapper.dart';
 
 /// Port of `repository/EventsRepositoryImpl.kt`.
 class EventsRepository {
   EventsRepository(
+    this._api,
     this._dao, {
     DateTime Function()? now,
     String Function()? createId,
@@ -15,6 +23,7 @@ class EventsRepository {
        _createId = createId ?? _defaultId;
 
   final MeetupDao _dao;
+  final PlanetApi _api;
   final DateTime Function() _now;
   final String Function() _createId;
 
@@ -143,6 +152,73 @@ class EventsRepository {
   }
 
   Future<List<MeetupRow>> pendingUploads() => _dao.pendingUploads();
+
+  Future<int> localCount() => _dao.count();
+
+  /// Pulls the CouchDB meetups database page-by-page while retaining local
+  /// edits. Cleanup only runs after a complete walk, matching the other sync
+  /// repositories' protection against a server changing mid-page.
+  Future<SyncResult> sync({
+    required ServerConfig config,
+    void Function(SyncProgress)? onProgress,
+  }) async {
+    final dbUrl = UrlUtils.dbUrl(config);
+    final auth = UrlUtils.basicAuthHeader('satellite', config.pin);
+    final countResult = await _api.getJsonObject(
+      '$dbUrl/meetups/_all_docs?limit=0',
+      authHeader: auth,
+    );
+    if (countResult is! NetworkSuccess<Map<String, dynamic>>) {
+      return SyncFailed(describeNetworkFailure(countResult));
+    }
+    final total = JsonUtils.getInt('total_rows', countResult.data);
+    if (total == 0) {
+      await _dao.deleteNotIn(const []);
+      onProgress?.call(const SyncProgress(completed: 0, total: 0));
+      return const SyncComplete(0);
+    }
+
+    final batchSizer = AdaptiveBatchProcessor(initialSize: 100);
+    final ids = <String>[];
+    var skip = 0;
+    var completeWalk = true;
+    while (skip < total) {
+      final size = batchSizer.currentSize;
+      final timer = Stopwatch()..start();
+      final result = await _api.getJsonObject(
+        '$dbUrl/meetups/_all_docs?include_docs=true&limit=$size&skip=$skip',
+        authHeader: auth,
+      );
+      timer.stop();
+      if (result is! NetworkSuccess<Map<String, dynamic>>) {
+        batchSizer.recordFailure();
+        return SyncFailed(describeNetworkFailure(result));
+      }
+      batchSizer.recordSuccess(timer.elapsedMilliseconds);
+      final rows = result.data['rows'];
+      if (rows is! List || rows.isEmpty) {
+        completeWalk = false;
+        break;
+      }
+      final documents = rows
+          .whereType<Map<String, dynamic>>()
+          .map((row) => JsonUtils.getObject('doc', row))
+          .whereType<Map<String, dynamic>>()
+          .toList(growable: false);
+      await cacheDocuments(documents);
+      ids.addAll(
+        documents
+            .map((doc) => JsonUtils.getString('_id', doc))
+            .where((id) => id.isNotEmpty && !id.startsWith('_design/')),
+      );
+      skip += rows.length;
+      onProgress?.call(
+        SyncProgress(completed: skip.clamp(0, total), total: total),
+      );
+    }
+    if (completeWalk) await _dao.deleteNotIn(ids);
+    return SyncComplete(ids.length);
+  }
 
   Future<void> markUploaded(
     String id,

--- a/flutter/lib/repository/events_repository.dart
+++ b/flutter/lib/repository/events_repository.dart
@@ -1,0 +1,182 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+import '../data/local/app_database.dart';
+import '../data/local/meetup_mapper.dart';
+
+/// Port of `repository/EventsRepositoryImpl.kt`.
+class EventsRepository {
+  EventsRepository(
+    this._dao, {
+    DateTime Function()? now,
+    String Function()? createId,
+  }) : _now = now ?? DateTime.now,
+       _createId = createId ?? _defaultId;
+
+  final MeetupDao _dao;
+  final DateTime Function() _now;
+  final String Function() _createId;
+
+  static String _defaultId() =>
+      'meetup-${DateTime.now().microsecondsSinceEpoch}';
+
+  Stream<List<MeetupRow>> watchAll() => _dao.watchAll();
+
+  Stream<List<MeetupRow>> watchForTeam(String teamId) =>
+      _dao.watchForTeam(teamId);
+
+  Future<MeetupRow?> getById(String id) =>
+      id.trim().isEmpty ? Future.value(null) : _dao.getById(id);
+
+  Future<MeetupRow?> getByMeetupId(String id) =>
+      id.trim().isEmpty ? Future.value(null) : _dao.getByMeetupId(id);
+
+  /// Server refreshes never overwrite a locally edited meetup.
+  Future<int> cacheDocuments(List<Map<String, dynamic>> documents) async {
+    if (documents.isEmpty) return 0;
+    final ids = documents
+        .map((doc) => doc['_id']?.toString() ?? '')
+        .where((id) => id.isNotEmpty)
+        .toList(growable: false);
+    final existing = {
+      for (final row in await _dao.getByMeetupIds(ids)) row.meetupId: row,
+    };
+    final rows = <MeetupsCompanion>[];
+    for (final doc in documents) {
+      final current = existing[doc['_id']?.toString()];
+      if (current?.updated == true) continue;
+      final mapped = MeetupMapper.fromDoc(doc, existing: current);
+      if (mapped != null) rows.add(mapped);
+    }
+    await _dao.upsertAll(rows);
+    return documents.length;
+  }
+
+  Future<bool> update(
+    String id, {
+    required String title,
+    required String description,
+    required int startDate,
+    required int endDate,
+    required String startTime,
+    required String endTime,
+    required String location,
+    required String link,
+    required String recurring,
+  }) async {
+    final row = await _dao.getById(id);
+    if (row == null || title.trim().isEmpty) return false;
+    await _dao.upsert(
+      row
+          .toCompanion(false)
+          .copyWith(
+            title: Value(title.trim()),
+            description: Value(description.trim()),
+            startDate: Value(startDate),
+            endDate: Value(endDate),
+            startTime: Value(startTime),
+            endTime: Value(endTime),
+            meetupLocation: Value(location.trim()),
+            meetupLink: Value(link.trim()),
+            recurring: Value(recurring),
+            updated: const Value(true),
+          ),
+    );
+    return true;
+  }
+
+  Future<String?> create({
+    required String title,
+    required String description,
+    required int startDate,
+    required int endDate,
+    required String startTime,
+    required String endTime,
+    required String location,
+    required String link,
+    required String recurring,
+    required String creator,
+    String? teamId,
+    String? sourcePlanet,
+  }) async {
+    final cleanTitle = title.trim();
+    if (cleanTitle.isEmpty) return null;
+    final id = _createId();
+    await _dao.upsert(
+      MeetupsCompanion.insert(
+        id: id,
+        title: Value(cleanTitle),
+        description: Value(description.trim()),
+        startDate: Value(startDate),
+        endDate: Value(endDate),
+        startTime: Value(startTime),
+        endTime: Value(endTime),
+        meetupLocation: Value(location.trim()),
+        meetupLink: Value(link.trim()),
+        recurring: Value(recurring),
+        creator: Value(creator),
+        teamId: Value(teamId),
+        link: Value(teamId == null ? null : jsonEncode({'teams': teamId})),
+        createdDate: Value(_now().millisecondsSinceEpoch),
+        sourcePlanet: Value(sourcePlanet),
+        sync: Value(
+          sourcePlanet == null
+              ? null
+              : jsonEncode({'type': 'local', 'planetCode': sourcePlanet}),
+        ),
+        updated: const Value(true),
+      ),
+    );
+    return id;
+  }
+
+  Future<MeetupRow?> toggleAttendance(String meetupId, String? userId) async {
+    final row = await _dao.getByMeetupId(meetupId);
+    if (row == null) return null;
+    final joined = row.userId?.isNotEmpty == true;
+    if (!joined && (userId == null || userId.isEmpty)) return row;
+    await _dao.upsert(
+      row.toCompanion(false).copyWith(userId: Value(joined ? '' : userId)),
+    );
+    return _dao.getByMeetupId(meetupId);
+  }
+
+  Future<List<MeetupRow>> pendingUploads() => _dao.pendingUploads();
+
+  Future<void> markUploaded(
+    String id,
+    String remoteId,
+    String remoteRev,
+  ) async {
+    await _dao.markUploaded(id, remoteId, remoteRev);
+  }
+
+  static Map<String, dynamic> serialize(MeetupRow row) => {
+    if (row.meetupId?.isNotEmpty == true) '_id': row.meetupId,
+    if (row.meetupIdRev?.isNotEmpty == true) '_rev': row.meetupIdRev,
+    'title': row.title,
+    'description': row.description,
+    'startDate': row.startDate,
+    'endDate': row.endDate,
+    'startTime': row.startTime,
+    'endTime': row.endTime,
+    'recurring': row.recurring,
+    'meetupLocation': row.meetupLocation,
+    'meetupLink': row.meetupLink,
+    'createdBy': row.creator,
+    'teamId': row.teamId,
+    'category': row.category,
+    'createdDate': row.createdDate,
+    'recurringNumber': row.recurringNumber,
+    'sourcePlanet': row.sourcePlanet,
+    'sync': _jsonObject(row.sync),
+    'link': _jsonObject(row.link),
+  };
+
+  static Map<String, dynamic>? _jsonObject(String? value) {
+    if (value == null || value.isEmpty) return null;
+    final decoded = jsonDecode(value);
+    return decoded is Map<String, dynamic> ? decoded : null;
+  }
+}

--- a/flutter/lib/repository/events_uploader.dart
+++ b/flutter/lib/repository/events_uploader.dart
@@ -1,0 +1,54 @@
+import '../core/config/server_config.dart';
+import '../core/network/network_result.dart';
+import '../core/utils/url_utils.dart';
+import '../data/api/planet_api.dart';
+import 'events_repository.dart';
+import 'outbox_drainer.dart';
+import 'outbox_repository.dart';
+
+/// Durable meetup upload, replacing the meetups branch of `UploadManager`.
+class EventsUploader {
+  EventsUploader(this._api, this._events, this._outbox);
+
+  static const type = 'meetups';
+  final PlanetApi _api;
+  final EventsRepository _events;
+  final OutboxRepository _outbox;
+  String? _authHeader;
+
+  static String endpointFor(ServerConfig config) =>
+      '${UrlUtils.dbUrl(config)}/meetups';
+
+  set authHeader(String? value) => _authHeader = value;
+
+  Future<int> queuePending({
+    required ServerConfig config,
+    String? userId,
+  }) async {
+    final rows = await _events.pendingUploads();
+    for (final row in rows) {
+      await _outbox.enqueue(
+        uploadType: type,
+        itemId: row.id,
+        endpoint: endpointFor(config),
+        payload: EventsRepository.serialize(row),
+        userId: userId,
+      );
+    }
+    return rows.length;
+  }
+
+  OutboxHandler get handler => (row, payload) async {
+    final result = await _api.postJsonObject(
+      row.endpoint,
+      payload,
+      authHeader: _authHeader,
+    );
+    if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
+      if (data case {'id': final String id, 'rev': final String rev}) {
+        await _events.markUploaded(row.itemId, id, rev);
+      }
+    }
+    return result;
+  };
+}

--- a/flutter/lib/repository/shelf_repository.dart
+++ b/flutter/lib/repository/shelf_repository.dart
@@ -30,6 +30,7 @@ class ShelfRepository {
     this._courseDao,
     this._libraryDao,
     this._removedLogDao,
+    this._meetupDao,
   );
 
   /// CouchDB table names, used as the `type` in the removed log.
@@ -40,6 +41,7 @@ class ShelfRepository {
   final CourseDao _courseDao;
   final MyLibraryDao _libraryDao;
   final RemovedLogDao _removedLogDao;
+  final MeetupDao _meetupDao;
 
   /// Pushes [userId]'s shelf to the server.
   ///
@@ -92,8 +94,6 @@ class ShelfRepository {
   /// Port of `getShelfData`. Exposed for testing — it is the whole of the merge
   /// logic, and the part worth pinning down.
   ///
-  /// `meetupIds` is passed through from the server untouched: meetups are not
-  /// ported yet, and dropping the key would delete the user's meetups server-side.
   Future<Map<String, dynamic>> buildShelfDocument({
     required String userId,
     required String shelfDocId,
@@ -101,6 +101,7 @@ class ShelfRepository {
   }) async {
     final localCourseIds = await _localCourseIds(userId);
     final localResourceIds = await _localResourceIds(userId);
+    final localMeetupIds = await _localMeetupIds(userId);
 
     final removedCourses = await _removedLogDao.removedDocIds(
       coursesType,
@@ -123,7 +124,11 @@ class ShelfRepository {
         JsonUtils.getStringList('resourceIds', serverDoc),
         removedResources,
       ),
-      'meetupIds': JsonUtils.getStringList('meetupIds', serverDoc),
+      'meetupIds': mergeIds(
+        localMeetupIds,
+        JsonUtils.getStringList('meetupIds', serverDoc),
+        const [],
+      ),
     };
 
     final rev = JsonUtils.getStringOrNull('_rev', serverDoc);
@@ -169,6 +174,14 @@ class ShelfRepository {
     final resources = await _libraryDao.resourcesOnShelf(userId);
     return resources
         .map((r) => r.resourceId ?? r.id)
+        .where((id) => id.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  Future<List<String>> _localMeetupIds(String userId) async {
+    final meetups = await _meetupDao.meetupsOnShelf(userId);
+    return meetups
+        .map((meetup) => meetup.meetupId ?? meetup.id)
         .where((id) => id.isNotEmpty)
         .toList(growable: false);
   }

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -72,6 +72,63 @@ class SubmissionsRepository {
     return id;
   }
 
+  /// Creates the empty answer sheet used when a user starts an offline survey.
+  Future<String> createSurveyDraft({
+    required SurveyRow survey,
+    required List<SurveyQuestionRow> questions,
+    required String userId,
+    Map<String, SubmissionDraftAnswer> answers = const {},
+    DateTime? now,
+  }) async {
+    final timestamp = (now ?? DateTime.now()).millisecondsSinceEpoch;
+    final id = sha1
+        .convert(utf8.encode('$userId:$timestamp:${survey.id}'))
+        .toString();
+    await _dao.upsertAll(
+      [
+        SubmissionsCompanion.insert(
+          id: id,
+          parentId: Value(survey.id),
+          parent: Value(jsonEncode({'_id': survey.id, 'name': survey.name})),
+          userId: Value(userId),
+          type: const Value('survey'),
+          startTime: Value(timestamp),
+          lastUpdateTime: Value(timestamp),
+          status: const Value('complete'),
+          uploaded: const Value(false),
+          isUpdated: const Value(true),
+        ),
+      ],
+      questions: {
+        id: [
+          for (final question in questions)
+            SubmissionQuestionsCompanion.insert(
+              id: '$id:${question.id}',
+              submissionId: id,
+              header: Value(question.header),
+              body: Value(question.body),
+              type: Value(question.type),
+              choices: Value(question.choices),
+              position: question.position,
+            ),
+        ],
+      },
+      answers: {
+        id: [
+          for (final question in questions)
+            SubmissionAnswersCompanion.insert(
+              id: '$id:${question.id}',
+              submissionId: id,
+              questionId: Value(question.questionId ?? question.id),
+              value: Value(answers[question.id]?.value),
+              valueChoices: Value(answers[question.id]?.choices ?? const []),
+            ),
+        ],
+      },
+    );
+    return id;
+  }
+
   Future<List<SubmissionRow>> pendingUploads(String userId) =>
       _dao.pendingUploads(userId);
 

--- a/flutter/lib/repository/surveys_repository.dart
+++ b/flutter/lib/repository/surveys_repository.dart
@@ -1,0 +1,98 @@
+import '../core/config/server_config.dart';
+import '../core/network/network_result.dart';
+import '../core/sync/adaptive_batch_processor.dart';
+import '../core/sync/sync_result.dart';
+import '../core/utils/json_utils.dart';
+import '../core/utils/url_utils.dart';
+import '../data/api/planet_api.dart';
+import '../data/local/app_database.dart';
+import '../data/local/survey_mapper.dart';
+import 'submissions_repository.dart';
+
+/// Port of the individual-survey path in `SurveysRepositoryImpl.kt`.
+class SurveysRepository {
+  SurveysRepository(this._api, this._dao, this._submissions);
+
+  final PlanetApi _api;
+  final SurveyDao _dao;
+  final SubmissionsRepository _submissions;
+
+  Stream<List<SurveyRow>> watchAll() => _dao.watchAll();
+  Future<SurveyRow?> getById(String id) => _dao.getById(id);
+  Future<List<SurveyQuestionRow>> questionsFor(String id) =>
+      _dao.questionsFor(id);
+
+  Future<String?> submitResponse(
+    String surveyId,
+    String userId,
+    Map<String, SubmissionDraftAnswer> answers,
+  ) async {
+    final survey = await _dao.getById(surveyId);
+    if (survey == null) return null;
+    final questions = await _dao.questionsFor(surveyId);
+    return _submissions.createSurveyDraft(
+      survey: survey,
+      questions: questions,
+      userId: userId,
+      answers: answers,
+    );
+  }
+
+  Future<SyncResult> sync({
+    required ServerConfig config,
+    void Function(SyncProgress)? onProgress,
+  }) async {
+    final dbUrl = UrlUtils.dbUrl(config);
+    final auth = UrlUtils.basicAuthHeader('satellite', config.pin);
+    final count = await _api.getJsonObject(
+      '$dbUrl/exams/_all_docs?limit=0',
+      authHeader: auth,
+    );
+    if (count is! NetworkSuccess<Map<String, dynamic>>) {
+      return SyncFailed(describeNetworkFailure(count));
+    }
+    final total = JsonUtils.getInt('total_rows', count.data);
+    final ids = <String>[];
+    var skip = 0;
+    var complete = true;
+    final sizer = AdaptiveBatchProcessor(initialSize: 100);
+    while (skip < total) {
+      final limit = sizer.currentSize;
+      final timer = Stopwatch()..start();
+      final result = await _api.getJsonObject(
+        '$dbUrl/exams/_all_docs?include_docs=true&limit=$limit&skip=$skip',
+        authHeader: auth,
+      );
+      timer.stop();
+      if (result is! NetworkSuccess<Map<String, dynamic>>) {
+        sizer.recordFailure();
+        return SyncFailed(describeNetworkFailure(result));
+      }
+      sizer.recordSuccess(timer.elapsedMilliseconds);
+      final rows = result.data['rows'];
+      if (rows is! List || rows.isEmpty) {
+        complete = false;
+        break;
+      }
+      final surveys = <SurveysCompanion>[];
+      final questions = <String, List<SurveyQuestionsCompanion>>{};
+      for (final row in rows.whereType<Map<String, dynamic>>()) {
+        final doc = JsonUtils.getObject('doc', row);
+        if (doc == null) continue;
+        final mapped = SurveyMapper.fromDoc(doc);
+        if (mapped == null) continue;
+        final id = mapped.survey.id.value;
+        ids.add(id);
+        surveys.add(mapped.survey);
+        questions[id] = mapped.questions;
+      }
+      await _dao.upsertAll(surveys, questions);
+      skip += rows.length;
+      onProgress?.call(
+        SyncProgress(completed: skip.clamp(0, total), total: total),
+      );
+    }
+    if (total == 0 || complete) await _dao.deleteNotIn(ids);
+    return SyncComplete(ids.length);
+  }
+}

--- a/flutter/lib/ui/calendar/calendar_screen.dart
+++ b/flutter/lib/ui/calendar/calendar_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../dashboard/dashboard_shell.dart';
+import '../router.dart';
 
 /// Port of `ui/calendar/CalendarFragment.kt` and `fragment_calendar.xml`.
 ///
@@ -34,7 +36,14 @@ class _CalendarScreenState extends State<CalendarScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.calendar),
-        actions: const [LogoutAction()],
+        actions: [
+          IconButton(
+            tooltip: l10n.meetups,
+            onPressed: () => context.push(Routes.events),
+            icon: const Icon(Icons.groups_outlined),
+          ),
+          const LogoutAction(),
+        ],
       ),
       body: SafeArea(
         child: Center(

--- a/flutter/lib/ui/events/event_detail_screen.dart
+++ b/flutter/lib/ui/events/event_detail_screen.dart
@@ -49,6 +49,14 @@ class _Details extends ConsumerWidget {
         ),
         const SizedBox(height: 16),
         _Value(label: l10n.createdBy, value: row.creator),
+        _Value(
+          label: l10n.startDate,
+          value: _dateTime(context, row.startDate, row.startTime),
+        ),
+        _Value(
+          label: l10n.endDate,
+          value: _dateTime(context, row.endDate, row.endTime),
+        ),
         _Value(label: l10n.category, value: row.category),
         _Value(label: l10n.location, value: row.meetupLocation),
         _Value(label: l10n.link, value: row.meetupLink),
@@ -66,13 +74,29 @@ class _Details extends ConsumerWidget {
         OutlinedButton.icon(
           onPressed: () => showDialog<void>(
             context: context,
-            builder: (_) => _MeetupEditor(existing: row),
+            builder: (_) => AlertDialog(
+              title: Text(l10n.editMeetup),
+              content: SizedBox(
+                width: 480,
+                child: _MeetupEditor(existing: row),
+              ),
+            ),
           ),
           icon: const Icon(Icons.edit),
           label: Text(l10n.editMeetup),
         ),
       ],
     );
+  }
+
+  String? _dateTime(BuildContext context, int millis, String? time) {
+    if (millis == 0 && (time == null || time.isEmpty)) return null;
+    final date = millis == 0
+        ? ''
+        : MaterialLocalizations.of(
+            context,
+          ).formatMediumDate(DateTime.fromMillisecondsSinceEpoch(millis));
+    return [date, time].where((value) => value?.isNotEmpty == true).join(' · ');
   }
 }
 
@@ -162,13 +186,43 @@ class _MeetupEditorState extends ConsumerState<_MeetupEditor> {
             controller: link,
             decoration: InputDecoration(labelText: l10n.link),
           ),
-          TextField(
-            controller: startTime,
-            decoration: InputDecoration(labelText: l10n.startTime),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            title: Text(l10n.startDate),
+            subtitle: Text(_dateLabel(context, startDate)),
+            trailing: const Icon(Icons.calendar_month),
+            onTap: () => _pickDate(start: true),
           ),
-          TextField(
-            controller: endTime,
-            decoration: InputDecoration(labelText: l10n.endTime),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            title: Text(l10n.endDate),
+            subtitle: Text(_dateLabel(context, endDate)),
+            trailing: const Icon(Icons.event),
+            onTap: () => _pickDate(start: false),
+          ),
+          Row(
+            children: [
+              Expanded(
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: Text(l10n.startTime),
+                  subtitle: Text(
+                    startTime.text.isEmpty ? l10n.timeNotSet : startTime.text,
+                  ),
+                  onTap: () => _pickTime(startTime),
+                ),
+              ),
+              Expanded(
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: Text(l10n.endTime),
+                  subtitle: Text(
+                    endTime.text.isEmpty ? l10n.timeNotSet : endTime.text,
+                  ),
+                  onTap: () => _pickTime(endTime),
+                ),
+              ),
+            ],
           ),
           DropdownButtonFormField<String>(
             initialValue: recurring,
@@ -211,5 +265,50 @@ class _MeetupEditorState extends ConsumerState<_MeetupEditor> {
         ],
       ),
     );
+  }
+
+  String _dateLabel(BuildContext context, int millis) => millis == 0
+      ? AppLocalizations.of(context).dateNotSet
+      : MaterialLocalizations.of(
+          context,
+        ).formatMediumDate(DateTime.fromMillisecondsSinceEpoch(millis));
+
+  Future<void> _pickDate({required bool start}) async {
+    final current = start ? startDate : endDate;
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: current == 0
+          ? DateTime.now()
+          : DateTime.fromMillisecondsSinceEpoch(current),
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (picked == null || !mounted) return;
+    setState(() {
+      final value = DateUtils.dateOnly(picked).millisecondsSinceEpoch;
+      if (start) {
+        startDate = value;
+        if (endDate != 0 && endDate < value) endDate = value;
+      } else {
+        endDate = value;
+      }
+    });
+  }
+
+  Future<void> _pickTime(TextEditingController controller) async {
+    final parts = controller.text.split(':');
+    final initial = parts.length == 2
+        ? TimeOfDay(
+            hour: int.tryParse(parts[0]) ?? 0,
+            minute: int.tryParse(parts[1]) ?? 0,
+          )
+        : TimeOfDay.now();
+    final picked = await showTimePicker(context: context, initialTime: initial);
+    if (picked == null || !mounted) return;
+    setState(() {
+      controller.text =
+          '${picked.hour.toString().padLeft(2, '0')}:'
+          '${picked.minute.toString().padLeft(2, '0')}';
+    });
   }
 }

--- a/flutter/lib/ui/events/event_detail_screen.dart
+++ b/flutter/lib/ui/events/event_detail_screen.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/local/app_database.dart';
+import '../../l10n/app_localizations.dart';
+import '../../providers/events_provider.dart';
+
+/// Port of `ui/events/EventsDetailFragment.kt`, including local editing and
+/// join/leave behavior.
+class EventDetailScreen extends ConsumerWidget {
+  const EventDetailScreen({required this.meetupId, super.key});
+  final String meetupId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final meetup = ref.watch(meetupProvider(meetupId));
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.meetupDetails)),
+      body: meetup.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => Center(child: Text(l10n.meetupsUnavailable)),
+        data: (row) => row == null
+            ? Center(child: Text(l10n.meetupNotFound))
+            : _Details(row: row),
+      ),
+    );
+  }
+}
+
+class _Details extends ConsumerWidget {
+  const _Details({required this.row});
+  final MeetupRow row;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final joined = row.userId?.isNotEmpty == true;
+    final eventEnded =
+        row.endDate > 0 &&
+        DateTime.now().millisecondsSinceEpoch >
+            row.endDate + const Duration(days: 1).inMilliseconds - 1;
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text(
+          row.title ?? l10n.untitledMeetup,
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        const SizedBox(height: 16),
+        _Value(label: l10n.createdBy, value: row.creator),
+        _Value(label: l10n.category, value: row.category),
+        _Value(label: l10n.location, value: row.meetupLocation),
+        _Value(label: l10n.link, value: row.meetupLink),
+        _Value(label: l10n.recurring, value: row.recurring),
+        _Value(label: l10n.description, value: row.description),
+        const SizedBox(height: 20),
+        FilledButton.icon(
+          onPressed: eventEnded
+              ? null
+              : () => ref.read(eventsActionsProvider).toggleAttendance(row),
+          icon: Icon(joined ? Icons.event_busy : Icons.event_available),
+          label: Text(joined ? l10n.leaveMeetup : l10n.joinMeetup),
+        ),
+        const SizedBox(height: 8),
+        OutlinedButton.icon(
+          onPressed: () => showDialog<void>(
+            context: context,
+            builder: (_) => _MeetupEditor(existing: row),
+          ),
+          icon: const Icon(Icons.edit),
+          label: Text(l10n.editMeetup),
+        ),
+      ],
+    );
+  }
+}
+
+class _Value extends StatelessWidget {
+  const _Value({required this.label, this.value});
+  final String label;
+  final String? value;
+
+  @override
+  Widget build(BuildContext context) {
+    if (value == null || value!.isEmpty) return const SizedBox.shrink();
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text(label),
+      subtitle: Text(value!),
+    );
+  }
+}
+
+class NewMeetupScreen extends StatelessWidget {
+  const NewMeetupScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    appBar: AppBar(title: Text(AppLocalizations.of(context).addMeetup)),
+    body: const Padding(padding: EdgeInsets.all(16), child: _MeetupEditor()),
+  );
+}
+
+class _MeetupEditor extends ConsumerStatefulWidget {
+  const _MeetupEditor({this.existing});
+  final MeetupRow? existing;
+
+  @override
+  ConsumerState<_MeetupEditor> createState() => _MeetupEditorState();
+}
+
+class _MeetupEditorState extends ConsumerState<_MeetupEditor> {
+  late final title = TextEditingController(text: widget.existing?.title);
+  late final description = TextEditingController(
+    text: widget.existing?.description,
+  );
+  late final location = TextEditingController(
+    text: widget.existing?.meetupLocation,
+  );
+  late final link = TextEditingController(text: widget.existing?.meetupLink);
+  late final startTime = TextEditingController(
+    text: widget.existing?.startTime,
+  );
+  late final endTime = TextEditingController(text: widget.existing?.endTime);
+  late int startDate = widget.existing?.startDate ?? 0;
+  late int endDate = widget.existing?.endDate ?? 0;
+  late String recurring = widget.existing?.recurring ?? 'none';
+
+  @override
+  void dispose() {
+    title.dispose();
+    description.dispose();
+    location.dispose();
+    link.dispose();
+    startTime.dispose();
+    endTime.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: title,
+            decoration: InputDecoration(labelText: l10n.title),
+          ),
+          TextField(
+            controller: description,
+            decoration: InputDecoration(labelText: l10n.description),
+            maxLines: 3,
+          ),
+          TextField(
+            controller: location,
+            decoration: InputDecoration(labelText: l10n.location),
+          ),
+          TextField(
+            controller: link,
+            decoration: InputDecoration(labelText: l10n.link),
+          ),
+          TextField(
+            controller: startTime,
+            decoration: InputDecoration(labelText: l10n.startTime),
+          ),
+          TextField(
+            controller: endTime,
+            decoration: InputDecoration(labelText: l10n.endTime),
+          ),
+          DropdownButtonFormField<String>(
+            initialValue: recurring,
+            decoration: InputDecoration(labelText: l10n.recurring),
+            items: [
+              DropdownMenuItem(value: 'none', child: Text(l10n.none)),
+              DropdownMenuItem(value: 'daily', child: Text(l10n.daily)),
+              DropdownMenuItem(value: 'weekly', child: Text(l10n.weekly)),
+            ],
+            onChanged: (value) => recurring = value ?? 'none',
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: () async {
+              final id = await ref
+                  .read(eventsActionsProvider)
+                  .save(
+                    id: widget.existing?.id,
+                    title: title.text,
+                    description: description.text,
+                    startDate: startDate,
+                    endDate: endDate,
+                    startTime: startTime.text,
+                    endTime: endTime.text,
+                    location: location.text,
+                    link: link.text,
+                    recurring: recurring,
+                  );
+              if (!context.mounted) return;
+              if (id == null) {
+                ScaffoldMessenger.of(
+                  context,
+                ).showSnackBar(SnackBar(content: Text(l10n.titleRequired)));
+              } else {
+                Navigator.of(context).pop();
+              }
+            },
+            child: Text(l10n.save),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter/lib/ui/events/events_screen.dart
+++ b/flutter/lib/ui/events/events_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../../providers/events_provider.dart';
+import '../../providers/sync_state.dart';
 import '../router.dart';
 
 /// Flutter port of the meetup list hosted by the Kotlin teams UI.
@@ -14,50 +15,131 @@ class EventsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final events = ref.watch(eventsProvider);
+    final sync = ref.watch(eventsSyncProvider);
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.meetups),
         actions: [
           IconButton(
-            tooltip: l10n.syncPendingMeetups,
-            onPressed: () => ref.read(eventsActionsProvider).queuePending(),
-            icon: const Icon(Icons.sync),
+            tooltip: l10n.syncMeetups,
+            onPressed: sync is SyncRunning
+                ? null
+                : () async {
+                    await ref.read(eventsSyncProvider.notifier).sync();
+                    await ref.read(eventsActionsProvider).queuePending();
+                  },
+            icon: sync is SyncRunning
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.sync),
           ),
         ],
       ),
-      body: events.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (_, _) => Center(child: Text(l10n.meetupsUnavailable)),
-        data: (rows) => rows.isEmpty
-            ? Center(child: Text(l10n.noMeetups))
-            : ListView.separated(
-                padding: const EdgeInsets.all(12),
-                itemCount: rows.length,
-                separatorBuilder: (_, _) => const SizedBox(height: 6),
-                itemBuilder: (context, index) {
-                  final row = rows[index];
-                  final date = row.startDate == 0
-                      ? l10n.dateNotSet
-                      : MaterialLocalizations.of(context).formatMediumDate(
-                          DateTime.fromMillisecondsSinceEpoch(row.startDate),
-                        );
-                  return Card(
-                    child: ListTile(
-                      leading: Icon(
-                        row.updated ? Icons.cloud_upload_outlined : Icons.event,
-                      ),
-                      title: Text(row.title ?? l10n.untitledMeetup),
-                      subtitle: Text(
-                        [date, row.meetupLocation]
-                            .where((value) => value?.isNotEmpty == true)
-                            .join(' · '),
-                      ),
-                      trailing: const Icon(Icons.chevron_right),
-                      onTap: () => context.push('${Routes.events}/${row.id}'),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+            child: Row(
+              children: [
+                Expanded(
+                  child: SearchBar(
+                    hintText: l10n.searchMeetups,
+                    leading: const Icon(Icons.search),
+                    onChanged: (value) =>
+                        ref.read(eventsSearchProvider.notifier).state = value,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                PopupMenuButton<EventsSort>(
+                  tooltip: l10n.sortMeetups,
+                  initialValue: ref.watch(eventsSortProvider),
+                  onSelected: (value) =>
+                      ref.read(eventsSortProvider.notifier).state = value,
+                  itemBuilder: (_) => [
+                    PopupMenuItem(
+                      value: EventsSort.dateDescending,
+                      child: Text(l10n.newestFirst),
                     ),
-                  );
-                },
+                    PopupMenuItem(
+                      value: EventsSort.dateAscending,
+                      child: Text(l10n.oldestFirst),
+                    ),
+                    PopupMenuItem(
+                      value: EventsSort.titleAscending,
+                      child: Text(l10n.titleAscending),
+                    ),
+                    PopupMenuItem(
+                      value: EventsSort.titleDescending,
+                      child: Text(l10n.titleDescending),
+                    ),
+                  ],
+                  icon: const Icon(Icons.sort),
+                ),
+              ],
+            ),
+          ),
+          if (sync is SyncRunning)
+            LinearProgressIndicator(
+              value: sync.progress.total == 0 ? null : sync.progress.fraction,
+            ),
+          Expanded(
+            child: RefreshIndicator(
+              onRefresh: () => ref.read(eventsSyncProvider.notifier).sync(),
+              child: events.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (_, _) => Center(child: Text(l10n.meetupsUnavailable)),
+                data: (rows) => rows.isEmpty
+                    ? ListView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        children: [
+                          SizedBox(
+                            height: 300,
+                            child: Center(child: Text(l10n.noMeetups)),
+                          ),
+                        ],
+                      )
+                    : ListView.separated(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        padding: const EdgeInsets.all(12),
+                        itemCount: rows.length,
+                        separatorBuilder: (_, _) => const SizedBox(height: 6),
+                        itemBuilder: (context, index) {
+                          final row = rows[index];
+                          final date = row.startDate == 0
+                              ? l10n.dateNotSet
+                              : MaterialLocalizations.of(
+                                  context,
+                                ).formatMediumDate(
+                                  DateTime.fromMillisecondsSinceEpoch(
+                                    row.startDate,
+                                  ),
+                                );
+                          return Card(
+                            child: ListTile(
+                              leading: Icon(
+                                row.updated
+                                    ? Icons.cloud_upload_outlined
+                                    : Icons.event,
+                              ),
+                              title: Text(row.title ?? l10n.untitledMeetup),
+                              subtitle: Text(
+                                [date, row.meetupLocation]
+                                    .where((value) => value?.isNotEmpty == true)
+                                    .join(' · '),
+                              ),
+                              trailing: const Icon(Icons.chevron_right),
+                              onTap: () =>
+                                  context.push('${Routes.events}/${row.id}'),
+                            ),
+                          );
+                        },
+                      ),
               ),
+            ),
+          ),
+        ],
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => context.push('${Routes.events}/new'),

--- a/flutter/lib/ui/events/events_screen.dart
+++ b/flutter/lib/ui/events/events_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../../providers/events_provider.dart';
+import '../router.dart';
+
+/// Flutter port of the meetup list hosted by the Kotlin teams UI.
+class EventsScreen extends ConsumerWidget {
+  const EventsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final events = ref.watch(eventsProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.meetups),
+        actions: [
+          IconButton(
+            tooltip: l10n.syncPendingMeetups,
+            onPressed: () => ref.read(eventsActionsProvider).queuePending(),
+            icon: const Icon(Icons.sync),
+          ),
+        ],
+      ),
+      body: events.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => Center(child: Text(l10n.meetupsUnavailable)),
+        data: (rows) => rows.isEmpty
+            ? Center(child: Text(l10n.noMeetups))
+            : ListView.separated(
+                padding: const EdgeInsets.all(12),
+                itemCount: rows.length,
+                separatorBuilder: (_, _) => const SizedBox(height: 6),
+                itemBuilder: (context, index) {
+                  final row = rows[index];
+                  final date = row.startDate == 0
+                      ? l10n.dateNotSet
+                      : MaterialLocalizations.of(context).formatMediumDate(
+                          DateTime.fromMillisecondsSinceEpoch(row.startDate),
+                        );
+                  return Card(
+                    child: ListTile(
+                      leading: Icon(
+                        row.updated ? Icons.cloud_upload_outlined : Icons.event,
+                      ),
+                      title: Text(row.title ?? l10n.untitledMeetup),
+                      subtitle: Text(
+                        [date, row.meetupLocation]
+                            .where((value) => value?.isNotEmpty == true)
+                            .join(' · '),
+                      ),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () => context.push('${Routes.events}/${row.id}'),
+                    ),
+                  );
+                },
+              ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => context.push('${Routes.events}/new'),
+        icon: const Icon(Icons.add),
+        label: Text(l10n.addMeetup),
+      ),
+    );
+  }
+}

--- a/flutter/lib/ui/life/life_screen.dart
+++ b/flutter/lib/ui/life/life_screen.dart
@@ -110,6 +110,9 @@ void _openFeature(BuildContext context, String feature) {
     case 'submissions':
       context.push(Routes.submissions);
       return;
+    case 'surveys':
+      context.push(Routes.surveys);
+      return;
     default:
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(AppLocalizations.of(context).featureComingSoon)),

--- a/flutter/lib/ui/router.dart
+++ b/flutter/lib/ui/router.dart
@@ -9,6 +9,8 @@ import 'courses/course_detail_screen.dart';
 import 'courses/courses_screen.dart';
 import 'dashboard/dashboard_shell.dart';
 import 'dictionary/dictionary_screen.dart';
+import 'events/event_detail_screen.dart';
+import 'events/events_screen.dart';
 import 'life/life_screen.dart';
 import 'onboarding/onboarding_screen.dart';
 import 'notifications/notifications_screen.dart';
@@ -47,6 +49,7 @@ class Routes {
   static const String references = '/life/references';
   static const String personals = '/life/personals';
   static const String submissions = '/life/submissions';
+  static const String events = '/calendar/events';
 }
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
@@ -133,6 +136,24 @@ final routerProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: Routes.calendar,
                 builder: (context, state) => const CalendarScreen(),
+                routes: [
+                  GoRoute(
+                    path: 'events',
+                    builder: (context, state) => const EventsScreen(),
+                    routes: [
+                      GoRoute(
+                        path: 'new',
+                        builder: (context, state) => const NewMeetupScreen(),
+                      ),
+                      GoRoute(
+                        path: ':meetupId',
+                        builder: (context, state) => EventDetailScreen(
+                          meetupId: state.pathParameters['meetupId']!,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ],
           ),

--- a/flutter/lib/ui/router.dart
+++ b/flutter/lib/ui/router.dart
@@ -23,6 +23,8 @@ import 'sync/server_config_screen.dart';
 import 'user/profile_screen.dart';
 import 'submissions/submissions_screen.dart';
 import 'submissions/submission_detail_screen.dart';
+import 'surveys/surveys_screen.dart';
+import 'surveys/take_survey_screen.dart';
 
 /// Replaces the Activity/Fragment navigation in `ui/components/FragmentNavigator`
 /// and the manual `Intent` hops between `SyncActivity` -> `LoginActivity` ->
@@ -50,6 +52,7 @@ class Routes {
   static const String personals = '/life/personals';
   static const String submissions = '/life/submissions';
   static const String events = '/calendar/events';
+  static const String surveys = '/life/surveys';
 }
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
@@ -203,6 +206,18 @@ final routerProvider = Provider<GoRouter>((ref) {
                         path: ':submissionId',
                         builder: (context, state) => SubmissionDetailScreen(
                           submissionId: state.pathParameters['submissionId']!,
+                        ),
+                      ),
+                    ],
+                  ),
+                  GoRoute(
+                    path: 'surveys',
+                    builder: (context, state) => const SurveysScreen(),
+                    routes: [
+                      GoRoute(
+                        path: ':surveyId',
+                        builder: (context, state) => TakeSurveyScreen(
+                          surveyId: state.pathParameters['surveyId']!,
                         ),
                       ),
                     ],

--- a/flutter/lib/ui/surveys/surveys_screen.dart
+++ b/flutter/lib/ui/surveys/surveys_screen.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../../providers/surveys_provider.dart';
+import '../../providers/sync_state.dart';
+import '../router.dart';
+
+/// Port of `ui/surveys/SurveyFragment.kt` for individual offline surveys.
+class SurveysScreen extends ConsumerWidget {
+  const SurveysScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final surveys = ref.watch(surveysProvider);
+    final sync = ref.watch(surveysSyncProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.mySurveys),
+        actions: [
+          IconButton(
+            tooltip: l10n.syncSurveys,
+            onPressed: sync is SyncRunning
+                ? null
+                : () => ref.read(surveysSyncProvider.notifier).sync(),
+            icon: const Icon(Icons.sync),
+          ),
+        ],
+        bottom: PreferredSize(
+          preferredSize: Size.fromHeight(sync is SyncRunning ? 76 : 72),
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: SearchBar(
+                        hintText: l10n.searchSurveys,
+                        leading: const Icon(Icons.search),
+                        onChanged: (value) =>
+                            ref.read(surveySearchProvider.notifier).state =
+                                value,
+                      ),
+                    ),
+                    PopupMenuButton<SurveySort>(
+                      tooltip: l10n.sortSurveys,
+                      onSelected: (value) =>
+                          ref.read(surveySortProvider.notifier).state = value,
+                      itemBuilder: (_) => [
+                        PopupMenuItem(
+                          value: SurveySort.newest,
+                          child: Text(l10n.newestFirst),
+                        ),
+                        PopupMenuItem(
+                          value: SurveySort.oldest,
+                          child: Text(l10n.oldestFirst),
+                        ),
+                        PopupMenuItem(
+                          value: SurveySort.titleAscending,
+                          child: Text(l10n.titleAscending),
+                        ),
+                        PopupMenuItem(
+                          value: SurveySort.titleDescending,
+                          child: Text(l10n.titleDescending),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              if (sync is SyncRunning)
+                LinearProgressIndicator(
+                  value: sync.progress.total == 0
+                      ? null
+                      : sync.progress.fraction,
+                ),
+            ],
+          ),
+        ),
+      ),
+      body: RefreshIndicator(
+        onRefresh: () => ref.read(surveysSyncProvider.notifier).sync(),
+        child: surveys.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (_, _) => Center(child: Text(l10n.surveysUnavailable)),
+          data: (rows) => ListView.separated(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.all(12),
+            itemCount: rows.isEmpty ? 1 : rows.length,
+            separatorBuilder: (_, _) => const SizedBox(height: 6),
+            itemBuilder: (context, index) {
+              if (rows.isEmpty) {
+                return SizedBox(
+                  height: 300,
+                  child: Center(child: Text(l10n.noSurveys)),
+                );
+              }
+              final row = rows[index];
+              return Card(
+                child: ListTile(
+                  leading: const Icon(Icons.poll_outlined),
+                  title: Text(row.name ?? l10n.untitledSurvey),
+                  subtitle: Text(row.description ?? ''),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => context.push('${Routes.surveys}/${row.id}'),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/lib/ui/surveys/take_survey_screen.dart
+++ b/flutter/lib/ui/surveys/take_survey_screen.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../data/local/app_database.dart';
+import '../../l10n/app_localizations.dart';
+import '../../providers/app_providers.dart';
+import '../../providers/session_provider.dart';
+import '../../providers/surveys_provider.dart';
+import '../../repository/submissions_repository.dart';
+import '../router.dart';
+
+/// Offline survey-taking form, replacing the survey mode of
+/// `ExamTakingFragment.kt` for text and single/multiple-choice questions.
+class TakeSurveyScreen extends ConsumerStatefulWidget {
+  const TakeSurveyScreen({required this.surveyId, super.key});
+  final String surveyId;
+
+  @override
+  ConsumerState<TakeSurveyScreen> createState() => _TakeSurveyScreenState();
+}
+
+class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
+  final textAnswers = <String, TextEditingController>{};
+  final choiceAnswers = <String, Set<String>>{};
+  bool submitting = false;
+
+  @override
+  void dispose() {
+    for (final controller in textAnswers.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final survey = ref.watch(surveyProvider(widget.surveyId));
+    final questions = ref.watch(surveyQuestionsProvider(widget.surveyId));
+    return Scaffold(
+      appBar: AppBar(title: Text(survey.valueOrNull?.name ?? l10n.takeSurvey)),
+      body: questions.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => Center(child: Text(l10n.surveyLoadFailed)),
+        data: (rows) => rows.isEmpty
+            ? Center(child: Text(l10n.surveyHasNoQuestions))
+            : ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  if (survey.valueOrNull?.description?.isNotEmpty == true)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 16),
+                      child: Text(survey.valueOrNull!.description!),
+                    ),
+                  for (var index = 0; index < rows.length; index++)
+                    _QuestionCard(
+                      number: index + 1,
+                      question: rows[index],
+                      controller: textAnswers.putIfAbsent(
+                        rows[index].id,
+                        TextEditingController.new,
+                      ),
+                      selected: choiceAnswers.putIfAbsent(
+                        rows[index].id,
+                        () => <String>{},
+                      ),
+                      onChanged: () => setState(() {}),
+                    ),
+                  const SizedBox(height: 12),
+                  FilledButton.icon(
+                    onPressed: submitting ? null : () => _submit(rows),
+                    icon: submitting
+                        ? const SizedBox.square(
+                            dimension: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.send),
+                    label: Text(l10n.submitSurvey),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+
+  Future<void> _submit(List<SurveyQuestionRow> questions) async {
+    final l10n = AppLocalizations.of(context);
+    final missing = questions.any(
+      (question) =>
+          question.required &&
+          textAnswers[question.id]!.text.trim().isEmpty &&
+          choiceAnswers[question.id]!.isEmpty,
+    );
+    if (missing) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(l10n.answerRequiredQuestions)));
+      return;
+    }
+    final user = ref.read(sessionProvider).valueOrNull;
+    if (user == null) return;
+    setState(() => submitting = true);
+    final answers = {
+      for (final question in questions)
+        question.id: SubmissionDraftAnswer(
+          questionId: question.id,
+          value: textAnswers[question.id]!.text.trim(),
+          choices: choiceAnswers[question.id]!.toList(growable: false),
+        ),
+    };
+    final id = await ref
+        .read(surveysRepositoryProvider)
+        .submitResponse(widget.surveyId, user.id, answers);
+    final config = ref.read(serverConfigProvider);
+    if (id != null && config != null) {
+      await ref
+          .read(submissionsUploaderProvider)
+          .queuePending(config: config, userId: user.id);
+    }
+    if (!mounted) return;
+    setState(() => submitting = false);
+    if (id != null) context.go('${Routes.submissions}/$id');
+  }
+}
+
+class _QuestionCard extends StatelessWidget {
+  const _QuestionCard({
+    required this.number,
+    required this.question,
+    required this.controller,
+    required this.selected,
+    required this.onChanged,
+  });
+  final int number;
+  final SurveyQuestionRow question;
+  final TextEditingController controller;
+  final Set<String> selected;
+  final VoidCallback onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final prompt = question.body?.isNotEmpty == true
+        ? question.body!
+        : question.header ?? '';
+    final multiple = question.type == 'selectMultiple';
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '$number. $prompt${question.required ? ' *' : ''}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            if (question.choices.isEmpty)
+              TextField(controller: controller, maxLines: 3)
+            else if (multiple)
+              for (final choice in question.choices)
+                CheckboxListTile(
+                  contentPadding: EdgeInsets.zero,
+                  value: selected.contains(choice),
+                  title: Text(choice),
+                  onChanged: (checked) {
+                    checked == true
+                        ? selected.add(choice)
+                        : selected.remove(choice);
+                    onChanged();
+                  },
+                )
+            else
+              RadioGroup<String>(
+                groupValue: selected.firstOrNull,
+                onChanged: (value) {
+                  selected
+                    ..clear()
+                    ..add(value!);
+                  onChanged();
+                },
+                child: Column(
+                  children: [
+                    for (final choice in question.choices)
+                      RadioListTile<String>(
+                        contentPadding: EdgeInsets.zero,
+                        value: choice,
+                        title: Text(choice),
+                      ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/test/repository/events_repository_test.dart
+++ b/flutter/test/repository/events_repository_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/events_repository.dart';
+
+void main() {
+  late AppDatabase database;
+  late EventsRepository repository;
+
+  setUp(() {
+    database = AppDatabase.memory();
+    repository = EventsRepository(
+      database.meetupDao,
+      now: () => DateTime.fromMillisecondsSinceEpoch(1234),
+      createId: () => 'local-meetup',
+    );
+  });
+  tearDown(() => database.close());
+
+  test('maps and watches server meetups for a team', () async {
+    expect(
+      await repository.cacheDocuments([
+        {
+          '_id': 'meetup-1',
+          '_rev': '1-a',
+          'title': 'Study group',
+          'startDate': 20,
+          'endDate': 30,
+          'day': ['Monday'],
+          'link': {'teams': 'team-1'},
+        },
+      ]),
+      1,
+    );
+
+    final rows = await repository.watchForTeam('team-1').first;
+    expect(rows.single.title, 'Study group');
+    expect(rows.single.day, '["Monday"]');
+    expect(rows.single.meetupIdRev, '1-a');
+  });
+
+  test(
+    'preserves local edits during refresh and exposes pending upload',
+    () async {
+      await repository.cacheDocuments([
+        {
+          '_id': 'meetup-1',
+          'title': 'Old',
+          'link': {'teams': 'team-1'},
+        },
+      ]);
+      expect(
+        await repository.update(
+          'meetup-1',
+          title: ' Local title ',
+          description: ' Local description ',
+          startDate: 1,
+          endDate: 2,
+          startTime: '09:00',
+          endTime: '10:00',
+          location: ' Room 1 ',
+          link: ' https://example.test ',
+          recurring: 'weekly',
+        ),
+        isTrue,
+      );
+      await repository.cacheDocuments([
+        {
+          '_id': 'meetup-1',
+          'title': 'Server title',
+          'link': {'teams': 'team-1'},
+        },
+      ]);
+
+      final row = await repository.getById('meetup-1');
+      expect(row?.title, 'Local title');
+      expect(row?.updated, isTrue);
+      expect(await repository.pendingUploads(), hasLength(1));
+    },
+  );
+
+  test('toggles attendance only when a user is available', () async {
+    await repository.cacheDocuments([
+      {'_id': 'meetup-1', 'title': 'Meetup'},
+    ]);
+    expect(
+      (await repository.toggleAttendance('meetup-1', null))?.userId,
+      isNull,
+    );
+    expect(
+      (await repository.toggleAttendance('meetup-1', 'user-1'))?.userId,
+      'user-1',
+    );
+    expect(
+      (await repository.toggleAttendance('meetup-1', 'user-1'))?.userId,
+      '',
+    );
+  });
+
+  test('creates and serializes a pending offline meetup', () async {
+    final id = await repository.create(
+      title: ' Community lesson ',
+      description: 'Bring a book',
+      startDate: 100,
+      endDate: 200,
+      startTime: '09:00',
+      endTime: '10:00',
+      location: 'Library',
+      link: 'https://example.test',
+      recurring: 'weekly',
+      creator: 'Ada',
+      teamId: 'team-1',
+      sourcePlanet: 'earth',
+    );
+
+    expect(id, 'local-meetup');
+    final row = await repository.getById(id!);
+    expect(row?.createdDate, 1234);
+    expect(row?.updated, isTrue);
+    final payload = EventsRepository.serialize(row!);
+    expect(payload.containsKey('_id'), isFalse);
+    expect(payload['link'], {'teams': 'team-1'});
+    expect(payload['sync'], {'type': 'local', 'planetCode': 'earth'});
+  });
+}

--- a/flutter/test/repository/events_repository_test.dart
+++ b/flutter/test/repository/events_repository_test.dart
@@ -1,14 +1,22 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/events_repository.dart';
 
 void main() {
   late AppDatabase database;
   late EventsRepository repository;
+  late MockPlanetApi api;
 
   setUp(() {
     database = AppDatabase.memory();
+    api = MockPlanetApi();
     repository = EventsRepository(
+      api,
       database.meetupDao,
       now: () => DateTime.fromMillisecondsSinceEpoch(1234),
       createId: () => 'local-meetup',
@@ -121,4 +129,39 @@ void main() {
     expect(payload['link'], {'teams': 'team-1'});
     expect(payload['sync'], {'type': 'local', 'planetCode': 'earth'});
   });
+
+  test('sync walks CouchDB pages and removes stale server rows', () async {
+    await repository.cacheDocuments([
+      {'_id': 'stale', 'title': 'Old'},
+    ]);
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer((invocation) async {
+      final url = invocation.positionalArguments.single as String;
+      if (url.endsWith('limit=0')) {
+        return NetworkSuccess<Map<String, dynamic>>({'total_rows': 1});
+      }
+      return NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          {
+            'doc': {'_id': 'fresh', 'title': 'Fresh meetup'},
+          },
+        ],
+      });
+    });
+    const config = ServerConfig(
+      serverUrl: 'https://planet.example',
+      couchDbUrl: 'https://satellite:1234@planet.example:443',
+      pin: '1234',
+    );
+
+    final result = await repository.sync(config: config);
+
+    expect(result, isA<SyncComplete>());
+    expect((result as SyncComplete).savedCount, 1);
+    expect(await repository.getById('stale'), isNull);
+    expect((await repository.getById('fresh'))?.title, 'Fresh meetup');
+  });
 }
+
+class MockPlanetApi extends Mock implements PlanetApi {}

--- a/flutter/test/repository/events_uploader_test.dart
+++ b/flutter/test/repository/events_uploader_test.dart
@@ -25,7 +25,11 @@ void main() {
   setUp(() {
     database = AppDatabase.memory();
     api = MockPlanetApi();
-    events = EventsRepository(database.meetupDao, createId: () => 'local-1');
+    events = EventsRepository(
+      api,
+      database.meetupDao,
+      createId: () => 'local-1',
+    );
     outbox = OutboxRepository(database.outboxDao);
     uploader = EventsUploader(api, events, outbox);
   });

--- a/flutter/test/repository/events_uploader_test.dart
+++ b/flutter/test/repository/events_uploader_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/events_repository.dart';
+import 'package:myplanet/repository/events_uploader.dart';
+import 'package:myplanet/repository/outbox_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  late AppDatabase database;
+  late MockPlanetApi api;
+  late EventsRepository events;
+  late OutboxRepository outbox;
+  late EventsUploader uploader;
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+
+  setUp(() {
+    database = AppDatabase.memory();
+    api = MockPlanetApi();
+    events = EventsRepository(database.meetupDao, createId: () => 'local-1');
+    outbox = OutboxRepository(database.outboxDao);
+    uploader = EventsUploader(api, events, outbox);
+  });
+  tearDown(() => database.close());
+
+  test('queues once and adopts CouchDB identity after upload', () async {
+    await events.create(
+      title: 'Meetup',
+      description: '',
+      startDate: 0,
+      endDate: 0,
+      startTime: '',
+      endTime: '',
+      location: '',
+      link: '',
+      recurring: 'none',
+      creator: 'Ada',
+    );
+
+    expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
+    expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
+    final operation = (await outbox.due()).single;
+    when(
+      () => api.postJsonObject(
+        operation.endpoint,
+        any(),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'id': 'remote-1',
+        'rev': '1-abc',
+      }),
+    );
+
+    await uploader.handler(operation, const {});
+
+    expect(await events.pendingUploads(), isEmpty);
+    final uploaded = await events.getById('local-1');
+    expect(uploaded?.meetupId, 'remote-1');
+    expect(uploaded?.meetupIdRev, '1-abc');
+  });
+}

--- a/flutter/test/repository/shelf_repository_test.dart
+++ b/flutter/test/repository/shelf_repository_test.dart
@@ -36,6 +36,7 @@ void main() {
       db.courseDao,
       db.myLibraryDao,
       db.removedLogDao,
+      db.meetupDao,
     );
   });
 
@@ -200,8 +201,14 @@ void main() {
       expect(doc['courseIds'], ['course-1']);
     });
 
-    /// Meetups are not ported; dropping the key would delete them server-side.
-    test('passes meetupIds through untouched', () async {
+    test('merges locally joined meetups with the server shelf', () async {
+      await db.meetupDao.upsert(
+        MeetupsCompanion.insert(
+          id: 'local-meetup',
+          meetupId: const Value('meetup-local'),
+          userId: const Value('user-1'),
+        ),
+      );
       final doc = await repository.buildShelfDocument(
         userId: 'user-1',
         shelfDocId: 'org.couchdb.user:ada',
@@ -210,7 +217,7 @@ void main() {
         },
       );
 
-      expect(doc['meetupIds'], ['meetup-1', 'meetup-2']);
+      expect(doc['meetupIds'], ['meetup-local', 'meetup-1', 'meetup-2']);
     });
   });
 

--- a/flutter/test/repository/surveys_repository_test.dart
+++ b/flutter/test/repository/surveys_repository_test.dart
@@ -1,0 +1,117 @@
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/surveys_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+void main() {
+  late AppDatabase database;
+  late MockPlanetApi api;
+  late SurveysRepository repository;
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+
+  setUp(() {
+    database = AppDatabase.memory();
+    api = MockPlanetApi();
+    repository = SurveysRepository(
+      api,
+      database.surveyDao,
+      SubmissionsRepository(api, database.submissionDao),
+    );
+  });
+  tearDown(() => database.close());
+
+  test('sync caches only surveys and their ordered questions', () async {
+    when(
+      () => api.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer((invocation) async {
+      final url = invocation.positionalArguments.single as String;
+      if (url.endsWith('limit=0')) {
+        return NetworkSuccess<Map<String, dynamic>>({'total_rows': 2});
+      }
+      return NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          {
+            'doc': {
+              '_id': 'survey-1',
+              'type': 'surveys',
+              'name': 'Community needs',
+              'questions': [
+                {
+                  '_id': 'q1',
+                  'body': 'What do you need?',
+                  'type': 'input',
+                  'required': true,
+                },
+                {
+                  '_id': 'q2',
+                  'body': 'Choose topics',
+                  'type': 'selectMultiple',
+                  'choices': ['Water', 'Health'],
+                },
+              ],
+            },
+          },
+          {
+            'doc': {'_id': 'exam-1', 'type': 'exam', 'name': 'Not a survey'},
+          },
+        ],
+      });
+    });
+
+    final result = await repository.sync(config: config);
+
+    expect(result, isA<SyncComplete>());
+    expect((result as SyncComplete).savedCount, 1);
+    expect((await repository.getById('survey-1'))?.name, 'Community needs');
+    final questions = await repository.questionsFor('survey-1');
+    expect(questions.map((row) => row.body), [
+      'What do you need?',
+      'Choose topics',
+    ]);
+    expect(questions.last.choices, ['Water', 'Health']);
+  });
+
+  test('completed offline response becomes an uploadable submission', () async {
+    await database.surveyDao.upsertAll(
+      [SurveysCompanion.insert(id: 'survey-1', name: const Value('Needs'))],
+      {
+        'survey-1': [
+          SurveyQuestionsCompanion.insert(
+            id: 'survey-1:q1',
+            surveyId: 'survey-1',
+            body: const Value('Your answer'),
+            position: 0,
+          ),
+        ],
+      },
+    );
+
+    final id = await repository.submitResponse('survey-1', 'user-1', {
+      'survey-1:q1': const SubmissionDraftAnswer(
+        questionId: 'survey-1:q1',
+        value: 'Clean water',
+      ),
+    });
+
+    final submission = await database.submissionDao.getById(id!);
+    expect(submission?.parentId, 'survey-1');
+    expect(submission?.status, 'complete');
+    expect(submission?.isUpdated, isTrue);
+    expect(
+      (await database.submissionDao.answersFor(id)).single.value,
+      'Clean water',
+    );
+  });
+}

--- a/flutter/test/ui/events_screen_test.dart
+++ b/flutter/test/ui/events_screen_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/events_provider.dart';
+import 'package:myplanet/ui/events/events_screen.dart';
+
+import '../support/widget_harness.dart';
+
+void main() {
+  testWidgets('shows cached meetups and pending-upload state', (tester) async {
+    final row = MeetupRow(
+      id: 'meetup-1',
+      title: 'Community lesson',
+      meetupLocation: 'Library',
+      startDate: DateTime(2026, 8, 3).millisecondsSinceEpoch,
+      endDate: 0,
+      createdDate: 0,
+      recurringNumber: 10,
+      updated: true,
+    );
+    await tester.pumpWidget(
+      wrapScreen(
+        const EventsScreen(),
+        overrides: [
+          eventsProvider.overrideWith((ref) => Stream.value([row])),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Meetups'), findsOneWidget);
+    expect(find.text('Community lesson'), findsOneWidget);
+    expect(find.textContaining('Library'), findsOneWidget);
+    expect(find.byIcon(Icons.cloud_upload_outlined), findsOneWidget);
+    expect(find.text('Add meetup'), findsOneWidget);
+  });
+
+  testWidgets('shows the offline empty state', (tester) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const EventsScreen(),
+        overrides: [
+          eventsProvider.overrideWith((ref) => Stream.value(const [])),
+        ],
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('No meetups yet'), findsOneWidget);
+  });
+}

--- a/flutter/test/ui/surveys_screen_test.dart
+++ b/flutter/test/ui/surveys_screen_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/surveys_provider.dart';
+import 'package:myplanet/ui/surveys/surveys_screen.dart';
+
+import '../support/widget_harness.dart';
+
+void main() {
+  testWidgets('renders the offline survey catalog', (tester) async {
+    final survey = SurveyRow(
+      id: 'survey-1',
+      name: 'Community needs',
+      description: 'Tell us what matters',
+      createdDate: 10,
+      updatedDate: 0,
+      adoptionDate: 0,
+      totalMarks: 0,
+      isFromNation: false,
+      teamShareAllowed: false,
+    );
+    await tester.pumpWidget(
+      wrapScreen(
+        const SurveysScreen(),
+        overrides: [
+          surveysProvider.overrideWith((ref) => Stream.value([survey])),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('My surveys'), findsOneWidget);
+    expect(find.text('Community needs'), findsOneWidget);
+    expect(find.text('Tell us what matters'), findsOneWidget);
+    expect(find.text('Search surveys'), findsOneWidget);
+  });
+
+  testWidgets('renders a refreshable empty state', (tester) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const SurveysScreen(),
+        overrides: [
+          surveysProvider.overrideWith((ref) => Stream.value(const [])),
+        ],
+      ),
+    );
+    await tester.pump();
+    expect(find.text('No surveys available'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
### Motivation
- Complete Phase 15 of the Kotlin→Flutter migration by porting the offline events/meetups feature including persistence, shelf integration and durable uploads so the Flutter app can manage meetups like the Kotlin app.
- Surface meetups in the UI and router and wire them into the existing outbox/upload plumbing to preserve offline edits and join/leave actions.

### Description
- Add a new `Meetups` Drift table, bump the database `schemaVersion` to `13`, and implement `MeetupDao` with upsert, queries, watchers and pending-upload helpers. 
- Implement `MeetupMapper`, `EventsRepository` (cache, create, update, toggleAttendance, serialization), and `EventsUploader` to queue and perform durable uploads via the outbox. 
- Wire providers (`meetupDaoProvider`, `eventsRepositoryProvider`, `eventsUploaderProvider`, `eventsActionsProvider`, `eventsProvider`) and register the events handler with `OutboxDrainer`, plus include meetups in `ShelfRepository` merging logic. 
- Add UI screens and routes: `EventsScreen`, `EventDetailScreen` (with editor and join/leave), integrate events route under `/calendar/events`, and add a calendar appbar action to navigate to events. 
- Update docs and README to mark Phase 15 complete and add English localization keys for meetups. 

### Testing
- Ran `flutter test` including `test/repository/events_repository_test.dart`, `test/repository/events_uploader_test.dart`, the updated `test/repository/shelf_repository_test.dart`, and `test/ui/events_screen_test.dart`, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ff9d42aa8832b9d042a21b478e65e)