### PR TITLE
sync: smoother sync repository server pulling (fixes #15466)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6419
-        versionName = "0.64.19"
+        versionCode = 6420
+        versionName = "0.64.20"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/RepositoryModule.kt
@@ -41,6 +41,8 @@ import org.ole.planet.myplanet.repository.SubmissionsRepository
 import org.ole.planet.myplanet.repository.SubmissionsRepositoryImpl
 import org.ole.planet.myplanet.repository.SurveysRepository
 import org.ole.planet.myplanet.repository.SurveysRepositoryImpl
+import org.ole.planet.myplanet.repository.SyncRepository
+import org.ole.planet.myplanet.repository.SyncRepositoryImpl
 import org.ole.planet.myplanet.repository.TagsRepository
 import org.ole.planet.myplanet.repository.TagsRepositoryImpl
 import org.ole.planet.myplanet.repository.TeamsRepository
@@ -157,4 +159,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindUploadRepository(impl: UploadRepositoryImpl): UploadRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSyncRepository(impl: SyncRepositoryImpl): SyncRepository
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SyncRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SyncRepository.kt
@@ -1,75 +1,13 @@
 package org.ole.planet.myplanet.repository
 
-import android.content.Context
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequest
-import androidx.work.WorkInfo
-import androidx.work.WorkManager
-import androidx.work.workDataOf
-import dagger.hilt.android.qualifiers.ApplicationContext
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
-import org.ole.planet.myplanet.services.UserDataWorker
-import org.ole.planet.myplanet.services.sync.TransactionSyncManager
+import org.ole.planet.myplanet.data.api.ApiInterface
 
-@Singleton
-class SyncRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val transactionSyncManager: dagger.Lazy<TransactionSyncManager>
-) {
-    suspend fun syncDashboardKeyId(role: String?): SyncUiState {
-        return try {
-            transactionSyncManager.get().syncDashboardKeyId(role)
-            SyncUiState.Success(null)
-        } catch (e: Exception) {
-            SyncUiState.Error(e.message)
-        }
-    }
-
-    fun uploadLoginData(): Flow<SyncUiState> {
-        val workRequest = OneTimeWorkRequest.Builder(UserDataWorker::class.java)
-            .setInputData(workDataOf(UserDataWorker.KEY_UPLOAD_TYPE to UserDataWorker.UPLOAD_TYPE_LOGIN))
-            .build()
-        val workManager = WorkManager.getInstance(context)
-        workManager.enqueueUniqueWork(
-            "UploadUserData_Login",
-            ExistingWorkPolicy.REPLACE,
-            workRequest
-        )
-        return workManager.getWorkInfoByIdFlow(workRequest.id).map { workInfo ->
-            mapWorkInfoToState(workInfo)
-        }
-    }
-
-    fun uploadBulkData(): Flow<SyncUiState> {
-        val workRequest = OneTimeWorkRequest.Builder(UserDataWorker::class.java)
-            .setInputData(workDataOf(UserDataWorker.KEY_UPLOAD_TYPE to UserDataWorker.UPLOAD_TYPE_BULK))
-            .build()
-        val workManager = WorkManager.getInstance(context)
-        workManager.enqueueUniqueWork(
-            "UploadUserData_Bulk",
-            ExistingWorkPolicy.REPLACE,
-            workRequest
-        )
-        return workManager.getWorkInfoByIdFlow(workRequest.id).map { workInfo ->
-            mapWorkInfoToState(workInfo)
-        }
-    }
-
-    private fun mapWorkInfoToState(workInfo: WorkInfo?): SyncUiState {
-        return when (workInfo?.state) {
-            WorkInfo.State.SUCCEEDED -> {
-                val message = workInfo.outputData.getString(UserDataWorker.KEY_SUCCESS_MESSAGE)
-                SyncUiState.Success(message)
-            }
-            WorkInfo.State.FAILED -> SyncUiState.Error("Upload failed")
-            WorkInfo.State.CANCELLED -> SyncUiState.Error("Upload cancelled")
-            WorkInfo.State.RUNNING -> SyncUiState.Loading
-            else -> SyncUiState.Idle
-        }
-    }
+interface SyncRepository {
+    fun uploadLoginData(): Flow<SyncUiState>
+    fun uploadBulkData(): Flow<SyncUiState>
+    suspend fun processShelfParallel(shelfId: String, apiInterface: ApiInterface): Int
+    suspend fun syncDashboardKeyId(role: String?): SyncUiState
 }
 
 sealed class SyncUiState {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SyncRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SyncRepositoryImpl.kt
@@ -1,0 +1,226 @@
+package org.ole.planet.myplanet.repository
+
+import android.content.Context
+import android.os.SystemClock
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import com.google.gson.JsonArray
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import org.ole.planet.myplanet.data.api.ApiClient
+import org.ole.planet.myplanet.data.api.ApiInterface
+import org.ole.planet.myplanet.services.UserDataWorker
+import org.ole.planet.myplanet.services.sync.AdaptiveBatchProcessor
+import org.ole.planet.myplanet.services.sync.TransactionSyncManager
+import org.ole.planet.myplanet.utils.Constants
+import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.JsonUtils.getJsonArray
+import org.ole.planet.myplanet.utils.JsonUtils.getJsonObject
+import org.ole.planet.myplanet.utils.JsonUtils.gson
+import org.ole.planet.myplanet.utils.SyncTimeLogger
+import org.ole.planet.myplanet.utils.UrlUtils
+
+@Singleton
+class SyncRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val dispatcherProvider: DispatcherProvider,
+    private val resourcesRepository: ResourcesRepository,
+    private val coursesRepository: CoursesRepository,
+    private val eventsRepository: EventsRepository,
+    private val teamsSyncRepository: TeamsSyncRepository,
+    private val transactionSyncManager: dagger.Lazy<TransactionSyncManager>
+) : SyncRepository {
+    override fun uploadLoginData(): Flow<SyncUiState> {
+        val workRequest = OneTimeWorkRequest.Builder(UserDataWorker::class.java)
+            .setInputData(workDataOf(UserDataWorker.KEY_UPLOAD_TYPE to UserDataWorker.UPLOAD_TYPE_LOGIN))
+            .build()
+        val workManager = WorkManager.getInstance(context)
+        workManager.enqueueUniqueWork(
+            "UploadUserData_Login",
+            ExistingWorkPolicy.REPLACE,
+            workRequest
+        )
+        return workManager.getWorkInfoByIdFlow(workRequest.id).map { workInfo ->
+            mapWorkInfoToState(workInfo)
+        }
+    }
+
+    override fun uploadBulkData(): Flow<SyncUiState> {
+        val workRequest = OneTimeWorkRequest.Builder(UserDataWorker::class.java)
+            .setInputData(workDataOf(UserDataWorker.KEY_UPLOAD_TYPE to UserDataWorker.UPLOAD_TYPE_BULK))
+            .build()
+        val workManager = WorkManager.getInstance(context)
+        workManager.enqueueUniqueWork(
+            "UploadUserData_Bulk",
+            ExistingWorkPolicy.REPLACE,
+            workRequest
+        )
+        return workManager.getWorkInfoByIdFlow(workRequest.id).map { workInfo ->
+            mapWorkInfoToState(workInfo)
+        }
+    }
+
+    private fun mapWorkInfoToState(workInfo: WorkInfo?): SyncUiState {
+        return when (workInfo?.state) {
+            WorkInfo.State.SUCCEEDED -> {
+                val message = workInfo.outputData.getString(UserDataWorker.KEY_SUCCESS_MESSAGE)
+                SyncUiState.Success(message)
+            }
+            WorkInfo.State.FAILED -> SyncUiState.Error("Upload failed")
+            WorkInfo.State.CANCELLED -> SyncUiState.Error("Upload cancelled")
+            WorkInfo.State.RUNNING -> SyncUiState.Loading
+            else -> SyncUiState.Idle
+        }
+    }
+
+    override suspend fun processShelfParallel(shelfId: String, apiInterface: ApiInterface): Int {
+        var processedItems = 0
+
+        try {
+            val shelfDoc: JsonObject? = withContext(dispatcherProvider.io) {
+                var doc: JsonObject? = null
+                ApiClient.executeWithRetryAndWrap {
+                    apiInterface.getJsonObject(
+                        UrlUtils.header,
+                        "${UrlUtils.getUrl()}/shelf/$shelfId"
+                    )
+                }?.let {
+                    doc = it.body()
+                }
+                coroutineContext.ensureActive()
+                doc
+            }
+
+            if (shelfDoc == null) {
+                return 0
+            }
+
+            coroutineScope {
+                val dataJobs = Constants.shelfDataList.mapNotNull { shelfData ->
+                    val array = getJsonArray(shelfData.key, shelfDoc)
+                    if (array.size() > 0) {
+                        async(dispatcherProvider.io) {
+                            processShelfDataOptimizedSync(shelfId, shelfData, shelfDoc, apiInterface)
+                        }
+                    } else null
+                }
+
+                processedItems = dataJobs.awaitAll().sum()
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
+        return processedItems
+    }
+
+    private suspend fun processShelfDataOptimizedSync(shelfId: String?, shelfData: Constants.ShelfData, shelfDoc: JsonObject?, apiInterface: ApiInterface): Int {
+        var processedCount = 0
+        val logger = SyncTimeLogger
+
+        try {
+            val array = getJsonArray(shelfData.key, shelfDoc)
+            if (array.size() == 0) return 0
+
+            val validIds = mutableListOf<String>()
+            for (i in 0 until array.size()) {
+                if (array[i] !is JsonNull) {
+                    validIds.add(array[i].asString)
+                }
+            }
+
+            if (validIds.isEmpty()) return 0
+
+            val batchSizer = AdaptiveBatchProcessor(initialSize = 50)
+            var i = 0
+            var batchNum = 0
+
+            while (i < validIds.size) {
+                batchNum++
+                val batchStartTime = SystemClock.elapsedRealtime()
+
+                val end = minOf(i + batchSizer.currentSize, validIds.size)
+                val batch = validIds.subList(i, end)
+                i = end
+
+                val keysObject = JsonObject()
+                keysObject.add("keys", gson.fromJson(gson.toJson(batch), JsonArray::class.java))
+
+                // API call
+                val apiStartTime = SystemClock.elapsedRealtime()
+                var response: JsonObject? = null
+                ApiClient.executeWithRetryAndWrap {
+                    apiInterface.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject)
+                }?.let {
+                    response = it.body()
+                }
+                val apiDuration = SystemClock.elapsedRealtime() - apiStartTime
+
+                if (response == null) {
+                    batchSizer.recordFailure()
+                    logger.logApiCall("${UrlUtils.getUrl()}/${shelfData.type}/_all_docs (shelf batch $batchNum)", apiDuration, false, 0)
+                    continue
+                }
+                batchSizer.recordSuccess(apiDuration)
+
+                val responseRows = getJsonArray("rows", response)
+                logger.logApiCall("${UrlUtils.getUrl()}/${shelfData.type}/_all_docs (shelf batch $batchNum)", apiDuration, true, responseRows.size())
+
+                if (responseRows.size() == 0) continue
+
+                val documentsToProcess = mutableListOf<JsonObject>()
+                for (j in 0 until responseRows.size()) {
+                    val rowObj = responseRows[j].asJsonObject
+                    if (rowObj.has("doc")) {
+                        val doc = getJsonObject("doc", rowObj)
+                        documentsToProcess.add(doc)
+                    }
+                }
+
+                if (documentsToProcess.isNotEmpty()) {
+                    val realmStartTime = SystemClock.elapsedRealtime()
+                    when (shelfData.type) {
+                        "resources" -> processedCount += resourcesRepository.batchInsertMyLibrary(shelfId, documentsToProcess)
+                        "courses" -> processedCount += coursesRepository.batchInsertMyCourses(shelfId, documentsToProcess)
+                        "meetups" -> processedCount += eventsRepository.batchInsertMeetups(documentsToProcess)
+                        "teams" -> processedCount += teamsSyncRepository.batchInsertMyTeams(documentsToProcess)
+                    }
+                    val realmDuration = SystemClock.elapsedRealtime() - realmStartTime
+                    logger.logRealmOperation("shelf_insert", shelfData.type, realmDuration, documentsToProcess.size)
+                }
+
+                val batchDuration = SystemClock.elapsedRealtime() - batchStartTime
+                if (batchDuration > 1000) {
+                    logger.logDetail("shelf_sync", "Shelf $shelfId ${shelfData.type} batch $batchNum ($end/${validIds.size} ids): ${batchDuration}ms for ${documentsToProcess.size} docs")
+                }
+            }
+
+        } catch (e: Exception) {
+            e.printStackTrace()
+            logger.logDetail("shelf_sync", "Shelf $shelfId ${shelfData.type} failed: ${e.message}")
+        }
+        return processedCount
+    }
+
+    override suspend fun syncDashboardKeyId(role: String?): SyncUiState {
+        return try {
+            transactionSyncManager.get().syncDashboardKeyId(role)
+            SyncUiState.Success(null)
+        } catch (e: Exception) {
+            SyncUiState.Error(e.message)
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -43,6 +43,7 @@ import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.CoursesRepository
 import org.ole.planet.myplanet.repository.EventsRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.repository.SyncRepository
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.TeamsSyncRepository
 import org.ole.planet.myplanet.repository.UserSyncRepository
@@ -76,10 +77,10 @@ class SyncManager @Inject constructor(
     private val teamsSyncRepository: TeamsSyncRepository,
     private val coursesRepository: CoursesRepository,
     private val eventsRepository: EventsRepository,
-    private val userSyncRepository: UserSyncRepository
+    private val userSyncRepository: UserSyncRepository,
+    private val syncRepository: SyncRepository
 ) {
     private val isSyncing = AtomicBoolean(false)
-    private val stringArray = arrayOfNulls<String>(4)
     private var listener: OnSyncListener? = null
     private var backgroundSync: Job? = null
     private val _syncStatus = MutableStateFlow<SyncStatus>(SyncStatus.Idle)
@@ -522,7 +523,7 @@ class SyncManager @Inject constructor(
                     async(dispatcherProvider.io) {
                         semaphore.withPermit {
                             val shelfStartTime = SystemClock.elapsedRealtime()
-                            val items = processShelfParallel(shelfId, apiInterface)
+                            val items = syncRepository.processShelfParallel(shelfId, apiInterface)
                             val shelfDuration = SystemClock.elapsedRealtime() - shelfStartTime
                             if (items > 0) {
                                 logger.logDetail("library_sync", "Shelf ${index + 1}/${shelvesWithData.size} ($shelfId): $items items in ${shelfDuration}ms")
@@ -554,138 +555,5 @@ class SyncManager @Inject constructor(
             val failDuration = SystemClock.elapsedRealtime() - librarySyncStartTime
             Log.d("SyncPerf", "  ✗ Library sync failed after ${failDuration}ms: ${e.message}")
         }
-    }
-
-    private suspend fun processShelfParallel(shelfId: String, apiInterface: ApiInterface): Int {
-        var processedItems = 0
-
-        try {
-            val shelfDoc: JsonObject? = withContext(dispatcherProvider.io) {
-                var doc: JsonObject? = null
-                ApiClient.executeWithRetryAndWrap {
-                    apiInterface.getJsonObject(
-                        UrlUtils.header,
-                        "${UrlUtils.getUrl()}/shelf/$shelfId"
-                    )
-                }?.let {
-                    doc = it.body()
-                }
-                coroutineContext.ensureActive()
-                doc
-            }
-
-            if (shelfDoc == null) {
-                return 0
-            }
-
-            coroutineScope {
-                val dataJobs = Constants.shelfDataList.mapNotNull { shelfData ->
-                    val array = getJsonArray(shelfData.key, shelfDoc)
-                    if (array.size() > 0) {
-                        async(dispatcherProvider.io) {
-                            processShelfDataOptimizedSync(shelfId, shelfData, shelfDoc, apiInterface)
-                        }
-                    } else null
-                }
-
-                processedItems = dataJobs.awaitAll().sum()
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-
-        return processedItems
-    }
-
-    private suspend fun processShelfDataOptimizedSync(shelfId: String?, shelfData: Constants.ShelfData, shelfDoc: JsonObject?, apiInterface: ApiInterface): Int {
-        var processedCount = 0
-        val logger = SyncTimeLogger
-
-        try {
-            val array = getJsonArray(shelfData.key, shelfDoc)
-            if (array.size() == 0) return 0
-
-            stringArray[0] = shelfId
-            stringArray[1] = shelfData.categoryKey
-            stringArray[2] = shelfData.type
-
-            val validIds = mutableListOf<String>()
-            for (i in 0 until array.size()) {
-                if (array[i] !is JsonNull) {
-                    validIds.add(array[i].asString)
-                }
-            }
-
-            if (validIds.isEmpty()) return 0
-
-            val batchSizer = AdaptiveBatchProcessor(initialSize = 50)
-            var i = 0
-            var batchNum = 0
-
-            while (i < validIds.size) {
-                batchNum++
-                val batchStartTime = SystemClock.elapsedRealtime()
-
-                val end = minOf(i + batchSizer.currentSize, validIds.size)
-                val batch = validIds.subList(i, end)
-                i = end
-
-                val keysObject = JsonObject()
-                keysObject.add("keys", gson.fromJson(gson.toJson(batch), JsonArray::class.java))
-
-                // API call
-                val apiStartTime = SystemClock.elapsedRealtime()
-                var response: JsonObject? = null
-                ApiClient.executeWithRetryAndWrap {
-                    apiInterface.postDoc(UrlUtils.header, "application/json", "${UrlUtils.getUrl()}/${shelfData.type}/_all_docs?include_docs=true", keysObject)
-                }?.let {
-                    response = it.body()
-                }
-                val apiDuration = SystemClock.elapsedRealtime() - apiStartTime
-
-                if (response == null) {
-                    batchSizer.recordFailure()
-                    logger.logApiCall("${UrlUtils.getUrl()}/${shelfData.type}/_all_docs (shelf batch $batchNum)", apiDuration, false, 0)
-                    continue
-                }
-                batchSizer.recordSuccess(apiDuration)
-
-                val responseRows = getJsonArray("rows", response)
-                logger.logApiCall("${UrlUtils.getUrl()}/${shelfData.type}/_all_docs (shelf batch $batchNum)", apiDuration, true, responseRows.size())
-
-                if (responseRows.size() == 0) continue
-
-                val documentsToProcess = mutableListOf<JsonObject>()
-                for (j in 0 until responseRows.size()) {
-                    val rowObj = responseRows[j].asJsonObject
-                    if (rowObj.has("doc")) {
-                        val doc = getJsonObject("doc", rowObj)
-                        documentsToProcess.add(doc)
-                    }
-                }
-
-                if (documentsToProcess.isNotEmpty()) {
-                    val realmStartTime = SystemClock.elapsedRealtime()
-                    when (shelfData.type) {
-                        "resources" -> processedCount += resourcesRepository.batchInsertMyLibrary(shelfId, documentsToProcess)
-                        "courses" -> processedCount += coursesRepository.batchInsertMyCourses(shelfId, documentsToProcess)
-                        "meetups" -> processedCount += eventsRepository.batchInsertMeetups(documentsToProcess)
-                        "teams" -> processedCount += teamsSyncRepository.batchInsertMyTeams(documentsToProcess)
-                    }
-                    val realmDuration = SystemClock.elapsedRealtime() - realmStartTime
-                    logger.logRealmOperation("shelf_insert", shelfData.type, realmDuration, documentsToProcess.size)
-                }
-
-                val batchDuration = SystemClock.elapsedRealtime() - batchStartTime
-                if (batchDuration > 1000) {
-                    logger.logDetail("shelf_sync", "Shelf $shelfId ${shelfData.type} batch $batchNum ($end/${validIds.size} ids): ${batchDuration}ms for ${documentsToProcess.size} docs")
-                }
-            }
-
-        } catch (e: Exception) {
-            e.printStackTrace()
-            logger.logDetail("shelf_sync", "Shelf $shelfId ${shelfData.type} failed: ${e.message}")
-        }
-        return processedCount
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/SyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/SyncManagerTest.kt
@@ -73,6 +73,7 @@ class SyncManagerTest {
             teamsSyncRepository,
             coursesRepository,
             eventsRepository,
+            mockk(),
             mockk()
         )
     }


### PR DESCRIPTION
Route `SyncManager`'s server pulls through `SyncRepository` by expanding the existing `SyncRepository` to be an interface, implementing logic in `SyncRepositoryImpl`, and injecting it into `SyncManager` so `SyncManager` only orchestrates state.

---
*PR created automatically by Jules for task [8270018884179952062](https://jules.google.com/task/8270018884179952062) started by @dogi*