### PR TITLE
dashboard: smoother health user handling (fixes #15426)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6334
-        versionName = "0.63.34"
+        versionCode = 6335
+        versionName = "0.63.35"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
@@ -343,22 +343,23 @@ open class BaseDashboardFragment : DashboardPluginFragment(), OnSyncListener {
             .setNegativeButton(R.string.dismiss, null)
             .create()
 
+        val adapter = HealthUsersAdapter { selected ->
+            selected._id?.let { userId ->
+                viewLifecycleOwner.lifecycleScope.launch {
+                    val libraryList = viewModel.getLibraryListForUser(userId)
+                    showDownloadDialog(libraryList)
+                }
+            }
+            dialog.dismiss()
+        }
+        alertHealthListBinding.list.layoutManager = LinearLayoutManager(requireActivity())
+        alertHealthListBinding.list.adapter = adapter
+
         val job = viewLifecycleOwner.lifecycleScope.launch {
             viewModel.uiState.collect {
                 if (dialog.isShowing) {
                     if (it.users.isNotEmpty()) {
-                        val adapter = HealthUsersAdapter { selected ->
-                            selected._id?.let { userId ->
-                                viewLifecycleOwner.lifecycleScope.launch {
-                                    val libraryList = viewModel.getLibraryListForUser(userId)
-                                    showDownloadDialog(libraryList)
-                                }
-                            }
-                            dialog.dismiss()
-                        }
                         adapter.submitList(it.users)
-                        alertHealthListBinding.list.layoutManager = LinearLayoutManager(requireActivity())
-                        alertHealthListBinding.list.adapter = adapter
                         alertHealthListBinding.list.visibility = View.VISIBLE
                     } else {
                         alertHealthListBinding.list.visibility = View.GONE


### PR DESCRIPTION
Fixes the health-users dialog in `BaseDashboardFragment` to reuse its `HealthUsersAdapter` instance across `uiState` emissions. Previously, the adapter and layout manager were reconstructed each time the state updated, rendering the underlying `DiffUtil` ineffective and causing unnecessary UI churn. The refactor initializes the adapter once before collection and only updates the data using `submitList` when new values are emitted.

---
*PR created automatically by Jules for task [5275298877146959422](https://jules.google.com/task/5275298877146959422) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the user resource dialog’s handling of health user data and list visibility.
  * Preserved existing selection, library loading, and dialog dismissal behavior.

* **Release**
  * Updated the app version to 0.63.35.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->