### PR TITLE
actions: smoother workflow automerge looping (fixes #15397)

### DIFF
--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -9,16 +9,16 @@
 #   2. bump the version on the PR branch
 #   3. push, and wait for the workflows that push triggers -- build and test
 #      run against the *prepared* commit, the exact tree that is about to land
-#   4. squash merge
+#   4. wait for $BASE to be settled and green, then squash merge
 #
 # Stop on the first failure; otherwise keep going until no labelled PR is left.
 #
-# Verification happens before the merge, not after it. The drain does not wait
-# for $BASE afterwards: release.yml only runs on master, it publishes rather
-# than gates, and blocking every PR behind a full signed release build was the
-# slow part. The next PR is prepared while that release runs. What the drain
-# still refuses to do is pile onto a base that has *already* gone red -- that
-# is a free lookup, not a wait (see base_already_failed).
+# Verification happens before the merge, not after it, and both waits sit in
+# front of step 4. That ordering is the whole point: while $BASE runs test and
+# release for the previous merge, this PR is already being prepared and built,
+# so the two overlap instead of queueing behind each other. Nothing merges
+# onto a base that is mid-release or red -- the drain just stops asking about
+# it at the moment it merged and starts asking at the moment it next needs to.
 #
 # Everything is driven by environment variables so the workflow stays thin.
 # This script is expected to run from a copy outside the work tree (see
@@ -51,6 +51,12 @@ summary() { [ -n "${GITHUB_STEP_SUMMARY:-}" ] && printf '%s\n' "$*" >> "$GITHUB_
 merged_count=0
 merged_list=""
 last_base_sha=""
+
+# A PR is re-prepared when $BASE moves under it. Bounded so a base that keeps
+# moving cannot spin the drain until the job times out.
+MAX_REPREPARES=2
+reprep_pr=""
+reprep_n=0
 
 # ---------------------------------------------------------------- helpers
 
@@ -90,10 +96,10 @@ runs_for() {
 runs_failed()  { jq '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length' <<<"$1"; }
 runs_pending() { jq '[.[] | select(.status != "completed")] | length' <<<"$1"; }
 
-# Which of $REQUIRED_WORKFLOWS have no successful run yet. Blank REQUIRED_WORKFLOWS
-# means "whatever ran is what we judge on".
+# Which of the comma-separated workflow names in $2 have no successful run
+# yet. A blank list means "whatever ran is what we judge on".
 runs_missing() {
-    jq -r --arg req "$REQUIRED_WORKFLOWS" '
+    jq -r --arg req "$2" '
         [ ($req | split(",")[] | gsub("^\\s+|\\s+$"; "")) | select(length > 0) ] as $need
         | ([ .[] | select(.status == "completed" and .conclusion == "success") | .name ] | unique) as $green
         | [ $need[] | select(. as $n | $green | index($n) | not) ]
@@ -102,10 +108,18 @@ runs_missing() {
 }
 
 # Wait for the workflows triggered by $sha. Green means: nothing failed,
-# nothing still running, and every required workflow has a successful run.
-# Fails fast on the first failing run rather than sitting out the rest.
+# nothing still running, and every workflow named in $need has a successful
+# run. Fails fast on the first failing run rather than sitting out the rest.
+#
+#   $need    comma-separated workflows that must have passed ('' = any)
+#   $absent  what "no runs at all" means: 'fail' or 'pass'
+#
+# The two callers want opposite things from $absent. For a commit we just
+# pushed, no runs means we never got a verdict, so merging would be merging
+# blind -- fail. For the base branch, no runs means there is simply nothing
+# in flight to wait for -- pass.
 wait_for_runs() {
-    local sha=$1
+    local sha=$1 need=$2 absent=$3
     local deadline=$(( SECONDS + WAIT_TIMEOUT_MIN * 60 ))
     local appear_deadline=$(( SECONDS + RUN_APPEAR_TIMEOUT_SEC ))
     local runs total pending failed missing announced=0
@@ -124,7 +138,7 @@ wait_for_runs() {
             fi
 
             pending=$(runs_pending "$runs")
-            missing=$(runs_missing "$runs")
+            missing=$(runs_missing "$runs" "$need")
 
             if [ "$pending" -eq 0 ] && [ -z "$missing" ]; then
                 jq -r '.[] | "    \(.conclusion)\t\(.name)"' <<<"$runs"
@@ -143,6 +157,10 @@ wait_for_runs() {
         if [ "$total" -eq 0 ] || { [ "${pending:-0}" -eq 0 ] && [ -n "${missing:-}" ]; }; then
             if [ "$SECONDS" -ge "$appear_deadline" ]; then
                 if [ "$total" -eq 0 ]; then
+                    if [ "$absent" = 'pass' ]; then
+                        log "  no workflow runs for ${sha:0:7} -- nothing to wait for"
+                        return 0
+                    fi
                     log "  no workflow runs exist for ${sha:0:7} -- refusing to merge blind"
                 else
                     log "  required workflow(s) never ran on ${sha:0:7}: $missing"
@@ -164,8 +182,10 @@ wait_for_runs() {
     done
 }
 
-# Non-blocking. The drain does not wait for $BASE after a merge, but it will
-# not stack another merge on top of one that has already reported a failure.
+# Non-blocking early exit, checked at the top of the loop: if the last merge
+# has *already* reported a failure there is no point preparing another PR, so
+# say so now rather than after a build. The blocking version of this question
+# is asked later, right before the merge (see step 4).
 base_already_failed() {
     local sha=$1 runs bad
     runs=$(runs_for "$sha")
@@ -235,6 +255,7 @@ while :; do
     fi
 
     git fetch --quiet origin "$BASE"
+    base_at_prepare=$(git rev-parse "origin/$BASE")
 
     pr_json=$(pick_pr)
     if [ "$pr_json" = "null" ] || [ -z "$pr_json" ]; then
@@ -298,12 +319,30 @@ while :; do
         exit 1
     fi
 
-    # 2. Bump. It rides inside the squash commit; bumping the base separately
-    #    would push two commits per PR and re-run release.yml at a version
-    #    that was already tagged and published.
+    # 2. Bump the version.
+    #
+    #    Every merge into master publishes a release, and release.yml takes
+    #    the tag it publishes (v0.62.98) straight from versionName in
+    #    app/build.gradle. So every merge needs its own new version number,
+    #    or the release overwrites the previous one.
+    #
+    #    The bump is written here, on the PR branch, so that it becomes part
+    #    of the squash commit -- one commit on master per PR, carrying both
+    #    the change and the version it ships as. Bumping master directly
+    #    instead would mean two commits per PR, and the first of them would
+    #    start a release build at a version that was already tagged.
+    #
+    #    "Next" is always computed from the base, never from this branch:
+    #    master is what the merge lands on, so master is what defines which
+    #    number is free. A branch cut weeks ago still says 0.62.97 while
+    #    master has moved to 0.62.98 -- which is also why step 1 had to merge
+    #    the base in first, or this write would land on top of a stale value.
     pre_bump_sha=$(git rev-parse HEAD)
     "$VERSION_SH" apply "$GRADLE_FILE" "$new_code" "$new_name"
 
+    # Already at the right version when a previous dispatch prepared this same
+    # PR and stopped before merging it. Nothing to redo -- the branch is the
+    # prepared commit, and CI has already run on it.
     merge_sha="$pre_bump_sha"
     if git diff --quiet -- "$GRADLE_FILE"; then
         log "  $GRADLE_FILE already at $new_name, nothing to commit"
@@ -324,15 +363,50 @@ while :; do
     fi
 
     if [ "$REQUIRE_CHECKS" = 'true' ]; then
-        wait_for_runs "$merge_sha" \
+        wait_for_runs "$merge_sha" "$REQUIRED_WORKFLOWS" fail \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: prepared commit not green |"; exit 1; }
     else
         log "  require_checks is off -- merging ${merge_sha:0:7} unverified"
     fi
 
-    # 4. Squash merge. Replace the PR description with just the attribution
-    #    that belongs in the commit log; the subject keeps the repo's
-    #    "<title> (#<number>)" shape.
+    # 4. Merge -- but only onto a settled, green base.
+    #
+    #    This is the wait that used to happen right after each merge. Asking
+    #    here instead is what buys the overlap: while $BASE was running test
+    #    and release for the previous merge, this PR was being prepared and
+    #    built, so by now that wait is usually already over. What it must not
+    #    do is merge onto a base that is still mid-release or has gone red.
+    if [ "$REQUIRE_CHECKS" = 'true' ]; then
+        git fetch --quiet origin "$BASE"
+        wait_for_runs "$(git rev-parse "origin/$BASE")" '' pass \
+            || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: \`$BASE\` is red |"; exit 1; }
+
+        # If $BASE moved while this PR was building -- somebody pushed to it
+        # directly, or a second drain is running -- the prepared commit was
+        # built against a base that no longer exists, and the version it
+        # claims may already be taken. Prepare the same PR again on the new
+        # base rather than merging a stale one.
+        git fetch --quiet origin "$BASE"
+        base_now=$(git rev-parse "origin/$BASE")
+        if [ "$base_now" != "$base_at_prepare" ]; then
+            if [ "$NUMBER" = "$reprep_pr" ]; then
+                reprep_n=$((reprep_n + 1))
+            else
+                reprep_pr="$NUMBER"; reprep_n=1
+            fi
+            if [ "$reprep_n" -gt "$MAX_REPREPARES" ]; then
+                log "  $BASE keeps moving under #$NUMBER -- giving up after $MAX_REPREPARES re-preparations"
+                summary "| #$NUMBER | → \`$new_name\` | **stopped**: \`$BASE\` moving under it |"
+                exit 1
+            fi
+            log "  $BASE moved to ${base_now:0:7} while #$NUMBER was building -- re-preparing it"
+            continue
+        fi
+    fi
+
+    #    Replace the PR description with just the attribution that belongs in
+    #    the commit log; the subject keeps the repo's "<title> (#<number>)"
+    #    shape.
     commit_body=$(REPO="$REPO" PR="$NUMBER" "$COAUTHORS_SH")
     if [ -n "$commit_body" ]; then
         log "  co-authors:"

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -7,12 +7,10 @@
 #   3. push, and wait for build + test on that prepared commit
 #   4. wait for $BASE to be settled and green, then squash merge
 #
-# Stop on the first failure, otherwise until no labelled PR is left. Both
-# waits sit in front of step 4 so they overlap: $BASE runs test and release
-# for the previous merge while this PR is prepared and built.
+# Stop on the first failure. Both waits sit in front of step 4 so they
+# overlap: $BASE releases the previous merge while this PR builds.
 #
-# Runs from a copy outside the work tree (see automerge.yml) -- it checks out
-# PR branches, and a script whose file is swapped underneath it is a bad time.
+# Runs from a copy outside the work tree -- it checks out PR branches.
 #
 set -euo pipefail
 
@@ -30,7 +28,6 @@ MAX_MERGES="${MAX_MERGES:-0}"
 WAIT_TIMEOUT_MIN="${WAIT_TIMEOUT_MIN:-45}"
 USING_PAT="${USING_PAT:-false}"
 
-# Grace period for a push's workflow runs to get queued.
 RUN_APPEAR_TIMEOUT_SEC=300
 
 log()     { printf '%s | %s\n' "$(date -u +%H:%M:%S)" "$*"; }
@@ -40,7 +37,6 @@ merged_count=0
 merged_list=""
 last_base_sha=""
 
-# Bounded so a $BASE that keeps moving cannot spin the drain forever.
 MAX_REPREPARES=2
 reprep_pr=""
 reprep_n=0
@@ -58,8 +54,7 @@ pick_pr() {
       | jq -c 'map(select(.isDraft | not)) | sort_by(.number) | first'
 }
 
-# Cheap early exit; UNKNOWN just means GitHub has not computed it yet. The
-# real conflict test is step 1.
+# Cheap early exit; the real conflict test is step 1.
 check_mergeable() {
     local pr=$1 state=""
     for _ in 1 2 3 4 5; do
@@ -73,7 +68,6 @@ check_mergeable() {
     fi
 }
 
-# Fetch the Actions runs for a commit as [{name, status, conclusion}].
 runs_for() {
     gh api "repos/$REPO/actions/runs?head_sha=$1&per_page=100" \
         --jq '[.workflow_runs[] | {name, status, conclusion}]' 2>/dev/null || echo '[]'
@@ -82,7 +76,7 @@ runs_for() {
 runs_failed()  { jq '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length' <<<"$1"; }
 runs_pending() { jq '[.[] | select(.status != "completed")] | length' <<<"$1"; }
 
-# Comma-separated names in $2 with no successful run yet; blank $2 = none.
+# Names in $2 with no successful run yet; blank $2 = none.
 runs_missing() {
     jq -r --arg req "$2" '
         [ ($req | split(",")[] | gsub("^\\s+|\\s+$"; "")) | select(length > 0) ] as $need
@@ -92,10 +86,8 @@ runs_missing() {
     ' <<<"$1"
 }
 
-# Wait for the workflows on $sha: green means nothing failed, nothing still
-# running, and every workflow named in $need passed. Fails fast on the first
-# failure. $absent is what "no runs at all" means -- 'fail' for a commit we
-# pushed (never verified), 'pass' for $BASE (nothing in flight).
+# Green: nothing failed, nothing running, every workflow in $need passed.
+# $absent = what no runs at all means: 'fail' (we pushed it), 'pass' ($BASE).
 wait_for_runs() {
     local sha=$1 need=$2 absent=$3
     local deadline=$(( SECONDS + WAIT_TIMEOUT_MIN * 60 ))
@@ -130,7 +122,6 @@ wait_for_runs() {
             fi
         fi
 
-        # Nothing running and something still absent: allow the grace period.
         if [ "$total" -eq 0 ] || { [ "${pending:-0}" -eq 0 ] && [ -n "${missing:-}" ]; }; then
             if [ "$SECONDS" -ge "$appear_deadline" ]; then
                 if [ "$total" -eq 0 ]; then
@@ -159,8 +150,7 @@ wait_for_runs() {
     done
 }
 
-# Non-blocking peek at the top of the loop, so an already-red $BASE stops the
-# drain before it spends a build. Step 4 does the blocking version.
+# Non-blocking peek; step 4 does the blocking version.
 base_already_failed() {
     local sha=$1 runs bad
     runs=$(runs_for "$sha")
@@ -171,8 +161,7 @@ base_already_failed() {
     return 0
 }
 
-# Guard against a broken version.sh: the bump must touch nothing but the two
-# version lines.
+# Guard against a broken version.sh.
 verify_version_only_diff() {
     local from=$1 to=$2 files bad
 
@@ -262,7 +251,6 @@ while :; do
     git fetch --quiet origin "$HEAD"
 
     if [ "$DRY_RUN" = 'true' ]; then
-        # Merge locally and detached so the report is real. Nothing is pushed.
         git checkout --quiet --detach "origin/$HEAD"
         if git merge --quiet --no-edit "origin/$BASE"; then
             log "  dry run: merges cleanly with $BASE, would bump to $new_name,"
@@ -279,9 +267,8 @@ while :; do
 
     git checkout --quiet -B "$HEAD" "origin/$HEAD"
 
-    # 1. Merge the base in first: it moves the version on every merge, so a
-    #    branch cut earlier collides on the exact lines step 2 rewrites. It
-    #    also makes the tree CI tests in step 3 the tree that lands.
+    # 1. Base first: a branch cut earlier collides on the exact version lines
+    #    step 2 rewrites, and this makes step 3 test what actually lands.
     if ! git merge --quiet --no-edit "origin/$BASE"; then
         git merge --abort || true
         log "  #$NUMBER conflicts with $BASE -- needs a human"
@@ -289,15 +276,11 @@ while :; do
         exit 1
     fi
 
-    # 2. Bump. Every merge into $BASE publishes a release tagged from
-    #    versionName, so every merge needs its own number. Writing it here
-    #    puts it inside the squash commit -- one commit per PR. Bumping $BASE
-    #    separately would push two, the first releasing an already-tagged
-    #    version.
+    # 2. Bump. Every merge publishes a release tagged from versionName, so
+    #    each needs its own number; writing it here puts it in the squash.
     pre_bump_sha=$(git rev-parse HEAD)
     "$VERSION_SH" apply "$GRADLE_FILE" "$new_code" "$new_name"
 
-    # Already right when an earlier dispatch prepared this PR and then stopped.
     merge_sha="$pre_bump_sha"
     if git diff --quiet -- "$GRADLE_FILE"; then
         log "  $GRADLE_FILE already at $new_name, nothing to commit"
@@ -324,15 +307,13 @@ while :; do
         log "  require_checks is off -- merging ${merge_sha:0:7} unverified"
     fi
 
-    # 4. Merge, but only onto a settled green base. Asking here rather than
-    #    right after the previous merge is what buys the overlap.
+    # 4. Merge, but only onto a settled green base.
     if [ "$REQUIRE_CHECKS" = 'true' ]; then
         git fetch --quiet origin "$BASE"
         wait_for_runs "$(git rev-parse "origin/$BASE")" '' pass \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: \`$BASE\` is red |"; exit 1; }
 
-        # $BASE moved under us: the prepared commit was built against a base
-        # that no longer exists and its version may be taken. Prepare again.
+        # Prepared against a base that no longer exists; prepare again.
         git fetch --quiet origin "$BASE"
         base_now=$(git rev-parse "origin/$BASE")
         if [ "$base_now" != "$base_at_prepare" ]; then
@@ -351,7 +332,6 @@ while :; do
         fi
     fi
 
-    # Only the attribution belongs in the commit log, not the PR description.
     commit_body=$(REPO="$REPO" PR="$NUMBER" "$COAUTHORS_SH")
     if [ -n "$commit_body" ]; then
         log "  co-authors:"

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -1,29 +1,18 @@
 #!/usr/bin/env bash
 #
-# Drain the automerge queue.
-#
-# Repeatedly: pick the lowest-numbered open non-draft PR carrying $LABEL and
-# take it through four steps, in this order:
+# Drain the automerge queue. Per PR labelled $LABEL, lowest number first:
 #
 #   1. merge $BASE into the PR branch          (a conflict stops the drain)
 #   2. bump the version on the PR branch
-#   3. push, and wait for the workflows that push triggers -- build and test
-#      run against the *prepared* commit, the exact tree that is about to land
+#   3. push, and wait for build + test on that prepared commit
 #   4. wait for $BASE to be settled and green, then squash merge
 #
-# Stop on the first failure; otherwise keep going until no labelled PR is left.
+# Stop on the first failure, otherwise until no labelled PR is left. Both
+# waits sit in front of step 4 so they overlap: $BASE runs test and release
+# for the previous merge while this PR is prepared and built.
 #
-# Verification happens before the merge, not after it, and both waits sit in
-# front of step 4. That ordering is the whole point: while $BASE runs test and
-# release for the previous merge, this PR is already being prepared and built,
-# so the two overlap instead of queueing behind each other. Nothing merges
-# onto a base that is mid-release or red -- the drain just stops asking about
-# it at the moment it merged and starts asking at the moment it next needs to.
-#
-# Everything is driven by environment variables so the workflow stays thin.
-# This script is expected to run from a copy outside the work tree (see
-# automerge.yml) -- it checks out PR branches, and a running bash script
-# whose file is swapped underneath it is a bad time.
+# Runs from a copy outside the work tree (see automerge.yml) -- it checks out
+# PR branches, and a script whose file is swapped underneath it is a bad time.
 #
 set -euo pipefail
 
@@ -41,8 +30,7 @@ MAX_MERGES="${MAX_MERGES:-0}"
 WAIT_TIMEOUT_MIN="${WAIT_TIMEOUT_MIN:-45}"
 USING_PAT="${USING_PAT:-false}"
 
-# How long to give workflow runs to show up for a commit before concluding
-# that none are coming. A push only queues its runs a few seconds later.
+# Grace period for a push's workflow runs to get queued.
 RUN_APPEAR_TIMEOUT_SEC=300
 
 log()     { printf '%s | %s\n' "$(date -u +%H:%M:%S)" "$*"; }
@@ -52,8 +40,7 @@ merged_count=0
 merged_list=""
 last_base_sha=""
 
-# A PR is re-prepared when $BASE moves under it. Bounded so a base that keeps
-# moving cannot spin the drain until the job times out.
+# Bounded so a $BASE that keeps moving cannot spin the drain forever.
 MAX_REPREPARES=2
 reprep_pr=""
 reprep_n=0
@@ -71,9 +58,8 @@ pick_pr() {
       | jq -c 'map(select(.isDraft | not)) | sort_by(.number) | first'
 }
 
-# GitHub computes mergeability lazily; UNKNOWN just means "ask again". This is
-# only an early, cheap "don't bother" -- the real conflict test is step 1, the
-# actual merge of $BASE into the branch.
+# Cheap early exit; UNKNOWN just means GitHub has not computed it yet. The
+# real conflict test is step 1.
 check_mergeable() {
     local pr=$1 state=""
     for _ in 1 2 3 4 5; do
@@ -96,8 +82,7 @@ runs_for() {
 runs_failed()  { jq '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length' <<<"$1"; }
 runs_pending() { jq '[.[] | select(.status != "completed")] | length' <<<"$1"; }
 
-# Which of the comma-separated workflow names in $2 have no successful run
-# yet. A blank list means "whatever ran is what we judge on".
+# Comma-separated names in $2 with no successful run yet; blank $2 = none.
 runs_missing() {
     jq -r --arg req "$2" '
         [ ($req | split(",")[] | gsub("^\\s+|\\s+$"; "")) | select(length > 0) ] as $need
@@ -107,17 +92,10 @@ runs_missing() {
     ' <<<"$1"
 }
 
-# Wait for the workflows triggered by $sha. Green means: nothing failed,
-# nothing still running, and every workflow named in $need has a successful
-# run. Fails fast on the first failing run rather than sitting out the rest.
-#
-#   $need    comma-separated workflows that must have passed ('' = any)
-#   $absent  what "no runs at all" means: 'fail' or 'pass'
-#
-# The two callers want opposite things from $absent. For a commit we just
-# pushed, no runs means we never got a verdict, so merging would be merging
-# blind -- fail. For the base branch, no runs means there is simply nothing
-# in flight to wait for -- pass.
+# Wait for the workflows on $sha: green means nothing failed, nothing still
+# running, and every workflow named in $need passed. Fails fast on the first
+# failure. $absent is what "no runs at all" means -- 'fail' for a commit we
+# pushed (never verified), 'pass' for $BASE (nothing in flight).
 wait_for_runs() {
     local sha=$1 need=$2 absent=$3
     local deadline=$(( SECONDS + WAIT_TIMEOUT_MIN * 60 ))
@@ -152,8 +130,7 @@ wait_for_runs() {
             fi
         fi
 
-        # Nothing running and something still absent: give runs the appearance
-        # window to get queued, then call it.
+        # Nothing running and something still absent: allow the grace period.
         if [ "$total" -eq 0 ] || { [ "${pending:-0}" -eq 0 ] && [ -n "${missing:-}" ]; }; then
             if [ "$SECONDS" -ge "$appear_deadline" ]; then
                 if [ "$total" -eq 0 ]; then
@@ -182,10 +159,8 @@ wait_for_runs() {
     done
 }
 
-# Non-blocking early exit, checked at the top of the loop: if the last merge
-# has *already* reported a failure there is no point preparing another PR, so
-# say so now rather than after a build. The blocking version of this question
-# is asked later, right before the merge (see step 4).
+# Non-blocking peek at the top of the loop, so an already-red $BASE stops the
+# drain before it spends a build. Step 4 does the blocking version.
 base_already_failed() {
     local sha=$1 runs bad
     runs=$(runs_for "$sha")
@@ -196,9 +171,8 @@ base_already_failed() {
     return 0
 }
 
-# The bump is a machine edit on top of a tree CI is about to test anyway, so
-# this is a guard against a broken version.sh rather than a gate: if it ever
-# rewrites something other than the two version lines, stop before pushing.
+# Guard against a broken version.sh: the bump must touch nothing but the two
+# version lines.
 verify_version_only_diff() {
     local from=$1 to=$2 files bad
 
@@ -280,8 +254,7 @@ while :; do
 
     check_mergeable "$NUMBER" || { summary "| #$NUMBER | | **stopped**: not mergeable |"; exit 1; }
 
-    # Next version always comes off the base branch: the base is what the
-    # merge lands on, so it is what defines "next".
+    # "Next" comes off the base -- it is what the merge lands on.
     git show "origin/$BASE:$GRADLE_FILE" > /tmp/base-build.gradle
     eval "$("$VERSION_SH" next /tmp/base-build.gradle | sed 's/^/new_/')"
     log "  version -> $new_name ($new_code)"
@@ -289,8 +262,7 @@ while :; do
     git fetch --quiet origin "$HEAD"
 
     if [ "$DRY_RUN" = 'true' ]; then
-        # Merge for real, locally and detached, so the report can say whether
-        # step 1 would actually work. Nothing is pushed.
+        # Merge locally and detached so the report is real. Nothing is pushed.
         git checkout --quiet --detach "origin/$HEAD"
         if git merge --quiet --no-edit "origin/$BASE"; then
             log "  dry run: merges cleanly with $BASE, would bump to $new_name,"
@@ -307,11 +279,9 @@ while :; do
 
     git checkout --quiet -B "$HEAD" "origin/$HEAD"
 
-    # 1. Merge the base in. Every merge moves the version on the base, so a
-    #    branch cut at an older version would collide on exactly the two lines
-    #    the bump is about to rewrite -- which is to say every PR after the
-    #    first one in a drain. Doing it first also means the tree CI tests in
-    #    step 3 is the tree that lands, not an older approximation of it.
+    # 1. Merge the base in first: it moves the version on every merge, so a
+    #    branch cut earlier collides on the exact lines step 2 rewrites. It
+    #    also makes the tree CI tests in step 3 the tree that lands.
     if ! git merge --quiet --no-edit "origin/$BASE"; then
         git merge --abort || true
         log "  #$NUMBER conflicts with $BASE -- needs a human"
@@ -319,30 +289,15 @@ while :; do
         exit 1
     fi
 
-    # 2. Bump the version.
-    #
-    #    Every merge into master publishes a release, and release.yml takes
-    #    the tag it publishes (v0.62.98) straight from versionName in
-    #    app/build.gradle. So every merge needs its own new version number,
-    #    or the release overwrites the previous one.
-    #
-    #    The bump is written here, on the PR branch, so that it becomes part
-    #    of the squash commit -- one commit on master per PR, carrying both
-    #    the change and the version it ships as. Bumping master directly
-    #    instead would mean two commits per PR, and the first of them would
-    #    start a release build at a version that was already tagged.
-    #
-    #    "Next" is always computed from the base, never from this branch:
-    #    master is what the merge lands on, so master is what defines which
-    #    number is free. A branch cut weeks ago still says 0.62.97 while
-    #    master has moved to 0.62.98 -- which is also why step 1 had to merge
-    #    the base in first, or this write would land on top of a stale value.
+    # 2. Bump. Every merge into $BASE publishes a release tagged from
+    #    versionName, so every merge needs its own number. Writing it here
+    #    puts it inside the squash commit -- one commit per PR. Bumping $BASE
+    #    separately would push two, the first releasing an already-tagged
+    #    version.
     pre_bump_sha=$(git rev-parse HEAD)
     "$VERSION_SH" apply "$GRADLE_FILE" "$new_code" "$new_name"
 
-    # Already at the right version when a previous dispatch prepared this same
-    # PR and stopped before merging it. Nothing to redo -- the branch is the
-    # prepared commit, and CI has already run on it.
+    # Already right when an earlier dispatch prepared this PR and then stopped.
     merge_sha="$pre_bump_sha"
     if git diff --quiet -- "$GRADLE_FILE"; then
         log "  $GRADLE_FILE already at $new_name, nothing to commit"
@@ -369,23 +324,15 @@ while :; do
         log "  require_checks is off -- merging ${merge_sha:0:7} unverified"
     fi
 
-    # 4. Merge -- but only onto a settled, green base.
-    #
-    #    This is the wait that used to happen right after each merge. Asking
-    #    here instead is what buys the overlap: while $BASE was running test
-    #    and release for the previous merge, this PR was being prepared and
-    #    built, so by now that wait is usually already over. What it must not
-    #    do is merge onto a base that is still mid-release or has gone red.
+    # 4. Merge, but only onto a settled green base. Asking here rather than
+    #    right after the previous merge is what buys the overlap.
     if [ "$REQUIRE_CHECKS" = 'true' ]; then
         git fetch --quiet origin "$BASE"
         wait_for_runs "$(git rev-parse "origin/$BASE")" '' pass \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: \`$BASE\` is red |"; exit 1; }
 
-        # If $BASE moved while this PR was building -- somebody pushed to it
-        # directly, or a second drain is running -- the prepared commit was
-        # built against a base that no longer exists, and the version it
-        # claims may already be taken. Prepare the same PR again on the new
-        # base rather than merging a stale one.
+        # $BASE moved under us: the prepared commit was built against a base
+        # that no longer exists and its version may be taken. Prepare again.
         git fetch --quiet origin "$BASE"
         base_now=$(git rev-parse "origin/$BASE")
         if [ "$base_now" != "$base_at_prepare" ]; then
@@ -404,9 +351,7 @@ while :; do
         fi
     fi
 
-    #    Replace the PR description with just the attribution that belongs in
-    #    the commit log; the subject keeps the repo's "<title> (#<number>)"
-    #    shape.
+    # Only the attribution belongs in the commit log, not the PR description.
     commit_body=$(REPO="$REPO" PR="$NUMBER" "$COAUTHORS_SH")
     if [ -n "$commit_body" ]; then
         log "  co-authors:"

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -2,10 +2,23 @@
 #
 # Drain the automerge queue.
 #
-# Repeatedly: pick the lowest-numbered open non-draft PR carrying $LABEL,
-# verify it is mergeable and green, bump the version, squash merge it, then
-# wait for the workflows the merge kicks off on $BASE. Stop on the first
-# failure; otherwise keep going until no labelled PR is left.
+# Repeatedly: pick the lowest-numbered open non-draft PR carrying $LABEL and
+# take it through four steps, in this order:
+#
+#   1. merge $BASE into the PR branch          (a conflict stops the drain)
+#   2. bump the version on the PR branch
+#   3. push, and wait for the workflows that push triggers -- build and test
+#      run against the *prepared* commit, the exact tree that is about to land
+#   4. squash merge
+#
+# Stop on the first failure; otherwise keep going until no labelled PR is left.
+#
+# Verification happens before the merge, not after it. The drain does not wait
+# for $BASE afterwards: release.yml only runs on master, it publishes rather
+# than gates, and blocking every PR behind a full signed release build was the
+# slow part. The next PR is prepared while that release runs. What the drain
+# still refuses to do is pile onto a base that has *already* gone red -- that
+# is a free lookup, not a wait (see base_already_failed).
 #
 # Everything is driven by environment variables so the workflow stays thin.
 # This script is expected to run from a copy outside the work tree (see
@@ -21,18 +34,23 @@ GRADLE_FILE="${GRADLE_FILE:?}"
 VERSION_SH="${VERSION_SH:?}"
 COAUTHORS_SH="${COAUTHORS_SH:?}"
 REQUIRE_CHECKS="${REQUIRE_CHECKS:-true}"
+REQUIRED_WORKFLOWS="${REQUIRED_WORKFLOWS:-}"
 DELETE_BRANCH="${DELETE_BRANCH:-true}"
 DRY_RUN="${DRY_RUN:-true}"
 MAX_MERGES="${MAX_MERGES:-0}"
 WAIT_TIMEOUT_MIN="${WAIT_TIMEOUT_MIN:-45}"
-WAIT_FOR_BUMP_CHECKS="${WAIT_FOR_BUMP_CHECKS:-false}"
 USING_PAT="${USING_PAT:-false}"
+
+# How long to give workflow runs to show up for a commit before concluding
+# that none are coming. A push only queues its runs a few seconds later.
+RUN_APPEAR_TIMEOUT_SEC=300
 
 log()     { printf '%s | %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 summary() { [ -n "${GITHUB_STEP_SUMMARY:-}" ] && printf '%s\n' "$*" >> "$GITHUB_STEP_SUMMARY"; return 0; }
 
 merged_count=0
 merged_list=""
+last_base_sha=""
 
 # ---------------------------------------------------------------- helpers
 
@@ -47,7 +65,9 @@ pick_pr() {
       | jq -c 'map(select(.isDraft | not)) | sort_by(.number) | first'
 }
 
-# GitHub computes mergeability lazily; UNKNOWN just means "ask again".
+# GitHub computes mergeability lazily; UNKNOWN just means "ask again". This is
+# only an early, cheap "don't bother" -- the real conflict test is step 1, the
+# actual merge of $BASE into the branch.
 check_mergeable() {
     local pr=$1 state=""
     for _ in 1 2 3 4 5; do
@@ -61,61 +81,104 @@ check_mergeable() {
     fi
 }
 
-# A PR whose CI is still running is not a failure, it is just not ready yet
-# -- so wait it out rather than stopping the drain. This is the normal state
-# for a PR that was pushed to moments ago, including by the drain's own bump
-# commit when the token re-triggers CI.
-check_green() {
-    local pr=$1
+# Fetch the Actions runs for a commit as [{name, status, conclusion}].
+runs_for() {
+    gh api "repos/$REPO/actions/runs?head_sha=$1&per_page=100" \
+        --jq '[.workflow_runs[] | {name, status, conclusion}]' 2>/dev/null || echo '[]'
+}
+
+runs_failed()  { jq '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length' <<<"$1"; }
+runs_pending() { jq '[.[] | select(.status != "completed")] | length' <<<"$1"; }
+
+# Which of $REQUIRED_WORKFLOWS have no successful run yet. Blank REQUIRED_WORKFLOWS
+# means "whatever ran is what we judge on".
+runs_missing() {
+    jq -r --arg req "$REQUIRED_WORKFLOWS" '
+        [ ($req | split(",")[] | gsub("^\\s+|\\s+$"; "")) | select(length > 0) ] as $need
+        | ([ .[] | select(.status == "completed" and .conclusion == "success") | .name ] | unique) as $green
+        | [ $need[] | select(. as $n | $green | index($n) | not) ]
+        | join(", ")
+    ' <<<"$1"
+}
+
+# Wait for the workflows triggered by $sha. Green means: nothing failed,
+# nothing still running, and every required workflow has a successful run.
+# Fails fast on the first failing run rather than sitting out the rest.
+wait_for_runs() {
+    local sha=$1
     local deadline=$(( SECONDS + WAIT_TIMEOUT_MIN * 60 ))
-    local checks bad pending announced=0
+    local appear_deadline=$(( SECONDS + RUN_APPEAR_TIMEOUT_SEC ))
+    local runs total pending failed missing announced=0
 
+    log "  waiting for workflows on ${sha:0:7} (timeout ${WAIT_TIMEOUT_MIN}m)"
     while :; do
-        checks=$(gh pr checks "$pr" --repo "$REPO" --json name,bucket 2>/dev/null || true)
+        runs=$(runs_for "$sha")
+        total=$(jq 'length' <<<"$runs")
 
-        if [ -z "$checks" ] || [ "$checks" = "[]" ]; then
-            log "  #$pr reports no checks -- refusing to merge blind"
-            return 1
+        if [ "$total" -gt 0 ]; then
+            failed=$(runs_failed "$runs")
+            if [ "$failed" -ne 0 ]; then
+                jq -r '.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | "    \(.conclusion)\t\(.name)"' <<<"$runs"
+                log "  $failed workflow(s) failed on ${sha:0:7}"
+                return 1
+            fi
+
+            pending=$(runs_pending "$runs")
+            missing=$(runs_missing "$runs")
+
+            if [ "$pending" -eq 0 ] && [ -z "$missing" ]; then
+                jq -r '.[] | "    \(.conclusion)\t\(.name)"' <<<"$runs"
+                log "  all $total workflow(s) green on ${sha:0:7}"
+                return 0
+            fi
+
+            if [ "$pending" -ne 0 ] && [ "$announced" -eq 0 ]; then
+                log "  $pending workflow(s) still running on ${sha:0:7}"
+                announced=1
+            fi
         fi
 
-        bad=$(jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length' <<<"$checks")
-        if [ "$bad" -ne 0 ]; then
-            jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | "    \(.bucket)\t\(.name)"' <<<"$checks"
-            log "  #$pr has $bad check(s) failing"
-            return 1
-        fi
-
-        pending=$(jq '[.[] | select(.bucket == "pending")] | length' <<<"$checks")
-        if [ "$pending" -eq 0 ]; then
-            log "  #$pr checks green"
-            return 0
-        fi
-
-        # A dry run is a report, not a gate -- say what is happening and move
-        # on rather than blocking for however long CI takes.
-        if [ "$DRY_RUN" = 'true' ]; then
-            jq -r '.[] | select(.bucket == "pending") | "    pending\t\(.name)"' <<<"$checks"
-            log "  #$pr has $pending check(s) still running (dry run does not wait)"
-            return 0
+        # Nothing running and something still absent: give runs the appearance
+        # window to get queued, then call it.
+        if [ "$total" -eq 0 ] || { [ "${pending:-0}" -eq 0 ] && [ -n "${missing:-}" ]; }; then
+            if [ "$SECONDS" -ge "$appear_deadline" ]; then
+                if [ "$total" -eq 0 ]; then
+                    log "  no workflow runs exist for ${sha:0:7} -- refusing to merge blind"
+                else
+                    log "  required workflow(s) never ran on ${sha:0:7}: $missing"
+                fi
+                if [ "$USING_PAT" != 'true' ]; then
+                    log "  a push made with GITHUB_TOKEN deliberately does not trigger workflows."
+                    log "  Set the AUTOMERGE_TOKEN secret to a PAT or GitHub App token so the"
+                    log "  prepared commit gets its own build and test run."
+                fi
+                return 1
+            fi
         fi
 
         if [ "$SECONDS" -ge "$deadline" ]; then
-            log "  #$pr still has $pending pending check(s) after ${WAIT_TIMEOUT_MIN}m"
+            log "  timed out after ${WAIT_TIMEOUT_MIN}m waiting on ${sha:0:7}"
             return 1
-        fi
-
-        if [ "$announced" -eq 0 ]; then
-            log "  #$pr has $pending check(s) running, waiting (timeout ${WAIT_TIMEOUT_MIN}m)"
-            announced=1
         fi
         sleep 20
     done
 }
 
-# The pre-merge checks ran on the PR head, but we merge the SHA *after* the
-# version bump, which GITHUB_TOKEN pushes deliberately do not re-run CI for.
-# Carrying the green verdict across that gap is only honest if the bump
-# provably changed nothing but the two version lines -- so prove it.
+# Non-blocking. The drain does not wait for $BASE after a merge, but it will
+# not stack another merge on top of one that has already reported a failure.
+base_already_failed() {
+    local sha=$1 runs bad
+    runs=$(runs_for "$sha")
+    bad=$(jq -r '.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | "\(.conclusion)\t\(.name)"' <<<"$runs")
+    [ -n "$bad" ] || return 1
+    printf '%s\n' "$bad" | sed 's/^/    /'
+    log "the last merge has already failed on $BASE (${sha:0:7})"
+    return 0
+}
+
+# The bump is a machine edit on top of a tree CI is about to test anyway, so
+# this is a guard against a broken version.sh rather than a gate: if it ever
+# rewrites something other than the two version lines, stop before pushing.
 verify_version_only_diff() {
     local from=$1 to=$2 files bad
 
@@ -130,10 +193,10 @@ verify_version_only_diff() {
           | grep -vE '^(\+\+\+|---)' \
           | grep -vcE '^[+-][[:space:]]*version(Code|Name)[[:space:]]*=' || true)
     if [ "${bad:-0}" -ne 0 ]; then
-        log "  bump changed $bad non-version line(s) -- refusing to carry the check verdict"
+        log "  bump changed $bad non-version line(s)"
         return 1
     fi
-    log "  bump is provably version-only ($from -> $to)"
+    log "  bump is version-only ($from -> $to)"
 }
 
 push_with_retry() {
@@ -145,46 +208,6 @@ push_with_retry() {
         fi
     done
     log "  push of $ref failed after retries"
-    return 1
-}
-
-# Wait for every workflow run triggered by $sha on the base branch.
-wait_for_runs() {
-    local sha=$1
-    local deadline=$(( SECONDS + WAIT_TIMEOUT_MIN * 60 ))
-    local appear_deadline=$(( SECONDS + 300 ))
-    local runs total pending failed
-
-    log "  waiting for workflows on ${sha:0:7} (timeout ${WAIT_TIMEOUT_MIN}m)"
-    while [ "$SECONDS" -lt "$deadline" ]; do
-        runs=$(gh api "repos/$REPO/actions/runs?head_sha=$sha&per_page=100" \
-                 --jq '[.workflow_runs[] | {name, status, conclusion}]' 2>/dev/null || echo '[]')
-        total=$(jq 'length' <<<"$runs")
-
-        if [ "$total" -eq 0 ]; then
-            if [ "$SECONDS" -ge "$appear_deadline" ]; then
-                log "  no workflow runs appeared for ${sha:0:7} -- nothing to wait for"
-                return 0
-            fi
-            sleep 20
-            continue
-        fi
-
-        pending=$(jq '[.[] | select(.status != "completed")] | length' <<<"$runs")
-        if [ "$pending" -eq 0 ]; then
-            jq -r '.[] | "    \(.conclusion)\t\(.name)"' <<<"$runs"
-            failed=$(jq '[.[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length' <<<"$runs")
-            if [ "$failed" -ne 0 ]; then
-                log "  $failed workflow(s) failed on ${sha:0:7}"
-                return 1
-            fi
-            log "  all $total workflow(s) green on ${sha:0:7}"
-            return 0
-        fi
-        sleep 20
-    done
-
-    log "  timed out after ${WAIT_TIMEOUT_MIN}m waiting on ${sha:0:7}"
     return 1
 }
 
@@ -204,6 +227,11 @@ while :; do
         log "reached max_merges=$MAX_MERGES, stopping"
         summary "| | | stopped at max_merges=$MAX_MERGES |"
         break
+    fi
+
+    if [ -n "$last_base_sha" ] && base_already_failed "$last_base_sha"; then
+        summary "| | | **stopped**: \`$BASE\` red after the last merge |"
+        exit 1
     fi
 
     git fetch --quiet origin "$BASE"
@@ -230,9 +258,6 @@ while :; do
     fi
 
     check_mergeable "$NUMBER" || { summary "| #$NUMBER | | **stopped**: not mergeable |"; exit 1; }
-    if [ "$REQUIRE_CHECKS" = 'true' ]; then
-        check_green "$NUMBER" || { summary "| #$NUMBER | | **stopped**: checks failing or stuck |"; exit 1; }
-    fi
 
     # Next version always comes off the base branch: the base is what the
     # merge lands on, so it is what defines "next".
@@ -240,20 +265,32 @@ while :; do
     eval "$("$VERSION_SH" next /tmp/base-build.gradle | sed 's/^/new_/')"
     log "  version -> $new_name ($new_code)"
 
+    git fetch --quiet origin "$HEAD"
+
     if [ "$DRY_RUN" = 'true' ]; then
-        log "  dry run: would bump to $new_name and squash merge #$NUMBER"
-        summary "| #$NUMBER | → \`$new_name\` | dry run, nothing changed |"
+        # Merge for real, locally and detached, so the report can say whether
+        # step 1 would actually work. Nothing is pushed.
+        git checkout --quiet --detach "origin/$HEAD"
+        if git merge --quiet --no-edit "origin/$BASE"; then
+            log "  dry run: merges cleanly with $BASE, would bump to $new_name,"
+            log "           wait for ${REQUIRED_WORKFLOWS:-the triggered workflows}, then squash merge #$NUMBER"
+            summary "| #$NUMBER | → \`$new_name\` | dry run: would merge |"
+        else
+            git merge --abort || true
+            log "  dry run: #$NUMBER conflicts with $BASE -- needs a human"
+            summary "| #$NUMBER | | dry run: **conflicts** with \`$BASE\` |"
+        fi
         log "dry run stops after one PR (nothing advances)"
         break
     fi
 
-    git fetch --quiet origin "$HEAD"
     git checkout --quiet -B "$HEAD" "origin/$HEAD"
 
-    # Bring the branch up to the current base BEFORE bumping. Every merge
-    # moves the version on the base, so a branch cut at an older version
-    # would otherwise collide on exactly the two lines we are about to
-    # rewrite -- which is to say every PR after the first one in a drain.
+    # 1. Merge the base in. Every merge moves the version on the base, so a
+    #    branch cut at an older version would collide on exactly the two lines
+    #    the bump is about to rewrite -- which is to say every PR after the
+    #    first one in a drain. Doing it first also means the tree CI tests in
+    #    step 3 is the tree that lands, not an older approximation of it.
     if ! git merge --quiet --no-edit "origin/$BASE"; then
         git merge --abort || true
         log "  #$NUMBER conflicts with $BASE -- needs a human"
@@ -261,6 +298,9 @@ while :; do
         exit 1
     fi
 
+    # 2. Bump. It rides inside the squash commit; bumping the base separately
+    #    would push two commits per PR and re-run release.yml at a version
+    #    that was already tagged and published.
     pre_bump_sha=$(git rev-parse HEAD)
     "$VERSION_SH" apply "$GRADLE_FILE" "$new_code" "$new_name"
 
@@ -275,20 +315,24 @@ while :; do
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump was not version-only |"; exit 1; }
     fi
 
+    # 3. Push and let CI judge the prepared commit.
     if [ "$merge_sha" != "$SHA" ]; then
         push_with_retry "$HEAD" \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"; exit 1; }
-
-        # A PAT push re-triggers CI. When the base also requires status
-        # checks, merging straight away races the checks it just started.
-        if [ "$WAIT_FOR_BUMP_CHECKS" = 'true' ]; then
-            wait_for_runs "$merge_sha" \
-                || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump commit failed CI |"; exit 1; }
-        fi
+    else
+        log "  branch already merged and bumped, head unchanged at ${SHA:0:7}"
     fi
 
-    # Replace the PR description with just the attribution that belongs in
-    # the commit log. Subject keeps the repo's "<title> (#<number>)" shape.
+    if [ "$REQUIRE_CHECKS" = 'true' ]; then
+        wait_for_runs "$merge_sha" \
+            || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: prepared commit not green |"; exit 1; }
+    else
+        log "  require_checks is off -- merging ${merge_sha:0:7} unverified"
+    fi
+
+    # 4. Squash merge. Replace the PR description with just the attribution
+    #    that belongs in the commit log; the subject keeps the repo's
+    #    "<title> (#<number>)" shape.
     commit_body=$(REPO="$REPO" PR="$NUMBER" "$COAUTHORS_SH")
     if [ -n "$commit_body" ]; then
         log "  co-authors:"
@@ -318,9 +362,9 @@ while :; do
                 fi
                 ;;
             *"Pull Request is not mergeable"*|*"required status check"*)
-                reason="**stopped**: base requires checks the bump commit has not passed"
-                log "  the bumped commit has not satisfied required checks."
-                log "  Re-dispatch with wait_for_bump_checks enabled."
+                reason="**stopped**: base requires checks the prepared commit has not passed"
+                log "  the prepared commit has not satisfied the base's required checks."
+                log "  Make sure required_workflows covers every check $BASE requires."
                 ;;
         esac
         summary "| #$NUMBER | → \`$new_name\` | $reason |"
@@ -329,20 +373,11 @@ while :; do
     log "  merged #$NUMBER"
 
     git fetch --quiet origin "$BASE"
+    last_base_sha=$(git rev-parse "origin/$BASE")
 
     merged_count=$((merged_count + 1))
     merged_list="$merged_list #$NUMBER"
-
-    # Whatever the merge produced on the base branch is what CI now runs on:
-    # on master that is test + release, on a test branch test + build.
-    base_sha=$(git rev-parse "origin/$BASE")
-    if ! wait_for_runs "$base_sha"; then
-        summary "| #$NUMBER | → \`$new_name\` | merged, but **workflows failed** -- stopping |"
-        log "stopping: post-merge workflows failed after #$NUMBER"
-        exit 1
-    fi
-
-    summary "| #$NUMBER | → \`$new_name\` | merged, workflows green |"
+    summary "| #$NUMBER | → \`$new_name\` | merged as \`${last_base_sha:0:7}\` |"
 done
 
 log "done: merged $merged_count PR(s):${merged_list:- none}"

--- a/.github/scripts/coauthors.sh
+++ b/.github/scripts/coauthors.sh
@@ -1,23 +1,13 @@
 #!/usr/bin/env bash
 #
-# Build the squash commit body for a PR.
+# Build the squash commit body for a PR: one Co-authored-by line per real
+# person who worked on it and is a collaborator here, then the repo owner on
+# anything they did not author themselves. The PR description is discarded.
 #
-# The PR description itself is thrown away -- it is release-note noise by the
-# time it reaches the commit log. What survives is attribution: one
-# Co-authored-by line per real person who worked on the PR and is a
-# collaborator on this repository, followed by the repo owner on anything
-# they did not author themselves.
-#
-# Who gets dropped, and why:
-#
-#   * coding agents. An agent either commits as a Bot account (filtered by
-#     type) or leaves a trailer whose address is not a GitHub account
-#     (`Co-Authored-By: Claude <noreply@anthropic.com>`). Only trailers whose
-#     address ties back to a real account survive, so agents fall out without
-#     needing a denylist to chase.
-#   * non-collaborators. Checked against the repository's collaborator list.
-#   * the PR author. They are already the commit author; listing them again
-#     would credit the same person twice.
+# Dropped: the PR author (already the commit author), non-collaborators, and
+# coding agents -- an agent either commits as a Bot account or leaves a
+# trailer whose address is not a GitHub account, so only trailers that tie
+# back to a real account survive and no denylist is needed.
 #
 # Usage: REPO=owner/name PR=123 coauthors.sh
 # Prints the body on stdout; empty output is a legitimate result.
@@ -35,8 +25,7 @@ noreply_for() { printf '%s <%s@users.noreply.github.com>' "$1" "$1"; }
 
 # ------------------------------------------------------------- gather
 
-# Listing collaborators needs push access. If it fails we stop rather than
-# quietly emitting a commit with nobody credited.
+# Needs push access; failing here beats crediting nobody.
 collaborators=$(
     gh api "repos/$REPO/collaborators?per_page=100" --paginate \
         --jq '.[] | select(.type == "User") | .login' | tr '[:upper:]' '[:lower:]' | sort -u
@@ -50,8 +39,7 @@ commits=$(gh api "repos/$REPO/pulls/$PR/commits?per_page=100" --paginate)
 
 candidates=""
 
-# Commit authors GitHub already resolved to an account. Bot accounts carry
-# type "Bot" and are skipped here.
+# Commit authors GitHub resolved to an account; type "Bot" is skipped.
 while IFS= read -r login; do
     if [ -n "$login" ]; then
         candidates+="$login"$'\n'
@@ -76,9 +64,8 @@ while IFS= read -r line; do
             candidates+="$login"$'\n'
             ;;
         *)
-            # Not a GitHub address, so it cannot be tied to an account or
-            # checked against the collaborator list. This is the branch that
-            # removes the coding agents.
+            # Not a GitHub address -- cannot be tied to an account. This is
+            # the branch that removes the coding agents.
             ;;
     esac
 done <<<"$trailers"

--- a/.github/scripts/coauthors.sh
+++ b/.github/scripts/coauthors.sh
@@ -1,29 +1,21 @@
 #!/usr/bin/env bash
 #
-# Build the squash commit body for a PR: one Co-authored-by line per real
-# person who worked on it and is a collaborator here, then the repo owner on
-# anything they did not author themselves. The PR description is discarded.
+# Build the squash commit body: one Co-authored-by per collaborator who
+# worked on the PR, then $OWNER_LOGIN if they did not author it. The PR
+# description is discarded. Coding agents fall out for free -- they commit as
+# Bot accounts or leave trailers that tie back to no GitHub account.
 #
-# Dropped: the PR author (already the commit author), non-collaborators, and
-# coding agents -- an agent either commits as a Bot account or leaves a
-# trailer whose address is not a GitHub account, so only trailers that tie
-# back to a real account survive and no denylist is needed.
-#
-# Usage: REPO=owner/name PR=123 coauthors.sh
-# Prints the body on stdout; empty output is a legitimate result.
+# Usage: REPO=owner/name PR=123 coauthors.sh   (empty output is legitimate)
 #
 set -euo pipefail
 
 REPO="${REPO:?}"
 PR="${PR:?}"
-# Appended to every PR this person did not author themselves.
 OWNER_LOGIN="${OWNER_LOGIN:-dogi}"
 
 lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
 
 noreply_for() { printf '%s <%s@users.noreply.github.com>' "$1" "$1"; }
-
-# ------------------------------------------------------------- gather
 
 # Needs push access; failing here beats crediting nobody.
 collaborators=$(
@@ -39,14 +31,12 @@ commits=$(gh api "repos/$REPO/pulls/$PR/commits?per_page=100" --paginate)
 
 candidates=""
 
-# Commit authors GitHub resolved to an account; type "Bot" is skipped.
 while IFS= read -r login; do
     if [ -n "$login" ]; then
         candidates+="$login"$'\n'
     fi
 done < <(jq -r '.[] | select(.author != null) | select(.author.type == "User") | .author.login' <<<"$commits")
 
-# Co-authored-by trailers, from both the commit messages and the PR body.
 trailers=$(
     { jq -r '.[].commit.message' <<<"$commits"; printf '%s\n' "$pr_body"; } \
     | grep -iE '^[[:space:]]*co-authored-by:[[:space:]]*' || true
@@ -64,13 +54,10 @@ while IFS= read -r line; do
             candidates+="$login"$'\n'
             ;;
         *)
-            # Not a GitHub address -- cannot be tied to an account. This is
-            # the branch that removes the coding agents.
+            # Not a GitHub address -- this is what drops the coding agents.
             ;;
     esac
 done <<<"$trailers"
-
-# ------------------------------------------------------------- filter
 
 author_l=$(lower "$author_login")
 owner_l=$(lower "$OWNER_LOGIN")

--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -1,32 +1,19 @@
 #!/usr/bin/env bash
 #
-# myPlanet version helper.
-#
-# The two version fields in app/build.gradle are kept in lockstep:
-#
-#   versionName = "<major>.<minor>.<patch>"   e.g. 0.63.0
-#   versionCode = major*10000 + minor*100 + patch    e.g. 6300
-#
-# Each block is 0..99, printed without zero padding, so a patch rollover
-# carries into the minor block (and a minor rollover into the major block):
+# myPlanet version helper. The two fields in app/build.gradle are kept in
+# lockstep -- versionCode = major*10000 + minor*100 + patch -- with each block
+# 0..99, so a patch rollover carries into the minor block:
 #
 #   0.62.97 / 6297  ->  0.62.98 / 6298
 #   0.62.99 / 6299  ->  0.63.0  / 6300
-#   0.99.99 / 9999  ->  1.0.0   / 10000
 #
-# Because of that encoding the bumped code is always exactly the old code
-# plus one; the script asserts that as a guard against a hand-edited file
-# where name and code have drifted apart.
+# That encoding makes the bumped code always the old code plus one, which the
+# script asserts to catch a hand-edited file where the two have drifted apart.
 #
 # Usage:
-#   version.sh read <gradle-file>
-#       Print "code=<n>" and "name=<x.y.z>" for the current version.
-#
-#   version.sh next <gradle-file>
-#       Print "code=<n>" and "name=<x.y.z>" for the *next* version.
-#
-#   version.sh apply <gradle-file> <code> <name>
-#       Rewrite the versionCode/versionName lines in place.
+#   version.sh read  <gradle-file>          print code= and name= as they are
+#   version.sh next  <gradle-file>          print code= and name= for the next
+#   version.sh apply <gradle-file> <code> <name>    rewrite them in place
 #
 set -euo pipefail
 

--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
 #
-# myPlanet version helper. The two fields in app/build.gradle are kept in
-# lockstep -- versionCode = major*10000 + minor*100 + patch -- with each block
-# 0..99, so a patch rollover carries into the minor block:
+# myPlanet version helper. versionCode = major*10000 + minor*100 + patch,
+# each block 0..99, so a patch rollover carries:  0.62.99/6299 -> 0.63.0/6300.
+# The bumped code is therefore always the old code plus one, which `next`
+# asserts to catch a file where the two have drifted apart.
 #
-#   0.62.97 / 6297  ->  0.62.98 / 6298
-#   0.62.99 / 6299  ->  0.63.0  / 6300
-#
-# That encoding makes the bumped code always the old code plus one, which the
-# script asserts to catch a hand-edited file where the two have drifted apart.
-#
-# Usage:
-#   version.sh read  <gradle-file>          print code= and name= as they are
-#   version.sh next  <gradle-file>          print code= and name= for the next
-#   version.sh apply <gradle-file> <code> <name>    rewrite them in place
+#   version.sh {read|next} <gradle-file>
+#   version.sh apply <gradle-file> <code> <name>
 #
 set -euo pipefail
 
@@ -34,8 +27,7 @@ next_version() {
     local file=$1
     read_version "$file"
 
-    # minor and patch are the carry blocks and stay at two digits; major is
-    # left wider so the script does not become the thing that breaks at 1.0.0.
+    # major is left wider so this is not the thing that breaks at 1.0.0.
     [[ "$cur_name" =~ ^([0-9]{1,3})\.([0-9]{1,2})\.([0-9]{1,2})$ ]] \
         || die "versionName '$cur_name' is not <major>.<minor>.<patch> with 1-2 digits in the minor and patch blocks"
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,7 +8,7 @@ name: myPlanet automerge
 #   1. merge the base branch into the PR branch   (a conflict stops the drain)
 #   2. bump the version in app/build.gradle
 #   3. push, and wait for build + test on that prepared commit
-#   4. squash merge
+#   4. wait for the base branch to be settled and green, then squash merge
 #
 # Stops on the first failure; keeps going until no labelled PR is left.
 #
@@ -29,16 +29,19 @@ name: myPlanet automerge
 #   base -- so this behaves like a merge queue rather than trusting a verdict
 #   from whenever the PR last ran against an older base.
 #
-# * Nothing waits on the base branch afterwards. release.yml only runs on
-#   master, and it publishes rather than gates; holding every PR behind a
-#   full signed release build was the slow part. The next PR is prepared
-#   while that release runs. The drain still refuses to stack a merge on top
-#   of a base that has *already* reported a failure -- that is a free lookup,
-#   not a wait.
+# * The base branch is waited on in front of the merge, not after it. Master
+#   still has to be settled and green before anything lands on it -- a
+#   running release or a red run stops the drain. Asking at step 4 rather
+#   than right after the previous merge is what buys the overlap: master runs
+#   test and release for merge N while the drain prepares and builds PR N+1,
+#   so by the time it needs an answer the wait is usually already over.
 #
-# * The bump has to ride along inside the squash commit. Bumping the base
-#   separately would push two commits per PR, and the first would re-run
-#   release.yml at a version that was already tagged and published.
+# * The bump has to ride along inside the squash commit. Every merge into
+#   master publishes a release tagged from versionName in app/build.gradle,
+#   so every merge needs its own version number. Writing it on the PR branch
+#   makes it part of the squash -- one commit per PR, carrying the change and
+#   the version it ships as. Bumping master separately would push two commits
+#   per PR, and the first would start a release at a version already tagged.
 #
 # * A PAT is not optional here. GITHUB_TOKEN pushes deliberately do not
 #   trigger workflow runs, so the prepared commit would never get the build
@@ -87,7 +90,7 @@ on:
         default: '0'
         type: string
       wait_timeout_minutes:
-        description: 'how long to wait for the prepared commit to finish build and test'
+        description: 'how long to wait for workflows: build and test on the prepared commit, and whatever is in flight on the base'
         required: false
         default: '45'
         type: string

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,10 +2,15 @@ name: myPlanet automerge
 
 # Manually started queue drainer.
 #
-# Loops: pick the lowest-numbered open non-draft PR carrying the `automerge`
-# label, bump the version in app/build.gradle, squash merge it, wait for the
-# workflows the merge triggers on the base branch (test + release on master),
-# and stop on the first failure. Keeps going until no labelled PR is left.
+# Loops over the open non-draft PRs carrying the `automerge` label, lowest
+# number first, and takes each one through four steps in this order:
+#
+#   1. merge the base branch into the PR branch   (a conflict stops the drain)
+#   2. bump the version in app/build.gradle
+#   3. push, and wait for build + test on that prepared commit
+#   4. squash merge
+#
+# Stops on the first failure; keeps going until no labelled PR is left.
 #
 # The label is the safety rail: the drainer only ever touches PRs somebody
 # deliberately marked, never "every open PR".
@@ -16,35 +21,32 @@ name: myPlanet automerge
 # twice -- with the repo owner credited on anything they did not author. See
 # scripts/coauthors.sh.
 #
-# THREE THINGS WORTH KNOWING:
+# FOUR THINGS WORTH KNOWING:
+#
+# * Verification happens before the merge, not after it. Because the base is
+#   merged in first (step 1) and the bump lands on top of it (step 2), the
+#   commit CI tests in step 3 is exactly the tree that gets squashed onto the
+#   base -- so this behaves like a merge queue rather than trusting a verdict
+#   from whenever the PR last ran against an older base.
+#
+# * Nothing waits on the base branch afterwards. release.yml only runs on
+#   master, and it publishes rather than gates; holding every PR behind a
+#   full signed release build was the slow part. The next PR is prepared
+#   while that release runs. The drain still refuses to stack a merge on top
+#   of a base that has *already* reported a failure -- that is a free lookup,
+#   not a wait.
 #
 # * The bump has to ride along inside the squash commit. Bumping the base
 #   separately would push two commits per PR, and the first would re-run
-#   release.yml at a version that was already tagged and published. So the
-#   drainer bumps on the PR branch -- and therefore has to bring the branch
-#   up to the current base first, since every merge moves the version and an
-#   older branch would collide on exactly those two lines.
+#   release.yml at a version that was already tagged and published.
 #
-# * GITHUB_TOKEN cannot merge into a protected branch. Verified against
-#   master: everything up to the merge works, then GitHub answers "You're not
-#   authorized to push to this branch". Set the AUTOMERGE_TOKEN secret to a
-#   PAT or GitHub App token belonging to someone allowed to merge there.
-#   Without it the drainer is dry-run-only against a protected base.
-#
-# * CI does not re-run on the bump when GITHUB_TOKEN pushes it -- pushes made
-#   with that token deliberately do not trigger workflow runs, so the bump
-#   commit arrives without its own build. The drainer proves the bump changed
-#   nothing but the two version lines before carrying the PR's green verdict
-#   across it (see verify_version_only_diff). An AUTOMERGE_TOKEN push *does*
-#   re-trigger CI; if the base also requires status checks, turn on
-#   wait_for_bump_checks so the drain waits for the bumped SHA instead of
-#   racing its own pending checks.
-#
-# * Checks are per-PR, not per-merged-state. Each PR was tested against the
-#   base as it was when the PR ran, not against the base as the drain leaves
-#   it. That is the tradeoff versus a real merge queue; it is why the drain
-#   waits for the base branch to go green after every single merge and stops
-#   dead on the first failure.
+# * A PAT is not optional here. GITHUB_TOKEN pushes deliberately do not
+#   trigger workflow runs, so the prepared commit would never get the build
+#   and test run step 3 waits for -- and GITHUB_TOKEN cannot merge into a
+#   protected branch anyway ("You're not authorized to push to this branch",
+#   verified against master). Set the AUTOMERGE_TOKEN secret to a PAT or
+#   GitHub App token belonging to someone allowed to merge there. Without it
+#   the drainer is dry-run-only.
 
 on:
   workflow_dispatch:
@@ -65,10 +67,15 @@ on:
         default: 'dogi'
         type: string
       require_checks:
-        description: 'refuse to merge unless the PR checks are green'
+        description: 'refuse to merge unless the prepared commit (base merged in + version bumped) is green'
         required: false
         default: true
         type: boolean
+      required_workflows:
+        description: 'comma-separated workflows that must have passed on the prepared commit (blank = judge whatever ran)'
+        required: false
+        default: 'myPlanet build, myPlanet test'
+        type: string
       delete_branch:
         description: 'delete each head branch after merging'
         required: false
@@ -80,15 +87,10 @@ on:
         default: '0'
         type: string
       wait_timeout_minutes:
-        description: 'how long to wait for running checks: on a PR before merging, and on the base branch after'
+        description: 'how long to wait for the prepared commit to finish build and test'
         required: false
         default: '45'
         type: string
-      wait_for_bump_checks:
-        description: 'wait for CI on the bump commit before merging (needed only when AUTOMERGE_TOKEN re-triggers CI and the base requires checks)'
-        required: false
-        default: false
-        type: boolean
       dry_run:
         description: 'report what would happen, change nothing'
         required: false
@@ -110,8 +112,9 @@ jobs:
   automerge:
     name: myPlanet automerge
     runs-on: ubuntu-24.04
-    # A full drain is many merges, each waiting on a release build. GitHub
-    # caps a job at 6h; stay under it and re-dispatch to continue.
+    # A full drain is many merges, each waiting on a build and test run for
+    # its prepared commit. GitHub caps a job at 6h; stay under it and
+    # re-dispatch to continue.
     timeout-minutes: 350
     steps:
       - name: checkout repository code
@@ -146,11 +149,11 @@ jobs:
           BASE: ${{ inputs.base || env.DEFAULT_BASE }}
           LABEL: ${{ inputs.label }}
           REQUIRE_CHECKS: ${{ inputs.require_checks }}
+          REQUIRED_WORKFLOWS: ${{ inputs.required_workflows }}
           DELETE_BRANCH: ${{ inputs.delete_branch }}
           DRY_RUN: ${{ inputs.dry_run }}
           MAX_MERGES: ${{ inputs.max_merges }}
           WAIT_TIMEOUT_MIN: ${{ inputs.wait_timeout_minutes }}
-          WAIT_FOR_BUMP_CHECKS: ${{ inputs.wait_for_bump_checks }}
           VERSION_SH: ${{ steps.stage.outputs.dir }}/version.sh
           COAUTHORS_SH: ${{ steps.stage.outputs.dir }}/coauthors.sh
           OWNER_LOGIN: ${{ inputs.owner_login }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,55 +1,15 @@
 name: myPlanet automerge
 
-# Manually started queue drainer.
+# Manually started queue drainer. For each open non-draft PR carrying the
+# `automerge` label: merge the base in, bump the version, wait for build and
+# test on that prepared commit, then squash merge. The label is the safety
+# rail -- only PRs somebody marked are ever touched. Logic lives in
+# .github/scripts/automerge.sh; this file just wires it up.
 #
-# Loops over the open non-draft PRs carrying the `automerge` label, lowest
-# number first, and takes each one through four steps in this order:
-#
-#   1. merge the base branch into the PR branch   (a conflict stops the drain)
-#   2. bump the version in app/build.gradle
-#   3. push, and wait for build + test on that prepared commit
-#   4. wait for the base branch to be settled and green, then squash merge
-#
-# Stops on the first failure; keeps going until no labelled PR is left.
-#
-# The label is the safety rail: the drainer only ever touches PRs somebody
-# deliberately marked, never "every open PR".
-#
-# The PR description does not survive into the commit log. Each squash commit
-# is "<title> (#<number>)" plus Co-authored-by lines for the real people who
-# worked on it -- collaborators only, no coding agents, never the PR author
-# twice -- with the repo owner credited on anything they did not author. See
-# scripts/coauthors.sh.
-#
-# FOUR THINGS WORTH KNOWING:
-#
-# * Verification happens before the merge, not after it. Because the base is
-#   merged in first (step 1) and the bump lands on top of it (step 2), the
-#   commit CI tests in step 3 is exactly the tree that gets squashed onto the
-#   base -- so this behaves like a merge queue rather than trusting a verdict
-#   from whenever the PR last ran against an older base.
-#
-# * The base branch is waited on in front of the merge, not after it. Master
-#   still has to be settled and green before anything lands on it -- a
-#   running release or a red run stops the drain. Asking at step 4 rather
-#   than right after the previous merge is what buys the overlap: master runs
-#   test and release for merge N while the drain prepares and builds PR N+1,
-#   so by the time it needs an answer the wait is usually already over.
-#
-# * The bump has to ride along inside the squash commit. Every merge into
-#   master publishes a release tagged from versionName in app/build.gradle,
-#   so every merge needs its own version number. Writing it on the PR branch
-#   makes it part of the squash -- one commit per PR, carrying the change and
-#   the version it ships as. Bumping master separately would push two commits
-#   per PR, and the first would start a release at a version already tagged.
-#
-# * A PAT is not optional here. GITHUB_TOKEN pushes deliberately do not
-#   trigger workflow runs, so the prepared commit would never get the build
-#   and test run step 3 waits for -- and GITHUB_TOKEN cannot merge into a
-#   protected branch anyway ("You're not authorized to push to this branch",
-#   verified against master). Set the AUTOMERGE_TOKEN secret to a PAT or
-#   GitHub App token belonging to someone allowed to merge there. Without it
-#   the drainer is dry-run-only.
+# Needs AUTOMERGE_TOKEN: a PAT or GitHub App token allowed to merge into the
+# base. GITHUB_TOKEN cannot merge into a protected branch, and pushes made
+# with it do not trigger workflow runs, so the prepared commit would never get
+# the build and test the drain waits for. Without it: dry runs only.
 
 on:
   workflow_dispatch:
@@ -115,27 +75,22 @@ jobs:
   automerge:
     name: myPlanet automerge
     runs-on: ubuntu-24.04
-    # A full drain is many merges, each waiting on a build and test run for
-    # its prepared commit. GitHub caps a job at 6h; stay under it and
-    # re-dispatch to continue.
+    # GitHub caps a job at 6h; stay under it and re-dispatch to continue.
     timeout-minutes: 350
     steps:
       - name: checkout repository code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          # Same token the merge uses, so the bump push and the merge are
-          # made by the same identity. Falls back to GITHUB_TOKEN, which is
-          # fine for a dry run but cannot merge into a protected branch.
+          # Same identity for the bump push and the merge.
           token: ${{ secrets.AUTOMERGE_TOKEN || github.token }}
 
       - name: stage helper scripts outside the work tree
         id: stage
         shell: bash
         run: |
-          # The drainer checks out PR branches, which would otherwise swap
-          # these scripts for PR-controlled copies mid-run. Take them from
-          # the trusted checkout now and run them from there.
+          # The drain checks out PR branches, which would otherwise swap these
+          # scripts for PR-controlled copies mid-run.
           mkdir -p "$RUNNER_TEMP/scripts"
           cp .github/scripts/automerge.sh \
              .github/scripts/version.sh \

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,15 +1,11 @@
 name: myPlanet automerge
 
-# Manually started queue drainer. For each open non-draft PR carrying the
-# `automerge` label: merge the base in, bump the version, wait for build and
-# test on that prepared commit, then squash merge. The label is the safety
-# rail -- only PRs somebody marked are ever touched. Logic lives in
-# .github/scripts/automerge.sh; this file just wires it up.
+# Manually started queue drainer: for each PR labelled `automerge`, merge the
+# base in, bump the version, wait for build + test, squash merge. The label is
+# the safety rail. Logic in .github/scripts/automerge.sh.
 #
-# Needs AUTOMERGE_TOKEN: a PAT or GitHub App token allowed to merge into the
-# base. GITHUB_TOKEN cannot merge into a protected branch, and pushes made
-# with it do not trigger workflow runs, so the prepared commit would never get
-# the build and test the drain waits for. Without it: dry runs only.
+# Needs AUTOMERGE_TOKEN. GITHUB_TOKEN cannot merge into a protected branch,
+# and its pushes do not trigger the workflow runs the drain waits for.
 
 on:
   workflow_dispatch:
@@ -82,15 +78,13 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          # Same identity for the bump push and the merge.
           token: ${{ secrets.AUTOMERGE_TOKEN || github.token }}
 
       - name: stage helper scripts outside the work tree
         id: stage
         shell: bash
         run: |
-          # The drain checks out PR branches, which would otherwise swap these
-          # scripts for PR-controlled copies mid-run.
+          # PR branches get checked out; run from a copy they cannot swap.
           mkdir -p "$RUNNER_TEMP/scripts"
           cp .github/scripts/automerge.sh \
              .github/scripts/version.sh \

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6302
-        versionName = "0.63.2"
+        versionCode = 6303
+        versionName = "0.63.3"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
## Summary

Restructure the automerge workflow to execute in four sequential steps that enable overlapping CI runs on the base branch and prepared PR commits, rather than waiting for each merge to complete before preparing the next PR. This reduces total drain time by running base branch workflows (test + release) in parallel with PR preparation and build.

## Key Changes

**Workflow restructuring (4-step process):**
- **Step 1**: Merge base branch into PR branch (conflict detection)
- **Step 2**: Bump version on PR branch
- **Step 3**: Push and wait for build + test on the prepared commit
- **Step 4**: Wait for base branch to settle and go green, then squash merge

**New environment variables and configuration:**
- `REQUIRED_WORKFLOWS`: Comma-separated list of workflows that must pass on the prepared commit (e.g., "myPlanet build, myPlanet test")
- `RUN_APPEAR_TIMEOUT_SEC`: 300-second window for workflow runs to appear after a push before concluding none are coming
- `MAX_REPREPARES`: Bounded re-preparation counter (default 2) to prevent infinite loops when base keeps moving

**Refactored workflow monitoring:**
- Replaced `check_green()` with new `wait_for_runs()` that accepts:
  - `$need`: Comma-separated required workflow names (blank = judge whatever ran)
  - `$absent`: Behavior when no runs exist ('fail' for pushed commits, 'pass' for base branch)
- Added helper functions: `runs_for()`, `runs_failed()`, `runs_pending()`, `runs_missing()`
- Added `base_already_failed()` for non-blocking early exit if last merge already failed

**Base branch re-preparation logic:**
- Detects when base branch moves during PR preparation (another push or second drain)
- Re-prepares the same PR on the new base (bounded by `MAX_REPREPARES`)
- Prevents merging stale prepared commits with potentially taken version numbers

**Verification timing:**
- Moved verification to before merge (step 3) rather than after
- Prepared commit CI runs against the exact tree that will land (base merged in + version bumped)
- Removed `WAIT_FOR_BUMP_CHECKS` in favor of always waiting on prepared commit when `REQUIRE_CHECKS=true`

**Improved error messaging:**
- Clarified that PAT/GitHub App token is required (GITHUB_TOKEN cannot merge to protected branches and doesn't trigger workflows)
- Updated summary messages to reflect new 4-step process
- Better diagnostics for missing required workflows

## Implementation Details

- The drain now tracks `last_base_sha` to check if the base has already failed before preparing another PR
- Workflow run queries use GitHub API directly (`/repos/{repo}/actions/runs?head_sha={sha}`) instead of `gh pr checks`
- Dry-run mode now performs a local merge test to report whether step 1 would succeed
- Version bump verification (`verify_version_only_diff`) is now a guard against broken version.sh rather than a gate for carrying check verdicts
- The squash merge happens only after confirming the base is settled and green, enabling the overlap with the next PR's preparation

## Workflow File Updates

- Updated `automerge.yml` input descriptions to reflect new 4-step process
- Added `required_workflows` input parameter (defaults to "myPlanet build, myPlanet test")
- Removed `wait_for_bump_checks` input (now always waits on prepared commit)
- Updated job timeout rationale and documentation comments

https://claude.ai/code/session_01JY7ssMwTYTckahgwprwtU8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the automated merge queue to prepare pull requests, verify the prepared changes, and then merge them safely.
  * Added support for requiring specific workflow checks, handling missing workflow runs, retries, and timeouts.
  * Improved recovery when the base branch changes or a previous merge fails.
  * Dry runs now validate the base merge locally and report the planned verification steps.
* **Documentation**
  * Updated workflow guidance to describe the revised merge process and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->