### PR TITLE
Fix myPlanet's status bar in dark mode

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/EdgeToEdgeUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/EdgeToEdgeUtils.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.utils
 
 import android.app.Activity
+import android.content.res.Configuration
 import android.view.View
 import android.view.Window
 import androidx.core.view.ViewCompat
@@ -8,19 +9,24 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 
 object EdgeToEdgeUtils {
+    private fun isDarkMode(activity: Activity): Boolean {
+        val uiMode = activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        return uiMode == Configuration.UI_MODE_NIGHT_YES
+    }
+
     /**
      * Sets up edge-to-edge display with transparent system bars and proper window insets handling
      * Works across all supported SDK versions (26-36)
      * @param activity The activity to apply edge-to-edge to
      * @param rootView The root view that should handle window insets
-     * @param lightStatusBar Whether to use light status bar icons (default: true)
-     * @param lightNavigationBar Whether to use light navigation bar icons (default: true)
+     * @param lightStatusBar Whether to use light status bar icons (default is based on light theme: true in light mode, false in dark mode)
+     * @param lightNavigationBar Whether to use light navigation bar icons (default is based on light theme: true in light mode, false in dark mode)
      */
     fun setupEdgeToEdge(
         activity: Activity,
         rootView: View,
-        lightStatusBar: Boolean = true,
-        lightNavigationBar: Boolean = true
+        lightStatusBar: Boolean = !isDarkMode(activity),
+        lightNavigationBar: Boolean = !isDarkMode(activity)
     ) {
         configureEdgeToEdge(activity, rootView, lightStatusBar, lightNavigationBar)
 
@@ -45,8 +51,8 @@ object EdgeToEdgeUtils {
     fun setupEdgeToEdgeWithKeyboard(
         activity: Activity,
         rootView: View,
-        lightStatusBar: Boolean = true,
-        lightNavigationBar: Boolean = true
+        lightStatusBar: Boolean = !isDarkMode(activity),
+        lightNavigationBar: Boolean = !isDarkMode(activity)
     ) {
         configureEdgeToEdge(activity, rootView, lightStatusBar, lightNavigationBar)
 

--- a/app/src/test/java/org/ole/planet/myplanet/utils/EdgeToEdgeUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/EdgeToEdgeUtilsTest.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.utils
 
 import android.app.Activity
 import android.app.Application
+import android.content.res.Configuration
 import android.view.View
 import android.view.Window
 import androidx.core.view.ViewCompat
@@ -16,6 +17,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -23,19 +25,15 @@ import org.robolectric.annotation.Config
 @Config(application = Application::class, sdk = [33])
 class EdgeToEdgeUtilsTest {
 
-    private lateinit var mockActivity: Activity
-    private lateinit var mockWindow: Window
+    private lateinit var activity: Activity
     private lateinit var mockRootView: View
     private lateinit var mockInsetsController: WindowInsetsControllerCompat
 
     @Before
     fun setup() {
-        mockActivity = mockk()
-        mockWindow = mockk(relaxed = true)
+        activity = Robolectric.buildActivity(Activity::class.java).create().get()
         mockRootView = mockk(relaxed = true)
         mockInsetsController = mockk(relaxed = true)
-
-        every { mockActivity.window } returns mockWindow
 
         mockkStatic(WindowCompat::class)
         every { WindowCompat.setDecorFitsSystemWindows(any(), any()) } returns Unit
@@ -53,15 +51,15 @@ class EdgeToEdgeUtilsTest {
     @Test
     fun `setupEdgeToEdge should configure window and insets`() {
         EdgeToEdgeUtils.setupEdgeToEdge(
-            activity = mockActivity,
+            activity = activity,
             rootView = mockRootView,
             lightStatusBar = true,
             lightNavigationBar = false
         )
 
         verify {
-            WindowCompat.setDecorFitsSystemWindows(mockWindow, false)
-            WindowCompat.getInsetsController(mockWindow, mockRootView)
+            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+            WindowCompat.getInsetsController(activity.window, mockRootView)
         }
         verify { mockInsetsController.isAppearanceLightStatusBars = true }
         verify { mockInsetsController.isAppearanceLightNavigationBars = false }
@@ -71,18 +69,60 @@ class EdgeToEdgeUtilsTest {
     @Test
     fun `setupEdgeToEdgeWithKeyboard should configure window and insets`() {
         EdgeToEdgeUtils.setupEdgeToEdgeWithKeyboard(
-            activity = mockActivity,
+            activity = activity,
             rootView = mockRootView,
             lightStatusBar = false,
             lightNavigationBar = true
         )
 
         verify {
-            WindowCompat.setDecorFitsSystemWindows(mockWindow, false)
-            WindowCompat.getInsetsController(mockWindow, mockRootView)
+            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+            WindowCompat.getInsetsController(activity.window, mockRootView)
         }
         verify { mockInsetsController.isAppearanceLightStatusBars = false }
         verify { mockInsetsController.isAppearanceLightNavigationBars = true }
         verify { ViewCompat.setOnApplyWindowInsetsListener(mockRootView, any()) }
+    }
+
+    @Test
+    fun `setupEdgeToEdge in light mode should default to light status bar and light navigation bar`() {
+        val configuration = activity.resources.configuration
+        configuration.uiMode = (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or Configuration.UI_MODE_NIGHT_NO
+
+        EdgeToEdgeUtils.setupEdgeToEdge(
+            activity = activity,
+            rootView = mockRootView
+        )
+
+        verify { mockInsetsController.isAppearanceLightStatusBars = true }
+        verify { mockInsetsController.isAppearanceLightNavigationBars = true }
+    }
+
+    @Test
+    fun `setupEdgeToEdge in dark mode should default to dark status bar and dark navigation bar`() {
+        val configuration = activity.resources.configuration
+        configuration.uiMode = (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or Configuration.UI_MODE_NIGHT_YES
+
+        EdgeToEdgeUtils.setupEdgeToEdge(
+            activity = activity,
+            rootView = mockRootView
+        )
+
+        verify { mockInsetsController.isAppearanceLightStatusBars = false }
+        verify { mockInsetsController.isAppearanceLightNavigationBars = false }
+    }
+
+    @Test
+    fun `setupEdgeToEdgeWithKeyboard in dark mode should default to dark status bar and dark navigation bar`() {
+        val configuration = activity.resources.configuration
+        configuration.uiMode = (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or Configuration.UI_MODE_NIGHT_YES
+
+        EdgeToEdgeUtils.setupEdgeToEdgeWithKeyboard(
+            activity = activity,
+            rootView = mockRootView
+        )
+
+        verify { mockInsetsController.isAppearanceLightStatusBars = false }
+        verify { mockInsetsController.isAppearanceLightNavigationBars = false }
     }
 }


### PR DESCRIPTION
This change fixes the issue where the status bar is rendered with white background/icons in dark mode by dynamically configuring EdgeToEdge system bars to respect the activity's active UI configuration (dark vs. light mode). We also refactor the tests to use Robolectric to avoid mockk limitations on final Android framework properties.

---
*PR created automatically by Jules for task [4907295140147550672](https://jules.google.com/task/4907295140147550672) started by @J-S-webskas*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge-to-edge display behavior in dark mode.
  * Status and navigation bar icons now automatically use appropriate light or dark appearances based on the active theme.
  * Keyboard-aware edge-to-edge layouts now receive the same theme-aware system bar handling.

* **Tests**
  * Added coverage for light- and dark-mode system bar appearance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->