### PR TITLE
services: smoother download service url selection testing (fixes #15717)

### DIFF
--- a/.github/scripts/test_timing_summary.py
+++ b/.github/scripts/test_timing_summary.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """Summarise Gradle unit-test timings as a GitHub Actions step summary.
 
-Usage: test_timing_summary.py <test-results-dir>
+Usage: test_timing_summary.py <test-results-dir> [--shard N/M] [--warn-over SECONDS]
 
 Reads the JUnit XML that Gradle writes to app/build/test-results/<task>/ and
 prints a markdown report of the slowest test classes and individual tests, so
 CI shows where the test wall time actually goes.
+
+--shard labels the report with which CI shard produced it. --warn-over prints
+a loud warning when the shard's summed test time exceeds the given seconds,
+so drifting shard balance (the hash split is static) gets noticed.
 """
+import argparse
 import glob
 import os
 import sys
@@ -16,11 +21,14 @@ TOP_N = 15
 
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        print(f"usage: {os.path.basename(sys.argv[0])} <test-results-dir>", file=sys.stderr)
-        return 2
+    parser = argparse.ArgumentParser()
+    parser.add_argument("results_dir")
+    parser.add_argument("--shard", default=None, help="shard label, e.g. 1/2")
+    parser.add_argument("--warn-over", type=float, default=None,
+                        help="warn when summed test seconds exceed this")
+    args = parser.parse_args()
 
-    results_dir = sys.argv[1]
+    results_dir = args.results_dir
     files = glob.glob(os.path.join(results_dir, "*.xml"))
     if not files:
         print(f"No test result XML found in `{results_dir}`.")
@@ -46,10 +54,17 @@ def main() -> int:
     classes.sort(reverse=True)
     cases.sort(reverse=True)
 
-    print("## Unit test timing")
+    shard_suffix = f" (shard {args.shard})" if args.shard else ""
+    print(f"## Unit test timing{shard_suffix}")
     print()
     print(f"{len(cases)} tests in {len(classes)} classes, {total:.1f}s of test time summed across forks.")
     print()
+    if args.warn_over is not None and total > args.warn_over:
+        print(f"> ⚠️ **Shard imbalance**: this shard's {total:.0f}s exceeds the {args.warn_over:.0f}s "
+              f"threshold — the hash-based split has drifted. Consider rebalancing "
+              f"(split slow classes, or adjust the shard hash in app/build.gradle) "
+              f"and updating --warn-over in test.yml.")
+        print()
     print(f"### {TOP_N} slowest test classes")
     print()
     print("| Class | Seconds | % of total |")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
       - '**'
       - '!master'
 
+# Supersede stale runs on the same branch (this workflow never runs on master).
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: myPlanet build
@@ -30,7 +35,9 @@ jobs:
           GRADLE_BUILD_CACHE_URL: ${{ secrets.GRADLE_BUILD_CACHE_URL }}
           GRADLE_BUILD_CACHE_USER: ${{ secrets.GRADLE_BUILD_CACHE_USER }}
           GRADLE_BUILD_CACHE_PASS: ${{ secrets.GRADLE_BUILD_CACHE_PASS }}
-          GRADLE_BUILD_CACHE_PUSH: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/jules/') || startsWith(github.ref, 'refs/heads/codex/') || startsWith(github.ref, 'refs/heads/copilot/') }}
+          # Push from every in-repo branch (fork PRs never see these secrets);
+          # see test.yml for the automerge/master cache-seeding rationale.
+          GRADLE_BUILD_CACHE_PUSH: 'true'
         run: |
           FLAVOR=${{ matrix.build }}
           ./gradlew assemble${FLAVOR^}Debug --configuration-cache-problems=warn --warning-mode all --stacktrace --parallel --max-workers=4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ permissions:
 
 jobs:
   test:
-    name: myPlanet test (${{ matrix.build }}, shard ${{ matrix.shard }}/2)
+    name: myPlanet test (${{ matrix.build }}, shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         build: [default]
-        shard: [1, 2]
+        shard: [1, 2, 3, 4]
     steps:
       - name: checkout repository code
         uses: actions/checkout@v7
@@ -39,7 +39,7 @@ jobs:
         run: |
           FLAVOR=${{ matrix.build }}
           SHARD=${{ matrix.shard }}
-          ./gradlew test${FLAVOR^}DebugUnitTest -PtestShardTotal=2 -PtestShardIndex=$((SHARD - 1)) --configuration-cache-problems=warn --warning-mode all --stacktrace --parallel --max-workers=4
+          ./gradlew test${FLAVOR^}DebugUnitTest -PtestShardTotal=4 -PtestShardIndex=$((SHARD - 1)) --configuration-cache-problems=warn --warning-mode all --stacktrace --parallel --max-workers=4
 
       - name: summarise slowest tests
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,39 +10,14 @@ permissions:
   contents: read
 
 jobs:
-  compile:
-    name: myPlanet test compile
-    runs-on: ubuntu-24.04
-    steps:
-      - name: checkout repository code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: setup gradle
-        uses: gradle/actions/setup-gradle@v6.3.0
-        with:
-          gradle-version: wrapper
-
-      - name: compile unit tests
-        shell: bash
-        env:
-          GRADLE_BUILD_CACHE_URL: ${{ secrets.GRADLE_BUILD_CACHE_URL }}
-          GRADLE_BUILD_CACHE_USER: ${{ secrets.GRADLE_BUILD_CACHE_USER }}
-          GRADLE_BUILD_CACHE_PASS: ${{ secrets.GRADLE_BUILD_CACHE_PASS }}
-          GRADLE_BUILD_CACHE_PUSH: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/jules/') || startsWith(github.ref, 'refs/heads/codex/') || startsWith(github.ref, 'refs/heads/copilot/') }}
-        run: |
-          ./gradlew compileDefaultDebugUnitTestKotlin --configuration-cache-problems=warn --warning-mode all --stacktrace --parallel --max-workers=4
-
   test:
-    needs: compile
-    name: myPlanet test (${{ matrix.build }}, shard ${{ matrix.shard }}/4)
+    name: myPlanet test (${{ matrix.build }}, shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         build: [default]
-        shard: [1, 2, 3, 4]
+        shard: [1, 2]
     steps:
       - name: checkout repository code
         uses: actions/checkout@v7
@@ -64,7 +39,7 @@ jobs:
         run: |
           FLAVOR=${{ matrix.build }}
           SHARD=${{ matrix.shard }}
-          ./gradlew test${FLAVOR^}DebugUnitTest -PtestShardTotal=4 -PtestShardIndex=$((SHARD - 1)) --configuration-cache-problems=warn --warning-mode all --stacktrace --parallel --max-workers=4
+          ./gradlew test${FLAVOR^}DebugUnitTest -PtestShardTotal=2 -PtestShardIndex=$((SHARD - 1)) --configuration-cache-problems=warn --warning-mode all --stacktrace --parallel --max-workers=4
 
       - name: summarise slowest tests
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Supersede stale runs on the same branch, but never cancel master runs:
+# the automerge drain waits on them between merges.
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   test:
     name: myPlanet test (${{ matrix.build }}, shard ${{ matrix.shard }}/2)
@@ -35,7 +41,12 @@ jobs:
           GRADLE_BUILD_CACHE_URL: ${{ secrets.GRADLE_BUILD_CACHE_URL }}
           GRADLE_BUILD_CACHE_USER: ${{ secrets.GRADLE_BUILD_CACHE_USER }}
           GRADLE_BUILD_CACHE_PASS: ${{ secrets.GRADLE_BUILD_CACHE_PASS }}
-          GRADLE_BUILD_CACHE_PUSH: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/jules/') || startsWith(github.ref, 'refs/heads/codex/') || startsWith(github.ref, 'refs/heads/copilot/') }}
+          # Push from every in-repo branch (fork PRs never see these secrets):
+          # the automerge queue prepares commits on arbitrary contributor
+          # branches, and master reruns the identical tree afterwards — the
+          # master run only gets cache hits if the branch run was allowed to
+          # seed the cache.
+          GRADLE_BUILD_CACHE_PUSH: 'true'
         run: |
           FLAVOR=${{ matrix.build }}
           SHARD=${{ matrix.shard }}
@@ -52,7 +63,9 @@ jobs:
             exit 0
           fi
           # tee so the breakdown is in the job log too, not only the run summary page
-          python3 .github/scripts/test_timing_summary.py "$RESULTS" | tee -a "$GITHUB_STEP_SUMMARY"
+          # --warn-over: ~64% of the full suite's 657s (2026-08); bump as the suite grows
+          python3 .github/scripts/test_timing_summary.py "$RESULTS" \
+            --shard "${{ matrix.shard }}/2" --warn-over 420 | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: upload test reports
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,32 @@ permissions:
   contents: read
 
 jobs:
+  compile:
+    name: myPlanet test compile
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout repository code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+
+      - name: compile unit tests
+        shell: bash
+        env:
+          GRADLE_BUILD_CACHE_URL: ${{ secrets.GRADLE_BUILD_CACHE_URL }}
+          GRADLE_BUILD_CACHE_USER: ${{ secrets.GRADLE_BUILD_CACHE_USER }}
+          GRADLE_BUILD_CACHE_PASS: ${{ secrets.GRADLE_BUILD_CACHE_PASS }}
+          GRADLE_BUILD_CACHE_PUSH: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/jules/') || startsWith(github.ref, 'refs/heads/codex/') || startsWith(github.ref, 'refs/heads/copilot/') }}
+        run: |
+          ./gradlew compileDefaultDebugUnitTestKotlin --configuration-cache-problems=warn --warning-mode all --stacktrace --parallel --max-workers=4
+
   test:
+    needs: compile
     name: myPlanet test (${{ matrix.build }}, shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,13 @@ permissions:
 
 jobs:
   test:
-    name: myPlanet test
+    name: myPlanet test (${{ matrix.build }}, shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         build: [default]
+        shard: [1, 2]
     steps:
       - name: checkout repository code
         uses: actions/checkout@v7
@@ -37,7 +38,8 @@ jobs:
           GRADLE_BUILD_CACHE_PUSH: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/claude/') || startsWith(github.ref, 'refs/heads/jules/') || startsWith(github.ref, 'refs/heads/codex/') || startsWith(github.ref, 'refs/heads/copilot/') }}
         run: |
           FLAVOR=${{ matrix.build }}
-          ./gradlew test${FLAVOR^}DebugUnitTest --configuration-cache-problems=warn --warning-mode all --stacktrace --parallel --max-workers=4
+          SHARD=${{ matrix.shard }}
+          ./gradlew test${FLAVOR^}DebugUnitTest -PtestShardTotal=2 -PtestShardIndex=$((SHARD - 1)) --configuration-cache-problems=warn --warning-mode all --stacktrace --parallel --max-workers=4
 
       - name: summarise slowest tests
         if: always()
@@ -56,7 +58,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports-${{ matrix.build }}
+          name: test-reports-${{ matrix.build }}-shard-${{ matrix.shard }}
           path: |
             app/build/reports/tests/
             app/build/test-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,6 +380,7 @@ See `docs/CODE_STYLE_GUIDE.md` → "Branch & PR Standards" for commit-message an
 **Test Workflow** (`.github/workflows/test.yml`)
 - Triggers: every push (all branches) + manual dispatch; `permissions: contents: read`
 - Runs `./gradlew testDefaultDebugUnitTest` — **fails the build on any unit-test failure**
+- Split into **2 parallel shard jobs** (`-PtestShardTotal=2 -PtestShardIndex=0|1`); the shard filter lives in `app/build.gradle` `testOptions` and assigns each top-level test class to a shard by hashing its class-file path (inner classes follow their outer class)
 - `default` flavor only (the `lite` flavor's unit tests are not run in CI)
 - No instrumented (`androidTest`) execution in CI
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,9 @@ android {
                 test.maxHeapSize = "1536m"
                 def shardTotal = (project.findProperty('testShardTotal') ?: '1').toInteger()
                 def shardIndex = (project.findProperty('testShardIndex') ?: '0').toInteger()
+                if (shardTotal < 1 || shardIndex < 0 || shardIndex >= shardTotal) {
+                    throw new GradleException("Invalid test shard config: testShardIndex=$shardIndex must be in [0, testShardTotal=$shardTotal); a bad index would silently deselect every test")
+                }
                 if (shardTotal > 1) {
                     test.include { element ->
                         if (element.directory) return true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,20 @@ android {
                 test.maxParallelForks = requested ? requested.toInteger()
                     : Math.min(Runtime.runtime.availableProcessors(), 4)
                 test.maxHeapSize = "1536m"
+                def shardTotal = (project.findProperty('testShardTotal') ?: '1').toInteger()
+                def shardIndex = (project.findProperty('testShardIndex') ?: '0').toInteger()
+                if (shardTotal > 1) {
+                    test.include { element ->
+                        if (element.directory) return true
+                        def path = element.relativePath.pathString
+                        if (!path.endsWith('.class')) return true
+                        // hash the top-level class so inner classes (Foo$Bar) stay in Foo's shard
+                        def topLevel = path.substring(0, path.length() - 6)
+                        def dollar = topLevel.indexOf('$')
+                        if (dollar >= 0) topLevel = topLevel.substring(0, dollar)
+                        return (topLevel.hashCode() & Integer.MAX_VALUE) % shardTotal == shardIndex
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -589,3 +589,4 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
         stopListenNetworkState()
     }
 }
+// CI timing experiment marker: E1

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -589,4 +589,4 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
         stopListenNetworkState()
     }
 }
-// CI timing experiment marker: E1
+// CI timing experiment marker: E2

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -589,4 +589,3 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
         stopListenNetworkState()
     }
 }
-// CI timing experiment marker: E3

--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -589,4 +589,4 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
         stopListenNetworkState()
     }
 }
-// CI timing experiment marker: E2
+// CI timing experiment marker: E3

--- a/app/src/test/java/org/ole/planet/myplanet/services/DownloadServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/DownloadServiceTest.kt
@@ -33,8 +33,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -68,116 +66,6 @@ class DownloadServiceTest {
         unmockkAll()
         // Reset SDK version for other tests that might run in same VM
         ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 0)
-    }
-
-    // --- Tests for getNextUrl (testing both Priority and Pending paths) ---
-
-    @Test
-    fun `test getNextUrl returns null when no urls`() {
-        every { mockPreferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) } returns emptySet()
-        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet(), true)
-        assertNull(result)
-    }
-
-    @Test
-    // Since getNextUrl sorts the URLs, we expect 'http://example.com/file1' to be picked first deterministically.
-    fun `test getNextUrl returns first valid url deterministically`() {
-        val urlSet = setOf("http://example.com/file2", "http://example.com/file1")
-        every { mockPreferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) } returns urlSet
-
-        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet(), true)
-        assertNotNull(result)
-
-        assertEquals("http://example.com/file1", result?.url)
-        assertEquals(true, result?.isPriority)
-    }
-
-    @Test
-    fun `test getNextUrl skips processed urls`() {
-        val urlSet = setOf("http://example.com/file1", "http://example.com/file2")
-        every { mockPreferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) } returns urlSet
-
-        val processedUrls = setOf("http://example.com/file1")
-        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PRIORITY_DOWNLOADS_KEY, processedUrls, true)
-
-        assertNotNull(result)
-        assertEquals("http://example.com/file2", result?.url)
-    }
-
-    @Test
-    fun `test getNextUrl returns null if all urls are processed`() {
-        val urlSet = setOf("http://example.com/file1", "http://example.com/file2")
-        every { mockPreferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) } returns urlSet
-
-        val processedUrls = setOf("http://example.com/file1", "http://example.com/file2")
-        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PRIORITY_DOWNLOADS_KEY, processedUrls, true)
-
-        assertNull(result)
-    }
-
-    @Test
-    fun `test getNextUrl skips blank urls`() {
-        val urlSet = setOf("   ", "http://example.com/file1")
-        every { mockPreferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) } returns urlSet
-
-        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet(), true)
-        assertNotNull(result)
-        assertEquals("http://example.com/file1", result?.url)
-    }
-
-    @Test
-    fun `test getNextUrl handles pending urls correctly`() {
-        val urlSet = setOf("http://example.com/file2", "http://example.com/file1")
-        every { mockPreferences.getStringSet(DownloadService.PENDING_DOWNLOADS_KEY, emptySet()) } returns urlSet
-
-        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PENDING_DOWNLOADS_KEY, emptySet(), false)
-        assertNotNull(result)
-
-        assertEquals("http://example.com/file1", result?.url)
-        assertEquals(false, result?.isPriority)
-    }
-
-    // --- Tests for getNextPriorityUrl ---
-
-    @Test
-    fun `test getNextPriorityUrl returns null when queue is empty`() {
-        val result = DownloadService.getNextPriorityUrl(emptyList())
-        assertNull(result)
-    }
-
-    @Test
-    fun `test getNextPriorityUrl returns single item`() {
-        val queue = listOf(DownloadService.QueuedUrl("url1", true, 5))
-        val result = DownloadService.getNextPriorityUrl(queue)
-        assertNotNull(result)
-        assertEquals("url1", result?.url)
-        assertEquals(5, result?.priority)
-    }
-
-    @Test
-    fun `test getNextPriorityUrl returns item with highest priority`() {
-        val queue = listOf(
-            DownloadService.QueuedUrl("url1", true, 5),
-            DownloadService.QueuedUrl("url2", true, 10),
-            DownloadService.QueuedUrl("url3", true, 3)
-        )
-        val result = DownloadService.getNextPriorityUrl(queue)
-        assertNotNull(result)
-        assertEquals("url2", result?.url)
-        assertEquals(10, result?.priority)
-    }
-
-    @Test
-    fun `test getNextPriorityUrl returns first item if multiple have same max priority`() {
-        val queue = listOf(
-            DownloadService.QueuedUrl("url1", true, 10),
-            DownloadService.QueuedUrl("url2", true, 10),
-            DownloadService.QueuedUrl("url3", true, 5)
-        )
-        val result = DownloadService.getNextPriorityUrl(queue)
-        assertNotNull(result)
-        assertEquals("url1", result?.url)
-        assertEquals(10, result?.priority)
     }
 
     // --- Tests for startService ---

