### PR TITLE
all: smoother user model caching (fixes #15468)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -77,7 +77,10 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         super.onViewCreated(view, savedInstanceState)
         postponeEnterTransition()
         viewLifecycleOwner.lifecycleScope.launch {
-            model = userRepository.getUserModel()
+            if (model == null) {
+                model = userRepository.getUserModel()
+            }
+            initView(model)
             val adapter = getAdapter()
             recyclerView.adapter = adapter
             if (isMyCourseLib && adapter.itemCount != 0 && courseLib == "courses") {
@@ -93,6 +96,8 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
             }
         }
     }
+
+    open suspend fun initView(userModel: org.ole.planet.myplanet.model.UserEntity?) {}
 
     private fun initDeleteButton() {
         tvDelete?.let {
@@ -144,7 +149,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
 
         viewLifecycleOwner.lifecycleScope.launch {
             try {
-                val userId = userRepository.getUserModel()?.id ?: return@launch
+                val userId = model?.id ?: return@launch
                 var libraryAdded = false
                 var courseAdded = false
                 var errorOccurred: Throwable? = null

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseResourceFragment.kt
@@ -299,7 +299,7 @@ abstract class BaseResourceFragment : Fragment() {
 
     fun removeFromShelf(`object`: Any) {
         lifecycleScope.launch {
-            val userId = userRepository.getUserModel()?.id
+            val userId = model?.id
             if (userId.isNullOrEmpty()) {
                 return@launch
             }
@@ -327,7 +327,7 @@ abstract class BaseResourceFragment : Fragment() {
 
     fun addToLibrary(libraryItems: List<MyLibrary?>, selectedItems: ArrayList<Int>) {
         lifecycleScope.launch {
-            val userId = userRepository.getUserModel()?.id ?: return@launch
+            val userId = model?.id ?: return@launch
             val resourceIds = selectedItems.mapNotNull { index ->
                 libraryItems.getOrNull(index)?.resourceId
             }
@@ -343,8 +343,7 @@ abstract class BaseResourceFragment : Fragment() {
 
     fun addAllToLibrary(libraryItems: List<MyLibrary?>) {
         lifecycleScope.launch {
-            val user = userRepository.getUserModel()
-            val userId = user?.id ?: return@launch
+            val userId = model?.id ?: return@launch
             val validLibraryItems = libraryItems.filterNotNull()
             resourcesRepository.addAllResourcesToUserLibrary(validLibraryItems, userId)
                 .onSuccess {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -48,7 +48,6 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
     private lateinit var orderByTitle: Button
     private lateinit var filterController: CourseFilterController
     private lateinit var selectionController: CourseSelectionController
-    var userModel: UserEntity? = null
     private lateinit var confirmation: AlertDialog
     private var selectionJob: Job? = null
     private var pendingScrollState: Parcelable? = null
@@ -81,7 +80,7 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
     }
 
     override fun deleteSelected(deleteProgress: Boolean) {
-        val userId = userModel?.id ?: return
+        val userId = model?.id ?: return
         val snapshot = selectedItems?.filterNotNull() ?: return
         if (snapshot.isEmpty()) return
         val courseIds = snapshot.mapNotNull { it.courseId }
@@ -96,15 +95,11 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
     override suspend fun getAdapter(): ListAdapter<*, *> {
         val hostActivity = activity ?: throw CancellationException("Fragment detached")
 
-        if (userModel == null) {
-            userModel = userSessionManager.getUserModel()
-        }
-
         val factory = adapterFactory ?: DefaultBaseAdapterFactory()
         adapterCourses = factory.createCoursesAdapter(
             context = hostActivity,
             map = HashMap(),
-            isGuest = userModel?.isGuest() ?: true,
+            isGuest = model?.isGuest() ?: true,
             isMyCourseLib = isMyCourseLib
         )
 
@@ -131,19 +126,6 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
         setupUI(requireView().findViewById(R.id.my_course_parent_layout), requireActivity())
         additionalSetup()
         setupMyProgressButton()
-
-        viewLifecycleOwner.lifecycleScope.launch {
-            userModel = userSessionManager.getUserModel()
-            model = userModel
-            initializeView()
-            setupButtonVisibility()
-            setupEventListeners()
-            if (!isMyCourseLib) tvFragmentInfo.setText(R.string.our_courses)
-            if (::adapterCourses.isInitialized) {
-                showNoData(tvMessage, adapterCourses.itemCount, "courses")
-            }
-            selectionController.clearAll(null)
-        }
 
         collectLatestWhenStarted(viewModel.coursesState) { state ->
             if (!::adapterCourses.isInitialized) return@collectLatestWhenStarted
@@ -173,6 +155,17 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
 
         realtimeSyncHelper = RealtimeSyncHelper(this, this)
         realtimeSyncHelper.setupRealtimeSync()
+    }
+
+    override suspend fun initView(userModel: UserEntity?) {
+        initializeView()
+        setupButtonVisibility()
+        setupEventListeners()
+        if (!isMyCourseLib) tvFragmentInfo.setText(R.string.our_courses)
+        if (::adapterCourses.isInitialized) {
+            showNoData(tvMessage, adapterCourses.itemCount, "courses")
+        }
+        selectionController.clearAll(null)
     }
 
     private fun initializeView() {
@@ -211,7 +204,7 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
         selectionController = CourseSelectionController(
             rootView = requireView(),
             isMyCourseLib = isMyCourseLib,
-            isGuest = userModel?.isGuest() ?: true,
+            isGuest = model?.isGuest() ?: true,
             onRemoveConfirmed = {
                 val courseIds = selectedItems?.mapNotNull { it?.courseId } ?: emptyList()
                 deleteSelected(true)
@@ -381,7 +374,7 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
         builder.setMessage(msg)
         builder.setCancelable(true)
             .setPositiveButton(R.string.go_to_mycourses) { _: DialogInterface, _: Int ->
-                if (userModel?.id?.startsWith("guest") == true) {
+                if (model?.id?.startsWith("guest") == true) {
                     DialogUtils.guestDialog(requireContext())
                 } else {
                     hasAdded = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -72,7 +72,6 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
     private lateinit var config: ChipCloudConfig
     private lateinit var adapterLibrary: ResourcesAdapter
     private var tagsMap: Map<String, List<TagEntity>> = emptyMap()
-    var userModel: UserEntity ?= null
     var map: HashMap<String?, JsonObject>? = null
     private var confirmation: AlertDialog? = null
     private var allResourceModels: List<ResourceListModel> = emptyList()
@@ -136,13 +135,12 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
     override suspend fun getAdapter(): ListAdapter<*, *> {
         allResourceModels = viewModel.getLibraryListModels(isMyCourseLib, model?.id)
 
-        val user = userRepository.getUserModel()
         val factory = adapterFactory ?: DefaultBaseAdapterFactory()
         adapterLibrary = factory.createResourcesAdapter(
             context = requireActivity(),
-            isGuest = user?.isGuest() == true,
+            isGuest = model?.isGuest() == true,
             openedResourceIds = emptySet(),
-            currentUserName = user?.name,
+            currentUserName = model?.name,
             onEditClick = { model -> openEditResource(model) }
         )
 
@@ -195,13 +193,15 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
                 }
             }
         }
-        lifecycleScope.launch {
-            userModel = userRepository.getUserModel()
-            setupGuestUserRestrictions()
+    }
 
-            val userId = userModel?.id
-            if (userId != null) {
-                viewModel.observeOpenedResourceIds(userId)
+    override suspend fun initView(userModel: UserEntity?) {
+        setupGuestUserRestrictions()
+
+        val userId = model?.id
+        if (userId != null) {
+            viewModel.observeOpenedResourceIds(userId)
+            viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     viewModel.openedResourceIds.collectLatest { openedResourceIds ->
                         if (::adapterLibrary.isInitialized) {
@@ -237,7 +237,7 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
     }
 
     private fun setupGuestUserRestrictions() {
-        if(userModel?.isGuest() == true){
+        if(model?.isGuest() == true){
             tvAddToLib.visibility = View.GONE
             selectAll.visibility = View.GONE
         }
@@ -356,7 +356,7 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
     private fun setupAddResourceButtonListener() {
         binding.addResource.visibility = if (isMyCourseLib) View.VISIBLE else View.GONE
         binding.addResource.setOnClickListener {
-            if (userModel?.id?.startsWith("guest") == false) {
+            if (model?.id?.startsWith("guest") == false) {
                 AddResourceFragment().show(childFragmentManager, getString(R.string.add_res))
             } else {
                 guestDialog(requireContext())
@@ -424,7 +424,7 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         builder.setMessage(buildAlertMessage())
         builder.setCancelable(true)
             .setPositiveButton(R.string.go_to_mylibrary) { dialog: DialogInterface, _: Int ->
-                if (userModel?.id?.startsWith("guest") == true) {
+                if (model?.id?.startsWith("guest") == true) {
                     guestDialog(requireContext())
                 } else {
                     hasAdded = true
@@ -714,7 +714,7 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
     }
 
     override fun deleteSelected(deleteProgress: Boolean) {
-        val userId = userModel?.id
+        val userId = model?.id
         val itemsToDelete = selectedItems?.mapNotNull { it?.resourceId } ?: emptyList()
 
         if (userId != null && itemsToDelete.isNotEmpty()) {
@@ -735,7 +735,7 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
     }
 
     override fun addToMyList(onComplete: (() -> Unit)?) {
-        val userId = userModel?.id
+        val userId = model?.id
         val itemsToAdd = selectedItems?.mapNotNull { it?.resourceId } ?: emptyList()
 
         if (userId != null && itemsToAdd.isNotEmpty()) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
@@ -235,7 +235,7 @@ class TeamFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewLifecycleOwner.lifecycleScope.launch {
-            user = userSessionManager.getUserModel()
+            user = viewModel.getUserModel()
             if (user?.isGuest() == true) {
                 binding.addTeam.visibility = View.GONE
             } else {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamViewModel.kt
@@ -32,7 +32,8 @@ class TeamViewModel @Inject constructor(
     private val teamsRepository: TeamsRepository,
     private val teamsSyncRepository: TeamsSyncRepository,
     private val dispatcherProvider: DispatcherProvider,
-    private val realtimeSyncManager: RealtimeSyncManager
+    private val realtimeSyncManager: RealtimeSyncManager,
+    private val userSessionManager: org.ole.planet.myplanet.services.UserSessionManager
 ) : ViewModel() {
     private val _teamData = MutableStateFlow<List<TeamDetails>>(emptyList())
     val teamData: StateFlow<List<TeamDetails>> = _teamData
@@ -60,7 +61,14 @@ class TeamViewModel @Inject constructor(
     private var currentType: String? = null
     private var loadJob: Job? = null
     private var loadTaskJob: Job? = null
+    var userModel: UserEntity? = null
 
+    suspend fun getUserModel(): UserEntity? {
+        if (userModel == null) {
+            userModel = userSessionManager.getUserModel()
+        }
+        return userModel
+    }
 
     fun loadTeams(fromDashboard: Boolean, type: String?, userId: String?) {
         currentFromDashboard = fromDashboard

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/TeamViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/TeamViewModelTest.kt
@@ -30,13 +30,14 @@ class TeamViewModelTest {
     private val teamsRepository = mockk<TeamsRepository>()
     private val teamsSyncRepository = mockk<TeamsSyncRepository>()
     private val realtimeSyncManager: RealtimeSyncManager = mockk(relaxed = true)
+    private val userSessionManager = mockk<org.ole.planet.myplanet.services.UserSessionManager>()
     private val testDispatcher = StandardTestDispatcher()
     private val testDispatcherProvider = TestDispatcherProvider(testDispatcher)
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = TeamViewModel(teamsRepository, teamsSyncRepository, testDispatcherProvider, realtimeSyncManager)
+        viewModel = TeamViewModel(teamsRepository, teamsSyncRepository, testDispatcherProvider, realtimeSyncManager, userSessionManager)
     }
 
     @After


### PR DESCRIPTION
Optimizes application performance and reduces database load by preventing the entire user model from being reloaded from Room on every screen setup. Base fragments and ViewModels now load and cache the `UserEntity` once, and subclasses hook into the new `initView` to configure the UI using the cached model.

---
*PR created automatically by Jules for task [10505843203790855576](https://jules.google.com/task/10505843203790855576) started by @dogi*