### PR TITLE
Fix BaseRecyclerFragment adapter swapping and fixed size

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -81,6 +81,8 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
             val adapter = getAdapter()
             if (recyclerView.adapter !== adapter) {
                 recyclerView.adapter = adapter
+            } else {
+                adapter.notifyItemRangeChanged(0, adapter.itemCount, "refresh")
             }
             if (isMyCourseLib && adapter.itemCount != 0 && courseLib == "courses") {
                 resources?.let { showDownloadDialog(it) }
@@ -112,6 +114,8 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
             val adapter = getAdapter()
             if (recyclerView.adapter !== adapter) {
                 recyclerView.adapter = adapter
+            } else {
+                adapter.notifyItemRangeChanged(0, adapter.itemCount, "refresh")
             }
         }
     }
@@ -198,6 +202,8 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         val newAdapter = getAdapter()
         if (recyclerView.adapter !== newAdapter) {
             recyclerView.adapter = newAdapter
+        } else {
+            newAdapter.notifyItemRangeChanged(0, newAdapter.itemCount, "refresh")
         }
         showNoData(tvMessage, newAdapter.itemCount, "")
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -62,6 +62,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         val v = inflater.inflate(getLayout(), container, false)
         recyclerView = v.findViewById(R.id.recycler)
         recyclerView.layoutManager = LinearLayoutManager(activity)
+        recyclerView.setHasFixedSize(true)
         if (isMyCourseLib) {
             tvDelete = v.findViewById(R.id.tv_delete)
             initDeleteButton()
@@ -112,6 +113,8 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
             val adapter = getAdapter()
             if (recyclerView.adapter != adapter) {
                 recyclerView.adapter = adapter
+            } else {
+                recyclerView.adapter?.notifyDataSetChanged()
             }
         }
     }
@@ -198,6 +201,8 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         val newAdapter = getAdapter()
         if (recyclerView.adapter != newAdapter) {
             recyclerView.adapter = newAdapter
+        } else {
+            recyclerView.adapter?.notifyDataSetChanged()
         }
         showNoData(tvMessage, newAdapter.itemCount, "")
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -62,7 +62,6 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         val v = inflater.inflate(getLayout(), container, false)
         recyclerView = v.findViewById(R.id.recycler)
         recyclerView.layoutManager = LinearLayoutManager(activity)
-        recyclerView.setHasFixedSize(true)
         if (isMyCourseLib) {
             tvDelete = v.findViewById(R.id.tv_delete)
             initDeleteButton()
@@ -80,7 +79,7 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         viewLifecycleOwner.lifecycleScope.launch {
             model = userRepository.getUserModel()
             val adapter = getAdapter()
-            if (recyclerView.adapter != adapter) {
+            if (recyclerView.adapter !== adapter) {
                 recyclerView.adapter = adapter
             }
             if (isMyCourseLib && adapter.itemCount != 0 && courseLib == "courses") {
@@ -111,10 +110,8 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
     override fun onRatingChanged() {
         viewLifecycleOwner.lifecycleScope.launch {
             val adapter = getAdapter()
-            if (recyclerView.adapter != adapter) {
+            if (recyclerView.adapter !== adapter) {
                 recyclerView.adapter = adapter
-            } else {
-                recyclerView.adapter?.notifyDataSetChanged()
             }
         }
     }
@@ -199,10 +196,8 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
 
     protected open suspend fun postAddRefresh() {
         val newAdapter = getAdapter()
-        if (recyclerView.adapter != newAdapter) {
+        if (recyclerView.adapter !== newAdapter) {
             recyclerView.adapter = newAdapter
-        } else {
-            recyclerView.adapter?.notifyDataSetChanged()
         }
         showNoData(tvMessage, newAdapter.itemCount, "")
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseRecyclerFragment.kt
@@ -81,8 +81,6 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
             val adapter = getAdapter()
             if (recyclerView.adapter !== adapter) {
                 recyclerView.adapter = adapter
-            } else {
-                adapter.notifyItemRangeChanged(0, adapter.itemCount, "refresh")
             }
             if (isMyCourseLib && adapter.itemCount != 0 && courseLib == "courses") {
                 resources?.let { showDownloadDialog(it) }
@@ -114,8 +112,6 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
             val adapter = getAdapter()
             if (recyclerView.adapter !== adapter) {
                 recyclerView.adapter = adapter
-            } else {
-                adapter.notifyItemRangeChanged(0, adapter.itemCount, "refresh")
             }
         }
     }
@@ -202,8 +198,6 @@ abstract class BaseRecyclerFragment<LI> : BaseRecyclerParentFragment<Any?>(), On
         val newAdapter = getAdapter()
         if (recyclerView.adapter !== newAdapter) {
             recyclerView.adapter = newAdapter
-        } else {
-            newAdapter.notifyItemRangeChanged(0, newAdapter.itemCount, "refresh")
         }
         showNoData(tvMessage, newAdapter.itemCount, "")
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -142,6 +142,7 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        recyclerView.setHasFixedSize(true)
         setupUI(requireView().findViewById(R.id.my_course_parent_layout), requireActivity())
         additionalSetup()
         setupMyProgressButton()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFragment.kt
@@ -170,6 +170,7 @@ class ResourcesFragment : BaseRecyclerFragment<MyLibrary?>(), OnLibraryItemSelec
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        recyclerView.setHasFixedSize(true)
         isMyCourseLib = arguments?.getBoolean("isMyCourseLib", false) ?: false
         searchTags = ArrayList()
         config = Utilities.getCloudConfig().showClose(R.color.black_overlay)


### PR DESCRIPTION
Optimizes BaseRecyclerFragment list rendering by utilizing setHasFixedSize and avoiding unnecessary adapter swapping during rating changes and post-add refresh operations.

---
*PR created automatically by Jules for task [11512320558434932575](https://jules.google.com/task/11512320558434932575) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list refresh behavior to prevent unnecessary adapter replacements.
  * Enhanced RecyclerView performance and stability in Courses and Resources screens.
  * Reduced visual disruptions when updating ratings or adding content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->