### PR TITLE
all: smoother crash log sweeping (fixes #15464)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6409
-        versionName = "0.64.9"
+        versionCode = 6410
+        versionName = "0.64.10"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -358,12 +358,10 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
 
     private suspend fun sweepPendingLogs() {
         try {
-            val pendingLogs = withContext(dispatcherProvider.io) {
-                CrashLogStore.loadPendingLogs(this@MainApplication)
-            }
-            if (pendingLogs.isNotEmpty()) {
-                if (saveLogsToRoom(pendingLogs)) {
-                    withContext(dispatcherProvider.io) {
+            withContext(dispatcherProvider.io) {
+                val pendingLogs = CrashLogStore.loadPendingLogs(this@MainApplication)
+                if (pendingLogs.isNotEmpty()) {
+                    if (saveLogsToRoom(pendingLogs)) {
                         for (pending in pendingLogs) {
                             pending.file.delete()
                         }


### PR DESCRIPTION
Wrap pending logs processing in single IO dispatcher boundary in `MainApplication.sweepPendingLogs()`.

---
*PR created automatically by Jules for task [16884056728238491932](https://jules.google.com/task/16884056728238491932) started by @dogi*