### PR TITLE
🧹 refactor: Flatten observeNetworkForDownloads logic

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -429,20 +429,24 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
     private suspend fun observeNetworkForDownloads() {
         withContext(dispatcherProvider.default) {
             isNetworkConnectedFlow.onEach { isConnected ->
-                if (isConnected) {
-                    val serverUrl = sharedPrefManager.getServerUrl()
-                    if (serverUrl.isNotEmpty()) {
-                        applicationScope.launch {
-                            val canReachServer = isServerReachable(serverUrl, dispatcherProvider.io)
-                            if (canReachServer && defaultPref.getBoolean("beta_auto_download", false)) {
-                                resourceDownloadCoordinator.startBackgroundDownload(
-                                    downloadAllFiles(resourcesRepository.getAllLibrariesToSync())
-                                )
-                            }
-                        }
-                    }
+                if (!isConnected) return@onEach
+
+                val serverUrl = sharedPrefManager.getServerUrl()
+                if (serverUrl.isEmpty()) return@onEach
+
+                applicationScope.launch {
+                    checkAndDownloadResources(serverUrl)
                 }
             }.launchIn(applicationScope)
+        }
+    }
+
+    private suspend fun checkAndDownloadResources(serverUrl: String) {
+        val canReachServer = isServerReachable(serverUrl, dispatcherProvider.io)
+        if (canReachServer && defaultPref.getBoolean("beta_auto_download", false)) {
+            resourceDownloadCoordinator.startBackgroundDownload(
+                downloadAllFiles(resourcesRepository.getAllLibrariesToSync())
+            )
         }
     }
 


### PR DESCRIPTION
🎯 **What:** Extracted background download logic in `MainApplication.kt` into a separate method `checkAndDownloadResources` and used early returns in `observeNetworkForDownloads`.
💡 **Why:** Reduces nesting depth from 5 levels down to 2 levels, significantly improving the readability and maintainability of the `observeNetworkForDownloads` method without altering any behavior. 
✅ **Verification:** Ran `MainApplicationTest` successfully to ensure no regressions were introduced.
✨ **Result:** Much cleaner, flattened conditional logic in network flow collection.

---
*PR created automatically by Jules for task [13962402808373563998](https://jules.google.com/task/13962402808373563998) started by @dogi*