### PR TITLE
Fix Resources screen crash and selection visibility on empty list

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -209,6 +209,9 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         lifecycleScope.launch {
             userModel = userRepository.getUserModel()
             setupGuestUserRestrictions()
+            if (::adapterLibrary.isInitialized) {
+                checkList()
+            }
 
             val userId = userModel?.id
             if (userId != null) {
@@ -438,15 +441,17 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         }
     }
 
-    private fun hideButton(){
+    private fun hideButton(listSizeParam: Int? = null) {
+        val listSize = listSizeParam ?: if (::adapterLibrary.isInitialized) adapterLibrary.currentList.size else 0
         val count = selectedItems?.size ?: 0
         tvDelete?.isEnabled = count != 0
         tvAddToLib.isEnabled = count != 0
-        if(count != 0){
-            if(isMyCourseLib) tvDelete?.visibility = View.VISIBLE
+        val isGuest = userModel?.isGuest() == true
+        if (count != 0 && !isGuest && listSize > 0) {
+            if (isMyCourseLib) tvDelete?.visibility = View.VISIBLE
             else tvAddToLib.visibility = View.VISIBLE
         } else {
-            if(isMyCourseLib) tvDelete?.visibility = View.GONE
+            if (isMyCourseLib) tvDelete?.visibility = View.GONE
             else tvAddToLib.visibility = View.GONE
         }
     }
@@ -454,22 +459,25 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
     private fun checkList(listSize: Int = if (::adapterLibrary.isInitialized) adapterLibrary.currentList.size else 0) {
         val hasAnyLibraryData = allResourceModels.isNotEmpty()
 
-        if (!hasAnyLibraryData && listSize == 0) {
+        if (listSize == 0) {
             selectAll.visibility = View.GONE
+        } else {
+            selectAll.visibility = if (userModel?.isGuest() == true) View.GONE else View.VISIBLE
+        }
+
+        if (!hasAnyLibraryData && listSize == 0) {
             etSearch.visibility = View.GONE
-            tvAddToLib.visibility = View.GONE
             tvSelected.visibility = View.GONE
             binding.btnCollections.visibility = View.GONE
             filter.visibility = View.GONE
             clearTags.visibility = View.GONE
-            tvDelete?.visibility = View.GONE
         } else {
-            selectAll.visibility = View.VISIBLE
             etSearch.visibility = View.VISIBLE
             binding.btnCollections.visibility = View.VISIBLE
             filter.visibility = View.VISIBLE
             clearTags.visibility = if (hasActiveFilters()) View.VISIBLE else View.GONE
         }
+        hideButton(listSize)
     }
 
     private fun hasActiveFilters(): Boolean {


### PR DESCRIPTION
This commit fixes the NullPointerException on first-time/fresh entry to the Resources screen, ensuring that asynchronous loading of the user model does not cause unsafe dereferences in hideButton(). It also ensures that the guest user constraints are properly re-applied once the model loads, and handles the visibility of selection action buttons ("Add to library", "Delete") and "Select All" correctly when filtering results down to an empty list.

---
*PR created automatically by Jules for task [15057998291547066692](https://jules.google.com/task/15057998291547066692) started by @J-S-webskas*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection controls when browsing filtered library results.
  * Prevented guest users from using selection actions.
  * Hid action buttons when no matching items are available.
  * Ensured the select-all option appears only when applicable.
  * Preserved search and filtering controls when library content exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->