### PR TITLE
🧹 Refactor nested `when` expressions to use early returns in DownloadService

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -283,39 +283,37 @@ class DownloadService : Service() {
         isAlternative: Boolean
     ): Boolean {
         val source = if (isAlternative) "alternative" else "primary"
-        return when (result) {
-            is DownloadResult.Success -> {
-                val contentLength = result.body.contentLength()
-                Log.d(TAG, "tryDownload [$source]: $fileName responded contentLength=${if (contentLength == -1L) "unknown" else "${contentLength}B"}")
-                val storageError = getStorageError(contentLength)
-                when {
-                    storageError != null -> {
-                        Log.e(TAG, "tryDownload [$source]: storage check failed — $storageError")
-                        downloadFailed(storageError, fromSync)
-                        false
-                    }
-                    contentLength == 0L -> {
-                        Log.e(TAG, "tryDownload [$source]: server returned empty body for $fileName")
-                        downloadFailed("Empty file from server", fromSync)
-                        false
-                    }
-                    else -> {
-                        try {
-                            downloadFile(result.body, url)
-                            true
-                        } catch (e: Exception) {
-                            Log.e(TAG, "tryDownload [$source]: write failed for $fileName", e)
-                            downloadFailed(e.localizedMessage ?: "Write failed", fromSync)
-                            false
-                        }
-                    }
-                }
-            }
-            is DownloadResult.Error -> {
-                Log.e(TAG, "tryDownload [$source]: $fileName — ${result.message} (code=${result.code})")
-                downloadFailed(result.message, fromSync)
-                false
-            }
+
+        if (result is DownloadResult.Error) {
+            Log.e(TAG, "tryDownload [$source]: $fileName — ${result.message} (code=${result.code})")
+            downloadFailed(result.message, fromSync)
+            return false
+        }
+
+        result as DownloadResult.Success
+        val contentLength = result.body.contentLength()
+        Log.d(TAG, "tryDownload [$source]: $fileName responded contentLength=${if (contentLength == -1L) "unknown" else "${contentLength}B"}")
+
+        val storageError = getStorageError(contentLength)
+        if (storageError != null) {
+            Log.e(TAG, "tryDownload [$source]: storage check failed — $storageError")
+            downloadFailed(storageError, fromSync)
+            return false
+        }
+
+        if (contentLength == 0L) {
+            Log.e(TAG, "tryDownload [$source]: server returned empty body for $fileName")
+            downloadFailed("Empty file from server", fromSync)
+            return false
+        }
+
+        return try {
+            downloadFile(result.body, url)
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "tryDownload [$source]: write failed for $fileName", e)
+            downloadFailed(e.localizedMessage ?: "Write failed", fromSync)
+            false
         }
     }
 


### PR DESCRIPTION
🎯 **What:** Refactored the deeply nested `when` structures inside `DownloadService.tryDownloadFromResult` by extracting guard checks and utilizing early returns.
💡 **Why:** To drastically improve the code's readability and code health by reducing the cognitive complexity caused by heavy block nesting.
✅ **Verification:** Verified via `./gradlew assembleDebug` (compilation passes) and `./gradlew test` (no logic broken). The code review agent confirmed exact logic equivalence.
✨ **Result:** A flatter, easier-to-read function that correctly casts and continues execution on valid states, immediately returning on error/invalid states.

---
*PR created automatically by Jules for task [13332932228770991970](https://jules.google.com/task/13332932228770991970) started by @dogi*