### PR TITLE
sync: smoother user repository security data preserving (fixes #15836)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6552
-        versionName = "0.65.52"
+        versionCode = 6553
+        versionName = "0.65.53"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UserRepositoryImpl.kt
@@ -405,10 +405,10 @@ class UserRepositoryImpl @Inject constructor(
         val user = getUserByName(name) ?: return
         user._id = userId
         user._rev = rev
-        user.derived_key = derivedKey
-        user.salt = salt
-        user.password_scheme = passwordScheme
-        user.iterations = iterations
+        derivedKey?.let { user.derived_key = it }
+        salt?.let { user.salt = it }
+        passwordScheme?.let { user.password_scheme = it }
+        iterations?.let { user.iterations = it }
         user.isUpdated = false
         upsertUser(user)
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UserRepositoryImplTest.kt
@@ -118,6 +118,31 @@ class UserRepositoryImplTest {
     }
 
     @Test
+    fun `updateSecurityData preserves existing credentials when server response omits them`() = runTest(testDispatcher) {
+        val user = UserEntity().apply {
+            id = "123"
+            name = "john"
+            derived_key = "oldDerivedKey"
+            salt = "oldSalt"
+            password_scheme = "oldScheme"
+            iterations = "10000"
+        }
+        coEvery { userDao.getByName("john") } returns user
+        coEvery { userDao.getById("123") } returns user
+
+        repository.updateSecurityData("john", "userId", "rev", null, null, null, null)
+
+        val slot = slot<UserEntity>()
+        coVerify { userDao.upsert(capture(slot)) }
+        assertEquals("oldDerivedKey", slot.captured.derived_key)
+        assertEquals("oldSalt", slot.captured.salt)
+        assertEquals("oldScheme", slot.captured.password_scheme)
+        assertEquals("10000", slot.captured.iterations)
+        assertEquals("userId", slot.captured._id)
+        assertEquals("rev", slot.captured._rev)
+    }
+
+    @Test
     fun `getDashboardProfile uses user name if fullName is blank`() = runTest(testDispatcher) {
         val user = UserEntity().apply { name = "john"; firstName = "  "; lastName = "  " }
         val spiedRepo = spyk(repository)


### PR DESCRIPTION
fixes #15836
Only overwrite derived_key, salt, password_scheme, and iterations in updateSecurityData when the server provides non-null values. This prevents clearing existing credentials during sync when the server response omits security fields.