### PR TITLE
Refactor StorageCategoryDetailFragment to remove remaining Realm comm…

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
@@ -171,7 +171,7 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
         val oleDir = File(FileUtils.getOlePath(requireContext()))
         if (!oleDir.exists() || !oleDir.isDirectory) return emptyList()
 
-        // Build a map of resourceId → title from Realm (one query)
+        // Build a map of resourceId → title from Room database (one query)
         val titleMap = resourcesRepository.getResourceTitlesMap()
 
         // Group files by resourceId directory
@@ -239,7 +239,7 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
                     }
                 }
 
-                // Sync Realm: mark deleted resources as not offline
+                // Sync database: mark deleted resources as not offline
                 val deletedIds = toDelete.map { it.resourceId }.toSet()
                 resourcesRepository.markResourcesAsNotOffline(deletedIds)
             }


### PR DESCRIPTION
…ents\n\nThe fragment had already been refactored to use the Room-backed `resourcesRepository`. This commit updates the remaining stale comments that referenced Realm to correctly reference Room/database instead.