### PR TITLE
Fix MyLife hide state and refresh issues on navigation

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
@@ -251,7 +251,8 @@ open class BaseDashboardFragment : DashboardPluginFragment(), OnSyncListener {
         imgTask.visibility = if (info.hasTask) View.VISIBLE else View.GONE
     }
 
-    private suspend fun myLifeListInit(flexboxLayout: FlexboxLayout) {
+    protected suspend fun myLifeListInit(flexboxLayout: FlexboxLayout) {
+        flexboxLayout.removeAllViews()
         val userId = prefData.getUserId().ifEmpty { "--" }
         val visibleItems = lifeRepository.getMyLifeForDashboard(userId, getMyLifeListBase(userId))
         for ((itemCnt, items) in visibleItems.withIndex()) {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/LifeRepositoryImpl.kt
@@ -29,6 +29,12 @@ class LifeRepositoryImpl @Inject constructor(
 
     override suspend fun updateVisibility(isVisible: Boolean, myLifeId: String) {
         myLifeDao.updateVisibility(myLifeId, isVisible)
+        val item = myLifeDao.getByIds(listOf(myLifeId)).firstOrNull()
+        val userId = item?.userId
+        if (userId != null) {
+            val updatedLives = getMyLifeByUserId(userId, ensureLatest = true)
+            cacheMyLifeItems(userId, updatedLives)
+        }
     }
 
     override suspend fun updateMyLifeListOrder(list: List<MyLife>) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -396,6 +396,12 @@ class BellDashboardFragment : BaseDashboardFragment() {
                 checkPendingSurveys()
             }
         }
+        val myLifeFlex = view?.findViewById<com.google.android.flexbox.FlexboxLayout>(R.id.flexboxLayoutMyLife)
+        if (myLifeFlex != null) {
+            viewLifecycleOwner.lifecycleScope.launch {
+                myLifeListInit(myLifeFlex)
+            }
+        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeFragment.kt
@@ -85,6 +85,11 @@ class LifeFragment : BaseRecyclerFragment<MyLife?>(), OnStartDragListener {
         recyclerView.addItemDecoration(dividerItemDecoration)
     }
 
+    override fun onResume() {
+        super.onResume()
+        refreshList()
+    }
+
     private suspend fun loadMyLifeList(): List<MyLife> {
         val userId = userRepository.getUserModel()?.id
         var myLifeList = lifeRepository.getMyLifeByUserId(userId)


### PR DESCRIPTION
Fixed a bug where the 'MyLife' items hide/show states were not correctly updated or refreshed upon navigating back to the fragment or dashboard from another activity/fragment. Refreshed the SharedPreferences cache when visibility changes, added removeAllViews() inside the dashboard's MyLife list initializer, and added onResume() lifecycle hooks to ensure proper, clean reloading.

---
*PR created automatically by Jules for task [2338548180412978050](https://jules.google.com/task/2338548180412978050) started by @J-S-webskas*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated life lists automatically refresh when returning to the Life screen.
  * Dashboard life items now reload when the dashboard resumes.
  * Changes to an item’s visibility are reflected in the associated life list and cached results.
  * Improved consistency between visibility updates and displayed life content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->