### PR TITLE
Fix course list alignment by refactoring checkbox visibility logic

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesAdapter.kt
@@ -305,30 +305,30 @@ class CoursesAdapter(
         return parts.joinToString(" · ")
     }
 
-    private fun updateVisibilityForMyCourse(course: Course, isMyCourseView: View, checkbox: CheckBox) {
-        if (isMyCourseLib) {
-            isMyCourseView.visibility = View.GONE
-            checkbox.visibility = View.VISIBLE
-        } else if (course.isMyCourse) {
-            isMyCourseView.visibility = View.VISIBLE
-            checkbox.visibility = View.GONE
-        } else {
-            isMyCourseView.visibility = View.GONE
-            checkbox.visibility = View.VISIBLE
-        }
+    private fun updateVisibilityForMyCourse(course: Course, isMyCourseView: View) {
+        isMyCourseView.visibility = if (!isMyCourseLib && course.isMyCourse) View.VISIBLE else View.GONE
+    }
+
+    /**
+     * List rows lay the checkbox out first, so hiding it with [View.GONE] collapses the column and
+     * drags that row's cover, title and meta line to the left. Only the guest case - which hides
+     * the checkbox on every row at once - may collapse it; a per-row hide keeps the space reserved
+     * so the whole list stays aligned.
+     */
+    internal fun checkboxVisibility(course: Course): Int = when {
+        isGuest -> View.GONE
+        isMyCourseLib || !course.isMyCourse -> View.VISIBLE
+        else -> View.INVISIBLE
     }
 
     private fun setupCheckbox(course: Course, checkbox: CheckBox, adapterPositionProvider: () -> Int) {
-        if (isGuest) {
-            checkbox.visibility = View.GONE
+        val visibility = checkboxVisibility(course)
+        checkbox.visibility = visibility
+        if (visibility != View.VISIBLE) {
+            checkbox.setOnClickListener(null)
+            checkbox.isChecked = false
             return
         }
-        val showCheckbox = isMyCourseLib || !course.isMyCourse
-        if (!showCheckbox) {
-            checkbox.visibility = View.GONE
-            return
-        }
-        checkbox.visibility = View.VISIBLE
         checkbox.isChecked = selectedItems.any { it?.courseId == course.courseId }
         checkbox.setOnClickListener { view: View ->
             checkbox.contentDescription = context.getString(R.string.select_res_course, course.courseTitle)
@@ -391,7 +391,7 @@ class CoursesAdapter(
             binding.tvSubjectLabel.text = context.getString(subjectLabelRes(subject))
             binding.title.text = course.courseTitle
             binding.tvMeta.text = buildMetaLine(course)
-            updateVisibilityForMyCourse(course, binding.isMyCourse, binding.checkbox)
+            updateVisibilityForMyCourse(course, binding.isMyCourse)
             setupCheckbox(course, binding.checkbox) { bindingAdapterPosition }
             bindProgress(course)
         }
@@ -399,7 +399,7 @@ class CoursesAdapter(
         fun bindPayloads(course: Course, hasProgressPayload: Boolean, hasSelectionPayload: Boolean) {
             if (hasProgressPayload) bindProgress(course)
             if (hasSelectionPayload) {
-                updateVisibilityForMyCourse(course, binding.isMyCourse, binding.checkbox)
+                updateVisibilityForMyCourse(course, binding.isMyCourse)
                 setupCheckbox(course, binding.checkbox) { bindingAdapterPosition }
             }
         }
@@ -438,7 +438,7 @@ class CoursesAdapter(
             bindCover(course, subject, binding.coverContainer, binding.ivCover, binding.ivSubjectIcon)
             binding.title.text = course.courseTitle
             binding.tvMeta.text = buildMetaLine(course)
-            updateVisibilityForMyCourse(course, binding.isMyCourse, binding.checkbox)
+            updateVisibilityForMyCourse(course, binding.isMyCourse)
             setupCheckbox(course, binding.checkbox) { bindingAdapterPosition }
             bindStatus(course)
         }
@@ -446,7 +446,7 @@ class CoursesAdapter(
         fun bindPayloads(course: Course, hasProgressPayload: Boolean, hasSelectionPayload: Boolean) {
             if (hasProgressPayload) bindStatus(course)
             if (hasSelectionPayload) {
-                updateVisibilityForMyCourse(course, binding.isMyCourse, binding.checkbox)
+                updateVisibilityForMyCourse(course, binding.isMyCourse)
                 setupCheckbox(course, binding.checkbox) { bindingAdapterPosition }
             }
         }

--- a/app/src/main/res/layout/fragment_my_course.xml
+++ b/app/src/main/res/layout/fragment_my_course.xml
@@ -127,16 +127,16 @@
                 android:id="@+id/selectAllCourse"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="10.5dp"
-                android:layout_gravity="center"
-                android:padding="8dp"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="@dimen/list_row_content_inset_start"
                 android:layout_weight="1"
+                android:buttonTint="@color/daynight_textColor"
+                android:checked="false"
+                android:maxWidth="0dp"
+                android:padding="@dimen/padding_normal"
                 android:text="@string/select_all"
                 android:textColor="@color/daynight_textColor"
-                android:textSize="@dimen/text_size_mid"
-                android:buttonTint="@color/daynight_textColor"
-                android:maxWidth="0dp"
-                android:checked="false" />
+                android:textSize="@dimen/text_size_mid" />
             <include
                 android:id="@+id/layout_search"
                 layout="@layout/layout_search_pill"

--- a/app/src/main/res/layout/fragment_my_library.xml
+++ b/app/src/main/res/layout/fragment_my_library.xml
@@ -109,14 +109,16 @@
                 android:id="@+id/selectAll"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_margin="10.5dp"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="@dimen/list_row_content_inset_start"
                 android:layout_weight="1"
-                android:padding="8dp"
+                android:buttonTint="@color/daynight_textColor"
+                android:checked="false"
+                android:maxWidth="0dp"
+                android:padding="@dimen/padding_normal"
                 android:text="@string/select_all"
                 android:textColor="@color/daynight_textColor"
-                android:textSize="@dimen/text_size_mid"
-                android:buttonTint="@color/daynight_textColor"
-                android:maxWidth="0dp" />
+                android:textSize="@dimen/text_size_mid" />
             <include
                 android:id="@+id/layout_search"
                 layout="@layout/layout_search_pill"

--- a/app/src/main/res/layout/item_course_list.xml
+++ b/app/src/main/res/layout/item_course_list.xml
@@ -25,9 +25,7 @@
             android:id="@+id/checkbox"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:buttonTint="@color/daynight_textColor"
-            android:scaleX="0.85"
-            android:scaleY="0.85" />
+            android:buttonTint="@color/daynight_textColor" />
         <FrameLayout
             android:id="@+id/cover_container"
             android:layout_width="44dp"

--- a/app/src/main/res/layout/item_library_list.xml
+++ b/app/src/main/res/layout/item_library_list.xml
@@ -25,9 +25,7 @@
             android:id="@+id/checkbox"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:buttonTint="@color/daynight_textColor"
-            android:scaleX="0.85"
-            android:scaleY="0.85" />
+            android:buttonTint="@color/daynight_textColor" />
         <FrameLayout
             android:id="@+id/cover_container"
             android:layout_width="44dp"

--- a/app/src/main/res/layout/row_steps.xml
+++ b/app/src/main/res/layout/row_steps.xml
@@ -14,14 +14,14 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@color/card_bg"
         android:orientation="vertical"
-        android:background="@color/card_bg">
+        android:padding="@dimen/padding_small">
 
         <TextView
             android:id="@+id/tv_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="@dimen/padding_normal"
             android:textColor="@color/daynight_textColor"
             android:textSize="@dimen/text_size_mid"
             android:textStyle="bold" />
@@ -30,6 +30,7 @@
             android:id="@+id/tv_description"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_small"
             android:textColor="@color/hint_color"
             android:visibility="gone" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -31,6 +31,10 @@
     <dimen name="status_badge_padding_vertical">4dp</dimen>
     <dimen name="status_badge_margin_start">8dp</dimen>
     <dimen name="item_margin_standard">16dp</dimen>
+    <!-- Leading inset of a list row's first control: 8dp card side margin + 8dp row padding.
+         Header controls that sit above the list (e.g. "select all") use it so they line up
+         with the column of row checkboxes underneath. -->
+    <dimen name="list_row_content_inset_start">16dp</dimen>
     <dimen name="image_thumbnail_size_100">100dp</dimen>
     <dimen name="image_thumbnail_size_120">120dp</dimen>
     <dimen name="profile_image_size">150dp</dimen>

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesAdapterTest.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.ui.courses
 
 import android.app.Application
 import android.content.Context
+import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -73,5 +74,37 @@ class CoursesAdapterTest {
         adapter.selectAllItems(true)
 
         assertEquals(false, adapter.areAllSelected())
+    }
+
+    @Test
+    fun `joined course keeps the checkbox laid out so list rows stay aligned`() {
+        val joined = Course("1", "A", "desc", "grade", "subject", 0, 10, isMyCourse = true)
+
+        assertEquals(View.INVISIBLE, adapter.checkboxVisibility(joined))
+    }
+
+    @Test
+    fun `selectable course shows the checkbox`() {
+        val selectable = Course("1", "A", "desc", "grade", "subject", 0, 10, isMyCourse = false)
+
+        assertEquals(View.VISIBLE, adapter.checkboxVisibility(selectable))
+    }
+
+    @Test
+    fun `my courses tab shows the checkbox for joined courses`() {
+        val myCoursesAdapter = CoursesAdapter(mockContext, false, true)
+        val joined = Course("1", "A", "desc", "grade", "subject", 0, 10, isMyCourse = true)
+
+        assertEquals(View.VISIBLE, myCoursesAdapter.checkboxVisibility(joined))
+    }
+
+    @Test
+    fun `guest collapses the checkbox on every row`() {
+        val guestAdapter = CoursesAdapter(mockContext, true, false)
+        val joined = Course("1", "A", "desc", "grade", "subject", 0, 10, isMyCourse = true)
+        val selectable = Course("2", "B", "desc", "grade", "subject", 0, 10, isMyCourse = false)
+
+        assertEquals(View.GONE, guestAdapter.checkboxVisibility(joined))
+        assertEquals(View.GONE, guestAdapter.checkboxVisibility(selectable))
     }
 }


### PR DESCRIPTION
## Summary
Refactors checkbox visibility handling in `CoursesAdapter` to prevent layout misalignment when checkboxes are hidden. Introduces a new `checkboxVisibility()` method that uses `View.INVISIBLE` for per-row hiding (preserving layout space) and `View.GONE` only for the guest case (where all checkboxes are hidden at once). Updates layout resources to align header controls with list row checkboxes and removes unnecessary checkbox scaling.

## Key Changes

**Adapter Logic (`CoursesAdapter.kt`)**
- Extracted checkbox visibility logic into a new `checkboxVisibility(course: Course): Int` method that returns:
  - `View.GONE` for guests (collapses the checkbox column across all rows)
  - `View.VISIBLE` for selectable courses or "my courses" tab
  - `View.INVISIBLE` for joined courses in the default view (hides but reserves layout space)
- Simplified `updateVisibilityForMyCourse()` to only handle the "my course" badge visibility
- Updated `setupCheckbox()` to use the new visibility method and clear listeners/state when checkbox is not visible
- Removed checkbox parameter from `updateVisibilityForMyCourse()` calls in both `CourseViewHolder` and `LibraryViewHolder`

**Layout Resources**
- `item_course_list.xml` & `item_library_list.xml`: Removed `scaleX="0.85"` and `scaleY="0.85"` from checkboxes (no longer needed with proper visibility handling)
- `fragment_my_course.xml` & `fragment_my_library.xml`: Updated "select all" checkbox styling to align with list rows:
  - Changed `layout_gravity` to `center_vertical` for proper vertical alignment
  - Replaced hardcoded margins with `@dimen/list_row_content_inset_start` (16dp = 8dp card margin + 8dp row padding)
  - Standardized padding to `@dimen/padding_normal`
  - Reordered attributes for consistency
- `row_steps.xml`: Moved padding from individual TextViews to parent LinearLayout for cleaner spacing

**Dimension Resources (`dimens.xml`)**
- Added `list_row_content_inset_start` (16dp) with documentation explaining its purpose for aligning header controls with list row checkbox columns

**Tests (`CoursesAdapterTest.kt`)**
- Added four new test cases covering the visibility logic:
  - Joined courses in default view use `INVISIBLE` to preserve alignment
  - Selectable courses show `VISIBLE` checkbox
  - "My courses" tab shows `VISIBLE` checkbox for joined courses
  - Guest mode collapses checkbox on all rows with `GONE`

## Implementation Details
The key insight is distinguishing between two hiding scenarios:
1. **Per-row hiding** (joined courses in default view): Use `View.INVISIBLE` to keep the checkbox column width, maintaining list alignment
2. **Bulk hiding** (guest mode): Use `View.GONE` to collapse the column, since all rows hide it uniformly

This prevents the visual "drag left" effect that occurred when individual rows hid their checkboxes with `GONE` while others kept them visible.

https://claude.ai/code/session_01AedqcpqhbRcKSFBauYcqwj