### PR TITLE
dashboard: smoother coroutine view modelling (fixes #15405)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6324
-        versionName = "0.63.24"
+        versionCode = 6325
+        versionName = "0.63.25"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardViewModel.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.coroutineScope
 import org.ole.planet.myplanet.model.MyCourse
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.MyTeam
@@ -131,9 +131,7 @@ class DashboardViewModel @Inject constructor(
 
         libraryJob?.cancel()
         libraryJob = viewModelScope.launch {
-            val myLibrary = withContext(dispatcherProvider.io) {
-                resourcesRepository.getMyLibrary(userId)
-            }
+            val myLibrary = resourcesRepository.getMyLibrary(userId)
             _uiState.update { it.copy(library = myLibrary) }
         }
 
@@ -157,9 +155,7 @@ class DashboardViewModel @Inject constructor(
 
         profileJob?.cancel()
         profileJob = viewModelScope.launch {
-            val profile = withContext(dispatcherProvider.io) {
-                userRepository.getDashboardProfile(userId)
-            }
+            val profile = userRepository.getDashboardProfile(userId)
 
             _uiState.update { it.copy(fullName = profile.fullName, offlineLogins = profile.offlineLogins) }
         }
@@ -175,9 +171,7 @@ class DashboardViewModel @Inject constructor(
 
     fun loadUsers() {
         viewModelScope.launch {
-            val users = withContext(dispatcherProvider.io) {
-                userRepository.getUsersSortedBy("joinDate", true)
-            }
+            val users = userRepository.getUsersSortedBy("joinDate", true)
             _uiState.update { it.copy(users = users) }
         }
     }
@@ -193,9 +187,7 @@ class DashboardViewModel @Inject constructor(
 
     fun handleTaskNavigation(taskId: String) {
         viewModelScope.launch {
-            val teamData = withContext(dispatcherProvider.io) {
-                teamsRepository.getTaskTeamInfo(taskId)
-            }
+            val teamData = teamsRepository.getTaskTeamInfo(taskId)
             if (teamData != null) {
                 _taskNavigationEvent.emit(teamData)
             }
@@ -204,9 +196,7 @@ class DashboardViewModel @Inject constructor(
 
     fun handleJoinRequestNavigation(requestId: String) {
         viewModelScope.launch {
-            val teamId = withContext(dispatcherProvider.io) {
-                teamsRepository.getJoinRequestTeamId(requestId)
-            }
+            val teamId = teamsRepository.getJoinRequestTeamId(requestId)
             if (teamId != null) {
                 _joinRequestNavigationEvent.emit(teamId)
             }
@@ -216,10 +206,8 @@ class DashboardViewModel @Inject constructor(
     fun refreshNotificationsWithRetry(userId: String, maxRetries: Int = 2) {
         viewModelScope.launch {
             val unreadCount = RetryUtils.retry(maxAttempts = maxRetries, delayMs = 300L) {
-                withContext(dispatcherProvider.io) {
-                    notificationsRepository.refresh()
-                    getUnreadNotificationsSize(userId)
-                }
+                notificationsRepository.refresh()
+                getUnreadNotificationsSize(userId)
             }
             if (unreadCount != null) {
                 setUnreadNotifications(unreadCount)
@@ -230,9 +218,7 @@ class DashboardViewModel @Inject constructor(
     fun markNotificationAsRead(notificationId: String, userId: String?) {
         viewModelScope.launch {
             try {
-                withContext(dispatcherProvider.io) {
-                    notificationsRepository.markNotificationAsRead(notificationId, userId)
-                }
+                notificationsRepository.markNotificationAsRead(notificationId, userId)
             } catch (e: Exception) {
                 e.printStackTrace()
             }
@@ -243,10 +229,8 @@ class DashboardViewModel @Inject constructor(
         viewModelScope.launch {
             kotlinx.coroutines.delay(100.milliseconds)
             try {
-                val unreadCount = withContext(dispatcherProvider.io) {
-                    notificationsRepository.refresh()
-                    getUnreadNotificationsSize(userId)
-                }
+                notificationsRepository.refresh()
+                val unreadCount = getUnreadNotificationsSize(userId)
                 setUnreadNotifications(unreadCount)
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -256,9 +240,7 @@ class DashboardViewModel @Inject constructor(
 
     fun handleSurveyNavigation(surveyId: String) {
         viewModelScope.launch {
-            val survey = withContext(dispatcherProvider.io) {
-                surveysRepository.getSurvey(surveyId)
-            }
+            val survey = surveysRepository.getSurvey(surveyId)
             survey?.id?.let { id ->
                 _surveyNavigationEvent.emit(id)
             }
@@ -277,7 +259,7 @@ class DashboardViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                val dialogData = withContext(dispatcherProvider.io) {
+                val dialogData = coroutineScope {
                     val courseDataDeferred = async { progressRepository.fetchCourseData(userId) }
                     val uniqueDatesDeferred = async { voicesRepository.getCommunityVoiceDates(startTime, endTime, userId) }
                     val allUniqueDatesDeferred = async { voicesRepository.getCommunityVoiceDates(startTime, endTime, null) }
@@ -344,10 +326,8 @@ class DashboardViewModel @Inject constructor(
 
     suspend fun checkAndCreateNewNotifications(userId: String?, isAdmin: Boolean = false) {
         try {
-            val unreadCount = withContext(dispatcherProvider.io) {
-                updateResourceNotification(userId)
-                getUnreadNotificationsSize(userId, isAdmin)
-            }
+            updateResourceNotification(userId)
+            val unreadCount = getUnreadNotificationsSize(userId, isAdmin)
             _uiState.update { it.copy(unreadNotifications = unreadCount) }
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
This commit addresses the issue of redundant context switching in `DashboardViewModel`. It removes the `withContext(dispatcherProvider.io)` wrappers from all suspendable repository calls, leaning on the architecture where repositories natively use appropriate background thread dispatchers. Structured concurrency has been preserved correctly for concurrent operations.

---
*PR created automatically by Jules for task [805558652128875233](https://jules.google.com/task/805558652128875233) started by @dogi*