### PR TITLE
all: smoother stable id utils generating (fixes #16144)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6756
-        versionName = "0.67.56"
+        versionCode = 6757
+        versionName = "0.67.57"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -33,6 +33,7 @@ import org.ole.planet.myplanet.utils.CourseSubjectClassifier
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.ListViewMode
 import org.ole.planet.myplanet.utils.SelectionUtils
+import org.ole.planet.myplanet.utils.StableIdGenerator
 import org.ole.planet.myplanet.utils.UrlUtils
 
 class CoursesAdapter(
@@ -124,6 +125,13 @@ class CoursesAdapter(
         if (context is OnHomeItemClickListener) {
             homeItemClickListener = context
         }
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        val item = getItem(position)
+        val id = StableIdGenerator.generateStringId(item.courseId)
+        return if (id != RecyclerView.NO_ID) id else StableIdGenerator.generateFallbackId(item)
     }
 
     fun setViewMode(mode: ListViewMode, onChanged: (() -> Unit)? = null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -32,6 +32,7 @@ import org.ole.planet.myplanet.utils.CourseSubjectClassifier
 import org.ole.planet.myplanet.utils.DiffUtils
 import org.ole.planet.myplanet.utils.ListViewMode
 import org.ole.planet.myplanet.utils.SelectionUtils
+import org.ole.planet.myplanet.utils.StableIdGenerator
 import org.ole.planet.myplanet.utils.UrlUtils
 
 class CoursesAdapter(
@@ -125,7 +126,9 @@ class CoursesAdapter(
     }
 
     override fun getItemId(position: Int): Long {
-        return org.ole.planet.myplanet.utils.StableIdGenerator.generateStringId(getItem(position).courseId)
+        val item = getItem(position)
+        val id = StableIdGenerator.generateStringId(item.courseId)
+        return if (id != RecyclerView.NO_ID) id else StableIdGenerator.generateFallbackId(item)
     }
 
     fun setViewMode(mode: ListViewMode, onChanged: (() -> Unit)? = null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -121,6 +121,11 @@ class CoursesAdapter(
         if (context is OnHomeItemClickListener) {
             homeItemClickListener = context
         }
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        return org.ole.planet.myplanet.utils.StableIdGenerator.generateStringId(getItem(position).courseId)
     }
 
     fun setViewMode(mode: ListViewMode, onChanged: (() -> Unit)? = null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -34,6 +34,7 @@ import org.ole.planet.myplanet.utils.LibraryType
 import org.ole.planet.myplanet.utils.LibraryTypeClassifier
 import org.ole.planet.myplanet.utils.ListViewMode
 import org.ole.planet.myplanet.utils.PdfThumbnailLoader
+import org.ole.planet.myplanet.utils.StableIdGenerator
 import org.ole.planet.myplanet.utils.Utilities
 
 class ResourcesAdapter(
@@ -58,7 +59,9 @@ class ResourcesAdapter(
     }
 
     override fun getItemId(position: Int): Long {
-        return org.ole.planet.myplanet.utils.StableIdGenerator.generateStringId(getItem(position).item.id)
+        val listModel = getItem(position)
+        val id = StableIdGenerator.generateStringId(listModel.item.id)
+        return if (id != RecyclerView.NO_ID) id else StableIdGenerator.generateFallbackId(listModel)
     }
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -34,6 +34,7 @@ import org.ole.planet.myplanet.utils.LibraryType
 import org.ole.planet.myplanet.utils.LibraryTypeClassifier
 import org.ole.planet.myplanet.utils.ListViewMode
 import org.ole.planet.myplanet.utils.PdfThumbnailLoader
+import org.ole.planet.myplanet.utils.StableIdGenerator
 import org.ole.planet.myplanet.utils.Utilities
 
 class ResourcesAdapter(
@@ -52,6 +53,16 @@ class ResourcesAdapter(
     private val locallyOfflineIds = mutableSetOf<String>()
     private val externalFilesDir: File? by lazy { FileUtils.getExternalFilesDir(context) }
     private var adapterScope = CoroutineScope(SupervisorJob() + dispatcherProvider.main)
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        val listModel = getItem(position)
+        val id = StableIdGenerator.generateStringId(listModel.item.id)
+        return if (id != RecyclerView.NO_ID) id else StableIdGenerator.generateFallbackId(listModel)
+    }
 
     companion object {
         const val PAYLOAD_SELECTION = "PAYLOAD_SELECTION"

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesAdapter.kt
@@ -53,6 +53,14 @@ class ResourcesAdapter(
     private val externalFilesDir: File? by lazy { FileUtils.getExternalFilesDir(context) }
     private var adapterScope = CoroutineScope(SupervisorJob() + dispatcherProvider.main)
 
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        return org.ole.planet.myplanet.utils.StableIdGenerator.generateStringId(getItem(position).item.id)
+    }
+
     companion object {
         const val PAYLOAD_SELECTION = "PAYLOAD_SELECTION"
         private const val VIEW_TYPE_GRID = 0

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysAdapter.kt
@@ -13,6 +13,7 @@ import org.ole.planet.myplanet.databinding.RowSurveyBinding
 import org.ole.planet.myplanet.model.SurveyRow
 import org.ole.planet.myplanet.ui.submissions.SubmissionsAdapter
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.StableIdGenerator
 
 class SurveysAdapter(
     private val context: Context,
@@ -37,6 +38,13 @@ class SurveysAdapter(
         if (context is OnHomeItemClickListener) {
             listener = context
         }
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        val item = getItem(position)
+        val id = StableIdGenerator.generateStringId(item.exam.id)
+        return if (id != RecyclerView.NO_ID) id else StableIdGenerator.generateFallbackId(item)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SurveysViewHolder {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysAdapter.kt
@@ -15,6 +15,7 @@ import org.ole.planet.myplanet.model.SurveyFormState
 import org.ole.planet.myplanet.model.SurveyInfo
 import org.ole.planet.myplanet.ui.submissions.SubmissionsAdapter
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.StableIdGenerator
 
 class SurveysAdapter(
     private val context: Context,
@@ -43,7 +44,9 @@ class SurveysAdapter(
     }
 
     override fun getItemId(position: Int): Long {
-        return org.ole.planet.myplanet.utils.StableIdGenerator.generateStringId(getItem(position).id)
+        val item = getItem(position)
+        val id = StableIdGenerator.generateStringId(item.id)
+        return if (id != RecyclerView.NO_ID) id else StableIdGenerator.generateFallbackId(item)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SurveysViewHolder {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/surveys/SurveysAdapter.kt
@@ -39,6 +39,11 @@ class SurveysAdapter(
         if (context is OnHomeItemClickListener) {
             listener = context
         }
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        return org.ole.planet.myplanet.utils.StableIdGenerator.generateStringId(getItem(position).id)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SurveysViewHolder {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamsAdapter.kt
@@ -13,6 +13,7 @@ import org.ole.planet.myplanet.databinding.ItemTeamListBinding
 import org.ole.planet.myplanet.model.TeamDetails
 import org.ole.planet.myplanet.model.TeamStatus
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.StableIdGenerator
 import org.ole.planet.myplanet.utils.TimeUtils
 
 class TeamsAdapter(
@@ -30,6 +31,16 @@ class TeamsAdapter(
     private var actionRequestedString: String? = null
     private var actionRequestToJoinString: String? = null
     private var pendingColor: Int = 0
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        val item = getItem(position)
+        val id = StableIdGenerator.generateStringId(item._id)
+        return if (id != RecyclerView.NO_ID) id else StableIdGenerator.generateFallbackId(item)
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TeamsViewHolder {
         if (actionEditString == null) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamsAdapter.kt
@@ -26,6 +26,14 @@ class TeamsAdapter(
     private var type: String? = ""
     private val dateCache = mutableMapOf<Long, String>()
 
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        return org.ole.planet.myplanet.utils.StableIdGenerator.generateStringId(getItem(position)._id)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TeamsViewHolder {
         val binding = ItemTeamListBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return TeamsViewHolder(binding)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamsAdapter.kt
@@ -13,6 +13,7 @@ import org.ole.planet.myplanet.databinding.ItemTeamListBinding
 import org.ole.planet.myplanet.model.TeamDetails
 import org.ole.planet.myplanet.model.TeamStatus
 import org.ole.planet.myplanet.utils.DiffUtils
+import org.ole.planet.myplanet.utils.StableIdGenerator
 import org.ole.planet.myplanet.utils.TimeUtils
 
 class TeamsAdapter(
@@ -31,7 +32,9 @@ class TeamsAdapter(
     }
 
     override fun getItemId(position: Int): Long {
-        return org.ole.planet.myplanet.utils.StableIdGenerator.generateStringId(getItem(position)._id)
+        val item = getItem(position)
+        val id = StableIdGenerator.generateStringId(item._id)
+        return if (id != RecyclerView.NO_ID) id else StableIdGenerator.generateFallbackId(item)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TeamsViewHolder {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -43,6 +43,7 @@ import org.ole.planet.myplanet.utils.ImageUtils
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.MarkdownUtils.prependBaseUrlToImages
 import org.ole.planet.myplanet.utils.MarkdownUtils.setMarkdownText
+import org.ole.planet.myplanet.utils.StableIdGenerator
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 import org.ole.planet.myplanet.utils.makeExpandable
 
@@ -188,6 +189,13 @@ class VoicesAdapter(
     init {
         fetchTeamLeaderStatus()
         preParseNews(parentNews)
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        val item = getItem(position)
+        val id = StableIdGenerator.generateStringId(item.id)
+        return if (id != RecyclerView.NO_ID) id else StableIdGenerator.generateFallbackId(item)
     }
 
     private fun fetchTeamLeaderStatus() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -43,6 +43,7 @@ import org.ole.planet.myplanet.utils.ImageUtils
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.MarkdownUtils.prependBaseUrlToImages
 import org.ole.planet.myplanet.utils.MarkdownUtils.setMarkdownText
+import org.ole.planet.myplanet.utils.StableIdGenerator
 import org.ole.planet.myplanet.utils.TimeUtils.formatDate
 import org.ole.planet.myplanet.utils.makeExpandable
 
@@ -192,7 +193,9 @@ class VoicesAdapter(
     }
 
     override fun getItemId(position: Int): Long {
-        return org.ole.planet.myplanet.utils.StableIdGenerator.generateStringId(getItem(position).id)
+        val item = getItem(position)
+        val id = StableIdGenerator.generateStringId(item.id)
+        return if (id != RecyclerView.NO_ID) id else StableIdGenerator.generateFallbackId(item)
     }
 
     private fun fetchTeamLeaderStatus() {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesAdapter.kt
@@ -188,6 +188,11 @@ class VoicesAdapter(
     init {
         fetchTeamLeaderStatus()
         preParseNews(parentNews)
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long {
+        return org.ole.planet.myplanet.utils.StableIdGenerator.generateStringId(getItem(position).id)
     }
 
     private fun fetchTeamLeaderStatus() {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/StableIdGenerator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/StableIdGenerator.kt
@@ -1,10 +1,15 @@
 package org.ole.planet.myplanet.utils
 
 import androidx.recyclerview.widget.RecyclerView
+import java.util.WeakHashMap
 
 object StableIdGenerator {
+    private val fallbackIds = WeakHashMap<Any, Long>()
+    private var nextFallbackId = -2L
+
     /**
      * Generates a collision-resistant stable Long ID from a String key using the FNV-1a 64-bit hash algorithm.
+     * Note: This implementation hashes UTF-16 code units (Char.code), not standard UTF-8 bytes.
      * This is useful for RecyclerView Adapters when setHasStableIds(true) is used.
      * If the string is null or empty, it returns RecyclerView.NO_ID.
      */
@@ -16,5 +21,15 @@ object StableIdGenerator {
             hash *= 1099511628211L // FNV prime
         }
         return hash
+    }
+
+    /**
+     * Generates a unique fallback Long ID for an object that lacks a valid string key.
+     * Uses a WeakHashMap to ensure the same object instance receives the same ID over its lifecycle.
+     */
+    fun generateFallbackId(item: Any): Long {
+        return fallbackIds.getOrPut(item) {
+            nextFallbackId--
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/StableIdGenerator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/StableIdGenerator.kt
@@ -7,12 +7,6 @@ object StableIdGenerator {
     private val fallbackIds = WeakHashMap<Any, Long>()
     private var nextFallbackId = -2L
 
-    /**
-     * Generates a collision-resistant stable Long ID from a String key using the FNV-1a 64-bit hash algorithm.
-     * Note: This implementation hashes UTF-16 code units (Char.code), not standard UTF-8 bytes.
-     * This is useful for RecyclerView Adapters when setHasStableIds(true) is used.
-     * If the string is null or empty, it returns RecyclerView.NO_ID.
-     */
     fun generateStringId(key: String?): Long {
         if (key.isNullOrEmpty()) return RecyclerView.NO_ID
         var hash = -3750763034362895579L // FNV offset basis
@@ -23,15 +17,6 @@ object StableIdGenerator {
         return hash
     }
 
-    /**
-     * Generates a fallback Long ID for an item that lacks a usable string key, so that keyless items
-     * never share RecyclerView.NO_ID under setHasStableIds(true).
-     *
-     * Keys are held in a WeakHashMap, so the ID is stable for as long as an equal key is reachable:
-     * items with a value-based equals (data classes) keep their ID across emissions, while items that
-     * inherit identity equality (the open Room entities) get a fresh ID on each new instance. Callers
-     * that need the stronger guarantee should pass a content-derived key to generateStringId instead.
-     */
     @Synchronized
     fun generateFallbackId(item: Any): Long {
         return fallbackIds.getOrPut(item) {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/StableIdGenerator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/StableIdGenerator.kt
@@ -1,0 +1,35 @@
+package org.ole.planet.myplanet.utils
+
+import androidx.recyclerview.widget.RecyclerView
+import java.util.WeakHashMap
+
+object StableIdGenerator {
+    private val fallbackIds = WeakHashMap<Any, Long>()
+    private var nextFallbackId = -2L
+
+    /**
+     * Generates a collision-resistant stable Long ID from a String key using the FNV-1a 64-bit hash algorithm.
+     * Note: This implementation hashes UTF-16 code units (Char.code), not standard UTF-8 bytes.
+     * This is useful for RecyclerView Adapters when setHasStableIds(true) is used.
+     * If the string is null or empty, it returns RecyclerView.NO_ID.
+     */
+    fun generateStringId(key: String?): Long {
+        if (key.isNullOrEmpty()) return RecyclerView.NO_ID
+        var hash = -3750763034362895579L // FNV offset basis
+        for (i in key.indices) {
+            hash = hash xor key[i].code.toLong()
+            hash *= 1099511628211L // FNV prime
+        }
+        return hash
+    }
+
+    /**
+     * Generates a unique fallback Long ID for an object that lacks a valid string key.
+     * Uses a WeakHashMap to ensure the same object instance receives the same ID over its lifecycle.
+     */
+    fun generateFallbackId(item: Any): Long {
+        return fallbackIds.getOrPut(item) {
+            nextFallbackId--
+        }
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/utils/StableIdGenerator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/StableIdGenerator.kt
@@ -1,0 +1,20 @@
+package org.ole.planet.myplanet.utils
+
+import androidx.recyclerview.widget.RecyclerView
+
+object StableIdGenerator {
+    /**
+     * Generates a collision-resistant stable Long ID from a String key using the FNV-1a 64-bit hash algorithm.
+     * This is useful for RecyclerView Adapters when setHasStableIds(true) is used.
+     * If the string is null or empty, it returns RecyclerView.NO_ID.
+     */
+    fun generateStringId(key: String?): Long {
+        if (key.isNullOrEmpty()) return RecyclerView.NO_ID
+        var hash = -3750763034362895579L // FNV offset basis
+        for (i in key.indices) {
+            hash = hash xor key[i].code.toLong()
+            hash *= 1099511628211L // FNV prime
+        }
+        return hash
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/utils/StableIdGenerator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/StableIdGenerator.kt
@@ -24,9 +24,15 @@ object StableIdGenerator {
     }
 
     /**
-     * Generates a unique fallback Long ID for an object that lacks a valid string key.
-     * Uses a WeakHashMap to ensure the same object instance receives the same ID over its lifecycle.
+     * Generates a fallback Long ID for an item that lacks a usable string key, so that keyless items
+     * never share RecyclerView.NO_ID under setHasStableIds(true).
+     *
+     * Keys are held in a WeakHashMap, so the ID is stable for as long as an equal key is reachable:
+     * items with a value-based equals (data classes) keep their ID across emissions, while items that
+     * inherit identity equality (the open Room entities) get a fresh ID on each new instance. Callers
+     * that need the stronger guarantee should pass a content-derived key to generateStringId instead.
      */
+    @Synchronized
     fun generateFallbackId(item: Any): Long {
         return fallbackIds.getOrPut(item) {
             nextFallbackId--

--- a/app/src/test/java/org/ole/planet/myplanet/utils/StableIdGeneratorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/StableIdGeneratorTest.kt
@@ -43,4 +43,33 @@ class StableIdGeneratorTest {
         assertNotEquals(RecyclerView.NO_ID, fallbackId1)
         assertNotEquals(RecyclerView.NO_ID, fallbackId2)
     }
+
+    private data class ValueItem(val name: String)
+
+    private class IdentityItem
+
+    @Test
+    fun testGenerateFallbackId_equalInstancesShareId() {
+        val first = ValueItem("unsynced-team")
+        val second = ValueItem("unsynced-team")
+
+        val firstId = StableIdGenerator.generateFallbackId(first)
+        val secondId = StableIdGenerator.generateFallbackId(second)
+
+        assertEquals(firstId, secondId)
+        // Also pins both keys as reachable across the lookups above, since the cache holds them weakly.
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun testGenerateFallbackId_identityInstancesGetDistinctIds() {
+        val first = IdentityItem()
+        val second = IdentityItem()
+
+        val firstId = StableIdGenerator.generateFallbackId(first)
+        val secondId = StableIdGenerator.generateFallbackId(second)
+
+        assertNotEquals(firstId, secondId)
+        assertNotEquals(first, second)
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/StableIdGeneratorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/StableIdGeneratorTest.kt
@@ -13,12 +13,34 @@ class StableIdGeneratorTest {
     }
 
     @Test
-    fun testGenerateStringId_stableAndCollisionResistant() {
+    fun testGenerateStringId_determinism() {
         val id1 = StableIdGenerator.generateStringId("course-1234")
-        val id2 = StableIdGenerator.generateStringId("course-1235")
         val id3 = StableIdGenerator.generateStringId("course-1234")
 
         assertEquals(id1, id3)
+    }
+
+    @Test
+    fun testGenerateStringId_collisionResistance() {
+        // "Aa" and "BB" have the same standard 32-bit java.lang.String.hashCode() (2112)
+        val id1 = StableIdGenerator.generateStringId("Aa")
+        val id2 = StableIdGenerator.generateStringId("BB")
+
         assertNotEquals(id1, id2)
+    }
+
+    @Test
+    fun testGenerateFallbackId() {
+        val item1 = Any()
+        val item2 = Any()
+
+        val fallbackId1 = StableIdGenerator.generateFallbackId(item1)
+        val fallbackId1Again = StableIdGenerator.generateFallbackId(item1)
+        val fallbackId2 = StableIdGenerator.generateFallbackId(item2)
+
+        assertEquals(fallbackId1, fallbackId1Again)
+        assertNotEquals(fallbackId1, fallbackId2)
+        assertNotEquals(RecyclerView.NO_ID, fallbackId1)
+        assertNotEquals(RecyclerView.NO_ID, fallbackId2)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/StableIdGeneratorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/StableIdGeneratorTest.kt
@@ -1,0 +1,46 @@
+package org.ole.planet.myplanet.utils
+
+import androidx.recyclerview.widget.RecyclerView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class StableIdGeneratorTest {
+    @Test
+    fun testGenerateStringId_nullOrEmpty() {
+        assertEquals(RecyclerView.NO_ID, StableIdGenerator.generateStringId(null))
+        assertEquals(RecyclerView.NO_ID, StableIdGenerator.generateStringId(""))
+    }
+
+    @Test
+    fun testGenerateStringId_determinism() {
+        val id1 = StableIdGenerator.generateStringId("course-1234")
+        val id3 = StableIdGenerator.generateStringId("course-1234")
+
+        assertEquals(id1, id3)
+    }
+
+    @Test
+    fun testGenerateStringId_collisionResistance() {
+        // "Aa" and "BB" have the same standard 32-bit java.lang.String.hashCode() (2112)
+        val id1 = StableIdGenerator.generateStringId("Aa")
+        val id2 = StableIdGenerator.generateStringId("BB")
+
+        assertNotEquals(id1, id2)
+    }
+
+    @Test
+    fun testGenerateFallbackId() {
+        val item1 = Any()
+        val item2 = Any()
+
+        val fallbackId1 = StableIdGenerator.generateFallbackId(item1)
+        val fallbackId1Again = StableIdGenerator.generateFallbackId(item1)
+        val fallbackId2 = StableIdGenerator.generateFallbackId(item2)
+
+        assertEquals(fallbackId1, fallbackId1Again)
+        assertNotEquals(fallbackId1, fallbackId2)
+        assertNotEquals(RecyclerView.NO_ID, fallbackId1)
+        assertNotEquals(RecyclerView.NO_ID, fallbackId2)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/utils/StableIdGeneratorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/StableIdGeneratorTest.kt
@@ -1,0 +1,24 @@
+package org.ole.planet.myplanet.utils
+
+import androidx.recyclerview.widget.RecyclerView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class StableIdGeneratorTest {
+    @Test
+    fun testGenerateStringId_nullOrEmpty() {
+        assertEquals(RecyclerView.NO_ID, StableIdGenerator.generateStringId(null))
+        assertEquals(RecyclerView.NO_ID, StableIdGenerator.generateStringId(""))
+    }
+
+    @Test
+    fun testGenerateStringId_stableAndCollisionResistant() {
+        val id1 = StableIdGenerator.generateStringId("course-1234")
+        val id2 = StableIdGenerator.generateStringId("course-1235")
+        val id3 = StableIdGenerator.generateStringId("course-1234")
+
+        assertEquals(id1, id3)
+        assertNotEquals(id1, id2)
+    }
+}


### PR DESCRIPTION
Implemented stable ID generation on the app's hottest `ListAdapter`s to improve `RecyclerView` track animations. Avoided `hashCode()` and implemented a custom `StableIdGenerator` that calculates FNV-1a 64-bit hashes for reliable, collision-resistant numeric IDs. Enabled on `CoursesAdapter`, `ResourcesAdapter`, `SurveysAdapter`, `TeamsAdapter`, and `VoicesAdapter`.

---
*PR created automatically by Jules for task [1453544108449837608](https://jules.google.com/task/1453544108449837608) started by @dogi*