### PR TITLE
teams: smoother voices removing (fixes #15407)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6329
-        versionName = "0.63.29"
+        versionCode = 6330
+        versionName = "0.63.30"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -314,26 +314,26 @@ class VoicesAdapter(
         }
 
         if (isParent) {
-            submitList(emptyList())
-        } else {
-            val updatedOriginalList = originalList.toMutableList()
-            val posInOriginal = updatedOriginalList.indexOfFirst { it.id == newsId }
-            if (posInOriginal != -1) {
-                updatedOriginalList.removeAt(posInOriginal)
-                originalList = updatedOriginalList.toList()
-            }
-
-            val updatedCurrentList = currentList.toMutableList()
-            if (posInCurrent != -1) {
-                updatedCurrentList.removeAt(posInCurrent)
-            }
-            val listToSubmit = if (parentNews != null && updatedCurrentList.isNotEmpty() && updatedCurrentList[0].id == parentNews?.id) {
-                updatedCurrentList.drop(1)
-            } else {
-                updatedCurrentList
-            }
-            submitList(listToSubmit)
+            parentNews = null
         }
+
+        val updatedOriginalList = originalList.toMutableList()
+        val posInOriginal = updatedOriginalList.indexOfFirst { it.id == newsId }
+        if (posInOriginal != -1) {
+            updatedOriginalList.removeAt(posInOriginal)
+            originalList = updatedOriginalList.toList()
+        }
+
+        val updatedCurrentList = currentList.toMutableList()
+        if (posInCurrent != -1) {
+            updatedCurrentList.removeAt(posInCurrent)
+        }
+        val listToSubmit = if (parentNews != null && updatedCurrentList.isNotEmpty() && updatedCurrentList[0].id == parentNews?.id) {
+            updatedCurrentList.drop(1)
+        } else {
+            updatedCurrentList
+        }
+        submitList(listToSubmit)
 
         parentNews?.id?.let { pid ->
             val current = replyCountCache[pid]


### PR DESCRIPTION
Fixes a UI bug in `VoicesAdapter` where removing a parent post rebuilt the entire list, causing visual jitter.

**Root Cause:**
`VoicesAdapter.removePost(newsId: String)` explicitly checked `if (isParent)` and submitted an empty list (`submitList(emptyList())`) prior to dropping it.

**Solution:**
Removed the `submitList(emptyList())` block entirely. Instead, if `isParent == true`, `parentNews` is correctly nulled out, and the method falls through to the existing list modification logic. This submits the properly filtered list only once. DiffUtil natively handles the deletion animation properly.

**Testing:**
Ran `testLiteDebugUnitTest --tests 'org.ole.planet.myplanet.ui.voices.*'` successfully. Tested with Git diff locally. Code review checked out cleanly.

---
*PR created automatically by Jules for task [2812647234433323472](https://jules.google.com/task/2812647234433323472) started by @dogi*