### PR TITLE
🧹 [Code Health] Remove unused `apiInterface` from `UploadToShelfService`

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceModule.kt
@@ -60,10 +60,9 @@ object ServiceModule {
         userSyncRepository: UserSyncRepository,
         healthRepository: HealthRepository,
         @ApplicationScope appScope: CoroutineScope,
-        dispatcherProvider: DispatcherProvider,
-        apiInterface: ApiInterface
+        dispatcherProvider: DispatcherProvider
     ): UploadToShelfService {
-        return UploadToShelfService(context, preferences, sharedPrefManager, userRepository, userSyncRepository, healthRepository, appScope, dispatcherProvider, apiInterface)
+        return UploadToShelfService(context, preferences, sharedPrefManager, userRepository, userSyncRepository, healthRepository, appScope, dispatcherProvider)
     }
 
     @Provides

--- a/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/UploadToShelfService.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.callback.OnSuccessListener
-import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.di.AppPreferences
 import org.ole.planet.myplanet.di.ApplicationScope
 import org.ole.planet.myplanet.repository.HealthRepository
@@ -27,8 +26,7 @@ class UploadToShelfService @Inject constructor(
     private val userSyncRepository: UserSyncRepository,
     private val healthRepository: HealthRepository,
     @ApplicationScope private val appScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider,
-    private val apiInterface: ApiInterface
+    private val dispatcherProvider: DispatcherProvider
 ) {
 
     fun uploadUserData(listener: OnSuccessListener) {

--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadToShelfServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadToShelfServiceTest.kt
@@ -14,7 +14,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.callback.OnSuccessListener
-import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.model.HealthExamination
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.HealthRepository
@@ -34,7 +33,6 @@ class UploadToShelfServiceTest {
     private lateinit var healthRepository: HealthRepository
     private lateinit var appScope: CoroutineScope
     private lateinit var dispatcherProvider: DispatcherProvider
-    private lateinit var apiInterface: ApiInterface
 
     private lateinit var service: UploadToShelfService
 
@@ -59,8 +57,6 @@ class UploadToShelfServiceTest {
             override val unconfined = testDispatcher
         }
 
-        apiInterface = mockk(relaxed = true)
-
         mockkObject(SecurePrefs)
         every { SecurePrefs.getPassword(context, sharedPreferences) } returns "testPassword"
 
@@ -72,8 +68,7 @@ class UploadToShelfServiceTest {
             userSyncRepository,
             healthRepository,
             appScope,
-            dispatcherProvider,
-            apiInterface
+            dispatcherProvider
         )
     }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of an unused private property, `apiInterface`, in the `UploadToShelfService` constructor.
💡 **Why:** Removing unused code improves maintainability and readability by reducing clutter. By removing this dependency, `UploadToShelfService` becomes easier to understand, test, and inject since it requires one less parameter. It simplifies the constructor and removes an unneeded import.
✅ **Verification:** I confirmed the change is safe by updating the corresponding dependency injection module (`ServiceModule.kt`) and unit test (`UploadToShelfServiceTest.kt`) to align with the new constructor signature. I ran the full test suite (`./gradlew testDefaultDebugUnitTest`) to ensure no functionality is broken.
✨ **Result:** The codebase is cleaner, and the redundant dependency injection parameter is gone.

---
*PR created automatically by Jules for task [2326338919881779006](https://jules.google.com/task/2326338919881779006) started by @dogi*