### PR TITLE
Add Android WorkManager-backed background sync and outbox scheduling (Phase 30)

### DIFF
--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -5,7 +5,7 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 
 ## Status
 
-**Phase 28 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
+**Phase 30 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
 **27 of 28 UI packages** have a screen, and a screen existing is not the same as the feature
 working. Counted honestly:
 
@@ -17,9 +17,9 @@ working. Counted honestly:
   the shape Kotlin has.
 
 Known gaps:
-- Background work with no user present (`AutoSyncWorker`'s timed sync,
-  `TaskNotificationWorker`'s deadline notifications, `DownloadWorker`'s background queue) needs
-  OS scheduling and is not ported.
+- Background auto-sync and outbox delivery now use constraint-aware Android WorkManager jobs and
+  survive process death. `TaskNotificationWorker`'s deadline notifications and
+  `DownloadWorker`'s background queue still need task-specific ports on top of that scheduler.
 - Team attachments are unported. Personal-note attachments are: the note POSTs, then the file
   PUTs as a CouchDB attachment, best-effort and in that order, as Kotlin does.
 - Public surveys reach `PublicSurveyScreen` only through a deep link whose URI carries an
@@ -166,6 +166,28 @@ Known gaps:
   both `''` and `'pending'` submission statuses as pending, because this port's survey
   get-or-create writes `''` where the Kotlin writes `'pending'` — reconciling the write side is
   open.
+- **Phase 30** — OS-scheduled background execution: the Flutter `workmanager` plugin registers
+  unique, updateable periodic jobs with connected-network and battery-not-low constraints. A
+  headless callback rebuilds the Riverpod graph, hydrates encrypted server credentials, recovers
+  and drains the durable outbox, and pulls resources, courses, teams, meetups, surveys, voices,
+  feedback, chat, submissions, and health. Persisted enablement, interval, and last-success time
+  preserve Kotlin's defaults; the interval is clamped to Android WorkManager's 15-minute floor,
+  failed table pulls request an OS retry, and every headless graph is disposed so Drift closes.
+  Registration is deliberately not an app-launch gate: plugin or OS failures are reported and
+  retried at the next cold start. Outbox claims carry a 20-minute lease, so startup recovery cannot
+  steal a live foreground/background send and double-post it. Pulls run sequentially rather than
+  making ten Drift writers contend at once; each table is failure-isolated, later tables still run,
+  and the last-success timestamp advances only when the outbox and every pull succeed. Clock
+  corrections into the past also force a sync instead of suppressing work behind a future timestamp.
+  Every recognized headless run persists a credential-free diagnostic containing its task, UTC
+  attempt time, terminal status, stable failed-step names, and (for a skip) the reason. This makes
+  "WorkManager never woke" distinguishable from "resources failed but later tables refreshed"
+  without storing endpoints, payloads, exception text, or credentials; failure to write the
+  diagnostic never turns successful domain work into a retry.
+  Settings exposes the persisted enable switch, 15/30-minute and 1/6-hour cadence choices, and the
+  sanitized last-run result. A change updates unique WorkManager registration immediately; if the OS
+  rejects that update, the preference remains durable, the user sees a warning, and cold-start
+  registration tries it again rather than rolling their choice back.
 
 - **Phase 27** — chat upload, member registration against `_users`, and the resource detail
   screen with its filter sheet. Three fixes were needed around it:
@@ -383,12 +405,14 @@ server on plain HTTP (`http://<ip>:5000`):
 
 Ordered by risk, highest first.
 
-1. **`WorkManager` → no equivalent. Resolved for write-back; still open for the rest.**
+1. **`WorkManager` → plugin-backed Android scheduling. Auto-sync resolved; specialized jobs remain.**
    `AutoSyncWorker`, `TaskNotificationWorker`, `NetworkMonitorWorker`, `RetryQueueWorker`,
    `DownloadWorker`, `FreeSpaceWorker`, `ServerReachabilityWorker` and `HeavyTableSyncWorker` rely
    on guaranteed, constraint-aware, OS-scheduled execution that survives process death. Flutter
    has no first-party answer; `workmanager` / `flutter_background_service` are thin
-   platform-channel wrappers whose Android side would remain Kotlin.
+   platform-channel wrappers whose Android side remains native. Phase 30 deliberately adopts
+   `workmanager`: it is a narrow platform boundary rather than reimplementing scheduling in app
+   lifecycle callbacks.
 
    The unblocking observation is that `RetryQueue` and `RetryQueueWorker` do two separable jobs.
    The queue is a SQLite table -- it is what actually survives process death -- and the worker only
@@ -398,17 +422,17 @@ Ordered by risk, highest first.
    `UploadCoordinator`), `OutboxDrainer` replaces the worker, and `OutboxDrainScope` triggers it
    at startup and on every app resume.
 
-   **The residual gap is scheduling, not durability**: a write made offline is sent the next time
-   the app is opened with connectivity, not while it is closed. For an app users open regularly
-   that is a latency cost rather than a correctness one, and it is bounded -- the operation sits in
-   SQLite until it succeeds or exhausts its attempts.
+   Phase 30 closes the scheduling gap for the outbox and table pulls: Android can now wake a
+   headless Flutter isolate when the network is connected and the battery is not low. App-resume
+   draining remains as a low-latency second trigger. A status-scoped SQLite update is the
+   cross-isolate claim, while each drainer also has an in-isolate single-flight guard, so the two
+   triggers cannot double-post the same operation.
 
    This unblocks the *append* write-backs (`submissions`, `voices`, personal notes) that the
    shelf's derived-payload trick could not cover, because an append lost to a dead network is not
    recoverable by recomputation. `PersonalsUploader` is the first one built on it. What is still
-   unresolved is periodic background work with no user present -- `AutoSyncWorker`'s timed sync and
-   `TaskNotificationWorker`'s deadline notifications genuinely need OS scheduling, and those are
-   the cases that may still argue for a permanent Kotlin platform layer.
+   unresolved is the task-specific behavior above the scheduler -- deadline notification display
+   and queued bulk downloads -- rather than the ability to run with no user present.
 2. **`TeamsRepositoryImpl` (~1785 lines).** The largest file in the codebase, spanning team
    creation, tasks, membership roles and reactive queries. Should be split by responsibility
    *during* the port, not carried over whole.
@@ -780,6 +804,6 @@ succeeds, it just doesn't do what the Kotlin did.
 
 ---
 
-**Last updated**: 2026-08-12 (Phase 29 complete)
+**Last updated**: 2026-08-16 (Phase 30 complete)
 **Phase**: 27 of N (27 of 28 UI packages have a screen — see Status for what that does and does
 not mean)

