### PR TITLE
resources: smoother download utils handling (fixes #15429)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6338
-        versionName = "0.63.38"
+        versionCode = 6339
+        versionName = "0.63.39"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -39,6 +39,7 @@ import org.ole.planet.myplanet.di.getBroadcastService
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.DownloadResult
 import org.ole.planet.myplanet.repository.DownloadRepository
+import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.services.DownloadWorker
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
@@ -57,6 +58,9 @@ class DownloadService : Service() {
 
     @Inject
     lateinit var downloadRepository: DownloadRepository
+
+    @Inject
+    lateinit var resourcesRepository: ResourcesRepository
 
     @Inject
     lateinit var serverUrlMapper: ServerUrlMapper
@@ -214,7 +218,11 @@ class DownloadService : Service() {
 
             if (FileUtils.checkFileExist(this, url)) {
                 Log.d(TAG, "initDownload: $fileName already on disk, marking offline and skipping download")
-                DownloadUtils.updateResourceOfflineStatus(url)
+                try {
+                    resourcesRepository.markResourceOfflineByUrl(url)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
                 onDownloadComplete(url)
                 return true
             }
@@ -462,7 +470,13 @@ class DownloadService : Service() {
 
     private fun onDownloadComplete(url: String) {
         if ((outputFile?.length() ?: 0) > 0) {
-            DownloadUtils.updateResourceOfflineStatus(url)
+            appScope.launch {
+                try {
+                    resourcesRepository.markResourceOfflineByUrl(url)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
         }
 
         val remainingPriority = preferences.getStringSet(PRIORITY_DOWNLOADS_KEY, emptySet())?.count { it !in processedUrls } ?: 0

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
@@ -22,6 +22,7 @@ import org.ole.planet.myplanet.di.DownloadPreferences
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.DownloadResult
 import org.ole.planet.myplanet.repository.DownloadRepository
+import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils
@@ -33,6 +34,7 @@ class DownloadWorker @AssistedInject constructor(
     @Assisted private val context: Context, @Assisted workerParams: WorkerParameters,
     private val downloadRepository: DownloadRepository, private val broadcastService: BroadcastService,
     private val dispatcherProvider: DispatcherProvider,
+    private val resourcesRepository: ResourcesRepository,
     @DownloadPreferences private val preferences: SharedPreferences
 ) : CoroutineWorker(context, workerParams) {
 
@@ -81,7 +83,11 @@ class DownloadWorker @AssistedInject constructor(
 
     private suspend fun downloadFile(url: String, index: Int, total: Int): Boolean {
         if (FileUtils.checkFileExist(context, url)) {
-            DownloadUtils.updateResourceOfflineStatus(url)
+            try {
+                resourcesRepository.markResourceOfflineByUrl(url)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
             return true
         }
         return try {
@@ -128,7 +134,11 @@ class DownloadWorker @AssistedInject constructor(
                 sink.flush()
             }
         }
-        DownloadUtils.updateResourceOfflineStatus(url)
+        try {
+            resourcesRepository.markResourceOfflineByUrl(url)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     private suspend fun showProgressNotification(current: Int, total: Int, fileName: String, fileProgress: Int = -1) {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/DownloadUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/DownloadUtils.kt
@@ -13,14 +13,9 @@ import androidx.core.content.edit
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
-import dagger.hilt.android.EntryPointAccessors
 import java.util.regex.Pattern
-import kotlinx.coroutines.launch
-import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
 import org.ole.planet.myplanet.model.MyLibrary
-import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.services.DownloadService
 import org.ole.planet.myplanet.services.DownloadWorker
 
@@ -249,23 +244,9 @@ object DownloadUtils {
         return links
     }
 
-    fun updateResourceOfflineStatus(url: String) {
-        MainApplication.applicationScope.launch {
-            try {
-                resourcesRepository.markResourceOfflineByUrl(url)
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-    }
 
-    private val resourcesRepository: ResourcesRepository by lazy {
-        val entryPoint = EntryPointAccessors.fromApplication(
-            MainApplication.context,
-            CoreDependenciesEntryPoint::class.java
-        )
-        entryPoint.resourcesRepository()
-    }
+
+
 
 
 }


### PR DESCRIPTION
This commit removes the stateless utility anti-pattern where `DownloadUtils` relied on Hilt's `EntryPointAccessors` to grab `ResourcesRepository` for database updates. Instead, `ResourcesRepository` is now appropriately injected into `DownloadService` and `DownloadWorker`. 

The update logic is executed natively within those classes, keeping crash safety via `try-catch` blocks and utilizing injected coroutine scopes appropriately.

---
*PR created automatically by Jules for task [12348765171443916182](https://jules.google.com/task/12348765171443916182) started by @dogi*