### PR TITLE
Notifications routing, batch resource selection/shelf actions, and team-finances summary (UI + repo + tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,16 @@ real — they had been setting a locale with no `.arb` to resolve to. Somali nee
 locale would otherwise resolve with no `MaterialLocalizations` and crash. Directional padding and
 alignment are done; a visual RTL review in Arabic is not.
 
+Phase 48 fixed the team-finance summary so it is derived from the filtered transaction stream.
+Phase 49 made notification rows actionable rather than read-only: resources and storage warnings
+open their matching screens, while task and join-request notifications resolve their cached team
+documents before opening that team's tasks or join-requests tab. Already-read notifications remain
+actionable, matching Kotlin's click behaviour.
+
+Phase 50 closed the resource-catalog batch-selection gap. Long-press enters selection mode in both
+list and grid layouts, further taps build a multi-selection, and one add/remove action atomically
+updates every resource plus its `removed_log` entry before attempting the derived shelf upload.
+
 ### Documentation Map
 
 | Document | Read it when… |

--- a/docs/kotlin-to-flutter-migration.md
+++ b/docs/kotlin-to-flutter-migration.md
@@ -5,7 +5,7 @@ Tracking document for migrating myPlanet from the **Kotlin/Android** app in `app
 
 ## Status
 
-**Phase 47 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
+**Phase 50 complete.** The Flutter app is *not* yet a replacement for the Kotlin app:
 **27 of 28 UI packages** have a screen, and a screen existing is not the same as the feature
 working. Counted honestly:
 
@@ -34,6 +34,8 @@ Known gaps:
   Phase 44 carries the same `androidId`/`deviceName`/`customDeviceName` identity onto personal,
   rating, submission and team uploads. Challenge actions (`user_challenge_actions`) remain
   unported because the challenge feature has no screen here.
+- Notification destination routing landed in Phase 49. Resource and storage rows open their
+  feature screens; task and join-request rows resolve cached team data before navigating.
 
 - **Phase 1** -- skeleton plus the server configuration → login → resources slice.
 - **Phase 2** -- dashboard shell (bottom-tab navigation) plus the courses list and detail.
@@ -1486,7 +1488,8 @@ features (deferred):
   blank-string nav arg as absent (`.takeIf { isNotBlank() }`). The port reads
   `teamName` from the watched `TeamRow`, not a blank-string nav arg, so the
   edge case does not arise. (2) Adds `subType` to `AppNotification` for
-  destination-view routing — see **deferred** below.
+  finer-grained destination-view routing — basic type/related-id routing is
+  now Phase 49; `subType` remains deferred below.
 - `d5f9998e1` (database service module removal) — deletes the vestigial
   `DatabaseService`/`DatabaseModule` and updates docs. The port has no
   `DatabaseService` equivalent (drift `AppDatabase` is used directly).
@@ -1566,10 +1569,11 @@ features (deferred):
   submitted. The port's `Surveys` table has no `courseId`, so
   course-attached surveys are not modeled; the toast is not portable to the
   current schema.
-- `a08fc5662`'s `subType` on `AppNotification` — enables notification
-  destination-view routing the port does not yet have (the port's
-  notification `onTap` only marks-as-read; there is no navigation to a team/
-  course/resource destination). The field would land with that routing.
+- `a08fc5662`'s `subType` on `AppNotification` — enables finer destination
+  selection within a feature. Phase 49 now routes the four notification types
+  Kotlin handles (`resource`, `storage`, `task`, and `join_request`) from the
+  existing `type`/`relatedId` fields. `subType` is still absent, so any newer
+  course/resource sub-destination that depends on it remains deferred.
 - `437a3d28a` (enterprises finances date picking) — carried over from the
   prior batch; enterprises is not ported.
 
@@ -1698,12 +1702,10 @@ already carries the equivalent behaviour where one exists.
 - `dd16b4d6b` (resources search view modelling) — wraps
   `saveSearchActivity`, `removeResourcesFromShelf`, and `getFilterFacets` in
   `ResourcesViewModel` methods and makes `removeResourcesFromShelf` surface
-  its `Result.onFailure` as an error toast. The port has no batch resource
-  selection / removal screen and no `saveSearchActivity` / `getFilterFacets`
-  (search-activity logging is unported), and its single-resource shelf removal
-  in `resource_detail_screen.dart` already shows a failure snackbar. Deferred
-  (lands on the unported batch-resources path); the error-surfacing half is
-  already present.
+  its `Result.onFailure` as an error toast. Phase 50 now carries batch resource
+  selection/removal and its failure snackbar. `saveSearchActivity` remains
+  unported; filter facets are computed locally from the cached catalog rather
+  than through a repository method.
 
 **RecyclerView / adapter-internal refactors (no Flutter equivalent).**
 
@@ -2107,8 +2109,70 @@ Also fixed: `l10n.yaml`'s header still pointed at `../crowdin.yml`, deleted from
 
 ---
 
-**Last updated**: 2026-08-20 (Phase 47 complete — Arabic, French, Nepali and Somali derived from the
-Kotlin `strings.xml`, the four dead language-picker entries made real, framework fallback delegates
-added for Somali, and the directional-layout half of the RTL pass done)
-**Phase**: 47 of N (27 of 28 UI packages have a screen — see Status for what that does and
+### Phase 48 -- make the finance summary reflect its transactions
+
+The team-finances screen already had the Kotlin enterprises date filters, sort control, receipt
+attachments, and debit/credit list, but its summary was calculated too late. The summary widgets
+were built with zeroes before the `AsyncValue.data` branch iterated the loaded transactions. The
+correct totals only changed local variables after those widgets had been created, so every team
+always displayed debit `0`, credit `0`, and balance `0` above an otherwise-correct ledger.
+
+The summary now lives in the same data branch as the transaction list. Debit and credit are reduced
+from the filtered rows, balance is derived from those totals, and all three values are built together
+for each stream emission. This also means a date-filter or sort-driven provider refresh cannot show
+a stale summary from an earlier result. A widget test pins a 125-credit/40-debit ledger to the
+expected 85 balance. No image, font, or other binary asset was added.
+
+---
+
+### Phase 49 -- restore notification destination routing
+
+The Flutter notification list had copied the grouped presentation and read/delete actions, but not
+`NotificationsFragment.handleNotificationClick`. Tapping an unread row only marked it read, after
+which Flutter set `onTap` to null. Resource, storage, task, and join-request notifications were all
+dead ends, and even that one mark-read action could not be repeated to revisit a destination.
+
+Notification rows now remain actionable whether read or unread. The first tap still marks an unread
+row, then a Dart resolver applies Kotlin's destination policy:
+
+- `resource` opens the resources catalog;
+- `storage` opens Flutter's storage-management screen;
+- `task` resolves `relatedId` through the cached task and opens that team's task screen; and
+- `join_request` resolves the cached request document and opens the join-requests tab on that
+  team's members screen.
+
+Resolution deliberately fails closed when a related id is blank, its cached document is missing, or
+the type is unknown; the row is still marked read, but the app does not invent a team or malformed
+route. The resolver is separate from the widget and covered for all four destinations plus missing,
+blank, and unknown inputs. This is entirely Dart/Drift/go_router work with no platform code or binary
+assets.
+
+---
+
+### Phase 50 -- batch resource shelf actions
+
+The resource catalog now ports the Kotlin adapter's multi-selection path instead of forcing a
+learner through one detail screen per resource. Long-pressing a list row or grid card enters a
+contextual selection mode; subsequent taps toggle more resources, selected tiles are visibly
+highlighted, and the app bar offers add-to-library and remove-from-library actions. Closing the
+contextual bar clears the selection without changing data.
+
+The write is more than a visual shortcut. `ResourcesRepository.setShelfMemberships` loads all
+selected rows and updates their `userId` membership arrays in one Drift transaction. In that same
+transaction it clears stale removal records for additions or records every removal, so the shelf
+merge cannot resurrect only part of a batch. Once the local write commits,
+`ResourceShelfActions` attempts the derived CouchDB shelf upload when server configuration and a
+CouchDB user id are available; offline and local-only accounts keep the durable local truth for a
+later push.
+
+Selection works in list and grid layouts and preserves the existing ordinary-tap navigation when
+selection mode is inactive. Repository coverage pins the two-row atomic removal/removal-log result,
+and a widget test exercises long-press, multi-select, contextual add, selection clearing, and the
+success message. No binary assets or platform code were added.
+
+---
+
+**Last updated**: 2026-08-20 (Phase 50 complete — the resource catalog now supports atomic
+multi-selection add/remove shelf actions in both list and grid layouts)
+**Phase**: 50 of N (27 of 28 UI packages have a screen — see Status for what that does and
 does not mean)

--- a/flutter/lib/providers/resources_providers.dart
+++ b/flutter/lib/providers/resources_providers.dart
@@ -5,6 +5,7 @@ import '../core/system/disk_stats.dart';
 import '../core/sync/sync_result.dart';
 import '../data/local/app_database.dart';
 import 'app_providers.dart';
+import 'session_provider.dart';
 import 'sync_state.dart';
 
 /// The resource-list search box. Replaces the `searchTags`/`etSearch` state that
@@ -21,6 +22,31 @@ final resourcesStreamProvider = StreamProvider<List<MyLibraryRow>>((ref) {
   final query = ref.watch(resourceSearchQueryProvider);
   return ref.watch(resourcesRepositoryProvider).watchResources(query: query);
 });
+
+class ResourceShelfActions {
+  const ResourceShelfActions(this.ref);
+  final Ref ref;
+
+  Future<void> setMemberships(
+    Iterable<String> resourceIds, {
+    required bool joined,
+  }) async {
+    final user = ref.read(sessionProvider).valueOrNull;
+    if (user == null) return;
+    await ref
+        .read(resourcesRepositoryProvider)
+        .setShelfMemberships(resourceIds, user.id, joined: joined);
+
+    final config = ref.read(serverConfigProvider);
+    final couchId = user.couchId;
+    if (config == null || couchId == null || couchId.isEmpty) return;
+    await ref
+        .read(shelfRepositoryProvider)
+        .upload(config: config, userId: user.id, shelfDocId: couchId);
+  }
+}
+
+final resourceShelfActionsProvider = Provider(ResourceShelfActions.new);
 
 class ResourceSyncNotifier extends SyncNotifier {
   @override

--- a/flutter/lib/repository/resources_repository.dart
+++ b/flutter/lib/repository/resources_repository.dart
@@ -71,32 +71,47 @@ class ResourcesRepository {
     String resourceId,
     String userId, {
     required bool joined,
+  }) => setShelfMemberships([resourceId], userId, joined: joined);
+
+  /// Applies a catalog multi-selection as one atomic shelf mutation.
+  Future<void> setShelfMemberships(
+    Iterable<String> resourceIds,
+    String userId, {
+    required bool joined,
   }) async {
+    final ids = resourceIds.where((id) => id.trim().isNotEmpty).toSet();
+    if (ids.isEmpty) return;
     // Both writes together: if only one landed, the local shelf and the
     // removal log would disagree and the next upload would push the wrong
     // document.
     await _dao.transaction(() async {
-      final row = await _dao.getById(resourceId);
-      if (row != null) {
-        final userIds = {
-          ...row.userId.where((id) => id.isNotEmpty && id != userId),
-          if (joined) userId,
-        }.toList(growable: false);
-        await _dao.upsertAll([row.copyWith(userId: userIds).toCompanion(true)]);
-      }
+      final rows = await _dao.getByIds(ids.toList(growable: false));
+      await _dao.upsertAll([
+        for (final row in rows)
+          row
+              .copyWith(
+                userId: {
+                  ...row.userId.where((id) => id.isNotEmpty && id != userId),
+                  if (joined) userId,
+                }.toList(growable: false),
+              )
+              .toCompanion(true),
+      ]);
 
-      if (joined) {
-        await _removedLogDao.clear(
-          type: ShelfRepository.resourcesType,
-          userId: userId,
-          docId: resourceId,
-        );
-      } else {
-        await _removedLogDao.record(
-          type: ShelfRepository.resourcesType,
-          userId: userId,
-          docId: resourceId,
-        );
+      for (final resourceId in ids) {
+        if (joined) {
+          await _removedLogDao.clear(
+            type: ShelfRepository.resourcesType,
+            userId: userId,
+            docId: resourceId,
+          );
+        } else {
+          await _removedLogDao.record(
+            type: ShelfRepository.resourcesType,
+            userId: userId,
+            docId: resourceId,
+          );
+        }
       }
     });
   }

--- a/flutter/lib/ui/notifications/notification_destination.dart
+++ b/flutter/lib/ui/notifications/notification_destination.dart
@@ -1,0 +1,79 @@
+import '../../data/local/app_database.dart';
+
+enum NotificationDestinationKind { resources, storage, teamTasks, teamMembers }
+
+class NotificationDestination {
+  const NotificationDestination(this.kind, {this.teamId});
+
+  final NotificationDestinationKind kind;
+  final String? teamId;
+
+  @override
+  bool operator ==(Object other) =>
+      other is NotificationDestination &&
+      other.kind == kind &&
+      other.teamId == teamId;
+
+  @override
+  int get hashCode => Object.hash(kind, teamId);
+}
+
+/// Resolves an in-app notification to the screen the Kotlin app opens from
+/// `NotificationsFragment.handleNotificationClick`.
+///
+/// Keeping the database lookups out of the widget makes the navigation policy
+/// independently testable. Task notifications carry a task id and therefore
+/// need the cached task to discover their team; join requests carry the id of
+/// the request document, whose `teamId` identifies the destination team.
+class NotificationDestinationResolver {
+  const NotificationDestinationResolver({
+    required TeamTaskDao taskDao,
+    required TeamDao teamDao,
+  }) : _taskDao = taskDao,
+       _teamDao = teamDao;
+
+  final TeamTaskDao _taskDao;
+  final TeamDao _teamDao;
+
+  Future<NotificationDestination?> resolve(NotificationRow notification) async {
+    switch (notification.type.trim().toLowerCase()) {
+      case 'storage':
+        return const NotificationDestination(
+          NotificationDestinationKind.storage,
+        );
+      case 'resource':
+        return const NotificationDestination(
+          NotificationDestinationKind.resources,
+        );
+      case 'task':
+        final relatedId = _nonBlank(notification.relatedId);
+        if (relatedId == null) return null;
+        final task = await _taskDao.getById(relatedId);
+        final teamId = _nonBlank(task?.teamId);
+        return teamId == null
+            ? null
+            : NotificationDestination(
+                NotificationDestinationKind.teamTasks,
+                teamId: teamId,
+              );
+      case 'join_request':
+        final relatedId = _nonBlank(notification.relatedId);
+        if (relatedId == null) return null;
+        final request = await _teamDao.getById(relatedId);
+        final teamId = _nonBlank(request?.teamId);
+        return teamId == null
+            ? null
+            : NotificationDestination(
+                NotificationDestinationKind.teamMembers,
+                teamId: teamId,
+              );
+      default:
+        return null;
+    }
+  }
+
+  static String? _nonBlank(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+}

--- a/flutter/lib/ui/notifications/notifications_screen.dart
+++ b/flutter/lib/ui/notifications/notifications_screen.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import '../../data/local/app_database.dart';
 import '../../l10n/app_localizations.dart';
+import '../../providers/app_providers.dart';
 import '../../providers/notifications_provider.dart';
+import '../router.dart';
+import 'notification_destination.dart';
 import 'notification_grouping.dart';
 
 /// Port of `ui/notifications/NotificationsFragment.kt`.
@@ -239,13 +243,34 @@ class _NotificationTile extends ConsumerWidget {
             ),
           ],
         ),
-        onTap: notification.isRead
-            ? null
-            : () => ref
-                  .read(notificationActionsProvider)
-                  .markAsRead(notification.id),
+        // Read notifications remain actionable. Kotlin marks an unread row and
+        // navigates on the same tap; making `onTap` null after that first tap
+        // prevented learners from ever reopening its destination in Flutter.
+        onTap: () => _openNotification(context, ref),
       ),
     );
+  }
+
+  Future<void> _openNotification(BuildContext context, WidgetRef ref) async {
+    if (!notification.isRead) {
+      await ref.read(notificationActionsProvider).markAsRead(notification.id);
+    }
+
+    final database = ref.read(appDatabaseProvider);
+    final destination = await NotificationDestinationResolver(
+      taskDao: database.teamTaskDao,
+      teamDao: database.teamDao,
+    ).resolve(notification);
+    if (destination == null || !context.mounted) return;
+    final path = switch (destination.kind) {
+      NotificationDestinationKind.resources => Routes.resources,
+      NotificationDestinationKind.storage => Routes.storageManagement,
+      NotificationDestinationKind.teamTasks =>
+        '${Routes.teams}/${destination.teamId}/tasks',
+      NotificationDestinationKind.teamMembers =>
+        '${Routes.teams}/${destination.teamId}/members?tab=requests',
+    };
+    context.go(path);
   }
 
   Future<bool> _confirmDelete(BuildContext context) async {

--- a/flutter/lib/ui/resources/resources_screen.dart
+++ b/flutter/lib/ui/resources/resources_screen.dart
@@ -20,11 +20,20 @@ import 'resources_filter_sheet.dart';
 /// Here the list is a `ListView.builder` / `GridView.builder` fed by a Drift
 /// stream, so a sync writing to `my_library` repaints the list with no callback
 /// plumbing.
-class ResourcesScreen extends ConsumerWidget {
+class ResourcesScreen extends ConsumerStatefulWidget {
   const ResourcesScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ResourcesScreen> createState() => _ResourcesScreenState();
+}
+
+class _ResourcesScreenState extends ConsumerState<ResourcesScreen> {
+  final Set<String> _selectedIds = {};
+
+  bool get _selecting => _selectedIds.isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final resources = ref.watch(resourcesStreamProvider);
     final syncState = ref.watch(resourceSyncProvider);
@@ -50,58 +59,88 @@ class ResourcesScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(l10n.resources),
+        leading: _selecting
+            ? IconButton(
+                icon: const Icon(Icons.close),
+                tooltip: l10n.cancel,
+                onPressed: () => setState(_selectedIds.clear),
+              )
+            : null,
+        title: Text(
+          _selecting
+              ? l10n.storageSelectedCount(_selectedIds.length)
+              : l10n.resources,
+        ),
         actions: [
-          ViewModeToggle(
-            mode: viewMode,
-            onChanged: ref.read(libraryViewModeProvider.notifier).set,
-          ),
-          IconButton(
-            tooltip: l10n.filterResources,
-            onPressed: () {
-              showModalBottomSheet(
-                context: context,
-                isScrollControlled: true,
-                builder: (context) => const ResourcesFilterSheet(),
-              );
-            },
-            icon: Badge(
-              isLabelVisible: !filter.isEmpty,
-              child: const Icon(Icons.filter_list),
+          if (_selecting) ...[
+            IconButton(
+              tooltip: l10n.addToMyLibrary,
+              icon: const Icon(Icons.bookmark_add_outlined),
+              onPressed: () => _setSelectedMembership(joined: true),
             ),
-          ),
-          IconButton(
-            tooltip: l10n.sync,
-            onPressed: syncState is SyncRunning
-                ? null
-                : () => ref.read(resourceSyncProvider.notifier).sync(),
-            icon: const Icon(Icons.sync),
-          ),
-          const LogoutAction(),
+            IconButton(
+              tooltip: l10n.removeFromMyLibrary,
+              icon: const Icon(Icons.bookmark_remove_outlined),
+              onPressed: () => _setSelectedMembership(joined: false),
+            ),
+          ] else ...[
+            ViewModeToggle(
+              mode: viewMode,
+              onChanged: ref.read(libraryViewModeProvider.notifier).set,
+            ),
+            IconButton(
+              tooltip: l10n.filterResources,
+              onPressed: () {
+                showModalBottomSheet(
+                  context: context,
+                  isScrollControlled: true,
+                  builder: (context) => const ResourcesFilterSheet(),
+                );
+              },
+              icon: Badge(
+                isLabelVisible: !filter.isEmpty,
+                child: const Icon(Icons.filter_list),
+              ),
+            ),
+            IconButton(
+              tooltip: l10n.sync,
+              onPressed: syncState is SyncRunning
+                  ? null
+                  : () => ref.read(resourceSyncProvider.notifier).sync(),
+              icon: const Icon(Icons.sync),
+            ),
+            const LogoutAction(),
+          ],
         ],
-        bottom: PreferredSize(
-          preferredSize: Size.fromHeight(syncState is SyncRunning ? 68 : 64),
-          child: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
-                child: SearchBar(
-                  hintText: l10n.search,
-                  leading: const Icon(Icons.search),
-                  onChanged: (value) =>
-                      ref.read(resourceSearchQueryProvider.notifier).state =
-                          value,
+        bottom: _selecting
+            ? null
+            : PreferredSize(
+                preferredSize: Size.fromHeight(
+                  syncState is SyncRunning ? 68 : 64,
+                ),
+                child: Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+                      child: SearchBar(
+                        hintText: l10n.search,
+                        leading: const Icon(Icons.search),
+                        onChanged: (value) =>
+                            ref
+                                    .read(resourceSearchQueryProvider.notifier)
+                                    .state =
+                                value,
+                      ),
+                    ),
+                    if (syncState is SyncRunning)
+                      LinearProgressIndicator(
+                        value: syncState.progress.total == 0
+                            ? null
+                            : syncState.progress.fraction,
+                      ),
+                  ],
                 ),
               ),
-              if (syncState is SyncRunning)
-                LinearProgressIndicator(
-                  value: syncState.progress.total == 0
-                      ? null
-                      : syncState.progress.fraction,
-                ),
-            ],
-          ),
-        ),
       ),
       body: resources.when(
         loading: () => const Center(child: CircularProgressIndicator()),
@@ -144,8 +183,13 @@ class ResourcesScreen extends ConsumerWidget {
                   ),
                   padding: const EdgeInsets.all(8),
                   itemCount: filteredItems.length,
-                  itemBuilder: (context, index) =>
-                      _ResourceGridTile(filteredItems[index]),
+                  itemBuilder: (context, index) => _ResourceGridTile(
+                    filteredItems[index],
+                    selected: _selectedIds.contains(filteredItems[index].id),
+                    onTap: () => _tapResource(filteredItems[index]),
+                    onLongPress: () =>
+                        _toggleSelection(filteredItems[index].id),
+                  ),
                 );
               },
             );
@@ -153,19 +197,69 @@ class ResourcesScreen extends ConsumerWidget {
           return ListView.separated(
             itemCount: filteredItems.length,
             separatorBuilder: (_, _) => const Divider(height: 1),
-            itemBuilder: (context, index) =>
-                _ResourceTile(filteredItems[index]),
+            itemBuilder: (context, index) => _ResourceTile(
+              filteredItems[index],
+              selected: _selectedIds.contains(filteredItems[index].id),
+              onTap: () => _tapResource(filteredItems[index]),
+              onLongPress: () => _toggleSelection(filteredItems[index].id),
+            ),
           );
         },
       ),
     );
   }
+
+  void _tapResource(MyLibraryRow resource) {
+    if (_selecting) {
+      _toggleSelection(resource.id);
+    } else {
+      context.push('/resources/detail/${resource.id}');
+    }
+  }
+
+  void _toggleSelection(String id) {
+    setState(() {
+      if (!_selectedIds.add(id)) _selectedIds.remove(id);
+    });
+  }
+
+  Future<void> _setSelectedMembership({required bool joined}) async {
+    final l10n = AppLocalizations.of(context);
+    final selected = Set<String>.from(_selectedIds);
+    try {
+      await ref
+          .read(resourceShelfActionsProvider)
+          .setMemberships(selected, joined: joined);
+      if (!mounted) return;
+      setState(_selectedIds.clear);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            joined ? l10n.addedToMyLibrary : l10n.removedFromMyLibrary,
+          ),
+        ),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(l10n.operationFailed)));
+    }
+  }
 }
 
 class _ResourceTile extends StatelessWidget {
-  const _ResourceTile(this.resource);
+  const _ResourceTile(
+    this.resource, {
+    required this.selected,
+    required this.onTap,
+    required this.onLongPress,
+  });
 
   final MyLibraryRow resource;
+  final bool selected;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -178,6 +272,8 @@ class _ResourceTile extends StatelessWidget {
     ];
 
     return ListTile(
+      selected: selected,
+      selectedTileColor: Theme.of(context).colorScheme.secondaryContainer,
       leading: Icon(_iconFor(resource.mediaType)),
       title: Text(
         resource.title ?? '',
@@ -191,15 +287,16 @@ class _ResourceTile extends StatelessWidget {
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
-      trailing: resource.resourceOffline
+      trailing: selected
+          ? const Icon(Icons.check_circle)
+          : resource.resourceOffline
           ? Tooltip(
               message: l10n.availableOffline,
               child: const Icon(Icons.offline_pin_outlined),
             )
           : null,
-      onTap: () {
-        context.push('/resources/detail/${resource.id}');
-      },
+      onTap: onTap,
+      onLongPress: onLongPress,
     );
   }
 
@@ -219,9 +316,17 @@ class _ResourceTile extends StatelessWidget {
 /// `item_library_grid.xml` layout the Kotlin `ResourcesAdapter` inflates in
 /// grid mode — a card with the media-type icon, title, and a subtitle.
 class _ResourceGridTile extends StatelessWidget {
-  const _ResourceGridTile(this.resource);
+  const _ResourceGridTile(
+    this.resource, {
+    required this.selected,
+    required this.onTap,
+    required this.onLongPress,
+  });
 
   final MyLibraryRow resource;
+  final bool selected;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -234,9 +339,11 @@ class _ResourceGridTile extends StatelessWidget {
     ];
 
     return Card(
+      color: selected ? theme.colorScheme.secondaryContainer : null,
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () => context.push('/resources/detail/${resource.id}'),
+        onTap: onTap,
+        onLongPress: onLongPress,
         child: Padding(
           padding: const EdgeInsets.all(8),
           child: Column(
@@ -252,7 +359,13 @@ class _ResourceGridTile extends StatelessWidget {
                         size: 40,
                         color: theme.colorScheme.primary.withValues(alpha: 0.6),
                       ),
-                      if (resource.resourceOffline)
+                      if (selected)
+                        Icon(
+                          Icons.check_circle,
+                          size: 28,
+                          color: theme.colorScheme.primary,
+                        )
+                      else if (resource.resourceOffline)
                         Positioned(
                           bottom: 0,
                           right: 0,

--- a/flutter/lib/ui/router.dart
+++ b/flutter/lib/ui/router.dart
@@ -464,6 +464,9 @@ final routerProvider = Provider<GoRouter>((ref) {
                             path: 'members',
                             builder: (context, state) => TeamMembersScreen(
                               teamId: state.pathParameters['teamId']!,
+                              openJoinRequests:
+                                  state.uri.queryParameters['tab'] ==
+                                  'requests',
                             ),
                           ),
                           GoRoute(

--- a/flutter/lib/ui/teams/team_finances_screen.dart
+++ b/flutter/lib/ui/teams/team_finances_screen.dart
@@ -44,10 +44,6 @@ class _TeamFinancesScreenState extends ConsumerState<TeamFinancesScreen> {
             ?.isLeader ??
         false;
 
-    int totalDebit = 0;
-    int totalCredit = 0;
-    int balance = 0;
-
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.finances),
@@ -93,26 +89,13 @@ class _TeamFinancesScreenState extends ConsumerState<TeamFinancesScreen> {
               ],
             ),
           ),
-          // Summary row
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            color: Theme.of(context).colorScheme.surfaceContainerHighest,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: [
-                _SummaryItem(label: l10n.debit, value: totalDebit),
-                _SummaryItem(label: l10n.credit, value: totalCredit),
-                _SummaryItem(label: l10n.balance, value: balance, bold: true),
-              ],
-            ),
-          ),
-          // Transaction list
           Expanded(
             child: transactions.when(
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (e, s) => Center(child: Text(l10n.unavailable)),
               data: (rows) {
-                // Calculate totals
+                var totalDebit = 0;
+                var totalCredit = 0;
                 for (final tx in rows) {
                   if (tx.row.type?.toLowerCase() == 'debit') {
                     totalDebit += tx.row.amount;
@@ -120,18 +103,28 @@ class _TeamFinancesScreenState extends ConsumerState<TeamFinancesScreen> {
                     totalCredit += tx.row.amount;
                   }
                 }
-                balance = totalCredit - totalDebit;
+                final balance = totalCredit - totalDebit;
 
-                if (rows.isEmpty) {
-                  return Center(child: Text(l10n.noTransactions));
-                }
-                return ListView.separated(
-                  padding: const EdgeInsets.all(12),
-                  itemCount: rows.length,
-                  separatorBuilder: (context, index) =>
-                      const SizedBox(height: 8),
-                  itemBuilder: (context, index) =>
-                      _TransactionCard(transaction: rows[index]),
+                return Column(
+                  children: [
+                    _FinanceSummary(
+                      debit: totalDebit,
+                      credit: totalCredit,
+                      balance: balance,
+                    ),
+                    Expanded(
+                      child: rows.isEmpty
+                          ? Center(child: Text(l10n.noTransactions))
+                          : ListView.separated(
+                              padding: const EdgeInsets.all(12),
+                              itemCount: rows.length,
+                              separatorBuilder: (context, index) =>
+                                  const SizedBox(height: 8),
+                              itemBuilder: (context, index) =>
+                                  _TransactionCard(transaction: rows[index]),
+                            ),
+                    ),
+                  ],
                 );
               },
             ),
@@ -354,6 +347,35 @@ class _TeamFinancesScreenState extends ConsumerState<TeamFinancesScreen> {
     );
     noteController.dispose();
     amountController.dispose();
+  }
+}
+
+class _FinanceSummary extends StatelessWidget {
+  const _FinanceSummary({
+    required this.debit,
+    required this.credit,
+    required this.balance,
+  });
+
+  final int debit;
+  final int credit;
+  final int balance;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          _SummaryItem(label: l10n.debit, value: debit),
+          _SummaryItem(label: l10n.credit, value: credit),
+          _SummaryItem(label: l10n.balance, value: balance, bold: true),
+        ],
+      ),
+    );
   }
 }
 

--- a/flutter/lib/ui/teams/team_members_screen.dart
+++ b/flutter/lib/ui/teams/team_members_screen.dart
@@ -6,8 +6,13 @@ import '../../providers/teams_provider.dart';
 import '../../data/local/app_database.dart';
 
 class TeamMembersScreen extends ConsumerWidget {
-  const TeamMembersScreen({required this.teamId, super.key});
+  const TeamMembersScreen({
+    required this.teamId,
+    this.openJoinRequests = false,
+    super.key,
+  });
   final String teamId;
+  final bool openJoinRequests;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -19,6 +24,7 @@ class TeamMembersScreen extends ConsumerWidget {
     final canManage = (memberships[teamId]?.isLeader ?? false);
     return DefaultTabController(
       length: canManage ? 2 : 1,
+      initialIndex: canManage && openJoinRequests ? 1 : 0,
       child: Scaffold(
         appBar: AppBar(
           title: Text(l10n.teamMembers),

--- a/flutter/test/repository/resources_repository_test.dart
+++ b/flutter/test/repository/resources_repository_test.dart
@@ -303,6 +303,30 @@ void main() {
   });
 
   group('setShelfMembership', () {
+    test('batch removal updates every row and removal log', () async {
+      stubCount(2);
+      stubPage(0, 100, [row('res-1', 'Algebra'), row('res-2', 'Biology')]);
+      await repository.sync(config: config);
+      await repository.setShelfMemberships(
+        ['res-1', 'res-2'],
+        'user-1',
+        joined: true,
+      );
+
+      await repository.setShelfMemberships(
+        ['res-1', 'res-2'],
+        'user-1',
+        joined: false,
+      );
+
+      expect((await db.myLibraryDao.getById('res-1'))!.userId, isEmpty);
+      expect((await db.myLibraryDao.getById('res-2'))!.userId, isEmpty);
+      expect(
+        await db.removedLogDao.removedDocIds('resources', 'user-1'),
+        containsAll(['res-1', 'res-2']),
+      );
+    });
+
     test(
       'leaving records the removal so the shelf push cannot re-add',
       () async {

--- a/flutter/test/ui/notification_destination_test.dart
+++ b/flutter/test/ui/notification_destination_test.dart
@@ -1,0 +1,104 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/ui/notifications/notification_destination.dart';
+
+NotificationRow _notification(String type, {String? relatedId}) =>
+    NotificationRow(
+      id: '$type-notification',
+      userId: 'user-1',
+      message: type,
+      type: type,
+      relatedId: relatedId,
+      isRead: false,
+      createdAt: 0,
+      priority: 0,
+      isFromServer: false,
+      needsSync: false,
+    );
+
+void main() {
+  late AppDatabase database;
+  late NotificationDestinationResolver resolver;
+
+  setUp(() {
+    database = AppDatabase.memory();
+    resolver = NotificationDestinationResolver(
+      taskDao: database.teamTaskDao,
+      teamDao: database.teamDao,
+    );
+  });
+  tearDown(() => database.close());
+
+  test('resource notifications open the resource catalog', () async {
+    expect(
+      await resolver.resolve(_notification('resource')),
+      const NotificationDestination(NotificationDestinationKind.resources),
+    );
+  });
+
+  test('storage notifications open storage management', () async {
+    expect(
+      await resolver.resolve(_notification('storage')),
+      const NotificationDestination(NotificationDestinationKind.storage),
+    );
+  });
+
+  test('task notifications resolve the cached task team', () async {
+    await database.teamTaskDao.upsert(
+      TeamTasksCompanion.insert(id: 'task-1', teamId: 'team-1'),
+    );
+
+    expect(
+      await resolver.resolve(_notification('task', relatedId: 'task-1')),
+      const NotificationDestination(
+        NotificationDestinationKind.teamTasks,
+        teamId: 'team-1',
+      ),
+    );
+  });
+
+  test('join requests resolve their team membership screen', () async {
+    await database.teamDao.upsert(
+      TeamsCompanion.insert(
+        id: 'request-1',
+        teamId: const Value('team-2'),
+        type: const Value('request'),
+      ),
+    );
+
+    expect(
+      await resolver.resolve(
+        _notification('join_request', relatedId: 'request-1'),
+      ),
+      const NotificationDestination(
+        NotificationDestinationKind.teamMembers,
+        teamId: 'team-2',
+      ),
+    );
+  });
+
+  test('missing related rows do not invent a destination', () async {
+    expect(
+      await resolver.resolve(_notification('task', relatedId: 'missing')),
+      isNull,
+    );
+    expect(
+      await resolver.resolve(
+        _notification('join_request', relatedId: 'missing'),
+      ),
+      isNull,
+    );
+  });
+
+  test(
+    'blank ids and unknown types stay on the notifications screen',
+    () async {
+      expect(
+        await resolver.resolve(_notification('task', relatedId: '  ')),
+        isNull,
+      );
+      expect(await resolver.resolve(_notification('other')), isNull);
+    },
+  );
+}

--- a/flutter/test/ui/resources_screen_test.dart
+++ b/flutter/test/ui/resources_screen_test.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/resources_providers.dart';
 import 'package:myplanet/ui/resources/resources_screen.dart';
 
 import '../support/widget_harness.dart';
+
+class MockResourceShelfActions extends Mock implements ResourceShelfActions {}
 
 void main() {
   testWidgets('renders the resources returned by the stream', (tester) async {
@@ -63,6 +66,47 @@ void main() {
 
     expect(find.byType(ListTile), findsNWidgets(2));
     expect(find.byType(GridView), findsNothing);
+  });
+
+  testWidgets('long press selects multiple resources for one shelf action', (
+    tester,
+  ) async {
+    final actions = MockResourceShelfActions();
+    when(
+      () => actions.setMemberships(any(), joined: true),
+    ).thenAnswer((_) async {});
+    await tester.pumpWidget(
+      wrapScreen(
+        const ResourcesScreen(),
+        overrides: [
+          resourcesStreamProvider.overrideWith(
+            (ref) => Stream.value([
+              buildLibraryRow(id: 'r1', title: 'Algebra'),
+              buildLibraryRow(id: 'r2', title: 'Biology'),
+            ]),
+          ),
+          resourceShelfActionsProvider.overrideWithValue(actions),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.longPress(find.text('Algebra'));
+    await tester.tap(find.text('Biology'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('2 selected'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsNWidgets(2));
+    await tester.tap(find.byTooltip('Add to My Library'));
+    await tester.pumpAndSettle();
+
+    final captured =
+        verify(
+              () => actions.setMemberships(captureAny(), joined: true),
+            ).captured.single
+            as Iterable<String>;
+    expect(captured, containsAll(['r1', 'r2']));
+    expect(find.text('Added to My Library'), findsOneWidget);
   });
 
   testWidgets('shows the empty state when nothing is synced', (tester) async {

--- a/flutter/test/ui/team_finances_screen_test.dart
+++ b/flutter/test/ui/team_finances_screen_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/teams_provider.dart';
+import 'package:myplanet/ui/teams/team_finances_screen.dart';
+
+import '../support/widget_harness.dart';
+
+TeamRow _transaction(String id, String type, int amount) => TeamRow(
+  id: id,
+  courses: const [],
+  createdDate: 0,
+  limit: 0,
+  isPublic: false,
+  isLeader: false,
+  beginningBalance: 0,
+  sales: 0,
+  otherIncome: 0,
+  wages: 0,
+  otherExpenses: 0,
+  startDate: 0,
+  endDate: 0,
+  updatedDate: 0,
+  date: 0,
+  amount: amount,
+  type: type,
+  isUpdated: false,
+);
+
+void main() {
+  testWidgets('summary displays totals from the loaded transactions', (
+    tester,
+  ) async {
+    final rows = [
+      TransactionRow(row: _transaction('credit', 'credit', 125), balance: 125),
+      TransactionRow(row: _transaction('debit', 'debit', 40), balance: 85),
+    ];
+
+    await tester.pumpWidget(
+      wrapScreen(
+        const TeamFinancesScreen(teamId: 'team-1'),
+        overrides: [
+          teamTransactionsProvider.overrideWith((ref, params) {
+            return Stream.value(rows);
+          }),
+          teamMembershipsProvider.overrideWith((ref) => Stream.value(const {})),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('125'), findsOneWidget);
+    expect(find.text('40'), findsOneWidget);
+    expect(find.text('85'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
### Motivation

- Make notification rows actionable and route to the same in-app destinations Kotlin opens instead of only marking-as-read.
- Support atomic multi-selection add/remove shelf actions in the resource catalog to match Kotlin's batch behavior and avoid partial updates during shelf upload.
- Ensure the team-finances summary is derived from the filtered transaction stream so totals are never shown as zero due to widget build ordering.

### Description

- Add `NotificationDestination` and `NotificationDestinationResolver` and wire them into `notifications_screen.dart` so rows remain actionable and navigate correctly for `resource`, `storage`, `task`, and `join_request` notifications; resolution fails closed for blank/missing/unknown ids. 
- Keep notification navigation testable by performing DB lookups in `NotificationDestinationResolver` and adding `ui/notification_destination_test.dart` to exercise all cases. 
- Introduce selection UX in `resources_screen.dart` by converting it to a `ConsumerStatefulWidget`, enabling long-press to enter contextual multi-select mode, visual selection indicators, and contextual app-bar actions for add/remove. 
- Add `ResourceShelfActions` provider in `resources_providers.dart` to orchestrate session lookup and optional shelf upload after local writes. 
- Implement atomic multi-row shelf changes in `resources_repository.dart` via new `setShelfMemberships` which writes all selected rows and their `removed_log` entries inside a single Drift transaction. 
- Add `resourceShelfActionsProvider` and hook it into the UI; update `resources_screen_test.dart` with a multi-select widget test using a mocked `ResourceShelfActions`. 
- Fix `team_finances_screen.dart` summary by computing debit/credit/balance inside the `data` branch and extract `_FinanceSummary` widget; add `team_finances_screen_test.dart` to validate totals. 
- Add support in routing and `TeamMembersScreen` to open the join-requests tab via a query parameter used by notification navigation. 
- Update/sync docs (`CLAUDE.md` and `docs/kotlin-to-flutter-migration.md`) to record Phase 48–50 changes. 
- Add and update repository tests in `flutter/test/repository/resources_repository_test.dart` to cover batch removal and removal-log behavior.

### Testing

- Ran repository unit tests including `resources_repository_test.dart` (added batch removal test) and they succeeded. 
- Ran widget tests including `resources_screen_test.dart` (renders, view toggle, multi-select flow) and `team_finances_screen_test.dart` (summary totals) and they succeeded. 
- Executed the new `notification_destination_test.dart` unit tests validating resolver behavior for all notification types and edge cases and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a866caecec4832b93da495e7fe2b898)