### PR TITLE
courses: smoother repository progess ratings view modelling (fixes #15538)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6406
-        versionName = "0.64.6"
+        versionCode = 6407
+        versionName = "0.64.7"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepository.kt
@@ -56,11 +56,9 @@ interface CoursesRepository {
     suspend fun removeCourseFromShelf(courseId: String, userId: String)
     suspend fun logCourseVisit(courseId: String, title: String, userId: String)
     suspend fun getCurrentProgress(steps: List<CourseStep?>?, userId: String?, courseId: String?): Int
-    suspend fun getCourseProgress(userId: String?, courseIds: List<String>): HashMap<String?, JsonObject>
     suspend fun isStepCompleted(stepId: String?, userId: String?): Boolean
     suspend fun hasUnfinishedSurveys(courseId: String, userId: String?): Boolean
     suspend fun getCourseTagsBulk(courseIds: List<String>): Map<String, List<TagEntity>>
-    suspend fun getCourseRatings(userId: String?): HashMap<String?, JsonObject>
     suspend fun deleteCourseProgress(courseId: String?)
     suspend fun bulkInsertFromSync(jsonArray: JsonArray)
     suspend fun flushPendingCourseResources()

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -485,10 +485,6 @@ class CoursesRepositoryImpl @Inject constructor(
         return progressRepository.getCurrentProgress(steps, userId, courseId)
     }
 
-    override suspend fun getCourseProgress(userId: String?, courseIds: List<String>): HashMap<String?, JsonObject> {
-        return progressRepository.getCourseProgress(courseIds, userId)
-    }
-
     override suspend fun isStepCompleted(stepId: String?, userId: String?): Boolean {
         return submissionsRepository.isStepCompleted(stepId, userId)
     }
@@ -499,10 +495,6 @@ class CoursesRepositoryImpl @Inject constructor(
 
     override suspend fun getCourseTagsBulk(courseIds: List<String>): Map<String, List<TagEntity>> {
         return tagsRepository.getTagsForCourses(courseIds)
-    }
-
-    override suspend fun getCourseRatings(userId: String?): HashMap<String?, JsonObject> {
-        return ratingsRepository.getCourseRatings(userId)
     }
 
     override suspend fun deleteCourseProgress(courseId: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
@@ -17,6 +17,8 @@ import org.ole.planet.myplanet.model.Course
 import org.ole.planet.myplanet.model.MyCourse
 import org.ole.planet.myplanet.model.Tag
 import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.ProgressRepository
+import org.ole.planet.myplanet.repository.RatingsRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
 data class CoursesUiState(
@@ -29,6 +31,8 @@ data class CoursesUiState(
 @HiltViewModel
 class CoursesViewModel @Inject constructor(
     private val coursesRepository: CoursesRepository,
+    private val progressRepository: ProgressRepository,
+    private val ratingsRepository: RatingsRepository,
     private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
 
@@ -72,9 +76,9 @@ class CoursesViewModel @Inject constructor(
                     val allCourseIds = validCourses.mapNotNull { it.courseId }
 
                     val (map, progressMap) = coroutineScope {
-                        val ratingsDeferred = async { coursesRepository.getCourseRatings(userId) }
+                        val ratingsDeferred = async { ratingsRepository.getCourseRatings(userId) }
                         val progressDeferred = async {
-                            coursesRepository.getCourseProgress(userId, allCourseIds)
+                            progressRepository.getCourseProgress(allCourseIds, userId)
                         }
                         Pair(ratingsDeferred.await(), progressDeferred.await())
                     }
@@ -97,7 +101,7 @@ class CoursesViewModel @Inject constructor(
     suspend fun refreshCourseRatings(userId: String?) {
         val map = withContext(dispatcherProvider.io) {
             try {
-                coursesRepository.getCourseRatings(userId)
+                ratingsRepository.getCourseRatings(userId)
             } catch (e: Exception) {
                 e.printStackTrace()
                 null

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseViewModel.kt
@@ -11,6 +11,7 @@ import org.ole.planet.myplanet.model.CourseStep
 import org.ole.planet.myplanet.model.MyCourse
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.ProgressRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 
 sealed interface TakeCourseUiState {
@@ -27,6 +28,7 @@ sealed interface TakeCourseUiState {
 @HiltViewModel
 class TakeCourseViewModel @Inject constructor(
     private val coursesRepository: CoursesRepository,
+    private val progressRepository: ProgressRepository,
     private val userSessionManager: UserSessionManager
 ) : ViewModel() {
 
@@ -59,7 +61,7 @@ class TakeCourseViewModel @Inject constructor(
                 }
 
                 val steps = coursesRepository.getCourseSteps(courseId)
-                val progressMap = coursesRepository.getCourseProgress(userModel?.id, listOf(courseId))
+                val progressMap = progressRepository.getCourseProgress(listOf(courseId), userModel?.id)
                 val progress = progressMap[courseId]?.asJsonObject?.get("current")?.asInt ?: 0
 
                 _uiState.value = TakeCourseUiState.Success(course, steps, userModel, progress)

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesViewModelTest.kt
@@ -8,6 +8,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.ProgressRepository
+import org.ole.planet.myplanet.repository.RatingsRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.MainDispatcherRule
 
@@ -17,6 +19,8 @@ class CoursesViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private val coursesRepository = mockk<CoursesRepository>(relaxed = true)
+    private val progressRepository = mockk<ProgressRepository>(relaxed = true)
+    private val ratingsRepository = mockk<RatingsRepository>(relaxed = true)
     private val dispatcherProvider = mockk<DispatcherProvider>()
 
     private lateinit var viewModel: CoursesViewModel
@@ -27,6 +31,8 @@ class CoursesViewModelTest {
         io.mockk.every { dispatcherProvider.main } returns Dispatchers.Unconfined
         viewModel = CoursesViewModel(
             coursesRepository,
+            progressRepository,
+            ratingsRepository,
             dispatcherProvider
         )
     }
@@ -59,13 +65,13 @@ class CoursesViewModelTest {
     @Test
     fun testLoadCourses_MyCoursesLib_CallsGetCourseProgress() = runTest {
         viewModel.loadCourses(true, "u1")
-        coVerify { coursesRepository.getCourseProgress("u1", any<List<String>>()) }
+        coVerify { progressRepository.getCourseProgress(any<List<String>>(), "u1") }
     }
 
     @Test
     fun testLoadCourses_NotMyCoursesLib_StillCallsGetCourseProgress() = runTest {
         viewModel.loadCourses(false, "u1")
-        coVerify { coursesRepository.getCourseProgress("u1", any<List<String>>()) }
+        coVerify { progressRepository.getCourseProgress(any<List<String>>(), "u1") }
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/TakeCourseViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/TakeCourseViewModelTest.kt
@@ -18,6 +18,7 @@ import org.ole.planet.myplanet.model.CourseStep
 import org.ole.planet.myplanet.model.MyCourse
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.CoursesRepository
+import org.ole.planet.myplanet.repository.ProgressRepository
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.MainDispatcherRule
 
@@ -30,6 +31,7 @@ class TakeCourseViewModelTest {
     val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     private val coursesRepository: CoursesRepository = mockk()
+    private val progressRepository: ProgressRepository = mockk()
     private val userSessionManager: UserSessionManager = mockk()
 
     private lateinit var viewModel: TakeCourseViewModel
@@ -45,13 +47,13 @@ class TakeCourseViewModelTest {
         coEvery { userSessionManager.getUserModel() } returns user
         coEvery { coursesRepository.getCourseById(courseId) } returns course
         coEvery { coursesRepository.getCourseSteps(courseId) } returns steps
-        coEvery { coursesRepository.getCourseProgress(user?.id, listOf(courseId)) } returns
+        coEvery { progressRepository.getCourseProgress(listOf(courseId), user?.id) } returns
             hashMapOf<String?, JsonObject>(courseId to JsonObject().apply { addProperty("current", currentProgress) })
     }
 
     @Before
     fun setUp() {
-        viewModel = TakeCourseViewModel(coursesRepository, userSessionManager)
+        viewModel = TakeCourseViewModel(coursesRepository, progressRepository, userSessionManager)
     }
 
     @Test
@@ -92,7 +94,7 @@ class TakeCourseViewModelTest {
 
         coVerify(exactly = 1) { coursesRepository.getCourseById(courseId) }
         coVerify(exactly = 1) { coursesRepository.getCourseSteps(courseId) }
-        coVerify(exactly = 1) { coursesRepository.getCourseProgress(any(), any<List<String>>()) }
+        coVerify(exactly = 1) { progressRepository.getCourseProgress(any<List<String>>(), any()) }
     }
 
     @Test
@@ -115,7 +117,7 @@ class TakeCourseViewModelTest {
         coEvery { coursesRepository.getCourseById(otherCourseId) } returns
             MyCourse().apply { courseId = otherCourseId }
         coEvery { coursesRepository.getCourseSteps(otherCourseId) } returns emptyList()
-        coEvery { coursesRepository.getCourseProgress(any(), listOf(otherCourseId)) } returns
+        coEvery { progressRepository.getCourseProgress(listOf(otherCourseId), any()) } returns
             hashMapOf<String?, JsonObject>()
 
         viewModel.loadCourse(courseId)


### PR DESCRIPTION
Removes `getCourseProgress` and `getCourseRatings` from `CoursesRepository` and its implementation. Injects `ProgressRepository` and `RatingsRepository` directly into `CoursesViewModel` and `TakeCourseViewModel` to avoid cross-repository passthroughs. Updated affected test files.

---
*PR created automatically by Jules for task [2081858438214264131](https://jules.google.com/task/2081858438214264131) started by @dogi*