### PR TITLE
actions: smoother workflow test caching (fixes #16156)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,10 @@ jobs:
             build-dir-test-${{ matrix.build }}-shard${{ matrix.shard }}-
             build-dir-test-${{ matrix.build }}-
 
+      - name: drop stale test results from restored build dir
+        shell: bash
+        run: rm -rf app/build/test-results app/build/reports/tests
+
       - name: run unit tests
         shell: bash
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,16 +39,14 @@ jobs:
         with:
           path: |
             app/build
+            !app/build/test-results/**
+            !app/build/reports/**
             .gradle/*
             !.gradle/configuration-cache
           key: build-dir-test-${{ matrix.build }}-shard${{ matrix.shard }}-${{ github.sha }}
           restore-keys: |
             build-dir-test-${{ matrix.build }}-shard${{ matrix.shard }}-
             build-dir-test-${{ matrix.build }}-
-
-      - name: drop stale test results from restored build dir
-        shell: bash
-        run: rm -rf app/build/test-results app/build/reports/tests
 
       - name: run unit tests
         shell: bash

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6707
-        versionName = "0.67.7"
+        versionCode = 6708
+        versionName = "0.67.8"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
Optimized the CI test workflow by preventing stale test reports from being cached.

- Updated the `actions/cache` paths in `.github/workflows/test.yml` to exclude `app/build/test-results/**` and `app/build/reports/**`.
- Removed the manual step that was previously used to delete these redundant directories after cache restoration.

---
*PR created automatically by Jules for task [8971901367436479351](https://jules.google.com/task/8971901367436479351) started by @dogi*