### PR TITLE
all: smoother flow collecting (fixes #15797)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6530
-        versionName = "0.65.30"
+        versionCode = 6531
+        versionName = "0.65.31"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseDashboardFragment.kt
@@ -13,9 +13,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexboxLayout
@@ -69,7 +67,6 @@ open class BaseDashboardFragment : DashboardPluginFragment() {
     }
     private var di: DialogUtils.CustomProgressDialog? = null
 
-
     @Inject
     lateinit var lifeRepository: LifeRepository
 
@@ -117,51 +114,25 @@ open class BaseDashboardFragment : DashboardPluginFragment() {
     }
 
     private fun observeUiState() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch {
-                    viewModel.uiState
-                        .map { it.library }
-                        .distinctUntilChanged()
-                        .collect { library ->
-                            renderMyLibrary(library)
-                        }
-                }
-                launch {
-                    viewModel.uiState
-                        .map { it.courses }
-                        .distinctUntilChanged()
-                        .collect { courses ->
-                            renderMyCourses(courses)
-                        }
-                }
-                launch {
-                    viewModel.uiState
-                        .map { it.teams }
-                        .distinctUntilChanged()
-                        .collect { teams ->
-                            renderMyTeams(teams)
-                        }
-                }
-                launch {
-                    viewModel.uiState
-                        .map { it.fullName to it.offlineLogins }
-                        .distinctUntilChanged()
-                        .collect { (fullName, offlineLogins) ->
-                            view?.findViewById<TextView>(R.id.txtFullName)?.text =
-                                getString(R.string.user_name, fullName, offlineLogins)
-                        }
-                }
-                launch {
-                    newsViewModel.privateImageUrls.collect { urls ->
-                        if (urls.isNotEmpty()) {
-                            Utilities.toast(activity, getString(R.string.downloading_images_please_check_notification))
-                            DownloadUtils.openDownloadService(activity, ArrayList(urls), false)
-                        } else {
-                            Utilities.toast(activity, getString(R.string.no_images_to_download))
-                        }
-                    }
-                }
+        collectWhenStarted(viewModel.uiState.map { it.library }.distinctUntilChanged()) { library ->
+            renderMyLibrary(library)
+        }
+        collectWhenStarted(viewModel.uiState.map { it.courses }.distinctUntilChanged()) { courses ->
+            renderMyCourses(courses)
+        }
+        collectWhenStarted(viewModel.uiState.map { it.teams }.distinctUntilChanged()) { teams ->
+            renderMyTeams(teams)
+        }
+        collectWhenStarted(viewModel.uiState.map { it.fullName to it.offlineLogins }.distinctUntilChanged()) { (fullName, offlineLogins) ->
+            view?.findViewById<TextView>(R.id.txtFullName)?.text =
+                getString(R.string.user_name, fullName, offlineLogins)
+        }
+        collectWhenStarted(newsViewModel.privateImageUrls) { urls ->
+            if (urls.isNotEmpty()) {
+                Utilities.toast(activity, getString(R.string.downloading_images_please_check_notification))
+                DownloadUtils.openDownloadService(activity, ArrayList(urls), false)
+            } else {
+                Utilities.toast(activity, getString(R.string.no_images_to_download))
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/chat/ChatDetailFragment.kt
@@ -22,9 +22,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isNotEmpty
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.gson.reflect.TypeToken
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesReportsFragment.kt
@@ -15,9 +15,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.google.android.material.snackbar.Snackbar
@@ -27,7 +25,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Locale
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
@@ -39,6 +36,7 @@ import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class EnterprisesReportsFragment : BaseTeamFragment() {
@@ -120,39 +118,32 @@ class EnterprisesReportsFragment : BaseTeamFragment() {
         binding.rvReports.adapter = reportsAdapter
         binding.rvReports.layoutManager = LinearLayoutManager(activity)
 
+        collectLatestWhenStarted(isMemberFlow) { isMember ->
+            val canManage = if (fromCommunity) user?.isManager() == true else isMember
+            binding.addReports.isVisible = canManage
+            reportsAdapter.setNonTeamMember(!canManage)
+        }
         viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch {
-                    isMemberFlow.collectLatest { isMember ->
-                        val canManage = if (fromCommunity) user?.isManager() == true else isMember
-                        binding.addReports.isVisible = canManage
-                        reportsAdapter.setNonTeamMember(!canManage)
+            val flow = viewModel.getReportsFlow(teamId)
+            collectLatestWhenStarted(flow) { reportList ->
+                updatedReportsList(reportList)
+            }
+        }
+        collectLatestWhenStarted(viewModel.reportEvent) { event ->
+            when (event) {
+                is ReportEvent.ReportAdded,
+                is ReportEvent.ReportUpdated -> {
+                    if (event is ReportEvent.ReportAdded) {
+                        scrollToLatestReport = true
                     }
+                    activeDialog?.dismiss()
+                    activeDialog = null
                 }
-                launch {
-                    viewModel.getReportsFlow(teamId).collectLatest { reportList ->
-                        updatedReportsList(reportList)
-                    }
+                is ReportEvent.ReportArchived -> {
+                    // archived successfully
                 }
-                launch {
-                    viewModel.reportEvent.collectLatest { event ->
-                        when (event) {
-                            is ReportEvent.ReportAdded,
-                            is ReportEvent.ReportUpdated -> {
-                                if (event is ReportEvent.ReportAdded) {
-                                    scrollToLatestReport = true
-                                }
-                                activeDialog?.dismiss()
-                                activeDialog = null
-                            }
-                            is ReportEvent.ReportArchived -> {
-                                // archived successfully
-                            }
-                            is ReportEvent.Error -> {
-                                Snackbar.make(view, event.message, Snackbar.LENGTH_LONG).show()
-                            }
-                        }
-                    }
+                is ReportEvent.Error -> {
+                    Snackbar.make(view, event.message, Snackbar.LENGTH_LONG).show()
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsFragment.kt
@@ -10,9 +10,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.ArrayList
@@ -30,6 +28,7 @@ import org.ole.planet.myplanet.ui.teams.TeamPageConfig.ChatPage
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.JoinRequestsPage
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.TasksPage
 import org.ole.planet.myplanet.ui.voices.ReplyActivity
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class NotificationsFragment : Fragment() {
@@ -85,41 +84,30 @@ class NotificationsFragment : Fragment() {
 
         viewModel.loadNotifications(userId, "all", isAdmin)
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch {
-                    viewModel.groupedItems.collect { items ->
-                        adapter.submitList(items)
-                        val isEmpty = items.isEmpty()
-                        binding.emptyData.visibility = if (isEmpty) View.VISIBLE else View.GONE
-                        binding.emptyData.text = when (currentFilter) {
-                            "unread" -> getString(R.string.no_unread_notifications)
-                            "read" -> getString(R.string.no_read_notifications)
-                            else -> getString(R.string.no_notifications)
-                        }
-                        binding.status.visibility = if (isEmpty && currentFilter == "all") View.GONE else View.VISIBLE
-                    }
-                }
-                launch {
-                    viewModel.unreadCount.collect { count ->
-                        notificationUpdateListener?.onNotificationCountUpdated(count)
-                        val showButton = count > 0 && currentFilter != "read"
-                        binding.btnMarkAllAsRead.visibility = if (showButton) View.VISIBLE else View.GONE
-                    }
-                }
-                launch {
-                    viewModel.isSelectionMode.collect { inSelectionMode ->
-                        binding.ltBulkActionBar.visibility = if (inSelectionMode) View.VISIBLE else View.GONE
-                        binding.ltTopBar.visibility = if (inSelectionMode) View.GONE else View.VISIBLE
-                    }
-                }
-                launch {
-                    viewModel.selectedCount.collect { count ->
-                        binding.tvSelectedCount.text = getString(R.string.selected_count, count)
-                    }
-                }
+        collectWhenStarted(viewModel.groupedItems) { items ->
+            adapter.submitList(items)
+            val isEmpty = items.isEmpty()
+            binding.emptyData.visibility = if (isEmpty) View.VISIBLE else View.GONE
+            binding.emptyData.text = when (currentFilter) {
+                "unread" -> getString(R.string.no_unread_notifications)
+                "read" -> getString(R.string.no_read_notifications)
+                else -> getString(R.string.no_notifications)
             }
+            binding.status.visibility = if (isEmpty && currentFilter == "all") View.GONE else View.VISIBLE
         }
+        collectWhenStarted(viewModel.unreadCount) { count ->
+            notificationUpdateListener?.onNotificationCountUpdated(count)
+            val showButton = count > 0 && currentFilter != "read"
+            binding.btnMarkAllAsRead.visibility = if (showButton) View.VISIBLE else View.GONE
+        }
+        collectWhenStarted(viewModel.isSelectionMode) { inSelectionMode ->
+            binding.ltBulkActionBar.visibility = if (inSelectionMode) View.VISIBLE else View.GONE
+            binding.ltTopBar.visibility = if (inSelectionMode) View.GONE else View.VISIBLE
+        }
+        collectWhenStarted(viewModel.selectedCount) { count ->
+            binding.tvSelectedCount.text = getString(R.string.selected_count, count)
+        }
+
         return binding.root
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/ratings/RatingsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/ratings/RatingsFragment.kt
@@ -10,15 +10,12 @@ import android.widget.RatingBar.OnRatingBarChangeListener
 import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
 import org.ole.planet.myplanet.databinding.FragmentRatingBinding
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class RatingsFragment : DialogFragment() {
@@ -89,60 +86,48 @@ class RatingsFragment : DialogFragment() {
     }
     
     private fun observeViewModel() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.ratingState.collect { state ->
-                    when (state) {
-                        is RatingsViewModel.RatingUiState.Loading -> {}
-                        is RatingsViewModel.RatingUiState.Success -> {
-                            state.existingRating?.let { rating ->
-                                binding.ratingBar.rating = rating.rate.toFloat()
-                                binding.etComment.setText(rating.comment)
-                            }
-                        }
-                        is RatingsViewModel.RatingUiState.Error -> {
-                            Utilities.toast(activity, state.message)
-                        }
+        collectWhenStarted(viewModel.ratingState) { state ->
+            when (state) {
+                is RatingsViewModel.RatingUiState.Loading -> {}
+                is RatingsViewModel.RatingUiState.Success -> {
+                    state.existingRating?.let { rating ->
+                        binding.ratingBar.rating = rating.rate.toFloat()
+                        binding.etComment.setText(rating.comment)
                     }
+                }
+                is RatingsViewModel.RatingUiState.Error -> {
+                    Utilities.toast(activity, state.message)
                 }
             }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.userState.collect { user ->
-                    isUserReady = user != null
-                    binding.userStatusContainer.isVisible = !isUserReady
-                    updateSubmitButtonState()
-                }
-            }
+        collectWhenStarted(viewModel.userState) { user ->
+            isUserReady = user != null
+            binding.userStatusContainer.isVisible = !isUserReady
+            updateSubmitButtonState()
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.submitState.collect { state ->
-                    currentSubmitState = state
-                    when (state) {
-                        is RatingsViewModel.SubmitState.Success -> {
-                            Utilities.toast(activity, "Thank you, your rating is submitted.")
-                            val t = type
-                            val i = id
-                            if (t != null && i != null) {
-                                ratingListener?.onRatingChanged(t, i)
-                            } else {
-                                ratingListener?.onRatingChanged()
-                            }
-                            dismiss()
-                        }
-                        is RatingsViewModel.SubmitState.Error -> {
-                            Utilities.toast(activity, state.message)
-                        }
-                        RatingsViewModel.SubmitState.Submitting,
-                        RatingsViewModel.SubmitState.Idle -> Unit
+        collectWhenStarted(viewModel.submitState) { state ->
+            currentSubmitState = state
+            when (state) {
+                is RatingsViewModel.SubmitState.Success -> {
+                    Utilities.toast(activity, "Thank you, your rating is submitted.")
+                    val t = type
+                    val i = id
+                    if (t != null && i != null) {
+                        ratingListener?.onRatingChanged(t, i)
+                    } else {
+                        ratingListener?.onRatingChanged()
                     }
-                    updateSubmitButtonState()
+                    dismiss()
                 }
+                is RatingsViewModel.SubmitState.Error -> {
+                    Utilities.toast(activity, state.message)
+                }
+                RatingsViewModel.SubmitState.Submitting,
+                RatingsViewModel.SubmitState.Idle -> Unit
             }
+            updateSubmitButtonState()
         }
     }
     

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionDetailFragment.kt
@@ -6,14 +6,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.databinding.FragmentSubmissionDetailBinding
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class SubmissionDetailFragment : Fragment() {
@@ -79,34 +76,20 @@ class SubmissionDetailFragment : Fragment() {
     }
 
     private fun observeViewModel() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch {
-                    viewModel.questionAnswers.collect { questionAnswers ->
-                        adapter.submitList(questionAnswers)
-                    }
-                }
-                launch {
-                    viewModel.title.collect { title ->
-                        binding.tvSubmissionTitle.text = title
-                    }
-                }
-                launch {
-                    viewModel.status.collect { status ->
-                        binding.tvSubmissionStatus.text = status
-                    }
-                }
-                launch {
-                    viewModel.date.collect { date ->
-                        binding.tvSubmissionDate.text = date
-                    }
-                }
-                launch {
-                    viewModel.submittedBy.collect { submittedBy ->
-                        binding.tvSubmittedBy.text = submittedBy
-                    }
-                }
-            }
+        collectWhenStarted(viewModel.questionAnswers) { questionAnswers ->
+            adapter.submitList(questionAnswers)
+        }
+        collectWhenStarted(viewModel.title) { title ->
+            binding.tvSubmissionTitle.text = title
+        }
+        collectWhenStarted(viewModel.status) { status ->
+            binding.tvSubmissionStatus.text = status
+        }
+        collectWhenStarted(viewModel.date) { date ->
+            binding.tvSubmissionDate.text = date
+        }
+        collectWhenStarted(viewModel.submittedBy) { submittedBy ->
+            binding.tvSubmittedBy.text = submittedBy
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveyFragment.kt
@@ -7,9 +7,7 @@ import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
@@ -32,6 +30,7 @@ import org.ole.planet.myplanet.model.TableDataUpdate
 import org.ole.planet.myplanet.services.sync.RealtimeSyncManager
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncHelper
 import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
+import org.ole.planet.myplanet.utils.collectWhenStarted
 import org.ole.planet.myplanet.utils.textChanges
 
 @AndroidEntryPoint
@@ -169,51 +168,35 @@ class SurveyFragment : BaseRecyclerFragment<StepExam?>(), OnSurveyAdoptListener,
     }
 
     private fun setupObservers() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch {
-                    viewModel.surveys.collect { surveys ->
-                        (getAdapter() as SurveysAdapter).submitList(surveys) {
-                            recyclerView.scrollToPosition(0)
-                            updateUIState()
-                        }
-                    }
-                }
-                launch {
-                    viewModel.surveyInfos.collect { infos ->
-                        surveyInfoMap.clear()
-                        surveyInfoMap.putAll(infos)
-                        getAdapter().notifyDataSetChanged()
-                    }
-                }
-                launch {
-                    viewModel.bindingData.collect { data ->
-                        bindingDataMap.clear()
-                        bindingDataMap.putAll(data)
-                        getAdapter().notifyDataSetChanged()
-                    }
-                }
-                launch {
-                    viewModel.isLoading.collect { isLoading ->
-                        binding.loadingSpinner.visibility = if (isLoading) View.VISIBLE else View.GONE
-                    }
-                }
-                launch {
-                    viewModel.errorMessage.collect { message ->
-                        message?.let {
-                            Snackbar.make(binding.root, it, Snackbar.LENGTH_LONG).show()
-                        }
-                    }
-                }
-                launch {
-                    viewModel.userMessage.collect { message ->
-                        message?.let {
-                            Snackbar.make(binding.root, it, Snackbar.LENGTH_LONG).show()
-                            if (it == "Survey adopted successfully") {
-                                 binding.rbTeamSurvey.isChecked = true
-                            }
-                        }
-                    }
+        collectWhenStarted(viewModel.surveys) { surveys ->
+            (getAdapter() as SurveysAdapter).submitList(surveys) {
+                recyclerView.scrollToPosition(0)
+                updateUIState()
+            }
+        }
+        collectWhenStarted(viewModel.surveyInfos) { infos ->
+            surveyInfoMap.clear()
+            surveyInfoMap.putAll(infos)
+            getAdapter().notifyDataSetChanged()
+        }
+        collectWhenStarted(viewModel.bindingData) { data ->
+            bindingDataMap.clear()
+            bindingDataMap.putAll(data)
+            getAdapter().notifyDataSetChanged()
+        }
+        collectWhenStarted(viewModel.isLoading) { isLoading ->
+            binding.loadingSpinner.visibility = if (isLoading) View.VISIBLE else View.GONE
+        }
+        collectWhenStarted(viewModel.errorMessage) { message ->
+            message?.let {
+                Snackbar.make(binding.root, it, Snackbar.LENGTH_LONG).show()
+            }
+        }
+        collectWhenStarted(viewModel.userMessage) { message ->
+            message?.let {
+                Snackbar.make(binding.root, it, Snackbar.LENGTH_LONG).show()
+                if (it == "Survey adopted successfully") {
+                     binding.rbTeamSurvey.isChecked = true
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersFragment.kt
@@ -8,9 +8,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -25,6 +23,7 @@ import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.JoinedMemberData
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class MembersFragment : BaseTeamFragment() {
@@ -83,25 +82,18 @@ class MembersFragment : BaseTeamFragment() {
         loadMembers()
 
         requestsViewModel.fetchMembers(teamId)
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch {
-                    requestsViewModel.uiState.collect { state ->
-                        requestsAdapter?.setData(state.members, state.isLeader, state.memberCount)
-                        val hasRequests = state.members.isNotEmpty()
-                        binding.llRequestsSection.visibility = if (hasRequests) View.VISIBLE else View.GONE
-                        if (hasRequests) {
-                            binding.tvRequestsHeader.text = getString(R.string.join_requests) + " (${state.members.size})"
-                        }
-                    }
-                }
-                launch {
-                    requestsViewModel.successAction.collect {
-                        onMemberChangeListener?.onMemberChanged()
-                        loadMembers()
-                    }
-                }
+
+        collectWhenStarted(requestsViewModel.uiState) { state ->
+            requestsAdapter?.setData(state.members, state.isLeader, state.memberCount)
+            val hasRequests = state.members.isNotEmpty()
+            binding.llRequestsSection.visibility = if (hasRequests) View.VISIBLE else View.GONE
+            if (hasRequests) {
+                binding.tvRequestsHeader.text = getString(R.string.join_requests) + " (${state.members.size})"
             }
+        }
+        collectWhenStarted(requestsViewModel.successAction) {
+            onMemberChangeListener?.onMemberChanged()
+            loadMembers()
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/RequestsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/RequestsFragment.kt
@@ -5,9 +5,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -19,6 +17,7 @@ import org.ole.planet.myplanet.callback.OnMemberChangeListener
 import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class RequestsFragment : BaseMemberFragment() {
@@ -44,23 +43,17 @@ class RequestsFragment : BaseMemberFragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             currentUser = userSessionManager.getUserModel() ?: UserEntity()
             (adapter as? RequestsAdapter)?.setUser(currentUser)
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch {
-                    viewModel.uiState.collect { uiState ->
-                        (adapter as? RequestsAdapter)?.setData(
-                            uiState.members,
-                            uiState.isLeader,
-                            uiState.memberCount
-                        )
-                        showNoData(binding.tvNodata, uiState.members.size, "members")
-                    }
-                }
-                launch {
-                    viewModel.successAction.collect {
-                        onMemberChangeListener?.onMemberChanged()
-                    }
-                }
-            }
+        }
+        collectWhenStarted(viewModel.uiState) { uiState ->
+            (adapter as? RequestsAdapter)?.setData(
+                uiState.members,
+                uiState.isLeader,
+                uiState.memberCount
+            )
+            showNoData(binding.tvNodata, uiState.members.size, "members")
+        }
+        collectWhenStarted(viewModel.successAction) {
+            onMemberChangeListener?.onMemberChanged()
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
@@ -15,15 +15,12 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.nex3z.togglebuttongroup.SingleSelectToggleGroup
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Calendar
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
@@ -39,6 +36,8 @@ import org.ole.planet.myplanet.ui.teams.TeamViewModel
 import org.ole.planet.myplanet.ui.user.UserArrayAdapter
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
+import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
 class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
@@ -234,51 +233,41 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
 
         teamViewModel.loadTasks(teamId)
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch {
-                    isMemberFlow.collectLatest { isMember ->
-                        binding.fab.isVisible = isMember
-                        val nonTeamMember = !isMember
-                        if (adapterTask.nonTeamMember != nonTeamMember) {
-                            adapterTask.nonTeamMember = nonTeamMember
-                        }
-                        updateTasks()
+        collectLatestWhenStarted(isMemberFlow) { isMember ->
+            binding.fab.isVisible = isMember
+            val nonTeamMember = !isMember
+            if (adapterTask.nonTeamMember != nonTeamMember) {
+                adapterTask.nonTeamMember = nonTeamMember
+            }
+            updateTasks()
+        }
+        collectLatestWhenStarted(teamViewModel.taskList) { tasks ->
+            updateTasks()
+        }
+        collectWhenStarted(teamsTasksViewModel.taskActionEvents) { event ->
+            when (event) {
+                is TaskActionEvent.TaskCreatedOrUpdated -> {
+                    val shouldStayOnMyTasks = currentTab == R.id.btn_my && event.assigneeId == user?.id
+                    if (!shouldStayOnMyTasks) {
+                        currentTab = R.id.btn_all
+                        binding.taskToggle.check(R.id.btn_all)
                     }
+                    Utilities.toast(
+                        activity,
+                        String.format(
+                            getString(R.string.task_s_successfully),
+                            if (event.isCreated) getString(R.string.added) else getString(R.string.updated)
+                        )
+                    )
+                    updateTasks()
                 }
-                launch {
-                    teamViewModel.taskList.collectLatest { tasks ->
-                        updateTasks()
-                    }
+                is TaskActionEvent.TaskDeleted -> {
+                    Utilities.toast(activity, getString(R.string.task_deleted_successfully))
+                    updateTasks()
                 }
-                launch {
-                    teamsTasksViewModel.taskActionEvents.collect { event ->
-                        when (event) {
-                            is TaskActionEvent.TaskCreatedOrUpdated -> {
-                                val shouldStayOnMyTasks = currentTab == R.id.btn_my && event.assigneeId == user?.id
-                                if (!shouldStayOnMyTasks) {
-                                    currentTab = R.id.btn_all
-                                    binding.taskToggle.check(R.id.btn_all)
-                                }
-                                Utilities.toast(
-                                    activity,
-                                    String.format(
-                                        getString(R.string.task_s_successfully),
-                                        if (event.isCreated) getString(R.string.added) else getString(R.string.updated)
-                                    )
-                                )
-                                updateTasks()
-                            }
-                            is TaskActionEvent.TaskDeleted -> {
-                                Utilities.toast(activity, getString(R.string.task_deleted_successfully))
-                                updateTasks()
-                            }
-                            is TaskActionEvent.TaskAssigned -> {
-                                Utilities.toast(activity, getString(R.string.assign_task_to) + " " + event.userName)
-                                updateTasks()
-                            }
-                        }
-                    }
+                is TaskActionEvent.TaskAssigned -> {
+                    Utilities.toast(activity, getString(R.string.assign_task_to) + " " + event.userName)
+                    updateTasks()
                 }
             }
         }


### PR DESCRIPTION
This change sweeps hand-rolled `repeatOnLifecycle` boilerplate code in fragment UI observers, replacing it with the cleaner `collectWhenStarted` and `collectLatestWhenStarted` extension functions found in `org.ole.planet.myplanet.utils.FlowExtensions.kt`. It covers 10 fragment files as requested: `RatingsFragment`, `ChatDetailFragment`, `TeamsTasksFragment`, `RequestsFragment`, `MembersFragment`, `SurveyFragment`, `SubmissionDetailFragment`, `NotificationsFragment`, `EnterprisesReportsFragment`, and `BaseDashboardFragment`. It also modifies the `getReportsFlow` function in `EnterprisesViewModel` and repositories to be non-suspend (since Room Flows are natively asynchronous) in order to satisfy the compilation requirements of the non-suspending flow extension function argument.

---
*PR created automatically by Jules for task [3681860848916751643](https://jules.google.com/task/3681860848916751643) started by @dogi*