### PR TITLE
teams: smoother voices replying (fixes #15792)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6526
-        versionName = "0.65.26"
+        versionCode = 6527
+        versionName = "0.65.27"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/voices/TeamsVoicesFragment.kt
@@ -249,8 +249,7 @@ class TeamsVoicesFragment : BaseTeamFragment() {
                     onAnimateTyping = VoicesAdapterHelper.createOnAnimateTyping(viewLifecycleOwner.lifecycleScope, dispatcherProvider),
                     labelManager = labelManager,
                     voicesRepository = voicesRepository,
-                    userRepository = userRepository,
-                    getCommunityLeadersFn = { sharedPrefManager.getCommunityLeaders() },
+                    leadersList = userRepository.parseLeadersJson(sharedPrefManager.getCommunityLeaders()),
                     setRepliedNewsIdFn = { sharedPrefManager.setRepliedNewsId(it) }
                 )
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
@@ -155,8 +155,7 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
                     onAnimateTyping = VoicesAdapterHelper.createOnAnimateTyping(lifecycleScope, dispatcherProvider),
                     labelManager = labelManager,
                     voicesRepository = voicesRepository,
-                    userRepository = userRepository,
-                    getCommunityLeadersFn = { sharedPrefManager.getCommunityLeaders() },
+                    leadersList = userRepository.parseLeadersJson(sharedPrefManager.getCommunityLeaders()),
                     setRepliedNewsIdFn = { sharedPrefManager.setRepliedNewsId(it) }
                 )
                 newsAdapter.setListener(this@ReplyActivity)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -34,7 +34,6 @@ import org.ole.planet.myplanet.model.Conversation
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.UserEntity
-import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.repository.VoicesRepository
 import org.ole.planet.myplanet.services.VoicesLabelManager
 import org.ole.planet.myplanet.ui.chat.ChatAdapter
@@ -63,8 +62,7 @@ class VoicesAdapter(
     private val onAnimateTyping: (String, (String) -> Unit, () -> Unit) -> (() -> Unit),
     private val labelManager: VoicesLabelManager,
     private val voicesRepository: VoicesRepository,
-    private val userRepository: UserRepository,
-    private val getCommunityLeadersFn: () -> String,
+    private val leadersList: List<UserEntity>,
     private val setRepliedNewsIdFn: (String?) -> Unit
 ) : ListAdapter<News, RecyclerView.ViewHolder>(
     DiffUtils.itemCallback<News>(
@@ -185,10 +183,6 @@ class VoicesAdapter(
     private val fetchingUserIds = mutableSetOf<String>()
     private val replyCountCache = mutableMapOf<String, Int>()
     private val userIdPositions = mutableMapOf<String, MutableList<Int>>()
-    private val leadersList: List<UserEntity> by lazy {
-        val raw = getCommunityLeadersFn()
-        userRepository.parseLeadersJson(raw)
-    }
     private var _isTeamLeader: Boolean? = null
 
     init {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesFragment.kt
@@ -268,8 +268,7 @@ class VoicesFragment : BaseVoicesFragment() {
             onAnimateTyping = VoicesAdapterHelper.createOnAnimateTyping(viewLifecycleOwner.lifecycleScope, dispatcherProvider),
             labelManager = labelManager,
             voicesRepository = voicesRepository,
-            userRepository = userRepository,
-            getCommunityLeadersFn = { sharedPrefManager.getCommunityLeaders() },
+            leadersList = userRepository.parseLeadersJson(sharedPrefManager.getCommunityLeaders()),
             setRepliedNewsIdFn = { sharedPrefManager.setRepliedNewsId(it) }
         )
         adapterNews?.setFromLogin(requireArguments().getBoolean("fromLogin"))


### PR DESCRIPTION
Refactor VoicesAdapter to remove UserRepository dependency

Removed `UserRepository` from `VoicesAdapter` constructor and replaced it with a pre-parsed `leadersList: List<UserEntity>`. The leaders list is now parsed inline at the adapter construction sites (`VoicesFragment`, `ReplyActivity`, `TeamsVoicesFragment`) using `userRepository.parseLeadersJson` and the result is passed directly to the adapter. This removes a data layer dependency from the UI adapter layer.

---
*PR created automatically by Jules for task [13368324851304894580](https://jules.google.com/task/13368324851304894580) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of community leaders in Voices and Teams Voices.
  * Ensured leader information loads consistently when viewing voices, replies, and team voices.
  * Improved the reliability of leader information shown alongside voice content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->