### PR TITLE
courses: smoother surveys repositories counting (fixes #15473)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6404
-        versionName = "0.64.4"
+        versionCode = 6405
+        versionName = "0.64.5"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/LegacyEntityDaos.kt
@@ -69,6 +69,7 @@ interface ExamDao {
     @Query("SELECT * FROM exams WHERE type = :type") fun observeByType(type: String): Flow<List<StepExam>>
     @Query("SELECT * FROM exams WHERE teamId = :teamId") suspend fun getByTeamId(teamId: String): List<StepExam>
     @Query("SELECT * FROM exams WHERE teamId = :teamId AND type = :type") suspend fun getByTeamIdAndType(teamId: String, type: String): List<StepExam>
+    @Query("SELECT COUNT(*) FROM exams WHERE courseId = :courseId AND type = :type") suspend fun countByCourseIdAndType(courseId: String, type: String): Int
     @Query("DELETE FROM exams WHERE id = :id") suspend fun deleteById(id: String): Int
     @Upsert suspend fun upsert(item: StepExam)
     @Upsert suspend fun upsertAll(items: List<StepExam>)
@@ -95,6 +96,7 @@ interface SubmissionDao {
     @Query("SELECT * FROM submissions WHERE userId = :userId AND type = 'exam'") suspend fun getExamSubmissionsByUser(userId: String?): List<Submission>
     @Query("SELECT * FROM submissions WHERE userId = :userId") fun observeByUserId(userId: String): Flow<List<Submission>>
     @Query("SELECT * FROM submissions WHERE userId = :userId AND status = 'pending' AND type = 'survey'") suspend fun getPendingSurveys(userId: String): List<Submission>
+    @Query("SELECT COUNT(*) FROM submissions WHERE userId = :userId AND status = 'pending' AND type = 'survey'") suspend fun countPendingSurveys(userId: String): Int
     @Query("SELECT * FROM submissions WHERE userId = :userId AND LOWER(status) = 'pending' AND type = 'survey'") fun observePendingSurveys(userId: String?): Flow<List<Submission>>
     @Query("SELECT * FROM submissions WHERE userId = :userId AND status = 'pending' AND type = 'survey' AND teamId IS NULL") suspend fun getUniquePendingSurveyCandidates(userId: String): List<Submission>
     @Query("SELECT COUNT(*) FROM submissions WHERE (isUpdated = 1 OR _id = '')") suspend fun countPendingOfflineSubmissions(): Int

--- a/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/CoursesRepositoryImpl.kt
@@ -180,7 +180,7 @@ class CoursesRepositoryImpl @Inject constructor(
         if (courseId.isNullOrEmpty()) {
             return 0
         }
-        return examDao.getByCourseIdAndType(courseId, "courses").size
+        return examDao.countByCourseIdAndType(courseId, "courses")
     }
 
     override suspend fun getCourseSteps(courseId: String): List<CourseStep> {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
@@ -364,7 +364,7 @@ class SurveysRepositoryImpl @Inject constructor(
 
     override suspend fun getSurveySubmissionCount(userId: String?): Int {
         if (userId.isNullOrEmpty()) return 0
-        return submissionDao.getPendingSurveys(userId).size
+        return submissionDao.countPendingSurveys(userId)
     }
 
     override suspend fun getSurvey(id: String): StepExam? {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -292,7 +292,7 @@ class CoursesRepositoryImplTest {
 
         coEvery { courseDao.observeByCourseId("course_id") } returns kotlinx.coroutines.flow.flowOf(course)
         coEvery { userRepository.get().getUserModel() } returns user
-        coEvery { examDao.getByCourseIdAndType("course_id", "courses") } returns listOf(mockk<org.ole.planet.myplanet.model.StepExam>(), mockk<org.ole.planet.myplanet.model.StepExam>(), mockk<org.ole.planet.myplanet.model.StepExam>(), mockk<org.ole.planet.myplanet.model.StepExam>(), mockk<org.ole.planet.myplanet.model.StepExam>())
+        coEvery { examDao.countByCourseIdAndType("course_id", "courses") } returns 5
         coEvery { myLibraryDao.getCourseResources("course_id", false) } returns emptyList()
         coEvery { myLibraryDao.getCourseResources("course_id", true) } returns emptyList()
         coEvery { courseStepDao.getByCourseId("course_id") } returns listOf(org.ole.planet.myplanet.model.CourseStep().apply { id = "step_1"; stepTitle = "Title" })

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SurveysRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SurveysRepositoryImplTest.kt
@@ -110,10 +110,7 @@ class SurveysRepositoryImplTest {
 
     @Test
     fun `getSurveySubmissionCount uses pending surveys dao query`() = runTest {
-        coEvery { submissionDao.getPendingSurveys("user1") } returns listOf(
-            Submission(id = "sub1"),
-            Submission(id = "sub2")
-        )
+        coEvery { submissionDao.countPendingSurveys("user1") } returns 2
 
         val count = repository.getSurveySubmissionCount("user1")
 


### PR DESCRIPTION
A11: Use COUNT(*) where the code only reads .size

---
*PR created automatically by Jules for task [14284269125738412683](https://jules.google.com/task/14284269125738412683) started by @dogi*