### PR TITLE
fix: allow guest users 4 free logins before becoming member

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -350,7 +350,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             lifecycleScope.launch {
                 delay(50)
                 val offlineVisits = user?.id?.let { activitiesRepository.getOfflineVisitCount(it) } ?: 0
-                if (!(user?.id?.startsWith("guest") == true && offlineVisits >= 3) &&
+                if (!(user?.id?.startsWith("guest") == true && offlineVisits >= 4) &&
                     resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
                 ) {
                     result?.recyclerView?.scrollToPosition(0)
@@ -708,8 +708,8 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             val offlineVisits = user?.id?.let { activitiesRepository.getOfflineVisitCount(it) } ?: 0
             if (user?.id?.startsWith("guest") == true) {
                 when {
-                    offlineVisits >= 3 -> showGuestDialog()
-                    offlineVisits == 2 -> showVisitLimitWarning()
+                    offlineVisits >= 4 -> showGuestDialog()
+                    offlineVisits == 3 -> showVisitLimitWarning()
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes #15213 - Guest user sees become a member dialogue when the user has 1 login remaining

### Problem
Guest users were seeing the "become a member" dialog prematurely. According to the issue, guest users should be free to explore until they log in for the 4th time.

### Root Cause
The login count thresholds in `DashboardActivity.kt` were incorrect:
- `offlineVisits >= 3` triggered the become member dialog (shown on 4th login)
- `offlineVisits == 2` triggered the warning (shown on 3rd login)

### Solution
Adjusted the thresholds to properly allow 4 free logins:
- `offlineVisits >= 4` triggers the become member dialog (shown on 5th login attempt)
- `offlineVisits == 3` triggers the warning with "1 login remaining" (shown on 4th login)

### Changes
Modified `app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt`:
1. Line 353: Changed `offlineVisits >= 3` to `offlineVisits >= 4` (drawer behavior)
2. Line 711: Changed `offlineVisits >= 3` to `offlineVisits >= 4` (become member dialog)
3. Line 712: Changed `offlineVisits == 2` to `offlineVisits == 3` (warning)

### Behavior After Fix
| Login | offlineVisits | Behavior |
|-------|---------------|----------|
| 1st   | 1             | No warning (3 logins remaining) |
| 2nd   | 2             | No warning (2 logins remaining) |
| 3rd   | 3             | Warning shown (1 login remaining) |
| 4th   | 4             | Become member dialog shown |

This PR was created by an AI agent (OpenHands) on behalf of the user.

@J-S-webskas can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8ce0a045-e47a-48aa-8a6b-e3d57e49c2df)