### PR TITLE
sync: smoother retry repository dao querying (fixes #16153)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6675
-        versionName = "0.66.75"
+        versionCode = 6676
+        versionName = "0.66.76"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/RetryDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/RetryDao.kt
@@ -48,4 +48,10 @@ interface RetryDao {
 
     @Query("UPDATE retry_operation SET status = 'pending', nextRetryTime = :retryTime WHERE status = 'in_progress'")
     suspend fun recoverStuck(retryTime: Long)
+
+    @Query("UPDATE retry_operation SET status = 'in_progress' WHERE id = :id")
+    suspend fun markInProgress(id: String): Int
+
+    @Query("UPDATE retry_operation SET status = 'completed', lastAttemptTime = :timestamp WHERE id = :id")
+    suspend fun markCompleted(id: String, timestamp: Long): Int
 }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/RetryRepositoryImpl.kt
@@ -58,18 +58,11 @@ class RetryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun markInProgress(operationId: String) {
-        retryDao.findById(operationId)?.let { op ->
-            op.status = RetryOperation.STATUS_IN_PROGRESS
-            retryDao.update(op)
-        }
+        retryDao.markInProgress(operationId)
     }
 
     override suspend fun markCompleted(operationId: String) {
-        retryDao.findById(operationId)?.let { op ->
-            op.status = RetryOperation.STATUS_COMPLETED
-            op.lastAttemptTime = timeProvider.now()
-            retryDao.update(op)
-        }
+        retryDao.markCompleted(operationId, timeProvider.now())
     }
 
     override suspend fun markFailed(operationId: String, errorMessage: String?, httpCode: Int?) {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/RetryRepositoryImplTest.kt
@@ -96,45 +96,38 @@ class RetryRepositoryImplTest {
 
     @Test
     fun `markInProgress updates status`() = runTest {
-        val operation = RetryOperation().apply { status = RetryOperation.STATUS_PENDING }
-        coEvery { retryDao.findById("opId") } returns operation
+        coEvery { retryDao.markInProgress("opId") } returns 1
 
         repository.markInProgress("opId")
 
-        assertEquals(RetryOperation.STATUS_IN_PROGRESS, operation.status)
-        coVerify { retryDao.update(operation) }
+        coVerify { retryDao.markInProgress("opId") }
     }
 
     @Test
     fun `markInProgress does nothing when operation not found`() = runTest {
-        coEvery { retryDao.findById("missingId") } returns null
+        coEvery { retryDao.markInProgress("missingId") } returns 0
 
         repository.markInProgress("missingId")
 
-        coVerify(exactly = 0) { retryDao.update(any()) }
+        coVerify { retryDao.markInProgress("missingId") }
     }
 
     @Test
     fun `markCompleted updates status and timestamp`() = runTest {
-        val operation = RetryOperation().apply {
-            status = RetryOperation.STATUS_PENDING; lastAttemptTime = 0
-        }
-        coEvery { retryDao.findById("opId") } returns operation
+        coEvery { retryDao.markCompleted("opId", any()) } returns 1
 
         repository.markCompleted("opId")
 
-        assertEquals(RetryOperation.STATUS_COMPLETED, operation.status)
-        assert(operation.lastAttemptTime > 0)
-        coVerify { retryDao.update(operation) }
+        coVerify { retryDao.markCompleted("opId", timeProvider.now()) }
     }
 
     @Test
     fun `markCompleted does nothing when operation not found`() = runTest {
-        coEvery { retryDao.findById("missingId") } returns null
+        coEvery { retryDao.markCompleted("missingId", any()) } returns 0
 
         repository.markCompleted("missingId")
 
-        coVerify(exactly = 0) { retryDao.update(any()) }
+        coVerify { retryDao.markCompleted("missingId", timeProvider.now()) }
     }
 
     @Test


### PR DESCRIPTION
Replaced read-modify-write data access patterns in RetryRepositoryImpl with direct, targeted `UPDATE` SQL queries for the `markInProgress` and `markCompleted` operations, avoiding extra round trips and full-row overwrites. Updated associated test cases to reflect the new targeted mock dependencies.

---
*PR created automatically by Jules for task [7840274181939526463](https://jules.google.com/task/7840274181939526463) started by @dogi*