### PR TITLE
teams: smoother task and meetup comment threads managing (fixes #15112)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6546
-        versionName = "0.65.46"
+        versionCode = 6547
+        versionName = "0.65.47"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NewsDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NewsDao.kt
@@ -54,6 +54,15 @@ interface NewsDao {
     @Query("SELECT * FROM news WHERE replyTo = :newsId COLLATE NOCASE ORDER BY time DESC")
     suspend fun getReplies(newsId: String): List<News>
 
+    @Query("SELECT * FROM news WHERE replyTo = :parentId COLLATE NOCASE ORDER BY time ASC")
+    fun getCommentsForParentFlow(parentId: String): Flow<List<News>>
+
+    @Query("SELECT * FROM news WHERE replyTo IN (:parentIds) COLLATE NOCASE ORDER BY time ASC")
+    fun getCommentsForParentsFlow(parentIds: List<String>): Flow<List<News>>
+
+    @Query("SELECT * FROM news WHERE replyTo = :parentId COLLATE NOCASE ORDER BY time ASC")
+    suspend fun getCommentsForParent(parentId: String): List<News>
+
     @Query("SELECT * FROM news WHERE replyTo = :newsId")
     suspend fun getDirectReplies(newsId: String): List<News>
 
@@ -89,6 +98,9 @@ interface NewsDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAll(news: List<News>)
+
+    @Query("DELETE FROM news WHERE id = :id")
+    suspend fun deleteById(id: String)
 
     @Query("DELETE FROM news WHERE id IN (:ids)")
     suspend fun deleteByIds(ids: List<String>)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepository.kt
@@ -1,8 +1,9 @@
 package org.ole.planet.myplanet.repository
 
-import com.google.gson.JsonObject
+import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.MeetupCreationParams
+import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.UserEntity
 
 interface EventsRepository {
@@ -18,4 +19,8 @@ interface EventsRepository {
                              recurring: String): Boolean
     suspend fun getPendingMeetupUploads(): List<Meetup>
     suspend fun markMeetupUploaded(localId: String, remoteId: String, remoteRev: String): Boolean
+    fun getCommentsForMeetupFlow(meetupId: String): Flow<List<News>>
+    fun getCommentsForMeetupsFlow(meetupIds: List<String>): Flow<List<News>>
+    suspend fun addComment(parentId: String, teamId: String?, message: String, user: UserEntity?): News
+    suspend fun deleteComment(commentId: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/EventsRepositoryImpl.kt
@@ -5,18 +5,21 @@ import com.google.gson.JsonObject
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
+import org.ole.planet.myplanet.data.room.dao.NewsDao
 import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.MeetupCreationParams
+import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.TimeProvider
-
 
 @Singleton
 class EventsRepositoryImpl @Inject constructor(
     private val timeProvider: TimeProvider,
     private val meetupDao: MeetupDao,
+    private val newsDao: NewsDao,
     private val userRepository: UserRepository,
     private val gson: Gson
 ) : EventsRepository, EventsSyncWriter {
@@ -176,5 +179,41 @@ class EventsRepositoryImpl @Inject constructor(
         meetup.updated = false
         meetupDao.upsert(meetup)
         return true
+    }
+
+    override fun getCommentsForMeetupFlow(meetupId: String): Flow<List<News>> {
+        return newsDao.getCommentsForParentFlow(meetupId)
+    }
+
+    override fun getCommentsForMeetupsFlow(meetupIds: List<String>): Flow<List<News>> {
+        return newsDao.getCommentsForParentsFlow(meetupIds)
+    }
+
+    override suspend fun addComment(parentId: String, teamId: String?, message: String, user: UserEntity?): News {
+        val news = News().apply {
+            id = UUID.randomUUID().toString()
+            this.message = message
+            time = timeProvider.now()
+            createdOn = user?.planetCode
+            avatar = ""
+            docType = "message"
+            userName = user?.name
+            parentCode = user?.parentCode
+            messagePlanetCode = user?.planetCode
+            messageType = "comment"
+            sharedBy = ""
+            viewableBy = if (teamId.isNullOrEmpty()) "" else "teams"
+            viewableId = teamId ?: ""
+            userId = user?.id
+            replyTo = parentId
+            this.user = if (user != null) JsonUtils.gson.toJson(user.serialize()) else ""
+            imageUrls = emptyList()
+        }
+        newsDao.upsert(news)
+        return news
+    }
+
+    override suspend fun deleteComment(commentId: String) {
+        newsDao.deleteById(commentId)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -6,6 +6,7 @@ import org.ole.planet.myplanet.model.CreateTeamRequest
 import org.ole.planet.myplanet.model.FinanceReportParams
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.MyTeam
+import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.TeamDetails
 import org.ole.planet.myplanet.model.TeamResourceDto
 import org.ole.planet.myplanet.model.TeamSummary
@@ -150,4 +151,9 @@ interface TeamsRepository {
 
     suspend fun getLastVisit(userName: String?, teamId: String?): Long?
     fun getTeamNameFromPrefs(): String?
+
+    fun getCommentsForTaskFlow(taskId: String): Flow<List<News>>
+    fun getCommentsForTasksFlow(taskIds: List<String>): Flow<List<News>>
+    suspend fun addComment(parentId: String, teamId: String?, message: String, user: UserEntity?): News
+    suspend fun deleteComment(commentId: String)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package org.ole.planet.myplanet.repository
 
 import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
 import android.content.SharedPreferences
 import android.os.Build
 import android.text.TextUtils
@@ -10,6 +9,7 @@ import androidx.room.withTransaction
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import dagger.hilt.android.qualifiers.ApplicationContext
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -29,6 +29,7 @@ import org.ole.planet.myplanet.data.room.AppDatabase
 import org.ole.planet.myplanet.data.room.dao.CourseDao
 import org.ole.planet.myplanet.data.room.dao.CourseStepDao
 import org.ole.planet.myplanet.data.room.dao.MyLibraryDao
+import org.ole.planet.myplanet.data.room.dao.NewsDao
 import org.ole.planet.myplanet.data.room.dao.TeamDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
@@ -37,6 +38,7 @@ import org.ole.planet.myplanet.model.CreateTeamRequest
 import org.ole.planet.myplanet.model.FinanceReportParams
 import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.model.MyTeam
+import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.TeamDetails
 import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.TeamResourceDto
@@ -78,6 +80,7 @@ class TeamsRepositoryImpl @Inject constructor(
     private val teamDao: TeamDao,
     private val courseDao: CourseDao,
     private val courseStepDao: CourseStepDao,
+    private val newsDao: NewsDao,
     private val appDatabase: AppDatabase,
 ) : TeamsRepository, TeamsSyncRepository {
     override fun getTasksFlow(userId: String?): Flow<List<TeamTask>> {
@@ -1425,6 +1428,43 @@ class TeamsRepositoryImpl @Inject constructor(
 
     override suspend fun markTeamLogUploaded(localId: String, remoteId: String, rev: String): Boolean {
         return teamLogDao.markUploaded(localId, remoteId, rev) != 0
+    }
+
+    override fun getCommentsForTaskFlow(taskId: String): Flow<List<News>> {
+        return newsDao.getCommentsForParentFlow(taskId).flowOn(dispatcherProvider.default)
+    }
+
+    override fun getCommentsForTasksFlow(taskIds: List<String>): Flow<List<News>> {
+        return newsDao.getCommentsForParentsFlow(taskIds).flowOn(dispatcherProvider.default)
+    }
+
+    override suspend fun addComment(parentId: String, teamId: String?, message: String, user: UserEntity?): News =
+        withContext(dispatcherProvider.io) {
+            val news = News().apply {
+                id = UUID.randomUUID().toString()
+                this.message = message
+                time = timeProvider.now()
+                createdOn = user?.planetCode
+                avatar = ""
+                docType = "message"
+                userName = user?.name
+                parentCode = user?.parentCode
+                messagePlanetCode = user?.planetCode
+                messageType = "comment"
+                sharedBy = ""
+                viewableBy = if (teamId.isNullOrEmpty()) "" else "teams"
+                viewableId = teamId ?: ""
+                userId = user?.id
+                replyTo = parentId
+                this.user = if (user != null) JsonUtils.gson.toJson(user.serialize()) else ""
+                imageUrls = emptyList()
+            }
+            newsDao.upsert(news)
+            news
+        }
+
+    override suspend fun deleteComment(commentId: String) = withContext(dispatcherProvider.io) {
+        newsDao.deleteById(commentId)
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsAdapter.kt
@@ -1,16 +1,22 @@
 package org.ole.planet.myplanet.ui.events
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemMeetupBinding
 import org.ole.planet.myplanet.model.Meetup
+import org.ole.planet.myplanet.model.News
+import org.ole.planet.myplanet.ui.teams.InlineCommentsAdapter
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 
 class EventsAdapter(
+    var nonTeamMember: Boolean = false,
     private val onMeetupClick: ((Meetup) -> Unit)? = null
 ) : ListAdapter<Meetup, EventsAdapter.EventsViewHolder>(
     DiffUtils.itemCallback<Meetup>(
@@ -32,6 +38,32 @@ class EventsAdapter(
     )
 ) {
     private val dateCache = mutableMapOf<Long, String>()
+    private val commentsMap: MutableMap<String, List<News>> = mutableMapOf()
+    private val expandedMeetupIds: MutableSet<String> = mutableSetOf()
+    private var currentUserId: String? = null
+    private var isLeader: Boolean = false
+    private var onSendCommentListener: ((meetupId: String, message: String) -> Unit)? = null
+    private var onDeleteCommentListener: ((News) -> Unit)? = null
+
+    fun setCurrentUser(userId: String?, leader: Boolean) {
+        currentUserId = userId
+        isLeader = leader
+        notifyDataSetChanged()
+    }
+
+    fun updateComments(newCommentsMap: Map<String, List<News>>) {
+        commentsMap.clear()
+        commentsMap.putAll(newCommentsMap)
+        notifyDataSetChanged()
+    }
+
+    fun setOnCommentActions(
+        onSend: (meetupId: String, message: String) -> Unit,
+        onDelete: (News) -> Unit
+    ) {
+        this.onSendCommentListener = onSend
+        this.onDeleteCommentListener = onDelete
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): EventsViewHolder {
         val binding = ItemMeetupBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -63,6 +95,7 @@ class EventsAdapter(
                     }
                 }
             }
+            bindCommentSection(holder, meetup)
             binding.root.setOnClickListener {
                 onMeetupClick?.invoke(meetup)
             }
@@ -82,8 +115,80 @@ class EventsAdapter(
         binding.tvLink.text = context.getString(R.string.message_placeholder, meetup.meetupLink)
         binding.tvRecurring.text = context.getString(R.string.message_placeholder, meetup.recurring)
         binding.tvCreator.text = context.getString(R.string.message_placeholder, meetup.creator)
+        bindCommentSection(holder, meetup)
         binding.root.setOnClickListener {
             onMeetupClick?.invoke(meetup)
+        }
+    }
+
+    private fun bindCommentSection(holder: EventsViewHolder, meetup: Meetup) {
+        val binding = holder.binding
+        val context = binding.root.context
+        val meetupId = meetup.id ?: ""
+        val comments = commentsMap[meetupId] ?: emptyList()
+
+        binding.tvCommentCount.text = context.getString(R.string.comments_count, comments.size)
+
+        if (nonTeamMember) {
+            binding.llCommentInput.visibility = View.GONE
+        } else {
+            binding.llCommentInput.visibility = View.VISIBLE
+        }
+
+        val isExpanded = expandedMeetupIds.contains(meetupId)
+        binding.llCommentsContainer.isVisible = isExpanded
+        binding.ivExpandComments.setImageResource(
+            if (isExpanded) R.drawable.ic_keyboard_arrow_up_black_24dp
+            else R.drawable.ic_keyboard_arrow_down_black_24dp
+        )
+
+        val commentsAdapter = InlineCommentsAdapter(
+            currentUserId = currentUserId,
+            isLeader = isLeader,
+            onDeleteComment = { comment -> onDeleteCommentListener?.invoke(comment) }
+        )
+        binding.rvComments.layoutManager = LinearLayoutManager(context)
+        binding.rvComments.adapter = commentsAdapter
+        commentsAdapter.submitList(comments)
+
+        binding.llCommentToggle.setOnClickListener {
+            val adapterPosition = holder.bindingAdapterPosition
+            val currentId: String = if (adapterPosition != RecyclerView.NO_POSITION && adapterPosition < itemCount) {
+                this@EventsAdapter.getItem(adapterPosition).id
+            } else {
+                meetup.id
+            }
+
+            if (expandedMeetupIds.contains(currentId)) {
+                expandedMeetupIds.remove(currentId)
+            } else {
+                expandedMeetupIds.add(currentId)
+            }
+            if (adapterPosition != RecyclerView.NO_POSITION && adapterPosition < itemCount) {
+                notifyItemChanged(adapterPosition)
+            } else {
+                val isExp = expandedMeetupIds.contains(currentId)
+                binding.llCommentsContainer.isVisible = isExp
+                binding.ivExpandComments.setImageResource(
+                    if (isExp) R.drawable.ic_keyboard_arrow_up_black_24dp
+                    else R.drawable.ic_keyboard_arrow_down_black_24dp
+                )
+            }
+        }
+
+        binding.btnSendComment.setOnClickListener {
+            val adapterPosition = holder.bindingAdapterPosition
+            val currentId: String = if (adapterPosition != RecyclerView.NO_POSITION && adapterPosition < itemCount) {
+                this@EventsAdapter.getItem(adapterPosition).id
+            } else {
+                meetup.id
+            }
+
+            val message = binding.etComment.text?.toString()?.trim().orEmpty()
+            if (message.isNotEmpty()) {
+                onSendCommentListener?.invoke(currentId, message)
+                binding.etComment.setText("")
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/InlineCommentsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/InlineCommentsAdapter.kt
@@ -1,0 +1,70 @@
+package org.ole.planet.myplanet.ui.teams
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import org.ole.planet.myplanet.databinding.ItemInlineCommentBinding
+import org.ole.planet.myplanet.model.News
+import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.ImageUtils
+import org.ole.planet.myplanet.utils.TimeUtils
+
+class InlineCommentsAdapter(
+    private var currentUserId: String? = null,
+    private var isLeader: Boolean = false,
+    private val onDeleteComment: ((News) -> Unit)? = null
+) : ListAdapter<News, InlineCommentsAdapter.CommentViewHolder>(DIFF_CALLBACK) {
+
+    fun updateCurrentUser(userId: String?, leader: Boolean) {
+        currentUserId = userId
+        isLeader = leader
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CommentViewHolder {
+        val binding = ItemInlineCommentBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return CommentViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: CommentViewHolder, position: Int) {
+        val comment = getItem(position)
+        val binding = holder.binding
+
+        binding.tvUserName.text = if (!comment.userName.isNullOrEmpty()) {
+            comment.userName
+        } else {
+            "Anonymous"
+        }
+
+        binding.tvTime.text = TimeUtils.getRelativeTime(comment.time)
+        binding.tvMessage.text = comment.message ?: ""
+        ImageUtils.loadImage(null, binding.imgUser)
+
+        val canDelete = (currentUserId != null && comment.userId == currentUserId) || isLeader
+        binding.btnDeleteComment.isVisible = canDelete
+        binding.btnDeleteComment.setOnClickListener {
+            onDeleteComment?.invoke(comment)
+        }
+    }
+
+    class CommentViewHolder(val binding: ItemInlineCommentBinding) :
+        RecyclerView.ViewHolder(binding.root)
+
+    companion object {
+        private val DIFF_CALLBACK = DiffUtils.itemCallback<News>(
+            areItemsTheSame = { old, new -> old.id == new.id },
+            areContentsTheSame = { old, new ->
+                old.message == new.message &&
+                    old.time == new.time &&
+                    old.userName == new.userName &&
+                    old.userId == new.userId
+            }
+        )
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarFragment.kt
@@ -437,9 +437,42 @@ class TeamCalendarFragment : BaseTeamFragment() {
         recyclerView.layoutParams.height = cardHeight + extraHeight
         recyclerView.requestLayout()
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
-        meetupAdapter = EventsAdapter { meetup ->
+        val isNonMember = arguments?.getBoolean("fromLogin", false) == true || user?.id?.startsWith("guest") == true
+        meetupAdapter = EventsAdapter(nonTeamMember = isNonMember) { meetup ->
             showEditMeetupDialog(meetup)
         }
+        meetupAdapter?.setOnCommentActions(
+            onSend = { meetupId, message ->
+                viewModel.addComment(meetupId, teamId, message)
+            },
+            onDelete = { comment ->
+                AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.delete)
+                    .setMessage(R.string.delete_comment_confirm)
+                    .setPositiveButton(R.string.delete) { _, _ ->
+                        comment.id?.let { viewModel.deleteComment(it) }
+                    }
+                    .setNegativeButton(R.string.cancel, null)
+                    .show()
+            }
+        )
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            val currentUser = viewModel.getCurrentUser()
+            val isLeader = viewModel.isTeamLeader(teamId, currentUser?.id)
+            meetupAdapter?.setCurrentUser(currentUser?.id, isLeader)
+        }
+
+        val meetupIds = meetupList.mapNotNull { it.id }.filter { it.isNotBlank() }
+        if (meetupIds.isNotEmpty()) {
+            viewLifecycleOwner.lifecycleScope.launch {
+                viewModel.getCommentsForMeetupsFlow(meetupIds).collect { comments ->
+                    val commentsMap = comments.groupBy { it.replyTo ?: "" }
+                    meetupAdapter?.updateComments(commentsMap)
+                }
+            }
+        }
+
         recyclerView.adapter = meetupAdapter
         meetupAdapter?.submitList(meetupList)
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamCalendarViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -13,11 +14,17 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.MeetupCreationParams
+import org.ole.planet.myplanet.model.News
+import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.EventsRepository
+import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.repository.UserRepository
 
 @HiltViewModel
 class TeamCalendarViewModel @Inject constructor(
-    private val eventsRepository: EventsRepository
+    private val eventsRepository: EventsRepository,
+    private val userRepository: UserRepository,
+    private val teamsRepository: TeamsRepository
 ) : ViewModel() {
 
     private val _meetups = MutableStateFlow<List<Meetup>>(emptyList())
@@ -61,5 +68,34 @@ class TeamCalendarViewModel @Inject constructor(
             meetupLink = meetupLink,
             recurring = recurring
         )
+    }
+
+    fun getCommentsForMeetupFlow(meetupId: String): Flow<List<News>> {
+        return eventsRepository.getCommentsForMeetupFlow(meetupId)
+    }
+
+    fun getCommentsForMeetupsFlow(meetupIds: List<String>): Flow<List<News>> {
+        return eventsRepository.getCommentsForMeetupsFlow(meetupIds)
+    }
+
+    fun addComment(meetupId: String, teamId: String?, message: String) {
+        viewModelScope.launch {
+            val currentUser = userRepository.getUserModel()
+            eventsRepository.addComment(meetupId, teamId, message, currentUser)
+        }
+    }
+
+    fun deleteComment(commentId: String) {
+        viewModelScope.launch {
+            eventsRepository.deleteComment(commentId)
+        }
+    }
+
+    suspend fun getCurrentUser(): UserEntity? {
+        return userRepository.getUserModel()
+    }
+
+    suspend fun isTeamLeader(teamId: String, userId: String?): Boolean {
+        return teamsRepository.isTeamLeader(teamId, userId)
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksAdapter.kt
@@ -6,12 +6,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnTaskCompletedListener
 import org.ole.planet.myplanet.databinding.RowTaskBinding
+import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.TeamTask
+import org.ole.planet.myplanet.ui.teams.InlineCommentsAdapter
 import org.ole.planet.myplanet.ui.teams.tasks.TeamsTasksAdapter.TeamsTasksViewHolder
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
@@ -21,9 +25,36 @@ class TeamsTasksAdapter(
     var nonTeamMember: Boolean
 ) : ListAdapter<TeamTask, TeamsTasksViewHolder>(DIFF_CALLBACK) {
     private val assigneeCache: MutableMap<String, String> = mutableMapOf()
+    private val commentsMap: MutableMap<String, List<News>> = mutableMapOf()
+    private val expandedTaskIds: MutableSet<String> = mutableSetOf()
+    private var currentUserId: String? = null
+    private var isLeader: Boolean = false
     private var listener: OnTaskCompletedListener? = null
+    private var onSendCommentListener: ((taskId: String, message: String) -> Unit)? = null
+    private var onDeleteCommentListener: ((News) -> Unit)? = null
+
     fun setListener(listener: OnTaskCompletedListener?) {
         this.listener = listener
+    }
+
+    fun setOnCommentActions(
+        onSend: (taskId: String, message: String) -> Unit,
+        onDelete: (News) -> Unit
+    ) {
+        this.onSendCommentListener = onSend
+        this.onDeleteCommentListener = onDelete
+    }
+
+    fun setCurrentUser(userId: String?, leader: Boolean) {
+        currentUserId = userId
+        isLeader = leader
+        notifyDataSetChanged()
+    }
+
+    fun updateComments(newCommentsMap: Map<String, List<News>>) {
+        commentsMap.clear()
+        commentsMap.putAll(newCommentsMap)
+        notifyDataSetChanged()
     }
 
     fun hasAssignee(id: String): Boolean = assigneeCache.containsKey(id)
@@ -94,9 +125,71 @@ class TeamsTasksAdapter(
             binding.icMore.visibility = View.GONE
             binding.checkbox.isClickable = false
             binding.checkbox.isFocusable = false
+            binding.llCommentInput.visibility = View.GONE
         } else {
+            binding.llCommentInput.visibility = View.VISIBLE
             binding.checkbox.setOnCheckedChangeListener { _: CompoundButton?, b: Boolean ->
                 listener?.onCheckChange(it, b)
+            }
+        }
+
+        val taskId = it.id ?: ""
+        val comments = commentsMap[taskId] ?: emptyList()
+        binding.tvCommentCount.text = context.getString(R.string.comments_count, comments.size)
+
+        val isExpanded = expandedTaskIds.contains(taskId)
+        binding.llCommentsContainer.isVisible = isExpanded
+        binding.ivExpandComments.setImageResource(
+            if (isExpanded) R.drawable.ic_keyboard_arrow_up_black_24dp
+            else R.drawable.ic_keyboard_arrow_down_black_24dp
+        )
+
+        val commentsAdapter = InlineCommentsAdapter(
+            currentUserId = currentUserId,
+            isLeader = isLeader,
+            onDeleteComment = { comment -> onDeleteCommentListener?.invoke(comment) }
+        )
+        binding.rvComments.layoutManager = LinearLayoutManager(context)
+        binding.rvComments.adapter = commentsAdapter
+        commentsAdapter.submitList(comments)
+
+        binding.llCommentToggle.setOnClickListener {
+            val adapterPosition = holder.bindingAdapterPosition
+            val currentId: String = if (adapterPosition != RecyclerView.NO_POSITION && adapterPosition < itemCount) {
+                this@TeamsTasksAdapter.getItem(adapterPosition).id ?: ""
+            } else {
+                taskId
+            }
+
+            if (expandedTaskIds.contains(currentId)) {
+                expandedTaskIds.remove(currentId)
+            } else {
+                expandedTaskIds.add(currentId)
+            }
+            if (adapterPosition != RecyclerView.NO_POSITION && adapterPosition < itemCount) {
+                notifyItemChanged(adapterPosition)
+            } else {
+                val isExp = expandedTaskIds.contains(currentId)
+                binding.llCommentsContainer.isVisible = isExp
+                binding.ivExpandComments.setImageResource(
+                    if (isExp) R.drawable.ic_keyboard_arrow_up_black_24dp
+                    else R.drawable.ic_keyboard_arrow_down_black_24dp
+                )
+            }
+        }
+
+        binding.btnSendComment.setOnClickListener {
+            val adapterPosition = holder.bindingAdapterPosition
+            val currentId: String = if (adapterPosition != RecyclerView.NO_POSITION && adapterPosition < itemCount) {
+                this@TeamsTasksAdapter.getItem(adapterPosition).id ?: ""
+            } else {
+                taskId
+            }
+
+            val commentText = binding.etComment.text?.toString()?.trim().orEmpty()
+            if (commentText.isNotEmpty()) {
+                onSendCommentListener?.invoke(currentId, commentText)
+                binding.etComment.setText("")
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
@@ -225,10 +225,31 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
         binding.rvTask.layoutManager = LinearLayoutManager(activity)
         adapterTask = TeamsTasksAdapter(requireContext(), !isMemberFlow.value)
         adapterTask.setListener(this)
+        adapterTask.setOnCommentActions(
+            onSend = { taskId, message ->
+                teamsTasksViewModel.addComment(taskId, teamId, message)
+            },
+            onDelete = { comment ->
+                AlertDialog.Builder(requireContext(), R.style.AlertDialogTheme)
+                    .setTitle(R.string.delete)
+                    .setMessage(R.string.delete_comment_confirm)
+                    .setPositiveButton(R.string.delete) { _, _ ->
+                        comment.id?.let { teamsTasksViewModel.deleteComment(it) }
+                    }
+                    .setNegativeButton(R.string.cancel, null)
+                    .show()
+            }
+        )
         binding.rvTask.adapter = adapterTask
         binding.taskToggle.setOnCheckedChangeListener { _: SingleSelectToggleGroup?, checkedId: Int ->
             currentTab = checkedId
             updateTasks()
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            val currentUser = teamsTasksViewModel.getCurrentUser()
+            val isLeader = teamsTasksViewModel.isTeamLeader(teamId, currentUser?.id)
+            adapterTask.setCurrentUser(currentUser?.id, isLeader)
         }
 
         teamViewModel.loadTasks(teamId)
@@ -242,6 +263,17 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
             updateTasks()
         }
         collectLatestWhenStarted(teamViewModel.taskList) { tasks ->
+            val taskIds = tasks.mapNotNull { it.id }.filter { it.isNotBlank() }
+            if (taskIds.isNotEmpty()) {
+                viewLifecycleOwner.lifecycleScope.launch {
+                    teamsTasksViewModel.getCommentsForTasksFlow(taskIds).collect { comments ->
+                        val commentsMap = comments.groupBy { it.replyTo ?: "" }
+                        adapterTask.updateComments(commentsMap)
+                    }
+                }
+            } else {
+                adapterTask.updateComments(emptyMap())
+            }
             updateTasks()
         }
         collectWhenStarted(teamsTasksViewModel.taskActionEvents) { event ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.TeamsRepository
@@ -127,5 +128,34 @@ class TeamsTasksViewModel @Inject constructor(
 
     suspend fun fetchAssigneeNames(assigneesToFetch: List<String>): Map<String, String> {
         return userRepository.getUsersByIds(assigneesToFetch).mapNotNull { user -> user.name?.let { user.id to it } }.toMap()
+    }
+
+    fun getCommentsForTaskFlow(taskId: String): Flow<List<News>> {
+        return teamsRepository.getCommentsForTaskFlow(taskId)
+    }
+
+    fun getCommentsForTasksFlow(taskIds: List<String>): Flow<List<News>> {
+        return teamsRepository.getCommentsForTasksFlow(taskIds)
+    }
+
+    fun addComment(taskId: String, teamId: String?, message: String) {
+        viewModelScope.launch {
+            val currentUser = userRepository.getUserModel()
+            teamsRepository.addComment(taskId, teamId, message, currentUser)
+        }
+    }
+
+    fun deleteComment(commentId: String) {
+        viewModelScope.launch {
+            teamsRepository.deleteComment(commentId)
+        }
+    }
+
+    suspend fun getCurrentUser(): UserEntity? {
+        return userRepository.getUserModel()
+    }
+
+    suspend fun isTeamLeader(teamId: String, userId: String?): Boolean {
+        return teamsRepository.isTeamLeader(teamId, userId)
     }
 }

--- a/app/src/main/res/drawable/bg_comment_input.xml
+++ b/app/src/main/res/drawable/bg_comment_input.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="8dp" />
+    <stroke
+        android:width="1dp"
+        android:color="#80808080" />
+    <solid android:color="@color/secondary_bg" />
+</shape>

--- a/app/src/main/res/layout/item_inline_comment.xml
+++ b/app/src/main/res/layout/item_inline_comment.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingStart="4dp"
+    android:paddingTop="6dp"
+    android:paddingEnd="4dp"
+    android:paddingBottom="6dp">
+
+    <de.hdodenhof.circleimageview.CircleImageView
+        android:id="@+id/img_user"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_gravity="top"
+        android:layout_marginTop="2dp"
+        android:src="@drawable/ole_logo" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="4dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/tv_user_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textColor="@color/daynight_textColor"
+                android:textSize="13sp"
+                android:textStyle="bold"
+                tools:text="Jane Doe" />
+
+            <TextView
+                android:id="@+id/tv_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="6dp"
+                android:textColor="@color/hint_color"
+                android:textSize="11sp"
+                tools:text="5m ago" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/tv_message"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textColor="@color/daynight_textColor"
+            android:textSize="13sp"
+            tools:text="This is an inline comment on the task." />
+    </LinearLayout>
+
+    <ImageView
+        android:id="@+id/btn_delete_comment"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:layout_gravity="top"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/delete"
+        android:padding="5dp"
+        android:src="@drawable/ic_delete"
+        android:visibility="gone"
+        app:tint="@color/hint_color"
+        tools:visibility="visible" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_meetup.xml
+++ b/app/src/main/res/layout/item_meetup.xml
@@ -223,5 +223,109 @@
                 android:layout_height="wrap_content"
                 android:textColor="@color/daynight_textColor" />
         </LinearLayout>
+
+        <View
+            android:id="@+id/v_comment_divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="2dp"
+            android:alpha="0.15"
+            android:background="@color/hint_color"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/ltCreator" />
+
+        <LinearLayout
+            android:id="@+id/ll_comment_toggle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="6dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="6dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/v_comment_divider">
+
+            <ImageView
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:src="@drawable/baseline_forum_24"
+                app:tint="@color/daynight_textColor" />
+
+            <TextView
+                android:id="@+id/tv_comment_count"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:text="@string/comments_count"
+                android:textColor="@color/daynight_textColor"
+                android:textSize="13sp"
+                android:textStyle="bold" />
+
+            <ImageView
+                android:id="@+id/iv_expand_comments"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_keyboard_arrow_down_black_24dp"
+                app:tint="@color/daynight_textColor" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/ll_comments_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/ll_comment_toggle">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_comments"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false" />
+
+            <LinearLayout
+                android:id="@+id/ll_comment_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <EditText
+                    android:id="@+id/et_comment"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:background="@drawable/bg_comment_input"
+                    android:hint="@string/add_a_comment"
+                    android:maxLines="3"
+                    android:padding="8dp"
+                    android:textColor="@color/daynight_textColor"
+                    android:textColorHint="@color/hint_color"
+                    android:textSize="13sp" />
+
+                <ImageView
+                    android:id="@+id/btn_send_comment"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:layout_marginStart="6dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:contentDescription="@string/send_comment"
+                    android:padding="6dp"
+                    android:src="@drawable/ic_send"
+                    app:tint="@color/mainColor" />
+            </LinearLayout>
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/row_task.xml
+++ b/app/src/main/res/layout/row_task.xml
@@ -10,58 +10,163 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <LinearLayout
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:orientation="vertical">
+            android:orientation="horizontal">
 
-            <CheckBox
-                android:id="@+id/checkbox"
-                android:layout_width="match_parent"
+            <LinearLayout
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/padding_normal"
-                android:textColor="@color/daynight_textColor"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                android:buttonTint="@color/daynight_textColor" />
-            <TextView
-                android:id="@+id/deadline"
-                android:layout_width="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <CheckBox
+                    android:id="@+id/checkbox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:buttonTint="@color/daynight_textColor"
+                    android:padding="@dimen/padding_normal"
+                    android:textColor="@color/daynight_textColor"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/deadline"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/padding_normal"
+                    android:textColor="@color/hint_color" />
+
+                <TextView
+                    android:id="@+id/assignee"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="@dimen/padding_normal"
+                    android:paddingRight="@dimen/padding_normal"
+                    android:textColor="@color/hint_color" />
+            </LinearLayout>
+
+            <ImageView
+                android:id="@+id/edit_task"
+                android:layout_width="@dimen/_30dp"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/padding_normal"
-                android:textColor="@color/hint_color" />
-            <TextView
-                android:id="@+id/assignee"
-                android:layout_width="match_parent"
+                android:layout_margin="@dimen/padding_small"
+                app:srcCompat="@drawable/ic_edit" />
+
+            <ImageView
+                android:id="@+id/delete_task"
+                android:layout_width="28dp"
+                android:layout_height="25dp"
+                android:layout_margin="@dimen/padding_small"
+                app:srcCompat="@drawable/ic_delete"
+                app:tint="@color/daynight_textColor" />
+
+            <ImageView
+                android:id="@+id/ic_more"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingLeft="@dimen/padding_normal"
-                android:paddingRight="@dimen/padding_normal"
-                android:textColor="@color/hint_color" />
+                android:layout_margin="@dimen/padding_small"
+                android:translationY="1dp"
+                app:srcCompat="@drawable/ic_more"
+                app:tint="@color/daynight_textColor" />
         </LinearLayout>
 
-        <ImageView
-            android:id="@+id/edit_task"
-            android:layout_width="@dimen/_30dp"
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="2dp"
+            android:alpha="0.15"
+            android:background="@color/hint_color" />
+
+        <LinearLayout
+            android:id="@+id/ll_comment_toggle"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/padding_small"
-            app:srcCompat="@drawable/ic_edit" />
-        <ImageView
-            android:id="@+id/delete_task"
-            android:layout_width="28dp"
-            android:layout_height="25dp"
-            android:layout_margin="@dimen/padding_small"
-            app:srcCompat="@drawable/ic_delete"
-            app:tint="@color/daynight_textColor" />
-        <ImageView
-            android:id="@+id/ic_more"
-            android:layout_width="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingTop="6dp"
+            android:paddingEnd="4dp"
+            android:paddingBottom="6dp">
+
+            <ImageView
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:src="@drawable/baseline_forum_24"
+                app:tint="@color/daynight_textColor" />
+
+            <TextView
+                android:id="@+id/tv_comment_count"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:text="@string/comments_count"
+                android:textColor="@color/daynight_textColor"
+                android:textSize="13sp"
+                android:textStyle="bold" />
+
+            <ImageView
+                android:id="@+id/iv_expand_comments"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_keyboard_arrow_down_black_24dp"
+                app:tint="@color/daynight_textColor" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/ll_comments_container"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/padding_small"
-            android:translationY="1dp"
-            app:srcCompat="@drawable/ic_more"
-            app:tint="@color/daynight_textColor" />
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_comments"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false" />
+
+            <LinearLayout
+                android:id="@+id/ll_comment_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <EditText
+                    android:id="@+id/et_comment"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:background="@drawable/bg_comment_input"
+                    android:hint="@string/add_a_comment"
+                    android:maxLines="3"
+                    android:padding="8dp"
+                    android:textColor="@color/daynight_textColor"
+                    android:textColorHint="@color/hint_color"
+                    android:textSize="13sp" />
+
+                <ImageView
+                    android:id="@+id/btn_send_comment"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:layout_marginStart="6dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:contentDescription="@string/send_comment"
+                    android:padding="6dp"
+                    android:src="@drawable/ic_send"
+                    app:tint="@color/mainColor" />
+            </LinearLayout>
+        </LinearLayout>
     </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1376,5 +1376,11 @@
     <string name="filter_pdfs">PDFs</string>
     <string name="downloaded">Downloaded</string>
     <string name="not_downloaded">Not downloaded</string>
+    <string name="delete">Delete</string>
+    <string name="comments_count">Comments (%d)</string>
+    <string name="add_a_comment">Add a comment…</string>
+    <string name="send_comment">Send comment</string>
+    <string name="comment_cannot_be_empty">Comment cannot be empty</string>
+    <string name="delete_comment_confirm">Are you sure you want to delete this comment?</string>
 
 </resources>

--- a/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/EventsRepositoryImplTest.kt
@@ -4,9 +4,12 @@ import com.google.gson.Gson
 import com.google.gson.JsonObject
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -16,8 +19,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.MeetupDao
+import org.ole.planet.myplanet.data.room.dao.NewsDao
 import org.ole.planet.myplanet.model.Meetup
 import org.ole.planet.myplanet.model.MeetupCreationParams
+import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.utils.SystemTimeProvider
 
@@ -25,6 +30,7 @@ import org.ole.planet.myplanet.utils.SystemTimeProvider
 class EventsRepositoryImplTest {
 
     private lateinit var meetupDao: MeetupDao
+    private lateinit var newsDao: NewsDao
     private lateinit var userRepository: UserRepository
     private lateinit var repository: EventsRepositoryImpl
 
@@ -35,8 +41,9 @@ class EventsRepositoryImplTest {
     @Before
     fun setup() {
         meetupDao = mockk(relaxed = true)
+        newsDao = mockk(relaxed = true)
         userRepository = mockk(relaxed = true)
-        repository = EventsRepositoryImpl(SystemTimeProvider(), meetupDao, userRepository, Gson())
+        repository = EventsRepositoryImpl(SystemTimeProvider(), meetupDao, newsDao, userRepository, Gson())
     }
 
     @Test
@@ -183,5 +190,57 @@ class EventsRepositoryImplTest {
 
         val result = repository.createMeetup(params)
         assertFalse(result)
+    }
+
+    @Test
+    fun getCommentsForMeetupFlow() = runTest {
+        val mockNews = News().apply {
+            id = "comment1"
+            replyTo = "meetup1"
+            message = "Meetup comment"
+        }
+        every { newsDao.getCommentsForParentFlow("meetup1") } returns flowOf(listOf(mockNews))
+
+        val result = repository.getCommentsForMeetupFlow("meetup1").first()
+        assertEquals(1, result.size)
+        assertEquals("comment1", result[0].id)
+        assertEquals("Meetup comment", result[0].message)
+    }
+
+    @Test
+    fun getCommentsForMeetupsFlow() = runTest {
+        val mockNews = News().apply {
+            id = "comment1"
+            replyTo = "meetup1"
+            message = "Meetup comment"
+        }
+        every { newsDao.getCommentsForParentsFlow(listOf("meetup1")) } returns flowOf(listOf(mockNews))
+
+        val result = repository.getCommentsForMeetupsFlow(listOf("meetup1")).first()
+        assertEquals(1, result.size)
+        assertEquals("comment1", result[0].id)
+    }
+
+    @Test
+    fun addComment() = runTest {
+        val user = UserEntity().apply {
+            id = "user1"
+            name = "Jane"
+            planetCode = "planet1"
+        }
+        val comment = repository.addComment("meetup1", "team1", "Meetup test comment", user)
+        assertEquals("meetup1", comment.replyTo)
+        assertEquals("team1", comment.viewableId)
+        assertEquals("teams", comment.viewableBy)
+        assertEquals("Meetup test comment", comment.message)
+        assertEquals("user1", comment.userId)
+        assertEquals("Jane", comment.userName)
+        coVerify { newsDao.upsert(any()) }
+    }
+
+    @Test
+    fun deleteComment() = runTest {
+        repository.deleteComment("comment1")
+        coVerify { newsDao.deleteById("comment1") }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBenchmarkTest.kt
@@ -77,6 +77,7 @@ class TeamsRepositoryBenchmarkTest {
             teamDao,
             courseDao,
             courseStepDao,
+            mockk<org.ole.planet.myplanet.data.room.dao.NewsDao>(relaxed = true),
             appDatabase,
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBulkInsertTransactionTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryBulkInsertTransactionTest.kt
@@ -91,6 +91,7 @@ class TeamsRepositoryBulkInsertTransactionTest {
             teamDao,
             mockk<CourseDao>(relaxed = true),
             mockk<CourseStepDao>(relaxed = true),
+            db.newsDao(),
             db,
         )
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
@@ -28,10 +28,12 @@ import org.ole.planet.myplanet.data.room.AppDatabase
 import org.ole.planet.myplanet.data.room.dao.CourseDao
 import org.ole.planet.myplanet.data.room.dao.CourseStepDao
 import org.ole.planet.myplanet.data.room.dao.MyLibraryDao
+import org.ole.planet.myplanet.data.room.dao.NewsDao
 import org.ole.planet.myplanet.data.room.dao.TeamDao
 import org.ole.planet.myplanet.data.room.dao.TeamLogDao
 import org.ole.planet.myplanet.data.room.dao.TeamTaskDao
 import org.ole.planet.myplanet.model.MyTeam
+import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.TeamLog
 import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.User
@@ -63,6 +65,7 @@ class TeamsRepositoryImplTest {
     private val teamDao: TeamDao = mockk(relaxed = true)
     private val courseDao: CourseDao = mockk(relaxed = true)
     private val courseStepDao: CourseStepDao = mockk(relaxed = true)
+    private val newsDao: NewsDao = mockk(relaxed = true)
     private val appDatabase: AppDatabase = mockk(relaxed = true)
 
     private val testDispatcher = StandardTestDispatcher()
@@ -103,6 +106,7 @@ class TeamsRepositoryImplTest {
             teamDao,
             courseDao,
             courseStepDao,
+            newsDao,
             appDatabase,
         )
     }
@@ -330,5 +334,60 @@ class TeamsRepositoryImplTest {
         io.mockk.unmockkStatic(android.text.TextUtils::class)
         io.mockk.unmockkObject(NetworkUtils)
         io.mockk.unmockkObject(org.ole.planet.myplanet.MainApplication.Companion)
+    }
+
+    @Test
+    fun `test getCommentsForTaskFlow returns comments from newsDao`() = runTest(testDispatcher) {
+        val mockNews = News().apply {
+            id = "comment1"
+            replyTo = "task1"
+            message = "Task comment"
+        }
+        every { newsDao.getCommentsForParentFlow("task1") } returns flowOf(listOf(mockNews))
+
+        val result = teamsRepository.getCommentsForTaskFlow("task1").first()
+
+        assertEquals(1, result.size)
+        assertEquals("comment1", result[0].id)
+        assertEquals("Task comment", result[0].message)
+    }
+
+    @Test
+    fun `test getCommentsForTasksFlow returns comments from newsDao`() = runTest(testDispatcher) {
+        val mockNews = News().apply {
+            id = "comment1"
+            replyTo = "task1"
+            message = "Task comment"
+        }
+        every { newsDao.getCommentsForParentsFlow(listOf("task1", "task2")) } returns flowOf(listOf(mockNews))
+
+        val result = teamsRepository.getCommentsForTasksFlow(listOf("task1", "task2")).first()
+
+        assertEquals(1, result.size)
+        assertEquals("comment1", result[0].id)
+    }
+
+    @Test
+    fun `test addComment persists news and returns created comment`() = runTest(testDispatcher) {
+        val user = UserEntity().apply {
+            id = "user1"
+            name = "John Doe"
+            planetCode = "planet1"
+        }
+        val comment = teamsRepository.addComment("task1", "team1", "Hello team", user)
+
+        assertEquals("task1", comment.replyTo)
+        assertEquals("team1", comment.viewableId)
+        assertEquals("teams", comment.viewableBy)
+        assertEquals("Hello team", comment.message)
+        assertEquals("user1", comment.userId)
+        assertEquals("John Doe", comment.userName)
+        coVerify { newsDao.upsert(any()) }
+    }
+
+    @Test
+    fun `test deleteComment deletes news by id`() = runTest(testDispatcher) {
+        teamsRepository.deleteComment("comment1")
+        coVerify { newsDao.deleteById("comment1") }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/events/EventsAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/events/EventsAdapterTest.kt
@@ -26,6 +26,7 @@ class EventsAdapterTest {
     @Before
     fun setup() {
         context = ApplicationProvider.getApplicationContext()
+        context.setTheme(androidx.appcompat.R.style.Theme_AppCompat)
         adapter = EventsAdapter { meetup ->
             clickedMeetup = meetup
         }
@@ -97,5 +98,59 @@ class EventsAdapterTest {
         holder.binding.root.performClick()
         assertEquals("New Title", clickedMeetup?.title)
         assertEquals("New Location", clickedMeetup?.meetupLocation)
+    }
+
+    @Test
+    fun `test comments section toggle and send actions`() {
+        val meetup = Meetup().apply {
+            id = "m1"
+            title = "Meetup 1"
+            description = "Desc"
+            startDate = 1000L
+            endDate = 2000L
+        }
+
+        var sentId: String? = null
+        var sentMsg: String? = null
+        adapter.setOnCommentActions(
+            onSend = { id, msg ->
+                sentId = id
+                sentMsg = msg
+            },
+            onDelete = {}
+        )
+
+        val comments = listOf(
+            org.ole.planet.myplanet.model.News().apply {
+                id = "c1"
+                replyTo = "m1"
+                message = "Meetup comment"
+                userName = "User1"
+            }
+        )
+        adapter.updateComments(mapOf("m1" to comments))
+
+        var committed = false
+        adapter.submitList(listOf(meetup)) { committed = true }
+        while (!committed) { ShadowLooper.idleMainLooper() }
+
+        val parent = LinearLayout(context)
+        val holder = adapter.onCreateViewHolder(parent, 0)
+        adapter.onBindViewHolder(holder, 0)
+
+        assertEquals("Comments (1)", holder.binding.tvCommentCount.text.toString())
+        assertEquals(android.view.View.GONE, holder.binding.llCommentsContainer.visibility)
+
+        // Toggle expand
+        holder.binding.llCommentToggle.performClick()
+        assertEquals(android.view.View.VISIBLE, holder.binding.llCommentsContainer.visibility)
+
+        // Send comment
+        holder.binding.etComment.setText("Hello meetup")
+        holder.binding.btnSendComment.performClick()
+
+        assertEquals("m1", sentId)
+        assertEquals("Hello meetup", sentMsg)
+        assertEquals("", holder.binding.etComment.text.toString())
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/InlineCommentsAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/InlineCommentsAdapterTest.kt
@@ -1,0 +1,106 @@
+package org.ole.planet.myplanet.ui.teams
+
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import android.view.View
+import android.widget.LinearLayout
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.model.News
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], application = Application::class)
+class InlineCommentsAdapterTest {
+
+    private lateinit var context: Context
+    private lateinit var adapter: InlineCommentsAdapter
+    private var deletedComment: News? = null
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        context.setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+        adapter = InlineCommentsAdapter(
+            currentUserId = "user1",
+            isLeader = false,
+            onDeleteComment = { comment -> deletedComment = comment }
+        )
+    }
+
+    @Test
+    fun `test binding comment and delete button visibility for author`() {
+        val comment1 = News().apply {
+            id = "c1"
+            userId = "user1"
+            userName = "Alice"
+            message = "Hello from Alice"
+            time = 1000L
+        }
+
+        var committed = false
+        adapter.submitList(listOf(comment1)) { committed = true }
+        while (!committed) { ShadowLooper.idleMainLooper() }
+
+        val parent = LinearLayout(context)
+        val holder = adapter.onCreateViewHolder(parent, 0)
+        adapter.onBindViewHolder(holder, 0)
+
+        assertEquals("Alice", holder.binding.tvUserName.text.toString())
+        assertEquals("Hello from Alice", holder.binding.tvMessage.text.toString())
+        assertEquals(View.VISIBLE, holder.binding.btnDeleteComment.visibility)
+
+        holder.binding.btnDeleteComment.performClick()
+        assertEquals("c1", deletedComment?.id)
+    }
+
+    @Test
+    fun `test delete button hidden for non-author and non-leader`() {
+        val comment2 = News().apply {
+            id = "c2"
+            userId = "user2"
+            userName = "Bob"
+            message = "Hello from Bob"
+            time = 1000L
+        }
+
+        var committed = false
+        adapter.submitList(listOf(comment2)) { committed = true }
+        while (!committed) { ShadowLooper.idleMainLooper() }
+
+        val parent = LinearLayout(context)
+        val holder = adapter.onCreateViewHolder(parent, 0)
+        adapter.onBindViewHolder(holder, 0)
+
+        assertEquals(View.GONE, holder.binding.btnDeleteComment.visibility)
+    }
+
+    @Test
+    fun `test delete button visible for leader even if not author`() {
+        adapter.updateCurrentUser(userId = "leader1", leader = true)
+
+        val comment2 = News().apply {
+            id = "c2"
+            userId = "user2"
+            userName = "Bob"
+            message = "Hello from Bob"
+            time = 1000L
+        }
+
+        var committed = false
+        adapter.submitList(listOf(comment2)) { committed = true }
+        while (!committed) { ShadowLooper.idleMainLooper() }
+
+        val parent = LinearLayout(context)
+        val holder = adapter.onCreateViewHolder(parent, 0)
+        adapter.onBindViewHolder(holder, 0)
+
+        assertEquals(View.VISIBLE, holder.binding.btnDeleteComment.visibility)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/TeamCalendarViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/TeamCalendarViewModelTest.kt
@@ -1,0 +1,142 @@
+package org.ole.planet.myplanet.ui.teams
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.yield
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.model.Meetup
+import org.ole.planet.myplanet.model.MeetupCreationParams
+import org.ole.planet.myplanet.model.News
+import org.ole.planet.myplanet.model.UserEntity
+import org.ole.planet.myplanet.repository.EventsRepository
+import org.ole.planet.myplanet.repository.TeamsRepository
+import org.ole.planet.myplanet.repository.UserRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TeamCalendarViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockEventsRepository: EventsRepository = mockk(relaxed = true)
+    private val mockUserRepository: UserRepository = mockk(relaxed = true)
+    private val mockTeamsRepository: TeamsRepository = mockk(relaxed = true)
+
+    private lateinit var viewModel: TeamCalendarViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = TeamCalendarViewModel(mockEventsRepository, mockUserRepository, mockTeamsRepository)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `fetchMeetups updates meetups StateFlow`() = runTest(testDispatcher) {
+        val meetupsList = listOf(Meetup().apply { id = "m1"; title = "Test Meetup" })
+        coEvery { mockEventsRepository.getMeetupsForTeam("team1") } returns meetupsList
+
+        viewModel.fetchMeetups("team1")
+        yield()
+
+        assertEquals(meetupsList, viewModel.meetups.value)
+    }
+
+    @Test
+    fun `createMeetup calls repository and emits result`() = runTest(testDispatcher) {
+        val params = MeetupCreationParams(
+            "title", "link", "desc", "loc", "10:00", "11:00", null, "planet", "user", 100L, 200L, "team1"
+        )
+        coEvery { mockEventsRepository.createMeetup(params) } returns true
+
+        val results = mutableListOf<Boolean>()
+        val job = backgroundScope.launch(testDispatcher) {
+            viewModel.createMeetupResult.collect { results.add(it) }
+        }
+
+        viewModel.createMeetup(params)
+        yield()
+
+        coVerify { mockEventsRepository.createMeetup(params) }
+        assertEquals(listOf(true), results)
+        job.cancel()
+    }
+
+    @Test
+    fun `updateMeetup delegates to repository`() = runTest(testDispatcher) {
+        coEvery {
+            mockEventsRepository.updateMeetup("m1", "t", "d", 1L, 2L, "10:00", "11:00", "loc", "link", "none")
+        } returns true
+
+        val result = viewModel.updateMeetup("m1", "t", "d", 1L, 2L, "10:00", "11:00", "loc", "link", "none")
+        assertTrue(result)
+    }
+
+    @Test
+    fun `getCommentsForMeetupFlow returns comments from repository`() = runTest(testDispatcher) {
+        val mockNews = News().apply { id = "c1"; message = "comment" }
+        every { mockEventsRepository.getCommentsForMeetupFlow("m1") } returns flowOf(listOf(mockNews))
+
+        val result = viewModel.getCommentsForMeetupFlow("m1").first()
+        assertEquals(1, result.size)
+        assertEquals("c1", result[0].id)
+    }
+
+    @Test
+    fun `getCommentsForMeetupsFlow returns comments from repository`() = runTest(testDispatcher) {
+        val mockNews = News().apply { id = "c1" }
+        every { mockEventsRepository.getCommentsForMeetupsFlow(listOf("m1")) } returns flowOf(listOf(mockNews))
+
+        val result = viewModel.getCommentsForMeetupsFlow(listOf("m1")).first()
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `addComment fetches current user and calls repository`() = runTest(testDispatcher) {
+        val mockUser = UserEntity().apply { id = "u1" }
+        coEvery { mockUserRepository.getUserModel() } returns mockUser
+
+        viewModel.addComment("m1", "team1", "hello")
+        yield()
+
+        coVerify { mockEventsRepository.addComment("m1", "team1", "hello", mockUser) }
+    }
+
+    @Test
+    fun `deleteComment calls repository deleteComment`() = runTest(testDispatcher) {
+        viewModel.deleteComment("c1")
+        yield()
+
+        coVerify { mockEventsRepository.deleteComment("c1") }
+    }
+
+    @Test
+    fun `getCurrentUser and isTeamLeader delegate to repositories`() = runTest(testDispatcher) {
+        val mockUser = UserEntity().apply { id = "u1" }
+        coEvery { mockUserRepository.getUserModel() } returns mockUser
+        coEvery { mockTeamsRepository.isTeamLeader("team1", "u1") } returns true
+
+        val user = viewModel.getCurrentUser()
+        val isLeader = viewModel.isTeamLeader("team1", "u1")
+
+        assertEquals(mockUser, user)
+        assertTrue(isLeader)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksAdapterTest.kt
@@ -1,0 +1,106 @@
+package org.ole.planet.myplanet.ui.teams.tasks
+
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import android.view.View
+import android.widget.LinearLayout
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.model.News
+import org.ole.planet.myplanet.model.TeamTask
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], application = Application::class)
+class TeamsTasksAdapterTest {
+
+    private lateinit var context: Context
+    private lateinit var adapter: TeamsTasksAdapter
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        context.setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+        adapter = TeamsTasksAdapter(context, nonTeamMember = false)
+    }
+
+    @Test
+    fun `test comments section toggle and send actions`() {
+        val task = TeamTask().apply {
+            id = "t1"
+            title = "Task Title"
+            description = "Task Desc"
+            deadline = 1000L
+            completed = false
+        }
+
+        var sentTaskId: String? = null
+        var sentMessage: String? = null
+        adapter.setOnCommentActions(
+            onSend = { id, msg ->
+                sentTaskId = id
+                sentMessage = msg
+            },
+            onDelete = {}
+        )
+
+        val comments = listOf(
+            News().apply {
+                id = "c1"
+                replyTo = "t1"
+                message = "Task comment 1"
+                userName = "User1"
+            }
+        )
+        adapter.updateComments(mapOf("t1" to comments))
+
+        var committed = false
+        adapter.submitList(listOf(task)) { committed = true }
+        while (!committed) { ShadowLooper.idleMainLooper() }
+
+        val parent = LinearLayout(context)
+        val holder = adapter.onCreateViewHolder(parent, 0)
+        adapter.onBindViewHolder(holder, 0)
+
+        assertEquals("Comments (1)", holder.binding.tvCommentCount.text.toString())
+        assertEquals(View.GONE, holder.binding.llCommentsContainer.visibility)
+
+        // Toggle expand
+        holder.binding.llCommentToggle.performClick()
+        assertEquals(View.VISIBLE, holder.binding.llCommentsContainer.visibility)
+
+        // Send comment
+        holder.binding.etComment.setText("New task comment")
+        holder.binding.btnSendComment.performClick()
+
+        assertEquals("t1", sentTaskId)
+        assertEquals("New task comment", sentMessage)
+        assertEquals("", holder.binding.etComment.text.toString())
+    }
+
+    @Test
+    fun `test nonTeamMember hides comment input`() {
+        adapter.nonTeamMember = true
+        val task = TeamTask().apply {
+            id = "t2"
+            title = "Task 2"
+            deadline = 1000L
+        }
+
+        var committed = false
+        adapter.submitList(listOf(task)) { committed = true }
+        while (!committed) { ShadowLooper.idleMainLooper() }
+
+        val parent = LinearLayout(context)
+        val holder = adapter.onCreateViewHolder(parent, 0)
+        adapter.onBindViewHolder(holder, 0)
+
+        assertEquals(View.GONE, holder.binding.llCommentInput.visibility)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksViewModelTest.kt
@@ -7,10 +7,13 @@ import io.mockk.mockk
 import java.util.Calendar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.yield
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -18,13 +21,12 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.TeamTask
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
 
 @ExperimentalCoroutinesApi
 class TeamsTasksViewModelTest {
@@ -243,5 +245,56 @@ class TeamsTasksViewModelTest {
 
         assertEquals(mapOf("1" to "Name1", "2" to "Name2"), result)
         coVerify { mockUserRepository.getUsersByIds(listOf("1", "2")) }
+    }
+
+    @Test
+    fun `getCommentsForTaskFlow returns comments from repository`() = runTest(testDispatcher) {
+        val mockNews = News().apply { id = "c1" }
+        every { mockTeamsRepository.getCommentsForTaskFlow("task1") } returns kotlinx.coroutines.flow.flowOf(listOf(mockNews))
+
+        val result = viewModel.getCommentsForTaskFlow("task1").first()
+        assertEquals(1, result.size)
+        assertEquals("c1", result[0].id)
+    }
+
+    @Test
+    fun `getCommentsForTasksFlow returns comments from repository`() = runTest(testDispatcher) {
+        val mockNews = News().apply { id = "c1" }
+        every { mockTeamsRepository.getCommentsForTasksFlow(listOf("task1")) } returns kotlinx.coroutines.flow.flowOf(listOf(mockNews))
+
+        val result = viewModel.getCommentsForTasksFlow(listOf("task1")).first()
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `addComment fetches current user and calls repository`() = runTest(testDispatcher) {
+        val mockUser = UserEntity().apply { id = "u1" }
+        coEvery { mockUserRepository.getUserModel() } returns mockUser
+
+        viewModel.addComment("task1", "team1", "hello")
+        yield()
+
+        coVerify { mockTeamsRepository.addComment("task1", "team1", "hello", mockUser) }
+    }
+
+    @Test
+    fun `deleteComment calls repository deleteComment`() = runTest(testDispatcher) {
+        viewModel.deleteComment("c1")
+        yield()
+
+        coVerify { mockTeamsRepository.deleteComment("c1") }
+    }
+
+    @Test
+    fun `getCurrentUser and isTeamLeader delegate to repositories`() = runTest(testDispatcher) {
+        val mockUser = UserEntity().apply { id = "u1" }
+        coEvery { mockUserRepository.getUserModel() } returns mockUser
+        coEvery { mockTeamsRepository.isTeamLeader("team1", "u1") } returns true
+
+        val user = viewModel.getCurrentUser()
+        val isLeader = viewModel.isTeamLeader("team1", "u1")
+
+        assertEquals(mockUser, user)
+        assertTrue(isLeader)
     }
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/7602cb1b-a17c-4e26-8642-3176cf26d49c

fixes #15112 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comments to team meetups and tasks.
  - Users can view comment counts, expand comment lists, add comments, and delete their own comments.
  - Team leaders can delete comments; comment input is restricted for non-members.
  - Updated meetup and task layouts with inline comment sections.
  - Increased app version to 0.65.47 (build 6547).

- **Tests**
  - Added coverage for comment display, permissions, creation, deletion, and repository behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->