### PR TITLE
Refactor Guest User Restrictions and Visibility in ResourcesFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -208,6 +208,8 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         lifecycleScope.launch {
             userModel = userRepository.getUserModel()
             setupGuestUserRestrictions()
+            checkList()
+            hideButton()
 
             val userId = userModel?.id
             if (userId != null) {
@@ -437,33 +439,37 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
         }
     }
 
-    private fun hideButton(){
+    private fun hideButton() {
         val count = selectedItems?.size ?: 0
+        val isGuest = userModel?.isGuest() == true
         tvDelete?.isEnabled = count != 0
         tvAddToLib.isEnabled = count != 0
-        if(count != 0){
-            if(isMyCourseLib) tvDelete?.visibility = View.VISIBLE
-            else tvAddToLib.visibility = View.VISIBLE
+        if (count != 0) {
+            if (isMyCourseLib) {
+                tvDelete?.visibility = View.VISIBLE
+            } else {
+                tvAddToLib.visibility = if (isGuest) View.GONE else View.VISIBLE
+            }
         } else {
-            if(isMyCourseLib) tvDelete?.visibility = View.GONE
+            if (isMyCourseLib) tvDelete?.visibility = View.GONE
             else tvAddToLib.visibility = View.GONE
         }
     }
 
     private fun checkList(listSize: Int = if (::adapterLibrary.isInitialized) adapterLibrary.currentList.size else 0) {
         val hasAnyLibraryData = allResourceModels.isNotEmpty()
+        val isGuest = userModel?.isGuest() == true
 
         if (!hasAnyLibraryData && listSize == 0) {
             selectAll.visibility = View.GONE
             etSearch.visibility = View.GONE
-            tvAddToLib.visibility = View.GONE
             tvSelected.visibility = View.GONE
             binding.btnCollections.visibility = View.GONE
             filter.visibility = View.GONE
             clearTags.visibility = View.GONE
             tvDelete?.visibility = View.GONE
         } else {
-            selectAll.visibility = View.VISIBLE
+            selectAll.visibility = if (isGuest) View.GONE else View.VISIBLE
             etSearch.visibility = View.VISIBLE
             binding.btnCollections.visibility = View.VISIBLE
             filter.visibility = View.VISIBLE


### PR DESCRIPTION
This change consolidates visibility ownership for the 'Select all' and 'Add to library' controls in ResourcesFragment to prevent conflicting overrides and UI state issues for guest users.

1. Updates `hideButton()` to manage the visibility of `tvAddToLib`, checking if the current user is a guest to hide it correctly when items are selected.
2. Updates `checkList()` to set `selectAll` visibility based on guest status while removing any direct overrides of `tvAddToLib` visibility.
3. Invokes both `checkList()` and `hideButton()` inside the `onViewCreated` coroutine immediately after `userModel` is resolved to guarantee immediate and reliable restriction enforcement.
4. Cleans up unnecessary redundant logic and validates with local unit testing.

---
*PR created automatically by Jules for task [1169505685638004328](https://jules.google.com/task/1169505685638004328) started by @J-S-webskas*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guest users can no longer add resources to their library.
  * Selection controls now correctly reflect guest access and library mode.
  * “Select all” and resource actions are shown or hidden based on the user’s access and current selections.
  * Resource action buttons now initialize consistently after refreshing the resource list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->