### PR TITLE
teams: smoother submissions repositories streamlining (fixes #15796)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6529
-        versionName = "0.65.29"
+        versionCode = 6530
+        versionName = "0.65.30"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/ApkLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ApkLog.kt
@@ -27,7 +27,7 @@ open class ApkLog {
     companion object {
         const val ERROR_TYPE_CRASH = "crash"
 
-        fun serialize(log: ApkLog): JsonObject {
+        fun serialize(log: ApkLog, customDeviceName: String): JsonObject {
             val `object` = JsonObject()
             `object`.addProperty("type", log.type)
             `object`.addProperty("error", log.error)
@@ -38,7 +38,7 @@ open class ApkLog {
             `object`.addProperty("createdOn", log.createdOn)
             `object`.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
             `object`.addProperty("deviceName", NetworkUtils.getDeviceName())
-            `object`.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(org.ole.planet.myplanet.MainApplication.context))
+            `object`.addProperty("customDeviceName", customDeviceName)
             `object`.addProperty("parentCode", log.parentCode)
             return `object`
         }

--- a/app/src/main/java/org/ole/planet/myplanet/model/ApkLog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/ApkLog.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.model
 
-import android.content.Context
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.google.gson.JsonObject
@@ -28,7 +27,7 @@ open class ApkLog {
     companion object {
         const val ERROR_TYPE_CRASH = "crash"
 
-        fun serialize(log: ApkLog, context: Context): JsonObject {
+        fun serialize(log: ApkLog): JsonObject {
             val `object` = JsonObject()
             `object`.addProperty("type", log.type)
             `object`.addProperty("error", log.error)
@@ -39,7 +38,7 @@ open class ApkLog {
             `object`.addProperty("createdOn", log.createdOn)
             `object`.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
             `object`.addProperty("deviceName", NetworkUtils.getDeviceName())
-            `object`.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
+            `object`.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(org.ole.planet.myplanet.MainApplication.context))
             `object`.addProperty("parentCode", log.parentCode)
             return `object`
         }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -57,7 +57,7 @@ interface SubmissionsRepository {
     suspend fun bulkInsertFromSync(jsonArray: JsonArray)
     suspend fun insertSubmission(submission: JsonObject)
     suspend fun getExamUploadPayload(submission: Submission): JsonObject
-    suspend fun serializeSubmission(submission: Submission, context: Context, source: String, parentCode: String): JsonObject
+    suspend fun serializeSubmission(submission: Submission, source: String, parentCode: String): JsonObject
     suspend fun generateSubmissionPdf(submissionId: String): File?
     suspend fun generateMultipleSubmissionsPdf(submissionIds: List<String>, examTitle: String): File?
     suspend fun getPendingExamResults(): List<Submission>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepository.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import android.content.Context
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import java.io.File

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -773,7 +773,7 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
         return `object`
     }
 
-    override suspend fun serializeSubmission(submission: Submission, context: Context, source: String, parentCode: String): JsonObject {
+    override suspend fun serializeSubmission(submission: Submission, source: String, parentCode: String): JsonObject {
         val jsonObject = JsonObject()
 
         try {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -59,6 +59,7 @@ import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.UrlUtils
 
 class TeamsRepositoryImpl @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val context: Context,
     private val activitiesRepository: ActivitiesRepository,
     private val userSessionManager: UserSessionManager,
     private val uploadManager: UploadManager,
@@ -1200,7 +1201,7 @@ class TeamsRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun serializeTeamActivities(log: TeamLog, context: Context): JsonObject {
+    override fun serializeTeamActivities(log: TeamLog): JsonObject {
         val ob = JsonObject()
         ob.addProperty("user", log.user)
         ob.addProperty("type", log.type)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.repository
 
 import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import android.content.SharedPreferences
 import android.os.Build
 import android.text.TextUtils
@@ -59,7 +60,7 @@ import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.UrlUtils
 
 class TeamsRepositoryImpl @Inject constructor(
-    @dagger.hilt.android.qualifiers.ApplicationContext private val context: Context,
+    @ApplicationContext private val context: Context,
     private val activitiesRepository: ActivitiesRepository,
     private val userSessionManager: UserSessionManager,
     private val uploadManager: UploadManager,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsSyncRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsSyncRepository.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.repository
 
-import android.content.Context
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.ole.planet.myplanet.model.TeamLog

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsSyncRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsSyncRepository.kt
@@ -14,7 +14,7 @@ interface TeamsSyncRepository {
     suspend fun syncTeamActivities()
     suspend fun insertTeamLog(json: JsonObject)
     suspend fun insertTeamLogs(logs: List<JsonObject>)
-    fun serializeTeamActivities(log: TeamLog, context: Context): JsonObject
+    fun serializeTeamActivities(log: TeamLog): JsonObject
     suspend fun insertMyTeam(doc: JsonObject)
     suspend fun batchInsertMyTeams(documents: List<JsonObject>): Int
     suspend fun bulkInsertFromSync(jsonArray: JsonArray)

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfig.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfig.kt
@@ -34,16 +34,8 @@ sealed class UploadSerializer<T : Any> {
         val serialize: (T) -> JsonObject
     ) : UploadSerializer<T>()
 
-    data class WithContext<T : Any>(
-        val serialize: (T, Context) -> JsonObject
-    ) : UploadSerializer<T>()
-
     data class Async<T : Any>(
         val serialize: suspend (T) -> JsonObject
-    ) : UploadSerializer<T>()
-
-    data class AsyncContext<T : Any>(
-        val serialize: suspend (T, Context) -> JsonObject
     ) : UploadSerializer<T>()
 }
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfig.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfig.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.services.upload
 
-import android.content.Context
 import com.google.gson.JsonObject
 import kotlin.reflect.KClass
 

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -95,7 +95,7 @@ class UploadConfigs @Inject constructor(
         endpoint = "team_activities",
         modelClassName = "TeamLog",
         fetchPendingItems = { teamsSyncRepository.get().getPendingTeamLogUploads() },
-        serializer = UploadSerializer.WithContext { log, context -> teamsSyncRepository.get().serializeTeamActivities(log, context) },
+        serializer = UploadSerializer.Simple { log -> teamsSyncRepository.get().serializeTeamActivities(log) },
         idExtractor = { it.id },
         markUploaded = { results ->
             results.filter { result ->
@@ -208,7 +208,7 @@ class UploadConfigs @Inject constructor(
         endpoint = "apk_logs",
         modelClassName = "ApkLog",
         fetchPendingItems = { diagnosticsRepository.getPendingApkLogs() },
-        serializer = UploadSerializer.WithContext(ApkLog::serialize),
+        serializer = UploadSerializer.Simple(ApkLog::serialize),
         idExtractor = { it.id },
         markUploaded = { results ->
             // A row is "pending" until it has a _rev; set it here. Rows that no longer exist
@@ -249,8 +249,8 @@ class UploadConfigs @Inject constructor(
         modelClass = Submission::class,
         endpoint = "submissions",
         fetchPendingItems = { submissionsRepository.getPendingSubmissionsForUpload() },
-        serializer = UploadSerializer.AsyncContext { submission, context ->
-            submissionsRepository.serializeSubmission(submission, context, sharedPrefManager.getPlanetCode(), sharedPrefManager.getParentCode())
+        serializer = UploadSerializer.Async { submission ->
+            submissionsRepository.serializeSubmission(submission, sharedPrefManager.getPlanetCode(), sharedPrefManager.getParentCode())
         },
         idExtractor = { it.id },
         dbIdExtractor = { it._id },

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -35,6 +35,7 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 
 @Singleton
 class UploadConfigs @Inject constructor(
+    @dagger.hilt.android.qualifiers.ApplicationContext private val context: android.content.Context,
     private val voicesRepository: VoicesRepository,
     private val submissionsRepository: SubmissionsRepository,
     private val activitiesRepository: ActivitiesRepository,
@@ -208,7 +209,7 @@ class UploadConfigs @Inject constructor(
         endpoint = "apk_logs",
         modelClassName = "ApkLog",
         fetchPendingItems = { diagnosticsRepository.getPendingApkLogs() },
-        serializer = UploadSerializer.Simple(ApkLog::serialize),
+        serializer = UploadSerializer.Simple { log -> ApkLog.serialize(log, org.ole.planet.myplanet.utils.NetworkUtils.getCustomDeviceName(context)) },
         idExtractor = { it.id },
         markUploaded = { results ->
             // A row is "pending" until it has a _rev; set it here. Rows that no longer exist

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadConfigs.kt
@@ -1,6 +1,8 @@
 package org.ole.planet.myplanet.services.upload
 
 import dagger.Lazy
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import org.ole.planet.myplanet.repository.DiagnosticsRepository
@@ -19,6 +21,7 @@ import org.ole.planet.myplanet.model.StepExam
 import org.ole.planet.myplanet.model.Submission
 import org.ole.planet.myplanet.model.SubmitPhotos
 import org.ole.planet.myplanet.model.TeamLog
+import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.ActivitiesRepository
@@ -35,7 +38,7 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 
 @Singleton
 class UploadConfigs @Inject constructor(
-    @dagger.hilt.android.qualifiers.ApplicationContext private val context: android.content.Context,
+    @ApplicationContext private val context: Context,
     private val voicesRepository: VoicesRepository,
     private val submissionsRepository: SubmissionsRepository,
     private val activitiesRepository: ActivitiesRepository,
@@ -209,7 +212,7 @@ class UploadConfigs @Inject constructor(
         endpoint = "apk_logs",
         modelClassName = "ApkLog",
         fetchPendingItems = { diagnosticsRepository.getPendingApkLogs() },
-        serializer = UploadSerializer.Simple { log -> ApkLog.serialize(log, org.ole.planet.myplanet.utils.NetworkUtils.getCustomDeviceName(context)) },
+        serializer = UploadSerializer.Simple { log -> ApkLog.serialize(log, NetworkUtils.getCustomDeviceName(context)) },
         idExtractor = { it.id },
         markUploaded = { results ->
             // A row is "pending" until it has a _rev; set it here. Rows that no longer exist

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
@@ -112,9 +112,7 @@ class UploadCoordinator @Inject constructor(
             val serialized = try {
                 when (val serializer = config.serializer) {
                     is UploadSerializer.Simple -> serializer.serialize(copiedItem)
-                    is UploadSerializer.WithContext -> serializer.serialize(copiedItem, context)
                     is UploadSerializer.Async -> null
-                    is UploadSerializer.AsyncContext -> null
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Serialization failed for item", e)
@@ -128,7 +126,6 @@ class UploadCoordinator @Inject constructor(
             val serialized = try {
                 when (val serializer = config.serializer) {
                     is UploadSerializer.Async -> serializer.serialize(copiedItem)
-                    is UploadSerializer.AsyncContext -> serializer.serialize(copiedItem, context)
                     else -> preSerialized ?: return@mapNotNull null
                 }
             } catch (e: Exception) {
@@ -355,9 +352,7 @@ class UploadCoordinator @Inject constructor(
             val serialized = try {
                 when (val serializer = config.serializer) {
                     is UploadSerializer.Simple -> serializer.serialize(item)
-                    is UploadSerializer.WithContext -> serializer.serialize(item, context)
                     is UploadSerializer.Async -> serializer.serialize(item)
-                    is UploadSerializer.AsyncContext -> serializer.serialize(item, context)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Serialization failed for item", e)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImplTest.kt
@@ -480,7 +480,7 @@ class SubmissionsRepositoryImplTest {
             user = "{\"_id\":\"stored_user\"}"
         }
 
-        val result = repository.serializeSubmission(submission, context, "planet", "parent")
+        val result = repository.serializeSubmission(submission, "planet", "parent")
 
         assertEquals("fresh_user", result.getAsJsonObject("user").get("_id").asString)
     }
@@ -499,7 +499,7 @@ class SubmissionsRepositoryImplTest {
             user = "{\"_id\":\"stored_user\"}"
         }
 
-        val result = repository.serializeSubmission(submission, context, "planet", "parent")
+        val result = repository.serializeSubmission(submission, "planet", "parent")
 
         assertEquals("stored_user", result.getAsJsonObject("user").get("_id").asString)
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
@@ -59,6 +59,7 @@ class TeamsRepositoryBenchmarkTest {
         every { dispatcherProvider.unconfined } returns testDispatcher
 
         teamsRepository = TeamsRepositoryImpl(
+            mockk(relaxed = true),
             activitiesRepository,
             userSessionManager,
             uploadManager,

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBulkInsertTransactionTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBulkInsertTransactionTest.kt
@@ -73,6 +73,7 @@ class TeamsRepositoryBulkInsertTransactionTest {
         teamDao = spyk(db.teamDao())
 
         repository = TeamsRepositoryImpl(
+            mockk<android.content.Context>(relaxed = true),
             mockk<ActivitiesRepository>(relaxed = true),
             mockk<UserSessionManager>(relaxed = true),
             mockk<UploadManager>(relaxed = true),

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
@@ -85,6 +85,7 @@ class TeamsRepositoryImplTest {
         val mockUserRepository = mockk<UserRepository>(relaxed = true)
 
         teamsRepository = TeamsRepositoryImpl(
+            mockk<android.content.Context>(relaxed = true),
             activitiesRepository,
             userSessionManager,
             uploadManager,
@@ -94,7 +95,7 @@ class TeamsRepositoryImplTest {
             serverUrlMapper,
             dispatcherProvider,
             mockUserRepository,
-            dagger.Lazy { mockk(relaxed = true) },
+            dagger.Lazy { mockk<ResourcesRepository>(relaxed = true) },
             TestTimeProvider(),
             teamLogDao,
             teamTaskDao,
@@ -279,7 +280,7 @@ class TeamsRepositoryImplTest {
         teamLog._rev = "rev1"
         teamLog._id = "id1"
 
-        val jsonObject = teamsRepository.serializeTeamActivities(teamLog, mockContext)
+        val jsonObject = teamsRepository.serializeTeamActivities(teamLog)
 
         assertEquals("user1", jsonObject.get("user").asString)
         assertEquals("type1", jsonObject.get("type").asString)
@@ -321,7 +322,7 @@ class TeamsRepositoryImplTest {
         teamLog._rev = ""
         teamLog._id = "id1"
 
-        val jsonObject = teamsRepository.serializeTeamActivities(teamLog, mockContext)
+        val jsonObject = teamsRepository.serializeTeamActivities(teamLog)
 
         assertFalse(jsonObject.has("_rev"))
         assertFalse(jsonObject.has("_id"))

--- a/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/upload/UploadConfigsTest.kt
@@ -23,6 +23,7 @@ class UploadConfigsTest {
     private val activitiesRepository: ActivitiesRepository = mockk(relaxed = true)
     private val voicesRepository: VoicesRepository = mockk(relaxed = true)
     private val uploadConfigs = UploadConfigs(
+        context = mockk(relaxed = true),
         voicesRepository = voicesRepository,
         submissionsRepository = mockk(relaxed = true),
         activitiesRepository = activitiesRepository,


### PR DESCRIPTION
Removes the `Context` parameter from repository interface serialization methods by injecting `@ApplicationContext` into the implementations instead. This makes the repositories more testable and decoupled from the Android framework. also cleans up unused upload serializer config variants.

---
*PR created automatically by Jules for task [15862076471608288046](https://jules.google.com/task/15862076471608288046) started by @dogi*