### PR TITLE
sync: smoother server url alternative credentials mapping (fixes #15834)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6551
-        versionName = "0.65.51"
+        versionCode = 6552
+        versionName = "0.65.52"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/ServerUrlMapper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/ServerUrlMapper.kt
@@ -52,11 +52,12 @@ class ServerUrlMapper @Inject constructor(
     }
 
     fun updateUrlPreferences(editor: SharedPreferences.Editor, uri: Uri, alternativeUrl: String, url: String, settings: SharedPreferences) {
+        val altUri = alternativeUrl.toUri()
         val urlUser: String
         val urlPwd: String
 
         if (alternativeUrl.contains("@")) {
-            val userinfo = getUserInfo(uri)
+            val userinfo = getUserInfo(altUri)
             urlUser = userinfo[0]
             urlPwd = userinfo[1]
         } else {
@@ -64,7 +65,6 @@ class ServerUrlMapper @Inject constructor(
             urlPwd = settings.getString("serverPin", "") ?: ""
         }
 
-        val altUri = alternativeUrl.toUri()
         val scheme = altUri.scheme
         val host = altUri.host
         val port = if (altUri.port == -1) {

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/ServerUrlMapperTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/ServerUrlMapperTest.kt
@@ -98,6 +98,34 @@ class ServerUrlMapperTest {
     }
 
     @Test
+    fun testUpdateUrlPreferencesExtractsCredentialsFromAlternativeUrlNotPrimary() {
+        val editor = mockk<SharedPreferences.Editor>()
+        val settings = mockk<SharedPreferences>()
+
+        every { editor.putString(any(), any()) } returns editor
+        every { editor.putBoolean(any(), any()) } returns editor
+        every { editor.apply() } just Runs
+
+        val uri = mockk<Uri>()
+        every { uri.userInfo } returns null
+        every { uri.scheme } returns "http"
+        every { uri.host } returns "primary.com"
+
+        val alternativeUrl = "http://clone_user:clone_pass@alternative.com:5984"
+
+        val url = "http://primary.com"
+
+        serverUrlMapper.updateUrlPreferences(editor, uri, alternativeUrl, url, settings)
+
+        verify { editor.putString("url_user", "clone_user") }
+        verify { editor.putString("url_pwd", "clone_pass") }
+        verify { editor.putString("url_Scheme", "http") }
+        verify { editor.putString("url_Host", "primary.com") }
+        verify { editor.putString("processedAlternativeUrl", alternativeUrl) }
+        verify { editor.apply() }
+    }
+
+    @Test
     fun testUpdateUrlPreferencesWithoutUserInfo() {
         val editor = mockk<SharedPreferences.Editor>()
         val settings = mockk<SharedPreferences>()


### PR DESCRIPTION
fixes #15834
Extract credentials from the alternative URL's userinfo instead of the primary URI when the alternative URL contains '@'. Moved altUri parsing before the credential extraction block so getUserInfo receives the correct URI.