### PR TITLE
courses: smoother submissions repository exporting (fixes #16151)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6672
-        versionName = "0.66.72"
+        versionCode = 6673
+        versionName = "0.66.73"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
@@ -78,7 +78,7 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
                 canvas.drawText("Date: ${TimeUtils.getFormattedDateWithTime(submission.lastUpdateTime)}", MARGIN, yPosition, normalPaint)
                 yPosition += LINE_HEIGHT * 2
 
-                val questions = examId?.let { questionDao.getByExamId(it).map { question -> question } }.orEmpty()
+                val questions = examId?.let { questionDao.getByExamId(it) }.orEmpty()
 
                 val answersMap = submission.answers?.associateBy { it.questionId } ?: emptyMap()
 
@@ -176,7 +176,7 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
                 yPosition += LINE_HEIGHT * 3
 
                 val examId = getExamId(submissions.firstOrNull()?.parentId)
-                val questions = examId?.let { questionDao.getByExamId(it).map { question -> question } }.orEmpty()
+                val questions = examId?.let { questionDao.getByExamId(it) }.orEmpty()
 
                 submissions.forEachIndexed { submissionIndex, submission ->
                     if (yPosition > PAGE_HEIGHT - MARGIN - 100) {


### PR DESCRIPTION
Removed the identity map operation on the question list in both the single-PDF and multi-PDF export paths. `questionDao.getByExamId` already returns `List<ExamQuestion>`, so the map operation merely allocated a duplicate list unnecessarily. Tests have been successfully verified to confirm no logic was altered.

---
*PR created automatically by Jules for task [1356566584618091516](https://jules.google.com/task/1356566584618091516) started by @dogi*