--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:workmanager/workmanager.dart';
+
+import 'core/background/background_task_runner.dart';
+import 'core/prefs/planet_prefs.dart';
+import 'core/sync/sync_result.dart';
+import 'providers/app_providers.dart';
+import 'repository/personals_uploader.dart';
+
+/// WorkManager launches this in a new isolate, so it must be a retained
+/// top-level entry point rather than a closure installed by the UI isolate.
+@pragma('vm:entry-point')
+void callbackDispatcher() {
+  Workmanager().executeTask((taskName, _) => executeBackgroundTask(taskName));
+}
+
+/// Executes one WorkManager invocation in a fresh Riverpod graph.
+///
+/// The graph is always disposed, which closes Drift and Dio resources even if
+/// Android stops the worker after its execution window.
+Future<bool> executeBackgroundTask(String taskName) async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await PlanetPrefs.load();
+  final container = ProviderContainer(
+    overrides: [planetPrefsProvider.overrideWithValue(prefs)],
+  );
+  try {
+    final config = prefs.serverConfig;
+    final drainer = container.read(outboxDrainerProvider);
+    bool completed(SyncResult result) => result is SyncComplete;
+    return BackgroundTaskRunner(
+      configured: config != null,
+      autoSyncEnabled: prefs.autoSyncEnabled,
+      autoSyncInterval: prefs.autoSyncInterval,
+      lastSync: prefs.lastSync,
+      recoverOutbox: drainer.recoverStuck,
+      drainOutbox: () async {
+        if (config == null) return;
+        await drainer.drain(
+          authHeader: PersonalsUploader.authHeaderFor(config),
+        );
+      },
+      syncSteps: config == null
+          ? const []
+          : [
+              BackgroundSyncStep(
+                'resources',
+                () async => completed(
+                  await container
+                      .read(resourcesRepositoryProvider)
+                      .sync(config: config),
+                ),
+              ),
+              BackgroundSyncStep(
+                'courses',
+                () async => completed(
+                  await container
+                      .read(coursesRepositoryProvider)
+                      .sync(config: config),
+                ),
+              ),
+              BackgroundSyncStep(
+                'teams',
+                () async => completed(
+                  await container
+                      .read(teamsRepositoryProvider)
+                      .sync(config: config),
+                ),
+              ),
+              BackgroundSyncStep(
+                'events',
+                () async => completed(
+                  await container
+                      .read(eventsRepositoryProvider)
+                      .sync(config: config),
+                ),
+              ),
+              BackgroundSyncStep(
+                'surveys',
+                () async => completed(
+                  await container
+                      .read(surveysRepositoryProvider)
+                      .sync(config: config),
+                ),
+              ),
+              BackgroundSyncStep(
+                'voices',
+                () async => completed(
+                  await container
+                      .read(voicesRepositoryProvider)
+                      .sync(config: config),
+                ),
+              ),
+              BackgroundSyncStep(
+                'feedback',
+                () async => completed(
+                  await container
+                      .read(feedbackRepositoryProvider)
+                      .sync(config: config),
+                ),
+              ),
+              BackgroundSyncStep(
+                'chat',
+                () async => completed(
+                  await container
+                      .read(chatRepositoryProvider)
+                      .sync(config: config),
+                ),
+              ),
+              BackgroundSyncStep(
+                'submissions',
+                () async => completed(
+                  await container
+                      .read(submissionsRepositoryProvider)
+                      .sync(config: config),
+                ),
+              ),
+              BackgroundSyncStep(
+                'health',
+                () async => completed(
+                  await container.read(healthRepositoryProvider).sync(),
+                ),
+              ),
+            ],
+      recordLastSync: prefs.setLastSync,
+      recordRun: (record) => prefs.recordBackgroundRun(
+        taskName: record.taskName,
+        attemptedAt: record.attemptedAt,
+        status: record.status.name,
+        failedSteps: record.failedSteps,
+        skipReason: record.skipReason,
+      ),
+    ).run(taskName);
+  } catch (_) {
+    return false;
+  } finally {
+    container.dispose();
+  }
+}

--- a/flutter/lib/core/background/background_scheduler.dart
+++ b/flutter/lib/core/background/background_scheduler.dart
@@ -1,0 +1,47 @@
+import 'package:workmanager/workmanager.dart';
+
+import '../../background_entrypoint.dart';
+
+/// Small seam around the plugin so scheduling policy has ordinary unit tests.
+abstract interface class BackgroundScheduler {
+  Future<void> initialize();
+
+  Future<void> schedulePeriodic({
+    required String uniqueName,
+    required String taskName,
+    required Duration frequency,
+    required bool requiresNetwork,
+  });
+
+  Future<void> cancel(String uniqueName);
+}
+
+class WorkmanagerScheduler implements BackgroundScheduler {
+  const WorkmanagerScheduler();
+
+  @override
+  Future<void> initialize() => Workmanager().initialize(callbackDispatcher);
+
+  @override
+  Future<void> schedulePeriodic({
+    required String uniqueName,
+    required String taskName,
+    required Duration frequency,
+    required bool requiresNetwork,
+  }) => Workmanager().registerPeriodicTask(
+    uniqueName,
+    taskName,
+    frequency: frequency,
+    existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
+    constraints: Constraints(
+      networkType: requiresNetwork
+          ? NetworkType.connected
+          : NetworkType.notRequired,
+      requiresBatteryNotLow: true,
+    ),
+  );
+
+  @override
+  Future<void> cancel(String uniqueName) =>
+      Workmanager().cancelByUniqueName(uniqueName);
+}

--- a/flutter/lib/core/background/background_task_names.dart
+++ b/flutter/lib/core/background/background_task_names.dart
@@ -1,0 +1,5 @@
+/// Stable names are part of the persisted Android WorkManager contract.
+abstract final class BackgroundTaskNames {
+  static const autoSync = 'myplanet.autoSync';
+  static const maintenance = 'myplanet.maintenance';
+}

