### PR TITLE
Refactor UserDao and Repositories for Narrow Queries

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserDao.kt
@@ -9,23 +9,20 @@ import org.ole.planet.myplanet.model.UserEntity
 interface UserDao {
     @Query("SELECT * FROM users WHERE id = :id OR _id = :id LIMIT 1")
     suspend fun getById(id: String): UserEntity?
-
     @Query("SELECT * FROM users") suspend fun getAll(): List<UserEntity>
     @Query("SELECT * FROM users WHERE id IN (:ids) OR _id IN (:ids)") suspend fun getByIds(ids: List<String>): List<UserEntity>
     @Query("SELECT * FROM users WHERE _id IS NOT NULL AND _id != '' AND id NOT LIKE 'guest%'") suspend fun getSyncedUsers(): List<UserEntity>
-@Query("SELECT * FROM users WHERE _id IS NOT NULL AND _id != ''") suspend fun getUsersForHealthSync(): List<UserEntity>
+    @Query("SELECT id, _id, planetCode FROM users WHERE _id IS NOT NULL AND _id != ''") suspend fun getUsersForHealthSync(): List<org.ole.planet.myplanet.model.UserHealthSync>
     @Query("SELECT * FROM users WHERE _id IS NULL OR _id = '' OR isUpdated = 1 LIMIT :limit") suspend fun getPendingSyncUsers(limit: Int): List<UserEntity>
     @Query("SELECT * FROM users WHERE name = :name LIMIT 1") suspend fun getByName(name: String): UserEntity?
     @Query("SELECT * FROM users WHERE name = :name COLLATE NOCASE LIMIT 1") suspend fun getByNameIgnoreCase(name: String): UserEntity?
     @Query("SELECT * FROM users WHERE name LIKE '%' || :query || '%' OR firstName LIKE '%' || :query || '%' OR lastName LIKE '%' || :query || '%'") suspend fun search(query: String): List<UserEntity>
-
     @Query("SELECT * FROM users ORDER BY joinDate ASC") suspend fun getPatientsSortedByJoinDateAsc(): List<UserEntity>
     @Query("SELECT * FROM users ORDER BY joinDate DESC") suspend fun getPatientsSortedByJoinDateDesc(): List<UserEntity>
     @Query("SELECT * FROM users ORDER BY name ASC") suspend fun getPatientsSortedByNameAsc(): List<UserEntity>
     @Query("SELECT * FROM users ORDER BY name DESC") suspend fun getPatientsSortedByNameDesc(): List<UserEntity>
-
-@Query("SELECT * FROM users WHERE IFNULL(name, '') IN (SELECT IFNULL(name, '') FROM users GROUP BY IFNULL(name, '') HAVING COUNT(*) > 1)") suspend fun getDuplicateUsers(): List<UserEntity>
-@Query("SELECT * FROM users WHERE name IN (:names) AND _id LIKE 'guest_%'") suspend fun getGuestUsersByNames(names: List<String>): List<UserEntity>
+    @Query("SELECT * FROM users WHERE IFNULL(name, '') IN (SELECT IFNULL(name, '') FROM users GROUP BY IFNULL(name, '') HAVING COUNT(*) > 1)") suspend fun getDuplicateUsers(): List<UserEntity>
+    @Query("SELECT * FROM users WHERE name IN (:names) AND _id LIKE 'guest_%'") suspend fun getGuestUsersByNames(names: List<String>): List<UserEntity>
     @Query("SELECT COUNT(*) FROM users") suspend fun count(): Int
     @Query("SELECT COUNT(*) FROM users WHERE planetCode = :planetCode") suspend fun countByPlanetCode(planetCode: String): Int
     @Query("DELETE FROM users WHERE id = :id") suspend fun deleteById(id: String): Int

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserDao.kt
@@ -9,10 +9,23 @@ import org.ole.planet.myplanet.model.UserEntity
 interface UserDao {
     @Query("SELECT * FROM users WHERE id = :id OR _id = :id LIMIT 1")
     suspend fun getById(id: String): UserEntity?
+
     @Query("SELECT * FROM users") suspend fun getAll(): List<UserEntity>
+    @Query("SELECT * FROM users WHERE id IN (:ids) OR _id IN (:ids)") suspend fun getByIds(ids: List<String>): List<UserEntity>
+    @Query("SELECT * FROM users WHERE _id IS NOT NULL AND _id != '' AND id NOT LIKE 'guest%'") suspend fun getSyncedUsers(): List<UserEntity>
+@Query("SELECT * FROM users WHERE _id IS NOT NULL AND _id != ''") suspend fun getUsersForHealthSync(): List<UserEntity>
+    @Query("SELECT * FROM users WHERE _id IS NULL OR _id = '' OR isUpdated = 1 LIMIT :limit") suspend fun getPendingSyncUsers(limit: Int): List<UserEntity>
     @Query("SELECT * FROM users WHERE name = :name LIMIT 1") suspend fun getByName(name: String): UserEntity?
     @Query("SELECT * FROM users WHERE name = :name COLLATE NOCASE LIMIT 1") suspend fun getByNameIgnoreCase(name: String): UserEntity?
     @Query("SELECT * FROM users WHERE name LIKE '%' || :query || '%' OR firstName LIKE '%' || :query || '%' OR lastName LIKE '%' || :query || '%'") suspend fun search(query: String): List<UserEntity>
+
+    @Query("SELECT * FROM users ORDER BY joinDate ASC") suspend fun getPatientsSortedByJoinDateAsc(): List<UserEntity>
+    @Query("SELECT * FROM users ORDER BY joinDate DESC") suspend fun getPatientsSortedByJoinDateDesc(): List<UserEntity>
+    @Query("SELECT * FROM users ORDER BY name ASC") suspend fun getPatientsSortedByNameAsc(): List<UserEntity>
+    @Query("SELECT * FROM users ORDER BY name DESC") suspend fun getPatientsSortedByNameDesc(): List<UserEntity>
+
+@Query("SELECT * FROM users WHERE IFNULL(name, '') IN (SELECT IFNULL(name, '') FROM users GROUP BY IFNULL(name, '') HAVING COUNT(*) > 1)") suspend fun getDuplicateUsers(): List<UserEntity>
+@Query("SELECT * FROM users WHERE name IN (:names) AND _id LIKE 'guest_%'") suspend fun getGuestUsersByNames(names: List<String>): List<UserEntity>
     @Query("SELECT COUNT(*) FROM users") suspend fun count(): Int
     @Query("SELECT COUNT(*) FROM users WHERE planetCode = :planetCode") suspend fun countByPlanetCode(planetCode: String): Int
     @Query("DELETE FROM users WHERE id = :id") suspend fun deleteById(id: String): Int

--- a/app/src/main/java/org/ole/planet/myplanet/model/UserHealthSync.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/UserHealthSync.kt
@@ -2,8 +2,11 @@ package org.ole.planet.myplanet.model
 
 import androidx.room.ColumnInfo
 
-data class UserHealthSync(
-    @ColumnInfo(name = "id") val id: String,
-    @ColumnInfo(name = "_id") val _id: String?,
-    @ColumnInfo(name = "planetCode") val planetCode: String?
-)
+class UserHealthSync {
+    @ColumnInfo(name = "id")
+    @JvmField var id: String = ""
+    @ColumnInfo(name = "_id")
+    @JvmField var _id: String? = null
+    @ColumnInfo(name = "planetCode")
+    @JvmField var planetCode: String? = null
+}

--- a/app/src/main/java/org/ole/planet/myplanet/model/UserHealthSync.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/UserHealthSync.kt
@@ -1,0 +1,9 @@
+package org.ole.planet.myplanet.model
+
+import androidx.room.ColumnInfo
+
+data class UserHealthSync(
+    @ColumnInfo(name = "id") val id: String,
+    @ColumnInfo(name = "_id") val _id: String?,
+    @ColumnInfo(name = "planetCode") val planetCode: String?
+)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/HealthRepositoryImpl.kt
@@ -152,13 +152,16 @@ class HealthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getPatientsSortedBy(fieldName: String, descending: Boolean): List<UserEntity> {
-        val users = userDao.getAll()
-        return sortPatients(users, fieldName, descending)
+        return when (fieldName) {
+            "joinDate" -> if (descending) userDao.getPatientsSortedByJoinDateDesc() else userDao.getPatientsSortedByJoinDateAsc()
+            "name" -> if (descending) userDao.getPatientsSortedByNameDesc() else userDao.getPatientsSortedByNameAsc()
+            else -> userDao.getAll()
+        }
     }
 
     override suspend fun searchPatients(query: String, sortField: String, descending: Boolean): List<UserEntity> {
         val users = if (query.isBlank()) {
-            userDao.getAll()
+            return getPatientsSortedBy(sortField, descending)
         } else {
             userDao.search(query)
         }
@@ -202,9 +205,7 @@ class HealthRepositoryImpl @Inject constructor(
         val userMap = if (userIds.isEmpty()) {
             emptyMap()
         } else {
-            val userIdSet = userIds.toSet()
-            userDao.getAll()
-                .filter { it.id in userIdSet }
+            userDao.getByIds(userIds)
                 .associateBy { it.id ?: "" }
         }
         return HealthRecord(mh, mm, list, userMap)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -108,9 +108,7 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun getUsersByIds(userIds: List<String>): List<UserEntity> {
         if (userIds.isEmpty()) return emptyList()
         val userIdSet = userIds.toSet()
-        return userDao.getAll()
-            .filter { it.id in userIdSet || it._id in userIdSet }
-            .map { it }
+        return userDao.getByIds(userIds)
     }
 
     override suspend fun getUserByAnyId(id: String): UserEntity? {
@@ -126,9 +124,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getSyncedUsers(): List<UserEntity> {
-        return userDao.getAll()
-            .filter { !it._id.isNullOrBlank() && !it.id.startsWith("guest") }
-            .map { it }
+        return userDao.getSyncedUsers()
     }
 
     private fun mapToLightweightUser(managedUser: UserEntity): UserEntity {
@@ -140,11 +136,13 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUsersForHealthSync(): List<UserEntity> {
-        return userDao.getAll()
-            .asSequence()
-            .filter { !it._id.isNullOrBlank() }
-            .map { mapToLightweightUser(it) }
-            .toList()
+        return userDao.getUsersForHealthSync().map {
+            UserEntity().apply {
+                this.id = it.id
+                this._id = it._id
+                this.planetCode = it.planetCode
+            }
+        }
     }
 
     override suspend fun getSyncedUserByName(name: String): UserEntity? {
@@ -166,7 +164,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getAllUsers(): List<UserEntity> {
-        return userDao.getAll().map { it }
+        return userDao.getAll()
     }
 
     override suspend fun getUsersSortedBy(fieldName: String, descending: Boolean): List<UserEntity> {
@@ -174,12 +172,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getPendingSyncUsers(limit: Int): List<UserEntity> {
-        return userDao.getAll()
-            .asSequence()
-            .filter { it._id.isNullOrBlank() || it.isUpdated }
-            .map { it }
-            .take(limit)
-            .toList()
+        return userDao.getPendingSyncUsers(limit)
     }
 
 
@@ -314,9 +307,11 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-    private suspend fun migrateGuestUser(id: String, userName: String, users: List<UserEntity>): UserEntity? {
-        val guestUser = users.firstOrNull {
-            it.name == userName && it._id?.startsWith("guest_") == true
+    private suspend fun migrateGuestUser(id: String, userName: String, users: List<UserEntity>?): UserEntity? {
+        val guestUser = if (users != null) {
+            users.firstOrNull { it.name == userName && it._id?.startsWith("guest_") == true }
+        } else {
+            userDao.getGuestUsersByNames(listOf(userName)).firstOrNull()
         } ?: return null
 
         userDao.deleteById(guestUser.id)
@@ -329,13 +324,16 @@ class UserRepositoryImpl @Inject constructor(
     private suspend fun buildUserFromJson(jsonDoc: JsonObject?, users: List<UserEntity>? = null): UserEntity? {
         if (jsonDoc == null) return null
         return try {
-            val availableUsers = users ?: userDao.getAll()
             val id = JsonUtils.getString("_id", jsonDoc).takeIf { it.isNotEmpty() } ?: UUID.randomUUID().toString()
             val userName = JsonUtils.getString("name", jsonDoc)
-            val existingUser = availableUsers.firstOrNull { it.id == id || it._id == id }
+            val existingUser = if (users != null) {
+                users.firstOrNull { it.id == id || it._id == id }
+            } else {
+                userDao.getById(id)
+            }
             val user = existingUser
                 ?: if (id.startsWith("org.couchdb.user:") && userName.isNotEmpty()) {
-                    migrateGuestUser(id, userName, availableUsers)
+                    migrateGuestUser(id, userName, users)
                 } else {
                     null
                 }
@@ -944,8 +942,8 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun cleanupDuplicateUsers() {
-        val allUsers = userDao.getAll()
-        val usersByName = allUsers.groupBy { it.name }
+        val duplicateUsers = userDao.getDuplicateUsers()
+        val usersByName = duplicateUsers.groupBy { it.name }
 
         usersByName.forEach { (_, users) ->
             if (users.size > 1) {
@@ -1173,7 +1171,9 @@ class UserRepositoryImpl @Inject constructor(
             }
         }
 
-        val existingUsersList = userDao.getAll()
+        val userIds = documentList.mapNotNull { JsonUtils.getString("_id", it).takeIf { id -> id.isNotEmpty() } }
+        val userNames = documentList.mapNotNull { JsonUtils.getString("name", it).takeIf { name -> name.isNotEmpty() } }
+        val existingUsersList = userDao.getByIds(userIds) + userDao.getGuestUsersByNames(userNames)
         val usersById = mutableMapOf<String, UserEntity>()
         val guestUsersByName = mutableMapOf<String, UserEntity>()
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryBulkInsertTest.kt
@@ -34,7 +34,8 @@ class UserRepositoryBulkInsertTest {
             userDao,
             mockk(relaxed = true)
         )
-        coEvery { userDao.getAll() } returns emptyList()
+        coEvery { userDao.getByIds(any()) } returns emptyList()
+        coEvery { userDao.getGuestUsersByNames(any()) } returns emptyList()
 
         val jsonArray = JsonArray()
         for (i in 1..10) {
@@ -86,7 +87,8 @@ class UserRepositoryBulkInsertTest {
             _id = "guest_123"
             name = "Guest User"
         }
-        coEvery { userDao.getAll() } returns listOf(existingGuest)
+        coEvery { userDao.getByIds(any()) } returns emptyList()
+        coEvery { userDao.getGuestUsersByNames(any()) } returns listOf(existingGuest)
 
         val list = mutableListOf<JsonObject>()
         val jObj = JsonObject()
@@ -126,7 +128,8 @@ class UserRepositoryBulkInsertTest {
             userDao,
             mockk(relaxed = true)
         )
-        coEvery { userDao.getAll() } returns emptyList()
+        coEvery { userDao.getByIds(any()) } returns emptyList()
+        coEvery { userDao.getGuestUsersByNames(any()) } returns emptyList()
 
         val list = mutableListOf<JsonObject>()
         for (i in 1..2) {


### PR DESCRIPTION
Replaced multiple `getAll().filter { }` patterns in the repositories with targeted SQL queries within `UserDao`. This includes retrieving users by IDs, fetching synced users, retrieving users for health sync with a specific projection, and getting pending sync users within limits. Addressed code review feedback and user formatting requirements. Updated test to mock the newly created narrow queries.

---
*PR created automatically by Jules for task [3087866265564946628](https://jules.google.com/task/3087866265564946628) started by @dogi*