### PR TITLE
life: smoother personals repository querying (fixes #16148)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6670
-        versionName = "0.66.70"
+        versionCode = 6671
+        versionName = "0.66.71"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
@@ -64,13 +64,10 @@ class PersonalsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updatePersonalResource(id: String, updater: (Personal) -> Unit) {
-        personalDao.findByDocId(id)?.let { personal ->
-            updater(personal)
-            personalDao.update(personal)
-        }
-        personalDao.findById(id)?.let { personal ->
-            updater(personal)
-            personalDao.update(personal)
+        val personal = personalDao.findByDocId(id) ?: personalDao.findById(id)
+        personal?.let {
+            updater(it)
+            personalDao.update(it)
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImplTest.kt
@@ -143,10 +143,27 @@ class PersonalsRepositoryImplTest {
     }
 
     @Test
-    fun `updatePersonalResource calls updater on matched _id and id`() = runTest {
+    fun `updatePersonalResource uses _id if found and updates once`() = runTest {
         val personalByDocId = Personal().apply { title = "Old" }
-        val personalById = Personal().apply { title = "Old" }
         coEvery { personalDao.findByDocId("test-id") } returns personalByDocId
+        coEvery { personalDao.findById("test-id") } returns null
+
+        var updateCount = 0
+        repository.updatePersonalResource("test-id") { personal ->
+            personal.title = "New Title"
+            updateCount++
+        }
+
+        assertEquals(1, updateCount)
+        assertEquals("New Title", personalByDocId.title)
+        coVerify(exactly = 1) { personalDao.update(personalByDocId) }
+        coVerify(exactly = 0) { personalDao.findById(any()) }
+    }
+
+    @Test
+    fun `updatePersonalResource falls back to id if _id is not found and updates once`() = runTest {
+        val personalById = Personal().apply { title = "Old" }
+        coEvery { personalDao.findByDocId("test-id") } returns null
         coEvery { personalDao.findById("test-id") } returns personalById
 
         var updateCount = 0
@@ -155,11 +172,9 @@ class PersonalsRepositoryImplTest {
             updateCount++
         }
 
-        assertEquals(2, updateCount)
-        assertEquals("New Title", personalByDocId.title)
+        assertEquals(1, updateCount)
         assertEquals("New Title", personalById.title)
-        coVerify { personalDao.update(personalByDocId) }
-        coVerify { personalDao.update(personalById) }
+        coVerify(exactly = 1) { personalDao.update(personalById) }
     }
 
     @Test


### PR DESCRIPTION
Collapsed the double write in `PersonalsRepositoryImpl.updatePersonalResource` to prevent non-idempotent updaters from running twice. Tests have been updated.

---
*PR created automatically by Jules for task [9705152882305891709](https://jules.google.com/task/9705152882305891709) started by @dogi*