### PR TITLE
Refactor getOfflineLogins flow

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepository.kt
@@ -11,7 +11,7 @@ import org.ole.planet.myplanet.model.UserEntity
 interface ActivitiesRepository {
     suspend fun getOfflineVisitCount(userId: String): Int
     suspend fun getOfflineLoginCount(userName: String): Int
-    suspend fun getOfflineLogins(userName: String): Flow<List<OfflineActivity>>
+    fun getOfflineLogins(userName: String): Flow<List<OfflineActivity>>
     suspend fun markResourceAdded(userId: String?, resourceId: String)
     suspend fun markResourceRemoved(userId: String, resourceId: String)
     suspend fun logCourseVisit(courseId: String, title: String, userId: String)

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import org.ole.planet.myplanet.data.api.ApiInterface
@@ -59,8 +60,8 @@ class ActivitiesRepositoryImpl @Inject constructor(
         return offlineActivityDao.countByUserNameAndType(userName, UserSessionManager.KEY_LOGIN)
     }
 
-    override suspend fun getOfflineLogins(userName: String): Flow<List<OfflineActivity>> {
-        return offlineActivityDao.observeByUserNameAndType(userName, UserSessionManager.KEY_LOGIN)
+    override fun getOfflineLogins(userName: String): Flow<List<OfflineActivity>> {
+        return offlineActivityDao.observeByUserNameAndType(userName, UserSessionManager.KEY_LOGIN).distinctUntilChanged()
     }
 
     override suspend fun markResourceAdded(userId: String?, resourceId: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/ActivitiesFragment.kt
@@ -17,11 +17,14 @@ import java.text.DateFormatSymbols
 import java.util.Calendar
 import javax.inject.Inject
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentActivitiesBinding
 import org.ole.planet.myplanet.model.OfflineActivity
 import org.ole.planet.myplanet.repository.ActivitiesRepository
+import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 
 @AndroidEntryPoint
@@ -32,6 +35,10 @@ class ActivitiesFragment : Fragment() {
     lateinit var userSessionManager: UserSessionManager
     @Inject
     lateinit var activitiesRepository: ActivitiesRepository
+    @Inject
+    lateinit var sharedPrefManager: SharedPrefManager
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentActivitiesBinding.inflate(inflater, container, false)
@@ -45,11 +52,13 @@ class ActivitiesFragment : Fragment() {
         val endMillis = Calendar.getInstance().timeInMillis
         val startMillis = Calendar.getInstance().apply { add(Calendar.YEAR, -1) }.timeInMillis
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            val userName = userSessionManager.getUserModel()?.name ?: return@launch
+        val userName = sharedPrefManager.getUserName()
+        if (userName.isNotEmpty()) {
             val loginsFlow = activitiesRepository.getOfflineLogins(userName)
             collectLatestWhenStarted(loginsFlow) { logins ->
-                val monthlyCounts = computeMonthlyCounts(logins, startMillis, endMillis)
+                val monthlyCounts = withContext(dispatcherProvider.default) {
+                    computeMonthlyCounts(logins, startMillis, endMillis)
+                }
                 renderChart(monthlyCounts, daynightTextColor)
             }
         }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImplTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import dagger.Lazy
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import java.util.logging.Level
@@ -98,7 +99,7 @@ class ActivitiesRepositoryImplTest {
     @Test
     fun `getOfflineLogins returns flow of activities`() = runTest {
         val mockActivities = listOf(OfflineActivity().apply { userName = "john" })
-        coEvery { offlineActivityDao.observeByUserNameAndType("john", UserSessionManager.KEY_LOGIN) } returns flowOf(mockActivities)
+        every { offlineActivityDao.observeByUserNameAndType("john", UserSessionManager.KEY_LOGIN) } returns flowOf(mockActivities)
 
         repository.getOfflineLogins("john").collect {
             assertEquals(mockActivities, it)


### PR DESCRIPTION
Removes the redundant `suspend` keyword from a method that constructs a Flow, preventing an unnecessary nested coroutine launch in `ActivitiesFragment`. Additionally, adds `distinctUntilChanged` for efficiency and offloads charting data aggregation to a background thread.

---
*PR created automatically by Jules for task [13149955147218574590](https://jules.google.com/task/13149955147218574590) started by @dogi*