### PR TITLE
teams: smoother surveys repository querying (fixes #16157)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6677
-        versionName = "0.66.77"
+        versionCode = 6678
+        versionName = "0.66.78"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SurveysRepositoryImpl.kt
@@ -61,7 +61,7 @@ class SurveysRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getExamQuestions(examId: String): List<ExamQuestion> {
-        return questionDao.getByExamId(examId).map { it }
+        return questionDao.getByExamId(examId)
     }
 
     override suspend fun adoptSurvey(
@@ -254,7 +254,6 @@ class SurveysRepositoryImpl @Inject constructor(
         return examDao.getByType("surveys")
             .asSequence()
             .filter { it.teamId == teamId || filteredSubmissionIds.contains(it.id) }
-            .map { it }
             .toList()
     }
 
@@ -267,14 +266,12 @@ class SurveysRepositoryImpl @Inject constructor(
             .asSequence()
             .filter { it.isTeamShareAllowed }
             .filterNot { excludedIds.contains(it.id) }
-            .map { it }
             .toList()
     }
 
     override suspend fun getIndividualSurveys(): List<StepExam> {
         return examDao.getByType("surveys")
             .filter { !it.isTeamShareAllowed && it.teamId.isNullOrEmpty() }
-            .map { it }
     }
 
     private suspend fun getTeamSubmissionExamIds(teamId: String): Set<String> {
@@ -378,7 +375,7 @@ class SurveysRepositoryImpl @Inject constructor(
 
     override suspend fun getSurveys(ascending: Boolean): List<StepExam> {
         val entities = examDao.getByType("surveys").sortedBy { it.createdDate }
-        return (if (ascending) entities else entities.asReversed()).map { it }
+        return if (ascending) entities else entities.asReversed()
     }
 
     override suspend fun bulkInsertExamsFromSync(jsonArray: JsonArray) {
@@ -464,7 +461,7 @@ class SurveysRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getPendingAdoptedSurveys(): List<StepExam> {
-        return examDao.getPendingAdoptedSurveys().map { it }
+        return examDao.getPendingAdoptedSurveys()
     }
 
     override suspend fun fetchPublicSurvey(baseUrl: String, teamId: String, surveyId: String): JsonObject? {


### PR DESCRIPTION
Removed redundant identity `.map { it }` calls in `SurveysRepositoryImpl`.

These `.map { it }` calls did nothing but create copies of existing lists or add unnecessary no-op wrappers in Sequence chains. Removing them streamlines the code and avoids unnecessary list allocations. The return values (e.g. from DAO queries or local lists like `entities.asReversed()`) can be safely returned directly.

---
*PR created automatically by Jules for task [11145326985975867422](https://jules.google.com/task/11145326985975867422) started by @dogi*