### PR TITLE
test: expand wildcard imports to explicit imports

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/services/UploadToShelfServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/UploadToShelfServiceTest.kt
@@ -2,7 +2,13 @@ package org.ole.planet.myplanet.services
 
 import android.content.Context
 import android.content.SharedPreferences
-import io.mockk.*
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScheduler

--- a/app/src/test/java/org/ole/planet/myplanet/utils/SecurePrefsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/SecurePrefsTest.kt
@@ -4,7 +4,8 @@ import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
Replace io.mockk.* in UploadToShelfServiceTest.kt and org.junit.Assert.* in SecurePrefsTest.kt with the specific symbols each file uses, matching the explicit-import style used across the rest of the test suite.