### PR TITLE
all: smoother guest user role handling (fixes #16158)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6678
-        versionName = "0.66.78"
+        versionCode = 6679
+        versionName = "0.66.79"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/UserEntity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/UserEntity.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.model
 
-import android.util.Base64
 import androidx.core.net.toUri
 import androidx.room.Entity
 import androidx.room.Index
@@ -120,7 +119,7 @@ open class UserEntity(
 
             inputStream?.use {
                 val bytes = it.readBytes()
-                Base64.encodeToString(bytes, Base64.NO_WRAP)
+                java.util.Base64.getEncoder().encodeToString(bytes)
             }
         } catch (e: Exception) {
             e.printStackTrace()
@@ -177,8 +176,8 @@ open class UserEntity(
 
     fun isGuest(): Boolean {
         val hasGuestId = _id?.startsWith("guest_") == true
-        val hasGuestRole = rolesList?.any { it?.lowercase() == "guest" } == true
-        return hasGuestId || (hasGuestRole && rolesList?.any { it?.lowercase() == "learner" } != true)
+        val hasGuestRole = rolesList?.any { it.equals("guest", ignoreCase = true) } == true
+        return hasGuestId || (hasGuestRole && rolesList?.any { it.equals("learner", ignoreCase = true) } != true)
     }
 
     override fun toString(): String {

--- a/app/src/test/java/org/ole/planet/myplanet/model/UserEntityEncodeImageTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/UserEntityEncodeImageTest.kt
@@ -77,14 +77,13 @@ class UserEntityEncodeImageTest {
 
         every { imagePath.toUri() } returns mockUri
         every { mockContentResolver.openInputStream(mockUri) } returns mockInputStream
-        every { Base64.encodeToString(any(), Base64.NO_WRAP) } returns "encoded_base64_string"
+        val expectedBase64 = java.util.Base64.getEncoder().encodeToString("test image data".toByteArray())
 
         val result = realmUser.encodeImageToBase64(imagePath)
 
-        assertEquals("encoded_base64_string", result)
+        assertEquals(expectedBase64, result)
         verify { imagePath.toUri() }
         verify { mockContentResolver.openInputStream(mockUri) }
-        verify { Base64.encodeToString(any(), Base64.NO_WRAP) }
     }
 
     @Test
@@ -95,12 +94,11 @@ class UserEntityEncodeImageTest {
 
         try {
             val imagePath = tempFile.absolutePath
-            every { Base64.encodeToString(any(), Base64.NO_WRAP) } returns "encoded_file_string"
+            val expectedBase64 = java.util.Base64.getEncoder().encodeToString("test file data".toByteArray())
 
             val result = realmUser.encodeImageToBase64(imagePath)
 
-            assertEquals("encoded_file_string", result)
-            verify { Base64.encodeToString(any(), Base64.NO_WRAP) }
+            assertEquals(expectedBase64, result)
         } finally {
             tempFile.delete()
         }


### PR DESCRIPTION
Optimizes string comparisons in `isGuest()` method to remove unnecessary allocations and safe calls.
Replaces the Android-specific `Base64` usage with standard Java `Base64` to reduce framework dependency in `UserEntity`.
Updates corresponding unit tests.

---
*PR created automatically by Jules for task [14360611546774808612](https://jules.google.com/task/14360611546774808612) started by @dogi*