### PR TITLE
actions: smoother workflow automerge base judging (fixes #15829)

### DIFF
--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -96,10 +96,6 @@ wait_pr_merged() {
     done
 }
 
-# Runs on a commit, optionally narrowed to the branch that commit is being
-# judged as. A sha is not owned by one branch: a branch cut from the base sits
-# on the base's tip, and its own (often concurrency-cancelled) runs answer to
-# the same head_sha. Judging the base by those is how a green base reads red.
 runs_for() {
     local raw
     raw=$(gh api "repos/$REPO/actions/runs?head_sha=$1&per_page=100" 2>/dev/null) \
@@ -113,11 +109,6 @@ runs_for() {
           | {id, name, status, conclusion} ]' <<<"$raw" 2>/dev/null || echo '[]'
 }
 
-# The runs that are a real verdict of red: completed, not green, and not
-# superseded by a green run of the same workflow on this commit. `cancelled` is
-# not a verdict at all -- `cancel-in-progress` retires runs by the dozen -- so a
-# cancelled run counts as absent, and runs_missing is what holds a required
-# workflow to actually having passed.
 runs_bad() {
     jq -c '
         ([ .[] | select(.status == "completed" and .conclusion == "success") | .name ] | unique) as $green

--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -96,19 +96,39 @@ wait_pr_merged() {
     done
 }
 
+# Runs on a commit, optionally narrowed to the branch that commit is being
+# judged as. A sha is not owned by one branch: a branch cut from the base sits
+# on the base's tip, and its own (often concurrency-cancelled) runs answer to
+# the same head_sha. Judging the base by those is how a green base reads red.
 runs_for() {
     local raw
     raw=$(gh api "repos/$REPO/actions/runs?head_sha=$1&per_page=100" 2>/dev/null) \
         || { echo '[]'; return 0; }
-    jq -c --arg self "$SELF_WORKFLOW_PATH" --arg run "$SELF_RUN_ID" '
+    jq -c --arg self "$SELF_WORKFLOW_PATH" --arg run "$SELF_RUN_ID" --arg branch "${2:-}" '
         [ .workflow_runs[]?
           | select(.path | startswith(".github/workflows/"))
           | select(.path != $self)
           | select(($run | length == 0) or ((.id | tostring) != $run))
+          | select(($branch | length == 0) or (.head_branch == $branch))
           | {id, name, status, conclusion} ]' <<<"$raw" 2>/dev/null || echo '[]'
 }
 
-runs_failed()  { jq '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length' <<<"$1"; }
+# The runs that are a real verdict of red: completed, not green, and not
+# superseded by a green run of the same workflow on this commit. `cancelled` is
+# not a verdict at all -- `cancel-in-progress` retires runs by the dozen -- so a
+# cancelled run counts as absent, and runs_missing is what holds a required
+# workflow to actually having passed.
+runs_bad() {
+    jq -c '
+        ([ .[] | select(.status == "completed" and .conclusion == "success") | .name ] | unique) as $green
+        | [ .[]
+            | select(.status == "completed")
+            | select(.conclusion != "success" and .conclusion != "skipped"
+                     and .conclusion != "neutral" and .conclusion != "cancelled")
+            | select(.name as $n | $green | index($n) | not) ]' <<<"$1"
+}
+
+runs_green()   { jq '[.[] | select(.conclusion == "success")] | length' <<<"$1"; }
 runs_pending() { jq '[.[] | select(.status != "completed")] | length' <<<"$1"; }
 
 runs_missing() {
@@ -121,20 +141,21 @@ runs_missing() {
 }
 
 wait_for_runs() {
-    local sha=$1 need=$2 absent=$3
+    local sha=$1 need=$2 absent=$3 branch=${4:-}
     local deadline=$(( SECONDS + WAIT_TIMEOUT_MIN * 60 ))
     local appear_deadline=$(( SECONDS + RUN_APPEAR_TIMEOUT_SEC ))
-    local runs total pending failed missing announced=0
+    local runs total bad pending failed green missing announced=0
 
-    log "  waiting for workflows on ${sha:0:7} (timeout ${WAIT_TIMEOUT_MIN}m)"
+    log "  waiting for workflows on ${sha:0:7}${branch:+ ($branch)} (timeout ${WAIT_TIMEOUT_MIN}m)"
     while :; do
-        runs=$(runs_for "$sha")
+        runs=$(runs_for "$sha" "$branch")
         total=$(jq 'length' <<<"$runs")
 
         if [ "$total" -gt 0 ]; then
-            failed=$(runs_failed "$runs")
+            bad=$(runs_bad "$runs")
+            failed=$(jq 'length' <<<"$bad")
             if [ "$failed" -ne 0 ]; then
-                jq -r '.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | "    \(.conclusion)\t\(.name)"' <<<"$runs"
+                jq -r '.[] | "    \(.conclusion)\t\(.name)"' <<<"$bad"
                 log "  $failed workflow(s) failed on ${sha:0:7}"
                 return 2
             fi
@@ -144,7 +165,8 @@ wait_for_runs() {
 
             if [ "$pending" -eq 0 ] && [ -z "$missing" ]; then
                 jq -r '.[] | "    \(.conclusion)\t\(.name)"' <<<"$runs"
-                log "  all $total workflow(s) green on ${sha:0:7}"
+                green=$(runs_green "$runs")
+                log "  $green of $total workflow(s) green on ${sha:0:7}, none red"
                 return 0
             fi
 
@@ -202,7 +224,7 @@ wait_run_restarted() {
 }
 
 rerun_failed_runs() {
-    local sha=$1 id name triggered=0
+    local sha=$1 branch=${2:-} id name triggered=0
     [ "$BASE_RERUN_ATTEMPTS" -gt 0 ] || return 1
 
     while IFS=$'\t' read -r id name; do
@@ -220,7 +242,7 @@ rerun_failed_runs() {
         else
             log "  could not re-run $name (run $id) -- does the token have actions: write?"
         fi
-    done < <(jq -r '.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | "\(.id)\t\(.name)"' <<<"$(runs_for "$sha")")
+    done < <(jq -r '.[] | "\(.id)\t\(.name)"' <<<"$(runs_bad "$(runs_for "$sha" "$branch")")")
 
     [ "$triggered" -eq 1 ]
 }
@@ -228,12 +250,12 @@ rerun_failed_runs() {
 wait_base_green() {
     local sha=$1 rc=0
     while :; do
-        wait_for_runs "$sha" '' pass && return 0
+        wait_for_runs "$sha" '' pass "$BASE" && return 0
         rc=$?
         [ "$rc" -eq 2 ] || return 1
         [ "$BASE_RERUN_ATTEMPTS" -gt 0 ] \
             && log "  ${sha:0:7} passed build and test as a PR head minutes ago -- treating this as flaky"
-        rerun_failed_runs "$sha" || return 1
+        rerun_failed_runs "$sha" "$BASE" || return 1
     done
 }
 
@@ -257,8 +279,8 @@ publish_failed() {
 
 base_already_failed() {
     local sha=$1 runs bad
-    runs=$(runs_for "$sha")
-    bad=$(jq -r '.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | "\(.conclusion)\t\(.name)"' <<<"$runs")
+    runs=$(runs_for "$sha" "$BASE")
+    bad=$(jq -r '.[] | "\(.conclusion)\t\(.name)"' <<<"$(runs_bad "$runs")")
     [ -n "$bad" ] || return 1
     printf '%s\n' "$bad" | sed 's/^/    /'
     log "the last merge has already failed on $BASE (${sha:0:7})"
@@ -442,7 +464,7 @@ while :; do
     fi
 
     if [ "$REQUIRE_CHECKS" = 'true' ]; then
-        wait_for_runs "$merge_sha" "$REQUIRED_WORKFLOWS" fail \
+        wait_for_runs "$merge_sha" "$REQUIRED_WORKFLOWS" fail "$HEAD" \
             || { summary "| #$NUMBER | → \`$new_name\` | **stopped**: prepared commit not green |"; exit 1; }
     else
         log "  require_checks is off -- merging ${merge_sha:0:7} unverified"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,7 +9,10 @@ name: myPlanet automerge
 #
 # A commit on the base was already built and tested green as a PR head, so a
 # red workflow there is treated as flaky first: it is re-run (base_rerun_attempts
-# times) and only a second failure stops the drain.
+# times) and only a second failure stops the drain. Only the base's own runs
+# count -- a sha is shared with every branch sitting on it -- and a `cancelled`
+# run is read as absent, not as red, since `cancel-in-progress` retires runs by
+# the dozen.
 
 on:
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,6 +399,7 @@ See `docs/CODE_STYLE_GUIDE.md` → "Branch & PR Standards" for commit-message an
 - For each labelled PR: merges the base branch in, bumps the version, waits for build + test to pass, then squash-merges
 - Logic lives in `.github/scripts/automerge.sh`; requires `AUTOMERGE_TOKEN` (the default `GITHUB_TOKEN` can't push to the protected base branch)
 - A red workflow on the base is re-run before the drain gives up (`base_rerun_attempts`, default 1): every base commit is a PR head that build + test passed on just before the squash merge, so a failure there is treated as flaky until it reproduces
+- Workflow verdicts are read per `head_sha` **and** `head_branch`: any branch cut from the base sits on the base's tip and its runs answer to the same sha, so an unscoped lookup lets another branch's runs judge the base. `cancelled` counts as absent rather than red (`cancel-in-progress` retires runs routinely), and a green run outranks an older red one of the same workflow on the same commit
 
 **Dependabot** (`.github/dependabot.yml`)
 - Daily checks for GitHub Actions updates (max 10 open PRs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,7 +399,6 @@ See `docs/CODE_STYLE_GUIDE.md` → "Branch & PR Standards" for commit-message an
 - For each labelled PR: merges the base branch in, bumps the version, waits for build + test to pass, then squash-merges
 - Logic lives in `.github/scripts/automerge.sh`; requires `AUTOMERGE_TOKEN` (the default `GITHUB_TOKEN` can't push to the protected base branch)
 - A red workflow on the base is re-run before the drain gives up (`base_rerun_attempts`, default 1): every base commit is a PR head that build + test passed on just before the squash merge, so a failure there is treated as flaky until it reproduces
-- Workflow verdicts are read per `head_sha` **and** `head_branch`: any branch cut from the base sits on the base's tip and its runs answer to the same sha, so an unscoped lookup lets another branch's runs judge the base. `cancelled` counts as absent rather than red (`cancel-in-progress` retires runs routinely), and a green run outranks an older red one of the same workflow on the same commit
 
 **Dependabot** (`.github/dependabot.yml`)
 - Daily checks for GitHub Actions updates (max 10 open PRs)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6547
-        versionName = "0.65.47"
+        versionCode = 6548
+        versionName = "0.65.48"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
The last drain ([run 32274107050](https://github.com/open-learning-exchange/myplanet/actions/runs/32274107050)) merged #15827's prepared commit, then read `master` as red while `master` was green, and started re-running workflows that were already done. It had to be cancelled and the queue drained by hand.

## What it saw

```
16:11:09 |   waiting for workflows on 9c54a03 (timeout 45m)
    cancelled	myPlanet test
    cancelled	myPlanet build
    cancelled	myPlanet test
    cancelled	myPlanet build
    cancelled	myPlanet test
    cancelled	myPlanet build
16:11:09 |   6 workflow(s) failed on 9c54a03
16:11:09 |   9c54a03 passed build and test as a PR head minutes ago -- treating this as flaky
16:11:10 |   re-running myPlanet test on 9c54a03 (run 32257235728)
...
```

None of those six runs belonged to `master`:

| run | head_branch |
|---|---|
| 32257235728 / 32257235790 | `codex/refactor-myplanet-for-performance-optimizations` |
| 32230118636 / 32230118660 | `codex/identify-tasks-for-roadmap-refactor` |
| 32230111346 / 32230111148 | `codex/identify-tasks-for-roadmap-analysis-suggestions` |

## Why

Two independent assumptions in the base check, both wrong:

1. **A sha is treated as owned by one branch.** `runs_for` asks for `actions/runs?head_sha=…` and filters only by workflow path. Three `codex/*` branches were sitting exactly on `master`'s tip, so their pushes carry the same `head_sha` — and got to vote on `master`'s health.
2. **`cancelled` is counted as red.** Anything not `success`/`skipped`/`neutral` was a failure. `build.yml` sets `cancel-in-progress: true`, so every new push to those branches retired the previous run; all six were cancelled, which is not a verdict at all.

On top of that, `wait_for_runs` returned on the first non-success without ever looking at what was green. `master`'s own `myPlanet test` and release runs on `9c54a03` were green the whole time and were never consulted.

The re-runs then landed on the `codex/*` refs, where `cancel-in-progress` was free to cancel them again — the loop had no reason to converge.

## Changes

- `runs_for` takes a branch. Base checks pass `$BASE`, the prepared-commit check passes `$HEAD`. Runs from a branch parked on the same commit no longer judge the base.
- New `runs_bad` is the single definition of "really red": completed, not green, not `cancelled`, and not superseded by a green run of the same workflow on that commit. `wait_for_runs`, `base_already_failed` and `rerun_failed_runs` all use it, so re-runs can only ever target the base's own red runs.
- `runs_missing` is unchanged and still requires each of `myPlanet build` / `myPlanet test` to have an actually-successful run on the prepared commit — a cancelled run reads as absent, never as passed, so nothing merges on the strength of one.
- Success log now reports `N of M workflow(s) green … none red` instead of claiming all of them are green when some were cancelled.

## Verification

`bash -n` clean. Replayed the incident's exact API payload (six cancelled `codex/*` runs plus `master`'s two green ones) as a fixture:

| | total | failed |
|---|---|---|
| before | 8 | **6** |
| after (`branch=master`) | 2 | **0** (2 green) |

Regression cases on the new logic: a genuinely red `master` still reports its failures, and a workflow that failed then went green on a re-run reports `0`.

Docs: the `automerge.yml` header comment and the automerge bullet in `CLAUDE.md` now state the sha-plus-branch scoping and the `cancelled` rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic merge checks by accurately tracking workflow runs for specific branches.
  * Prevented successful workflows from being incorrectly reported as failed.
  * Improved handling of retries and cancelled workflow runs.

* **Documentation**
  * Expanded workflow comments to clarify retry behavior and run tracking.

* **Chores**
  * Updated the Android app version to 0.65.48.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->