### PR TITLE
feat(flutter): durable background resource downloads (one‑shot WorkManager queue)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ a testable Dart seam, though that plugin's own Android side is Kotlin, and
 resource requests are persisted before the foreground attempt and handed to a network-constrained
 one-shot worker for retry and process-death recovery. Phase 44 then closed the device-identity
 serializer gap for personal, rating, submission and team uploads using the Phase 41 platform seam.
+Phase 45 hardened both: the download queue moved from a preference list to a preserved Drift table
+at schema v33, and device identity gained a UI-primed cache for headless WorkManager engines.
 
 ### Documentation Map
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ a testable Dart seam, though that plugin's own Android side is Kotlin, and
 `maintenance` cadence (`TaskDeadlineNotifier` policy behind a `NotificationPresenter` seam, with
 `team_tasks.isNotified` making the reminder once-only). Phase 43 closes the final WorkManager gap:
 resource requests are persisted before the foreground attempt and handed to a network-constrained
-one-shot worker for retry and process-death recovery.
+one-shot worker for retry and process-death recovery. Phase 44 then closed the device-identity
+serializer gap for personal, rating, submission and team uploads using the Phase 41 platform seam.
 
 ### Documentation Map
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,9 @@ present — `AutoSyncWorker`'s timed sync landed in Phase 38 through the `workma
 a testable Dart seam, though that plugin's own Android side is Kotlin, and
 `TaskNotificationWorker`'s deadline notifications landed in Phase 42 on the same plugin's
 `maintenance` cadence (`TaskDeadlineNotifier` policy behind a `NotificationPresenter` seam, with
-`team_tasks.isNotified` making the reminder once-only). `DownloadWorker`'s queue is the last
-unported `WorkManager` job.
+`team_tasks.isNotified` making the reminder once-only). Phase 43 closes the final WorkManager gap:
+resource requests are persisted before the foreground attempt and handed to a network-constrained
+one-shot worker for retry and process-death recovery.
 
 ### Documentation Map
 

--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -5,7 +5,7 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 
 ## Status
 
-**Phase 41 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
+**Phase 43 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
 **27 of 28 UI packages** have a screen, and a screen existing is not the same as the feature
 working. Counted honestly:
 
@@ -17,9 +17,9 @@ working. Counted honestly:
   the shape Kotlin has.
 
 Known gaps:
-- `DownloadWorker`'s background queue is the last unported `WorkManager` job. Timed background
-  *sync* landed in Phase 38 and `TaskNotificationWorker`'s deadline notifications in Phase 42,
-  both on the `workmanager` plugin, so what remains is one job rather than the whole category.
+- All three WorkManager responsibilities are ported. Timed background sync landed in Phase 38,
+  task deadline notifications in Phase 42, and Phase 43 added the durable one-shot resource
+  download queue.
 - Team attachments are ported as of Phase 39: a receipt image on a finance transaction or a
   report is written under `team_attachments/<docId>/<imageName>`, the document POSTs, then the
   bytes PUT as a CouchDB attachment — best-effort and in that order, the same shape the
@@ -1983,9 +1983,25 @@ listing as an open localisation item.
 
 ---
 
