### PR TITLE
resources: less apply filter button is more (fixes #16091)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6669
-        versionName = "0.66.69"
+        versionCode = 6670
+        versionName = "0.66.70"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFilterFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/ResourcesFilterFragment.kt
@@ -80,7 +80,6 @@ class ResourcesFilterFragment : DialogFragment(), AdapterView.OnItemClickListene
             )
             isLevelsExpanded = !isLevelsExpanded
         }
-        binding.btnApplyFilter.setOnClickListener { dismiss() }
         return binding.root
     }
 

--- a/app/src/main/res/layout/fragment_library_filter.xml
+++ b/app/src/main/res/layout/fragment_library_filter.xml
@@ -165,18 +165,6 @@
                     android:choiceMode="multipleChoice"
                     android:nestedScrollingEnabled="true" />
             </LinearLayout>
-
-            <Button
-                android:id="@+id/btn_apply_filter"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/padding_normal"
-                android:background="@drawable/buttonblue"
-                android:text="@string/close"
-                android:textColor="@color/md_white_1000"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/expandable_layout_levels" />
-      </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.core.widget.NestedScrollView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesFilterFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/resources/ResourcesFilterFragmentTest.kt
@@ -1,0 +1,33 @@
+package org.ole.planet.myplanet.ui.resources
+
+import android.app.Application
+import android.widget.ImageView
+import androidx.appcompat.app.AppCompatActivity
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.R
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [32], application = Application::class)
+class ResourcesFilterFragmentTest {
+
+    @Test
+    fun `test fragment inflates and iv_close is present`() {
+        val activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
+        activity.setTheme(com.google.android.material.R.style.Theme_MaterialComponents)
+
+        val fragment = ResourcesFilterFragment()
+        fragment.show(activity.supportFragmentManager, "filter_dialog")
+        activity.supportFragmentManager.executePendingTransactions()
+
+        val view = fragment.view
+        assertNotNull(view)
+        val ivClose = view?.findViewById<ImageView>(R.id.iv_close)
+        assertNotNull(ivClose)
+    }
+}


### PR DESCRIPTION
Root Cause & Fix

- Duplicate Close Button: In the Resources Category Filter dialog (fragment_library_filter.xml), there was both a top-right X close icon (iv_close) and a bottom "Close" button (btn_apply_filter), both performing dialog dismissal (dismiss()).
- Fix: Removed the redundant bottom btn_apply_filter button from  fragment_library_filter.xml and its click listener from ResourcesFilterFragment.kt, keeping the top-right X close button

fixes #16091 