### PR TITLE
all: smoother refresh job cancelling (fixes #15564)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6435
-        versionName = "0.64.35"
+        versionCode = 6436
+        versionName = "0.64.36"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6436
-        versionName = "0.64.36"
+        versionCode = 6437
+        versionName = "0.64.37"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -63,6 +63,7 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
     var userModel: UserEntity? = null
     private lateinit var confirmation: AlertDialog
     private var selectionJob: Job? = null
+    private val refreshJobs = mutableMapOf<String, Job>()
     private var pendingScrollState: Parcelable? = null
     private val viewModel: CoursesViewModel by viewModels()
 
@@ -595,7 +596,8 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
 
     override fun onRatingChanged(type: String, id: String) {
         if (type == "course" && ::adapterCourses.isInitialized) {
-            viewLifecycleOwner.lifecycleScope.launch {
+            refreshJobs[id]?.cancel()
+            refreshJobs[id] = viewLifecycleOwner.lifecycleScope.launch {
                 viewModel.refreshCourseRatings(model?.id)
                 adapterCourses.refreshWithDiff(id)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthViewModel.kt
@@ -49,6 +49,7 @@ class HealthViewModel @Inject constructor(
     val loggedInUser: StateFlow<UserEntity?> = _loggedInUser.asStateFlow()
 
     private var searchJob: Job? = null
+    private var selectPatientJob: Job? = null
 
     fun loadPatients(sortBy: String = "joinDate", descending: Boolean = true) {
         viewModelScope.launch {
@@ -84,7 +85,8 @@ class HealthViewModel @Inject constructor(
     }
 
     fun selectPatient(userId: String) {
-        viewModelScope.launch {
+        selectPatientJob?.cancel()
+        selectPatientJob = viewModelScope.launch {
             _isLoading.value = true
             val user = healthRepository.getPatientById(userId)
             if (user != null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -102,6 +102,7 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
 
     private lateinit var realtimeSyncHelper: RealtimeSyncHelper
     private var refreshJob: Job? = null
+    private var searchJob: Job? = null
 
     internal val addResourceLauncher = registerForActivityResult(
         androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult()
@@ -547,7 +548,8 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
             mediums.clear()
             subjects.clear()
             languages.clear()
-            viewLifecycleOwner.lifecycleScope.launch {
+            searchJob?.cancel()
+            searchJob = viewLifecycleOwner.lifecycleScope.launch {
                 applyFiltersAndUpdateUI()
             }
         }
@@ -597,7 +599,8 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         if (!searchTags.any { it.name == tag.name }) searchTags.add(tag)
         chipCloud.addChips(searchTags)
         showTagText(searchTags, tvSelected)
-        viewLifecycleOwner.lifecycleScope.launch {
+        searchJob?.cancel()
+        searchJob = viewLifecycleOwner.lifecycleScope.launch {
             applyFiltersAndUpdateUI()
         }
     }
@@ -608,7 +611,8 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         li.add(tag)
         searchTags = li
         tvSelected.text = getString(R.string.tag_selected, tag.name)
-        viewLifecycleOwner.lifecycleScope.launch {
+        searchJob?.cancel()
+        searchJob = viewLifecycleOwner.lifecycleScope.launch {
             applyFiltersAndUpdateUI()
         }
     }
@@ -616,7 +620,8 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
     override fun onOkClicked(list: List<TagEntity>?) {
         if (list?.isEmpty() == true) {
             searchTags.clear()
-            viewLifecycleOwner.lifecycleScope.launch {
+            searchJob?.cancel()
+            searchJob = viewLifecycleOwner.lifecycleScope.launch {
                 applyFiltersAndUpdateUI()
             }
         } else {
@@ -639,7 +644,8 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
 
     override fun chipDeleted(i: Int, s: String) {
         searchTags.removeAt(i)
-        viewLifecycleOwner.lifecycleScope.launch {
+        searchJob?.cancel()
+        searchJob = viewLifecycleOwner.lifecycleScope.launch {
             applyFiltersAndUpdateUI()
         }
     }
@@ -649,7 +655,8 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         this.languages = languages
         this.mediums = mediums
         this.levels = levels
-        viewLifecycleOwner.lifecycleScope.launch {
+        searchJob?.cancel()
+        searchJob = viewLifecycleOwner.lifecycleScope.launch {
             applyFiltersAndUpdateUI()
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
@@ -46,7 +46,7 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
     private val binding get() = _binding!!
     private var datePicker: TextView? = null
     private var currentTab = R.id.btn_all
-    private var updateTasksJob: Job? = null
+    private var refreshJob: Job? = null
 
     private data class TaskSnapshot(
         val id: String?,
@@ -299,8 +299,8 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
     private fun updateTasks() {
         if (!isAdded) return
 
-        updateTasksJob?.cancel()
-        updateTasksJob = viewLifecycleOwner.lifecycleScope.launch(dispatcherProvider.main) {
+        refreshJob?.cancel()
+        refreshJob = viewLifecycleOwner.lifecycleScope.launch(dispatcherProvider.main) {
             val knownAssigneeIds = adapterTask.getKnownAssigneeIds()
             val tasksSnapshot = teamViewModel.taskList.value.toList()
 


### PR DESCRIPTION
Cancel stale coroutine jobs in long-lived fragments to prevent older requests from overwriting newer results.

---
*PR created automatically by Jules for task [13281221085887992775](https://jules.google.com/task/13281221085887992775) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course rating refreshes by preventing overlapping updates.
  * Prevented duplicate patient-selection operations from running simultaneously.
  * Improved resource filtering and tag updates by cancelling outdated operations.
  * Improved task refresh reliability by managing refresh operations more consistently.
  * Reduced stale or conflicting updates when actions are performed quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->