### PR TITLE
all: less service module injection is more (fixes #15434)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6343
-        versionName = "0.63.43"
+        versionCode = 6344
+        versionName = "0.63.44"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
@@ -23,4 +23,5 @@ interface CoreDependenciesEntryPoint {
     fun apkLogDao(): ApkLogDao
     fun timeProvider(): TimeProvider
     fun resourcesRepository(): ResourcesRepository
+    fun realtimeSyncManager(): org.ole.planet.myplanet.services.sync.RealtimeSyncManager
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
@@ -8,6 +8,7 @@ import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.TimeProvider
@@ -23,5 +24,5 @@ interface CoreDependenciesEntryPoint {
     fun apkLogDao(): ApkLogDao
     fun timeProvider(): TimeProvider
     fun resourcesRepository(): ResourcesRepository
-    fun realtimeSyncManager(): org.ole.planet.myplanet.services.sync.RealtimeSyncManager
+    fun realtimeSyncManager(): RealtimeSyncManager
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -67,63 +67,6 @@ object ServiceModule {
 
     @Provides
     @Singleton
-    fun provideSyncManager(
-        @ApplicationContext context: Context,
-        sharedPrefManager: SharedPrefManager,
-        apiInterface: ApiInterface,
-        transactionSyncManager: TransactionSyncManager,
-        resourcesRepository: ResourcesRepository,
-        loginSyncManager: LoginSyncManager,
-        @ApplicationScope scope: CoroutineScope,
-        activitiesRepository: ActivitiesRepository,
-        dispatcherProvider: DispatcherProvider,
-        timeProvider: TimeProvider,
-        teamsRepository: TeamsRepository,
-        teamsSyncRepository: TeamsSyncRepository,
-        coursesRepository: CoursesRepository,
-        eventsRepository: EventsRepository,
-        userSyncRepository: UserSyncRepository
-    ): SyncManager {
-        return SyncManager(context, sharedPrefManager, apiInterface, transactionSyncManager, resourcesRepository, loginSyncManager, scope, activitiesRepository, dispatcherProvider, timeProvider, teamsRepository, teamsSyncRepository, coursesRepository, eventsRepository, userSyncRepository)
-    }
-
-    @Provides
-    @Singleton
-    fun provideUploadManager(
-        @ApplicationContext context: Context,
-        submissionsRepository: SubmissionsRepository,
-        sharedPrefManager: SharedPrefManager,
-        gson: Gson,
-        uploadCoordinator: UploadCoordinator,
-        uploadRepository: UploadRepository,
-        retryQueue: RetryQueue,
-        personalsRepository: PersonalsRepository,
-        userRepository: UserRepository,
-        chatRepository: ChatRepository,
-        voicesRepository: VoicesRepository,
-        uploadConfigs: UploadConfigs,
-        resourcesRepository: ResourcesRepository,
-        teamsRepository: Lazy<TeamsRepository>,
-        teamsSyncRepository: Lazy<TeamsSyncRepository>,
-        activitiesRepository: ActivitiesRepository,
-        apiInterface: ApiInterface,
-        @ApplicationScope scope: CoroutineScope,
-        dispatcherProvider: DispatcherProvider,
-        photoUploader: PhotoUploader,
-        achievementUploader: AchievementUploader,
-        timeProvider: TimeProvider
-    ): UploadManager {
-        return UploadManager(context, submissionsRepository, sharedPrefManager, gson, uploadCoordinator, uploadRepository, retryQueue, personalsRepository, userRepository, chatRepository, voicesRepository, uploadConfigs, resourcesRepository, teamsRepository, teamsSyncRepository, apiInterface, activitiesRepository, dispatcherProvider, scope, photoUploader, achievementUploader, timeProvider)
-    }
-
-    @Provides
-    @Singleton
-    fun provideRealtimeSyncManager(): RealtimeSyncManager {
-        return RealtimeSyncManager.getInstance()
-    }
-
-    @Provides
-    @Singleton
     fun provideUploadToShelfService(
         @ApplicationContext context: Context,
         @AppPreferences preferences: SharedPreferences,

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/RealtimeSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/RealtimeSyncManager.kt
@@ -1,21 +1,14 @@
 package org.ole.planet.myplanet.services.sync
 
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import org.ole.planet.myplanet.model.TableDataUpdate
 
-class RealtimeSyncManager {
-    companion object {
-        @Volatile
-        private var INSTANCE: RealtimeSyncManager? = null
-        
-        fun getInstance(): RealtimeSyncManager {
-            return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: RealtimeSyncManager().also { INSTANCE = it }
-            }
-        }
-    }
+@Singleton
+class RealtimeSyncManager @Inject constructor() {
     
     private val _dataUpdateFlow = MutableSharedFlow<TableDataUpdate>(extraBufferCapacity = 1)
     val dataUpdateFlow: SharedFlow<TableDataUpdate> = _dataUpdateFlow.asSharedFlow()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/RealtimeSyncMixin.kt
@@ -4,11 +4,13 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.FlowPreview
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.callback.OnDiffRefreshListener
+import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
 import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
 import org.ole.planet.myplanet.utils.collectWhenStarted
@@ -21,7 +23,12 @@ interface RealtimeSyncMixin {
 }
 
 class RealtimeSyncHelper(private val fragment: Fragment, private val mixin: RealtimeSyncMixin) {
-    private val syncManagerInstance = RealtimeSyncManager.getInstance()
+    private val syncManagerInstance: RealtimeSyncManager by lazy {
+        EntryPointAccessors.fromApplication(
+            fragment.requireContext().applicationContext,
+            CoreDependenciesEntryPoint::class.java
+        ).realtimeSyncManager()
+    }
 
     @OptIn(FlowPreview::class)
     fun setupRealtimeSync() {

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/RealtimeSyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/RealtimeSyncManagerTest.kt
@@ -1,48 +1,16 @@
 package org.ole.planet.myplanet.services.sync
 
-import java.lang.reflect.Modifier
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.model.TableDataUpdate
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RealtimeSyncManagerTest {
-
-    @Before
-    @After
-    fun resetSingleton() {
-        try {
-            val clazz = RealtimeSyncManager.Companion::class.java
-            val field = clazz.getDeclaredFields().find { it.name == "INSTANCE" }
-                ?: RealtimeSyncManager::class.java.getDeclaredFields().find { it.name == "INSTANCE" }
-
-            field?.let {
-                it.isAccessible = true
-                if (Modifier.isStatic(it.modifiers)) {
-                    it.set(null, null)
-                } else {
-                    it.set(RealtimeSyncManager.Companion, null)
-                }
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-    }
-
-    @Test
-    fun testGetInstance() {
-        val instance1 = RealtimeSyncManager.getInstance()
-        val instance2 = RealtimeSyncManager.getInstance()
-        assertSame(instance1, instance2)
-    }
 
     @Test
     fun testNotifyTableUpdatedFlow() = runTest {


### PR DESCRIPTION
Shrunk `ServiceModule` constructor-injection bloat by removing manual `@Provides` methods for `SyncManager`, `UploadManager` and `RealtimeSyncManager`. Refactored `RealtimeSyncManager` to use standard constructor injection (`@Inject`) and removed the previous `getInstance()` companion singleton logic. usages of `RealtimeSyncManager` were updated to use `EntryPointAccessors`. The codebase already had the `@Inject` constructors on `SyncManager` and `UploadManager`.

---
*PR created automatically by Jules for task [11130493835689496436](https://jules.google.com/task/11130493835689496436) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved real-time synchronization service management through centralized dependency injection.
  * Updated synchronization components to access the shared service through the application’s dependency system.
  * Removed legacy manual singleton handling.

* **Tests**
  * Removed obsolete singleton-specific test setup and coverage.

* **Chores**
  * Updated the app version to 0.63.44.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->