-**Last updated**: 2026-08-19 (Phase 42 complete — `TaskNotificationWorker`'s deadline notifications
-ported on the `maintenance` cadence: `TaskDeadlineNotifier` policy + `NotificationPresenter` seam +
-`team_tasks.isNotified` at schema v32. `DownloadWorker`'s queue is the last unported WorkManager
-job)
-**Phase**: 42 of N (27 of 28 UI packages have a screen — see Status for what that does and
+## Phase 43 — durable background resource downloads (`DownloadWorker`)
+
+The last unported WorkManager responsibility now has an end-to-end caller. A viewer download first
+stores the resource id in `PlanetPrefs`, deduplicating the queue in the same spirit as Kotlin's
+persisted URL set, and registers unique network-constrained one-shot work. The foreground request
+still starts immediately, so the viewer's existing progress and success experience does not become
+worker-latency-bound. Successful writes remove the id; failures and process death leave it durable.
+
+The background entrypoint recognizes the stable `myplanet.download` task separately from periodic
+sync and maintenance. It resolves each current library row, reuses `ResourceDownloader` so file
+placement, authentication, empty-body rejection and Drift write-back cannot diverge, removes stale
+ids whose metadata vanished, and requests WorkManager retry if any attachment fails. The background
+call disables re-enqueueing, preventing a worker from recursively scheduling itself.
+
+`BackgroundScheduler` now exposes one-shot work in addition to periodic work, keeping the plugin
+behind the same test seam. Queue policy has a focused test covering persistence, deduplication,
+scheduling constraints and completion.
+
+**Last updated**: 2026-08-19 (Phase 43 complete — the durable, network-constrained resource download
+queue closes the final unported WorkManager job)
+**Phase**: 43 of N (27 of 28 UI packages have a screen — see Status for what that does and
 does not mean)

--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -5,7 +5,7 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 
 ## Status
 
-**Phase 44 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
+**Phase 45 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
 **27 of 28 UI packages** have a screen, and a screen existing is not the same as the feature
 working. Counted honestly:
 
@@ -2012,7 +2012,28 @@ outbox payload. Teams have several enqueue sites, so their shared handler adds t
 time before POSTing. A fixed source keeps repository tests platform-independent, and each uploader
 now asserts all three values on the actual queued or posted document.
 
-**Last updated**: 2026-08-19 (Phase 44 complete — device identity parity for personal, rating,
-submission and team uploads)
-**Phase**: 44 of N (27 of 28 UI packages have a screen — see Status for what that does and
+## Phase 45 — hardening process-death work and headless identity
+
+The first download-queue pass used a `SharedPreferences` string list. That was durable but not
+transactional: the UI and WorkManager isolates could each read an old list and overwrite the
+other's update. It also used `ExistingWorkPolicy.keep`, which can strand a request added after the
+running worker snapshots the list—the new registration is ignored and the running worker never
+saw the late id.
+
+The queue is now a preserved Drift table at schema v33, one primary-keyed row per resource. SQLite
+serializes cross-isolate inserts/deletes, deduplicates by construction and participates in the
+database's local-authority migration contract. Its migration test proves a requested download
+survives an upgrade. One-shot work uses `append`, so every enqueue while another worker is active
+has a successor rather than depending on snapshot timing.
+
+Phase 44 also exposed a headless-engine edge: the device-stats channel is registered by
+`MainActivity`, which may not exist when WorkManager starts Flutter. App bootstrap now caches the
+stable composite id and model name from the UI engine. `PlatformDeviceIdentitySource` refreshes
+that cache whenever the channel is available and falls back to it when headless, while continuing
+to read the user-editable custom name live. Tests cover platform refresh, headless fallback and the
+fail-closed no-platform/no-cache case.
+
+**Last updated**: 2026-08-19 (Phase 45 complete — transactional download queue, race-free one-shot
+chaining and headless-safe device identity)
+**Phase**: 45 of N (27 of 28 UI packages have a screen — see Status for what that does and
 does not mean)

--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -5,7 +5,7 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 
 ## Status
 
-**Phase 43 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
+**Phase 44 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
 **27 of 28 UI packages** have a screen, and a screen existing is not the same as the feature
 working. Counted honestly:
 
@@ -30,10 +30,10 @@ Known gaps:
   app is Android-only.
 - The dashboard's About and Disclaimer destinations are ported (see Phase 33);
   their translated HTML bodies are rendered as markdown.
-- Device and tablet usage telemetry (`myplanet_activities`, `MyPlanet.getTabletUsages`) is
-  unported: it needs a device-info plugin, and the same absence is why the activity documents
-  the port posts omit the `androidId`/`deviceName`/`customDeviceName` trio. Challenge actions
-  (`user_challenge_actions`) are unported because the challenge feature has no screen here.
+- Device/tablet usage telemetry and device identity on activity documents landed in Phase 41.
+  Phase 44 carries the same `androidId`/`deviceName`/`customDeviceName` identity onto personal,
+  rating, submission and team uploads. Challenge actions (`user_challenge_actions`) remain
+  unported because the challenge feature has no screen here.
 
 - **Phase 1** -- skeleton plus the server configuration → login → resources slice.
 - **Phase 2** -- dashboard shell (bottom-tab navigation) plus the courses list and detail.
@@ -1880,14 +1880,10 @@ activity queue (login/resource/course rows) that landed in earlier phases.
   omitted. `ActivitiesUploader` reads them once per `queuePending` through the
   `DeviceStats` seam.
 
-### Known gap: other uploaders
+### Closed in Phase 44: other uploaders
 
-The `androidId`/`deviceName`/`customDeviceName` fields the Kotlin adds to
-**submissions, personals, ratings, and teams** uploads are still absent. Adding them
-to those serializers is a cross-cutting sweep through every uploader; this phase
-added them to the *activity* serializers only, matching the scoped task. The
-`DeviceStats` seam now exists, so closing the gap is a matter of threading it
-through each remaining uploader's constructor and doc builder.
+The `androidId`/`deviceName`/`customDeviceName` fields Kotlin adds to submissions,
+personals, ratings and teams now use the same platform seam; see Phase 44 below.
 
 ### Fixed on merge: the identity fields on a usage row
 
@@ -2001,7 +1997,22 @@ call disables re-enqueueing, preventing a worker from recursively scheduling its
 behind the same test seam. Queue policy has a focused test covering persistence, deduplication,
 scheduling constraints and completion.
 
-**Last updated**: 2026-08-19 (Phase 43 complete — the durable, network-constrained resource download
-queue closes the final unported WorkManager job)
-**Phase**: 43 of N (27 of 28 UI packages have a screen — see Status for what that does and
+## Phase 44 — device identity parity across locally-authored uploads
+
+Phase 41 introduced the platform seam but intentionally limited its serializer changes to
+activities. That left four known document families distinguishable from Kotlin at the server:
+personal resources, ratings, submissions and team documents. All four now carry Kotlin's exact
+field trio: `androidId` is the `ANDROID_ID_buildId` composite from `uniqueIdentifier()`,
+`deviceName` is the normalized manufacturer/model string, and `customDeviceName` is read from
+preferences at upload time so a renamed tablet does not retain a stale cached label.
+
+`DeviceIdentitySource` centralizes that contract rather than teaching four repositories about
+platform channels. Queue-based uploaders read it once per batch and persist the fields in each
+outbox payload. Teams have several enqueue sites, so their shared handler adds the fields at drain
+time before POSTing. A fixed source keeps repository tests platform-independent, and each uploader
+now asserts all three values on the actual queued or posted document.
+
+**Last updated**: 2026-08-19 (Phase 44 complete — device identity parity for personal, rating,
+submission and team uploads)
+**Phase**: 44 of N (27 of 28 UI packages have a screen — see Status for what that does and
 does not mean)

--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -4,6 +4,7 @@ import 'package:workmanager/workmanager.dart';
 
 import 'core/background/background_task_runner.dart';
 import 'core/background/background_task_names.dart';
+import 'core/background/background_download_queue.dart';
 import 'core/network/network_result.dart';
 import 'core/prefs/planet_prefs.dart';
 import 'core/sync/sync_result.dart';
@@ -33,10 +34,14 @@ Future<bool> executeBackgroundTask(String taskName) async {
       if (config == null) return true;
       var succeeded = true;
       final downloader = container.read(resourceDownloaderProvider);
-      for (final id in prefs.pendingResourceDownloads) {
+      final queue = BackgroundDownloadQueue(
+        container.read(downloadQueueDaoProvider),
+        container.read(backgroundSchedulerProvider),
+      );
+      for (final id in await queue.pending()) {
         final resource = await container.read(myLibraryDaoProvider).getById(id);
         if (resource == null) {
-          await prefs.removePendingResourceDownload(id);
+          await queue.complete(id);
           continue;
         }
         final result = await downloader.download(

--- a/flutter/lib/background_entrypoint.dart
+++ b/flutter/lib/background_entrypoint.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:workmanager/workmanager.dart';
 
 import 'core/background/background_task_runner.dart';
+import 'core/background/background_task_names.dart';
+import 'core/network/network_result.dart';
 import 'core/prefs/planet_prefs.dart';
 import 'core/sync/sync_result.dart';
 import 'providers/app_providers.dart';
@@ -27,6 +29,25 @@ Future<bool> executeBackgroundTask(String taskName) async {
   );
   try {
     final config = prefs.serverConfig;
+    if (taskName == BackgroundTaskNames.download) {
+      if (config == null) return true;
+      var succeeded = true;
+      final downloader = container.read(resourceDownloaderProvider);
+      for (final id in prefs.pendingResourceDownloads) {
+        final resource = await container.read(myLibraryDaoProvider).getById(id);
+        if (resource == null) {
+          await prefs.removePendingResourceDownload(id);
+          continue;
+        }
+        final result = await downloader.download(
+          resource,
+          config: config,
+          persistInBackground: false,
+        );
+        if (result is! NetworkSuccess<String>) succeeded = false;
+      }
+      return succeeded;
+    }
     final drainer = container.read(outboxDrainerProvider);
     bool completed(SyncResult result) => result is SyncComplete;
     return BackgroundTaskRunner(

--- a/flutter/lib/core/background/background_download_queue.dart
+++ b/flutter/lib/core/background/background_download_queue.dart
@@ -1,0 +1,23 @@
+import '../prefs/planet_prefs.dart';
+import 'background_scheduler.dart';
+import 'background_task_names.dart';
+
+/// Durable hand-off to the Android one-shot worker used for resource files.
+class BackgroundDownloadQueue {
+  const BackgroundDownloadQueue(this._prefs, this._scheduler);
+
+  final PlanetPrefs _prefs;
+  final BackgroundScheduler _scheduler;
+
+  Future<void> enqueue(String resourceId) async {
+    await _prefs.addPendingResourceDownload(resourceId);
+    await _scheduler.scheduleOneOff(
+      uniqueName: BackgroundTaskNames.downloadWork,
+      taskName: BackgroundTaskNames.download,
+      requiresNetwork: true,
+    );
+  }
+
+  Future<void> complete(String resourceId) =>
+      _prefs.removePendingResourceDownload(resourceId);
+}

--- a/flutter/lib/core/background/background_download_queue.dart
+++ b/flutter/lib/core/background/background_download_queue.dart
@@ -1,16 +1,16 @@
-import '../prefs/planet_prefs.dart';
+import '../../data/local/app_database.dart';
 import 'background_scheduler.dart';
 import 'background_task_names.dart';
 
 /// Durable hand-off to the Android one-shot worker used for resource files.
 class BackgroundDownloadQueue {
-  const BackgroundDownloadQueue(this._prefs, this._scheduler);
+  const BackgroundDownloadQueue(this._dao, this._scheduler);
 
-  final PlanetPrefs _prefs;
+  final DownloadQueueDao _dao;
   final BackgroundScheduler _scheduler;
 
   Future<void> enqueue(String resourceId) async {
-    await _prefs.addPendingResourceDownload(resourceId);
+    await _dao.enqueue(resourceId);
     await _scheduler.scheduleOneOff(
       uniqueName: BackgroundTaskNames.downloadWork,
       taskName: BackgroundTaskNames.download,
@@ -18,6 +18,10 @@ class BackgroundDownloadQueue {
     );
   }
 
-  Future<void> complete(String resourceId) =>
-      _prefs.removePendingResourceDownload(resourceId);
+  Future<List<String>> pending() async =>
+      (await _dao.pending()).map((row) => row.resourceId).toList();
+
+  Future<void> complete(String resourceId) async {
+    await _dao.complete(resourceId);
+  }
 }

--- a/flutter/lib/core/background/background_scheduler.dart
+++ b/flutter/lib/core/background/background_scheduler.dart
@@ -59,7 +59,10 @@ class WorkmanagerScheduler implements BackgroundScheduler {
   }) => Workmanager().registerOneOffTask(
     uniqueName,
     taskName,
-    existingWorkPolicy: ExistingWorkPolicy.keep,
+    // Every enqueue gets a successor. `keep` can strand an id inserted after
+    // the running worker took its snapshot because that registration is
+    // ignored and the current worker never sees the late row.
+    existingWorkPolicy: ExistingWorkPolicy.append,
     constraints: Constraints(
       networkType: requiresNetwork
           ? NetworkType.connected

--- a/flutter/lib/core/background/background_scheduler.dart
+++ b/flutter/lib/core/background/background_scheduler.dart
@@ -14,6 +14,12 @@ abstract interface class BackgroundScheduler {
   });
 
   Future<void> cancel(String uniqueName);
+
+  Future<void> scheduleOneOff({
+    required String uniqueName,
+    required String taskName,
+    required bool requiresNetwork,
+  });
 }
 
 class WorkmanagerScheduler implements BackgroundScheduler {
@@ -44,4 +50,21 @@ class WorkmanagerScheduler implements BackgroundScheduler {
   @override
   Future<void> cancel(String uniqueName) =>
       Workmanager().cancelByUniqueName(uniqueName);
+
+  @override
+  Future<void> scheduleOneOff({
+    required String uniqueName,
+    required String taskName,
+    required bool requiresNetwork,
+  }) => Workmanager().registerOneOffTask(
+    uniqueName,
+    taskName,
+    existingWorkPolicy: ExistingWorkPolicy.keep,
+    constraints: Constraints(
+      networkType: requiresNetwork
+          ? NetworkType.connected
+          : NetworkType.notRequired,
+      requiresBatteryNotLow: true,
+    ),
+  );
 }

--- a/flutter/lib/core/background/background_task_names.dart
+++ b/flutter/lib/core/background/background_task_names.dart
@@ -2,4 +2,6 @@
 abstract final class BackgroundTaskNames {
   static const autoSync = 'myplanet.autoSync';
   static const maintenance = 'myplanet.maintenance';
+  static const download = 'myplanet.download';
+  static const downloadWork = 'myplanet.download.work';
 }

--- a/flutter/lib/core/prefs/planet_prefs.dart
+++ b/flutter/lib/core/prefs/planet_prefs.dart
@@ -52,6 +52,7 @@ class PlanetPrefs {
   static const String _keyAutoSync = 'autoSync';
   static const String _keyAutoSyncInterval = 'autoSyncInterval';
   static const String _keyBackgroundRun = 'backgroundRun';
+  static const String _keyPendingResourceDownloads = 'pendingResourceDownloads';
 
   /// Prefix of the per-reminder keys, matching the Kotlin's
   /// `reminder_time_<surveyIds>` in its `survey_reminders` preferences file.
@@ -222,6 +223,23 @@ class PlanetPrefs {
   Future<void> clearSession() async {
     await _prefs.remove(_keyLoggedInUserId);
     await _secureStorage.delete(key: _secureKeyPassword);
+  }
+
+  /// Resource ids waiting for the one-shot background download worker.
+  /// SharedPreferences mirrors Kotlin's persisted URL set: an OS restart may
+  /// postpone the work, but cannot forget what the user asked to download.
+  List<String> get pendingResourceDownloads => List.unmodifiable(
+    _prefs.getStringList(_keyPendingResourceDownloads) ?? const [],
+  );
+
+  Future<void> addPendingResourceDownload(String resourceId) async {
+    final pending = pendingResourceDownloads.toSet()..add(resourceId);
+    await _prefs.setStringList(_keyPendingResourceDownloads, pending.toList());
+  }
+
+  Future<void> removePendingResourceDownload(String resourceId) async {
+    final pending = pendingResourceDownloads.toSet()..remove(resourceId);
+    await _prefs.setStringList(_keyPendingResourceDownloads, pending.toList());
   }
 
   /// JSON string of community leaders fetched from the server.

--- a/flutter/lib/core/prefs/planet_prefs.dart
+++ b/flutter/lib/core/prefs/planet_prefs.dart
@@ -52,7 +52,6 @@ class PlanetPrefs {
   static const String _keyAutoSync = 'autoSync';
   static const String _keyAutoSyncInterval = 'autoSyncInterval';
   static const String _keyBackgroundRun = 'backgroundRun';
-  static const String _keyPendingResourceDownloads = 'pendingResourceDownloads';
 
   /// Prefix of the per-reminder keys, matching the Kotlin's
   /// `reminder_time_<surveyIds>` in its `survey_reminders` preferences file.
@@ -76,6 +75,8 @@ class PlanetPrefs {
   /// blob, cached so `MyPlanet.getNormalMyPlanetActivities` can echo
   /// `planetVersion` back. `null` until the first server handshake reports it.
   static const String _keyVersionDetail = 'versionDetail';
+  static const String _keyDeviceUniqueIdentifier = 'deviceUniqueIdentifier';
+  static const String _keyDeviceModelName = 'deviceModelName';
 
   /// `libraryViewMode` / `courseViewMode` — port of
   /// `SharedPrefManager.getLibraryViewMode` / `getCourseViewMode`.
@@ -225,23 +226,6 @@ class PlanetPrefs {
     await _secureStorage.delete(key: _secureKeyPassword);
   }
 
-  /// Resource ids waiting for the one-shot background download worker.
-  /// SharedPreferences mirrors Kotlin's persisted URL set: an OS restart may
-  /// postpone the work, but cannot forget what the user asked to download.
-  List<String> get pendingResourceDownloads => List.unmodifiable(
-    _prefs.getStringList(_keyPendingResourceDownloads) ?? const [],
-  );
-
-  Future<void> addPendingResourceDownload(String resourceId) async {
-    final pending = pendingResourceDownloads.toSet()..add(resourceId);
-    await _prefs.setStringList(_keyPendingResourceDownloads, pending.toList());
-  }
-
-  Future<void> removePendingResourceDownload(String resourceId) async {
-    final pending = pendingResourceDownloads.toSet()..remove(resourceId);
-    await _prefs.setStringList(_keyPendingResourceDownloads, pending.toList());
-  }
-
   /// JSON string of community leaders fetched from the server.
   /// Port of `SharedPrefManager.getCommunityLeaders` / `setCommunityLeaders`.
   String get communityLeaders => _prefs.getString(_keyCommunityLeaders) ?? '';
@@ -282,6 +266,20 @@ class PlanetPrefs {
   /// Port of `SharedPrefManager.getCustomDeviceName` /
   /// `setCustomDeviceName`. Empty by default.
   String get customDeviceName => _prefs.getString(_keyCustomDeviceName) ?? '';
+
+  /// Cached for headless WorkManager engines, where MainActivity's custom
+  /// method-channel handler is not necessarily registered.
+  String? get deviceUniqueIdentifier =>
+      _prefs.getString(_keyDeviceUniqueIdentifier);
+  String? get deviceModelName => _prefs.getString(_keyDeviceModelName);
+
+  Future<void> cacheDeviceIdentity({
+    required String uniqueIdentifier,
+    required String deviceName,
+  }) async {
+    await _prefs.setString(_keyDeviceUniqueIdentifier, uniqueIdentifier);
+    await _prefs.setString(_keyDeviceModelName, deviceName);
+  }
 
   Future<void> setCustomDeviceName(String name) =>
       _prefs.setString(_keyCustomDeviceName, name);

--- a/flutter/lib/core/system/device_identity.dart
+++ b/flutter/lib/core/system/device_identity.dart
@@ -43,10 +43,29 @@ class PlatformDeviceIdentitySource implements DeviceIdentitySource {
   final PlanetPrefs _prefs;
 
   @override
-  Future<DeviceIdentity> read() async => DeviceIdentity(
-    // Kotlin calls NetworkUtils.getUniqueIdentifier(), not bare ANDROID_ID.
-    androidId: await _stats.uniqueIdentifier(),
-    deviceName: await _stats.deviceName(),
-    customDeviceName: _prefs.customDeviceName,
-  );
+  Future<DeviceIdentity> read() async {
+    String androidId;
+    String deviceName;
+    try {
+      // Kotlin calls NetworkUtils.getUniqueIdentifier(), not bare ANDROID_ID.
+      androidId = await _stats.uniqueIdentifier();
+      deviceName = await _stats.deviceName();
+      await _prefs.cacheDeviceIdentity(
+        uniqueIdentifier: androidId,
+        deviceName: deviceName,
+      );
+    } catch (_) {
+      // WorkManager may launch a Flutter engine without MainActivity, which is
+      // where this app registers its custom channel. Bootstrap primes these
+      // values from the UI engine so headless outbox drains retain parity.
+      androidId = _prefs.deviceUniqueIdentifier ?? '';
+      deviceName = _prefs.deviceModelName ?? '';
+      if (androidId.isEmpty && deviceName.isEmpty) rethrow;
+    }
+    return DeviceIdentity(
+      androidId: androidId,
+      deviceName: deviceName,
+      customDeviceName: _prefs.customDeviceName,
+    );
+  }
 }

--- a/flutter/lib/core/system/device_identity.dart
+++ b/flutter/lib/core/system/device_identity.dart
@@ -1,0 +1,52 @@
+import '../prefs/planet_prefs.dart';
+import 'device_stats.dart';
+
+/// The three device fields Kotlin appends to locally-authored CouchDB docs.
+class DeviceIdentity {
+  const DeviceIdentity({
+    required this.androidId,
+    required this.deviceName,
+    required this.customDeviceName,
+  });
+
+  final String androidId;
+  final String deviceName;
+  final String customDeviceName;
+
+  Map<String, dynamic> get documentFields => {
+    'androidId': androidId,
+    'deviceName': deviceName,
+    'customDeviceName': customDeviceName,
+  };
+}
+
+abstract interface class DeviceIdentitySource {
+  Future<DeviceIdentity> read();
+}
+
+/// Deterministic source for tests and non-platform embedders.
+class FixedDeviceIdentitySource implements DeviceIdentitySource {
+  const FixedDeviceIdentitySource(this.identity);
+
+  final DeviceIdentity identity;
+
+  @override
+  Future<DeviceIdentity> read() async => identity;
+}
+
+/// Reads identity at queue time rather than caching it: Android's identity is
+/// stable, but the user-editable custom device name is not.
+class PlatformDeviceIdentitySource implements DeviceIdentitySource {
+  const PlatformDeviceIdentitySource(this._stats, this._prefs);
+
+  final DeviceStats _stats;
+  final PlanetPrefs _prefs;
+
+  @override
+  Future<DeviceIdentity> read() async => DeviceIdentity(
+    // Kotlin calls NetworkUtils.getUniqueIdentifier(), not bare ANDROID_ID.
+    androidId: await _stats.uniqueIdentifier(),
+    deviceName: await _stats.deviceName(),
+    customDeviceName: _prefs.customDeviceName,
+  );
+}

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -55,6 +55,7 @@ part 'app_database.g.dart';
     ResourceActivities,
     CourseActivities,
     TeamNotifications,
+    DownloadQueueEntries,
   ],
   daos: [
     UserDao,
@@ -83,6 +84,7 @@ part 'app_database.g.dart';
     ResourceActivityDao,
     CourseActivityDao,
     TeamNotificationDao,
+    DownloadQueueDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -95,7 +97,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.memory() : super(NativeDatabase.memory());
 
   @override
-  int get schemaVersion => 32;
+  int get schemaVersion => 33;
 
   /// Tables holding local intent the server cannot give back.
   ///
@@ -185,6 +187,9 @@ class AppDatabase extends _$AppDatabase {
     // write-only from this app's side — no sync pulls them back.
     'resource_activity',
     'course_activity',
+    // Resource ids awaiting a network-constrained one-shot worker. This is
+    // local intent, not a server cache; dropping it silently loses downloads.
+    'download_queue',
   };
 
   @override
@@ -2928,4 +2933,26 @@ class TeamNotificationDao extends DatabaseAccessor<AppDatabase>
 
   Future<void> upsert(TeamNotificationsCompanion row) =>
       into(teamNotifications).insertOnConflictUpdate(row);
+}
+
+@DriftAccessor(tables: [DownloadQueueEntries])
+class DownloadQueueDao extends DatabaseAccessor<AppDatabase>
+    with _$DownloadQueueDaoMixin {
+  DownloadQueueDao(super.db);
+
+  Future<void> enqueue(String resourceId, {int? createdAt}) =>
+      into(downloadQueueEntries).insertOnConflictUpdate(
+        DownloadQueueEntriesCompanion.insert(
+          resourceId: resourceId,
+          createdAt: createdAt ?? DateTime.now().millisecondsSinceEpoch,
+        ),
+      );
+
+  Future<List<DownloadQueueRow>> pending() => (select(
+    downloadQueueEntries,
+  )..orderBy([(row) => OrderingTerm.asc(row.createdAt)])).get();
+
+  Future<int> complete(String resourceId) => (delete(
+    downloadQueueEntries,
+  )..where((row) => row.resourceId.equals(resourceId))).go();
 }

--- a/flutter/lib/data/local/tables.dart
+++ b/flutter/lib/data/local/tables.dart
@@ -1071,3 +1071,19 @@ class Certifications extends Table {
   @override
   Set<Column> get primaryKey => {id};
 }
+
+/// Durable resource-file work owned by this device.
+///
+/// This is intentionally separate from the upload outbox: a download has no
+/// JSON payload or CouchDB write, but needs the same process-death guarantee.
+@DataClassName('DownloadQueueRow')
+class DownloadQueueEntries extends Table {
+  @override
+  String get tableName => 'download_queue';
+
+  TextColumn get resourceId => text()();
+  IntColumn get createdAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {resourceId};
+}

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -8,6 +8,7 @@ import 'core/background/background_scheduler.dart';
 import 'core/background/background_work_coordinator.dart';
 import 'core/notifications/notification_presenter.dart';
 import 'core/prefs/planet_prefs.dart';
+import 'core/system/device_stats.dart';
 import 'providers/app_providers.dart';
 
 /// Entry point, replacing `MainApplication.kt` and the launcher Activity.
@@ -32,6 +33,7 @@ Future<void> main() async {
   // failed request must not block launch, and the reminder path tolerates the
   // permission being absent.
   unawaited(_requestNotificationPermission());
+  unawaited(_primeDeviceIdentity(prefs));
 
   runApp(
     ProviderScope(
@@ -39,6 +41,23 @@ Future<void> main() async {
       child: const MyPlanetApp(),
     ),
   );
+}
+
+Future<void> _primeDeviceIdentity(PlanetPrefs prefs) async {
+  try {
+    await prefs.cacheDeviceIdentity(
+      uniqueIdentifier: await DeviceStats.instance.uniqueIdentifier(),
+      deviceName: await DeviceStats.instance.deviceName(),
+    );
+  } catch (error, stack) {
+    FlutterError.reportError(
+      FlutterErrorDetails(
+        exception: error,
+        stack: stack,
+        library: 'device identity bootstrap',
+      ),
+    );
+  }
 }
 
 Future<void> _requestNotificationPermission() async {

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/config/server_config.dart';
+import '../core/background/background_download_queue.dart';
+import '../core/background/background_scheduler.dart';
 import '../core/notifications/notification_presenter.dart';
 import '../core/notifications/task_deadline_notifier.dart';
 import '../core/prefs/planet_prefs.dart';
@@ -65,6 +67,10 @@ import 'resources_providers.dart' show diskStatsProvider;
 /// `SharedPreferencesModule` provides a ready instance.
 final planetPrefsProvider = Provider<PlanetPrefs>(
   (ref) => throw UnimplementedError('planetPrefsProvider must be overridden'),
+);
+
+final backgroundSchedulerProvider = Provider<BackgroundScheduler>(
+  (ref) => const WorkmanagerScheduler(),
 );
 
 /// Replaces `DatabaseModule` / `DatabaseService`.
@@ -232,6 +238,10 @@ final resourceDownloaderProvider = Provider<ResourceDownloader>(
   (ref) => ResourceDownloader(
     ref.watch(planetApiProvider),
     ref.watch(myLibraryDaoProvider),
+    queue: BackgroundDownloadQueue(
+      ref.watch(planetPrefsProvider),
+      ref.watch(backgroundSchedulerProvider),
+    ),
   ),
 );
 

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -8,6 +8,7 @@ import '../core/notifications/task_deadline_notifier.dart';
 import '../core/prefs/planet_prefs.dart';
 import '../core/sync/server_url_mapper.dart';
 import '../core/system/device_stats.dart';
+import '../core/system/device_identity.dart';
 import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
@@ -131,8 +132,11 @@ final teamTasksUploaderProvider = Provider<TeamTasksUploader>(
 );
 
 final teamsUploaderProvider = Provider<TeamsUploader>(
-  (ref) =>
-      TeamsUploader(ref.watch(planetApiProvider), ref.watch(teamDaoProvider)),
+  (ref) => TeamsUploader(
+    ref.watch(planetApiProvider),
+    ref.watch(teamDaoProvider),
+    ref.watch(deviceIdentitySourceProvider),
+  ),
 );
 
 final eventsRepositoryProvider = Provider<EventsRepository>(
@@ -222,6 +226,13 @@ final activitiesUploaderProvider = Provider<ActivitiesUploader>(
 /// fake so the platform channel is never invoked.
 final deviceStatsProvider = Provider<DeviceStats>(
   (ref) => DeviceStats.instance,
+);
+
+final deviceIdentitySourceProvider = Provider<DeviceIdentitySource>(
+  (ref) => PlatformDeviceIdentitySource(
+    ref.watch(deviceStatsProvider),
+    ref.watch(planetPrefsProvider),
+  ),
 );
 
 /// Port of the `myplanet_activities` telemetry upload path
@@ -314,6 +325,7 @@ final submissionsUploaderProvider = Provider<SubmissionsUploader>(
     ref.watch(planetApiProvider),
     ref.watch(submissionsRepositoryProvider),
     ref.watch(outboxRepositoryProvider),
+    ref.watch(deviceIdentitySourceProvider),
   ),
 );
 
@@ -436,6 +448,7 @@ final personalsUploaderProvider = Provider<PersonalsUploader>(
     ref.watch(planetApiProvider),
     ref.watch(personalsRepositoryProvider),
     ref.watch(outboxRepositoryProvider),
+    ref.watch(deviceIdentitySourceProvider),
   ),
 );
 
@@ -548,6 +561,7 @@ final ratingsUploaderProvider = Provider<RatingsUploader>(
     ref.watch(appDatabaseProvider).ratingDao,
     ref.watch(userDaoProvider),
     ref.watch(outboxRepositoryProvider),
+    ref.watch(deviceIdentitySourceProvider),
   ),
 );
 

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -81,6 +81,10 @@ final appDatabaseProvider = Provider<AppDatabase>((ref) {
   return database;
 });
 
+final downloadQueueDaoProvider = Provider<DownloadQueueDao>(
+  (ref) => ref.watch(appDatabaseProvider).downloadQueueDao,
+);
+
 final userDaoProvider = Provider<UserDao>(
   (ref) => ref.watch(appDatabaseProvider).userDao,
 );
@@ -250,7 +254,7 @@ final resourceDownloaderProvider = Provider<ResourceDownloader>(
     ref.watch(planetApiProvider),
     ref.watch(myLibraryDaoProvider),
     queue: BackgroundDownloadQueue(
-      ref.watch(planetPrefsProvider),
+      ref.watch(downloadQueueDaoProvider),
       ref.watch(backgroundSchedulerProvider),
     ),
   ),

--- a/flutter/lib/providers/settings_provider.dart
+++ b/flutter/lib/providers/settings_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../core/background/background_scheduler.dart';
 import '../core/background/background_work_coordinator.dart';
 import 'app_providers.dart';
 
@@ -65,9 +64,6 @@ class LocaleNotifier extends Notifier<Locale?> {
 
 final localeProvider = NotifierProvider<LocaleNotifier, Locale?>(
   LocaleNotifier.new,
-);
-final backgroundSchedulerProvider = Provider<BackgroundScheduler>(
-  (ref) => const WorkmanagerScheduler(),
 );
 
 class BackgroundSettings {

--- a/flutter/lib/repository/personals_repository.dart
+++ b/flutter/lib/repository/personals_repository.dart
@@ -89,9 +89,8 @@ class PersonalsRepository {
 
   /// Port of `Personal.serialize`.
   ///
-  /// The `androidId`/`deviceName`/`customDeviceName` trio is device telemetry
-  /// from `NetworkUtils` that the server does not key on; it is noted in the
-  /// migration doc rather than guessed at.
+  /// Device telemetry is deliberately added by [PersonalsUploader], where the
+  /// platform seam is available; this pure row serializer remains deterministic.
   static Map<String, dynamic> serialize(
     PersonalRow row, {
     DateTime? uploadedAt,

--- a/flutter/lib/repository/personals_uploader.dart
+++ b/flutter/lib/repository/personals_uploader.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 
 import '../core/config/server_config.dart';
 import '../core/network/network_result.dart';
+import '../core/system/device_identity.dart';
 import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
@@ -28,7 +29,7 @@ import 'personals_repository.dart';
 /// the attachment is attempted, and an attachment failure does not roll the
 /// document back. This handler mirrors that ordering.
 class PersonalsUploader {
-  PersonalsUploader(this._api, this._personals, this._outbox);
+  PersonalsUploader(this._api, this._personals, this._outbox, this._identity);
 
   /// The `uploadType` these operations carry in the outbox.
   static const String type = 'personals';
@@ -36,6 +37,7 @@ class PersonalsUploader {
   final PlanetApi _api;
   final PersonalsRepository _personals;
   final OutboxRepository _outbox;
+  final DeviceIdentitySource _identity;
 
   /// Credential-free: this string is persisted in `outbox.endpoint`.
   /// The PIN travels as the `Authorization` header at send time instead.
@@ -53,12 +55,16 @@ class PersonalsUploader {
   }) async {
     final endpoint = endpointFor(config);
     final pending = await _personals.pendingUploads(userId);
+    final identity = pending.isEmpty ? null : await _identity.read();
     for (final row in pending) {
       await _outbox.enqueue(
         uploadType: type,
         itemId: row.id,
         endpoint: endpoint,
-        payload: PersonalsRepository.serialize(row),
+        payload: {
+          ...PersonalsRepository.serialize(row),
+          ...identity!.documentFields,
+        },
         userId: userId,
       );
     }

--- a/flutter/lib/repository/ratings_uploader.dart
+++ b/flutter/lib/repository/ratings_uploader.dart
@@ -1,5 +1,6 @@
 import '../core/config/server_config.dart';
 import '../core/network/network_result.dart';
+import '../core/system/device_identity.dart';
 import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
@@ -22,6 +23,7 @@ class RatingsUploader {
     this._dao,
     this._userDao,
     this._outbox,
+    this._identity,
   );
 
   static const type = 'rating';
@@ -31,6 +33,7 @@ class RatingsUploader {
   final RatingDao _dao;
   final UserDao _userDao;
   final OutboxRepository _outbox;
+  final DeviceIdentitySource _identity;
 
   /// Credential-free: this string is persisted in `outbox.endpoint`, a table
   /// that deliberately survives schema upgrades. The PIN travels as the
@@ -41,12 +44,16 @@ class RatingsUploader {
   /// Queues all pending ratings for upload.
   Future<int> queuePending({required ServerConfig config}) async {
     final rows = await _repository.pendingUploads();
+    final identity = rows.isEmpty ? null : await _identity.read();
     for (final row in rows) {
       await _outbox.enqueue(
         uploadType: type,
         itemId: row.id,
         endpoint: endpointFor(config),
-        payload: _toDoc(row, await _userDao.getById(row.userId)),
+        payload: {
+          ..._toDoc(row, await _userDao.getById(row.userId)),
+          ...identity!.documentFields,
+        },
         userId: row.userId,
       );
     }
@@ -98,9 +105,6 @@ class RatingsUploader {
       'createdOn': row.parentCode,
       'parentCode': row.parentCode,
       'planetCode': row.planetCode,
-      // Device info would go here in the Kotlin, but Flutter doesn't have
-      // access to the same device identification utilities. The server accepts
-      // ratings without these fields.
     };
     if (row.couchId != null) {
       doc['_id'] = row.couchId;

--- a/flutter/lib/repository/resource_downloader.dart
+++ b/flutter/lib/repository/resource_downloader.dart
@@ -1,4 +1,5 @@
 import '../core/config/server_config.dart';
+import '../core/background/background_download_queue.dart';
 import '../core/files/resource_files.dart';
 import '../core/network/network_result.dart';
 import '../core/utils/url_utils.dart';
@@ -12,13 +13,16 @@ import '../data/local/app_database.dart';
 /// *metadata* only: the list rendered, the viewer opened, and every resource
 /// reported itself as not downloaded because nothing had ever written a file.
 ///
-/// This is a foreground, user-initiated download. `DownloadWorker`'s
-/// background queue still needs OS scheduling and is not ported.
+/// The user-initiated request starts in the foreground, but is first persisted
+/// through [BackgroundDownloadQueue]. If the process disappears or the first
+/// attempt fails, WorkManager can finish the same request in a headless isolate.
 class ResourceDownloader {
-  ResourceDownloader(this._api, this._dao);
+  ResourceDownloader(this._api, this._dao, {BackgroundDownloadQueue? queue})
+    : _queue = queue;
 
   final PlanetApi _api;
   final MyLibraryDao _dao;
+  final BackgroundDownloadQueue? _queue;
 
   /// The attachment URL, or null when the row cannot name a file.
   static String? urlFor(ServerConfig config, MyLibraryRow resource) =>
@@ -28,7 +32,9 @@ class ResourceDownloader {
     MyLibraryRow resource, {
     required ServerConfig config,
     void Function(int received, int total)? onProgress,
+    bool persistInBackground = true,
   }) async {
+    if (persistInBackground) await _queue?.enqueue(resource.id);
     final url = urlFor(config, resource);
     if (url == null) {
       return const NetworkError<String>(null, 'Resource has no attachment');
@@ -64,6 +70,7 @@ class ResourceDownloader {
     await file.writeAsBytes(result.data, flush: true);
 
     await _dao.markDownloaded(resource.id, file.path, resource.rev);
+    await _queue?.complete(resource.id);
     return NetworkSuccess<String>(file.path);
   }
 }

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -338,11 +338,9 @@ class SubmissionsRepository {
   /// the original. This is reachable: [upsertDocuments] takes `isUpdated`
   /// straight from the server document, and [pendingUploads] selects on it.
   ///
-  /// The `androidId`/`deviceName`/`customDeviceName` telemetry and the
-  /// `source`/`parentCode` planet identifiers that Kotlin also sends are absent
-  /// — the first is device metadata the server does not key on, the second
-  /// belongs with the community-code slice. Both are noted in the migration
-  /// doc rather than guessed at.
+  /// Device telemetry is added by [SubmissionsUploader], where the platform
+  /// seam is available. The `source`/`parentCode` planet identifiers Kotlin
+  /// also sends remain part of the community-code parity gap.
   Future<Map<String, dynamic>> serialize(SubmissionRow row) async {
     final answers = await _dao.answersFor(row.id);
     return {

--- a/flutter/lib/repository/submissions_uploader.dart
+++ b/flutter/lib/repository/submissions_uploader.dart
@@ -1,5 +1,6 @@
 import '../core/config/server_config.dart';
 import '../core/network/network_result.dart';
+import '../core/system/device_identity.dart';
 import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import 'outbox_drainer.dart';
@@ -8,12 +9,18 @@ import 'submissions_repository.dart';
 
 /// Durable append-style port of the submissions `UploadConfig`.
 class SubmissionsUploader {
-  SubmissionsUploader(this._api, this._submissions, this._outbox);
+  SubmissionsUploader(
+    this._api,
+    this._submissions,
+    this._outbox,
+    this._identity,
+  );
 
   static const type = 'submissions';
   final PlanetApi _api;
   final SubmissionsRepository _submissions;
   final OutboxRepository _outbox;
+  final DeviceIdentitySource _identity;
 
   /// Credential-free — see [PersonalsUploader.endpointFor].
   static String endpointFor(ServerConfig config) =>
@@ -24,12 +31,16 @@ class SubmissionsUploader {
     required String userId,
   }) async {
     final rows = await _submissions.pendingUploads(userId);
+    final identity = rows.isEmpty ? null : await _identity.read();
     for (final row in rows) {
       await _outbox.enqueue(
         uploadType: type,
         itemId: row.id,
         endpoint: endpointFor(config),
-        payload: await _submissions.serialize(row),
+        payload: {
+          ...await _submissions.serialize(row),
+          ...identity!.documentFields,
+        },
         userId: userId,
       );
     }

--- a/flutter/lib/repository/teams_uploader.dart
+++ b/flutter/lib/repository/teams_uploader.dart
@@ -1,6 +1,7 @@
 import '../core/config/server_config.dart';
 import '../core/files/team_attachments.dart';
 import '../core/network/network_result.dart';
+import '../core/system/device_identity.dart';
 import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
@@ -30,7 +31,7 @@ import 'dart:developer';
 /// already uploaded before the bytes are attempted, and an attachment failure
 /// does not roll the document back.
 class TeamsUploader {
-  TeamsUploader(this._api, this._dao);
+  TeamsUploader(this._api, this._dao, this._identity);
 
   /// The upload types enqueued by the team providers, all handled the same way.
   static const membershipType = 'teamMembership';
@@ -48,21 +49,23 @@ class TeamsUploader {
 
   final PlanetApi _api;
   final TeamDao _dao;
+  final DeviceIdentitySource _identity;
 
   static String endpointFor(ServerConfig config) =>
       '${UrlUtils.credentialFreeDbUrl(config)}/teams';
 
   OutboxHandler get handler => (row, payload, authHeader) async {
+    final document = {...payload, ...(await _identity.read()).documentFields};
     final result = await _api.postJsonObject(
       row.endpoint,
-      payload,
+      document,
       authHeader: authHeader,
     );
     if (result case NetworkSuccess<Map<String, dynamic>>(:final data)) {
       // A tombstone's subject was already deleted locally; there is no row
       // left to stamp, and treating the missing revision as a failure would
       // retry a delete that already succeeded.
-      if (payload['_deleted'] == true) return result;
+      if (document['_deleted'] == true) return result;
       final rev = data['rev'];
       if (rev is! String) {
         return const NetworkError<Map<String, dynamic>>(

--- a/flutter/test/core/background/background_download_queue_test.dart
+++ b/flutter/test/core/background/background_download_queue_test.dart
@@ -1,13 +1,8 @@
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/core/background/background_download_queue.dart';
 import 'package:myplanet/core/background/background_scheduler.dart';
 import 'package:myplanet/core/background/background_task_names.dart';
-import 'package:myplanet/core/prefs/planet_prefs.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-
-class _MockSecureStorage extends Mock implements FlutterSecureStorage {}
+import 'package:myplanet/data/local/app_database.dart';
 
 class _Scheduler implements BackgroundScheduler {
   final oneOff = <String>[];
@@ -40,24 +35,22 @@ class _Scheduler implements BackgroundScheduler {
 }
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
+  late AppDatabase database;
+
+  setUp(() => database = AppDatabase.memory());
+  tearDown(() => database.close());
 
   test('persists unique downloads and schedules one-shot work', () async {
-    SharedPreferences.setMockInitialValues({});
-    final prefs = PlanetPrefs(
-      await SharedPreferences.getInstance(),
-      secureStorage: _MockSecureStorage(),
-    );
     final scheduler = _Scheduler();
-    final queue = BackgroundDownloadQueue(prefs, scheduler);
+    final queue = BackgroundDownloadQueue(database.downloadQueueDao, scheduler);
 
     await queue.enqueue('resource-1');
     await queue.enqueue('resource-1');
 
-    expect(prefs.pendingResourceDownloads, ['resource-1']);
+    expect(await queue.pending(), ['resource-1']);
     expect(scheduler.oneOff, hasLength(2));
 
     await queue.complete('resource-1');
-    expect(prefs.pendingResourceDownloads, isEmpty);
+    expect(await queue.pending(), isEmpty);
   });
 }

--- a/flutter/test/core/background/background_download_queue_test.dart
+++ b/flutter/test/core/background/background_download_queue_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/background/background_download_queue.dart';
+import 'package:myplanet/core/background/background_scheduler.dart';
+import 'package:myplanet/core/background/background_task_names.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockSecureStorage extends Mock implements FlutterSecureStorage {}
+
+class _Scheduler implements BackgroundScheduler {
+  final oneOff = <String>[];
+
+  @override
+  Future<void> scheduleOneOff({
+    required String uniqueName,
+    required String taskName,
+    required bool requiresNetwork,
+  }) async {
+    expect(uniqueName, BackgroundTaskNames.downloadWork);
+    expect(taskName, BackgroundTaskNames.download);
+    expect(requiresNetwork, isTrue);
+    oneOff.add(uniqueName);
+  }
+
+  @override
+  Future<void> cancel(String uniqueName) async {}
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> schedulePeriodic({
+    required String uniqueName,
+    required String taskName,
+    required Duration frequency,
+    required bool requiresNetwork,
+  }) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('persists unique downloads and schedules one-shot work', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = PlanetPrefs(
+      await SharedPreferences.getInstance(),
+      secureStorage: _MockSecureStorage(),
+    );
+    final scheduler = _Scheduler();
+    final queue = BackgroundDownloadQueue(prefs, scheduler);
+
+    await queue.enqueue('resource-1');
+    await queue.enqueue('resource-1');
+
+    expect(prefs.pendingResourceDownloads, ['resource-1']);
+    expect(scheduler.oneOff, hasLength(2));
+
+    await queue.complete('resource-1');
+    expect(prefs.pendingResourceDownloads, isEmpty);
+  });
+}

--- a/flutter/test/core/background/background_work_coordinator_test.dart
+++ b/flutter/test/core/background/background_work_coordinator_test.dart
@@ -21,6 +21,13 @@ class _RecordingScheduler implements BackgroundScheduler {
   Future<void> cancel(String uniqueName) async => cancelled.add(uniqueName);
 
   @override
+  Future<void> scheduleOneOff({
+    required String uniqueName,
+    required String taskName,
+    required bool requiresNetwork,
+  }) async {}
+
+  @override
   Future<void> schedulePeriodic({
     required String uniqueName,
     required String taskName,

--- a/flutter/test/core/system/device_identity_test.dart
+++ b/flutter/test/core/system/device_identity_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/core/system/device_identity.dart';
+import 'package:myplanet/core/system/device_stats.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _Stats extends Mock implements DeviceStats {}
+
+class _SecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late PlanetPrefs prefs;
+  late _Stats stats;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({
+      'customDeviceName': 'library tablet',
+    });
+    prefs = PlanetPrefs(
+      await SharedPreferences.getInstance(),
+      secureStorage: _SecureStorage(),
+    );
+    stats = _Stats();
+  });
+
+  test('reads the platform identity and caches it for headless work', () async {
+    when(() => stats.uniqueIdentifier()).thenAnswer((_) async => 'id_build');
+    when(() => stats.deviceName()).thenAnswer((_) async => 'TEST DEVICE');
+
+    final identity = await PlatformDeviceIdentitySource(stats, prefs).read();
+
+    expect(identity.androidId, 'id_build');
+    expect(identity.deviceName, 'TEST DEVICE');
+    expect(identity.customDeviceName, 'library tablet');
+    expect(prefs.deviceUniqueIdentifier, 'id_build');
+    expect(prefs.deviceModelName, 'TEST DEVICE');
+  });
+
+  test('uses the cache when the background engine has no channel', () async {
+    await prefs.cacheDeviceIdentity(
+      uniqueIdentifier: 'cached_build',
+      deviceName: 'CACHED DEVICE',
+    );
+    when(() => stats.uniqueIdentifier()).thenThrow(StateError('no channel'));
+
+    final identity = await PlatformDeviceIdentitySource(stats, prefs).read();
+
+    expect(identity.androidId, 'cached_build');
+    expect(identity.deviceName, 'CACHED DEVICE');
+    expect(identity.customDeviceName, 'library tablet');
+  });
+
+  test('does not fabricate an identity when platform and cache are absent', () {
+    when(() => stats.uniqueIdentifier()).thenThrow(StateError('no channel'));
+
+    expect(
+      () => PlatformDeviceIdentitySource(stats, prefs).read(),
+      throwsStateError,
+    );
+  });
+}

--- a/flutter/test/data/local/migration_test.dart
+++ b/flutter/test/data/local/migration_test.dart
@@ -50,6 +50,18 @@ void main() {
     );
   });
 
+  test('a queued resource download survives a schema upgrade', () async {
+    await database.downloadQueueDao.enqueue('resource-1', createdAt: 1000);
+
+    await runUpgrade();
+
+    expect(
+      (await database.downloadQueueDao.pending()).map((row) => row.resourceId),
+      ['resource-1'],
+      reason: 'the server cannot reconstruct a download the user requested',
+    );
+  });
+
   test('an un-uploaded personal note survives a schema upgrade', () async {
     await database.personalDao.upsert(
       PersonalEntriesCompanion.insert(
@@ -591,6 +603,7 @@ void main() {
       'offline_activity',
       'resource_activity',
       'course_activity',
+      'download_queue',
     };
     expect(
       AppDatabase.localAuthorityTables,

--- a/flutter/test/repository/device_identity_fixture.dart
+++ b/flutter/test/repository/device_identity_fixture.dart
@@ -1,0 +1,15 @@
+import 'package:myplanet/core/system/device_identity.dart';
+
+const testDeviceIdentity = FixedDeviceIdentitySource(
+  DeviceIdentity(
+    androidId: 'android-id_build-id',
+    deviceName: 'TEST DEVICE',
+    customDeviceName: 'classroom tablet',
+  ),
+);
+
+const testDeviceFields = <String, dynamic>{
+  'androidId': 'android-id_build-id',
+  'deviceName': 'TEST DEVICE',
+  'customDeviceName': 'classroom tablet',
+};

--- a/flutter/test/repository/personals_uploader_test.dart
+++ b/flutter/test/repository/personals_uploader_test.dart
@@ -12,6 +12,8 @@ import 'package:myplanet/repository/outbox_repository.dart';
 import 'package:myplanet/repository/personals_repository.dart';
 import 'package:myplanet/repository/personals_uploader.dart';
 
+import 'device_identity_fixture.dart';
+
 class MockPlanetApi extends Mock implements PlanetApi {}
 
 void main() {
@@ -39,7 +41,7 @@ void main() {
       createId: () => 'note-${nextId++}',
     );
     outbox = OutboxRepository(database.outboxDao, now: () => clock);
-    uploader = PersonalsUploader(api, personals, outbox);
+    uploader = PersonalsUploader(api, personals, outbox, testDeviceIdentity);
   });
   tearDown(() => database.close());
 
@@ -140,6 +142,10 @@ void main() {
     final row = (await outbox.due()).single;
     expect(row.endpoint, isNot(contains(config.pin)));
     expect(row.payload, isNot(contains(config.pin)));
+    final payload = jsonDecode(row.payload) as Map<String, dynamic>;
+    for (final field in testDeviceFields.entries) {
+      expect(payload, containsPair(field.key, field.value));
+    }
   });
 
   test('a successful upload adopts the ids CouchDB assigned', () async {

--- a/flutter/test/repository/ratings_uploader_test.dart
+++ b/flutter/test/repository/ratings_uploader_test.dart
@@ -11,6 +11,8 @@ import 'package:myplanet/repository/outbox_repository.dart';
 import 'package:myplanet/repository/ratings_repository.dart';
 import 'package:myplanet/repository/ratings_uploader.dart';
 
+import 'device_identity_fixture.dart';
+
 void main() {
   late AppDatabase database;
   late MockPlanetApi api;
@@ -37,6 +39,7 @@ void main() {
       database.ratingDao,
       database.userDao,
       outbox,
+      testDeviceIdentity,
     );
   });
   tearDown(() => database.close());
@@ -97,6 +100,10 @@ void main() {
       DateTime.now().millisecondsSinceEpoch + 1000,
     );
     expect(queued.map((row) => row.itemId), ['rating-1']);
+    final payload = jsonDecode(queued.single.payload) as Map<String, dynamic>;
+    for (final field in testDeviceFields.entries) {
+      expect(payload, containsPair(field.key, field.value));
+    }
   });
 
   test('a successful upload marks the rating as uploaded', () async {

--- a/flutter/test/repository/submissions_uploader_test.dart
+++ b/flutter/test/repository/submissions_uploader_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -8,6 +10,8 @@ import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/outbox_repository.dart';
 import 'package:myplanet/repository/submissions_repository.dart';
 import 'package:myplanet/repository/submissions_uploader.dart';
+
+import 'device_identity_fixture.dart';
 
 class MockPlanetApi extends Mock implements PlanetApi {}
 
@@ -28,7 +32,7 @@ void main() {
     api = MockPlanetApi();
     repository = SubmissionsRepository(api, db.submissionDao);
     outbox = OutboxRepository(db.outboxDao);
-    uploader = SubmissionsUploader(api, repository, outbox);
+    uploader = SubmissionsUploader(api, repository, outbox, testDeviceIdentity);
   });
   tearDown(() => db.close());
 
@@ -42,6 +46,10 @@ void main() {
     expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
     expect(await uploader.queuePending(config: config, userId: 'user-1'), 1);
     final operation = (await outbox.due()).single;
+    final queuedDoc = jsonDecode(operation.payload) as Map<String, dynamic>;
+    for (final field in testDeviceFields.entries) {
+      expect(queuedDoc, containsPair(field.key, field.value));
+    }
     when(
       () => api.postJsonObject(
         operation.endpoint,

--- a/flutter/test/repository/teams_uploader_test.dart
+++ b/flutter/test/repository/teams_uploader_test.dart
@@ -11,6 +11,8 @@ import 'package:myplanet/data/local/team_mapper.dart';
 import 'package:myplanet/repository/teams_uploader.dart';
 import 'package:path_provider/path_provider.dart';
 
+import 'device_identity_fixture.dart';
+
 void main() {
   late AppDatabase database;
   late MockPlanetApi api;
@@ -20,7 +22,7 @@ void main() {
   setUp(() async {
     database = AppDatabase.memory();
     api = MockPlanetApi();
-    uploader = TeamsUploader(api, database.teamDao);
+    uploader = TeamsUploader(api, database.teamDao, testDeviceIdentity);
     registerFallbackValue(<String, dynamic>{});
 
     // Route `TeamAttachments` at a temp dir so the write-back can read the
@@ -62,22 +64,27 @@ void main() {
 
   test('a successful upload hands the row back to the server', () async {
     await seedLocalReport();
+    late Map<String, dynamic> posted;
     when(
       () => api.postJsonObject(
         any(),
         any(),
         authHeader: any(named: 'authHeader'),
       ),
-    ).thenAnswer(
-      (_) async => NetworkSuccess<Map<String, dynamic>>({
+    ).thenAnswer((invocation) async {
+      posted = invocation.positionalArguments[1] as Map<String, dynamic>;
+      return NetworkSuccess<Map<String, dynamic>>({
         'id': 'report-1',
         'rev': '2-b',
-      }),
-    );
+      });
+    });
 
     final result = await uploader.handler(rowFor('report-1'), {}, 'auth');
 
     expect(result, isA<NetworkSuccess<Map<String, dynamic>>>());
+    for (final field in testDeviceFields.entries) {
+      expect(posted, containsPair(field.key, field.value));
+    }
     final row = await database.teamDao.getById('report-1');
     expect(row?.rev, '2-b');
     // Still flagged, the row would outrank every future server refresh and

--- a/flutter/test/ui/settings_screen_test.dart
+++ b/flutter/test/ui/settings_screen_test.dart
@@ -6,7 +6,6 @@ import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/core/background/background_scheduler.dart';
 import 'package:myplanet/core/prefs/planet_prefs.dart';
 import 'package:myplanet/providers/app_providers.dart';
-import 'package:myplanet/providers/settings_provider.dart';
 import 'package:myplanet/ui/settings/settings_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -205,6 +204,13 @@ class _RecordingScheduler implements BackgroundScheduler {
 
   @override
   Future<void> initialize() async {}
+
+  @override
+  Future<void> scheduleOneOff({
+    required String uniqueName,
+    required String taskName,
+    required bool requiresNetwork,
+  }) async {}
 
   @override
   Future<void> schedulePeriodic({


### PR DESCRIPTION
### Motivation

- Close the remaining WorkManager gap by making resource downloads durable so a foreground attempt can be recovered by a network‑constrained one‑shot worker after process death.
- Ensure the downloader and the headless worker share the same logic for authentication, file placement and Drift write‑back so behavior cannot diverge.

### Description

- Add a durable queue `BackgroundDownloadQueue` that persists resource ids in `PlanetPrefs` and schedules unique one‑shot work via a new `scheduleOneOff` API on the `BackgroundScheduler` seam, and two new task names `myplanet.download` / `myplanet.download.work`.
- Extend `ResourceDownloader` to persist the download request before the foreground attempt and to remove the pending id only after the file is written and `markDownloaded` updates Drift, with an opt‑out flag (`persistInBackground`) for headless runs.
- Teach the background entrypoint to handle the `myplanet.download` task by draining `PlanetPrefs.pendingResourceDownloads`, resolving each library row, calling the existing downloader with `persistInBackground: false`, dropping stale ids, and returning a failure flag when any attachment failed so WorkManager may retry.
- Wire the new queue into the provider graph (`resourceDownloaderProvider` + `backgroundSchedulerProvider`) and add a focused unit test `background_download_queue_test.dart` covering persistence, deduplication, scheduling and completion.

### Testing

- Ran formatting check `dart format --output=none --set-exit-if-changed lib test`, which succeeded.
- Ran static analysis with `flutter analyze`, which reported no issues.
- Ran the full Flutter unit test suite with `flutter test`, and all tests passed (including the new `background_download_queue_test.dart`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86039fdca8832b8467e0190b87b344)