### PR TITLE
Guard SyncManager and SyncTimeLogger debug logging

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -9,6 +9,7 @@ import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.SystemClock
 import android.util.Log
+import org.ole.planet.myplanet.BuildConfig
 import androidx.core.content.edit
 import com.google.gson.JsonArray
 import com.google.gson.JsonNull
@@ -141,9 +142,9 @@ class SyncManager @Inject constructor(
         val syncStartTime = SystemClock.elapsedRealtime()
         val logger = SyncTimeLogger
         logger.startLogging()
-        Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-        Log.d("SyncPerf", "FULL SYNC STARTED at ${java.text.SimpleDateFormat("HH:mm:ss.SSS").format(Date())}")
-        Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "FULL SYNC STARTED at ${java.text.SimpleDateFormat("HH:mm:ss.SSS").format(Date())}")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
         try {
 
             initializeSync()
@@ -210,17 +211,17 @@ class SyncManager @Inject constructor(
             val totalSyncTime = syncEndTime - syncStartTime
             val minutes = totalSyncTime / 60000
             val seconds = (totalSyncTime % 60000) / 1000
-            Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-            Log.d("SyncPerf", "FULL SYNC COMPLETED at ${java.text.SimpleDateFormat("HH:mm:ss.SSS").format(Date())}")
-            Log.d("SyncPerf", "TOTAL SYNC TIME: ${minutes}m ${seconds}s (${totalSyncTime}ms)")
-            Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "FULL SYNC COMPLETED at ${java.text.SimpleDateFormat("HH:mm:ss.SSS").format(Date())}")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "TOTAL SYNC TIME: ${minutes}m ${seconds}s (${totalSyncTime}ms)")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
         } catch (err: Exception) {
             val syncEndTime = SystemClock.elapsedRealtime()
             val totalSyncTime = syncEndTime - syncStartTime
-            Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-            Log.d("SyncPerf", "SYNC FAILED after ${totalSyncTime}ms")
-            Log.d("SyncPerf", "Error: ${err.message}")
-            Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "SYNC FAILED after ${totalSyncTime}ms")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "Error: ${err.message}")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
             err.printStackTrace()
             handleException(err.message)
         } finally {
@@ -267,7 +268,7 @@ class SyncManager @Inject constructor(
 
     private suspend fun resourceTransactionSync() {
         val resourceSyncStartTime = SystemClock.elapsedRealtime()
-        Log.d("SyncPerf", "  ▶ Starting resource sync")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ▶ Starting resource sync")
 
         val logger = SyncTimeLogger
         logger.startProcess("resource_sync_main")
@@ -295,7 +296,7 @@ class SyncManager @Inject constructor(
             var skip = 0
             var batchCount = 0
 
-            Log.d("SyncPerf", "    Resources: Found $totalRows documents to sync")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "    Resources: Found $totalRows documents to sync")
             logger.logDetail("resource_sync", "Total resources: $totalRows, batch size: ${batchSizer.currentSize} (adaptive)")
 
             while (skip < totalRows || (totalRows == 0 && skip == 0)) {
@@ -377,7 +378,7 @@ class SyncManager @Inject constructor(
                     val batchEndTime = SystemClock.elapsedRealtime()
                     val batchTime = batchEndTime - batchStartTime
                     if (batchCount % 10 == 0) {
-                        Log.d("SyncPerf", "    Resources batch $batchCount: ${batchTime}ms - Progress: $skip/$totalRows (${(skip * 100 / totalRows.coerceAtLeast(1))}%)")
+                        if (BuildConfig.DEBUG) Log.d("SyncPerf", "    Resources batch $batchCount: ${batchTime}ms - Progress: $skip/$totalRows (${(skip * 100 / totalRows.coerceAtLeast(1))}%)")
                         logger.logDetail("resource_sync", "Batch $batchCount progress: $skip/$totalRows (${(skip * 100 / totalRows.coerceAtLeast(1))}%)")
                         sharedPrefManager.rawPreferences.edit {
                             putLong("ResourceLastSyncTime", timeProvider.now())
@@ -414,12 +415,12 @@ class SyncManager @Inject constructor(
             val resourceSyncTime = resourceSyncEndTime - resourceSyncStartTime
             val minutes = resourceSyncTime / 60000
             val seconds = (resourceSyncTime % 60000) / 1000
-            Log.d("SyncPerf", "  ✓ Resources sync completed: ${minutes}m ${seconds}s - $processedItems items")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ✓ Resources sync completed: ${minutes}m ${seconds}s - $processedItems items")
         } catch (e: Exception) {
             e.printStackTrace()
             logger.endProcess("resource_sync_main", processedItems)
             val resourceSyncEndTime = SystemClock.elapsedRealtime()
-            Log.d("SyncPerf", "  ✗ Resources sync failed after ${resourceSyncEndTime - resourceSyncStartTime}ms: ${e.message}")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ✗ Resources sync failed after ${resourceSyncEndTime - resourceSyncStartTime}ms: ${e.message}")
         }
     }
 
@@ -494,7 +495,7 @@ class SyncManager @Inject constructor(
     private suspend fun myLibraryTransactionSync() {
         val logger = SyncTimeLogger
         val librarySyncStartTime = SystemClock.elapsedRealtime()
-        Log.d("SyncPerf", "  ▶ Starting library sync")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ▶ Starting library sync")
 
         logger.startProcess("library_sync_main")
         var processedItems = 0
@@ -505,7 +506,7 @@ class SyncManager @Inject constructor(
             val shelvesWithData = getShelvesWithDataBatchOptimized()
             val shelvesDuration = SystemClock.elapsedRealtime() - shelvesStartTime
             logger.endProcess("library_get_shelves", shelvesWithData.size)
-            Log.d("SyncPerf", "    Library: Found ${shelvesWithData.size} shelves with data in ${shelvesDuration}ms")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "    Library: Found ${shelvesWithData.size} shelves with data in ${shelvesDuration}ms")
 
             if (shelvesWithData.isEmpty()) {
                 logger.logDetail("library_sync", "No shelves with data found, skipping library sync")
@@ -547,12 +548,12 @@ class SyncManager @Inject constructor(
             logger.endProcess("library_sync_main", processedItems)
 
             val totalDuration = SystemClock.elapsedRealtime() - librarySyncStartTime
-            Log.d("SyncPerf", "  ✓ Library sync completed: ${totalDuration}ms - $processedItems items from ${shelvesWithData.size} shelves")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ✓ Library sync completed: ${totalDuration}ms - $processedItems items from ${shelvesWithData.size} shelves")
         } catch (e: Exception) {
             e.printStackTrace()
             logger.endProcess("library_sync_main", processedItems)
             val failDuration = SystemClock.elapsedRealtime() - librarySyncStartTime
-            Log.d("SyncPerf", "  ✗ Library sync failed after ${failDuration}ms: ${e.message}")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ✗ Library sync failed after ${failDuration}ms: ${e.message}")
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -86,6 +86,10 @@ class SyncManager @Inject constructor(
     private val _syncStatus = MutableStateFlow<SyncStatus>(SyncStatus.Idle)
     val syncStatus: StateFlow<SyncStatus> = _syncStatus
 
+    private inline fun perf(msg: () -> String) {
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", msg())
+    }
+
     fun start(listener: OnSyncListener?, type: String, syncTables: List<String>? = null) {
         this.listener = listener
         if (isSyncing.compareAndSet(false, true)) {
@@ -142,9 +146,9 @@ class SyncManager @Inject constructor(
         val syncStartTime = SystemClock.elapsedRealtime()
         val logger = SyncTimeLogger
         logger.startLogging()
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "FULL SYNC STARTED at ${java.text.SimpleDateFormat("HH:mm:ss.SSS").format(Date())}")
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        perf { """═══════════════════════════════════════════════════════════════""" }
+        perf { """FULL SYNC STARTED at ${java.text.SimpleDateFormat("HH:mm:ss.SSS").format(Date())}""" }
+        perf { """═══════════════════════════════════════════════════════════════""" }
         try {
 
             initializeSync()
@@ -211,17 +215,17 @@ class SyncManager @Inject constructor(
             val totalSyncTime = syncEndTime - syncStartTime
             val minutes = totalSyncTime / 60000
             val seconds = (totalSyncTime % 60000) / 1000
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "FULL SYNC COMPLETED at ${java.text.SimpleDateFormat("HH:mm:ss.SSS").format(Date())}")
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "TOTAL SYNC TIME: ${minutes}m ${seconds}s (${totalSyncTime}ms)")
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+            perf { """═══════════════════════════════════════════════════════════════""" }
+            perf { """FULL SYNC COMPLETED at ${java.text.SimpleDateFormat("HH:mm:ss.SSS").format(Date())}""" }
+            perf { """TOTAL SYNC TIME: ${minutes}m ${seconds}s (${totalSyncTime}ms)""" }
+            perf { """═══════════════════════════════════════════════════════════════""" }
         } catch (err: Exception) {
             val syncEndTime = SystemClock.elapsedRealtime()
             val totalSyncTime = syncEndTime - syncStartTime
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "SYNC FAILED after ${totalSyncTime}ms")
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "Error: ${err.message}")
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+            perf { """═══════════════════════════════════════════════════════════════""" }
+            perf { """SYNC FAILED after ${totalSyncTime}ms""" }
+            perf { """Error: ${err.message}""" }
+            perf { """═══════════════════════════════════════════════════════════════""" }
             err.printStackTrace()
             handleException(err.message)
         } finally {
@@ -268,7 +272,7 @@ class SyncManager @Inject constructor(
 
     private suspend fun resourceTransactionSync() {
         val resourceSyncStartTime = SystemClock.elapsedRealtime()
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ▶ Starting resource sync")
+        perf { """  ▶ Starting resource sync""" }
 
         val logger = SyncTimeLogger
         logger.startProcess("resource_sync_main")
@@ -296,7 +300,7 @@ class SyncManager @Inject constructor(
             var skip = 0
             var batchCount = 0
 
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "    Resources: Found $totalRows documents to sync")
+            perf { """    Resources: Found $totalRows documents to sync""" }
             logger.logDetail("resource_sync", "Total resources: $totalRows, batch size: ${batchSizer.currentSize} (adaptive)")
 
             while (skip < totalRows || (totalRows == 0 && skip == 0)) {
@@ -378,7 +382,7 @@ class SyncManager @Inject constructor(
                     val batchEndTime = SystemClock.elapsedRealtime()
                     val batchTime = batchEndTime - batchStartTime
                     if (batchCount % 10 == 0) {
-                        if (BuildConfig.DEBUG) Log.d("SyncPerf", "    Resources batch $batchCount: ${batchTime}ms - Progress: $skip/$totalRows (${(skip * 100 / totalRows.coerceAtLeast(1))}%)")
+                        perf { """    Resources batch $batchCount: ${batchTime}ms - Progress: $skip/$totalRows (${(skip * 100 / totalRows.coerceAtLeast(1))}%)""" }
                         logger.logDetail("resource_sync", "Batch $batchCount progress: $skip/$totalRows (${(skip * 100 / totalRows.coerceAtLeast(1))}%)")
                         sharedPrefManager.rawPreferences.edit {
                             putLong("ResourceLastSyncTime", timeProvider.now())
@@ -415,12 +419,12 @@ class SyncManager @Inject constructor(
             val resourceSyncTime = resourceSyncEndTime - resourceSyncStartTime
             val minutes = resourceSyncTime / 60000
             val seconds = (resourceSyncTime % 60000) / 1000
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ✓ Resources sync completed: ${minutes}m ${seconds}s - $processedItems items")
+            perf { """  ✓ Resources sync completed: ${minutes}m ${seconds}s - $processedItems items""" }
         } catch (e: Exception) {
             e.printStackTrace()
             logger.endProcess("resource_sync_main", processedItems)
             val resourceSyncEndTime = SystemClock.elapsedRealtime()
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ✗ Resources sync failed after ${resourceSyncEndTime - resourceSyncStartTime}ms: ${e.message}")
+            perf { """  ✗ Resources sync failed after ${resourceSyncEndTime - resourceSyncStartTime}ms: ${e.message}""" }
         }
     }
 
@@ -495,7 +499,7 @@ class SyncManager @Inject constructor(
     private suspend fun myLibraryTransactionSync() {
         val logger = SyncTimeLogger
         val librarySyncStartTime = SystemClock.elapsedRealtime()
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ▶ Starting library sync")
+        perf { """  ▶ Starting library sync""" }
 
         logger.startProcess("library_sync_main")
         var processedItems = 0
@@ -506,7 +510,7 @@ class SyncManager @Inject constructor(
             val shelvesWithData = getShelvesWithDataBatchOptimized()
             val shelvesDuration = SystemClock.elapsedRealtime() - shelvesStartTime
             logger.endProcess("library_get_shelves", shelvesWithData.size)
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "    Library: Found ${shelvesWithData.size} shelves with data in ${shelvesDuration}ms")
+            perf { """    Library: Found ${shelvesWithData.size} shelves with data in ${shelvesDuration}ms""" }
 
             if (shelvesWithData.isEmpty()) {
                 logger.logDetail("library_sync", "No shelves with data found, skipping library sync")
@@ -548,12 +552,12 @@ class SyncManager @Inject constructor(
             logger.endProcess("library_sync_main", processedItems)
 
             val totalDuration = SystemClock.elapsedRealtime() - librarySyncStartTime
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ✓ Library sync completed: ${totalDuration}ms - $processedItems items from ${shelvesWithData.size} shelves")
+            perf { """  ✓ Library sync completed: ${totalDuration}ms - $processedItems items from ${shelvesWithData.size} shelves""" }
         } catch (e: Exception) {
             e.printStackTrace()
             logger.endProcess("library_sync_main", processedItems)
             val failDuration = SystemClock.elapsedRealtime() - librarySyncStartTime
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "  ✗ Library sync failed after ${failDuration}ms: ${e.message}")
+            perf { """  ✗ Library sync failed after ${failDuration}ms: ${e.message}""" }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.utils
 
 import android.util.Log
+import org.ole.planet.myplanet.BuildConfig
 import androidx.core.net.toUri
 import dagger.hilt.android.EntryPointAccessors
 import java.text.SimpleDateFormat
@@ -61,9 +62,9 @@ object SyncTimeLogger {
         detailedLogs.clear()
         apiCallCounter.set(0)
         realmOpCounter.set(0)
-        Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-        Log.d("SyncPerf", "SYNC STARTED at ${formatTimestamp(startTime)}")
-        Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "SYNC STARTED at ${formatTimestamp(startTime)}")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
     }
 
     fun stopLogging(uploadManager: UploadManager? = null) {
@@ -74,10 +75,10 @@ object SyncTimeLogger {
         val summary = generateSummary()
         saveSummaryToRealm(summary, uploadManager)
 
-        Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-        Log.d("SyncPerf", "SYNC COMPLETED at ${formatTimestamp(endTime)}")
-        Log.d("SyncPerf", "TOTAL DURATION: ${formatTime(endTime - startTime)}")
-        Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "SYNC COMPLETED at ${formatTimestamp(endTime)}")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "TOTAL DURATION: ${formatTime(endTime - startTime)}")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
     }
 
     private fun saveSummaryToRealm(summary: String, uploadManager: UploadManager? = null) {
@@ -139,9 +140,9 @@ object SyncTimeLogger {
 
         val elapsed = endTime - this.startTime
         if (itemCount > 0) {
-            Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}, $itemCount items")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}, $itemCount items")
         } else {
-            Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}")
+            if (BuildConfig.DEBUG) Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}")
         }
     }
 
@@ -158,7 +159,7 @@ object SyncTimeLogger {
 
         val statusIcon = if (success) "✓" else "✗"
         val itemInfo = if (itemsReturned > 0) ", $itemsReturned items" else ""
-        Log.d("SyncPerf", "[${formatElapsed(elapsed)}] $statusIcon API #$callNum: ${shortenEndpoint(endpoint)} - ${formatTime(duration)}$itemInfo")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "[${formatElapsed(elapsed)}] $statusIcon API #$callNum: ${shortenEndpoint(endpoint)} - ${formatTime(duration)}$itemInfo")
     }
 
     fun logRealmOperation(operation: String, model: String, duration: Long, itemCount: Int) {
@@ -171,7 +172,7 @@ object SyncTimeLogger {
         val log = RealmOperationLog(operation, model, duration, itemCount, timestamp)
         realmOperationTimes.getOrPut(model) { mutableListOf() }.add(log)
 
-        Log.d("SyncPerf", "[${formatElapsed(elapsed)}] 💾 DB #$opNum: $operation $model - ${formatTime(duration)}, $itemCount items")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "[${formatElapsed(elapsed)}] 💾 DB #$opNum: $operation $model - ${formatTime(duration)}, $itemCount items")
     }
 
     fun logDetail(context: String, message: String) {
@@ -181,7 +182,7 @@ object SyncTimeLogger {
         val elapsed = timestamp - startTime
         detailedLogs.getOrPut(context) { mutableListOf() }.add(message)
 
-        Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ℹ $context: $message")
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ℹ $context: $message")
     }
 
     internal fun extractProcessName(endpoint: String): String {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/SyncTimeLogger.kt
@@ -36,6 +36,10 @@ object SyncTimeLogger {
     private val apiCallCounter = AtomicInteger(0)
     private val realmOpCounter = AtomicInteger(0)
 
+    private inline fun perf(msg: () -> String) {
+        if (BuildConfig.DEBUG) Log.d("SyncPerf", msg())
+    }
+
     data class ApiCallLog(
         val endpoint: String,
         val duration: Long,
@@ -62,9 +66,9 @@ object SyncTimeLogger {
         detailedLogs.clear()
         apiCallCounter.set(0)
         realmOpCounter.set(0)
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "SYNC STARTED at ${formatTimestamp(startTime)}")
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        perf { """═══════════════════════════════════════════════════════════════""" }
+        perf { """SYNC STARTED at ${formatTimestamp(startTime)}""" }
+        perf { """═══════════════════════════════════════════════════════════════""" }
     }
 
     fun stopLogging(uploadManager: UploadManager? = null) {
@@ -75,10 +79,10 @@ object SyncTimeLogger {
         val summary = generateSummary()
         saveSummaryToRealm(summary, uploadManager)
 
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "SYNC COMPLETED at ${formatTimestamp(endTime)}")
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "TOTAL DURATION: ${formatTime(endTime - startTime)}")
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "═══════════════════════════════════════════════════════════════")
+        perf { """═══════════════════════════════════════════════════════════════""" }
+        perf { """SYNC COMPLETED at ${formatTimestamp(endTime)}""" }
+        perf { """TOTAL DURATION: ${formatTime(endTime - startTime)}""" }
+        perf { """═══════════════════════════════════════════════════════════════""" }
     }
 
     private fun saveSummaryToRealm(summary: String, uploadManager: UploadManager? = null) {
@@ -140,9 +144,9 @@ object SyncTimeLogger {
 
         val elapsed = endTime - this.startTime
         if (itemCount > 0) {
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}, $itemCount items")
+            perf { """[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}, $itemCount items""" }
         } else {
-            if (BuildConfig.DEBUG) Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}")
+            perf { """[${formatElapsed(elapsed)}] ✓ $processName completed: ${formatTime(duration)}""" }
         }
     }
 
@@ -159,7 +163,7 @@ object SyncTimeLogger {
 
         val statusIcon = if (success) "✓" else "✗"
         val itemInfo = if (itemsReturned > 0) ", $itemsReturned items" else ""
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "[${formatElapsed(elapsed)}] $statusIcon API #$callNum: ${shortenEndpoint(endpoint)} - ${formatTime(duration)}$itemInfo")
+        perf { """[${formatElapsed(elapsed)}] $statusIcon API #$callNum: ${shortenEndpoint(endpoint)} - ${formatTime(duration)}$itemInfo""" }
     }
 
     fun logRealmOperation(operation: String, model: String, duration: Long, itemCount: Int) {
@@ -172,7 +176,7 @@ object SyncTimeLogger {
         val log = RealmOperationLog(operation, model, duration, itemCount, timestamp)
         realmOperationTimes.getOrPut(model) { mutableListOf() }.add(log)
 
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "[${formatElapsed(elapsed)}] 💾 DB #$opNum: $operation $model - ${formatTime(duration)}, $itemCount items")
+        perf { """[${formatElapsed(elapsed)}] 💾 DB #$opNum: $operation $model - ${formatTime(duration)}, $itemCount items""" }
     }
 
     fun logDetail(context: String, message: String) {
@@ -182,7 +186,7 @@ object SyncTimeLogger {
         val elapsed = timestamp - startTime
         detailedLogs.getOrPut(context) { mutableListOf() }.add(message)
 
-        if (BuildConfig.DEBUG) Log.d("SyncPerf", "[${formatElapsed(elapsed)}] ℹ $context: $message")
+        perf { """[${formatElapsed(elapsed)}] ℹ $context: $message""" }
     }
 
     internal fun extractProcessName(endpoint: String): String {


### PR DESCRIPTION
Guard `SyncManager` and `SyncTimeLogger` debug logging

* Replaced all 20 `Log.d("SyncPerf", ...)` calls in `SyncManager.kt` with `if (BuildConfig.DEBUG) Log.d("SyncPerf", ...)` to prevent string formatting overhead in release builds.
* Replaced all `Log.d("SyncPerf", ...)` calls in `SyncTimeLogger.kt` with `if (BuildConfig.DEBUG) Log.d("SyncPerf", ...)`.
* Added `import org.ole.planet.myplanet.BuildConfig` to both files.
* Ran unit tests for `org.ole.planet.myplanet.services.sync.*` to ensure no regressions.

---
*PR created automatically by Jules for task [12890280953934138960](https://jules.google.com/task/12890280953934138960) started by @dogi*