### PR TITLE
login: smoother creation username validating (fixes #15406)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6321
-        versionName = "0.63.21"
+        versionCode = 6322
+        versionName = "0.63.22"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
@@ -11,6 +11,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
@@ -38,6 +40,7 @@ class BecomeMemberActivity : BaseActivity() {
     private lateinit var activityBecomeMemberBinding: ActivityBecomeMemberBinding
     var dob: String = ""
     var guest: Boolean = false
+    private var usernameValidationJob: Job? = null
     private var usernameWatcher: TextWatcher? = null
     private var passwordWatcher: TextWatcher? = null
     private var rePasswordWatcher: TextWatcher? = null
@@ -185,6 +188,8 @@ class BecomeMemberActivity : BaseActivity() {
     }
 
     override fun onDestroy() {
+        usernameValidationJob?.cancel()
+        usernameValidationJob = null
         activityBecomeMemberBinding.etUsername.removeTextChangedListener(usernameWatcher)
         activityBecomeMemberBinding.etPassword.removeTextChangedListener(passwordWatcher)
         activityBecomeMemberBinding.etRePassword.removeTextChangedListener(rePasswordWatcher)
@@ -222,19 +227,24 @@ class BecomeMemberActivity : BaseActivity() {
 
             override fun afterTextChanged(s: Editable?) {
                 val input = s?.toString() ?: ""
-                lifecycleScope.launch {
+                usernameValidationJob?.cancel()
+                usernameValidationJob = lifecycleScope.launch {
+                    delay(300)
                     val error = userRepository.validateUsername(input)
-                    withContext(dispatcherProvider.main) {
-                        if (error != null) {
-                            activityBecomeMemberBinding.etUsername.error = error
-                        } else {
-                            val lowercase = input.lowercase()
-                            if (input != lowercase) {
-                                activityBecomeMemberBinding.etUsername.setText(lowercase)
-                                activityBecomeMemberBinding.etUsername.setSelection(lowercase.length)
-                            }
-                            activityBecomeMemberBinding.etUsername.error = null
+
+                    if (activityBecomeMemberBinding.etUsername.text.toString() != input) {
+                        return@launch
+                    }
+
+                    if (error != null) {
+                        activityBecomeMemberBinding.etUsername.error = error
+                    } else {
+                        val lowercase = input.lowercase()
+                        if (input != lowercase) {
+                            activityBecomeMemberBinding.etUsername.setText(lowercase)
+                            activityBecomeMemberBinding.etUsername.setSelection(lowercase.length)
                         }
+                        activityBecomeMemberBinding.etUsername.error = null
                     }
                 }
             }


### PR DESCRIPTION
Cancel stale username-validation work in BecomeMemberActivity

Replaces the per-keystroke `lifecycleScope.launch` in the username
`TextWatcher` with a debounced execution that tracks and cancels
the previous `Job`. A `delay(300)` is added to batch rapid text changes.
Also drops an unnecessary `withContext` switch to the main dispatcher
and ensures stale validations do not overwrite newer input by checking
if the text has changed since the coroutine was launched. Finally,
the running job is cleaned up in `onDestroy()`.

---
*PR created automatically by Jules for task [3668074042637295628](https://jules.google.com/task/3668074042637295628) started by @dogi*