### PR TITLE
Refactor TeamFragment and MyHealthFragment to use textChanges Flow

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/HealthViewModel.kt
@@ -59,7 +59,6 @@ class HealthViewModel @Inject constructor(
     fun searchPatients(query: String, sortBy: String = "joinDate", descending: Boolean = true) {
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
-            delay(300)
             val loadingJob = launch {
                 delay(100)
                 _isListLoading.value = true

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -16,9 +16,6 @@ import androidx.appcompat.widget.AppCompatSpinner
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.debounce
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -26,6 +23,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.debounce
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.AlertHealthListBinding
 import org.ole.planet.myplanet.databinding.AlertMyPersonalBinding
@@ -38,10 +38,6 @@ import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
 import org.ole.planet.myplanet.utils.textChanges
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MyHealthFragment : Fragment() {
@@ -312,12 +308,11 @@ class MyHealthFragment : Fragment() {
     @OptIn(FlowPreview::class)
     private fun setTextWatcher(etSearch: EditText, btnAddMember: Button, rv: RecyclerView) {
         searchJob?.cancel()
-        searchJob = etSearch.textChanges()
-            .debounce(300)
-            .onEach { editable ->
-                viewModel.searchPatients(editable?.toString() ?: "", "joinDate", true)
-            }
-            .launchIn(viewLifecycleOwner.lifecycleScope)
+        searchJob = collectWhenStarted(
+            etSearch.textChanges().debounce(300)
+        ) { editable ->
+            viewModel.searchPatients(editable?.toString() ?: "", "joinDate", true)
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -276,7 +276,7 @@ class MyHealthFragment : Fragment() {
         alertHealthListBinding?.let { binding ->
             binding.list.layoutManager = LinearLayoutManager(requireContext())
             binding.list.adapter = adapter
-            setTextWatcher(binding.etSearch, binding.btnAddMember, binding.list)
+            observeSearchInput(binding.etSearch)
             sortList(binding.spnSort, binding.list)
             dialog = AlertDialog.Builder(requireActivity(), R.style.AlertDialogTheme)
                 .setTitle(getString(R.string.select_health_member)).setView(binding.root)
@@ -306,10 +306,10 @@ class MyHealthFragment : Fragment() {
     }
 
     @OptIn(FlowPreview::class)
-    private fun setTextWatcher(etSearch: EditText, btnAddMember: Button, rv: RecyclerView) {
+    private fun observeSearchInput(etSearch: EditText) {
         searchJob?.cancel()
         searchJob = collectWhenStarted(
-            etSearch.textChanges()
+            etSearch.textChanges().debounce(300)
         ) { editable ->
             viewModel.searchPatients(editable?.toString() ?: "", "joinDate", true)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -309,7 +309,7 @@ class MyHealthFragment : Fragment() {
     private fun setTextWatcher(etSearch: EditText, btnAddMember: Button, rv: RecyclerView) {
         searchJob?.cancel()
         searchJob = collectWhenStarted(
-            etSearch.textChanges().debounce(300)
+            etSearch.textChanges()
         ) { editable ->
             viewModel.searchPatients(editable?.toString() ?: "", "joinDate", true)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/health/MyHealthFragment.kt
@@ -4,7 +4,6 @@ import android.app.DatePickerDialog
 import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -15,9 +14,11 @@ import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.core.content.ContextCompat
-import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -36,6 +37,11 @@ import org.ole.planet.myplanet.utils.ImageUtils
 import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
+import org.ole.planet.myplanet.utils.textChanges
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MyHealthFragment : Fragment() {
@@ -57,7 +63,7 @@ class MyHealthFragment : Fragment() {
     private lateinit var healthAdapter: HealthExaminationAdapter
     var dialog: AlertDialog? = null
 
-    private var textWatcher: TextWatcher? = null
+    private var searchJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -279,6 +285,10 @@ class MyHealthFragment : Fragment() {
             dialog = AlertDialog.Builder(requireActivity(), R.style.AlertDialogTheme)
                 .setTitle(getString(R.string.select_health_member)).setView(binding.root)
                 .setCancelable(false).setNegativeButton(R.string.dismiss, null).create()
+            dialog?.setOnDismissListener {
+                searchJob?.cancel()
+                searchJob = null
+            }
             dialog?.show()
         }
     }
@@ -299,10 +309,15 @@ class MyHealthFragment : Fragment() {
         }
     }
 
+    @OptIn(FlowPreview::class)
     private fun setTextWatcher(etSearch: EditText, btnAddMember: Button, rv: RecyclerView) {
-        textWatcher = etSearch.doAfterTextChanged { editable ->
-            viewModel.searchPatients(editable?.toString() ?: "", "joinDate", true)
-        }
+        searchJob?.cancel()
+        searchJob = etSearch.textChanges()
+            .debounce(300)
+            .onEach { editable ->
+                viewModel.searchPatients(editable?.toString() ?: "", "joinDate", true)
+            }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     override fun onResume() {
@@ -332,9 +347,8 @@ class MyHealthFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        alertHealthListBinding?.etSearch?.removeTextChangedListener(textWatcher)
-        textWatcher = null
-
+        searchJob?.cancel()
+        searchJob = null
         _binding = null
         super.onDestroyView()
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
@@ -17,8 +17,6 @@ import javax.inject.Inject
 import kotlin.OptIn
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.AlertCreateTeamBinding
@@ -30,7 +28,7 @@ import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.utils.Utilities
-import org.ole.planet.myplanet.utils.collectLatestWhenStarted
+import org.ole.planet.myplanet.utils.collectWhenStarted
 import org.ole.planet.myplanet.utils.textChanges
 
 @AndroidEntryPoint
@@ -303,7 +301,7 @@ class TeamFragment : Fragment() {
     }
 
     private fun observeTeamData() {
-        collectLatestWhenStarted(viewModel.teamData) { teamDataList ->
+        collectWhenStarted(viewModel.teamData) { teamDataList ->
             teamListAdapter.submitList(teamDataList)
             showNoResultsMessage(teamDataList.isEmpty())
             listContentDescription(conditionApplied)
@@ -312,10 +310,11 @@ class TeamFragment : Fragment() {
 
     @OptIn(FlowPreview::class)
     private fun setupTextWatcher() {
-        binding.etSearch.textChanges()
-            .debounce(300)
-            .onEach { text -> viewModel.searchTeams(text?.toString() ?: "") }
-            .launchIn(viewLifecycleOwner.lifecycleScope)
+        collectWhenStarted(
+            binding.etSearch.textChanges().debounce(300)
+        ) { text ->
+            viewModel.searchTeams(text?.toString() ?: "")
+        }
     }
 
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamFragment.kt
@@ -28,6 +28,7 @@ import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.ui.feedback.FeedbackFragment
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import org.ole.planet.myplanet.utils.collectWhenStarted
 import org.ole.planet.myplanet.utils.textChanges
 
@@ -301,7 +302,7 @@ class TeamFragment : Fragment() {
     }
 
     private fun observeTeamData() {
-        collectWhenStarted(viewModel.teamData) { teamDataList ->
+        collectLatestWhenStarted(viewModel.teamData) { teamDataList ->
             teamListAdapter.submitList(teamDataList)
             showNoResultsMessage(teamDataList.isEmpty())
             listContentDescription(conditionApplied)

--- a/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/health/HealthViewModelTest.kt
@@ -49,7 +49,7 @@ class HealthViewModelTest {
     }
 
     @Test
-    fun `searchPatients updates patientList with debounce`() = runTest {
+    fun `searchPatients updates patientList`() = runTest {
         val query = "John"
         val patients = listOf(UserEntity().apply { id = "2"; name = "John Doe" })
         coEvery { healthRepository.searchPatients(query, "joinDate", true) } returns patients


### PR DESCRIPTION
Refactor TeamFragment and MyHealthFragment to use textChanges Flow

- Replaced raw TextWatcher bindings with textChanges().debounce() flows.
- Collected the flows safely in the UI using collectWhenStarted.
- Handled lifecycle issues when binding flow to AlertDialog inputs by managing a Job explicitly.
- Removed manual watcher bookkeeping logic.

---
*PR created automatically by Jules for task [11360845641091705820](https://jules.google.com/task/11360845641091705820) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved patient search responsiveness by removing redundant delays.
  - Search now waits briefly until typing pauses, reducing unnecessary requests.
  - Search activity is properly canceled when dialogs close or screens are destroyed.
  - Team search now updates reliably in line with the screen lifecycle.

- **Tests**
  - Updated search test naming to reflect the current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->