### PR TITLE
sync: smoother user repository inserting (fixes #15432)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6341
-        versionName = "0.63.41"
+        versionCode = 6342
+        versionName = "0.63.42"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -1241,35 +1241,54 @@ class UserRepositoryImpl @Inject constructor(
             }
         }
 
-        val existingUsers = userDao.getAll().toMutableList()
+        val existingUsersList = userDao.getAll()
+        val usersById = mutableMapOf<String, UserEntity>()
+        val guestUsersByName = mutableMapOf<String, UserEntity>()
+
+        for (user in existingUsersList) {
+            usersById[user.id] = user
+            if (user._id != null) usersById[user._id!!] = user
+            if (!user.name.isNullOrEmpty() && user._id?.startsWith("guest_") == true) {
+                guestUsersByName[user.name!!] = user
+            }
+        }
+
         val usersToDelete = linkedSetOf<String>()
-        val usersToUpsert = mutableListOf<UserEntity>()
+        val usersToUpsert = linkedMapOf<String, UserEntity>()
 
         for (jsonDoc in documentList) {
             try {
                 val id = JsonUtils.getString("_id", jsonDoc).takeIf { it.isNotEmpty() } ?: UUID.randomUUID().toString()
                 val userName = JsonUtils.getString("name", jsonDoc)
-                val existingUser = existingUsers.firstOrNull { it.id == id || it._id == id }
+
+                val existingUser = usersById[id]
                 val guestUser = if (existingUser == null && id.startsWith("org.couchdb.user:") && userName.isNotEmpty()) {
-                    existingUsers.firstOrNull { it.name == userName && it._id?.startsWith("guest_") == true }
+                    guestUsersByName[userName]
                 } else {
                     null
                 }
 
                 val user = existingUser
                     ?: guestUser?.apply {
-                        usersToDelete += guestUser.id
+                        usersToDelete += this.id
+                        if (!this.name.isNullOrEmpty()) guestUsersByName.remove(this.name!!)
+                        usersById.remove(this.id)
+                        if (this._id != null) usersById.remove(this._id!!)
                         this.id = id
                         this._id = id
                     }
                     ?: UserEntity().apply { this.id = id }
 
                 applyJsonToUser(jsonDoc, user, settings)
-                val entity = user ?: continue
-                usersToUpsert.removeAll { it.id == entity.id }
-                usersToUpsert += entity
-                existingUsers.removeAll { it.id == entity.id || it._id == entity._id }
-                existingUsers += entity
+                val entity = user
+
+                usersToUpsert[entity.id] = entity
+
+                usersById[entity.id] = entity
+                if (entity._id != null) usersById[entity._id!!] = entity
+                if (!entity.name.isNullOrEmpty() && entity._id?.startsWith("guest_") == true) {
+                    guestUsersByName[entity.name!!] = entity
+                }
             } catch (err: Exception) {
                 err.printStackTrace()
             }
@@ -1277,7 +1296,7 @@ class UserRepositoryImpl @Inject constructor(
 
         if (usersToDelete.isNotEmpty()) userDao.deleteByIds(usersToDelete.toList())
         if (usersToUpsert.isNotEmpty()) {
-            userDao.upsertAll(usersToUpsert)
+            userDao.upsertAll(usersToUpsert.values.toList())
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
@@ -54,4 +54,89 @@ class UserRepositoryBulkInsertTest {
 
         coVerify(exactly = 1) { userDao.upsertAll(match { it.size == 10 }) }
     }
+
+    @Test
+    fun `insertUsersFromSync handles existing user and guest promotion correctly`() = runTest {
+        val userDao = mockk<UserDao>(relaxed = true)
+        val userRepository = UserRepositoryImpl(
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            userDao
+        )
+
+        val existingGuest = org.ole.planet.myplanet.model.UserEntity().apply {
+            id = "guest_123"
+            _id = "guest_123"
+            name = "Guest User"
+        }
+        coEvery { userDao.getAll() } returns listOf(existingGuest)
+
+        val list = mutableListOf<JsonObject>()
+        val jObj = JsonObject()
+        val doc = JsonObject()
+        doc.addProperty("_id", "org.couchdb.user:Guest User")
+        doc.addProperty("name", "Guest User")
+        jObj.add("doc", doc)
+        list.add(jObj)
+
+        userRepository.insertUsersFromSync(list)
+
+        coVerify(exactly = 1) { userDao.deleteByIds(listOf("guest_123")) }
+        coVerify(exactly = 1) { userDao.upsertAll(match { it.size == 1 && it[0]._id == "org.couchdb.user:Guest User" }) }
+    }
+
+    @Test
+    fun `insertUsersFromSync deduplicates ids correctly`() = runTest {
+        val userDao = mockk<UserDao>(relaxed = true)
+        val userRepository = UserRepositoryImpl(
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            userDao
+        )
+        coEvery { userDao.getAll() } returns emptyList()
+
+        val list = mutableListOf<JsonObject>()
+        for (i in 1..2) {
+            val jObj = JsonObject()
+            val doc = JsonObject()
+            doc.addProperty("_id", "user_1")
+            doc.addProperty("name", "User 1 (version $i)")
+            jObj.add("doc", doc)
+            list.add(jObj)
+        }
+
+        userRepository.insertUsersFromSync(list)
+
+        coVerify(exactly = 1) { userDao.upsertAll(match { it.size == 1 && it[0].name == "User 1 (version 2)" }) }
+    }
 }


### PR DESCRIPTION
Implements linear map-based matching to optimize `insertUsersFromSync` in `UserRepositoryImpl.kt`. Replaces quadratic O(N^2) list operations with O(1) map lookups (`usersById`, `guestUsersByName`) and uses an insertion-ordered map (`usersToUpsert`) for accumulating upserts, ensuring duplicate documents within a batch retain the correct last-write behavior. Added coverage for these cases in `UserRepositoryBulkInsertTest.kt`.

---
*PR created automatically by Jules for task [8066325465883263555](https://jules.google.com/task/8066325465883263555) started by @dogi*