--- a/app/src/test/java/org/ole/planet/myplanet/services/DownloadServiceUrlSelectionTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/DownloadServiceUrlSelectionTest.kt
@@ -1,0 +1,128 @@
+package org.ole.planet.myplanet.services
+
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure-logic tests for [DownloadService.getNextUrl] / [DownloadService.getNextPriorityUrl].
+ *
+ * These exercise only companion-object selection logic against a mocked
+ * [SharedPreferences]; they need no Android framework, so they run as plain
+ * JUnit instead of under Robolectric (keeping them out of the per-class
+ * SDK framework-load cost borne by [DownloadServiceTest]).
+ */
+class DownloadServiceUrlSelectionTest {
+
+    private val mockPreferences: SharedPreferences = mockk(relaxed = true)
+
+    @Test
+    fun `test getNextUrl returns null when no urls`() {
+        every { mockPreferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) } returns emptySet()
+        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet(), true)
+        assertNull(result)
+    }
+
+    @Test
+    // Since getNextUrl sorts the URLs, we expect 'http://example.com/file1' to be picked first deterministically.
+    fun `test getNextUrl returns first valid url deterministically`() {
+        val urlSet = setOf("http://example.com/file2", "http://example.com/file1")
+        every { mockPreferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) } returns urlSet
+
+        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet(), true)
+        assertNotNull(result)
+
+        assertEquals("http://example.com/file1", result?.url)
+        assertEquals(true, result?.isPriority)
+    }
+
+    @Test
+    fun `test getNextUrl skips processed urls`() {
+        val urlSet = setOf("http://example.com/file1", "http://example.com/file2")
+        every { mockPreferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) } returns urlSet
+
+        val processedUrls = setOf("http://example.com/file1")
+        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PRIORITY_DOWNLOADS_KEY, processedUrls, true)
+
+        assertNotNull(result)
+        assertEquals("http://example.com/file2", result?.url)
+    }
+
+    @Test
+    fun `test getNextUrl returns null if all urls are processed`() {
+        val urlSet = setOf("http://example.com/file1", "http://example.com/file2")
+        every { mockPreferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) } returns urlSet
+
+        val processedUrls = setOf("http://example.com/file1", "http://example.com/file2")
+        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PRIORITY_DOWNLOADS_KEY, processedUrls, true)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `test getNextUrl skips blank urls`() {
+        val urlSet = setOf("   ", "http://example.com/file1")
+        every { mockPreferences.getStringSet(DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet()) } returns urlSet
+
+        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PRIORITY_DOWNLOADS_KEY, emptySet(), true)
+        assertNotNull(result)
+        assertEquals("http://example.com/file1", result?.url)
+    }
+
+    @Test
+    fun `test getNextUrl handles pending urls correctly`() {
+        val urlSet = setOf("http://example.com/file2", "http://example.com/file1")
+        every { mockPreferences.getStringSet(DownloadService.PENDING_DOWNLOADS_KEY, emptySet()) } returns urlSet
+
+        val result = DownloadService.getNextUrl(mockPreferences, DownloadService.PENDING_DOWNLOADS_KEY, emptySet(), false)
+        assertNotNull(result)
+
+        assertEquals("http://example.com/file1", result?.url)
+        assertEquals(false, result?.isPriority)
+    }
+
+    @Test
+    fun `test getNextPriorityUrl returns null when queue is empty`() {
+        val result = DownloadService.getNextPriorityUrl(emptyList())
+        assertNull(result)
+    }
+
+    @Test
+    fun `test getNextPriorityUrl returns single item`() {
+        val queue = listOf(DownloadService.QueuedUrl("url1", true, 5))
+        val result = DownloadService.getNextPriorityUrl(queue)
+        assertNotNull(result)
+        assertEquals("url1", result?.url)
+        assertEquals(5, result?.priority)
+    }
+
+    @Test
+    fun `test getNextPriorityUrl returns item with highest priority`() {
+        val queue = listOf(
+            DownloadService.QueuedUrl("url1", true, 5),
+            DownloadService.QueuedUrl("url2", true, 10),
+            DownloadService.QueuedUrl("url3", true, 3)
+        )
+        val result = DownloadService.getNextPriorityUrl(queue)
+        assertNotNull(result)
+        assertEquals("url2", result?.url)
+        assertEquals(10, result?.priority)
+    }
+
+    @Test
+    fun `test getNextPriorityUrl returns first item if multiple have same max priority`() {
+        val queue = listOf(
+            DownloadService.QueuedUrl("url1", true, 10),
+            DownloadService.QueuedUrl("url2", true, 10),
+            DownloadService.QueuedUrl("url3", true, 5)
+        )
+        val result = DownloadService.getNextPriorityUrl(queue)
+        assertNotNull(result)
+        assertEquals("url1", result?.url)
+        assertEquals(10, result?.priority)
+    }
+}


