### PR TITLE
actions: smoother workflow automerging (fixes #15393)

### DIFF
--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -19,6 +19,7 @@ BASE="${BASE:?}"
 LABEL="${LABEL:?}"
 GRADLE_FILE="${GRADLE_FILE:?}"
 VERSION_SH="${VERSION_SH:?}"
+COAUTHORS_SH="${COAUTHORS_SH:?}"
 REQUIRE_CHECKS="${REQUIRE_CHECKS:-true}"
 DELETE_BRANCH="${DELETE_BRANCH:-true}"
 DRY_RUN="${DRY_RUN:-true}"
@@ -244,7 +245,18 @@ while :; do
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"; exit 1; }
     fi
 
-    ARGS=(--repo "$REPO" --squash --match-head-commit "$merge_sha")
+    # Replace the PR description with just the attribution that belongs in
+    # the commit log. Subject keeps the repo's "<title> (#<number>)" shape.
+    commit_body=$(REPO="$REPO" PR="$NUMBER" "$COAUTHORS_SH")
+    if [ -n "$commit_body" ]; then
+        log "  co-authors:"
+        printf '%s\n' "$commit_body" | sed 's/^/    /'
+    else
+        log "  no co-authors to credit"
+    fi
+
+    ARGS=(--repo "$REPO" --squash --match-head-commit "$merge_sha"
+          --subject "$TITLE (#$NUMBER)" --body "$commit_body")
     if [ "$DELETE_BRANCH" = 'true' ]; then
         ARGS+=(--delete-branch)
     fi

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+#
+# Drain the automerge queue.
+#
+# Repeatedly: pick the lowest-numbered open non-draft PR carrying $LABEL,
+# verify it is mergeable and green, bump the version, squash merge it, then
+# wait for the workflows the merge kicks off on $BASE. Stop on the first
+# failure; otherwise keep going until no labelled PR is left.
+#
+# Everything is driven by environment variables so the workflow stays thin.
+# This script is expected to run from a copy outside the work tree (see
+# automerge.yml) -- it checks out PR branches, and a running bash script
+# whose file is swapped underneath it is a bad time.
+#
+set -euo pipefail
+
+REPO="${REPO:?}"
+BASE="${BASE:?}"
+LABEL="${LABEL:?}"
+GRADLE_FILE="${GRADLE_FILE:?}"
+VERSION_SH="${VERSION_SH:?}"
+REQUIRE_CHECKS="${REQUIRE_CHECKS:-true}"
+DELETE_BRANCH="${DELETE_BRANCH:-true}"
+DRY_RUN="${DRY_RUN:-true}"
+MAX_MERGES="${MAX_MERGES:-0}"
+WAIT_TIMEOUT_MIN="${WAIT_TIMEOUT_MIN:-45}"
+
+log()     { printf '%s | %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+summary() { [ -n "${GITHUB_STEP_SUMMARY:-}" ] && printf '%s\n' "$*" >> "$GITHUB_STEP_SUMMARY"; return 0; }
+
+merged_count=0
+merged_list=""
+
+# ---------------------------------------------------------------- helpers
+
+pick_pr() {
+    gh pr list \
+        --repo "$REPO" \
+        --state open \
+        --base "$BASE" \
+        --label "$LABEL" \
+        --limit 100 \
+        --json number,title,isDraft,headRefName,headRefOid,headRepositoryOwner \
+      | jq -c 'map(select(.isDraft | not)) | sort_by(.number) | first'
+}
+
+# GitHub computes mergeability lazily; UNKNOWN just means "ask again".
+check_mergeable() {
+    local pr=$1 state=""
+    for _ in 1 2 3 4 5; do
+        state=$(gh pr view "$pr" --repo "$REPO" --json mergeable --jq '.mergeable')
+        [ "$state" = "UNKNOWN" ] || break
+        sleep 5
+    done
+    if [ "$state" != "MERGEABLE" ]; then
+        log "  #$pr is not mergeable (state: $state)"
+        return 1
+    fi
+}
+
+check_green() {
+    local pr=$1 checks bad
+    checks=$(gh pr checks "$pr" --repo "$REPO" --json name,bucket 2>/dev/null || true)
+
+    if [ -z "$checks" ] || [ "$checks" = "[]" ]; then
+        log "  #$pr reports no checks -- refusing to merge blind"
+        return 1
+    fi
+
+    bad=$(jq -r '[.[] | select(.bucket != "pass" and .bucket != "skipping")] | length' <<<"$checks")
+    if [ "$bad" -ne 0 ]; then
+        jq -r '.[] | select(.bucket != "pass" and .bucket != "skipping") | "    \(.bucket)\t\(.name)"' <<<"$checks"
+        log "  #$pr has $bad check(s) not passing"
+        return 1
+    fi
+    log "  #$pr checks green"
+}
+
+# The pre-merge checks ran on the PR head, but we merge the SHA *after* the
+# version bump, which GITHUB_TOKEN pushes deliberately do not re-run CI for.
+# Carrying the green verdict across that gap is only honest if the bump
+# provably changed nothing but the two version lines -- so prove it.
+verify_version_only_diff() {
+    local from=$1 to=$2 files bad
+
+    files=$(git diff --name-only "$from" "$to")
+    if [ "$files" != "$GRADLE_FILE" ]; then
+        log "  bump touched unexpected files: ${files//$'\n'/, }"
+        return 1
+    fi
+
+    bad=$(git diff --unified=0 "$from" "$to" -- "$GRADLE_FILE" \
+          | grep -E '^[+-]' \
+          | grep -vE '^(\+\+\+|---)' \
+          | grep -vcE '^[+-][[:space:]]*version(Code|Name)[[:space:]]*=' || true)
+    if [ "${bad:-0}" -ne 0 ]; then
+        log "  bump changed $bad non-version line(s) -- refusing to carry the check verdict"
+        return 1
+    fi
+    log "  bump is provably version-only ($from -> $to)"
+}
+
+push_with_retry() {
+    local ref=$1
+    for delay in 0 2 4 8 16; do
+        [ "$delay" -eq 0 ] || sleep "$delay"
+        if git push origin "$ref"; then
+            return 0
+        fi
+    done
+    log "  push of $ref failed after retries"
+    return 1
+}
+
+# Wait for every workflow run triggered by $sha on the base branch.
+wait_for_runs() {
+    local sha=$1
+    local deadline=$(( SECONDS + WAIT_TIMEOUT_MIN * 60 ))
+    local appear_deadline=$(( SECONDS + 300 ))
+    local runs total pending failed
+
+    log "  waiting for workflows on ${sha:0:7} (timeout ${WAIT_TIMEOUT_MIN}m)"
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        runs=$(gh api "repos/$REPO/actions/runs?head_sha=$sha&per_page=100" \
+                 --jq '[.workflow_runs[] | {name, status, conclusion}]' 2>/dev/null || echo '[]')
+        total=$(jq 'length' <<<"$runs")
+
+        if [ "$total" -eq 0 ]; then
+            if [ "$SECONDS" -ge "$appear_deadline" ]; then
+                log "  no workflow runs appeared for ${sha:0:7} -- nothing to wait for"
+                return 0
+            fi
+            sleep 20
+            continue
+        fi
+
+        pending=$(jq '[.[] | select(.status != "completed")] | length' <<<"$runs")
+        if [ "$pending" -eq 0 ]; then
+            jq -r '.[] | "    \(.conclusion)\t\(.name)"' <<<"$runs"
+            failed=$(jq '[.[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length' <<<"$runs")
+            if [ "$failed" -ne 0 ]; then
+                log "  $failed workflow(s) failed on ${sha:0:7}"
+                return 1
+            fi
+            log "  all $total workflow(s) green on ${sha:0:7}"
+            return 0
+        fi
+        sleep 20
+    done
+
+    log "  timed out after ${WAIT_TIMEOUT_MIN}m waiting on ${sha:0:7}"
+    return 1
+}
+
+# ------------------------------------------------------------------- main
+
+log "draining '$LABEL' into $BASE (dry_run=$DRY_RUN)"
+summary "### automerge: draining \`$LABEL\` into \`$BASE\`"
+summary ""
+summary "| PR | version | result |"
+summary "|---|---|---|"
+
+git config user.name  'github-actions[bot]'
+git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+while :; do
+    if [ "$MAX_MERGES" -gt 0 ] && [ "$merged_count" -ge "$MAX_MERGES" ]; then
+        log "reached max_merges=$MAX_MERGES, stopping"
+        summary "| | | stopped at max_merges=$MAX_MERGES |"
+        break
+    fi
+
+    git fetch --quiet origin "$BASE"
+
+    pr_json=$(pick_pr)
+    if [ "$pr_json" = "null" ] || [ -z "$pr_json" ]; then
+        log "no open non-draft PR labelled '$LABEL' targets $BASE -- queue empty"
+        summary "| | | queue empty |"
+        break
+    fi
+
+    NUMBER=$(jq -r '.number'                    <<<"$pr_json")
+    TITLE=$(jq  -r '.title'                     <<<"$pr_json")
+    HEAD=$(jq   -r '.headRefName'               <<<"$pr_json")
+    SHA=$(jq    -r '.headRefOid'                <<<"$pr_json")
+    OWNER=$(jq  -r '.headRepositoryOwner.login' <<<"$pr_json")
+
+    log "picked #$NUMBER ($HEAD @ ${SHA:0:7}): $TITLE"
+
+    if [ "$OWNER" != "${REPO%%/*}" ]; then
+        log "  #$NUMBER comes from fork $OWNER -- cannot push a version bump to it"
+        summary "| #$NUMBER | | **stopped**: fork, cannot bump |"
+        exit 1
+    fi
+
+    check_mergeable "$NUMBER" || { summary "| #$NUMBER | | **stopped**: not mergeable |"; exit 1; }
+    if [ "$REQUIRE_CHECKS" = 'true' ]; then
+        check_green "$NUMBER" || { summary "| #$NUMBER | | **stopped**: checks not green |"; exit 1; }
+    fi
+
+    # Next version always comes off the base branch: the base is what the
+    # merge lands on, so it is what defines "next".
+    git show "origin/$BASE:$GRADLE_FILE" > /tmp/base-build.gradle
+    eval "$("$VERSION_SH" next /tmp/base-build.gradle | sed 's/^/new_/')"
+    log "  version -> $new_name ($new_code)"
+
+    if [ "$DRY_RUN" = 'true' ]; then
+        log "  dry run: would bump to $new_name and squash merge #$NUMBER"
+        summary "| #$NUMBER | → \`$new_name\` | dry run, nothing changed |"
+        log "dry run stops after one PR (nothing advances)"
+        break
+    fi
+
+    git fetch --quiet origin "$HEAD"
+    git checkout --quiet -B "$HEAD" "origin/$HEAD"
+
+    # Bring the branch up to the current base BEFORE bumping. Every merge
+    # moves the version on the base, so a branch cut at an older version
+    # would otherwise collide on exactly the two lines we are about to
+    # rewrite -- which is to say every PR after the first one in a drain.
+    if ! git merge --quiet --no-edit "origin/$BASE"; then
+        git merge --abort || true
+        log "  #$NUMBER conflicts with $BASE -- needs a human"
+        summary "| #$NUMBER | | **stopped**: conflicts with \`$BASE\` |"
+        exit 1
+    fi
+
+    pre_bump_sha=$(git rev-parse HEAD)
+    "$VERSION_SH" apply "$GRADLE_FILE" "$new_code" "$new_name"
+
+    merge_sha="$pre_bump_sha"
+    if git diff --quiet -- "$GRADLE_FILE"; then
+        log "  $GRADLE_FILE already at $new_name, nothing to commit"
+    else
+        git add "$GRADLE_FILE"
+        git commit --quiet -m "version: bump to $new_name"
+        merge_sha=$(git rev-parse HEAD)
+        verify_version_only_diff "$pre_bump_sha" "$merge_sha" \
+            || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump was not version-only |"; exit 1; }
+    fi
+
+    if [ "$merge_sha" != "$SHA" ]; then
+        push_with_retry "$HEAD" \
+            || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"; exit 1; }
+    fi
+
+    ARGS=(--repo "$REPO" --squash --match-head-commit "$merge_sha")
+    if [ "$DELETE_BRANCH" = 'true' ]; then
+        ARGS+=(--delete-branch)
+    fi
+    if ! gh pr merge "$NUMBER" "${ARGS[@]}"; then
+        log "  merge of #$NUMBER refused"
+        summary "| #$NUMBER | → \`$new_name\` | **stopped**: merge refused |"
+        exit 1
+    fi
+    log "  merged #$NUMBER"
+
+    git fetch --quiet origin "$BASE"
+
+    merged_count=$((merged_count + 1))
+    merged_list="$merged_list #$NUMBER"
+
+    # Whatever the merge produced on the base branch is what CI now runs on:
+    # on master that is test + release, on a test branch test + build.
+    base_sha=$(git rev-parse "origin/$BASE")
+    if ! wait_for_runs "$base_sha"; then
+        summary "| #$NUMBER | → \`$new_name\` | merged, but **workflows failed** -- stopping |"
+        log "stopping: post-merge workflows failed after #$NUMBER"
+        exit 1
+    fi
+
+    summary "| #$NUMBER | → \`$new_name\` | merged, workflows green |"
+done
+
+log "done: merged $merged_count PR(s):${merged_list:- none}"
+summary ""
+summary "**merged $merged_count PR(s)**:${merged_list:- none}"

--- a/.github/scripts/coauthors.sh
+++ b/.github/scripts/coauthors.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Build the squash commit body for a PR.
+#
+# The PR description itself is thrown away -- it is release-note noise by the
+# time it reaches the commit log. What survives is attribution: one
+# Co-authored-by line per real person who worked on the PR and is a
+# collaborator on this repository, followed by the repo owner on anything
+# they did not author themselves.
+#
+# Who gets dropped, and why:
+#
+#   * coding agents. An agent either commits as a Bot account (filtered by
+#     type) or leaves a trailer whose address is not a GitHub account
+#     (`Co-Authored-By: Claude <noreply@anthropic.com>`). Only trailers whose
+#     address ties back to a real account survive, so agents fall out without
+#     needing a denylist to chase.
+#   * non-collaborators. Checked against the repository's collaborator list.
+#   * the PR author. They are already the commit author; listing them again
+#     would credit the same person twice.
+#
+# Usage: REPO=owner/name PR=123 coauthors.sh
+# Prints the body on stdout; empty output is a legitimate result.
+#
+set -euo pipefail
+
+REPO="${REPO:?}"
+PR="${PR:?}"
+# Appended to every PR this person did not author themselves.
+OWNER_LOGIN="${OWNER_LOGIN:-dogi}"
+
+lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+noreply_for() { printf '%s <%s@users.noreply.github.com>' "$1" "$1"; }
+
+# ------------------------------------------------------------- gather
+
+# Listing collaborators needs push access. If it fails we stop rather than
+# quietly emitting a commit with nobody credited.
+collaborators=$(
+    gh api "repos/$REPO/collaborators?per_page=100" --paginate \
+        --jq '.[] | select(.type == "User") | .login' | tr '[:upper:]' '[:lower:]' | sort -u
+)
+
+pr_json=$(gh pr view "$PR" --repo "$REPO" --json author,body)
+author_login=$(jq -r '.author.login // ""' <<<"$pr_json")
+pr_body=$(jq -r '.body // ""' <<<"$pr_json")
+
+commits=$(gh api "repos/$REPO/pulls/$PR/commits?per_page=100" --paginate)
+
+candidates=""
+
+# Commit authors GitHub already resolved to an account. Bot accounts carry
+# type "Bot" and are skipped here.
+while IFS= read -r login; do
+    if [ -n "$login" ]; then
+        candidates+="$login"$'\n'
+    fi
+done < <(jq -r '.[] | select(.author != null) | select(.author.type == "User") | .author.login' <<<"$commits")
+
+# Co-authored-by trailers, from both the commit messages and the PR body.
+trailers=$(
+    { jq -r '.[].commit.message' <<<"$commits"; printf '%s\n' "$pr_body"; } \
+    | grep -iE '^[[:space:]]*co-authored-by:[[:space:]]*' || true
+)
+
+while IFS= read -r line; do
+    if [ -z "$line" ]; then
+        continue
+    fi
+    email=$(sed -nE 's/.*<([^>]+)>.*/\1/p' <<<"$line")
+    case "$email" in
+        *@users.noreply.github.com)
+            login=${email%@users.noreply.github.com}
+            login=${login#*+}   # drop the numeric id prefix, if any
+            candidates+="$login"$'\n'
+            ;;
+        *)
+            # Not a GitHub address, so it cannot be tied to an account or
+            # checked against the collaborator list. This is the branch that
+            # removes the coding agents.
+            ;;
+    esac
+done <<<"$trailers"
+
+# ------------------------------------------------------------- filter
+
+author_l=$(lower "$author_login")
+owner_l=$(lower "$OWNER_LOGIN")
+
+body=""
+seen=""
+
+while IFS= read -r login; do
+    if [ -z "$login" ]; then
+        continue
+    fi
+    l=$(lower "$login")
+
+    case "$l" in
+        *'[bot]') continue ;;
+    esac
+    if [ "$l" = "$author_l" ]; then
+        continue                       # already the commit author
+    fi
+    if [ "$l" = "$owner_l" ]; then
+        continue                       # appended at the end instead
+    fi
+    if printf '%s' "$seen" | grep -qxF "$l"; then
+        continue
+    fi
+    if ! printf '%s' "$collaborators" | grep -qxF "$l"; then
+        continue
+    fi
+
+    seen+="$l"$'\n'
+    body+="Co-authored-by: $(noreply_for "$login")"$'\n'
+done <<<"$candidates"
+
+if [ -n "$author_l" ] && [ "$author_l" != "$owner_l" ]; then
+    body+="Co-authored-by: $(noreply_for "$OWNER_LOGIN")"$'\n'
+fi
+
+printf '%s' "$body"