--- a/flutter/lib/core/background/background_task_runner.dart
+++ b/flutter/lib/core/background/background_task_runner.dart
@@ -1,0 +1,181 @@
+import 'background_task_names.dart';
+
+typedef BackgroundStep = Future<void> Function();
+
+class BackgroundSyncStep {
+  const BackgroundSyncStep(this.name, this.run);
+
+  final String name;
+  final Future<bool> Function() run;
+}
+
+enum BackgroundRunStatus { succeeded, skipped, retryRequested }
+
+class BackgroundRunRecord {
+  const BackgroundRunRecord({
+    required this.taskName,
+    required this.attemptedAt,
+    required this.status,
+    this.failedSteps = const [],
+    this.skipReason,
+  });
+
+  final String taskName;
+  final DateTime attemptedAt;
+  final BackgroundRunStatus status;
+  final List<String> failedSteps;
+  final String? skipReason;
+}
+
+/// Pure-Dart policy engine for a single headless invocation.
+///
+/// Plugin bootstrap and Riverpod graph construction stay in the entrypoint;
+/// this class owns ordering, cadence, failure isolation, and retry semantics so
+/// those decisions can be tested without launching a Flutter background
+/// isolate.
+class BackgroundTaskRunner {
+  BackgroundTaskRunner({
+    required this.configured,
+    required this.autoSyncEnabled,
+    required this.autoSyncInterval,
+    required this.lastSync,
+    required this.recoverOutbox,
+    required this.drainOutbox,
+    required this.syncSteps,
+    required this.recordLastSync,
+    this.recordRun,
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  final bool configured;
+  final bool autoSyncEnabled;
+  final Duration autoSyncInterval;
+  final DateTime? lastSync;
+  final BackgroundStep recoverOutbox;
+  final BackgroundStep drainOutbox;
+  final List<BackgroundSyncStep> syncSteps;
+  final Future<void> Function(DateTime value) recordLastSync;
+  final Future<void> Function(BackgroundRunRecord record)? recordRun;
+  final DateTime Function() _now;
+
+  /// Returns WorkManager's success flag. `false` asks the OS to retry.
+  Future<bool> run(String taskName) async {
+    if (taskName != BackgroundTaskNames.autoSync &&
+        taskName != BackgroundTaskNames.maintenance) {
+      // A renamed task may remain persisted across an upgrade. Retrying a task
+      // this version cannot execute would create an infinite retry loop.
+      return true;
+    }
+    if (!configured) {
+      await _finish(
+        taskName,
+        BackgroundRunStatus.skipped,
+        skipReason: 'notConfigured',
+      );
+      return true;
+    }
+
+    final failed = <String>[];
+    if (!await _attempt(recoverOutbox)) failed.add('outboxRecovery');
+    if (!await _attempt(drainOutbox)) failed.add('outboxDrain');
+
+    if (taskName == BackgroundTaskNames.maintenance) {
+      return _complete(taskName, failed);
+    }
+    if (!autoSyncEnabled) {
+      await _finish(
+        taskName,
+        failed.isEmpty
+            ? BackgroundRunStatus.skipped
+            : BackgroundRunStatus.retryRequested,
+        failedSteps: failed,
+        skipReason: 'autoSyncDisabled',
+      );
+      return failed.isEmpty;
+    }
+    if (!_isDue()) {
+      await _finish(
+        taskName,
+        failed.isEmpty
+            ? BackgroundRunStatus.skipped
+            : BackgroundRunStatus.retryRequested,
+        failedSteps: failed,
+        skipReason: 'notDue',
+      );
+      return failed.isEmpty;
+    }
+
+    // Run independently and in order. Future.wait made all ten repositories
+    // write Drift concurrently and an early exception discarded the remaining
+    // outcomes. A failed table should request a retry without preventing an
+    // unrelated table from refreshing.
+    for (final sync in syncSteps) {
+      try {
+        if (!await sync.run()) failed.add(sync.name);
+      } catch (_) {
+        failed.add(sync.name);
+      }
+    }
+
+    if (failed.isEmpty) {
+      try {
+        await recordLastSync(_now().toUtc());
+      } catch (_) {
+        failed.add('lastSyncWrite');
+      }
+    }
+    return _complete(taskName, failed);
+  }
+
+  bool _isDue() {
+    final previous = lastSync;
+    if (previous == null) return true;
+    final elapsed = _now().difference(previous);
+    // A wall clock corrected backwards must not suppress sync until it catches
+    // up with a future timestamp.
+    return elapsed.isNegative || elapsed >= autoSyncInterval;
+  }
+
+  Future<bool> _attempt(BackgroundStep step) async {
+    try {
+      await step();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<bool> _complete(String taskName, List<String> failed) async {
+    await _finish(
+      taskName,
+      failed.isEmpty
+          ? BackgroundRunStatus.succeeded
+          : BackgroundRunStatus.retryRequested,
+      failedSteps: failed,
+    );
+    return failed.isEmpty;
+  }
+
+  Future<void> _finish(
+    String taskName,
+    BackgroundRunStatus status, {
+    List<String> failedSteps = const [],
+    String? skipReason,
+  }) async {
+    final writer = recordRun;
+    if (writer == null) return;
+    try {
+      await writer(
+        BackgroundRunRecord(
+          taskName: taskName,
+          attemptedAt: _now().toUtc(),
+          status: status,
+          failedSteps: List.unmodifiable(failedSteps),
+          skipReason: skipReason,
+        ),
+      );
+    } catch (_) {
+      // Telemetry must never turn successful domain work into an OS retry.
+    }
+  }
+}

--- a/flutter/lib/core/background/background_work_coordinator.dart
+++ b/flutter/lib/core/background/background_work_coordinator.dart
@@ -1,0 +1,42 @@
+import '../prefs/planet_prefs.dart';
+import 'background_scheduler.dart';
+import 'background_task_names.dart';
+
+/// Applies persisted user policy to OS-scheduled jobs.
+class BackgroundWorkCoordinator {
+  BackgroundWorkCoordinator(this._scheduler, this._prefs);
+
+  static const minimumPeriodicInterval = Duration(minutes: 15);
+  static const maintenanceInterval = Duration(minutes: 15);
+
+  final BackgroundScheduler _scheduler;
+  final PlanetPrefs _prefs;
+
+  Future<void> start() async {
+    await _scheduler.initialize();
+    await applyAutoSyncSettings();
+    await _scheduler.schedulePeriodic(
+      uniqueName: BackgroundTaskNames.maintenance,
+      taskName: BackgroundTaskNames.maintenance,
+      frequency: maintenanceInterval,
+      requiresNetwork: true,
+    );
+  }
+
+  Future<void> applyAutoSyncSettings() async {
+    if (!_prefs.autoSyncEnabled) {
+      await _scheduler.cancel(BackgroundTaskNames.autoSync);
+      return;
+    }
+
+    final requested = _prefs.autoSyncInterval;
+    await _scheduler.schedulePeriodic(
+      uniqueName: BackgroundTaskNames.autoSync,
+      taskName: BackgroundTaskNames.autoSync,
+      frequency: requested < minimumPeriodicInterval
+          ? minimumPeriodicInterval
+          : requested,
+      requiresNetwork: true,
+    );
+  }
+}

--- a/flutter/lib/core/prefs/planet_prefs.dart
+++ b/flutter/lib/core/prefs/planet_prefs.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -44,6 +46,10 @@ class PlanetPrefs {
   static const String _keyCommunityName = 'communityName';
   static const String _keyPlanetType = 'planetType';
   static const String _keyLastSurveyDialog = 'lastSurveyDialogShown';
+  static const String _keyAutoSync = 'autoSync';
+  static const String _keyAutoSyncInterval = 'autoSyncInterval';
+  static const String _keyLastSync = 'lastSync';
+  static const String _keyBackgroundRun = 'backgroundRun';
 
   static const String _secureKeyServerPin = 'serverPin';
   static const String _secureKeyCouchDbUrl = 'couchdbURL';
@@ -195,4 +201,60 @@ class PlanetPrefs {
 
   Future<void> setLastSurveyDialogShown(int epochMillis) =>
       _prefs.setInt(_keyLastSurveyDialog, epochMillis);
+
+  /// Whether Android should wake the app to synchronize while it is closed.
+  bool get autoSyncEnabled => _prefs.getBool(_keyAutoSync) ?? true;
+
+  Future<void> setAutoSyncEnabled(bool value) =>
+      _prefs.setBool(_keyAutoSync, value);
+
+  /// Requested automatic-sync cadence. Android WorkManager enforces a
+  /// 15-minute floor; older Kotlin preferences below that are clamped by the
+  /// scheduler rather than silently discarded.
+  Duration get autoSyncInterval =>
+      Duration(seconds: _prefs.getInt(_keyAutoSyncInterval) ?? 60 * 60);
+
+  Future<void> setAutoSyncInterval(Duration value) =>
+      _prefs.setInt(_keyAutoSyncInterval, value.inSeconds);
+
+  DateTime? get lastSync {
+    final millis = _prefs.getInt(_keyLastSync);
+    return millis == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(millis, isUtc: true);
+  }
+
+  Future<void> setLastSync(DateTime value) =>
+      _prefs.setInt(_keyLastSync, value.millisecondsSinceEpoch);
+
+  /// Last headless-run diagnostic. It intentionally contains no URLs,
+  /// credentials, payloads, or exception text; only stable step names are
+  /// persisted so support can distinguish scheduling from domain failures.
+  Map<String, dynamic>? get lastBackgroundRun {
+    final encoded = _prefs.getString(_keyBackgroundRun);
+    if (encoded == null) return null;
+    try {
+      final decoded = jsonDecode(encoded);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } on FormatException {
+      return null;
+    }
+  }
+
+  Future<void> recordBackgroundRun({
+    required String taskName,
+    required DateTime attemptedAt,
+    required String status,
+    required List<String> failedSteps,
+    String? skipReason,
+  }) => _prefs.setString(
+    _keyBackgroundRun,
+    jsonEncode({
+      'taskName': taskName,
+      'attemptedAt': attemptedAt.toUtc().toIso8601String(),
+      'status': status,
+      'failedSteps': failedSteps,
+      'skipReason': ?skipReason,
+    }),
+  );
 }

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -1227,10 +1227,19 @@ class OutboxDao extends DatabaseAccessor<AppDatabase> with _$OutboxDaoMixin {
     return query.watchSingle().map((row) => row.read(count) ?? 0);
   }
 
-  Future<int> setStatus(String id, String status) =>
-      (update(outboxEntries)..where((row) => row.id.equals(id))).write(
-        OutboxEntriesCompanion(status: Value(status)),
-      );
+  /// Atomically claims a pending row. Two isolates may both have selected the
+  /// same due row, but only one conditional update can win.
+  Future<bool> claim(String id, int now) async =>
+      await (update(outboxEntries)..where(
+            (row) => row.id.equals(id) & row.status.equals(statusPending),
+          ))
+          .write(
+            OutboxEntriesCompanion(
+              status: const Value(statusInProgress),
+              lastAttemptAt: Value(now),
+            ),
+          ) ==
+      1;
 
   /// Deletes only while the row is still claimed by a drain.
   ///
@@ -1267,9 +1276,12 @@ class OutboxDao extends DatabaseAccessor<AppDatabase> with _$OutboxDaoMixin {
   /// Kotlin calls this `recoverStuckOperations` and runs it at startup for the
   /// same reason: without it a killed drain leaves the operation permanently
   /// invisible to [due].
-  Future<int> recoverStuck() =>
-      (update(outboxEntries)
-            ..where((row) => row.status.equals(statusInProgress)))
+  Future<int> recoverStuck(int claimedBefore) =>
+      (update(outboxEntries)..where(
+            (row) =>
+                row.status.equals(statusInProgress) &
+                row.lastAttemptAt.isSmallerThanValue(claimedBefore),
+          ))
           .write(const OutboxEntriesCompanion(status: Value(statusPending)));
 
   /// Drops rows that are finished with — completed, or given up on.

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -39,6 +39,26 @@
   "sync": "Sync",
   "cancel": "Cancel",
   "settings": "Settings",
+  "backgroundSync": "Background sync",
+  "backgroundSyncDescription": "Send pending changes and refresh learning data while the app is closed",
+  "syncFrequency": "Sync frequency",
+  "every15Minutes": "Every 15 minutes",
+  "every30Minutes": "Every 30 minutes",
+  "everyHour": "Every hour",
+  "every6Hours": "Every 6 hours",
+  "lastBackgroundRun": "Last background run",
+  "backgroundNeverRun": "No background run has been recorded yet",
+  "backgroundSucceeded": "Completed successfully",
+  "backgroundRetryRequested": "Incomplete — Android will retry",
+  "backgroundSkipped": "Skipped",
+  "backgroundUnknown": "Unknown result",
+  "backgroundScheduleFailed": "The preference was saved, but Android could not update the schedule. It will be retried when the app restarts.",
+  "backgroundFailedSteps": "Needs retry: {steps}",
+  "@backgroundFailedSteps": {
+    "placeholders": {
+      "steps": {"type": "String"}
+    }
+  },
   "logOut": "Log out",
   "noDataAvailable": "No data available",
   "ok": "OK",

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -1,16 +1,17 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
+import 'core/background/background_scheduler.dart';
+import 'core/background/background_work_coordinator.dart';
 import 'core/prefs/planet_prefs.dart';
 import 'providers/app_providers.dart';
 
 /// Entry point, replacing `MainApplication.kt` and the launcher Activity.
 ///
-/// Only the bootstrap lives here. Theme, locale and routing belong to
-/// `app.dart`, and the background work `MainApplication` schedules through
-/// WorkManager has no equivalent yet — see
-/// `docs/kotlin-to-flutter-migration.md`.
+/// Only bootstrap lives here. Theme, locale and routing belong to `app.dart`.
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
@@ -19,10 +20,32 @@ Future<void> main() async {
   // SharedPrefManager before anything else.
   final prefs = await PlanetPrefs.load();
 
+  // Scheduling is best-effort infrastructure, not an app-launch gate. A
+  // plugin/OS registration failure must not leave the user staring at a blank
+  // screen; WorkManager will be retried on the next cold start.
+  unawaited(_startBackgroundWork(prefs));
+
   runApp(
     ProviderScope(
       overrides: [planetPrefsProvider.overrideWithValue(prefs)],
       child: const MyPlanetApp(),
     ),
   );
+}
+
+Future<void> _startBackgroundWork(PlanetPrefs prefs) async {
+  try {
+    await BackgroundWorkCoordinator(
+      const WorkmanagerScheduler(),
+      prefs,
+    ).start();
+  } catch (error, stack) {
+    FlutterError.reportError(
+      FlutterErrorDetails(
+        exception: error,
+        stack: stack,
+        library: 'background scheduling',
+      ),
+    );
+  }
 }

--- a/flutter/lib/providers/settings_provider.dart
+++ b/flutter/lib/providers/settings_provider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../core/background/background_scheduler.dart';
+import '../core/background/background_work_coordinator.dart';
 import 'app_providers.dart';
 
 /// Port of `services/ThemeManager.kt` and the `dark_mode` preference in
@@ -27,3 +29,55 @@ ThemeMode _fromName(String name) => switch (name) {
 final themeModeProvider = NotifierProvider<ThemeModeNotifier, ThemeMode>(
   ThemeModeNotifier.new,
 );
+
+final backgroundSchedulerProvider = Provider<BackgroundScheduler>(
+  (ref) => const WorkmanagerScheduler(),
+);
+
+class BackgroundSettings {
+  const BackgroundSettings({required this.enabled, required this.interval});
+
+  final bool enabled;
+  final Duration interval;
+
+  BackgroundSettings copyWith({bool? enabled, Duration? interval}) =>
+      BackgroundSettings(
+        enabled: enabled ?? this.enabled,
+        interval: interval ?? this.interval,
+      );
+}
+
+class BackgroundSettingsNotifier extends Notifier<BackgroundSettings> {
+  @override
+  BackgroundSettings build() {
+    final prefs = ref.watch(planetPrefsProvider);
+    return BackgroundSettings(
+      enabled: prefs.autoSyncEnabled,
+      interval: prefs.autoSyncInterval,
+    );
+  }
+
+  Future<void> setEnabled(bool enabled) async {
+    final prefs = ref.read(planetPrefsProvider);
+    await prefs.setAutoSyncEnabled(enabled);
+    state = state.copyWith(enabled: enabled);
+    await _apply();
+  }
+
+  Future<void> setInterval(Duration interval) async {
+    final prefs = ref.read(planetPrefsProvider);
+    await prefs.setAutoSyncInterval(interval);
+    state = state.copyWith(interval: interval);
+    if (state.enabled) await _apply();
+  }
+
+  Future<void> _apply() => BackgroundWorkCoordinator(
+    ref.read(backgroundSchedulerProvider),
+    ref.read(planetPrefsProvider),
+  ).applyAutoSyncSettings();
+}
+
+final backgroundSettingsProvider =
+    NotifierProvider<BackgroundSettingsNotifier, BackgroundSettings>(
+      BackgroundSettingsNotifier.new,
+    );

--- a/flutter/lib/repository/feedback_uploader.dart
+++ b/flutter/lib/repository/feedback_uploader.dart
@@ -11,8 +11,8 @@ import 'outbox_repository.dart';
 /// Durable write-back for the `feedback` database.
 ///
 /// Kotlin uploads feedback from `AutoSyncWorker` through
-/// `UploadManager.uploadFeedback`. There is no background scheduling here yet,
-/// so the outbox carries it instead: queued on write, drained on app resume.
+/// `UploadManager.uploadFeedback`. The outbox carries it here: queued on write,
+/// then drained on app resume or by the constraint-aware background job.
 /// Without this the port filed feedback that never left the device —
 /// `getPendingFeedback` existed but nothing called it.
 class FeedbackUploader {

--- a/flutter/lib/repository/health_uploader.dart
+++ b/flutter/lib/repository/health_uploader.dart
@@ -10,8 +10,8 @@ import 'outbox_repository.dart';
 /// Durable write-back for the `health` database.
 ///
 /// Kotlin uploads examinations from `UploadManager.uploadExamResult` via
-/// `AutoSyncWorker`. There is no background scheduling here yet, so the outbox
-/// carries it instead: queued on write, drained on app resume.
+/// `AutoSyncWorker`. The outbox carries it here: queued on write, then drained
+/// on app resume or by the constraint-aware background job.
 ///
 /// Without this the port recorded examinations that never left the device —
 /// `getUpdated()`, `markUploaded()` and `serialize()` all existed and none of

--- a/flutter/lib/repository/outbox_drainer.dart
+++ b/flutter/lib/repository/outbox_drainer.dart
@@ -36,16 +36,10 @@ typedef OutboxHandler =
 
 /// Replaces `services/retry/RetryQueueWorker.kt`.
 ///
-/// The Kotlin worker is a `CoroutineWorker` that `WorkManager` wakes on a
-/// periodic schedule with a network constraint. Flutter has no equivalent that
-/// runs while the app is closed, so the trigger changes rather than the queue:
-/// [drain] is called on app resume and after a successful sync, and the queue
-/// itself — being a SQLite table — carries pending work across process death
-/// exactly as before.
-///
-/// The honest gap this leaves is documented in
-/// `docs/kotlin-to-flutter-migration.md`: a write made offline is sent the next
-/// time the app is opened with connectivity, not while it is closed.
+/// The queue remains SQLite-backed and therefore survives process death.
+/// [drain] has two triggers: app startup/resume for low latency and the
+/// constraint-aware headless job in `background_entrypoint.dart` for delivery
+/// while the UI process is closed.
 class OutboxDrainer {
   OutboxDrainer(this._api, this._outbox, {Map<String, OutboxHandler>? handlers})
     : _handlers = handlers ?? const {};
@@ -95,12 +89,18 @@ class OutboxDrainer {
   Future<List<OutboxOutcome>> _drain({String? authHeader}) async {
     final outcomes = <OutboxOutcome>[];
     for (final row in await _outbox.due()) {
-      outcomes.add(await _send(row, authHeader: authHeader));
+      final outcome = await _send(row, authHeader: authHeader);
+      if (outcome != null) outcomes.add(outcome);
     }
     return outcomes;
   }
 
-  Future<OutboxOutcome> _send(OutboxRow row, {String? authHeader}) async {
+  Future<OutboxOutcome?> _send(OutboxRow row, {String? authHeader}) async {
+    // The UI and WorkManager use separate Dart isolates and therefore have
+    // separate in-memory single-flight guards. The status-scoped SQL update is
+    // the cross-isolate lock: a losing drainer skips the row before sending.
+    if (!await _outbox.markInProgress(row.id)) return null;
+
     Map<String, dynamic> payload;
     try {
       final decoded = jsonDecode(row.payload);
@@ -116,8 +116,6 @@ class OutboxDrainer {
       );
       return OutboxOutcome.abandoned;
     }
-
-    await _outbox.markInProgress(row.id);
 
     final handler = _handlers[row.uploadType];
     final NetworkResult<Map<String, dynamic>> result;

--- a/flutter/lib/repository/outbox_repository.dart
+++ b/flutter/lib/repository/outbox_repository.dart
@@ -29,6 +29,11 @@ class OutboxRepository {
   /// `RetryOperation.DEFAULT_MAX_ATTEMPTS`.
   static const int defaultMaxAttempts = 5;
 
+  /// A worker gets ten minutes on Android. Twice that window avoids stealing
+  /// a live claim when a foreground drain overlaps a headless isolate, while
+  /// still recovering promptly after a killed process.
+  static const Duration stuckClaimTimeout = Duration(minutes: 20);
+
   final OutboxDao _dao;
   final DateTime Function() _now;
   final String Function() _createId;
@@ -131,8 +136,8 @@ class OutboxRepository {
   Future<bool> cancel(String uploadType, String itemId) async =>
       await _dao.deletePending(uploadType, itemId) > 0;
 
-  Future<void> markInProgress(String id) =>
-      _dao.setStatus(id, OutboxDao.statusInProgress);
+  Future<bool> markInProgress(String id) =>
+      _dao.claim(id, _now().millisecondsSinceEpoch);
 
   /// Drops the row outright rather than marking it `completed`.
   ///
@@ -181,7 +186,9 @@ class OutboxRepository {
   }
 
   /// Port of `recoverStuckOperations`, for the startup path.
-  Future<int> recoverStuck() => _dao.recoverStuck();
+  Future<int> recoverStuck() => _dao.recoverStuck(
+    _now().subtract(stuckClaimTimeout).millisecondsSinceEpoch,
+  );
 
   Future<int> cleanup() => _dao.cleanup();
 }

--- a/flutter/lib/repository/ratings_uploader.dart
+++ b/flutter/lib/repository/ratings_uploader.dart
@@ -10,8 +10,8 @@ import 'ratings_repository.dart';
 /// Durable write-back for the `ratings` database.
 ///
 /// Kotlin uploads ratings from `AutoSyncWorker` through `UploadManager.uploadRating`.
-/// There is no background scheduling here yet, so the outbox carries it instead:
-/// queued on write, drained on app resume.
+/// The outbox carries it instead: queued on write, then drained on app resume
+/// or by the constraint-aware background job.
 ///
 /// Without this the port saved ratings locally but they never left the device —
 /// `RatingsRepository.pendingUploads()` existed but nothing called it.

--- a/flutter/lib/ui/outbox_drain_scope.dart
+++ b/flutter/lib/ui/outbox_drain_scope.dart
@@ -7,19 +7,12 @@ import '../repository/personals_uploader.dart';
 /// Replaces the `WorkManager` registration `MainApplication.kt` performs for
 /// `RetryQueueWorker`.
 ///
-/// WorkManager can wake a process that is not running; Flutter has no
-/// first-party equivalent, so the trigger moves into the app's own lifecycle.
-/// Wrapping the router in this widget drains the outbox:
+/// The OS-scheduled trigger lives in `background_entrypoint.dart`; this scope
+/// remains the low-latency foreground trigger. Wrapping the router drains:
 ///
 /// - once at startup, after clearing rows stranded `in_progress` by a kill
 ///   mid-drain (`recoverStuckOperations`), and
-/// - on every resume, which is the closest honest analogue to the periodic
-///   worker.
-///
-/// What this does **not** do is send while the app is closed. That is the real
-/// residual gap, and it is survivable rather than silent: the queue is a SQLite
-/// table, so a write made offline persists across process death and goes out on
-/// the next launch. `docs/kotlin-to-flutter-migration.md` records it.
+/// - on every resume, without waiting for Android's next periodic window.
 class OutboxDrainScope extends ConsumerStatefulWidget {
   const OutboxDrainScope({required this.child, super.key});
 

--- a/flutter/lib/ui/settings/settings_screen.dart
+++ b/flutter/lib/ui/settings/settings_screen.dart
@@ -22,6 +22,8 @@ class SettingsScreen extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final selectedTheme = ref.watch(themeModeProvider);
     final server = ref.watch(serverConfigProvider);
+    final background = ref.watch(backgroundSettingsProvider);
+    final backgroundRun = ref.watch(planetPrefsProvider).lastBackgroundRun;
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.settings)),
@@ -69,6 +71,81 @@ class SettingsScreen extends ConsumerWidget {
               subtitle: Text(server.code),
             ),
           const Divider(),
+          _SectionHeader(title: l10n.backgroundSync),
+          SwitchListTile(
+            value: background.enabled,
+            onChanged: (enabled) async {
+              try {
+                await ref
+                    .read(backgroundSettingsProvider.notifier)
+                    .setEnabled(enabled);
+              } catch (_) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(l10n.backgroundScheduleFailed)),
+                  );
+                }
+              }
+            },
+            secondary: const Icon(Icons.sync_outlined),
+            title: Text(l10n.backgroundSync),
+            subtitle: Text(l10n.backgroundSyncDescription),
+          ),
+          ListTile(
+            enabled: background.enabled,
+            leading: const Icon(Icons.schedule_outlined),
+            title: Text(l10n.syncFrequency),
+            trailing: DropdownButton<Duration>(
+              value: _supportedInterval(background.interval),
+              onChanged: background.enabled
+                  ? (interval) async {
+                      if (interval != null) {
+                        try {
+                          await ref
+                              .read(backgroundSettingsProvider.notifier)
+                              .setInterval(interval);
+                        } catch (_) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text(l10n.backgroundScheduleFailed),
+                              ),
+                            );
+                          }
+                        }
+                      }
+                    }
+                  : null,
+              items: [
+                DropdownMenuItem(
+                  value: const Duration(minutes: 15),
+                  child: Text(l10n.every15Minutes),
+                ),
+                DropdownMenuItem(
+                  value: const Duration(minutes: 30),
+                  child: Text(l10n.every30Minutes),
+                ),
+                DropdownMenuItem(
+                  value: const Duration(hours: 1),
+                  child: Text(l10n.everyHour),
+                ),
+                DropdownMenuItem(
+                  value: const Duration(hours: 6),
+                  child: Text(l10n.every6Hours),
+                ),
+              ],
+            ),
+          ),
+          ListTile(
+            leading: Icon(
+              _backgroundRunIcon(backgroundRun),
+              color: _backgroundRunColor(context, backgroundRun),
+            ),
+            title: Text(l10n.lastBackgroundRun),
+            subtitle: Text(_backgroundRunSummary(context, l10n, backgroundRun)),
+            isThreeLine: backgroundRun != null,
+          ),
+          const Divider(),
           _SectionHeader(title: l10n.learningTools),
           ListTile(
             leading: const Icon(Icons.menu_book_outlined),
@@ -108,6 +185,55 @@ class SettingsScreen extends ConsumerWidget {
       ),
     );
   }
+}
+
+Duration _supportedInterval(Duration interval) {
+  const supported = [
+    Duration(minutes: 15),
+    Duration(minutes: 30),
+    Duration(hours: 1),
+    Duration(hours: 6),
+  ];
+  return supported.contains(interval) ? interval : const Duration(hours: 1);
+}
+
+IconData _backgroundRunIcon(Map<String, dynamic>? run) =>
+    switch (run?['status']) {
+      'succeeded' => Icons.check_circle_outline,
+      'retryRequested' => Icons.error_outline,
+      'skipped' => Icons.pause_circle_outline,
+      _ => Icons.history,
+    };
+
+Color? _backgroundRunColor(BuildContext context, Map<String, dynamic>? run) =>
+    switch (run?['status']) {
+      'succeeded' => Colors.green,
+      'retryRequested' => Theme.of(context).colorScheme.error,
+      _ => null,
+    };
+
+String _backgroundRunSummary(
+  BuildContext context,
+  AppLocalizations l10n,
+  Map<String, dynamic>? run,
+) {
+  if (run == null) return l10n.backgroundNeverRun;
+  final status = switch (run['status']) {
+    'succeeded' => l10n.backgroundSucceeded,
+    'retryRequested' => l10n.backgroundRetryRequested,
+    'skipped' => l10n.backgroundSkipped,
+    _ => l10n.backgroundUnknown,
+  };
+  final attempted = DateTime.tryParse('${run['attemptedAt'] ?? ''}')?.toLocal();
+  final timestamp = attempted == null
+      ? ''
+      : ' • ${MaterialLocalizations.of(context).formatShortDate(attempted)} '
+            '${TimeOfDay.fromDateTime(attempted).format(context)}';
+  final failures = run['failedSteps'];
+  final failedText = failures is List && failures.isNotEmpty
+      ? '\n${l10n.backgroundFailedSteps(failures.join(', '))}'
+      : '';
+  return '$status$timestamp$failedText';
 }
 
 class _SectionHeader extends StatelessWidget {

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -1234,6 +1234,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  workmanager:
+    dependency: "direct main"
+    description:
+      name: workmanager
+      sha256: "06fc5bdd83e2da35f33b682e25167245d0ccb8b56e9a9ada5bfa079fa3af4b9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.7"
+  workmanager_android:
+    dependency: transitive
+    description:
+      name: workmanager_android
+      sha256: f89029cbcf0695c772287aa8fbbd7af776f1ea63bc95b60a00617f69468ddaa0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.6"
+  workmanager_apple:
+    dependency: transitive
+    description:
+      name: workmanager_apple
+      sha256: "15558fb54415a010910c3529eaf8f61f94d23903dac620331895c472602d6f6e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.10"
+  workmanager_linux:
+    dependency: transitive
+    description:
+      name: workmanager_linux
+      sha256: "7d8520e1103b910a43d8bafe37ec2415f4c7c148afcb1eee0ec73ae67b4cdd22"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1+1"
+  workmanager_platform_interface:
+    dependency: transitive
+    description:
+      name: workmanager_platform_interface
+      sha256: "378b392db15ee88cd878ab983d3a0b4b1e460cfbb0f096ff74fda2614b1ba172"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.4"
+  workmanager_web:
+    dependency: transitive
+    description:
+      name: workmanager_web
+      sha256: "2ac481ade599bdd957ee2891be09a0c34be87923a2c3ca4dfe36add6fc735ffd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -37,6 +37,10 @@ dependencies:
 
   # Preferences — replaces SharedPrefManager.
   shared_preferences: ^2.3.3
+  # Constraint-aware, process-death-safe background execution. Replaces the
+  # Android app's direct WorkManager registrations while keeping scheduling
+  # behind a Dart abstraction that is unit-testable.
+  workmanager: ^0.10.7
   # Encrypted credential storage — replaces SecurePrefs (Tink-backed EncryptedSharedPreferences).
   flutter_secure_storage: ^9.2.2
 

--- a/flutter/test/core/background/background_task_runner_test.dart
+++ b/flutter/test/core/background/background_task_runner_test.dart
@@ -1,0 +1,250 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/core/background/background_task_names.dart';
+import 'package:myplanet/core/background/background_task_runner.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 8, 16, 12);
+
+  late List<String> calls;
+  late List<DateTime> recorded;
+  late List<BackgroundRunRecord> runs;
+
+  setUp(() {
+    calls = [];
+    recorded = [];
+    runs = [];
+  });
+
+  BackgroundTaskRunner runner({
+    bool configured = true,
+    bool enabled = true,
+    Duration interval = const Duration(hours: 1),
+    DateTime? lastSync,
+    Future<void> Function()? recover,
+    Future<void> Function()? drain,
+    List<BackgroundSyncStep>? syncs,
+  }) => BackgroundTaskRunner(
+    configured: configured,
+    autoSyncEnabled: enabled,
+    autoSyncInterval: interval,
+    lastSync: lastSync,
+    recoverOutbox:
+        recover ??
+        () async {
+          calls.add('recover');
+        },
+    drainOutbox:
+        drain ??
+        () async {
+          calls.add('drain');
+        },
+    syncSteps:
+        syncs ??
+        [
+          BackgroundSyncStep('default', () async {
+            calls.add('sync');
+            return true;
+          }),
+        ],
+    recordLastSync: (value) async => recorded.add(value),
+    recordRun: (record) async => runs.add(record),
+    now: () => now,
+  );
+
+  test(
+    'unknown persisted work succeeds without touching dependencies',
+    () async {
+      expect(await runner().run('old.task.name'), isTrue);
+      expect(calls, isEmpty);
+      expect(recorded, isEmpty);
+      expect(runs, isEmpty, reason: 'unknown work is not this version’s run');
+    },
+  );
+
+  test('an unconfigured app has nothing to deliver or synchronize', () async {
+    expect(
+      await runner(configured: false).run(BackgroundTaskNames.autoSync),
+      isTrue,
+    );
+    expect(calls, isEmpty);
+    expect(runs.single.status, BackgroundRunStatus.skipped);
+    expect(runs.single.skipReason, 'notConfigured');
+  });
+
+  test('maintenance only recovers and drains the outbox', () async {
+    expect(await runner().run(BackgroundTaskNames.maintenance), isTrue);
+    expect(calls, ['recover', 'drain']);
+    expect(recorded, isEmpty);
+    expect(runs.single.status, BackgroundRunStatus.succeeded);
+  });
+
+  test('disabled auto sync still delivers durable writes', () async {
+    expect(
+      await runner(enabled: false).run(BackgroundTaskNames.autoSync),
+      isTrue,
+    );
+    expect(calls, ['recover', 'drain']);
+    expect(runs.single.skipReason, 'autoSyncDisabled');
+  });
+
+  test('a recent sync suppresses pulls but not outbox delivery', () async {
+    expect(
+      await runner(
+        lastSync: now.subtract(const Duration(minutes: 59)),
+      ).run(BackgroundTaskNames.autoSync),
+      isTrue,
+    );
+    expect(calls, ['recover', 'drain']);
+    expect(recorded, isEmpty);
+    expect(runs.single.skipReason, 'notDue');
+  });
+
+  test('the exact interval boundary is due', () async {
+    expect(
+      await runner(
+        lastSync: now.subtract(const Duration(hours: 1)),
+      ).run(BackgroundTaskNames.autoSync),
+      isTrue,
+    );
+    expect(calls, ['recover', 'drain', 'sync']);
+    expect(recorded, [now]);
+    expect(runs.single.status, BackgroundRunStatus.succeeded);
+  });
+
+  test('a future wall-clock timestamp does not suppress sync', () async {
+    expect(
+      await runner(
+        lastSync: now.add(const Duration(days: 1)),
+      ).run(BackgroundTaskNames.autoSync),
+      isTrue,
+    );
+    expect(calls, ['recover', 'drain', 'sync']);
+  });
+
+  test('sync steps run sequentially in declaration order', () async {
+    var firstFinished = false;
+    final subject = runner(
+      syncs: [
+        BackgroundSyncStep('first', () async {
+          calls.add('first:start');
+          await Future<void>.delayed(Duration.zero);
+          firstFinished = true;
+          calls.add('first:end');
+          return true;
+        }),
+        BackgroundSyncStep('second', () async {
+          expect(firstFinished, isTrue);
+          calls.add('second');
+          return true;
+        }),
+      ],
+    );
+
+    expect(await subject.run(BackgroundTaskNames.autoSync), isTrue);
+    expect(calls, ['recover', 'drain', 'first:start', 'first:end', 'second']);
+  });
+
+  test(
+    'a failed table does not prevent later tables from refreshing',
+    () async {
+      final subject = runner(
+        syncs: [
+          BackgroundSyncStep('failedTable', () async {
+            calls.add('failed');
+            return false;
+          }),
+          BackgroundSyncStep('laterTable', () async {
+            calls.add('later');
+            return true;
+          }),
+        ],
+      );
+
+      expect(await subject.run(BackgroundTaskNames.autoSync), isFalse);
+      expect(calls, ['recover', 'drain', 'failed', 'later']);
+      expect(recorded, isEmpty);
+      expect(runs.single.status, BackgroundRunStatus.retryRequested);
+      expect(runs.single.failedSteps, ['failedTable']);
+    },
+  );
+
+  test('a throwing table is isolated and requests an OS retry', () async {
+    final subject = runner(
+      syncs: [
+        BackgroundSyncStep(
+          'throwingTable',
+          () async => throw StateError('broken mapper'),
+        ),
+        BackgroundSyncStep('laterTable', () async {
+          calls.add('later');
+          return true;
+        }),
+      ],
+    );
+
+    expect(await subject.run(BackgroundTaskNames.autoSync), isFalse);
+    expect(calls, ['recover', 'drain', 'later']);
+    expect(recorded, isEmpty);
+    expect(runs.single.failedSteps, ['throwingTable']);
+  });
+
+  test('outbox failure requests retry but still refreshes tables', () async {
+    final subject = runner(
+      drain: () async => throw StateError('database busy'),
+    );
+
+    expect(await subject.run(BackgroundTaskNames.autoSync), isFalse);
+    expect(calls, ['recover', 'sync']);
+    expect(recorded, isEmpty);
+    expect(runs.single.failedSteps, ['outboxDrain']);
+  });
+
+  test('recovery failure does not prevent a drain or table pulls', () async {
+    final subject = runner(
+      recover: () async => throw StateError('recovery failed'),
+    );
+
+    expect(await subject.run(BackgroundTaskNames.autoSync), isFalse);
+    expect(calls, ['drain', 'sync']);
+    expect(runs.single.failedSteps, ['outboxRecovery']);
+  });
+
+  test(
+    'diagnostic persistence failure does not retry successful work',
+    () async {
+      final subject = BackgroundTaskRunner(
+        configured: true,
+        autoSyncEnabled: true,
+        autoSyncInterval: const Duration(hours: 1),
+        lastSync: null,
+        recoverOutbox: () async {},
+        drainOutbox: () async {},
+        syncSteps: [BackgroundSyncStep('resources', () async => true)],
+        recordLastSync: (_) async {},
+        recordRun: (_) async => throw StateError('preferences unavailable'),
+        now: () => now,
+      );
+
+      expect(await subject.run(BackgroundTaskNames.autoSync), isTrue);
+    },
+  );
+
+  test('last-sync persistence failure is diagnosed and retried', () async {
+    final subject = BackgroundTaskRunner(
+      configured: true,
+      autoSyncEnabled: true,
+      autoSyncInterval: const Duration(hours: 1),
+      lastSync: null,
+      recoverOutbox: () async {},
+      drainOutbox: () async {},
+      syncSteps: [BackgroundSyncStep('resources', () async => true)],
+      recordLastSync: (_) async => throw StateError('disk full'),
+      recordRun: (record) async => runs.add(record),
+      now: () => now,
+    );
+
+    expect(await subject.run(BackgroundTaskNames.autoSync), isFalse);
+    expect(runs.single.failedSteps, ['lastSyncWrite']);
+    expect(runs.single.status, BackgroundRunStatus.retryRequested);
+  });
+}

--- a/flutter/test/core/background/background_work_coordinator_test.dart
+++ b/flutter/test/core/background/background_work_coordinator_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/background/background_scheduler.dart';
+import 'package:myplanet/core/background/background_task_names.dart';
+import 'package:myplanet/core/background/background_work_coordinator.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockSecureStorage extends Mock implements FlutterSecureStorage {}
+
+class _RecordingScheduler implements BackgroundScheduler {
+  var initializeCalls = 0;
+  final scheduled = <({String name, Duration frequency, bool network})>[];
+  final cancelled = <String>[];
+
+  @override
+  Future<void> initialize() async => initializeCalls++;
+
+  @override
+  Future<void> cancel(String uniqueName) async => cancelled.add(uniqueName);
+
+  @override
+  Future<void> schedulePeriodic({
+    required String uniqueName,
+    required String taskName,
+    required Duration frequency,
+    required bool requiresNetwork,
+  }) async {
+    expect(taskName, uniqueName);
+    scheduled.add((
+      name: uniqueName,
+      frequency: frequency,
+      network: requiresNetwork,
+    ));
+  }
+}
+
+Future<PlanetPrefs> _prefs(Map<String, Object> values) async {
+  SharedPreferences.setMockInitialValues(values);
+  return PlanetPrefs(
+    await SharedPreferences.getInstance(),
+    secureStorage: _MockSecureStorage(),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('start registers network sync and battery-aware maintenance', () async {
+    final scheduler = _RecordingScheduler();
+    final coordinator = BackgroundWorkCoordinator(scheduler, await _prefs({}));
+
+    await coordinator.start();
+
+    expect(scheduler.initializeCalls, 1);
+    expect(scheduler.cancelled, isEmpty);
+    expect(scheduler.scheduled, [
+      (
+        name: BackgroundTaskNames.autoSync,
+        frequency: const Duration(hours: 1),
+        network: true,
+      ),
+      (
+        name: BackgroundTaskNames.maintenance,
+        frequency: const Duration(minutes: 15),
+        network: true,
+      ),
+    ]);
+  });
+
+  test('disabled auto sync cancels persisted periodic work', () async {
+    final scheduler = _RecordingScheduler();
+    final coordinator = BackgroundWorkCoordinator(
+      scheduler,
+      await _prefs({'autoSync': false}),
+    );
+
+    await coordinator.start();
+
+    expect(scheduler.cancelled, [BackgroundTaskNames.autoSync]);
+    expect(scheduler.scheduled.map((work) => work.name), [
+      BackgroundTaskNames.maintenance,
+    ]);
+  });
+
+  test('intervals below WorkManager floor are clamped to 15 minutes', () async {
+    final scheduler = _RecordingScheduler();
+    final coordinator = BackgroundWorkCoordinator(
+      scheduler,
+      await _prefs({'autoSyncInterval': 60}),
+    );
+
+    await coordinator.applyAutoSyncSettings();
+
+    expect(scheduler.scheduled.single.frequency, const Duration(minutes: 15));
+  });
+}

--- a/flutter/test/core/prefs/planet_prefs_test.dart
+++ b/flutter/test/core/prefs/planet_prefs_test.dart
@@ -40,4 +40,61 @@ void main() {
     expect(prefs.themeModeName, 'dark');
     expect(sharedPreferences.getString('themeMode'), 'dark');
   });
+
+  test(
+    'background work preferences default to Kotlin policy and persist',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final sharedPreferences = await SharedPreferences.getInstance();
+      final prefs = PlanetPrefs(
+        sharedPreferences,
+        secureStorage: _MockSecureStorage(),
+      );
+
+      expect(prefs.autoSyncEnabled, isTrue);
+      expect(prefs.autoSyncInterval, const Duration(hours: 1));
+      expect(prefs.lastSync, isNull);
+
+      final syncedAt = DateTime.utc(2026, 8, 16, 12, 30);
+      await prefs.setAutoSyncEnabled(false);
+      await prefs.setAutoSyncInterval(const Duration(minutes: 30));
+      await prefs.setLastSync(syncedAt);
+
+      expect(prefs.autoSyncEnabled, isFalse);
+      expect(prefs.autoSyncInterval, const Duration(minutes: 30));
+      expect(prefs.lastSync, syncedAt);
+    },
+  );
+
+  test('background diagnostics persist only stable fields', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = PlanetPrefs(
+      await SharedPreferences.getInstance(),
+      secureStorage: _MockSecureStorage(),
+    );
+
+    await prefs.recordBackgroundRun(
+      taskName: 'myplanet.autoSync',
+      attemptedAt: DateTime.utc(2026, 8, 16, 13, 45),
+      status: 'retryRequested',
+      failedSteps: const ['resources', 'outboxDrain'],
+    );
+
+    expect(prefs.lastBackgroundRun, {
+      'taskName': 'myplanet.autoSync',
+      'attemptedAt': '2026-08-16T13:45:00.000Z',
+      'status': 'retryRequested',
+      'failedSteps': ['resources', 'outboxDrain'],
+    });
+  });
+
+  test('malformed background diagnostics fail closed', () async {
+    SharedPreferences.setMockInitialValues({'backgroundRun': 'not-json'});
+    final prefs = PlanetPrefs(
+      await SharedPreferences.getInstance(),
+      secureStorage: _MockSecureStorage(),
+    );
+
+    expect(prefs.lastBackgroundRun, isNull);
+  });
 }

