### PR TITLE
courses: smoother filter tags controlling (fixes #15404)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6318
-        versionName = "0.63.18"
+        versionCode = 6319
+        versionName = "0.63.19"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
@@ -119,7 +119,12 @@ class CourseFilterController(
 
     fun setTags(list: List<TagEntity>) {
         searchTags.clear()
-        list.forEach { tag -> if (!searchTags.any { it.name == tag.name }) searchTags.add(tag) }
+        val seenNames = HashSet<String?>()
+        list.forEach { tag ->
+            if (seenNames.add(tag.name)) {
+                searchTags.add(tag)
+            }
+        }
         _filterState.value = currentState()
         onScrollToTop()
     }


### PR DESCRIPTION
Deduplicate course filter tags without quadratic `any` checks in `CourseFilterController`.

---
*PR created automatically by Jules for task [6970004180703444471](https://jules.google.com/task/6970004180703444471) started by @dogi*