--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -47,8 +47,10 @@ next_version() {
     local file=$1
     read_version "$file"
 
-    [[ "$cur_name" =~ ^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$ ]] \
-        || die "versionName '$cur_name' is not <major>.<minor>.<patch> with 1-2 digits per block"
+    # minor and patch are the carry blocks and stay at two digits; major is
+    # left wider so the script does not become the thing that breaks at 1.0.0.
+    [[ "$cur_name" =~ ^([0-9]{1,3})\.([0-9]{1,2})\.([0-9]{1,2})$ ]] \
+        || die "versionName '$cur_name' is not <major>.<minor>.<patch> with 1-2 digits in the minor and patch blocks"
 
     local major=$((10#${BASH_REMATCH[1]}))
     local minor=$((10#${BASH_REMATCH[2]}))

--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# myPlanet version helper.
+#
+# The two version fields in app/build.gradle are kept in lockstep:
+#
+#   versionName = "<major>.<minor>.<patch>"   e.g. 0.63.0
+#   versionCode = major*10000 + minor*100 + patch    e.g. 6300
+#
+# Each block is 0..99, printed without zero padding, so a patch rollover
+# carries into the minor block (and a minor rollover into the major block):
+#
+#   0.62.97 / 6297  ->  0.62.98 / 6298
+#   0.62.99 / 6299  ->  0.63.0  / 6300
+#   0.99.99 / 9999  ->  1.0.0   / 10000
+#
+# Because of that encoding the bumped code is always exactly the old code
+# plus one; the script asserts that as a guard against a hand-edited file
+# where name and code have drifted apart.
+#
+# Usage:
+#   version.sh read <gradle-file>
+#       Print "code=<n>" and "name=<x.y.z>" for the current version.
+#
+#   version.sh next <gradle-file>
+#       Print "code=<n>" and "name=<x.y.z>" for the *next* version.
+#
+#   version.sh apply <gradle-file> <code> <name>
+#       Rewrite the versionCode/versionName lines in place.
+#
+set -euo pipefail
+
+die() { echo "version.sh: $*" >&2; exit 1; }
+
+read_version() {
+    local file=$1
+    [ -f "$file" ] || die "no such file: $file"
+
+    cur_code=$(sed -nE 's/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*([0-9]+).*/\1/p' "$file" | head -1)
+    cur_name=$(sed -nE 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$file" | head -1)
+
+    [ -n "$cur_code" ] || die "could not find versionCode in $file"
+    [ -n "$cur_name" ] || die "could not find versionName in $file"
+}
+
+next_version() {
+    local file=$1
+    read_version "$file"
+
+    [[ "$cur_name" =~ ^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$ ]] \
+        || die "versionName '$cur_name' is not <major>.<minor>.<patch> with 1-2 digits per block"
+
+    local major=$((10#${BASH_REMATCH[1]}))
+    local minor=$((10#${BASH_REMATCH[2]}))
+    local patch=$((10#${BASH_REMATCH[3]}))
+
+    patch=$((patch + 1))
+    if [ "$patch" -gt 99 ]; then
+        patch=0
+        minor=$((minor + 1))
+    fi
+    if [ "$minor" -gt 99 ]; then
+        minor=0
+        major=$((major + 1))
+    fi
+
+    new_name="${major}.${minor}.${patch}"
+    new_code=$((major * 10000 + minor * 100 + patch))
+
+    local expected=$((10#$cur_code + 1))
+    [ "$new_code" -eq "$expected" ] || die \
+        "versionCode $cur_code and versionName $cur_name disagree: bumping the name gives code $new_code but the file implies $expected. Fix app/build.gradle by hand."
+}
+
+apply_version() {
+    local file=$1 code=$2 name=$3
+    [ -f "$file" ] || die "no such file: $file"
+
+    sed -i -E \
+        -e "s/^([[:space:]]*versionCode[[:space:]]*=[[:space:]]*)[0-9]+/\1${code}/" \
+        -e "s/^([[:space:]]*versionName[[:space:]]*=[[:space:]]*\")[^\"]+\"/\1${name}\"/" \
+        "$file"
+
+    read_version "$file"
+    [ "$cur_code" = "$code" ] || die "failed to write versionCode $code into $file"
+    [ "$cur_name" = "$name" ] || die "failed to write versionName $name into $file"
+}
+
+case "${1:-}" in
+    read)
+        read_version "${2:?gradle file required}"
+        echo "code=$cur_code"
+        echo "name=$cur_name"
+        ;;
+    next)
+        next_version "${2:?gradle file required}"
+        echo "code=$new_code"
+        echo "name=$new_name"
+        ;;
+    apply)
+        apply_version "${2:?gradle file required}" "${3:?code required}" "${4:?name required}"
+        ;;
+    *)
+        die "usage: version.sh {read|next|apply} <gradle-file> [code] [name]"
+        ;;
+esac

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,291 @@
+name: myPlanet automerge
+
+# Manually started queue drainer.
+#
+# Picks the oldest (lowest number) open PR carrying the `automerge` label,
+# bumps the version in app/build.gradle, and squash merges it.
+#
+# One PR per run, on purpose: each merge changes the version that the next
+# PR has to bump from, so the runs are inherently sequential. Re-run (or
+# schedule) to take the next one.
+#
+# NOTE ON CI RE-RUNS: the version bump is pushed with GITHUB_TOKEN, and
+# pushes made with GITHUB_TOKEN deliberately do not trigger new workflow
+# runs. So the bump commit arrives without its own build/test run. That is
+# fine when `bump_target: branch` and the branch is not protected by
+# required status checks -- but if master requires checks on the head SHA,
+# the merge will be refused. Two ways out:
+#   * use `bump_target: base` (merge first, then commit the bump on top of
+#     the base branch), or
+#   * swap GITHUB_TOKEN for a PAT / GitHub App token in the checkout and
+#     push steps so CI re-runs on the bumped SHA.
+
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: 'label marking PRs as mergeable'
+        required: false
+        default: 'automerge'
+        type: string
+      base:
+        description: 'base branch to merge into (blank = workflow default)'
+        required: false
+        default: ''
+        type: string
+      bump_target:
+        description: 'where the version bump commit lands'
+        required: false
+        default: 'branch'
+        type: choice
+        options:
+          - branch
+          - base
+      require_checks:
+        description: 'refuse to merge unless the PR checks are green'
+        required: false
+        default: true
+        type: boolean
+      delete_branch:
+        description: 'delete the head branch after merging'
+        required: false
+        default: true
+        type: boolean
+      dry_run:
+        description: 'report what would happen, change nothing'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  statuses: read
+
+env:
+  # --- TESTING -------------------------------------------------------
+  # While trying this out, only drain PRs targeting the test branch.
+  DEFAULT_BASE: claude/github-automerge-workflow-ge5yge
+  # Flip to this once the workflow has proven itself:
+  # DEFAULT_BASE: master
+  # -------------------------------------------------------------------
+  GRADLE_FILE: app/build.gradle
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  automerge:
+    name: myPlanet automerge
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout repository code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: resolve base branch
+        id: base
+        shell: bash
+        run: |
+          BASE="${{ inputs.base }}"
+          [ -n "$BASE" ] || BASE="$DEFAULT_BASE"
+          echo "ref=$BASE" >> "$GITHUB_OUTPUT"
+          echo "draining PRs into $BASE"
+
+      - name: pick oldest labelled pull request
+        id: pick
+        shell: bash
+        run: |
+          LABEL="${{ inputs.label }}"
+          BASE="${{ steps.base.outputs.ref }}"
+
+          # Lowest PR number wins -- "oldest" in this repo's terms.
+          PR=$(gh pr list \
+                --repo "$GITHUB_REPOSITORY" \
+                --state open \
+                --base "$BASE" \
+                --label "$LABEL" \
+                --limit 100 \
+                --json number,title,isDraft,headRefName,headRepositoryOwner,headRefOid \
+              | jq -c 'map(select(.isDraft | not)) | sort_by(.number) | first')
+
+          if [ "$PR" = "null" ] || [ -z "$PR" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "### nothing to merge" >> "$GITHUB_STEP_SUMMARY"
+            echo "No open, non-draft PR labelled \`$LABEL\` targets \`$BASE\`." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          NUMBER=$(jq -r '.number'                <<< "$PR")
+          TITLE=$(jq  -r '.title'                 <<< "$PR")
+          HEAD=$(jq   -r '.headRefName'           <<< "$PR")
+          SHA=$(jq    -r '.headRefOid'            <<< "$PR")
+          OWNER=$(jq  -r '.headRepositoryOwner.login' <<< "$PR")
+
+          if [ "$OWNER" != "${GITHUB_REPOSITORY%%/*}" ]; then
+            echo "PR #$NUMBER comes from fork $OWNER -- cannot push a version bump to it." >&2
+            exit 1
+          fi
+
+          {
+            echo "found=true"
+            echo "number=$NUMBER"
+            echo "title=$TITLE"
+            echo "head=$HEAD"
+            echo "sha=$SHA"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "picked #$NUMBER ($HEAD @ ${SHA:0:7}): $TITLE"
+
+      - name: check mergeability
+        if: steps.pick.outputs.found == 'true'
+        shell: bash
+        run: |
+          PR="${{ steps.pick.outputs.number }}"
+
+          # GitHub computes mergeability lazily; UNKNOWN just means "ask again".
+          for attempt in 1 2 3 4 5; do
+            STATE=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json mergeable --jq '.mergeable')
+            [ "$STATE" = "UNKNOWN" ] || break
+            echo "mergeability still UNKNOWN, retrying ($attempt/5)"
+            sleep 5
+          done
+
+          if [ "$STATE" != "MERGEABLE" ]; then
+            echo "PR #$PR is not mergeable (state: $STATE) -- resolve conflicts first." >&2
+            exit 1
+          fi
+          echo "PR #$PR is mergeable"
+
+      - name: check pull request checks
+        if: steps.pick.outputs.found == 'true' && inputs.require_checks
+        shell: bash
+        run: |
+          PR="${{ steps.pick.outputs.number }}"
+
+          CHECKS=$(gh pr checks "$PR" --repo "$GITHUB_REPOSITORY" --json name,bucket 2>/dev/null || true)
+          if [ -z "$CHECKS" ] || [ "$CHECKS" = "[]" ]; then
+            echo "PR #$PR reports no checks -- refusing to merge blind." >&2
+            echo "Re-run with require_checks: false to override." >&2
+            exit 1
+          fi
+
+          echo "$CHECKS" | jq -r '.[] | "  \(.bucket)\t\(.name)"'
+
+          BAD=$(jq -r '[.[] | select(.bucket != "pass" and .bucket != "skipping")] | length' <<< "$CHECKS")
+          if [ "$BAD" -ne 0 ]; then
+            echo "PR #$PR has $BAD check(s) that are not passing." >&2
+            exit 1
+          fi
+          echo "all checks green"
+
+      - name: compute next version
+        id: version
+        if: steps.pick.outputs.found == 'true'
+        shell: bash
+        run: |
+          BASE="${{ steps.base.outputs.ref }}"
+
+          # Read the version off the base branch, not the PR branch: the base
+          # is what the merge lands on, so it is what defines "next".
+          git show "origin/$BASE:$GRADLE_FILE" > /tmp/base-build.gradle
+
+          .github/scripts/version.sh read /tmp/base-build.gradle | sed 's/^/current_/' >> "$GITHUB_OUTPUT"
+          .github/scripts/version.sh next /tmp/base-build.gradle | sed 's/^/next_/'   >> "$GITHUB_OUTPUT"
+
+          echo "current: $(.github/scripts/version.sh read /tmp/base-build.gradle | tr '\n' ' ')"
+          echo "next:    $(.github/scripts/version.sh next /tmp/base-build.gradle | tr '\n' ' ')"
+
+      - name: summarise plan
+        if: steps.pick.outputs.found == 'true'
+        shell: bash
+        env:
+          # via env, never inlined: a PR title is attacker-controlled text
+          PR_TITLE: ${{ steps.pick.outputs.title }}
+          PR_HEAD: ${{ steps.pick.outputs.head }}
+        run: |
+          {
+            echo "### ${{ inputs.dry_run && 'dry run -- would merge' || 'merging' }} #${{ steps.pick.outputs.number }}"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| title | $PR_TITLE |"
+            echo "| head | \`$PR_HEAD\` @ \`${{ steps.pick.outputs.sha }}\` |"
+            echo "| base | \`${{ steps.base.outputs.ref }}\` |"
+            echo "| version | \`${{ steps.version.outputs.current_name }}\` (\`${{ steps.version.outputs.current_code }}\`) → \`${{ steps.version.outputs.next_name }}\` (\`${{ steps.version.outputs.next_code }}\`) |"
+            echo "| bump lands on | ${{ inputs.bump_target }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: bump version on head branch
+        id: bump
+        if: steps.pick.outputs.found == 'true' && inputs.bump_target == 'branch' && !inputs.dry_run
+        shell: bash
+        env:
+          HEAD: ${{ steps.pick.outputs.head }}
+        run: |
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git checkout -B "$HEAD" "origin/$HEAD"
+          .github/scripts/version.sh apply "$GRADLE_FILE" \
+            '${{ steps.version.outputs.next_code }}' '${{ steps.version.outputs.next_name }}'
+
+          if git diff --quiet -- "$GRADLE_FILE"; then
+            echo "$GRADLE_FILE already at the target version, nothing to commit"
+          else
+            git add "$GRADLE_FILE"
+            git commit -m 'version: bump to ${{ steps.version.outputs.next_name }}'
+            for delay in 0 2 4 8 16; do
+              [ "$delay" -eq 0 ] || sleep "$delay"
+              git push -u origin "$HEAD" && break
+            done
+          fi
+
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: merge pull request
+        id: merge
+        if: steps.pick.outputs.found == 'true' && !inputs.dry_run
+        shell: bash
+        run: |
+          PR="${{ steps.pick.outputs.number }}"
+          SHA="${{ steps.bump.outputs.sha || steps.pick.outputs.sha }}"
+
+          ARGS=(--repo "$GITHUB_REPOSITORY" --squash --match-head-commit "$SHA")
+          if [ '${{ inputs.delete_branch }}' = 'true' ]; then
+            ARGS+=(--delete-branch)
+          fi
+
+          gh pr merge "$PR" "${ARGS[@]}"
+          echo "merged #$PR at ${SHA:0:7}"
+
+      - name: bump version on base branch
+        if: steps.pick.outputs.found == 'true' && inputs.bump_target == 'base' && !inputs.dry_run
+        shell: bash
+        run: |
+          BASE="${{ steps.base.outputs.ref }}"
+
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git fetch origin "$BASE"
+          git checkout -B "$BASE" "origin/$BASE"
+          .github/scripts/version.sh apply "$GRADLE_FILE" \
+            '${{ steps.version.outputs.next_code }}' '${{ steps.version.outputs.next_name }}'
+
+          if git diff --quiet -- "$GRADLE_FILE"; then
+            echo "$GRADLE_FILE already at the target version, nothing to commit"
+          else
+            git add "$GRADLE_FILE"
+            git commit -m 'version: bump to ${{ steps.version.outputs.next_name }} (#${{ steps.pick.outputs.number }})'
+            for delay in 0 2 4 8 16; do
+              [ "$delay" -eq 0 ] || sleep "$delay"
+              git push origin "$BASE" && break
+            done
+          fi
+
+      - name: report result
+        if: steps.pick.outputs.found == 'true' && !inputs.dry_run && success()
+        shell: bash
+        run: |
+          echo "### merged #${{ steps.pick.outputs.number }} at \`${{ steps.version.outputs.next_name }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -91,12 +91,7 @@ permissions:
   actions: read
 
 env:
-  # --- TESTING -------------------------------------------------------
-  # While trying this out, only drain PRs targeting the test branch.
-  DEFAULT_BASE: claude/github-automerge-workflow-ge5yge
-  # Flip to this once the workflow has proven itself:
-  # DEFAULT_BASE: master
-  # -------------------------------------------------------------------
+  DEFAULT_BASE: master
   GRADLE_FILE: app/build.gradle
 
 jobs:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,23 +2,36 @@ name: myPlanet automerge
 
 # Manually started queue drainer.
 #
-# Picks the oldest (lowest number) open PR carrying the `automerge` label,
-# bumps the version in app/build.gradle, and squash merges it.
+# Loops: pick the lowest-numbered open non-draft PR carrying the `automerge`
+# label, bump the version in app/build.gradle, squash merge it, wait for the
+# workflows the merge triggers on the base branch (test + release on master),
+# and stop on the first failure. Keeps going until no labelled PR is left.
 #
-# One PR per run, on purpose: each merge changes the version that the next
-# PR has to bump from, so the runs are inherently sequential. Re-run (or
-# schedule) to take the next one.
+# The label is the safety rail: the drainer only ever touches PRs somebody
+# deliberately marked, never "every open PR".
 #
-# NOTE ON CI RE-RUNS: the version bump is pushed with GITHUB_TOKEN, and
-# pushes made with GITHUB_TOKEN deliberately do not trigger new workflow
-# runs. So the bump commit arrives without its own build/test run. That is
-# fine when `bump_target: branch` and the branch is not protected by
-# required status checks -- but if master requires checks on the head SHA,
-# the merge will be refused. Two ways out:
-#   * use `bump_target: base` (merge first, then commit the bump on top of
-#     the base branch), or
-#   * swap GITHUB_TOKEN for a PAT / GitHub App token in the checkout and
-#     push steps so CI re-runs on the bumped SHA.
+# THREE THINGS WORTH KNOWING:
+#
+# * The bump has to ride along inside the squash commit. Bumping the base
+#   separately would push two commits per PR, and the first would re-run
+#   release.yml at a version that was already tagged and published. So the
+#   drainer bumps on the PR branch -- and therefore has to bring the branch
+#   up to the current base first, since every merge moves the version and an
+#   older branch would collide on exactly those two lines.
+#
+# * CI does not re-run on the bump. Pushes made with GITHUB_TOKEN
+#   deliberately do not trigger workflow runs, so the version-bump commit
+#   arrives without its own build. The drainer proves the bump changed
+#   nothing but the two version lines before carrying the PR's green verdict
+#   across it (see verify_version_only_diff). If the base branch has required
+#   status checks, GitHub will still refuse the merge -- swap GITHUB_TOKEN for
+#   a PAT or a GitHub App token so CI re-runs on the bumped SHA.
+#
+# * Checks are per-PR, not per-merged-state. Each PR was tested against the
+#   base as it was when the PR ran, not against the base as the drain leaves
+#   it. That is the tradeoff versus a real merge queue; it is why the drain
+#   waits for the base branch to go green after every single merge and stops
+#   dead on the first failure.
 
 on:
   workflow_dispatch:
@@ -33,24 +46,26 @@ on:
         required: false
         default: ''
         type: string
-      bump_target:
-        description: 'where the version bump commit lands'
-        required: false
-        default: 'branch'
-        type: choice
-        options:
-          - branch
-          - base
       require_checks:
         description: 'refuse to merge unless the PR checks are green'
         required: false
         default: true
         type: boolean
       delete_branch:
-        description: 'delete the head branch after merging'
+        description: 'delete each head branch after merging'
         required: false
         default: true
         type: boolean
+      max_merges:
+        description: 'stop after this many merges (0 = until the queue is empty)'
+        required: false
+        default: '0'
+        type: string
+      wait_timeout_minutes:
+        description: 'how long to wait for the base branch workflows after each merge'
+        required: false
+        default: '45'
+        type: string
       dry_run:
         description: 'report what would happen, change nothing'
         required: false
@@ -62,6 +77,7 @@ permissions:
   pull-requests: write
   checks: read
   statuses: read
+  actions: read
 
 env:
   # --- TESTING -------------------------------------------------------
@@ -71,221 +87,43 @@ env:
   # DEFAULT_BASE: master
   # -------------------------------------------------------------------
   GRADLE_FILE: app/build.gradle
-  GH_TOKEN: ${{ github.token }}
 
 jobs:
   automerge:
     name: myPlanet automerge
     runs-on: ubuntu-24.04
+    # A full drain is many merges, each waiting on a release build. GitHub
+    # caps a job at 6h; stay under it and re-dispatch to continue.
+    timeout-minutes: 350
     steps:
       - name: checkout repository code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - name: resolve base branch
-        id: base
+      - name: stage helper scripts outside the work tree
+        id: stage
         shell: bash
         run: |
-          BASE="${{ inputs.base }}"
-          [ -n "$BASE" ] || BASE="$DEFAULT_BASE"
-          echo "ref=$BASE" >> "$GITHUB_OUTPUT"
-          echo "draining PRs into $BASE"
+          # The drainer checks out PR branches, which would otherwise swap
+          # these scripts for PR-controlled copies mid-run. Take them from
+          # the trusted checkout now and run them from there.
+          mkdir -p "$RUNNER_TEMP/scripts"
+          cp .github/scripts/automerge.sh .github/scripts/version.sh "$RUNNER_TEMP/scripts/"
+          chmod +x "$RUNNER_TEMP/scripts/automerge.sh" "$RUNNER_TEMP/scripts/version.sh"
+          echo "dir=$RUNNER_TEMP/scripts" >> "$GITHUB_OUTPUT"
 
-      - name: pick oldest labelled pull request
-        id: pick
-        shell: bash
-        run: |
-          LABEL="${{ inputs.label }}"
-          BASE="${{ steps.base.outputs.ref }}"
-
-          # Lowest PR number wins -- "oldest" in this repo's terms.
-          PR=$(gh pr list \
-                --repo "$GITHUB_REPOSITORY" \
-                --state open \
-                --base "$BASE" \
-                --label "$LABEL" \
-                --limit 100 \
-                --json number,title,isDraft,headRefName,headRepositoryOwner,headRefOid \
-              | jq -c 'map(select(.isDraft | not)) | sort_by(.number) | first')
-
-          if [ "$PR" = "null" ] || [ -z "$PR" ]; then
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "### nothing to merge" >> "$GITHUB_STEP_SUMMARY"
-            echo "No open, non-draft PR labelled \`$LABEL\` targets \`$BASE\`." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          NUMBER=$(jq -r '.number'                <<< "$PR")
-          TITLE=$(jq  -r '.title'                 <<< "$PR")
-          HEAD=$(jq   -r '.headRefName'           <<< "$PR")
-          SHA=$(jq    -r '.headRefOid'            <<< "$PR")
-          OWNER=$(jq  -r '.headRepositoryOwner.login' <<< "$PR")
-
-          if [ "$OWNER" != "${GITHUB_REPOSITORY%%/*}" ]; then
-            echo "PR #$NUMBER comes from fork $OWNER -- cannot push a version bump to it." >&2
-            exit 1
-          fi
-
-          {
-            echo "found=true"
-            echo "number=$NUMBER"
-            echo "title=$TITLE"
-            echo "head=$HEAD"
-            echo "sha=$SHA"
-          } >> "$GITHUB_OUTPUT"
-
-          echo "picked #$NUMBER ($HEAD @ ${SHA:0:7}): $TITLE"
-
-      - name: check mergeability
-        if: steps.pick.outputs.found == 'true'
-        shell: bash
-        run: |
-          PR="${{ steps.pick.outputs.number }}"
-
-          # GitHub computes mergeability lazily; UNKNOWN just means "ask again".
-          for attempt in 1 2 3 4 5; do
-            STATE=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json mergeable --jq '.mergeable')
-            [ "$STATE" = "UNKNOWN" ] || break
-            echo "mergeability still UNKNOWN, retrying ($attempt/5)"
-            sleep 5
-          done
-
-          if [ "$STATE" != "MERGEABLE" ]; then
-            echo "PR #$PR is not mergeable (state: $STATE) -- resolve conflicts first." >&2
-            exit 1
-          fi
-          echo "PR #$PR is mergeable"
-
-      - name: check pull request checks
-        if: steps.pick.outputs.found == 'true' && inputs.require_checks
-        shell: bash
-        run: |
-          PR="${{ steps.pick.outputs.number }}"
-
-          CHECKS=$(gh pr checks "$PR" --repo "$GITHUB_REPOSITORY" --json name,bucket 2>/dev/null || true)
-          if [ -z "$CHECKS" ] || [ "$CHECKS" = "[]" ]; then
-            echo "PR #$PR reports no checks -- refusing to merge blind." >&2
-            echo "Re-run with require_checks: false to override." >&2
-            exit 1
-          fi
-
-          echo "$CHECKS" | jq -r '.[] | "  \(.bucket)\t\(.name)"'
-
-          BAD=$(jq -r '[.[] | select(.bucket != "pass" and .bucket != "skipping")] | length' <<< "$CHECKS")
-          if [ "$BAD" -ne 0 ]; then
-            echo "PR #$PR has $BAD check(s) that are not passing." >&2
-            exit 1
-          fi
-          echo "all checks green"
-
-      - name: compute next version
-        id: version
-        if: steps.pick.outputs.found == 'true'
-        shell: bash
-        run: |
-          BASE="${{ steps.base.outputs.ref }}"
-
-          # Read the version off the base branch, not the PR branch: the base
-          # is what the merge lands on, so it is what defines "next".
-          git show "origin/$BASE:$GRADLE_FILE" > /tmp/base-build.gradle
-
-          .github/scripts/version.sh read /tmp/base-build.gradle | sed 's/^/current_/' >> "$GITHUB_OUTPUT"
-          .github/scripts/version.sh next /tmp/base-build.gradle | sed 's/^/next_/'   >> "$GITHUB_OUTPUT"
-
-          echo "current: $(.github/scripts/version.sh read /tmp/base-build.gradle | tr '\n' ' ')"
-          echo "next:    $(.github/scripts/version.sh next /tmp/base-build.gradle | tr '\n' ' ')"
-
-      - name: summarise plan
-        if: steps.pick.outputs.found == 'true'
+      - name: drain the automerge queue
         shell: bash
         env:
-          # via env, never inlined: a PR title is attacker-controlled text
-          PR_TITLE: ${{ steps.pick.outputs.title }}
-          PR_HEAD: ${{ steps.pick.outputs.head }}
-        run: |
-          {
-            echo "### ${{ inputs.dry_run && 'dry run -- would merge' || 'merging' }} #${{ steps.pick.outputs.number }}"
-            echo
-            echo "| | |"
-            echo "|---|---|"
-            echo "| title | $PR_TITLE |"
-            echo "| head | \`$PR_HEAD\` @ \`${{ steps.pick.outputs.sha }}\` |"
-            echo "| base | \`${{ steps.base.outputs.ref }}\` |"
-            echo "| version | \`${{ steps.version.outputs.current_name }}\` (\`${{ steps.version.outputs.current_code }}\`) → \`${{ steps.version.outputs.next_name }}\` (\`${{ steps.version.outputs.next_code }}\`) |"
-            echo "| bump lands on | ${{ inputs.bump_target }} |"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: bump version on head branch
-        id: bump
-        if: steps.pick.outputs.found == 'true' && inputs.bump_target == 'branch' && !inputs.dry_run
-        shell: bash
-        env:
-          HEAD: ${{ steps.pick.outputs.head }}
-        run: |
-          git config user.name  'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-          git checkout -B "$HEAD" "origin/$HEAD"
-          .github/scripts/version.sh apply "$GRADLE_FILE" \
-            '${{ steps.version.outputs.next_code }}' '${{ steps.version.outputs.next_name }}'
-
-          if git diff --quiet -- "$GRADLE_FILE"; then
-            echo "$GRADLE_FILE already at the target version, nothing to commit"
-          else
-            git add "$GRADLE_FILE"
-            git commit -m 'version: bump to ${{ steps.version.outputs.next_name }}'
-            for delay in 0 2 4 8 16; do
-              [ "$delay" -eq 0 ] || sleep "$delay"
-              git push -u origin "$HEAD" && break
-            done
-          fi
-
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: merge pull request
-        id: merge
-        if: steps.pick.outputs.found == 'true' && !inputs.dry_run
-        shell: bash
-        run: |
-          PR="${{ steps.pick.outputs.number }}"
-          SHA="${{ steps.bump.outputs.sha || steps.pick.outputs.sha }}"
-
-          ARGS=(--repo "$GITHUB_REPOSITORY" --squash --match-head-commit "$SHA")
-          if [ '${{ inputs.delete_branch }}' = 'true' ]; then
-            ARGS+=(--delete-branch)
-          fi
-
-          gh pr merge "$PR" "${ARGS[@]}"
-          echo "merged #$PR at ${SHA:0:7}"
-
-      - name: bump version on base branch
-        if: steps.pick.outputs.found == 'true' && inputs.bump_target == 'base' && !inputs.dry_run
-        shell: bash
-        run: |
-          BASE="${{ steps.base.outputs.ref }}"
-
-          git config user.name  'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-          git fetch origin "$BASE"
-          git checkout -B "$BASE" "origin/$BASE"
-          .github/scripts/version.sh apply "$GRADLE_FILE" \
-            '${{ steps.version.outputs.next_code }}' '${{ steps.version.outputs.next_name }}'
-
-          if git diff --quiet -- "$GRADLE_FILE"; then
-            echo "$GRADLE_FILE already at the target version, nothing to commit"
-          else
-            git add "$GRADLE_FILE"
-            git commit -m 'version: bump to ${{ steps.version.outputs.next_name }} (#${{ steps.pick.outputs.number }})'
-            for delay in 0 2 4 8 16; do
-              [ "$delay" -eq 0 ] || sleep "$delay"
-              git push origin "$BASE" && break
-            done
-          fi
-
-      - name: report result
-        if: steps.pick.outputs.found == 'true' && !inputs.dry_run && success()
-        shell: bash
-        run: |
-          echo "### merged #${{ steps.pick.outputs.number }} at \`${{ steps.version.outputs.next_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ inputs.base || env.DEFAULT_BASE }}
+          LABEL: ${{ inputs.label }}
+          REQUIRE_CHECKS: ${{ inputs.require_checks }}
+          DELETE_BRANCH: ${{ inputs.delete_branch }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          MAX_MERGES: ${{ inputs.max_merges }}
+          WAIT_TIMEOUT_MIN: ${{ inputs.wait_timeout_minutes }}
+          VERSION_SH: ${{ steps.stage.outputs.dir }}/version.sh
+        run: '${{ steps.stage.outputs.dir }}/automerge.sh'

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,6 +10,12 @@ name: myPlanet automerge
 # The label is the safety rail: the drainer only ever touches PRs somebody
 # deliberately marked, never "every open PR".
 #
+# The PR description does not survive into the commit log. Each squash commit
+# is "<title> (#<number>)" plus Co-authored-by lines for the real people who
+# worked on it -- collaborators only, no coding agents, never the PR author
+# twice -- with the repo owner credited on anything they did not author. See
+# scripts/coauthors.sh.
+#
 # THREE THINGS WORTH KNOWING:
 #
 # * The bump has to ride along inside the squash commit. Bumping the base
@@ -45,6 +51,11 @@ on:
         description: 'base branch to merge into (blank = workflow default)'
         required: false
         default: ''
+        type: string
+      owner_login:
+        description: 'credited as co-author on every PR they did not author'
+        required: false
+        default: 'dogi'
         type: string
       require_checks:
         description: 'refuse to merge unless the PR checks are green'
@@ -109,8 +120,10 @@ jobs:
           # these scripts for PR-controlled copies mid-run. Take them from
           # the trusted checkout now and run them from there.
           mkdir -p "$RUNNER_TEMP/scripts"
-          cp .github/scripts/automerge.sh .github/scripts/version.sh "$RUNNER_TEMP/scripts/"
-          chmod +x "$RUNNER_TEMP/scripts/automerge.sh" "$RUNNER_TEMP/scripts/version.sh"
+          cp .github/scripts/automerge.sh \
+             .github/scripts/version.sh \
+             .github/scripts/coauthors.sh "$RUNNER_TEMP/scripts/"
+          chmod +x "$RUNNER_TEMP/scripts/"*.sh
           echo "dir=$RUNNER_TEMP/scripts" >> "$GITHUB_OUTPUT"
 
       - name: drain the automerge queue
@@ -126,4 +139,6 @@ jobs:
           MAX_MERGES: ${{ inputs.max_merges }}
           WAIT_TIMEOUT_MIN: ${{ inputs.wait_timeout_minutes }}
           VERSION_SH: ${{ steps.stage.outputs.dir }}/version.sh
+          COAUTHORS_SH: ${{ steps.stage.outputs.dir }}/coauthors.sh
+          OWNER_LOGIN: ${{ inputs.owner_login }}
         run: '${{ steps.stage.outputs.dir }}/automerge.sh'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6300
-        versionName = "0.63.0"
+        versionCode = 6301
+        versionName = "0.63.1"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
## Summary

Introduces an automated pull request merging workflow that selects the oldest open PR labeled with `automerge`, bumps the version in `app/build.gradle`, and performs a squash merge. This enables streamlined release management with manual trigger points and configurable merge strategies.

## Key Changes

- **`.github/workflows/automerge.yml`** (291 lines)
  - New workflow triggered manually via `workflow_dispatch` with configurable inputs:
    - `label`: PR label marking mergeable PRs (default: `automerge`)
    - `base`: Target base branch (defaults to test branch during rollout)
    - `bump_target`: Where version bump lands (`branch` or `base`)
    - `require_checks`: Enforce passing CI checks before merge
    - `delete_branch`: Clean up head branch post-merge
    - `dry_run`: Preview mode without making changes
  - Workflow steps:
    1. Resolves base branch from input or environment default
    2. Queries GitHub API to find oldest non-draft PR with the label
    3. Validates PR mergeability and (optionally) CI check status
    4. Computes next version using helper script
    5. Bumps version on either the PR branch or base branch (configurable)
    6. Performs squash merge with optional branch deletion
    7. Reports results to job summary
  - Includes detailed comments on CI re-run behavior and GITHUB_TOKEN limitations

- **`.github/scripts/version.sh`** (106 lines)
  - New bash helper for semantic version management
  - Maintains lockstep between `versionName` (e.g., `0.63.0`) and `versionCode` (e.g., `6300`)
  - Encoding: `versionCode = major*10000 + minor*100 + patch`
  - Three operations:
    - `read`: Extract current version from gradle file
    - `next`: Calculate next version with automatic rollover (e.g., `0.62.99` → `0.63.0`)
    - `apply`: Rewrite both fields in place with validation
  - Guards against hand-edited drift between name and code via assertion

## Notable Implementation Details

- **Sequential merging**: One PR per run by design; each merge changes the base version, making runs inherently sequential
- **Retry logic**: Version bump push includes exponential backoff (0, 2, 4, 8, 16 seconds) to handle transient failures
- **Mergeability polling**: Retries up to 5 times with 5-second delays since GitHub computes mergeability lazily
- **Fork detection**: Rejects PRs from forks to prevent inability to push version bump commits
- **Dry-run support**: Full workflow execution without side effects for validation
- **Currently targeting test branch** (`claude/github-automerge-workflow-ge5yge`) during rollout; ready to flip to `master` once proven

https://claude.ai/code/session_01YSAfUv3hGd9T61UVP3j6V4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow to process eligible pull requests, validate checks, update application versions, and squash-merge changes.
  * Added configurable dry-run support, branch cleanup, merge limits, wait times, and co-author attribution.

* **Bug Fixes**
  * Improved safeguards for version updates, merge conflicts, failed checks, and incomplete workflow runs.

* **Chores**
  * Updated the Android app to version 0.63.1 with version code 6301.
  * Improved semantic version validation and consistency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->