### PR TITLE
sync: smoother file uploading streaming (fixes #15794)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6528
-        versionName = "0.65.28"
+        versionCode = 6529
+        versionName = "0.65.29"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
@@ -5,7 +5,7 @@ import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.dao.AnswerDao
 import org.ole.planet.myplanet.data.room.dao.ExamDao
@@ -14,7 +14,6 @@ import org.ole.planet.myplanet.model.MembershipDoc
 import org.ole.planet.myplanet.model.StepExam
 import org.ole.planet.myplanet.model.Submission
 import org.ole.planet.myplanet.services.FileUploader
-import org.ole.planet.myplanet.utils.FileUtils
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.UrlUtils
@@ -127,9 +126,7 @@ class UploadRepositoryImpl @Inject constructor(
         val (mimeType, body) = withContext(dispatcherProvider.io) {
             val connection = file.toURI().toURL().openConnection()
             val type = connection.contentType ?: "application/octet-stream"
-            val requestBody = FileUtils.fullyReadFileToBytes(file)
-                .toRequestBody("application/octet-stream".toMediaTypeOrNull())
-            type to requestBody
+            type to file.asRequestBody("application/octet-stream".toMediaTypeOrNull())
         }
         val url = String.format(destinationFormat, UrlUtils.getUrl(), id, name)
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadManager.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.di.ApplicationScope
@@ -359,7 +359,7 @@ class UploadManager @Inject constructor(
         if (!imageFile.exists()) return rev
         return try {
             val mimeType = FileUtils.getMimeType(imageName) ?: "image/*"
-            val body = imageFile.readBytes().toRequestBody(mimeType.toMediaTypeOrNull())
+            val body = imageFile.asRequestBody(mimeType.toMediaTypeOrNull())
             val encodedName = Uri.encode(imageName)
             val url = "${UrlUtils.getUrl()}/teams/$teamId/$encodedName"
             val response = uploadRepository.uploadResource(FileUploader.getHeaderMap(mimeType, rev), url, body)
@@ -445,8 +445,7 @@ class UploadManager @Inject constructor(
                             val imageFile = File(getString("imageUrl", imgObject))
                             val fileName = FileUtils.getFileNameFromUrl(getString("imageUrl", imgObject))
                             val mimeType = imageFile.toURI().toURL().openConnection().contentType
-                            val fileBody = FileUtils.fullyReadFileToBytes(imageFile)
-                                .toRequestBody("application/octet-stream".toMediaTypeOrNull())
+                            val fileBody = imageFile.asRequestBody("application/octet-stream".toMediaTypeOrNull())
 
                             uploadRepository.uploadResource(
                                 getHeaderMap(mimeType, resourceRev),

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/AchievementUploader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/AchievementUploader.kt
@@ -7,7 +7,7 @@ import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import org.ole.planet.myplanet.repository.UploadRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.services.FileUploader
@@ -50,7 +50,7 @@ class AchievementUploader @Inject constructor(
         val cvFile = File(FileUtils.getOlePath(context) + "cv/$resumeFileName")
         if (!cvFile.exists()) return
         try {
-            val body = cvFile.readBytes().toRequestBody("application/pdf".toMediaTypeOrNull())
+            val body = cvFile.asRequestBody("application/pdf".toMediaTypeOrNull())
             // CouchDB attachment key is always "resume.pdf"
             val url = "${UrlUtils.getUrl()}/achievements/$docId/resume.pdf"
             uploadRepository.uploadResource(FileUploader.getHeaderMap("application/pdf", rev), url, body)

--- a/app/src/main/java/org/ole/planet/myplanet/utils/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/FileUtils.kt
@@ -48,9 +48,6 @@ object FileUtils {
         return File(externalFilesDir, "ole/$libraryId/$address")
     }
 
-    @Throws(IOException::class)
-    fun fullyReadFileToBytes(f: File): ByteArray = f.readBytes()
-
     private fun createFilePath(context: Context, folder: String, filename: String): File {
         val baseDirectory = File(getExternalFilesDir(context), folder)
 

--- a/app/src/test/java/org/ole/planet/myplanet/utils/FileUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/FileUtilsTest.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import android.os.Environment
 import java.io.File
 import org.junit.After
-import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -49,16 +48,6 @@ class FileUtilsTest {
         val path = FileUtils.getOlePath(context)
         assertTrue(path.endsWith("/ole/"))
         assertTrue(path.contains(context.getExternalFilesDir(null)?.absolutePath ?: ""))
-    }
-
-    @Test
-    fun fullyReadFileToBytes_returnsCorrectBytes() {
-        val file = File(tempDir, "test.txt")
-        val data = "Hello, World!".toByteArray()
-        file.writeBytes(data)
-
-        val bytes = FileUtils.fullyReadFileToBytes(file)
-        assertArrayEquals(data, bytes)
     }
 
     @Test


### PR DESCRIPTION
Replaced `file.readBytes().toRequestBody()` with OkHttp's streaming `file.asRequestBody()` extension function in `UploadManager.kt` (for team image attachments) and `AchievementUploader.kt` (for CV PDF attachments). This change prevents large files from being fully loaded into memory before uploading, effectively addressing high memory usage and out-of-memory risks during syncs while preserving MIME types, URL encoding, and retry behaviors.

---
*PR created automatically by Jules for task [12183164733263910298](https://jules.google.com/task/12183164733263910298) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * File uploads now use a more memory-efficient approach, reducing the need to load entire files into memory.
  * Updated attachment, team image, news image, and achievement uploads accordingly.

* **Release**
  * Android app version updated to 0.65.29.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->