### PR TITLE
all: smoother download server checking (fixes #15410)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6325
-        versionName = "0.63.25"
+        versionCode = 6326
+        versionName = "0.63.26"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6326
-        versionName = "0.63.26"
+        versionCode = 6327
+        versionName = "0.63.27"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -429,20 +429,24 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
     private suspend fun observeNetworkForDownloads() {
         withContext(dispatcherProvider.default) {
             isNetworkConnectedFlow.onEach { isConnected ->
-                if (isConnected) {
-                    val serverUrl = sharedPrefManager.getServerUrl()
-                    if (serverUrl.isNotEmpty()) {
-                        applicationScope.launch {
-                            val canReachServer = isServerReachable(serverUrl, dispatcherProvider.io)
-                            if (canReachServer && defaultPref.getBoolean("beta_auto_download", false)) {
-                                resourceDownloadCoordinator.startBackgroundDownload(
-                                    downloadAllFiles(resourcesRepository.getAllLibrariesToSync())
-                                )
-                            }
-                        }
-                    }
+                if (!isConnected) return@onEach
+
+                val serverUrl = sharedPrefManager.getServerUrl()
+                if (serverUrl.isEmpty()) return@onEach
+
+                applicationScope.launch {
+                    checkServerAndStartDownload(serverUrl)
                 }
             }.launchIn(applicationScope)
+        }
+    }
+
+    private suspend fun checkServerAndStartDownload(serverUrl: String) {
+        val canReachServer = isServerReachable(serverUrl, dispatcherProvider.io)
+        if (canReachServer && defaultPref.getBoolean("beta_auto_download", false)) {
+            resourceDownloadCoordinator.startBackgroundDownload(
+                downloadAllFiles(resourcesRepository.getAllLibrariesToSync())
+            )
         }
     }
 


### PR DESCRIPTION
🎯 **What:** 
Refactored the `observeNetworkForDownloads` method in `MainApplication.kt` to eliminate deeply nested code logic. Used guard clauses with `return@onEach` and extracted the background network check and download trigger into a dedicated suspend function (`checkServerAndStartDownload`).

💡 **Why:** 
The previous implementation had a "arrow code" structure with 4 levels of nested `if` statements inside an `onEach` flow builder. This made the code difficult to read and maintain. Extracting the core logic into its own function and flattening the conditionals significantly improves clarity.

✅ **Verification:** 
- The logical behavior is preserved identically.
- Tested compilation using `./gradlew test` to ensure there are no build errors.
- Checked using `./gradlew lint` for code style errors. 

✨ **Result:** 
A more readable, cleaner, and maintainable implementation of `observeNetworkForDownloads`.

---
*PR created automatically by Jules for task [12201996761640978127](https://jules.google.com/task/12201996761640978127) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background downloads now start more reliably when network connectivity is restored and a server is configured.

* **Bug Fixes**
  * Prevented download checks when the device is offline or no server URL is available.

* **Chores**
  * Updated the Android app version to 0.63.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->