--- a/flutter/test/repository/outbox_drainer_test.dart
+++ b/flutter/test/repository/outbox_drainer_test.dart
@@ -252,6 +252,14 @@ void main() {
     final subject = drainer();
 
     expect(await subject.drain(), isEmpty, reason: 'claimed, so not due');
+    clock = clock.add(OutboxRepository.stuckClaimTimeout);
+    await subject.recoverStuck();
+    expect(
+      await subject.drain(),
+      isEmpty,
+      reason: 'a claim exactly at the lease boundary is still live',
+    );
+    clock = clock.add(const Duration(milliseconds: 1));
     await subject.recoverStuck();
     expect(await subject.drain(), [OutboxOutcome.completed]);
   });

--- a/flutter/test/repository/outbox_repository_test.dart
+++ b/flutter/test/repository/outbox_repository_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/outbox_repository.dart';
@@ -204,6 +205,11 @@ void main() {
       await repository.markInProgress(id);
       expect(await repository.due(), isEmpty, reason: 'claimed by a drain');
 
+      clock = clock.add(OutboxRepository.stuckClaimTimeout);
+      await repository.recoverStuck();
+      expect(await repository.due(), isEmpty, reason: 'boundary is still live');
+
+      clock = clock.add(const Duration(milliseconds: 1));
       await repository.recoverStuck();
       expect(
         await repository.due(),
@@ -212,6 +218,55 @@ void main() {
       );
     },
   );
