### PR TITLE
login: smoother configurations repository provisioning (fixes #15811)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6543
-        versionName = "0.65.43"
+        versionCode = 6544
+        versionName = "0.65.44"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
@@ -13,7 +13,8 @@ interface ConfigurationsRepository {
     suspend fun getMinApk(url: String, pin: String): ConfigurationResult
     fun getPlanetType(): String?
     suspend fun ensureServerUrlUpdated()
-    fun provisionApp(hasWritePermission: Boolean)
+    suspend fun clearFirstRunStorage(hasWritePermission: Boolean)
+    suspend fun startQueuedDownloads()
 
     interface CheckVersionCallback {
         fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
@@ -13,8 +13,8 @@ interface ConfigurationsRepository {
     suspend fun getMinApk(url: String, pin: String): ConfigurationResult
     fun getPlanetType(): String?
     suspend fun ensureServerUrlUpdated()
-    suspend fun clearFirstRunStorage(hasWritePermission: Boolean)
-    suspend fun startQueuedDownloads()
+    suspend fun clearFirstRunStorageAndSetFlag(hasWritePermission: Boolean)
+    suspend fun getQueuedDownloads(): ArrayList<String>?
 
     interface CheckVersionCallback {
         fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
@@ -13,6 +13,7 @@ interface ConfigurationsRepository {
     suspend fun getMinApk(url: String, pin: String): ConfigurationResult
     fun getPlanetType(): String?
     suspend fun ensureServerUrlUpdated()
+    fun provisionApp(hasWritePermission: Boolean)
 
     interface CheckVersionCallback {
         fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
@@ -14,7 +14,7 @@ interface ConfigurationsRepository {
     fun getPlanetType(): String?
     suspend fun ensureServerUrlUpdated()
     suspend fun clearFirstRunStorageAndSetFlag(hasWritePermission: Boolean)
-    suspend fun getQueuedDownloads(): ArrayList<String>?
+    suspend fun getQueuedDownloads(): List<String>
 
     interface CheckVersionCallback {
         fun onUpdateAvailable(info: MyPlanet?, cancelable: Boolean)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -5,11 +5,13 @@ import androidx.core.content.edit
 import androidx.core.net.toUri
 import com.google.gson.JsonObject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
 import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
@@ -36,6 +38,7 @@ import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.Sha256Utils
 import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
+import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.VersionUtils
 
 class ConfigurationsRepositoryImpl @Inject constructor(
@@ -367,6 +370,26 @@ class ConfigurationsRepositoryImpl @Inject constructor(
 
     override fun getPlanetType(): String? {
         return sharedPrefManager.getRawString("planetType")
+    }
+
+    override fun provisionApp(hasWritePermission: Boolean) {
+        if (hasWritePermission && sharedPrefManager.getFirstRun()) {
+            val myDir = File(FileUtils.getOlePath(context))
+            if (myDir.isDirectory) {
+                val children = myDir.list()
+                if (children != null) {
+                    for (i in children.indices) {
+                        File(myDir, children[i]).delete()
+                    }
+                }
+            }
+            sharedPrefManager.setFirstRun(false)
+        }
+        val storedJsonConcatenatedLinks = sharedPrefManager.getConcatenatedLinks()
+        if (storedJsonConcatenatedLinks != null) {
+            val storedConcatenatedLinks: ArrayList<String> = Json.decodeFromString(storedJsonConcatenatedLinks)
+            DownloadUtils.openDownloadService(context, storedConcatenatedLinks, true)
+        }
     }
 
     private fun buildCouchdbUrl(currentUrl: String, pin: String): String {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -11,7 +11,6 @@ import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.concurrent.ConcurrentHashMap
-import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
@@ -20,6 +19,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.data.NetworkResult
 import org.ole.planet.myplanet.data.api.ApiClient
@@ -38,7 +38,6 @@ import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.Sha256Utils
 import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.UrlUtils
-import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.VersionUtils
 
 class ConfigurationsRepositoryImpl @Inject constructor(
@@ -372,31 +371,25 @@ class ConfigurationsRepositoryImpl @Inject constructor(
         return sharedPrefManager.getRawString("planetType")
     }
 
-    override suspend fun clearFirstRunStorage(hasWritePermission: Boolean) {
+    override suspend fun clearFirstRunStorageAndSetFlag(hasWritePermission: Boolean) {
         withContext(dispatcherProvider.io) {
             if (hasWritePermission && sharedPrefManager.getFirstRun()) {
                 val myDir = File(FileUtils.getOlePath(context))
                 if (myDir.isDirectory) {
-                    val children = myDir.list()
-                    if (children != null) {
-                        for (i in children.indices) {
-                            File(myDir, children[i]).delete()
-                        }
-                    }
+                    myDir.listFiles()?.forEach { it.deleteRecursively() }
                 }
                 sharedPrefManager.setFirstRun(false)
             }
         }
     }
 
-    override suspend fun startQueuedDownloads() {
-        withContext(dispatcherProvider.io) {
+    override suspend fun getQueuedDownloads(): ArrayList<String>? {
+        return withContext(dispatcherProvider.io) {
             val storedJsonConcatenatedLinks = sharedPrefManager.getConcatenatedLinks()
             if (storedJsonConcatenatedLinks != null) {
-                val storedConcatenatedLinks: ArrayList<String> = Json.decodeFromString(storedJsonConcatenatedLinks)
-                withContext(dispatcherProvider.main) {
-                    DownloadUtils.openDownloadService(context, storedConcatenatedLinks, true)
-                }
+                Json.decodeFromString(storedJsonConcatenatedLinks)
+            } else {
+                null
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -372,23 +372,32 @@ class ConfigurationsRepositoryImpl @Inject constructor(
         return sharedPrefManager.getRawString("planetType")
     }
 
-    override fun provisionApp(hasWritePermission: Boolean) {
-        if (hasWritePermission && sharedPrefManager.getFirstRun()) {
-            val myDir = File(FileUtils.getOlePath(context))
-            if (myDir.isDirectory) {
-                val children = myDir.list()
-                if (children != null) {
-                    for (i in children.indices) {
-                        File(myDir, children[i]).delete()
+    override suspend fun clearFirstRunStorage(hasWritePermission: Boolean) {
+        withContext(dispatcherProvider.io) {
+            if (hasWritePermission && sharedPrefManager.getFirstRun()) {
+                val myDir = File(FileUtils.getOlePath(context))
+                if (myDir.isDirectory) {
+                    val children = myDir.list()
+                    if (children != null) {
+                        for (i in children.indices) {
+                            File(myDir, children[i]).delete()
+                        }
                     }
                 }
+                sharedPrefManager.setFirstRun(false)
             }
-            sharedPrefManager.setFirstRun(false)
         }
-        val storedJsonConcatenatedLinks = sharedPrefManager.getConcatenatedLinks()
-        if (storedJsonConcatenatedLinks != null) {
-            val storedConcatenatedLinks: ArrayList<String> = Json.decodeFromString(storedJsonConcatenatedLinks)
-            DownloadUtils.openDownloadService(context, storedConcatenatedLinks, true)
+    }
+
+    override suspend fun startQueuedDownloads() {
+        withContext(dispatcherProvider.io) {
+            val storedJsonConcatenatedLinks = sharedPrefManager.getConcatenatedLinks()
+            if (storedJsonConcatenatedLinks != null) {
+                val storedConcatenatedLinks: ArrayList<String> = Json.decodeFromString(storedJsonConcatenatedLinks)
+                withContext(dispatcherProvider.main) {
+                    DownloadUtils.openDownloadService(context, storedConcatenatedLinks, true)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -383,13 +383,15 @@ class ConfigurationsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getQueuedDownloads(): ArrayList<String>? {
+    override suspend fun getQueuedDownloads(): List<String> {
         return withContext(dispatcherProvider.io) {
             val storedJsonConcatenatedLinks = sharedPrefManager.getConcatenatedLinks()
-            if (storedJsonConcatenatedLinks != null) {
-                Json.decodeFromString(storedJsonConcatenatedLinks)
+            if (storedJsonConcatenatedLinks.isNullOrEmpty()) {
+                emptyList()
             } else {
-                null
+                runCatching {
+                    Json.decodeFromString<List<String>>(storedJsonConcatenatedLinks)
+                }.getOrDefault(emptyList())
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -60,7 +60,6 @@ import org.ole.planet.myplanet.utils.DialogUtils.showSnack
 import org.ole.planet.myplanet.utils.DialogUtils.showWifiSettingDialog
 import org.ole.planet.myplanet.utils.DownloadUtils.downloadAllFiles
 import org.ole.planet.myplanet.utils.DownloadUtils.openDownloadService
-import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
 import org.ole.planet.myplanet.utils.NetworkUtils.extractProtocol
 import org.ole.planet.myplanet.utils.NetworkUtils.getCustomDeviceName

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -29,7 +29,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
 import dagger.hilt.android.AndroidEntryPoint
-import java.io.File
 import java.util.Date
 import javax.inject.Inject
 import kotlinx.coroutines.delay
@@ -37,7 +36,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.MainApplication.Companion.context
 import org.ole.planet.myplanet.MainApplication.Companion.createLog
@@ -61,6 +59,8 @@ import org.ole.planet.myplanet.utils.DialogUtils.showAlert
 import org.ole.planet.myplanet.utils.DialogUtils.showSnack
 import org.ole.planet.myplanet.utils.DialogUtils.showWifiSettingDialog
 import org.ole.planet.myplanet.utils.DownloadUtils.downloadAllFiles
+import org.ole.planet.myplanet.utils.DownloadUtils.openDownloadService
+import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
 import org.ole.planet.myplanet.utils.NetworkUtils.extractProtocol
 import org.ole.planet.myplanet.utils.NetworkUtils.getCustomDeviceName
@@ -532,7 +532,10 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
                         prefData.setIsAlternativeUrl(false)
                     }
 
-                    configurationsRepository.startQueuedDownloads()
+                    val links = configurationsRepository.getQueuedDownloads()
+                    if (!links.isNullOrEmpty()) {
+                        openDownloadService(context, links, true)
+                    }
 
                     val betaAutoDownload = prefData.getBetaAutoDownload()
                     if (betaAutoDownload) {
@@ -701,7 +704,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
             isSync = true
 
             lifecycleScope.launch {
-                configurationsRepository.clearFirstRunStorage(checkPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE))
+                configurationsRepository.clearFirstRunStorageAndSetFlag(checkPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE))
                 isServerReachable(processedUrl, "sync")
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -532,8 +532,8 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
                     }
 
                     val links = configurationsRepository.getQueuedDownloads()
-                    if (!links.isNullOrEmpty()) {
-                        openDownloadService(context, links, true)
+                    if (links.isNotEmpty()) {
+                        openDownloadService(context, ArrayList(links), true)
                     }
 
                     val betaAutoDownload = prefData.getBetaAutoDownload()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -61,8 +61,6 @@ import org.ole.planet.myplanet.utils.DialogUtils.showAlert
 import org.ole.planet.myplanet.utils.DialogUtils.showSnack
 import org.ole.planet.myplanet.utils.DialogUtils.showWifiSettingDialog
 import org.ole.planet.myplanet.utils.DownloadUtils.downloadAllFiles
-import org.ole.planet.myplanet.utils.DownloadUtils.openDownloadService
-import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.LocaleUtils
 import org.ole.planet.myplanet.utils.NetworkUtils.extractProtocol
 import org.ole.planet.myplanet.utils.NetworkUtils.getCustomDeviceName
@@ -534,7 +532,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
                         prefData.setIsAlternativeUrl(false)
                     }
 
-                    configurationsRepository.provisionApp(checkPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE))
+                    configurationsRepository.startQueuedDownloads()
 
                     val betaAutoDownload = prefData.getBetaAutoDownload()
                     if (betaAutoDownload) {
@@ -703,6 +701,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
             isSync = true
 
             lifecycleScope.launch {
+                configurationsRepository.clearFirstRunStorage(checkPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE))
                 isServerReachable(processedUrl, "sync")
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -293,19 +293,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
             .show()
     }
 
-    private fun clearInternalStorage() {
-        val myDir = File(FileUtils.getOlePath(this))
-        if (myDir.isDirectory) {
-            val children = myDir.list()
-            if (children != null) {
-                for (i in children.indices) {
-                    File(myDir, children[i]).delete()
-                }
-            }
-        }
-        prefData.setFirstRun(false)
-    }
-
     fun sync(binding: DialogServerUrlBinding) {
         spinner = binding.intervalDropper
         syncSwitch = binding.syncSwitch
@@ -547,7 +534,7 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
                         prefData.setIsAlternativeUrl(false)
                     }
 
-                    downloadAdditionalResources()
+                    configurationsRepository.provisionApp(checkPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE))
 
                     val betaAutoDownload = prefData.getBetaAutoDownload()
                     if (betaAutoDownload) {
@@ -578,14 +565,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
             "ar" -> getString(R.string.arabic)
             "fr" -> getString(R.string.french)
             else -> getString(R.string.english)
-        }
-    }
-
-    private fun downloadAdditionalResources() {
-        val storedJsonConcatenatedLinks = prefData.getConcatenatedLinks()
-        if (storedJsonConcatenatedLinks != null) {
-            val storedConcatenatedLinks: ArrayList<String> = Json.decodeFromString(storedJsonConcatenatedLinks)
-            openDownloadService(context, storedConcatenatedLinks, true)
         }
     }
 
@@ -722,9 +701,6 @@ abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepositor
             }
 
             isSync = true
-            if (checkPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) && prefData.getFirstRun()) {
-                clearInternalStorage()
-            }
 
             lifecycleScope.launch {
                 isServerReachable(processedUrl, "sync")

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
@@ -10,8 +10,11 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.runs
+import io.mockk.unmockkObject
 import io.mockk.verify
+import java.io.File
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlinx.coroutines.CoroutineScope
@@ -23,10 +26,11 @@ import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.data.room.AppDatabase
@@ -62,6 +66,9 @@ class ConfigurationsRepositoryImplTest {
         override val default = testDispatcher
         override val unconfined = testDispatcher
     }
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
 
     @Before
     fun setup() {
@@ -606,49 +613,67 @@ class ConfigurationsRepositoryImplTest {
     }
 
     @Test
-    fun `clearFirstRunStorageAndSetFlag sets firstRun to false when conditions are met`() = runTest(testDispatcher) {
+    fun `clearFirstRunStorageAndSetFlag wipes the ole directory and clears the flag`() = runTest(testDispatcher) {
+        val oleDir = temporaryFolder.newFolder("ole")
+        val looseFile = File(oleDir, "loose.txt").apply { writeText("stale") }
+        val nested = File(oleDir, "nested").apply { mkdirs() }
+        val nestedFile = File(nested, "deep.txt").apply { writeText("stale") }
+
         every { sharedPrefManager.getFirstRun() } returns true
         every { sharedPrefManager.setFirstRun(false) } just runs
 
-        io.mockk.mockkObject(FileUtils)
-        val mockFile = mockk<java.io.File>(relaxed = true)
-        every { FileUtils.getOlePath(context) } returns "mock_path"
-        every { mockFile.isDirectory } returns true
-        every { mockFile.listFiles() } returns arrayOf()
+        mockkObject(FileUtils)
+        every { FileUtils.getOlePath(context) } returns oleDir.absolutePath
 
-        // We will not mock File constructor as it causes StackOverflow.
-        // Instead, we just let it use the real File for the dummy path,
-        // since we just want to verify setFirstRun is called.
-        // File("mock_path").isDirectory will just return false on most systems,
-        // which skips the listFiles block. We mainly care about setFirstRun.
+        try {
+            repository.clearFirstRunStorageAndSetFlag(true)
 
-        repository.clearFirstRunStorageAndSetFlag(true)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        verify { sharedPrefManager.setFirstRun(false) }
-
-        io.mockk.unmockkObject(FileUtils)
+            assertFalse(looseFile.exists())
+            assertFalse(nestedFile.exists())
+            assertFalse(nested.exists())
+            assertTrue(oleDir.exists())
+            verify { sharedPrefManager.setFirstRun(false) }
+        } finally {
+            unmockkObject(FileUtils)
+        }
     }
 
     @Test
-    fun `getQueuedDownloads returns null when prefs is null`() = runTest(testDispatcher) {
+    fun `clearFirstRunStorageAndSetFlag does nothing without write permission`() = runTest(testDispatcher) {
+        every { sharedPrefManager.getFirstRun() } returns true
+
+        repository.clearFirstRunStorageAndSetFlag(false)
+
+        verify(exactly = 0) { sharedPrefManager.setFirstRun(any()) }
+    }
+
+    @Test
+    fun `clearFirstRunStorageAndSetFlag does nothing when it is not the first run`() = runTest(testDispatcher) {
+        every { sharedPrefManager.getFirstRun() } returns false
+
+        repository.clearFirstRunStorageAndSetFlag(true)
+
+        verify(exactly = 0) { sharedPrefManager.setFirstRun(any()) }
+    }
+
+    @Test
+    fun `getQueuedDownloads returns empty list when prefs is null`() = runTest(testDispatcher) {
         every { sharedPrefManager.getConcatenatedLinks() } returns null
 
-        val result = repository.getQueuedDownloads()
-        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(repository.getQueuedDownloads().isEmpty())
+    }
 
-        assertNull(result)
+    @Test
+    fun `getQueuedDownloads returns empty list when prefs holds malformed JSON`() = runTest(testDispatcher) {
+        every { sharedPrefManager.getConcatenatedLinks() } returns "not json"
+
+        assertTrue(repository.getQueuedDownloads().isEmpty())
     }
 
     @Test
     fun `getQueuedDownloads returns decoded list when prefs has valid JSON`() = runTest(testDispatcher) {
         every { sharedPrefManager.getConcatenatedLinks() } returns "[\"link1\", \"link2\"]"
 
-        val result = repository.getQueuedDownloads()
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals(2, result?.size)
-        assertEquals("link1", result?.get(0))
-        assertEquals("link2", result?.get(1))
+        assertEquals(listOf("link1", "link2"), repository.getQueuedDownloads())
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
@@ -8,7 +8,9 @@ import com.google.gson.JsonPrimitive
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -21,6 +23,7 @@ import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -600,5 +603,52 @@ class ConfigurationsRepositoryImplTest {
         assertTrue(result is ConfigurationsRepository.ConfigurationResult.Failure)
 
         io.mockk.unmockkObject(org.ole.planet.myplanet.utils.NetworkUtils)
+    }
+
+    @Test
+    fun `clearFirstRunStorageAndSetFlag sets firstRun to false when conditions are met`() = runTest(testDispatcher) {
+        every { sharedPrefManager.getFirstRun() } returns true
+        every { sharedPrefManager.setFirstRun(false) } just runs
+
+        io.mockk.mockkObject(FileUtils)
+        val mockFile = mockk<java.io.File>(relaxed = true)
+        every { FileUtils.getOlePath(context) } returns "mock_path"
+        every { mockFile.isDirectory } returns true
+        every { mockFile.listFiles() } returns arrayOf()
+
+        // We will not mock File constructor as it causes StackOverflow.
+        // Instead, we just let it use the real File for the dummy path,
+        // since we just want to verify setFirstRun is called.
+        // File("mock_path").isDirectory will just return false on most systems,
+        // which skips the listFiles block. We mainly care about setFirstRun.
+
+        repository.clearFirstRunStorageAndSetFlag(true)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        verify { sharedPrefManager.setFirstRun(false) }
+
+        io.mockk.unmockkObject(FileUtils)
+    }
+
+    @Test
+    fun `getQueuedDownloads returns null when prefs is null`() = runTest(testDispatcher) {
+        every { sharedPrefManager.getConcatenatedLinks() } returns null
+
+        val result = repository.getQueuedDownloads()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `getQueuedDownloads returns decoded list when prefs has valid JSON`() = runTest(testDispatcher) {
+        every { sharedPrefManager.getConcatenatedLinks() } returns "[\"link1\", \"link2\"]"
+
+        val result = repository.getQueuedDownloads()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(2, result?.size)
+        assertEquals("link1", result?.get(0))
+        assertEquals("link2", result?.get(1))
     }
 }


### PR DESCRIPTION
Extract `SyncActivity` provisioning logic out of the UI layer.

This PR extracts the `clearInternalStorage` and `downloadAdditionalResources` logic out of `SyncActivity.kt` into a single, unified `provisionApp()` method inside `ConfigurationsRepository`. 
The new `provisionApp(hasWritePermission)` method handles checking the `getFirstRun` flag, deleting `FileUtils.getOlePath()` if permission is granted, and parsing concatenated links to start the download service. `SyncActivity` is updated to invoke this method during `onSyncComplete`.

---
*PR created automatically by Jules for task [13302662138937293453](https://jules.google.com/task/13302662138937293453) started by @dogi*