### PR TITLE
resources: smoother repository offline item category detail storing (fixes #15545)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6417
-        versionName = "0.64.17"
+        versionCode = 6418
+        versionName = "0.64.18"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/OfflineResourceItem.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/OfflineResourceItem.kt
@@ -1,0 +1,9 @@
+package org.ole.planet.myplanet.model
+
+data class OfflineResourceItem(
+    val resourceId: String,
+    val title: String,
+    val filePaths: List<String>,
+    val totalSizeBytes: Long,
+    val isChecked: Boolean = false
+)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepository.kt
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.model.MyLibrary
+import org.ole.planet.myplanet.model.OfflineResourceItem
 import org.ole.planet.myplanet.model.ResourceListModel
 import org.ole.planet.myplanet.model.TagEntity
 
@@ -104,6 +105,8 @@ interface ResourcesRepository {
     suspend fun getPendingResourceUploads(): List<MyLibrary>
     suspend fun markResourceUploaded(localId: String, remoteId: String, remoteRev: String, planetCode: String?): Boolean
     suspend fun trackResourceOpen(item: MyLibrary)
+    suspend fun getOfflineResourceItems(oleDirPath: String, extensions: Set<String>, allKnownExtensions: Set<String>): List<OfflineResourceItem>
+    suspend fun deleteOfflineResources(oleDirPath: String, items: List<OfflineResourceItem>)
 }
 
 sealed class ResourceUrlsResponse {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImpl.kt
@@ -10,6 +10,7 @@ import java.util.Calendar
 import java.util.UUID
 import javax.inject.Inject
 import kotlin.math.ceil
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -20,6 +21,7 @@ import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TeamDao
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.MyTeam
+import org.ole.planet.myplanet.model.OfflineResourceItem
 import org.ole.planet.myplanet.model.RemovedLog
 import org.ole.planet.myplanet.model.ResourceItem
 import org.ole.planet.myplanet.model.ResourceListModel
@@ -30,6 +32,8 @@ import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.model.TagItem
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils
@@ -50,7 +54,8 @@ class ResourcesRepositoryImpl @Inject constructor(
     private val userRepository: UserRepository,
     private val teamDao: TeamDao,
     private val userSessionManager: UserSessionManager,
-    private val configurationsRepository: ConfigurationsRepository
+    private val configurationsRepository: ConfigurationsRepository,
+    private val dispatcherProvider: DispatcherProvider
 ) : ResourcesRepository {
 
     // Shelf membership is stored as a JSON userId list; match a single entry with LIKE %"id"%.
@@ -711,5 +716,49 @@ override suspend fun downloadFiles(libraryList: List<MyLibrary>?): List<MyLibrar
 
     override suspend fun trackResourceOpen(item: MyLibrary) {
         userSessionManager.setResourceOpenCount(item, UserSessionManager.KEY_RESOURCE_OPEN)
+    }
+
+    override suspend fun getOfflineResourceItems(
+        oleDirPath: String,
+        extensions: Set<String>,
+        allKnownExtensions: Set<String>
+    ): List<OfflineResourceItem> = withContext(dispatcherProvider.io) {
+        val oleDir = File(oleDirPath)
+        if (!oleDir.exists() || !oleDir.isDirectory) return@withContext emptyList()
+
+        val titleMap = getResourceTitlesMap()
+
+        val grouped = mutableMapOf<String, MutableList<File>>()
+        oleDir.walkTopDown().filter { it.isFile }.forEach { file ->
+            val ext = file.extension.lowercase()
+            val matchesCategory = if (extensions.isEmpty()) {
+                ext !in allKnownExtensions
+            } else {
+                ext in extensions
+            }
+            if (matchesCategory) {
+                val resourceId = file.parentFile?.name ?: return@forEach
+                grouped.getOrPut(resourceId) { mutableListOf() }.add(file)
+            }
+        }
+
+        return@withContext grouped.map { (resourceId, files) ->
+            val totalSize = files.sumOf { it.length() }
+            val title = titleMap[resourceId]?.takeIf { it.isNotBlank() } ?: context.getString(R.string.storage_unknown_resource)
+            OfflineResourceItem(resourceId, title, files.map { it.absolutePath }, totalSize)
+        }.sortedBy { it.title }
+    }
+
+    override suspend fun deleteOfflineResources(oleDirPath: String, items: List<OfflineResourceItem>) = withContext(dispatcherProvider.io) {
+        val oleDir = File(oleDirPath)
+        items.forEach { item ->
+            item.filePaths.forEach { File(it).delete() }
+            val parentDir = oleDir.resolve(item.resourceId)
+            if (parentDir.exists() && parentDir.list().isNullOrEmpty()) {
+                parentDir.delete()
+            }
+        }
+        val deletedIds = items.map { it.resourceId }.toSet()
+        markResourcesAsNotOffline(deletedIds)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
@@ -16,16 +16,14 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentStorageCategoryDetailBinding
 import org.ole.planet.myplanet.databinding.ItemDownloadedResourceBinding
+import org.ole.planet.myplanet.model.OfflineResourceItem
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.utils.DiffUtils
-import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.FileUtils
 
 @AndroidEntryPoint
@@ -35,22 +33,11 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
 
     @Inject
     lateinit var resourcesRepository: ResourcesRepository
-    @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
-
     private var categoryLabel: String = ""
     private var extensions: Set<String> = emptySet()
     private var allKnownExtensions: Set<String> = emptySet()
 
-    data class ResourceItem(
-        val resourceId: String,
-        val title: String,
-        val files: List<File>,
-        val totalSizeBytes: Long,
-        val isChecked: Boolean = false
-    )
-
-    private var items: List<ResourceItem> = emptyList()
+    private var items: List<OfflineResourceItem> = emptyList()
     private lateinit var adapter: ResourceAdapter
 
     companion object {
@@ -147,7 +134,8 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
         binding.selectAllDivider.visibility = View.GONE
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val loaded = withContext(dispatcherProvider.io) { buildResourceItems() }
+            val olePath = FileUtils.getOlePath(requireContext())
+            val loaded = resourcesRepository.getOfflineResourceItems(olePath, extensions, allKnownExtensions)
             binding.progressBar.visibility = View.GONE
 
             if (loaded.isEmpty()) {
@@ -163,33 +151,6 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
             binding.selectAllRow.visibility = View.VISIBLE
             binding.selectAllDivider.visibility = View.VISIBLE
         }
-    }
-
-    private suspend fun buildResourceItems(): List<ResourceItem> {
-        val oleDir = File(FileUtils.getOlePath(requireContext()))
-        if (!oleDir.exists() || !oleDir.isDirectory) return emptyList()
-
-        val titleMap = resourcesRepository.getResourceTitlesMap()
-
-        val grouped = mutableMapOf<String, MutableList<File>>()
-        oleDir.walkTopDown().filter { it.isFile }.forEach { file ->
-            val ext = file.extension.lowercase()
-            val matchesCategory = if (extensions.isEmpty()) {
-                ext !in allKnownExtensions
-            } else {
-                ext in extensions
-            }
-            if (matchesCategory) {
-                val resourceId = file.parentFile?.name ?: return@forEach
-                grouped.getOrPut(resourceId) { mutableListOf() }.add(file)
-            }
-        }
-
-        return grouped.map { (resourceId, files) ->
-            val totalSize = files.sumOf { it.length() }
-            val title = titleMap[resourceId]?.takeIf { it.isNotBlank() } ?: getString(R.string.storage_unknown_resource)
-            ResourceItem(resourceId, title, files, totalSize)
-        }.sortedBy { it.title }
     }
 
     private fun updateSelectionState() {
@@ -217,41 +178,29 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
             .show()
     }
 
-    private fun deleteItems(toDelete: List<ResourceItem>) {
+    private fun deleteItems(toDelete: List<OfflineResourceItem>) {
         if (_binding == null) return
         binding.deleteSelectedButton.isEnabled = false
         binding.deleteAllButton.isEnabled = false
 
         viewLifecycleOwner.lifecycleScope.launch {
-            withContext(dispatcherProvider.io) {
-                val oleDir = File(FileUtils.getOlePath(requireContext()))
-
-                toDelete.forEach { item ->
-                    item.files.forEach { it.delete() }
-                    val parentDir = oleDir.resolve(item.resourceId)
-                    if (parentDir.exists() && parentDir.list().isNullOrEmpty()) {
-                        parentDir.delete()
-                    }
-                }
-
-                val deletedIds = toDelete.map { it.resourceId }.toSet()
-                resourcesRepository.markResourcesAsNotOffline(deletedIds)
-            }
+            val olePath = FileUtils.getOlePath(requireContext())
+            resourcesRepository.deleteOfflineResources(olePath, toDelete)
 
             parentFragmentManager.setFragmentResult(RESULT_KEY, Bundle())
             dismiss()
         }
     }
 
-    private val DIFF_CALLBACK = DiffUtils.itemCallback<ResourceItem>(
+    private val DIFF_CALLBACK = DiffUtils.itemCallback<OfflineResourceItem>(
         areItemsTheSame = { o, n -> o.resourceId == n.resourceId },
         areContentsTheSame = { o, n -> o == n },
         getChangePayload = { o, n -> if (o.copy(isChecked = n.isChecked) == n) PAYLOAD_CHECKED_CHANGED else null }
     )
 
     inner class ResourceAdapter(
-        private val onItemClicked: (ResourceItem) -> Unit
-    ) : ListAdapter<ResourceItem, ResourceAdapter.ViewHolder>(DIFF_CALLBACK) {
+        private val onItemClicked: (OfflineResourceItem) -> Unit
+    ) : ListAdapter<OfflineResourceItem, ResourceAdapter.ViewHolder>(DIFF_CALLBACK) {
 
         inner class ViewHolder(val binding: ItemDownloadedResourceBinding) :
             RecyclerView.ViewHolder(binding.root)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryBenchmarkTest.kt
@@ -16,6 +16,7 @@ import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
 import org.ole.planet.myplanet.data.room.dao.TeamDao
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ResourcesRepositoryBenchmarkTest {
@@ -33,6 +34,8 @@ class ResourcesRepositoryBenchmarkTest {
     private val userRepository: UserRepository = mockk(relaxed = true)
     private val teamDao: TeamDao = mockk(relaxed = true)
     private val userSessionManager: UserSessionManager = mockk(relaxed = true)
+    private val configurationsRepository: ConfigurationsRepository = mockk(relaxed = true)
+    private val dispatcherProvider: DispatcherProvider = mockk(relaxed = true)
 
     @Before
     fun setup() {
@@ -50,7 +53,8 @@ class ResourcesRepositoryBenchmarkTest {
             userRepository,
             teamDao,
             userSessionManager,
-            mockk(relaxed = true)
+            configurationsRepository,
+            dispatcherProvider
         )
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryImplTest.kt
@@ -69,6 +69,7 @@ class ResourcesRepositoryImplTest {
             userRepository,
             teamDao,
             userSessionManager,
+            mockk(relaxed = true),
             mockk(relaxed = true)
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryLibrarySyncTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryLibrarySyncTest.kt
@@ -73,7 +73,8 @@ class ResourcesRepositoryLibrarySyncTest {
             mockk<UserRepository>(relaxed = true),
             mockk<TeamDao>(relaxed = true),
             mockk<org.ole.planet.myplanet.services.UserSessionManager>(relaxed = true),
-            mockk<org.ole.planet.myplanet.repository.ConfigurationsRepository>(relaxed = true)
+            mockk<org.ole.planet.myplanet.repository.ConfigurationsRepository>(relaxed = true),
+            mockk<org.ole.planet.myplanet.utils.DispatcherProvider>(relaxed = true)
         )
     }
 


### PR DESCRIPTION
Refactored `StorageCategoryDetailFragment` logic into `ResourcesRepository`. Extracted `ResourceItem` into a domain model `OfflineResourceItem` that uses file paths to decouple file-system logic from the View. Fragment now delegates background-threaded tasks to the repository without needing manual context-switching. Validated test dependencies are correctly configured.

---
*PR created automatically by Jules for task [1153312135665869495](https://jules.google.com/task/1153312135665869495) started by @dogi*