### PR TITLE
perf(CameraUtils): move JPEG byte copy off main thread

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/CameraUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/CameraUtils.kt
@@ -52,11 +52,11 @@ object CameraUtils {
         imageReader?.setOnImageAvailableListener({ reader ->
             val image = reader.acquireLatestImage()
             if (image != null) {
-                val buffer = image.planes[0].buffer
-                val bytes = ByteArray(buffer.capacity())
-                buffer.get(bytes)
-                image.close()
-                scope.launch {
+                scope.launch(dispatcherProvider.io) {
+                    val buffer = image.planes[0].buffer
+                    val bytes = ByteArray(buffer.capacity())
+                    buffer.get(bytes)
+                    image.close()
                     savePicture(bytes, callback, dispatcherProvider)
                 }
             }


### PR DESCRIPTION
Moves the `buffer.get(bytes)` call from the `ImageReader.OnImageAvailableListener`
(which executes on the main thread) into a coroutine launched on `dispatcherProvider.io`.
This prevents stalling the UI thread during image captures. Also ensures `image.close()`
happens safely within the same coroutine after the buffer is copied.

---
*PR created automatically by Jules for task [3569912595753770855](https://jules.google.com/task/3569912595753770855) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image capture reliability by moving image processing and saving to background execution.
  * Reduced the risk of UI slowdowns or freezes when capturing and saving photos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->