### PR TITLE
login: less auth utils username validation is more (fixes #15414)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6328
-        versionName = "0.63.28"
+        versionCode = 6329
+        versionName = "0.63.29"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/GuestLoginExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/GuestLoginExtensions.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.AlertGuestLoginBinding
 import org.ole.planet.myplanet.repository.UserRepository
-import org.ole.planet.myplanet.utils.AuthUtils
 import org.ole.planet.myplanet.utils.Utilities.toast
 import org.ole.planet.myplanet.utils.textChanges
 
@@ -37,7 +36,7 @@ fun LoginActivity.showGuestLoginDialog(userRepository: UserRepository) {
                 if (input.isEmpty()) {
                     binding.etUserName.error = null
                 } else {
-                    val error = AuthUtils.validateUsername(input, userRepository)
+                    val error = userRepository.validateUsername(input)
                     binding.etUserName.error = error
                 }
             }
@@ -56,7 +55,7 @@ fun LoginActivity.showGuestLoginDialog(userRepository: UserRepository) {
     login.setOnClickListener {
         val username = binding.etUserName.text.toString().trim { it <= ' ' }
         lifecycleScope.launch {
-            val error = AuthUtils.validateUsername(username, userRepository)
+            val error = userRepository.validateUsername(username)
             if (error == null) {
                 val existingUser = userRepository.findUserByName(username)
                 dialog.dismiss()

--- a/app/src/main/java/org/ole/planet/myplanet/utils/AuthUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/AuthUtils.kt
@@ -5,18 +5,10 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnSyncListener
-import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.services.sync.LoginSyncManager
 import org.ole.planet.myplanet.ui.sync.LoginActivity
 
 object AuthUtils {
-    suspend fun validateUsername(
-        username: String,
-        userRepository: UserRepository,
-    ): String? {
-        return userRepository.validateUsername(username)
-    }
-
     suspend fun login(activity: LoginActivity, loginSyncManager: LoginSyncManager, name: String?, password: String?, ioDispatcher: CoroutineDispatcher) {
         if (activity.forceSyncTrigger()) return
 


### PR DESCRIPTION
Removed the redundant `AuthUtils.validateUsername` wrapper method, which merely delegated to `UserRepository`, and updated all callers to invoke the repository method directly. Unused imports were also cleaned up.

---
*PR created automatically by Jules for task [7022513679959212049](https://jules.google.com/task/7022513679959212049) started by @dogi*