### PR TITLE
actions: smoother workflow building (fixes #16216)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '**'
       - '!master'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: build-${{ github.ref }}
@@ -14,6 +18,7 @@ jobs:
   build:
     name: myPlanet build
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - '**'
       - '!master'
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     name: myPlanet build
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6705
-        versionName = "0.67.5"
+        versionCode = 6706
+        versionName = "0.67.6"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
This adds `workflow_dispatch` for manual triggering, `permissions: contents: read` for improved security with GITHUB_TOKEN, and `timeout-minutes: 45` on the build job to prevent hanging processes from consuming runner minutes indefinitely.

---
*PR created automatically by Jules for task [7711650949743367320](https://jules.google.com/task/7711650949743367320) started by @dogi*