### PR TITLE
all: smoother branch overtaking plugin providing (fixes #16057)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,12 @@
         "repo": "dogi/kotlin-importing"
       }
     },
+    "overtaking": {
+      "source": {
+        "source": "github",
+        "repo": "dogi/branch-overtaking"
+      }
+    },
     "prepping": {
       "source": {
         "source": "github",
@@ -14,6 +20,7 @@
     }
   },
   "enabledPlugins": {
+    "branch-overtaking@overtaking": true,
     "kotlin-importing@importing": true,
     "merge-prepping@prepping": true
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,7 +367,7 @@ git push -u origin claude/feature-name-sessionid
 
 See `docs/CODE_STYLE_GUIDE.md` → "Branch & PR Standards" for commit-message and PR conventions.
 
-**Session opened on a branch that isn't `master`?** That's a takeover of someone else's PR branch: the web UI binds its PR panel to this session's auto-minted `claude/…` outcome branch instead, and the PR's CI failures and review comments never arrive. Call `get_session` first, then follow the `overtaking` skill ([dogi/branch-overtaking](https://github.com/dogi/branch-overtaking) — clone it and read `SKILL.md` if the plugin isn't installed) to bind a session to the branch and subscribe to the PR.
+**Session opened on a branch that isn't `master`?** That's a takeover of someone else's PR branch: the web UI binds its PR panel to this session's auto-minted `claude/…` outcome branch instead, and the PR's CI failures and review comments never arrive. Call `get_session` first, then follow the `overtaking` skill — wired as a plugin in `.claude/settings.json` — to bind a session to the branch and subscribe to the PR. If the plugin didn't load (an empty `~/.claude/plugins/installed_plugins.json` is the tell), clone the marketplace repo listed there and read its `SKILL.md`.
 
 ### CI/CD Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,6 +367,8 @@ git push -u origin claude/feature-name-sessionid
 
 See `docs/CODE_STYLE_GUIDE.md` → "Branch & PR Standards" for commit-message and PR conventions.
 
+**Session opened on a branch that isn't `master`?** That's a takeover of someone else's PR branch: the web UI binds its PR panel to this session's auto-minted `claude/…` outcome branch instead, and the PR's CI failures and review comments never arrive. Call `get_session` first, then follow the `overtaking` skill ([dogi/branch-overtaking](https://github.com/dogi/branch-overtaking) — clone it and read `SKILL.md` if the plugin isn't installed) to bind a session to the branch and subscribe to the PR.
+
 ### CI/CD Pipeline
 
 **Build Workflow** (`.github/workflows/build.yml`)


### PR DESCRIPTION
## Summary
This PR adds support for the `branch-overtaking` plugin to handle sessions opened on non-master branches, which typically indicate takeovers of existing PR branches. The plugin is configured in `.claude/settings.json` and documented in `CLAUDE.md`.

## Changes
- **`.claude/settings.json`**: 
  - Added `overtaking` plugin source configuration pointing to `dogi/branch-overtaking` repository
  - Enabled `branch-overtaking@overtaking` plugin in the `enabledPlugins` section

- **`CLAUDE.md`**:
  - Added guidance section explaining branch takeover scenarios and how to use the `overtaking` skill
  - Documents the problem: sessions on non-master branches cause PR panels to bind to auto-minted `claude/…` outcome branches instead, missing CI failures and review comments
  - Provides troubleshooting steps: call `get_session` first, follow the `overtaking` skill, and check `~/.claude/plugins/installed_plugins.json` if the plugin fails to load

## Implementation Details
The `overtaking` plugin is wired as a Hilt-style plugin in the settings configuration, following the same pattern as existing plugins (`kotlin-importing@importing`, `merge-prepping@prepping`). The documentation clarifies that this plugin helps bind sessions to the correct branch and subscribe to PR updates when working on existing PR branches.

https://claude.ai/code/session_01JZekF1jrLrxFS1BCKwZmro