### PR TITLE
chat: smoother history view binding (fixes #15403)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6316
-        versionName = "0.63.16"
+        versionCode = 6317
+        versionName = "0.63.17"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryAdapter.kt
@@ -51,7 +51,6 @@ class ChatHistoryAdapter(
         }
     )
 ) {
-    private lateinit var rowChatHistoryBinding: RowChatHistoryBinding
     private var chatHistoryItemClickListener: OnChatHistoryItemClickListener? = null
     private var chatTitle: String? = ""
     private lateinit var shareTargetAdapter: ChatShareTargetAdapter
@@ -84,7 +83,7 @@ class ChatHistoryAdapter(
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderChat {
-        rowChatHistoryBinding = RowChatHistoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val rowChatHistoryBinding = RowChatHistoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return ViewHolderChat(rowChatHistoryBinding)
     }
 
@@ -135,7 +134,7 @@ class ChatHistoryAdapter(
             val sharedIds = getSharedViewInIds(item._id)
             val isCommunityShared = shareTargets.community?._id?.let { it in sharedIds } == true
             val sharedChildren = if (isCommunityShared) setOf(context.getString(R.string.community)) else emptySet()
-            val dataMap = getData() as HashMap<String, List<String>>
+            val dataMap = getData() as? Map<String, List<String>> ?: emptyMap()
 
             var currentFlatList = generateFlatList(dataMap, sharedChildren, emptySet())
 


### PR DESCRIPTION
Fixes a correctness bug in `ChatHistoryAdapter` where the ViewBinding was stored as an adapter-level property, causing shared state among ViewHolders. Also addresses an unsafe type cast in `bindShareChat`.

---
*PR created automatically by Jules for task [13324263415112653590](https://jules.google.com/task/13324263415112653590) started by @dogi*