### PR TITLE
🧹 [Code Health] Flatten deeply nested expression in DownloadService

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -288,27 +288,25 @@ class DownloadService : Service() {
                 val contentLength = result.body.contentLength()
                 Log.d(TAG, "tryDownload [$source]: $fileName responded contentLength=${if (contentLength == -1L) "unknown" else "${contentLength}B"}")
                 val storageError = getStorageError(contentLength)
-                when {
-                    storageError != null -> {
-                        Log.e(TAG, "tryDownload [$source]: storage check failed — $storageError")
-                        downloadFailed(storageError, fromSync)
-                        false
-                    }
-                    contentLength == 0L -> {
-                        Log.e(TAG, "tryDownload [$source]: server returned empty body for $fileName")
-                        downloadFailed("Empty file from server", fromSync)
-                        false
-                    }
-                    else -> {
-                        try {
-                            downloadFile(result.body, url)
-                            true
-                        } catch (e: Exception) {
-                            Log.e(TAG, "tryDownload [$source]: write failed for $fileName", e)
-                            downloadFailed(e.localizedMessage ?: "Write failed", fromSync)
-                            false
-                        }
-                    }
+                if (storageError != null) {
+                    Log.e(TAG, "tryDownload [$source]: storage check failed — $storageError")
+                    downloadFailed(storageError, fromSync)
+                    return false
+                }
+
+                if (contentLength == 0L) {
+                    Log.e(TAG, "tryDownload [$source]: server returned empty body for $fileName")
+                    downloadFailed("Empty file from server", fromSync)
+                    return false
+                }
+
+                return try {
+                    downloadFile(result.body, url)
+                    true
+                } catch (e: Exception) {
+                    Log.e(TAG, "tryDownload [$source]: write failed for $fileName", e)
+                    downloadFailed(e.localizedMessage ?: "Write failed", fromSync)
+                    false
                 }
             }
             is DownloadResult.Error -> {


### PR DESCRIPTION
🎯 **What:** Refactored the `tryDownloadFromResult` function in `DownloadService.kt` to flatten a deeply nested `when` expression.
💡 **Why:** Deeply nested `when` expressions, particularly those that implicitly return boolean flags out to an outer block, are hard to read and mentally trace. Converting this to sequential `if` checks with early returns simplifies the control flow, reduces nesting, and improves maintainability.
✅ **Verification:** Verified by inspecting the target file and running the `:app:testDefaultDebugUnitTest --tests '*DownloadServiceTest*'` targets to ensure compilation and existing test passes.
✨ **Result:** Improved code readability and reduced nesting depth without changing behavior.

---
*PR created automatically by Jules for task [9660077719850729880](https://jules.google.com/task/9660077719850729880) started by @dogi*