+
+  test('only one drainer can claim a pending operation', () async {
+    final id = await repository.enqueue(
+      uploadType: 'submission',
+      itemId: 'claim-once',
+      payload: const {'answer': 42},
+      endpoint: 'https://planet.test/db/submissions',
+    );
+
+    expect(await repository.markInProgress(id), isTrue);
+    expect(await repository.markInProgress(id), isFalse);
+  });
+
+  test('recovery does not steal a live claim from another isolate', () async {
+    final id = await repository.enqueue(
+      uploadType: 'submission',
+      itemId: 'still-sending',
+      payload: const {'answer': 42},
+      endpoint: 'https://planet.test/db/submissions',
+    );
+    await repository.markInProgress(id);
+
+    clock = clock.add(const Duration(minutes: 19));
+    expect(await repository.recoverStuck(), 0);
+    expect(
+      (await database.outboxDao.getById(id))?.status,
+      OutboxDao.statusInProgress,
+    );
+  });
+
+  test('recovery repairs a legacy claim with a zero lease timestamp', () async {
+    final id = await repository.enqueue(
+      uploadType: 'submission',
+      itemId: 'legacy-claim',
+      payload: const {'answer': 42},
+      endpoint: 'https://planet.test/db/submissions',
+    );
+    await database.outboxDao.patch(
+      id,
+      const OutboxEntriesCompanion(
+        status: Value(OutboxDao.statusInProgress),
+        lastAttemptAt: Value(0),
+      ),
+    );
+
+    clock = clock.add(OutboxRepository.stuckClaimTimeout);
+    expect(await repository.recoverStuck(), 1);
+    expect(await repository.due(), hasLength(1));
+  });
 
   test('a completed item can be queued again', () async {
     final first = await repository.enqueue(

--- a/flutter/test/ui/settings_screen_test.dart
+++ b/flutter/test/ui/settings_screen_test.dart
@@ -3,8 +3,10 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/background/background_scheduler.dart';
 import 'package:myplanet/core/prefs/planet_prefs.dart';
 import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/settings_provider.dart';
 import 'package:myplanet/ui/settings/settings_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -72,9 +74,106 @@ void main() {
       ),
     );
 
+    await tester.scrollUntilVisible(
+      find.text('Storage Management'),
+      300,
+      scrollable: _settingsScrollable(),
+    );
     expect(find.text('Storage Management'), findsOneWidget);
   });
