### PR TITLE
docs: remove legacy Realm references from PublicSurveyActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/PublicSurveyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/PublicSurveyActivity.kt
@@ -31,7 +31,7 @@ import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 /**
  * Lets anyone respond to a `publicAccess` survey without logging in. Opened from
  * /survey/<teamId>/<surveyId> deep links. Fetches the survey from the server's public
- * API, stores it in Realm, and hosts the standard [ExamTakingFragment] survey form;
+ * API, stores it locally, and hosts the standard [ExamTakingFragment] survey form;
  * the completed submission is then posted back through the public API.
  */
 @AndroidEntryPoint


### PR DESCRIPTION
Updated the Javadoc in `PublicSurveyActivity` to accurately reflect the migration to the new Repository layer by replacing the reference to storing data in "Realm" with a more accurate description ("stores it locally"). The actual code was already migrated to use the Repository pattern.