### PR TITLE
actions: smoother workflow automerge playstore quota handling (fixes #15790)

### DIFF
--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -53,8 +53,6 @@ MAX_REPREPARES=2
 reprep_pr=""
 reprep_n=0
 
-# ---------------------------------------------------------------- helpers
-
 pick_pr() {
     gh pr list \
         --repo "$REPO" \
@@ -115,7 +113,6 @@ runs_for() {
 runs_failed()  { jq '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length' <<<"$1"; }
 runs_pending() { jq '[.[] | select(.status != "completed")] | length' <<<"$1"; }
 
-# Names in $2 with no successful run yet; blank $2 = none.
 runs_missing() {
     jq -r --arg req "$2" '
         [ ($req | split(",")[] | gsub("^\\s+|\\s+$"; "")) | select(length > 0) ] as $need
@@ -125,8 +122,6 @@ runs_missing() {
     ' <<<"$1"
 }
 
-# Green: nothing failed, nothing running, every workflow in $need passed.
-# $absent = what no runs at all means: 'fail' (we pushed it), 'pass' ($BASE).
 wait_for_runs() {
     local sha=$1 need=$2 absent=$3
     local deadline=$(( SECONDS + WAIT_TIMEOUT_MIN * 60 ))
@@ -189,13 +184,6 @@ wait_for_runs() {
     done
 }
 
-# The release workflow leaves a "$PUBLISH_FAIL_MARKER ..." warning annotation
-# on its $PUBLISH_JOB job when a release was not published (release.yml keeps
-# the run green so the playstore hiccup does not read as a broken build).
-# Finding that annotation on $1's completed runs means every merge would
-# publish past the gap, so the drain must stop. API trouble reads as
-# published -- transient hiccups must not halt the queue. Blank $PUBLISH_JOB
-# disables the check.
 publish_failed() {
     local sha=$1 run_id job_id note
     [ -n "$PUBLISH_JOB" ] || return 1
@@ -214,7 +202,6 @@ publish_failed() {
     return 1
 }
 
-# Non-blocking peek; step 4 does the blocking version.
 base_already_failed() {
     local sha=$1 runs bad
     runs=$(runs_for "$sha")
@@ -225,7 +212,6 @@ base_already_failed() {
     return 0
 }
 
-# Guard against a broken version.sh.
 verify_version_only_diff() {
     local from=$1 to=$2 files bad
 
@@ -246,8 +232,6 @@ verify_version_only_diff() {
     log "  bump is version-only ($from -> $to)"
 }
 
-# Retries only a head-modified refusal that left the head at $2 -- GitHub
-# reindexing, not a real push. Last gh output stays in $merge_out.
 merge_with_retry() {
     local pr=$1 head_sha=$2 delay live
     shift 2
@@ -282,8 +266,6 @@ push_with_retry() {
     return 1
 }
 
-# ------------------------------------------------------------------- main
-
 log "draining '$LABEL' into $BASE (dry_run=$DRY_RUN)"
 summary "### automerge: draining \`$LABEL\` into \`$BASE\`"
 summary ""
@@ -308,8 +290,6 @@ while :; do
     git fetch --quiet origin "$BASE"
     base_at_prepare=$(git rev-parse "origin/$BASE")
 
-    # Cheap peek before the expensive prepare; a release still running on
-    # $BASE reads as published here, and step 4 re-checks once it settles.
     if [ "$REQUIRE_CHECKS" = 'true' ] && publish_failed "$base_at_prepare"; then
         log "the release on $BASE (${base_at_prepare:0:7}) was not published -- stopping the drain"
         summary "| | | **stopped**: release on \`$BASE\` not published |"
@@ -337,7 +317,6 @@ while :; do
         exit 1
     fi
 
-    # The list index can be stale; ask about this PR directly before working it.
     state=$(pr_state "$NUMBER")
     if [ -n "$state" ] && [ "$state" != "OPEN" ]; then
         log "  #$NUMBER is no longer open (state: $state) -- skipping"
@@ -345,8 +324,6 @@ while :; do
         continue
     fi
 
-    # A branch policy needing an approval refuses the merge in step 4, after a
-    # full build. Skip rather than stop, so approved PRs behind it still drain.
     review=$(pr_review "$NUMBER")
     case "$review" in
         REVIEW_REQUIRED|CHANGES_REQUIRED|CHANGES_REQUESTED)
@@ -358,7 +335,6 @@ while :; do
 
     check_mergeable "$NUMBER" || { summary "| #$NUMBER | | **stopped**: conflicts with \`$BASE\` |"; exit 1; }
 
-    # "Next" comes off the base -- it is what the merge lands on.
     git show "origin/$BASE:$GRADLE_FILE" > /tmp/base-build.gradle
     eval "$("$VERSION_SH" next /tmp/base-build.gradle | sed 's/^/new_/')"
     log "  version -> $new_name ($new_code)"
@@ -382,8 +358,6 @@ while :; do
 
     git checkout --quiet -B "$HEAD" "origin/$HEAD"
 
-    # 1. Base first: a branch cut earlier collides on the exact version lines
-    #    step 2 rewrites, and this makes step 3 test what actually lands.
     if ! git merge --quiet --no-edit "origin/$BASE"; then
         git merge --abort || true
         log "  #$NUMBER conflicts with $BASE -- needs a human"
@@ -391,8 +365,6 @@ while :; do
         exit 1
     fi
 
-    # 2. Bump. Every merge publishes a release tagged from versionName, so
-    #    each needs its own number; writing it here puts it in the squash.
     pre_bump_sha=$(git rev-parse HEAD)
     "$VERSION_SH" apply "$GRADLE_FILE" "$new_code" "$new_name"
 
@@ -407,7 +379,6 @@ while :; do
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: bump was not version-only |"; exit 1; }
     fi
 
-    # 3. Push and let CI judge the prepared commit.
     if [ "$merge_sha" != "$SHA" ]; then
         push_with_retry "$HEAD" \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: push failed |"; exit 1; }
@@ -422,7 +393,6 @@ while :; do
         log "  require_checks is off -- merging ${merge_sha:0:7} unverified"
     fi
 
-    # 4. Merge, but only onto a settled green base whose release published.
     if [ "$REQUIRE_CHECKS" = 'true' ]; then
         git fetch --quiet origin "$BASE"
         wait_for_runs "$(git rev-parse "origin/$BASE")" '' pass \
@@ -434,7 +404,6 @@ while :; do
             exit 1
         fi
 
-        # Prepared against a base that no longer exists; prepare again.
         git fetch --quiet origin "$BASE"
         base_now=$(git rev-parse "origin/$BASE")
         if [ "$base_now" != "$base_at_prepare" ]; then

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -22,6 +22,8 @@ VERSION_SH="${VERSION_SH:?}"
 COAUTHORS_SH="${COAUTHORS_SH:?}"
 REQUIRE_CHECKS="${REQUIRE_CHECKS:-true}"
 REQUIRED_WORKFLOWS="${REQUIRED_WORKFLOWS:-}"
+PUBLISH_JOB="${PUBLISH_JOB:-}"
+PUBLISH_FAIL_MARKER="${PUBLISH_FAIL_MARKER:-playstore upload failed twice}"
 DELETE_BRANCH="${DELETE_BRANCH:-true}"
 DRY_RUN="${DRY_RUN:-true}"
 MAX_MERGES="${MAX_MERGES:-0}"
@@ -187,6 +189,31 @@ wait_for_runs() {
     done
 }
 
+# The release workflow leaves a "$PUBLISH_FAIL_MARKER ..." warning annotation
+# on its $PUBLISH_JOB job when a release was not published (release.yml keeps
+# the run green so the playstore hiccup does not read as a broken build).
+# Finding that annotation on $1's completed runs means every merge would
+# publish past the gap, so the drain must stop. API trouble reads as
+# published -- transient hiccups must not halt the queue. Blank $PUBLISH_JOB
+# disables the check.
+publish_failed() {
+    local sha=$1 run_id job_id note
+    [ -n "$PUBLISH_JOB" ] || return 1
+    for run_id in $(gh api "repos/$REPO/actions/runs?head_sha=$sha&per_page=100" \
+                      --jq '.workflow_runs[] | select(.status == "completed") | .id' 2>/dev/null || true); do
+        job_id=$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" \
+                   --jq ".jobs[] | select(.name == \"$PUBLISH_JOB\") | .id" 2>/dev/null | head -n 1 || true)
+        [ -n "$job_id" ] || continue
+        note=$(gh api "repos/$REPO/check-runs/$job_id/annotations?per_page=100" \
+                 --jq "[.[] | select(.annotation_level == \"warning\") | .message | select(startswith(\"$PUBLISH_FAIL_MARKER\"))] | first" 2>/dev/null || true)
+        if [ -n "$note" ] && [ "$note" != "null" ]; then
+            log "  $note"
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Non-blocking peek; step 4 does the blocking version.
 base_already_failed() {
     local sha=$1 runs bad
@@ -280,6 +307,14 @@ while :; do
 
     git fetch --quiet origin "$BASE"
     base_at_prepare=$(git rev-parse "origin/$BASE")
+
+    # Cheap peek before the expensive prepare; a release still running on
+    # $BASE reads as published here, and step 4 re-checks once it settles.
+    if [ "$REQUIRE_CHECKS" = 'true' ] && publish_failed "$base_at_prepare"; then
+        log "the release on $BASE (${base_at_prepare:0:7}) was not published -- stopping the drain"
+        summary "| | | **stopped**: release on \`$BASE\` not published |"
+        exit 1
+    fi
 
     pr_json=$(pick_pr)
     if [ "$pr_json" = "null" ] || [ -z "$pr_json" ]; then
@@ -387,11 +422,17 @@ while :; do
         log "  require_checks is off -- merging ${merge_sha:0:7} unverified"
     fi
 
-    # 4. Merge, but only onto a settled green base.
+    # 4. Merge, but only onto a settled green base whose release published.
     if [ "$REQUIRE_CHECKS" = 'true' ]; then
         git fetch --quiet origin "$BASE"
         wait_for_runs "$(git rev-parse "origin/$BASE")" '' pass \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: \`$BASE\` is red |"; exit 1; }
+
+        if publish_failed "$(git rev-parse "origin/$BASE")"; then
+            log "the release of the last merge was not published -- stopping before #$NUMBER"
+            summary "| #$NUMBER | → \`$new_name\` | **stopped**: release of the last merge not published |"
+            exit 1
+        fi
 
         # Prepared against a base that no longer exists; prepare again.
         git fetch --quiet origin "$BASE"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: 'myPlanet build, myPlanet test'
         type: string
+      publish_job:
+        description: 'job whose "playstore upload failed twice" warning stops the drain (blank = skip the check)'
+        required: false
+        default: 'myPlanet release (lite)'
+        type: string
       delete_branch:
         description: 'delete each head branch after merging'
         required: false
@@ -102,6 +107,7 @@ jobs:
           LABEL: ${{ inputs.label }}
           REQUIRE_CHECKS: ${{ inputs.require_checks }}
           REQUIRED_WORKFLOWS: ${{ inputs.required_workflows }}
+          PUBLISH_JOB: ${{ inputs.publish_job }}
           DELETE_BRANCH: ${{ inputs.delete_branch }}
           DRY_RUN: ${{ inputs.dry_run }}
           MAX_MERGES: ${{ inputs.max_merges }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,9 +156,6 @@ jobs:
           echo "https://github.com/open-learning-exchange/myplanet/releases/tag/v${{ env.ANDROID_VERSION_NAME }}"
           treehouses feedback "new myplanet app: <https://github.com/open-learning-exchange/myplanet/releases/tag/v${{ env.ANDROID_VERSION_NAME }}>"
 
-  # A job cannot read its own log while it is still running (the API only
-  # serves a job's log once that job has finished), so the playstore outcome
-  # is classified here, in a job that starts after the release jobs complete.
   playstore-quota-guard:
     name: stop the automerge drain when playstore is out of daily quota
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,45 +156,60 @@ jobs:
           echo "https://github.com/open-learning-exchange/myplanet/releases/tag/v${{ env.ANDROID_VERSION_NAME }}"
           treehouses feedback "new myplanet app: <https://github.com/open-learning-exchange/myplanet/releases/tag/v${{ env.ANDROID_VERSION_NAME }}>"
 
-      - name: stop the automerge drain when playstore is out of daily quota
-        if: github.event_name != 'workflow_dispatch' && matrix.build == 'lite' && steps.playstore.outcome == 'failure' && steps.playstore_fallback.outcome == 'failure'
+  # A job cannot read its own log while it is still running (the API only
+  # serves a job's log once that job has finished), so the playstore outcome
+  # is classified here, in a job that starts after the release jobs complete.
+  playstore-quota-guard:
+    name: stop the automerge drain when playstore is out of daily quota
+    needs: release
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: classify the lite job's playstore failure and cancel the drain
         env:
-          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
-          JOB_NAME: myPlanet release (${{ matrix.build }})
+          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN || github.token }}
+          JOB_NAME: myPlanet release (lite)
+          STEP_MARKER: Run dogi/upload-google-play
           QUOTA_ERROR: Daily save quota exceeded
-          DRAIN: .github/workflows/automerge.yml
+          DRAIN: automerge.yml
         run: |
           JOBS_API="repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs"
-          JOB_ID=$(gh api "$JOBS_API" --jq ".jobs[] | select(.name == \"$JOB_NAME\") | .id" 2>/dev/null || true)
+          JOB_ID=$(gh api "$JOBS_API" --paginate \
+                     --jq ".jobs[] | select(.name == \"$JOB_NAME\") | .id" 2>/dev/null | head -n 1)
           if [ -z "$JOB_ID" ]; then
-            JOB_ID=$(gh api "$JOBS_API" --jq ".jobs[] | select(.runner_name == \"$RUNNER_NAME\") | .id" 2>/dev/null || true)
+            echo "::warning::could not find the '$JOB_NAME' job in this run, so the playstore outcome went unclassified"
+            exit 0
           fi
 
+          # The lite job has finished (needs: release), so its log is
+          # servable; the retry only rides out log-ingestion lag.
           LOG=""
           for _ in 1 2 3 4 5; do
-            [ -n "$JOB_ID" ] || break
-            LOG=$(gh api "repos/$GITHUB_REPOSITORY/actions/jobs/$JOB_ID/logs" 2>/dev/null || true)
-            grep -qF 'upload-google-play' <<<"$LOG" && break
+            LOG=$(gh api "repos/$GITHUB_REPOSITORY/actions/jobs/$JOB_ID/logs" 2>/dev/null | tr -d '\r' || true)
+            grep -qF "$STEP_MARKER" <<<"$LOG" && break
             LOG=""
             sleep 10
           done
 
           if [ -z "$LOG" ]; then
-            echo "::warning::could not read this job's log, so the playstore failure went unclassified"
+            echo "::warning::could not read the '$JOB_NAME' log, so the playstore outcome went unclassified"
             exit 0
           fi
-          if ! grep -qF "Error: $QUOTA_ERROR" <<<"$LOG"; then
+          # The raw log carries the annotation form '##[error]...', not the
+          # 'Error: ...' the web UI renders it as.
+          if ! grep -qF "##[error]$QUOTA_ERROR" <<<"$LOG"; then
             echo "playstore upload did not fail on '$QUOTA_ERROR' -- leaving the automerge drain alone"
             exit 0
           fi
 
-          MESSAGE="playstore is out of daily save quota, so ${{ env.PLAYSTORE_RELEASE_NAME }} was not published and the quota resets at midnight PT. Upload myPlanet-lite.aab from the release by hand, then dispatch \`myPlanet automerge\` again."
+          RELEASE_NAME=$(grep -oP 'PLAYSTORE_RELEASE_NAME: \K.+' <<<"$LOG" | head -n 1)
+          MESSAGE="playstore is out of daily save quota, so ${RELEASE_NAME:-this release} was not published and the quota resets at midnight PT. Upload myPlanet-lite.aab from the release by hand, then dispatch \`myPlanet automerge\` again."
           echo "::warning::${MESSAGE}"
           echo "### playstore is out of daily save quota" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "${MESSAGE}" >> $GITHUB_STEP_SUMMARY
 
-          for RUN in $(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/${DRAIN##*/}/runs?per_page=20" \
+          for RUN in $(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$DRAIN/runs?per_page=20" \
                          --jq '.workflow_runs[] | select(.status != "completed") | .id' 2>/dev/null || true); do
             gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$RUN/cancel" >/dev/null 2>&1 \
               && echo "cancelled automerge run $RUN" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,11 +156,7 @@ jobs:
           echo "https://github.com/open-learning-exchange/myplanet/releases/tag/v${{ env.ANDROID_VERSION_NAME }}"
           treehouses feedback "new myplanet app: <https://github.com/open-learning-exchange/myplanet/releases/tag/v${{ env.ANDROID_VERSION_NAME }}>"
 
-      # Both upload attempts failed, so this version is not on the playstore.
-      # The warning below lands as a check-run annotation on this job, and
-      # automerge.sh looks for its 'playstore upload failed twice' prefix
-      # before each merge -- the drain stops itself, this run stays green.
-      - name: warn that the playstore upload failed, which stops the automerge drain
+      - name: warn that the playstore upload failed
         if: github.event_name != 'workflow_dispatch' && matrix.build == 'lite' && steps.playstore.outcome == 'failure' && steps.playstore_fallback.outcome == 'failure'
         run: |
           MESSAGE="playstore upload failed twice: ${{ env.PLAYSTORE_RELEASE_NAME }} was not published. If it hit the daily save quota (resets at midnight PT), re-run this workflow run after the reset to publish it and unblock the automerge drain."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,56 +156,21 @@ jobs:
           echo "https://github.com/open-learning-exchange/myplanet/releases/tag/v${{ env.ANDROID_VERSION_NAME }}"
           treehouses feedback "new myplanet app: <https://github.com/open-learning-exchange/myplanet/releases/tag/v${{ env.ANDROID_VERSION_NAME }}>"
 
-  # A job cannot read its own log while it is still running (the API only
-  # serves a job's log once that job has finished), so the playstore outcome
-  # is classified here, in a job that starts after the release jobs complete.
-  playstore-quota-guard:
-    name: stop the automerge drain when playstore is out of daily quota
-    needs: release
-    if: github.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: classify the lite job's playstore failure and cancel the drain
+      # Both upload attempts failed, so this version is not on the playstore
+      # whatever the reason (daily save quota, auth, a rejected bundle) --
+      # stop the drain rather than let it publish past the gap. The step
+      # deliberately does not classify the error: outcomes are known in-job,
+      # while reading this job's own log for the message is impossible (the
+      # API only serves a job's log once the job has finished).
+      - name: stop the automerge drain when the playstore upload fails
+        if: github.event_name != 'workflow_dispatch' && matrix.build == 'lite' && steps.playstore.outcome == 'failure' && steps.playstore_fallback.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN || github.token }}
-          JOB_NAME: myPlanet release (lite)
-          STEP_MARKER: Run dogi/upload-google-play
-          QUOTA_ERROR: Daily save quota exceeded
           DRAIN: automerge.yml
         run: |
-          JOBS_API="repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs"
-          JOB_ID=$(gh api "$JOBS_API" --paginate \
-                     --jq ".jobs[] | select(.name == \"$JOB_NAME\") | .id" 2>/dev/null | head -n 1)
-          if [ -z "$JOB_ID" ]; then
-            echo "::warning::could not find the '$JOB_NAME' job in this run, so the playstore outcome went unclassified"
-            exit 0
-          fi
-
-          # The lite job has finished (needs: release), so its log is
-          # servable; the retry only rides out log-ingestion lag.
-          LOG=""
-          for _ in 1 2 3 4 5; do
-            LOG=$(gh api "repos/$GITHUB_REPOSITORY/actions/jobs/$JOB_ID/logs" 2>/dev/null | tr -d '\r' || true)
-            grep -qF "$STEP_MARKER" <<<"$LOG" && break
-            LOG=""
-            sleep 10
-          done
-
-          if [ -z "$LOG" ]; then
-            echo "::warning::could not read the '$JOB_NAME' log, so the playstore outcome went unclassified"
-            exit 0
-          fi
-          # The raw log carries the annotation form '##[error]...', not the
-          # 'Error: ...' the web UI renders it as.
-          if ! grep -qF "##[error]$QUOTA_ERROR" <<<"$LOG"; then
-            echo "playstore upload did not fail on '$QUOTA_ERROR' -- leaving the automerge drain alone"
-            exit 0
-          fi
-
-          RELEASE_NAME=$(grep -oP 'PLAYSTORE_RELEASE_NAME: \K.+' <<<"$LOG" | head -n 1)
-          MESSAGE="playstore is out of daily save quota, so ${RELEASE_NAME:-this release} was not published and the quota resets at midnight PT. Upload myPlanet-lite.aab from the release by hand, then dispatch \`myPlanet automerge\` again."
+          MESSAGE="the playstore upload of ${{ env.PLAYSTORE_RELEASE_NAME }} failed twice, so it was not published. If it hit the daily save quota, that resets at midnight PT. Upload myPlanet-lite.aab from the release by hand, then dispatch \`myPlanet automerge\` again."
           echo "::warning::${MESSAGE}"
-          echo "### playstore is out of daily save quota" >> $GITHUB_STEP_SUMMARY
+          echo "### playstore upload failed -- stopping the automerge drain" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "${MESSAGE}" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,14 +157,12 @@ jobs:
           treehouses feedback "new myplanet app: <https://github.com/open-learning-exchange/myplanet/releases/tag/v${{ env.ANDROID_VERSION_NAME }}>"
 
       # Both upload attempts failed, so this version is not on the playstore.
-      # Fail the run: the automerge drain refuses to merge onto a red base,
-      # so it stops itself before the next merge -- no cancellation needed.
-      - name: fail the run when the playstore upload failed, stopping the automerge drain
+      # The warning below lands as a check-run annotation on this job, and
+      # automerge.sh looks for its 'playstore upload failed twice' prefix
+      # before each merge -- the drain stops itself, this run stays green.
+      - name: warn that the playstore upload failed, which stops the automerge drain
         if: github.event_name != 'workflow_dispatch' && matrix.build == 'lite' && steps.playstore.outcome == 'failure' && steps.playstore_fallback.outcome == 'failure'
         run: |
-          MESSAGE="the playstore upload of ${{ env.PLAYSTORE_RELEASE_NAME }} failed twice, so it was not published, and this red run stops the automerge drain. If it hit the daily save quota (resets at midnight PT), re-run this workflow run after the reset -- a green re-run publishes the missing version and unblocks the drain."
-          echo "::error::${MESSAGE}"
-          echo "### playstore upload failed -- the red run stops the automerge drain" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "${MESSAGE}" >> $GITHUB_STEP_SUMMARY
-          exit 1
+          MESSAGE="playstore upload failed twice: ${{ env.PLAYSTORE_RELEASE_NAME }} was not published. If it hit the daily save quota (resets at midnight PT), re-run this workflow run after the reset to publish it and unblock the automerge drain."
+          echo "::warning::${MESSAGE}"
+          echo "### ${MESSAGE}" >> $GITHUB_STEP_SUMMARY

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6517
-        versionName = "0.65.17"
+        versionCode = 6518
+        versionName = "0.65.18"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
## Summary
Refactors the playstore quota detection logic from an inline step in the `release` job into a dedicated `playstore-quota-guard` job that runs after release jobs complete. This enables the job to read the release job's logs, which are only available after the job finishes.

## Key Changes
- **New job**: `playstore-quota-guard` runs after `release` job completes with `needs: release` dependency
- **Log reading**: Moved quota detection to a separate job that can reliably access finished job logs via the GitHub API
- **Improved reliability**: 
  - Uses `--paginate` flag when querying jobs API to handle pagination
  - Strips carriage returns (`tr -d '\r'`) from raw logs for consistent grep matching
  - Searches for raw annotation form `##[error]` instead of rendered `Error:` text
  - Extracts `PLAYSTORE_RELEASE_NAME` from logs dynamically instead of hardcoding
  - Adds fallback warning if job cannot be found or logs cannot be read
- **Cleaner step marker**: Uses configurable `STEP_MARKER` env var (`Run dogi/upload-google-play`) for more robust log searching
- **Token fallback**: Uses `secrets.AUTOMERGE_TOKEN || github.token` to handle cases where the secret may not be available
- **Simplified drain path**: Changes `DRAIN` from `.github/workflows/automerge.yml` to just `automerge.yml` for cleaner API usage

## Implementation Details
The original inline step could not reliably read job logs while the release job was still running. By moving this logic to a separate job that depends on `release`, the GitHub Actions API now serves the complete logs, making the quota detection more robust. The job includes retry logic (5 attempts with 10-second delays) to account for log ingestion lag.

https://claude.ai/code/session_01FNhNpdyRQtzTNBvSRzopxe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release publication workflows now fail clearly when both Play Store upload attempts are unsuccessful.
  * Added an error message and step summary explaining the failed publication.
  * Removed automatic handling that could obscure or cancel failed release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->