+
+  testWidgets('updates auto-sync policy and reschedules Android work', (
+    tester,
+  ) async {
+    final prefs = await _prefs();
+    final scheduler = _RecordingScheduler();
+    await tester.pumpWidget(
+      wrapScreen(
+        const SettingsScreen(),
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          backgroundSchedulerProvider.overrideWithValue(scheduler),
+        ],
+      ),
+    );
+
+    await tester.scrollUntilVisible(
+      find.byType(SwitchListTile),
+      300,
+      scrollable: _settingsScrollable(),
+    );
+    expect(find.text('Every hour'), findsOneWidget);
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+    expect(prefs.autoSyncEnabled, isFalse);
+    expect(scheduler.cancelled, ['myplanet.autoSync']);
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+    expect(prefs.autoSyncEnabled, isTrue);
+    expect(scheduler.scheduled.last.frequency, const Duration(hours: 1));
+  });
+
+  testWidgets('shows sanitized background retry diagnostics', (tester) async {
+    final prefs = await _prefs();
+    await prefs.recordBackgroundRun(
+      taskName: 'myplanet.autoSync',
+      attemptedAt: DateTime.utc(2026, 8, 16, 13, 45),
+      status: 'retryRequested',
+      failedSteps: const ['resources', 'outboxDrain'],
+    );
+    await tester.pumpWidget(
+      wrapScreen(
+        const SettingsScreen(),
+        overrides: [planetPrefsProvider.overrideWithValue(prefs)],
+      ),
+    );
+
+    await tester.scrollUntilVisible(
+      find.text('Last background run'),
+      300,
+      scrollable: _settingsScrollable(),
+    );
+    expect(find.textContaining('Android will retry'), findsOneWidget);
+    expect(find.textContaining('resources, outboxDrain'), findsOneWidget);
+  });
+
+  testWidgets('warns when Android rejects an immediate schedule update', (
+    tester,
+  ) async {
+    final prefs = await _prefs();
+    final scheduler = _RecordingScheduler()..throwOnCancel = true;
+    await tester.pumpWidget(
+      wrapScreen(
+        const SettingsScreen(),
+        overrides: [
+          planetPrefsProvider.overrideWithValue(prefs),
+          backgroundSchedulerProvider.overrideWithValue(scheduler),
+        ],
+      ),
+    );
+    await tester.scrollUntilVisible(
+      find.byType(SwitchListTile),
+      300,
+      scrollable: _settingsScrollable(),
+    );
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+
+    expect(
+      prefs.autoSyncEnabled,
+      isFalse,
+      reason: 'the user choice is durable',
+    );
+    expect(find.textContaining('preference was saved'), findsOneWidget);
+  });
 }
