### PR TITLE
all: smoother download service testing (fixes #16149)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6671
-        versionName = "0.66.71"
+        versionCode = 6672
+        versionName = "0.66.72"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/services/DownloadServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/DownloadServiceTest.kt
@@ -71,7 +71,6 @@ class DownloadServiceTest {
     // --- Tests for startService ---
 
     @Test
-    @Config(sdk = [Build.VERSION_CODES.R])
     fun `test startService starts foreground service when API is less than S`() {
         val mContext = mockk<Context>(relaxed = true)
         every { ContextCompat.startForegroundService(any(), any()) } returns mockk()
@@ -83,7 +82,6 @@ class DownloadServiceTest {
     }
 
     @Test
-    @Config(sdk = [Build.VERSION_CODES.S])
     fun `test startService starts foreground service for Activity context on Android S and above`() {
         val mockActivity: Activity = mockk(relaxed = true)
         every { ContextCompat.startForegroundService(any(), any()) } returns mockk()


### PR DESCRIPTION
Removed two method-level `@Config` annotations specifying different SDKs in `DownloadServiceTest`. The SDK branch logic is already controlled via `ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", ...)`.
Removing these `@Config` annotations prevents Robolectric from booting multiple, separate test sandboxes for this class, decreasing test execution time by executing all tests within a single sandbox.

---
*PR created automatically by Jules for task [4674187310653638073](https://jules.google.com/task/4674187310653638073) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Release**
  * Updated the Android app version to **0.66.72**.

* **Tests**
  * Improved service-start test consistency across supported Android versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->