### PR TITLE
all: smoother skill merge prepping (fixes #15452)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,9 +5,16 @@
         "source": "github",
         "repo": "dogi/kotlin-importing"
       }
+    },
+    "merge-prepping": {
+      "source": {
+        "source": "github",
+        "repo": "dogi/merge-prepping"
+      }
     }
   },
   "enabledPlugins": {
-    "kotlin-importing@dogi": true
+    "kotlin-importing@dogi": true,
+    "merge-prepping@merge-prepping": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,12 @@
 {
   "extraKnownMarketplaces": {
-    "dogi": {
+    "importing": {
       "source": {
         "source": "github",
         "repo": "dogi/kotlin-importing"
       }
     },
-    "merge-prepping": {
+    "prepping": {
       "source": {
         "source": "github",
         "repo": "dogi/merge-prepping"
@@ -14,7 +14,7 @@
     }
   },
   "enabledPlugins": {
-    "kotlin-importing@dogi": true,
-    "merge-prepping@merge-prepping": true
+    "kotlin-importing@importing": true,
+    "merge-prepping@prepping": true
   }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6346
-        versionName = "0.63.46"
+        versionCode = 6347
+        versionName = "0.63.47"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
Enables the [merge-prepping](https://github.com/dogi/merge-prepping) plugin in Claude Code cloud sessions by declaring its marketplace and enabling the plugin in `.claude/settings.json`, with the marketplace map keys named so the `enabledPlugins` entries read as phrases:

```json
"extraKnownMarketplaces": {
  "importing": { "source": { "source": "github", "repo": "dogi/kotlin-importing" } },
  "prepping":  { "source": { "source": "github", "repo": "dogi/merge-prepping" } }
},
"enabledPlugins": {
  "kotlin-importing@importing": true,
  "merge-prepping@prepping": true
}
```

The map key in `extraKnownMarketplaces` is the authoritative namespace for `plugin@marketplace` references (the catalogs' self-declared names are ignored), so the key naming is settings-only: plugin names, skill repos, and slash commands (`/merge-prepping:title`, `/kotlin-importing:sort`) are unaffected, and the two single-plugin marketplaces coexist cleanly.

Also points CLAUDE.md (new "PR Titles" subsection under Branch Strategy) at both skills, so agents that read repo docs but can't load Claude plugins learn the house title style — and clarifies that `fix:/feat:` prefixes are for intermediate branch commits only, never PR titles, since the squash commit message *is* the PR title.

The skill itself rewrites PR titles into the house style (`scope: smoother thing doing (fixes #N)`), ensures a tracking issue exists (promoting the old title to an issue when there is none), consults a title corpus distilled from the last 500 merged PRs here, and offers candidate titles when scope, gerund, or shape is genuinely ambiguous.

Diff: `.claude/settings.json` + `CLAUDE.md` (+ the automerge version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNGTqqC8mqk2VDc3wp5VHi