### PR TITLE
Refactor Collections, Activities, StorageCategoryDetail, and ResourceDetail Fragments to use ViewModels

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.lifecycleScope
+import androidx.fragment.app.viewModels
 import com.github.mikephil.charting.data.BarData
 import com.github.mikephil.charting.data.BarDataSet
 import com.github.mikephil.charting.data.BarEntry
@@ -14,23 +14,17 @@ import com.github.mikephil.charting.formatter.ValueFormatter
 import dagger.hilt.android.AndroidEntryPoint
 import java.text.DateFormatSymbols
 import java.util.Calendar
-import javax.inject.Inject
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentActivitiesBinding
 import org.ole.planet.myplanet.model.OfflineActivity
-import org.ole.planet.myplanet.repository.ActivitiesRepository
-import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class ActivitiesFragment : Fragment() {
     private var _binding: FragmentActivitiesBinding? = null
     private val binding get() = _binding!!
-    @Inject
-    lateinit var userSessionManager: UserSessionManager
-    @Inject
-    lateinit var activitiesRepository: ActivitiesRepository
+
+    private val viewModel: ActivitiesViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentActivitiesBinding.inflate(inflater, container, false)
@@ -44,10 +38,8 @@ class ActivitiesFragment : Fragment() {
         val endMillis = Calendar.getInstance().timeInMillis
         val startMillis = Calendar.getInstance().apply { add(Calendar.YEAR, -1) }.timeInMillis
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            val userName = userSessionManager.getUserModel()?.name ?: return@launch
-            val loginsFlow = activitiesRepository.getOfflineLogins(userName)
-            collectLatestWhenStarted(loginsFlow) { logins ->
+        collectLatestWhenStarted(viewModel.offlineActivities) { logins ->
+            if (logins != null) {
                 val monthlyCounts = computeMonthlyCounts(logins, startMillis, endMillis)
                 renderChart(monthlyCounts, daynightTextColor)
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesViewModel.kt
@@ -1,0 +1,34 @@
+package org.ole.planet.myplanet.ui.dashboard
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.OfflineActivity
+import org.ole.planet.myplanet.repository.ActivitiesRepository
+import org.ole.planet.myplanet.services.UserSessionManager
+
+@HiltViewModel
+class ActivitiesViewModel @Inject constructor(
+    private val activitiesRepository: ActivitiesRepository,
+    private val userSessionManager: UserSessionManager
+) : ViewModel() {
+
+    private val _offlineActivities = MutableStateFlow<List<OfflineActivity>?>(null)
+    val offlineActivities: StateFlow<List<OfflineActivity>?> = _offlineActivities.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val userName = userSessionManager.getUserModel()?.name ?: return@launch
+            val loginsFlow = activitiesRepository.getOfflineLogins(userName)
+            loginsFlow.collectLatest { logins ->
+                _offlineActivities.value = logins
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -6,23 +6,22 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
-import javax.inject.Inject
 import kotlin.collections.ArrayList
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnTagClickListener
 import org.ole.planet.myplanet.databinding.FragmentCollectionsBinding
 import org.ole.planet.myplanet.model.TagData
 import org.ole.planet.myplanet.model.TagEntity
-import org.ole.planet.myplanet.repository.TagsRepository
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import org.ole.planet.myplanet.utils.KeyboardUtils
 import org.ole.planet.myplanet.utils.textChanges
 
@@ -30,11 +29,9 @@ import org.ole.planet.myplanet.utils.textChanges
 class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton.OnCheckedChangeListener {
     private var _binding: FragmentCollectionsBinding? = null
     private val binding get() = _binding!!
-    @Inject
-    lateinit var tagsRepository: TagsRepository
+    private val viewModel: CollectionsViewModel by viewModels()
     private lateinit var list: List<TagEntity>
     private lateinit var childMap: HashMap<String, List<TagEntity>>
-    private var filteredList: ArrayList<TagEntity> = ArrayList()
     private lateinit var adapter: ResourcesTagsAdapter
     private var dbType: String? = null
     private var listener: OnTagClickListener? = null
@@ -87,16 +84,24 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
     }
 
     private fun setListAdapter() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            val tagsWithChildren = tagsRepository.getTagsWithChildren(dbType)
-            list = tagsWithChildren.keys.toList()
-            selectedItemsList = ArrayList(recentList)
-            childMap = tagsWithChildren.entries.filter { it.value.isNotEmpty() }.associate { (it.key.id ?: "") to it.value }.toMap(HashMap())
-            adapter = ResourcesTagsAdapter(this@CollectionsFragment)
-            binding.listTags.adapter = adapter
-            currentTagDataList = buildTagDataList(list).toMutableList()
-            adapter.submitList(currentTagDataList)
-            binding.btnOk.visibility = View.VISIBLE
+        viewModel.loadTags(dbType)
+        collectLatestWhenStarted(viewModel.tagsWithChildren) { tagsWithChildren ->
+            if (tagsWithChildren != null) {
+                list = tagsWithChildren.keys.toList()
+                selectedItemsList = ArrayList(recentList)
+                childMap = HashMap(tagsWithChildren.entries.filter { it.value.isNotEmpty() }.associate { (it.key.id ?: "") to it.value })
+
+                if (!::adapter.isInitialized) {
+                    adapter = ResourcesTagsAdapter(this@CollectionsFragment)
+                }
+                if (binding.listTags.adapter == null) {
+                    binding.listTags.adapter = adapter
+                }
+
+                currentTagDataList = buildTagDataList(list).toMutableList()
+                adapter.submitList(currentTagDataList)
+                binding.btnOk.visibility = View.VISIBLE
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsViewModel.kt
@@ -1,0 +1,29 @@
+package org.ole.planet.myplanet.ui.resources
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.TagEntity
+import org.ole.planet.myplanet.repository.TagsRepository
+
+@HiltViewModel
+class CollectionsViewModel @Inject constructor(
+    private val tagsRepository: TagsRepository
+) : ViewModel() {
+
+    private val _tagsWithChildren = MutableStateFlow<Map<TagEntity, List<TagEntity>>?>(null)
+    val tagsWithChildren: StateFlow<Map<TagEntity, List<TagEntity>>?> = _tagsWithChildren.asStateFlow()
+
+    fun loadTags(dbType: String?) {
+        if (_tagsWithChildren.value == null) {
+            viewModelScope.launch {
+                _tagsWithChildren.value = tagsRepository.getTagsWithChildren(dbType)
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailFragment.kt
@@ -7,11 +7,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
-import androidx.lifecycle.lifecycleScope
+import androidx.fragment.app.viewModels
 import com.google.gson.JsonObject
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseContainerFragment
 import org.ole.planet.myplanet.callback.OnRatingChangeListener
@@ -19,26 +17,23 @@ import org.ole.planet.myplanet.databinding.FragmentLibraryDetailBinding
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.MyLibrary.Companion.listToString
 import org.ole.planet.myplanet.model.UserEntity
-import org.ole.planet.myplanet.repository.RatingsRepository
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.utils.FileUtils.getFileExtension
 import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.Utilities
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
-    @Inject
-    lateinit var ratingsRepository: RatingsRepository
     private var _binding: FragmentLibraryDetailBinding? = null
     private val binding get() = _binding!!
     private var libraryId: String? = null
     private var lastKnownRating: JsonObject? = null
     private lateinit var library: MyLibrary
     var userModel: UserEntity? = null
-    private suspend fun fetchLibrary(libraryId: String): MyLibrary? {
-        return resourcesRepository.getLibraryItemById(libraryId)
-            ?: resourcesRepository.getLibraryItemByResourceId(libraryId)
-    }
+
+    private val viewModel: ResourceDetailViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
@@ -48,37 +43,11 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
 
     override fun onDownloadComplete() {
         super.onDownloadComplete()
-        if (!::library.isInitialized) {
+        if (_binding == null || !::library.isInitialized) {
             return
         }
-        val binding = _binding ?: return
-        viewLifecycleOwner.lifecycleScope.launch {
-            if (!isAdded) {
-                return@launch
-            }
-            val id = libraryId ?: return@launch
-            val userId = userRepository.getUserModel()?.id
-            try {
-                val backgroundLibrary = fetchLibrary(id)
-                val updatedLibrary = when {
-                    backgroundLibrary == null -> null
-                    backgroundLibrary.userId?.contains(userId) != true && userId != null ->
-                        resourcesRepository.updateUserLibrary(id, userId, true)
-                    else -> backgroundLibrary
-                }
-                if (updatedLibrary != null) {
-                    library = updatedLibrary
-                }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-            updateDownloadButtonState()
-            val currentUserId = userRepository.getUserModel()?.id
-            if (currentUserId != null && library.userId?.contains(currentUserId) != true) {
-                Utilities.toast(activity, getString(R.string.added_to_my_library))
-                binding.btnRemove.setImageResource(R.drawable.close_x)
-            }
-        }
+        viewModel.onDownloadComplete(libraryId)
+        updateDownloadButtonState()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -90,25 +59,50 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewLifecycleOwner.lifecycleScope.launch {
-            userModel = userRepository.getUserModel()
-            val id = libraryId
-            if (id.isNullOrBlank()) {
+
+        viewModel.initData(libraryId)
+
+        collectLatestWhenStarted(viewModel.userModel) { user ->
+            userModel = user
+        }
+
+        collectLatestWhenStarted(viewModel.isLibraryNotFound) { notFound ->
+            if (notFound) {
                 handleLibraryNotFound()
-                return@launch
             }
+        }
 
-            val fetchedLibrary = fetchLibrary(id)
+        collectLatestWhenStarted(viewModel.library) { lib ->
+            if (lib != null) {
+                val previousLibrary = if (::library.isInitialized) library else null
+                library = lib
+                setLoadingState(false)
 
-            if (fetchedLibrary == null) {
-                handleLibraryNotFound()
-                return@launch
+                if (previousLibrary == null) {
+                    initRatingView("resource", library.resourceId, library.title, this@ResourceDetailFragment)
+                }
+
+                setLibraryData()
+
+                val currentUserId = userModel?.id
+                if (previousLibrary != null && currentUserId != null) {
+                    val previouslyHadUser = previousLibrary.userId?.contains(currentUserId) == true
+                    val currentlyHasUser = library.userId?.contains(currentUserId) == true
+
+                    if (!previouslyHadUser && currentlyHasUser) {
+                        Utilities.toast(activity, getString(R.string.resources) + " " + getString(R.string.added_to_my_library))
+                    } else if (previouslyHadUser && !currentlyHasUser) {
+                        Utilities.toast(activity, getString(R.string.resources) + " " + getString(R.string.removed_from_mylibrary))
+                    }
+                }
             }
+        }
 
-            library = fetchedLibrary
-            setLoadingState(false)
-            initRatingView("resource", library.resourceId, library.title, this@ResourceDetailFragment)
-            setLibraryData()
+        collectLatestWhenStarted(viewModel.rating) { rating ->
+            if (rating != null) {
+                lastKnownRating = rating
+                setRatings(rating)
+            }
         }
     }
 
@@ -138,18 +132,8 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             setTextViewVisibility(tvResource, llResource, listToString(library.resourceFor))
             setTextViewVisibility(tvType, llType, library.resourceType)
         }
-        viewLifecycleOwner.lifecycleScope.launch {
-            if (!isAdded) {
-                return@launch
-            }
-            try {
-                onRatingChanged()
-            } catch (ex: Exception) {
-                ex.printStackTrace()
-            }
-            setupDownloadButton()
-            setClickListeners()
-        }
+        setupDownloadButton()
+        setClickListeners()
     }
 
     private fun setupDownloadButton() {
@@ -236,34 +220,7 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
             binding.btnRemove.visibility = View.GONE
         }
         binding.btnRemove.setOnClickListener {
-            viewLifecycleOwner.lifecycleScope.launch {
-                val id = libraryId ?: return@launch
-                val userId = userRepository.getUserModel()?.id
-                if (!isAdded) {
-                    return@launch
-                }
-                val updatedLibrary = try {
-                    if (userId != null) {
-                        resourcesRepository.updateUserLibrary(id, userId, isAdd)
-                    } else {
-                        null
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                    null
-                }
-                try {
-                    if (updatedLibrary != null) {
-                        library = updatedLibrary
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-                Utilities.toast(activity, getString(R.string.resources) + " " +
-                        if (isAdd) getString(R.string.added_to_my_library)
-                        else getString(R.string.removed_from_mylibrary))
-                setLibraryData()
-            }
+            viewModel.toggleLibraryAdd(libraryId, isAdd)
         }
         binding.btnBack.setOnClickListener {
             val activity = requireActivity()
@@ -280,16 +237,8 @@ class ResourceDetailFragment : BaseContainerFragment(), OnRatingChangeListener {
     }
 
     override fun onRatingChanged() {
-        lastKnownRating?.let { setRatings(it) }
-        lifecycleScope.launch {
-            if (!isAdded) return@launch
-            try {
-                val rating = ratingsRepository.getRatingsById("resource", library.resourceId, userModel?.id)
-                lastKnownRating = rating
-                setRatings(rating)
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
+        if (::library.isInitialized) {
+            viewModel.loadRating(library.resourceId)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourceDetailViewModel.kt
@@ -1,0 +1,113 @@
+package org.ole.planet.myplanet.ui.resources
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.gson.JsonObject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.MyLibrary
+import org.ole.planet.myplanet.model.UserEntity
+import org.ole.planet.myplanet.repository.RatingsRepository
+import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.repository.UserRepository
+
+@HiltViewModel
+class ResourceDetailViewModel @Inject constructor(
+    private val resourcesRepository: ResourcesRepository,
+    private val userRepository: UserRepository,
+    private val ratingsRepository: RatingsRepository
+) : ViewModel() {
+
+    private val _library = MutableStateFlow<MyLibrary?>(null)
+    val library: StateFlow<MyLibrary?> = _library.asStateFlow()
+
+    private val _userModel = MutableStateFlow<UserEntity?>(null)
+    val userModel: StateFlow<UserEntity?> = _userModel.asStateFlow()
+
+    private val _rating = MutableStateFlow<JsonObject?>(null)
+    val rating: StateFlow<JsonObject?> = _rating.asStateFlow()
+
+    private val _isLibraryNotFound = MutableStateFlow(false)
+    val isLibraryNotFound: StateFlow<Boolean> = _isLibraryNotFound.asStateFlow()
+
+    fun initData(libraryId: String?) {
+        if (_library.value != null) return
+
+        viewModelScope.launch {
+            _userModel.value = userRepository.getUserModel()
+
+            if (libraryId.isNullOrBlank()) {
+                _isLibraryNotFound.value = true
+                return@launch
+            }
+
+            val fetchedLibrary = resourcesRepository.getLibraryItemById(libraryId)
+                ?: resourcesRepository.getLibraryItemByResourceId(libraryId)
+
+            if (fetchedLibrary == null) {
+                _isLibraryNotFound.value = true
+                return@launch
+            }
+
+            _library.value = fetchedLibrary
+            loadRating(fetchedLibrary.resourceId)
+        }
+    }
+
+    fun onDownloadComplete(libraryId: String?) {
+        if (libraryId == null) return
+
+        viewModelScope.launch {
+            val userId = _userModel.value?.id
+            try {
+                val backgroundLibrary = resourcesRepository.getLibraryItemById(libraryId)
+                    ?: resourcesRepository.getLibraryItemByResourceId(libraryId)
+
+                val updatedLibrary = when {
+                    backgroundLibrary == null -> null
+                    backgroundLibrary.userId?.contains(userId) != true && userId != null ->
+                        resourcesRepository.updateUserLibrary(libraryId, userId, true)
+                    else -> backgroundLibrary
+                }
+
+                if (updatedLibrary != null) {
+                    _library.value = updatedLibrary
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    fun toggleLibraryAdd(libraryId: String?, isAdd: Boolean) {
+        if (libraryId == null) return
+
+        viewModelScope.launch {
+            val userId = _userModel.value?.id ?: return@launch
+
+            try {
+                val updatedLibrary = resourcesRepository.updateUserLibrary(libraryId, userId, isAdd)
+                if (updatedLibrary != null) {
+                    _library.value = updatedLibrary
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    fun loadRating(resourceId: String?) {
+        viewModelScope.launch {
+            try {
+                val userId = _userModel.value?.id
+                _rating.value = ratingsRepository.getRatingsById("resource", resourceId, userId)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailFragment.kt
@@ -8,7 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.appcompat.app.AlertDialog
-import androidx.lifecycle.lifecycleScope
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -16,23 +16,20 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
-import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentStorageCategoryDetailBinding
 import org.ole.planet.myplanet.databinding.ItemDownloadedResourceBinding
 import org.ole.planet.myplanet.model.OfflineResourceItem
-import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.FileUtils
+import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
 class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
     private var _binding: FragmentStorageCategoryDetailBinding? = null
     private val binding get() = _binding!!
 
-    @Inject
-    lateinit var resourcesRepository: ResourcesRepository
+    private val viewModel: StorageCategoryDetailViewModel by viewModels()
     private var categoryLabel: String = ""
     private var extensions: Set<String> = emptySet()
     private var allKnownExtensions: Set<String> = emptySet()
@@ -133,23 +130,27 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
         binding.selectAllRow.visibility = View.GONE
         binding.selectAllDivider.visibility = View.GONE
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            val olePath = FileUtils.getOlePath(requireContext())
-            val loaded = resourcesRepository.getOfflineResourceItems(olePath, extensions, allKnownExtensions)
-            binding.progressBar.visibility = View.GONE
+        val olePath = FileUtils.getOlePath(requireContext())
+        viewModel.loadResources(olePath, extensions, allKnownExtensions)
 
-            if (loaded.isEmpty()) {
-                binding.emptyText.visibility = View.VISIBLE
-                return@launch
+        collectLatestWhenStarted(viewModel.items) { loaded ->
+            if (loaded != null) {
+                binding.progressBar.visibility = View.GONE
+
+                if (loaded.isEmpty()) {
+                    binding.emptyText.visibility = View.VISIBLE
+                    return@collectLatestWhenStarted
+                }
+
+                items = loaded
+                adapter.submitList(items)
+
+                binding.resourceList.visibility = View.VISIBLE
+                binding.actionButtons.visibility = View.VISIBLE
+                binding.selectAllRow.visibility = View.VISIBLE
+                binding.selectAllDivider.visibility = View.VISIBLE
+                updateSelectionState()
             }
-
-            items = loaded
-            adapter.submitList(items)
-
-            binding.resourceList.visibility = View.VISIBLE
-            binding.actionButtons.visibility = View.VISIBLE
-            binding.selectAllRow.visibility = View.VISIBLE
-            binding.selectAllDivider.visibility = View.VISIBLE
         }
     }
 
@@ -183,10 +184,8 @@ class StorageCategoryDetailFragment : BottomSheetDialogFragment() {
         binding.deleteSelectedButton.isEnabled = false
         binding.deleteAllButton.isEnabled = false
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            val olePath = FileUtils.getOlePath(requireContext())
-            resourcesRepository.deleteOfflineResources(olePath, toDelete)
-
+        val olePath = FileUtils.getOlePath(requireContext())
+        viewModel.deleteResources(olePath, toDelete) {
             parentFragmentManager.setFragmentResult(RESULT_KEY, Bundle())
             dismiss()
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/StorageCategoryDetailViewModel.kt
@@ -1,0 +1,39 @@
+package org.ole.planet.myplanet.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.OfflineResourceItem
+import org.ole.planet.myplanet.repository.ResourcesRepository
+
+@HiltViewModel
+class StorageCategoryDetailViewModel @Inject constructor(
+    private val resourcesRepository: ResourcesRepository
+) : ViewModel() {
+
+    private val _items = MutableStateFlow<List<OfflineResourceItem>?>(null)
+    val items: StateFlow<List<OfflineResourceItem>?> = _items.asStateFlow()
+
+    fun loadResources(olePath: String, extensions: Set<String>, allKnownExtensions: Set<String>) {
+        if (_items.value == null) {
+            viewModelScope.launch {
+                val loaded = resourcesRepository.getOfflineResourceItems(olePath, extensions, allKnownExtensions)
+                _items.value = loaded
+            }
+        }
+    }
+
+    fun deleteResources(olePath: String, toDelete: List<OfflineResourceItem>, onComplete: () -> Unit) {
+        viewModelScope.launch {
+            resourcesRepository.deleteOfflineResources(olePath, toDelete)
+            val currentList = _items.value ?: emptyList()
+            _items.value = currentList.filterNot { item -> toDelete.any { it.resourceId == item.resourceId } }
+            onComplete()
+        }
+    }
+}


### PR DESCRIPTION
Extracts logic from four remaining screens (`CollectionsFragment`, `ActivitiesFragment`, `StorageCategoryDetailFragment`, and `ResourceDetailFragment`) into explicitly scoped Hilt ViewModels:

- `CollectionsViewModel`: Handles loading Tag data from DB via `TagsRepository`.
- `ActivitiesViewModel`: Handles long-running `getOfflineLogins` stream via `ActivitiesRepository`.
- `StorageCategoryDetailViewModel`: Manages storage items logic (load and delete via `ResourcesRepository`).
- `ResourceDetailViewModel`: Handles `MyLibrary` logic, rating tracking, and `UserEntity` injection via `ResourcesRepository`, `RatingsRepository`, and `UserRepository`.

All fragments are updated to strictly observe state flows using `collectLatestWhenStarted`. Cleaned up direct IO Coroutine usage and obsolete DAO/Repository injections inside these fragments.

---
*PR created automatically by Jules for task [17118903205406121772](https://jules.google.com/task/17118903205406121772) started by @dogi*