### PR TITLE
add dismiss button to last synced status container (fixes #15516)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -129,6 +129,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     private var onGlobalLayoutListener: ViewTreeObserver.OnGlobalLayoutListener? = null
     private var exitSnackbar: Snackbar? = null
     private var lastSyncStatus: SyncManager.SyncStatus? = null
+    private var dismissedSyncTime = -1L
 
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(LocaleUtils.onAttach(base))
@@ -136,6 +137,9 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (savedInstanceState != null) {
+            dismissedSyncTime = savedInstanceState.getLong(KEY_DISMISSED_SYNC_TIME, -1L)
+        }
         postponeEnterTransition()
         initViews()
 
@@ -274,6 +278,10 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         }
         binding.dashboardSyncNow.setOnClickListener {
             logSyncInSharedPrefs()
+        }
+        binding.btnDismissSync.setOnClickListener {
+            dismissedSyncTime = prefData.getLastSync()
+            binding.dashboardSyncBanner.visibility = View.GONE
         }
     }
 
@@ -588,8 +596,9 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
 
     private fun updateLastSyncStatus() {
         val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-        binding.dashboardSyncBanner.visibility = if (isLandscape) View.GONE else View.VISIBLE
-        if (isLandscape) return
+        val isDismissed = dismissedSyncTime >= 0L && prefData.getLastSync() <= dismissedSyncTime
+        binding.dashboardSyncBanner.visibility = if (!isLandscape && !isDismissed) View.VISIBLE else View.GONE
+        if (binding.dashboardSyncBanner.visibility == View.GONE) return
 
         val lastSyncMillis = prefData.getLastSync()
         val timeText = if (lastSyncMillis <= 0L) {
@@ -1081,6 +1090,11 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         updateLastSyncStatus()
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putLong(KEY_DISMISSED_SYNC_TIME, dismissedSyncTime)
+    }
+
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         setIntent(intent)
@@ -1122,6 +1136,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     }
 
     companion object {
+        const val KEY_DISMISSED_SYNC_TIME = "dismissed_sync_time"
         const val MESSAGE_PROGRESS = "message_progress"
         var isFromNotificationAction = false
     }

--- a/app/src/main/res/layout/activity_dashboard.xml
+++ b/app/src/main/res/layout/activity_dashboard.xml
@@ -68,6 +68,16 @@
                 android:textColor="@color/dashboard_accent_blue"
                 android:textSize="12sp"
                 android:textStyle="bold" />
+            <ImageView
+                android:id="@+id/btn_dismiss_sync"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/dismiss"
+                android:padding="12dp"
+                android:scaleType="centerInside"
+                app:srcCompat="@drawable/baseline_close_24"
+                app:tint="@color/daynight_textColor" />
         </LinearLayout>
 
         <com.google.android.material.bottomnavigation.BottomNavigationView

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -883,7 +883,7 @@
     <string name="auto_sync_device">स्वचालित सिङ्क यन्त्र</string>
     <string name="beta_functionality">बीटा कार्यक्षमता</string>
     <string name="main_controls">मुख्य नियन्त्रणहरू</string>
-    <string name ="dismiss"> खारेज गर्नुहोस्</string>
+    <string name="dismiss">खारेज गर्नुहोस्</string>
     <string name="available_space_colon">उपलब्ध ठाउँ: </string>
     <string name="community_leaders">सामुदायिक नेताहरू</string>
     <string name="services">सेवाहरू</string>

--- a/app/src/test/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivityTest.kt
@@ -1,0 +1,96 @@
+package org.ole.planet.myplanet.ui.dashboard
+
+import android.os.Bundle
+import android.view.View
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import javax.inject.Inject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.utils.UrlUtils
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+@HiltAndroidTest
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = HiltTestApplication::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+class DashboardActivityTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var sharedPrefManager: SharedPrefManager
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        UrlUtils.init(sharedPrefManager)
+    }
+
+    @Test
+    fun testSyncBannerDismissalSurvivesRecreation() {
+        sharedPrefManager.setLastSync(1000L)
+        val controller = Robolectric.buildActivity(DashboardActivity::class.java).setup()
+        val activity = controller.get()
+        assertNotNull(activity)
+
+        val syncBanner = activity.findViewById<View>(R.id.dashboard_sync_banner)
+        val dismissButton = activity.findViewById<View>(R.id.btn_dismiss_sync)
+        assertNotNull(syncBanner)
+        assertNotNull(dismissButton)
+
+        assertEquals(View.VISIBLE, syncBanner.visibility)
+
+        dismissButton.performClick()
+        assertEquals(View.GONE, syncBanner.visibility)
+
+        val bundle = Bundle()
+        controller.saveInstanceState(bundle).pause().stop().destroy()
+
+        val recreatedController = Robolectric.buildActivity(DashboardActivity::class.java).setup(bundle)
+        val recreatedActivity = recreatedController.get()
+        val recreatedSyncBanner = recreatedActivity.findViewById<View>(R.id.dashboard_sync_banner)
+
+        assertEquals(View.GONE, recreatedSyncBanner.visibility)
+        recreatedController.pause().stop().destroy()
+    }
+
+    @Test
+    fun testSyncBannerShowsAgainAfterNewSync() {
+        sharedPrefManager.setLastSync(1000L)
+        val controller = Robolectric.buildActivity(DashboardActivity::class.java).setup()
+        val activity = controller.get()
+
+        val syncBanner = activity.findViewById<View>(R.id.dashboard_sync_banner)
+        val dismissButton = activity.findViewById<View>(R.id.btn_dismiss_sync)
+
+        assertEquals(View.VISIBLE, syncBanner.visibility)
+
+        dismissButton.performClick()
+        assertEquals(View.GONE, syncBanner.visibility)
+
+        val bundle = Bundle()
+        controller.saveInstanceState(bundle).pause().stop().destroy()
+
+        // Newer sync timestamp arrives
+        sharedPrefManager.setLastSync(2000L)
+
+        val recreatedController = Robolectric.buildActivity(DashboardActivity::class.java).setup(bundle)
+        val recreatedActivity = recreatedController.get()
+        val recreatedSyncBanner = recreatedActivity.findViewById<View>(R.id.dashboard_sync_banner)
+
+        assertEquals(View.VISIBLE, recreatedSyncBanner.visibility)
+        recreatedController.pause().stop().destroy()
+    }
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/10cf94fc-c8a8-4d22-92f9-e5a14a22b088


fixes #15516 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dismiss button to the dashboard sync-status banner.
  * Banner dismissal is preserved when the dashboard is recreated.
  * Successful synchronization clears the dismissal, allowing the banner to reappear.
  * Sync-status banner visibility is limited to portrait orientation.

* **Accessibility**
  * Added accessible text and clear visual styling for the dismiss control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->