+
+Finder _settingsScrollable() => find
+    .descendant(of: find.byType(ListView), matching: find.byType(Scrollable))
+    .first;
 
 Future<PlanetPrefs> _prefs() async {
   SharedPreferences.setMockInitialValues({});
@@ -91,4 +190,29 @@ class _TestServerConfig extends ServerConfigNotifier {
 
   @override
   ServerConfig? build() => config;
+}
+
+class _RecordingScheduler implements BackgroundScheduler {
+  bool throwOnCancel = false;
+  final cancelled = <String>[];
+  final scheduled = <({String name, Duration frequency})>[];
+
+  @override
+  Future<void> cancel(String uniqueName) async {
+    if (throwOnCancel) throw StateError('WorkManager unavailable');
+    cancelled.add(uniqueName);
+  }
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> schedulePeriodic({
+    required String uniqueName,
+    required String taskName,
+    required Duration frequency,
+    required bool requiresNetwork,
+  }) async {
+    scheduled.add((name: uniqueName, frequency: frequency));
+  }
 }


### PR DESCRIPTION
### Motivation

- Restore OS-scheduled, constraint-aware background execution so the app can deliver outbox writes and pull tables while the UI process is closed.
- Keep the durable SQLite outbox and make headless runs deterministic, observable and testable without coupling scheduling policy to the UI graph.
- Expose user-controllable auto-sync settings and sanitize persisted headless diagnostics for support and UX.

### Description

- Integrates the `workmanager` plugin and adds a top-level headless entry point `callbackDispatcher` in `background_entrypoint.dart` that builds a Riverpod graph and runs background work.
- Implements a pure-Dart policy engine `BackgroundTaskRunner` and tests for ordering, failure isolation, retry signaling and diagnostic persistence in `core/background/*`.
- Adds `BackgroundScheduler` abstraction and `WorkmanagerScheduler` binding, plus `BackgroundWorkCoordinator` to apply persisted user preferences to OS scheduling.
- Extends `PlanetPrefs` with background fields: `autoSyncEnabled`, `autoSyncInterval`, `lastSync`, and `lastBackgroundRun` plus `recordBackgroundRun`, and updates `main.dart` to start scheduling best-effort on cold start.
- Changes outbox plumbing: `OutboxDao.claim`, `OutboxRepository.markInProgress` returning a `bool`, a `stuckClaimTimeout` and time-aware `recoverStuck` semantics so headless/UI isolates do not double-send; `OutboxDrainer` now skips lost claims and returns nullable outcomes accordingly.
- Adds UI/settings integration: providers, `BackgroundSettings` notifier, settings screen controls, sanitized background-run summary and localization strings in `app_en.arb`.
- Updates doc `docs/kotlin-to-flutter-migration.md` to mark Phase 30 complete and describes the scheduling decisions and known remaining gaps.
- Updates `pubspec.yaml`/`pubspec.lock` to depend on `workmanager` and adds numerous unit and widget tests exercising the new behaviour.

### Testing

- Added and ran unit tests `core/background/background_task_runner_test.dart` and `core/background/background_work_coordinator_test.dart` which validate headless run semantics, cadence/clamping, and scheduler interactions; these tests passed.
- Extended prefs and repository tests: `core/prefs/planet_prefs_test.dart`, `repository/outbox_repository_test.dart`, and `repository/outbox_drainer_test.dart` to cover persistence, claim/recovery semantics and cross-isolate lease behaviour; these tests passed.
- Added widget tests `ui/settings_screen_test.dart` to cover the new settings UI, scheduling interactions and sanitized diagnostics display; these tests passed when run via `flutter test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81989d4448832b856bccef9e4366cb)