### PR TITLE
all: smoother anr watchdog log persisting (fixes #15534)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6403
-        versionName = "0.64.3"
+        versionCode = 6404
+        versionName = "0.64.4"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -249,15 +249,19 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
             }
         }
 
-        fun handleUncaughtException(e: Throwable) {
-            e.printStackTrace()
-            val error = e.stackTraceToString()
-            val pendingFile = CrashLogStore.save(context, ApkLog.ERROR_TYPE_CRASH, error, coreDependenciesEntryPoint.timeProvider())
+        fun persistCriticalLog(type: String, error: String) {
+            val pendingFile = CrashLogStore.save(context, type, error, coreDependenciesEntryPoint.timeProvider())
             applicationScope.launch {
-                if (saveLogToRoom(ApkLog.ERROR_TYPE_CRASH, error, "${coreDependenciesEntryPoint.timeProvider().now()}")) {
+                if (saveLogToRoom(type, error, "${coreDependenciesEntryPoint.timeProvider().now()}")) {
                     pendingFile?.delete()
                 }
             }
+        }
+
+        fun handleUncaughtException(e: Throwable) {
+            e.printStackTrace()
+            val error = e.stackTraceToString()
+            persistCriticalLog(ApkLog.ERROR_TYPE_CRASH, error)
 
             val homeIntent = Intent(Intent.ACTION_MAIN).apply {
                 addCategory(Intent.CATEGORY_HOME)
@@ -357,12 +361,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
                 listener = object : ANRWatchdog.ANRListener {
                     override fun onAppNotResponding(message: String, blockedThread: Thread, duration: Long) {
                         val error = "ANR detected! Duration: ${duration}ms\n $message"
-                        val pendingFile = CrashLogStore.save(context, ANR_LOG_TYPE, error, coreDependenciesEntryPoint.timeProvider())
-                        applicationScope.launch {
-                            if (saveLogToRoom(ANR_LOG_TYPE, error, "${coreDependenciesEntryPoint.timeProvider().now()}")) {
-                                pendingFile?.delete()
-                            }
-                        }
+                        persistCriticalLog(ANR_LOG_TYPE, error)
                     }
                 },
                 dispatcherProvider = dispatcherProvider


### PR DESCRIPTION
🎯 **What:** Extracted log saving logic in `MainApplication` into a companion method `persistCriticalLog`, reducing nesting inside `setupAnrWatchdog`.
💡 **Why:** Both `handleUncaughtException` and the inline `ANRListener` duplicated the exact same `CrashLogStore.save` and `saveLogToRoom` file logic. Moving this deduplicates code and resolves a code health issue involving deep nesting in the listener.
✅ **Verification:** Verified by checking `git diff`, ensuring compilation passed via `./gradlew compileDefaultDebugKotlin`, and executing `./gradlew lint` and `./gradlew test` directly.
✨ **Result:** Clean, deduplicated exception persistence logic and flatter, readable ANR watchdog setup.

---
*PR created automatically by Jules for task [4726603364127240617](https://jules.google.com/task/4726603364127240617) started by @dogi*