### PR TITLE
all: smoother network utils lazy entering (fixes #15402)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6313
-        versionName = "0.63.13"
+        versionCode = 6314
+        versionName = "0.63.14"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt
@@ -25,8 +25,9 @@ import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
 import org.ole.planet.myplanet.services.SharedPrefManager
 
 object NetworkUtils {
-    private val coreEntryPoint: CoreDependenciesEntryPoint get() =
+    private val coreEntryPoint: CoreDependenciesEntryPoint by lazy {
         EntryPointAccessors.fromApplication(context, CoreDependenciesEntryPoint::class.java)
+    }
 
     // Safe because NetworkUtils is only accessed after MainApplication.onCreate sets the context
     private val sharedPrefManager: SharedPrefManager by lazy {


### PR DESCRIPTION
Changed `get() =` to `by lazy { ... }` in `NetworkUtils` for `coreEntryPoint`.

This prevents `NetworkUtils` from rebuilding its Hilt entry point on every access, saving performance and memory overhead, especially since it is called from network-state callbacks and sync paths.

---
*PR created automatically by Jules for task [8276060961420480187](https://jules.google.com/task/8276060961420480187) started by @dogi*