### PR TITLE
all: smoother resources courses sorting view modelling (fixes #15544)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6416
-        versionName = "0.64.16"
+        versionCode = 6417
+        versionName = "0.64.17"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -39,8 +39,6 @@ class ResourcesAdapter(
     private var listener: OnLibraryItemSelectedListener? = null
     private var homeItemClickListener: OnHomeItemClickListener? = null
     private var ratingChangeListener: OnRatingChangeListener? = null
-    private var isAscending = true
-    private var isTitleAscending = true
 
     init {
         if (context is OnHomeItemClickListener) {
@@ -289,32 +287,6 @@ class ResourcesAdapter(
         if (holder is ResourcesViewHolder) {
             holder.cachedTags = emptyList()
             holder.rowLibraryBinding.flexboxDrawable.removeAllViews()
-        }
-    }
-
-    fun toggleTitleSortOrder(onComplete: (() -> Unit)? = null) {
-        isTitleAscending = !isTitleAscending
-        setLibraryList(sortLibraryListByTitle(), onComplete)
-    }
-
-    fun toggleSortOrder(onComplete: (() -> Unit)? = null) {
-        isAscending = !isAscending
-        setLibraryList(sortLibraryList(), onComplete)
-    }
-
-    private fun sortLibraryListByTitle(): List<ResourceListModel> {
-        return if (isTitleAscending) {
-            currentList.sortedBy { it.item.title?.lowercase(Locale.ROOT) }
-        } else {
-            currentList.sortedByDescending { it.item.title?.lowercase(Locale.ROOT) }
-        }
-    }
-
-    private fun sortLibraryList(): List<ResourceListModel> {
-        return if (isAscending) {
-            currentList.sortedBy { it.item.createdDate }
-        } else {
-            currentList.sortedByDescending { it.item.createdDate }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -386,7 +386,7 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         }
     }
 
-    private fun checkList(listSize: Int = if (::adapterLibrary.isInitialized) adapterLibrary.getLibraryList().size else 0) {
+    private fun checkList(listSize: Int = if (::adapterLibrary.isInitialized) adapterLibrary.currentList.size else 0) {
         val hasAnyLibraryData = allResourceModels.isNotEmpty()
 
         if (!hasAnyLibraryData && listSize == 0) {
@@ -682,14 +682,20 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         }
         binding.orderByDateButton.setOnClickListener {
             bottomSheet.visibility = View.GONE
-            adapterLibrary.toggleSortOrder {
-                recyclerView.scrollToPosition(0)
+            viewLifecycleOwner.lifecycleScope.launch {
+                val sorted = viewModel.toggleSortOrder(adapterLibrary.currentList)
+                adapterLibrary.setLibraryList(sorted) {
+                    recyclerView.scrollToPosition(0)
+                }
             }
         }
         binding.orderByTitleButton.setOnClickListener {
             bottomSheet.visibility = View.GONE
-            adapterLibrary.toggleTitleSortOrder {
-                recyclerView.scrollToPosition(0)
+            viewLifecycleOwner.lifecycleScope.launch {
+                val sorted = viewModel.toggleTitleSortOrder(adapterLibrary.currentList)
+                adapterLibrary.setLibraryList(sorted) {
+                    recyclerView.scrollToPosition(0)
+                }
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesViewModel.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.ui.resources
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,6 +21,11 @@ class ResourcesViewModel @Inject constructor(
     private val resourcesRepository: ResourcesRepository,
     private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
+
+    enum class SortMode { NONE, DATE, TITLE }
+    private var sortMode = SortMode.NONE
+    private var isAscending = true
+    private var isTitleAscending = true
 
     private val _downloadComplete = MutableStateFlow(false)
     val downloadComplete: StateFlow<Boolean> = _downloadComplete.asStateFlow()
@@ -53,6 +59,33 @@ class ResourcesViewModel @Inject constructor(
     }
 
     suspend fun getLibraryListModels(isMyCourseLib: Boolean, modelId: String?): List<ResourceListModel> = withContext(dispatcherProvider.io) {
-        resourcesRepository.getResourceListModels(isMyCourseLib, modelId)
+        applyCurrentSort(resourcesRepository.getResourceListModels(isMyCourseLib, modelId))
+    }
+
+    suspend fun toggleSortOrder(list: List<ResourceListModel>): List<ResourceListModel> = withContext(dispatcherProvider.io) {
+        sortMode = SortMode.DATE
+        isAscending = !isAscending
+        applyCurrentSort(list)
+    }
+
+    suspend fun toggleTitleSortOrder(list: List<ResourceListModel>): List<ResourceListModel> = withContext(dispatcherProvider.io) {
+        sortMode = SortMode.TITLE
+        isTitleAscending = !isTitleAscending
+        applyCurrentSort(list)
+    }
+
+    suspend fun applyCurrentSort(list: List<ResourceListModel>): List<ResourceListModel> = withContext(dispatcherProvider.io) {
+        when (sortMode) {
+            SortMode.DATE -> {
+                if (isAscending) list.sortedBy { it.item.createdDate }
+                else list.sortedByDescending { it.item.createdDate }
+            }
+            SortMode.TITLE -> {
+                val withKeys = list.map { it to (it.item.title?.lowercase(Locale.ROOT) ?: "") }
+                if (isTitleAscending) withKeys.sortedBy { it.second }.map { it.first }
+                else withKeys.sortedByDescending { it.second }.map { it.first }
+            }
+            SortMode.NONE -> list
+        }
     }
 }


### PR DESCRIPTION
Move sorting logic from adapters to viewmodels

- Extracted sorting flags and logic from `ResourcesAdapter` and `CoursesAdapter` to their respective ViewModels.
- Used Schwartzian transform to precompute lowercased keys for title sort to prevent redundant `.lowercase()` calls.
- Connected fragment list sort triggers properly to ViewModels, preserving `scrollToTop()` functionality.

---
*PR created automatically by Jules for task [2722493514456134837](https://jules.google.com/task/2722493514456134837) started by @dogi*