### PR TITLE
all: smoother theme managing (fixes #15424)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6333
-        versionName = "0.63.33"
+        versionCode = 6334
+        versionName = "0.63.34"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -84,6 +84,9 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
     lateinit var sharedPrefManager: SharedPrefManager
 
     @Inject
+    lateinit var themeManager: ThemeManager
+
+    @Inject
     @DefaultPreferences
     lateinit var defaultPreferencesProvider: Provider<SharedPreferences>
     val defaultPref: SharedPreferences by lazy { defaultPreferencesProvider.get() }
@@ -501,7 +504,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
     }
 
     private fun getCurrentThemeMode(): String {
-        return ThemeManager.getCurrentThemeMode(context)
+        return themeManager.getCurrentThemeMode()
     }
 
     private fun onAppForegrounded() {

--- a/app/src/main/java/org/ole/planet/myplanet/services/ThemeManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/ThemeManager.kt
@@ -5,33 +5,22 @@ import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
-import dagger.hilt.android.EntryPointAccessors
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
 import org.ole.planet.myplanet.utils.ThemeMode
+import javax.inject.Inject
+import javax.inject.Singleton
 
-object ThemeManager {
-    private var sharedPrefManager: SharedPrefManager? = null
-
-    @androidx.annotation.VisibleForTesting
-    fun clearSharedPrefManager() {
-        sharedPrefManager = null
-    }
-
-    private fun getSpm(context: Context): SharedPrefManager {
-        return sharedPrefManager ?: EntryPointAccessors.fromApplication(
-            context.applicationContext,
-            CoreDependenciesEntryPoint::class.java
-        ).sharedPrefManager().also { sharedPrefManager = it }
-    }
-
+@Singleton
+class ThemeManager @Inject constructor(
+    private val sharedPrefManager: SharedPrefManager
+) {
     fun showThemeDialog(context: Context) {
         val options = arrayOf(
             context.getString(R.string.theme_mode_light),
             context.getString(R.string.theme_mode_dark),
             context.getString(R.string.dark_mode_follow_system)
         )
-        val currentMode = getCurrentThemeMode(context)
+        val currentMode = getCurrentThemeMode()
         val checkedItem = when (currentMode) {
             ThemeMode.LIGHT -> 0
             ThemeMode.DARK -> 1
@@ -46,7 +35,7 @@ object ThemeManager {
                     2 -> ThemeMode.FOLLOW_SYSTEM
                     else -> ThemeMode.FOLLOW_SYSTEM
                 }
-                setThemeMode(context, selectedMode)
+                setThemeMode(selectedMode)
                 dialog.dismiss()
             }
             .setNegativeButton(R.string.cancel, null)
@@ -55,11 +44,11 @@ object ThemeManager {
         dialog.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
     }
 
-    fun getCurrentThemeMode(context: Context): String =
-        getSpm(context).getRawString("theme_mode", ThemeMode.FOLLOW_SYSTEM)
+    fun getCurrentThemeMode(): String =
+        sharedPrefManager.getRawString("theme_mode", ThemeMode.FOLLOW_SYSTEM)
 
-    fun setThemeMode(context: Context, themeMode: String) {
-        getSpm(context).setRawString("theme_mode", themeMode)
+    fun setThemeMode(themeMode: String) {
+        sharedPrefManager.setRawString("theme_mode", themeMode)
         AppCompatDelegate.setDefaultNightMode(
             when (themeMode) {
                 ThemeMode.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -109,6 +109,8 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     @Inject
     lateinit var userSessionManager: UserSessionManager
     @Inject
+    lateinit var themeManager: ThemeManager
+    @Inject
     override lateinit var timeProvider: TimeProvider
 
     @Inject
@@ -427,7 +429,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             R.id.action_about -> openCallFragment(AboutFragment(), AboutFragment::class.java.simpleName)
             R.id.action_logout -> logout()
             R.id.change_language -> SettingsActivity.SettingFragment.languageChanger(this)
-            R.id.action_theme -> ThemeManager.showThemeDialog(this)
+            R.id.action_theme -> themeManager.showThemeDialog(this)
             else -> {}
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsActivity.kt
@@ -90,6 +90,8 @@ class SettingsActivity : AppCompatActivity() {
         @Inject
         lateinit var sharedPrefManager: SharedPrefManager
         @Inject
+        lateinit var themeManager: ThemeManager
+        @Inject
         lateinit var timeProvider: TimeProvider
         var user: UserEntity? = null
         private var libraryList: List<MyLibrary>? = null
@@ -202,7 +204,7 @@ class SettingsActivity : AppCompatActivity() {
 
             val darkMode = findPreference<Preference>("dark_mode")
             darkMode?.setOnPreferenceClickListener {
-                ThemeManager.showThemeDialog(requireActivity())
+                themeManager.showThemeDialog(requireContext())
                 true
             }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginActivity.kt
@@ -72,6 +72,8 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
     lateinit var loginSyncManager: LoginSyncManager
     @Inject
     override lateinit var sharedPrefManager: SharedPrefManager
+    @Inject
+    lateinit var themeManager: ThemeManager
 
     private lateinit var binding: ActivityLoginBinding
     private var guest = false
@@ -205,7 +207,7 @@ class LoginActivity : SyncActivity(), OnUserProfileClickListener {
         }
         val selectDarkModeButton = binding.themeToggleButton
         selectDarkModeButton.setOnClickListener {
-            ThemeManager.showThemeDialog(this)
+            themeManager.showThemeDialog(this)
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/services/ThemeManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/ThemeManagerTest.kt
@@ -4,7 +4,6 @@ import android.os.Looper
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
-import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.testing.HiltTestApplication
 import io.mockk.every
 import io.mockk.mockk
@@ -18,7 +17,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
 import org.ole.planet.myplanet.utils.ThemeMode
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
@@ -35,7 +33,7 @@ class ThemeManagerTest {
     private lateinit var activityController: ActivityController<AppCompatActivity>
     private lateinit var activity: AppCompatActivity
     private lateinit var mockSpm: SharedPrefManager
-    private lateinit var mockEntryPoint: CoreDependenciesEntryPoint
+    private lateinit var themeManager: ThemeManager
 
     @Before
     fun setUp() {
@@ -43,46 +41,41 @@ class ThemeManagerTest {
         activity = activityController.get()
 
         mockSpm = mockk(relaxed = true)
-        mockEntryPoint = mockk(relaxed = true)
-
-        mockkStatic(EntryPointAccessors::class)
         mockkStatic(AppCompatDelegate::class)
 
-        every { EntryPointAccessors.fromApplication(any(), CoreDependenciesEntryPoint::class.java) } returns mockEntryPoint
-        every { mockEntryPoint.sharedPrefManager() } returns mockSpm
+        themeManager = ThemeManager(mockSpm)
     }
 
     @After
     fun tearDown() {
         activityController.pause().stop().destroy()
-        org.ole.planet.myplanet.services.ThemeManager.clearSharedPrefManager()
         unmockkAll()
     }
 
     @Test
     fun testGetCurrentThemeMode() {
         every { mockSpm.getRawString("theme_mode", ThemeMode.FOLLOW_SYSTEM) } returns ThemeMode.DARK
-        val mode = ThemeManager.getCurrentThemeMode(activity)
+        val mode = themeManager.getCurrentThemeMode()
         assertEquals(ThemeMode.DARK, mode)
     }
 
     @Test
     fun testSetThemeModeLight() {
-        ThemeManager.setThemeMode(activity, ThemeMode.LIGHT)
+        themeManager.setThemeMode( ThemeMode.LIGHT)
         verify { mockSpm.setRawString("theme_mode", ThemeMode.LIGHT) }
         verify { AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO) }
     }
 
     @Test
     fun testSetThemeModeDark() {
-        ThemeManager.setThemeMode(activity, ThemeMode.DARK)
+        themeManager.setThemeMode( ThemeMode.DARK)
         verify { mockSpm.setRawString("theme_mode", ThemeMode.DARK) }
         verify { AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES) }
     }
 
     @Test
     fun testSetThemeModeFollowSystem() {
-        ThemeManager.setThemeMode(activity, ThemeMode.FOLLOW_SYSTEM)
+        themeManager.setThemeMode( ThemeMode.FOLLOW_SYSTEM)
         verify { mockSpm.setRawString("theme_mode", ThemeMode.FOLLOW_SYSTEM) }
         verify { AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM) }
     }
@@ -91,7 +84,7 @@ class ThemeManagerTest {
     fun testShowThemeDialog() {
         every { mockSpm.getRawString("theme_mode", ThemeMode.FOLLOW_SYSTEM) } returns ThemeMode.LIGHT
 
-        ThemeManager.showThemeDialog(activity)
+        themeManager.showThemeDialog(activity)
 
         Shadows.shadowOf(Looper.getMainLooper()).idle()
 


### PR DESCRIPTION
Converted `ThemeManager` from an `object` using `EntryPointAccessors` to a `@Singleton class` with an `@Inject constructor`. Injected it into `MainApplication`, `SettingsActivity`, `DashboardActivity`, and `LoginActivity`. Updated the corresponding tests to pass the mock directly.

---
*PR created automatically by Jules for task [6621382372797430541](https://jules.google.com/task/6621382372797430541) started by @dogi*