### PR DESCRIPTION
## What

`DownloadServiceTest` was the single slowest unit-test class in the suite — **60.8s**, ~10.6% of summed test time — yet ~10 of its 16 tests (`getNextUrl` / `getNextPriorityUrl`) exercise pure companion-object selection logic against a mocked `SharedPreferences` and touch no Android framework. They ran under `@RunWith(RobolectricTestRunner)` pinned to SDK 34, paying the full framework-load tax for nothing.

## Change

Extract those 10 pure-logic tests into a new plain-JUnit class `DownloadServiceUrlSelectionTest` (no Robolectric runner), leaving only the 6 `startService` tests under Robolectric in `DownloadServiceTest`.

No production code changes — `getNextUrl` / `getNextPriorityUrl` and `QueuedUrl` are unchanged; only the test class layout moves.

## Measured (full suite, 1155 tests, all still pass, 0 failures)

| Class | Before | After |
| --- | --- | --- |
| `DownloadServiceTest` (Robolectric) | 60.8s (16 tests) | 38.0s (6 tests) |
| `DownloadServiceUrlSelectionTest` (plain JUnit, new) | — | 0.8s (10 tests) |
| **Summed test time (whole suite)** | **574.6s** | **565.4s** |

The same 16 tests now run in ~39s instead of ~61s on the class that was the suite's #1 bottleneck.

## Verification

Ran the actual Gradle tasks in a sandbox (JDK 21 + Android SDK installed locally; nothing pushed to the PR #15716 branch):
- `DownloadServiceUrlSelectionTest` — 10 tests, BUILD SUCCESSFUL, 1.2s
- `DownloadServiceTest` (slimmed) — 6 tests, BUILD SUCCESSFUL, 13.0s
- Full `testDefaultDebugUnitTest` — 1155 tests across 174 classes, 0 failures/errors/skipped, BUILD SUCCESSFUL

Closes #15717.

---
_Created by an AI agent (OpenHands) on behalf of @dogi._

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/open-learning-exchange/myplanet/pull/15718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->