### PR TITLE
all: smoother crash log store handling (fixes #16150)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6674
-        versionName = "0.66.74"
+        versionCode = 6675
+        versionName = "0.66.75"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/CrashLogStore.kt
@@ -18,11 +18,19 @@ object CrashLogStore {
 
     private fun dir(context: Context): File = File(context.filesDir, DIR_NAME)
 
+    private fun isValidLogFile(file: File): Boolean {
+        if (!file.isFile || !file.name.endsWith(FILE_EXTENSION)) return false
+        val name = file.name.removeSuffix(FILE_EXTENSION)
+        val separator = name.indexOf('_')
+        if (separator <= 0) return false
+        return name.substring(0, separator).toLongOrNull() != null
+    }
+
     fun save(context: Context, type: String, error: String, timeProvider: TimeProvider): File? {
         return try {
             val logDir = dir(context)
             if (!logDir.exists() && !logDir.mkdirs()) return null
-            if ((logDir.listFiles()?.size ?: 0) >= MAX_PENDING_FILES) return null
+            if ((logDir.listFiles()?.count { isValidLogFile(it) } ?: 0) >= MAX_PENDING_FILES) return null
             val file = File(logDir, "${timeProvider.now()}_$type$FILE_EXTENSION")
             file.writeText(error)
             file
@@ -34,13 +42,11 @@ object CrashLogStore {
 
     fun loadPendingLogs(context: Context): List<PendingLog> {
         val files = dir(context).listFiles() ?: return emptyList()
-        return files.filter { it.isFile && it.name.endsWith(FILE_EXTENSION) }.mapNotNull { file ->
+        return files.filter { isValidLogFile(it) }.mapNotNull { file ->
             try {
                 val name = file.name.removeSuffix(FILE_EXTENSION)
                 val separator = name.indexOf('_')
-                if (separator <= 0) return@mapNotNull null
                 val time = name.substring(0, separator)
-                if (time.toLongOrNull() == null) return@mapNotNull null
                 PendingLog(file, name.substring(separator + 1), time, file.readText())
             } catch (e: Exception) {
                 e.printStackTrace()

--- a/app/src/test/java/org/ole/planet/myplanet/utils/CrashLogStoreTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/CrashLogStoreTest.kt
@@ -72,6 +72,19 @@ class CrashLogStoreTest {
     }
 
     @Test
+    fun `save ignores unrelated files when enforcing cap`() {
+        pendingDir.mkdirs()
+        repeat(19) { i ->
+            File(pendingDir, "${1000L + i}_crash.log").writeText("e$i")
+        }
+        File(pendingDir, "not-a-log.txt").writeText("junk")
+        File(pendingDir, "noseparator.log").writeText("junk")
+
+        assertNotNull(CrashLogStore.save(context, "crash", "one more fits", SystemTimeProvider()))
+        assertEquals(20, CrashLogStore.loadPendingLogs(context).size)
+    }
+
+    @Test
     fun `loadPendingLogs on missing directory returns empty list`() {
         assertTrue(CrashLogStore.loadPendingLogs(context).isEmpty())
     }


### PR DESCRIPTION
CrashLogStore `save` previously aborted if there were 20 or more items in the log directory, regardless of whether they were valid log files or not. This meant stray/malformed files could silently suppress real crash reports.

This extracts `isValidLogFile` to share the same file filtering requirements between `save` and `loadPendingLogs`, ignoring malformed logs during cap enforcement. Added test case for verification.

---
*PR created automatically by Jules for task [7081659680194256275](https://jules.google.com/task/7081659680194256275) started by @dogi*