### PR TITLE
Refactor UserRepositoryImpl to use targeted UserDao queries

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
@@ -18,6 +18,22 @@ interface UserDao {
     @Query("SELECT * FROM users WHERE id = :id OR _id = :id LIMIT 1")
     suspend fun getById(id: String): UserEntity?
     @Query("SELECT * FROM users") suspend fun getAll(): List<UserEntity>
+    @Query("SELECT * FROM users WHERE id IN (:ids) OR _id IN (:ids)")
+    suspend fun getByIdsOr_Ids(ids: List<String>): List<UserEntity>
+    @Query("SELECT * FROM users WHERE _id IS NOT NULL AND _id != '' AND id NOT LIKE 'guest%'")
+    suspend fun getSyncedUsers(): List<UserEntity>
+    @Query("SELECT * FROM users WHERE _id IS NOT NULL AND _id != ''")
+    suspend fun getUsersWith_Id(): List<UserEntity>
+    @Query("SELECT * FROM users WHERE _id IS NULL OR _id = '' OR isUpdated = 1 LIMIT :limit")
+    suspend fun getPendingSyncUsers(limit: Int): List<UserEntity>
+    @Query("SELECT * FROM users WHERE id IN (:ids)")
+    suspend fun getByIds(ids: List<String>): List<UserEntity>
+    @Query("SELECT * FROM users WHERE name IN (SELECT name FROM users GROUP BY name HAVING COUNT(*) > 1)")
+    suspend fun getDuplicateUsers(): List<UserEntity>
+    @Query("SELECT * FROM users WHERE id IN (:ids) OR _id IN (:ids) OR name IN (:names)")
+    suspend fun getByIdsOr_IdsOrNames(ids: List<String>, names: List<String>): List<UserEntity>
+    @Query("SELECT * FROM users WHERE id = :id OR _id = :id LIMIT 1")
+    suspend fun getByIdOr_Id(id: String): UserEntity?
     @Query("SELECT * FROM users WHERE name = :name LIMIT 1") suspend fun getByName(name: String): UserEntity?
     @Query("SELECT * FROM users WHERE name = :name COLLATE NOCASE LIMIT 1") suspend fun getByNameIgnoreCase(name: String): UserEntity?
     @Query("SELECT * FROM users WHERE name LIKE '%' || :query || '%' OR firstName LIKE '%' || :query || '%' OR lastName LIKE '%' || :query || '%'") suspend fun search(query: String): List<UserEntity>

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
@@ -35,6 +35,7 @@ interface UserDao {
     @Query("SELECT * FROM users WHERE id = :id OR _id = :id LIMIT 1")
     suspend fun getByIdOr_Id(id: String): UserEntity?
     @Query("SELECT * FROM users WHERE name = :name LIMIT 1") suspend fun getByName(name: String): UserEntity?
+    @Query("SELECT * FROM users WHERE name = :name") suspend fun getAllByName(name: String): List<UserEntity>
     @Query("SELECT * FROM users WHERE name = :name COLLATE NOCASE LIMIT 1") suspend fun getByNameIgnoreCase(name: String): UserEntity?
     @Query("SELECT * FROM users WHERE name LIKE '%' || :query || '%' OR firstName LIKE '%' || :query || '%' OR lastName LIKE '%' || :query || '%'") suspend fun search(query: String): List<UserEntity>
     @Query("SELECT COUNT(*) FROM users") suspend fun count(): Int

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -325,10 +325,7 @@ class UserRepositoryImpl @Inject constructor(
             val existingUser = if (users != null) users.firstOrNull { it.id == id || it._id == id } else userDao.getByIdOr_Id(id)
             val user = existingUser
                 ?: if (id.startsWith("org.couchdb.user:") && userName.isNotEmpty()) {
-                    if (users != null) migrateGuestUser(id, userName, users) else userDao.getByName(userName)?.takeIf { it._id?.startsWith("guest_") == true }?.let { guestUser ->
-                        userDao.deleteById(guestUser.id)
-                        guestUser.apply { this.id = id; this._id = id }
-                    }
+                    migrateGuestUser(id, userName, users ?: userDao.getAllByName(userName))
                 } else {
                     null
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -99,10 +99,7 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun getUsersByIds(userIds: List<String>): List<UserEntity> {
         if (userIds.isEmpty()) return emptyList()
-        val userIdSet = userIds.toSet()
-        return userDao.getAll()
-            .filter { it.id in userIdSet || it._id in userIdSet }
-            .map { it }
+        return userDao.getByIdsOr_Ids(userIds.toList())
     }
 
     override suspend fun getUserByAnyId(id: String): UserEntity? {
@@ -118,9 +115,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getSyncedUsers(): List<UserEntity> {
-        return userDao.getAll()
-            .filter { !it._id.isNullOrBlank() && !it.id.startsWith("guest") }
-            .map { it }
+        return userDao.getSyncedUsers()
     }
 
     private fun mapToLightweightUser(managedUser: UserEntity): UserEntity {
@@ -132,11 +127,8 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUsersForHealthSync(): List<UserEntity> {
-        return userDao.getAll()
-            .asSequence()
-            .filter { !it._id.isNullOrBlank() }
+        return userDao.getUsersWith_Id()
             .map { mapToLightweightUser(it) }
-            .toList()
     }
 
     override suspend fun getSyncedUserByName(name: String): UserEntity? {
@@ -158,7 +150,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getAllUsers(): List<UserEntity> {
-        return userDao.getAll().map { it }
+        return userDao.getAll()
     }
 
     override suspend fun getUsersSortedBy(fieldName: String, descending: Boolean): List<UserEntity> {
@@ -166,12 +158,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getPendingSyncUsers(limit: Int): List<UserEntity> {
-        return userDao.getAll()
-            .asSequence()
-            .filter { it._id.isNullOrBlank() || it.isUpdated }
-            .map { it }
-            .take(limit)
-            .toList()
+        return userDao.getPendingSyncUsers(limit)
     }
 
     override suspend fun searchUsers(query: String, sortField: String, descending: Boolean): List<UserEntity> {
@@ -179,7 +166,7 @@ class UserRepositoryImpl @Inject constructor(
             userDao.getAll()
         } else {
             userDao.search(query)
-        }.map { it }
+        }
         return sortUsers(users, sortField, descending)
     }
 
@@ -333,13 +320,15 @@ class UserRepositoryImpl @Inject constructor(
     private suspend fun buildUserFromJson(jsonDoc: JsonObject?, users: List<UserEntity>? = null): UserEntity? {
         if (jsonDoc == null) return null
         return try {
-            val availableUsers = users ?: userDao.getAll()
             val id = JsonUtils.getString("_id", jsonDoc).takeIf { it.isNotEmpty() } ?: UUID.randomUUID().toString()
             val userName = JsonUtils.getString("name", jsonDoc)
-            val existingUser = availableUsers.firstOrNull { it.id == id || it._id == id }
+            val existingUser = if (users != null) users.firstOrNull { it.id == id || it._id == id } else userDao.getByIdOr_Id(id)
             val user = existingUser
                 ?: if (id.startsWith("org.couchdb.user:") && userName.isNotEmpty()) {
-                    migrateGuestUser(id, userName, availableUsers)
+                    if (users != null) migrateGuestUser(id, userName, users) else userDao.getByName(userName)?.takeIf { it._id?.startsWith("guest_") == true }?.let { guestUser ->
+                        userDao.deleteById(guestUser.id)
+                        guestUser.apply { this.id = id; this._id = id }
+                    }
                 } else {
                     null
                 }
@@ -907,9 +896,7 @@ class UserRepositoryImpl @Inject constructor(
             emptyMap()
         } else {
             val userIdSet = userIds.toSet()
-            userDao.getAll()
-                .filter { it.id in userIdSet }
-                .map { it }
+            userDao.getByIds(userIdSet.toList())
                 .associateBy { it.id ?: "" }
         }
         return HealthRecord(mh, mm, list, userMap)
@@ -1012,8 +999,8 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun cleanupDuplicateUsers() {
-        val allUsers = userDao.getAll()
-        val usersByName = allUsers.groupBy { it.name }
+        val duplicateUsers = userDao.getDuplicateUsers()
+        val usersByName = duplicateUsers.groupBy { it.name }
 
         usersByName.forEach { (_, users) ->
             if (users.size > 1) {
@@ -1241,7 +1228,9 @@ class UserRepositoryImpl @Inject constructor(
             }
         }
 
-        val existingUsers = userDao.getAll().toMutableList()
+        val ids = documentList.mapNotNull { JsonUtils.getString("_id", it).takeIf { id -> id.isNotEmpty() } }
+        val names = documentList.mapNotNull { JsonUtils.getString("name", it).takeIf { name -> name.isNotEmpty() } }
+        val existingUsers = userDao.getByIdsOr_IdsOrNames(ids, names).toMutableList()
         val usersToDelete = linkedSetOf<String>()
         val usersToUpsert = mutableListOf<UserEntity>()
 


### PR DESCRIPTION
Optimized data access in `UserRepositoryImpl` by avoiding full-table scans via `userDao.getAll()` and translating the filtering logic into specific SQLite `@Query` methods in `UserDao`. This improves memory efficiency and query performance.

---
*PR created automatically by Jules for task [15197987516865157169](https://jules.google.com/task/15197987516865157169) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the speed and reliability of user lookups and synchronization.
  * Enhanced handling of users identified by local IDs, remote IDs, or names.
  * Improved processing of pending and completed synchronization records.
  * Strengthened duplicate-user detection and cleanup.
  * Improved migration and matching of guest user records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->