### PR TITLE
chat: smoother history voices view modelling (fixes #15422)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6331
-        versionName = "0.63.31"
+        versionCode = 6332
+        versionName = "0.63.32"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatHistoryFragment.kt
@@ -28,7 +28,6 @@ import org.ole.planet.myplanet.model.Conversation
 import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.ChatRepository
-import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
@@ -54,8 +53,6 @@ class ChatHistoryFragment : Fragment() {
     
     @Inject
     lateinit var chatRepository: ChatRepository
-    @Inject
-    lateinit var voicesRepository: VoicesRepository
     private val serverUrl: String
         get() = sharedPrefManager.getServerUrl()
 
@@ -174,23 +171,10 @@ class ChatHistoryFragment : Fragment() {
             if (!isAdded || _binding == null) {
                 return@ChatHistoryAdapter
             }
-            viewLifecycleOwner.lifecycleScope.launch {
-                val currentUser = user
-                val chatId = chat._id ?: ""
-                val viewInId = map["viewInId"] ?: ""
-                if (chatId.isNotEmpty() && viewInId.isNotEmpty() &&
-                    voicesRepository.isAlreadyShared(chatId, viewInId)) {
-                    Snackbar.make(binding.root, getString(R.string.chat_already_shared_to_destination), Snackbar.LENGTH_SHORT).show()
-                    return@launch
-                }
-                val createdNews = voicesRepository.createNews(map, currentUser, null)
-                if (currentUser?.planetCode != null) {
-                    sharedNewsMessages = sharedNewsMessages + createdNews
-                }
-                (binding.recyclerView.adapter as? ChatHistoryAdapter)?.let { adapter ->
-                    adapter.updateCachedData(currentUser, sharedNewsMessages, sharedViewInIds)
-                    adapter.notifyChatShared(chat._id)
-                }
+            val chatId = chat._id ?: ""
+            val viewInId = map["viewInId"] ?: ""
+            if (chatId.isNotEmpty() && viewInId.isNotEmpty()) {
+                sharedViewModel.shareChatToVoices(chatId, viewInId, map)
             }
         }
         newAdapter.setChatHistoryItemClickListener(object : OnChatHistoryItemClickListener {
@@ -253,6 +237,26 @@ class ChatHistoryFragment : Fragment() {
     private fun setupRealtimeSync() {
         collectWhenStarted(sharedViewModel.refreshChatSignal) {
             refreshChatHistory()
+        }
+        collectWhenStarted(sharedViewModel.shareResult) { result ->
+            when (result) {
+                is ChatViewModel.ShareChatResult.AlreadyShared -> {
+                    if (isAdded && _binding != null) {
+                        Snackbar.make(binding.root, getString(R.string.chat_already_shared_to_destination), Snackbar.LENGTH_SHORT).show()
+                    }
+                }
+                is ChatViewModel.ShareChatResult.Shared -> {
+                    if (isAdded && _binding != null) {
+                        if (user?.planetCode != null) {
+                            sharedNewsMessages = sharedNewsMessages + result.news
+                        }
+                        (binding.recyclerView.adapter as? ChatHistoryAdapter)?.let { adapter ->
+                            adapter.updateCachedData(user, sharedNewsMessages, sharedViewInIds)
+                            adapter.notifyChatShared(result.chatId)
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatViewModel.kt
@@ -18,6 +18,7 @@ import org.ole.planet.myplanet.model.ChatHistory
 import org.ole.planet.myplanet.model.ChatMessage
 import org.ole.planet.myplanet.model.ChatShareTargets
 import org.ole.planet.myplanet.model.Conversation
+import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.TeamSummary
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.ChatRepository
@@ -75,6 +76,14 @@ class ChatViewModel @Inject constructor(
 
     private var loadDataJob: kotlinx.coroutines.Job? = null
     private var searchJob: kotlinx.coroutines.Job? = null
+
+    sealed class ShareChatResult {
+        object AlreadyShared : ShareChatResult()
+        data class Shared(val news: News, val chatId: String) : ShareChatResult()
+    }
+
+    private val _shareResult = MutableSharedFlow<ShareChatResult>()
+    val shareResult: SharedFlow<ShareChatResult> = _shareResult.asSharedFlow()
 
     private val _screenData = MutableStateFlow<ChatHistoryScreenData?>(null)
     val screenData: StateFlow<ChatHistoryScreenData?> = _screenData.asStateFlow()
@@ -347,5 +356,16 @@ class ChatViewModel @Inject constructor(
 
     fun shouldFetchAiProviders(): Boolean {
         return _aiProviders.value == null && !_aiProvidersLoading.value
+    }
+
+    fun shareChatToVoices(chatId: String, viewInId: String, payload: HashMap<String?, String>) {
+        viewModelScope.launch {
+            if (voicesRepository.isAlreadyShared(chatId, viewInId)) {
+                _shareResult.emit(ShareChatResult.AlreadyShared)
+            } else {
+                val news = voicesRepository.createNews(payload, cachedUser, null)
+                _shareResult.emit(ShareChatResult.Shared(news, chatId))
+            }
+        }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/chat/ChatViewModelTest.kt
@@ -312,4 +312,59 @@ class ChatViewModelTest {
 
         job.cancel()
     }
+
+    @Test
+    fun `shareChatToVoices emits AlreadyShared when previously shared`() = runTest {
+        val chatId = "chat_123"
+        val viewInId = "view_456"
+        val payload = hashMapOf<String?, String>("test" to "data")
+
+        coEvery { voicesRepository.isAlreadyShared(chatId, viewInId) } returns true
+
+        val emissions = mutableListOf<ChatViewModel.ShareChatResult>()
+        val job = launch(testDispatcher) {
+            viewModel.shareResult.collect { emissions.add(it) }
+        }
+
+        viewModel.shareChatToVoices(chatId, viewInId, payload)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(1, emissions.size)
+        assertTrue(emissions[0] is ChatViewModel.ShareChatResult.AlreadyShared)
+
+        coVerify(exactly = 1) { voicesRepository.isAlreadyShared(chatId, viewInId) }
+        coVerify(exactly = 0) { voicesRepository.createNews(any(), any(), any()) }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `shareChatToVoices emits Shared when successfully creates news`() = runTest {
+        val chatId = "chat_123"
+        val viewInId = "view_456"
+        val payload = hashMapOf<String?, String>("test" to "data")
+        val createdNews = News().apply { id = "news_123" }
+
+        coEvery { voicesRepository.isAlreadyShared(chatId, viewInId) } returns false
+        coEvery { voicesRepository.createNews(payload, any(), null) } returns createdNews
+
+        val emissions = mutableListOf<ChatViewModel.ShareChatResult>()
+        val job = launch(testDispatcher) {
+            viewModel.shareResult.collect { emissions.add(it) }
+        }
+
+        viewModel.shareChatToVoices(chatId, viewInId, payload)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(1, emissions.size)
+        assertTrue(emissions[0] is ChatViewModel.ShareChatResult.Shared)
+        val result = emissions[0] as ChatViewModel.ShareChatResult.Shared
+        assertEquals(createdNews, result.news)
+        assertEquals(chatId, result.chatId)
+
+        coVerify(exactly = 1) { voicesRepository.isAlreadyShared(chatId, viewInId) }
+        coVerify(exactly = 1) { voicesRepository.createNews(payload, any(), null) }
+
+        job.cancel()
+    }
 }


### PR DESCRIPTION
Refactored `ChatHistoryFragment` so it no longer writes to Voices directly.

- Removed `VoicesRepository` injection from `ChatHistoryFragment`.
- Added `shareChatToVoices` method to `ChatViewModel`.
- Created a `ShareChatResult` sealed class with `AlreadyShared` and `Shared` states.
- The fragment now observes a `shareResult` `SharedFlow` to perform Snackbar display and adapter updates.
- Added tests for `shareChatToVoices` in `ChatViewModelTest`.

---
*PR created automatically by Jules for task [853938676527771487](https://jules.google.com/task/853938676527771487) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat sharing now provides clear feedback when content has already been shared or sharing succeeds.
  - Successfully shared chats update related news and displayed content automatically.

- **Bug Fixes**
  - Prevented duplicate sharing of the same chat.

- **Tests**
  - Added coverage for successful sharing and duplicate-share scenarios.

- **Chores**
  - Updated the Android app version to 0.63.32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->