### PR TITLE
all: smoother upload to shelf service secure prefs testing (fixes #15711)

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadToShelfServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadToShelfServiceTest.kt
@@ -2,7 +2,13 @@ package org.ole.planet.myplanet.services
 
 import android.content.Context
 import android.content.SharedPreferences
-import io.mockk.*
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScheduler

--- a/app/src/test/java/org/ole/planet/myplanet/utils/SecurePrefsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/SecurePrefsTest.kt
@@ -4,7 +4,8 @@ import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
## Summary

Replaces the two wildcard imports in the test suite with explicit imports, matching the style used across the rest of the test suite (no other test file uses wildcards).

**`UploadToShelfServiceTest.kt`** — `io.mockk.*` →
```kotlin
import io.mockk.coEvery
import io.mockk.coVerify
import io.mockk.every
import io.mockk.mockk
import io.mockk.mockkObject
import io.mockk.unmockkAll
import io.mockk.verify
```
(`any()` is a MockK DSL scope member called inside `every {}` / `verify {}` blocks — it is not imported anywhere else in the suite, so no import is needed.)

**`SecurePrefsTest.kt`** — `org.junit.Assert.*` →
```kotlin
import org.junit.Assert.assertEquals
import org.junit.Assert.assertNull
```

Verified with the `kotlin-importing` skill that no further sorting/unused-import changes are needed and no wildcards remain under `app/src`.

Fixes #15711

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bd8af330-afa9-4bcd-acf3-1ca394e5d239)