### PR TITLE
Fix: suppress DEPRECATION warning in MainApplication

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/MainApplication.kt
@@ -525,6 +525,7 @@ class MainApplication : Application(), WorkManagerConfiguration.Provider {
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
+        @Suppress("DEPRECATION")
         if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
             PdfThumbnailLoader.evictAll()
         }


### PR DESCRIPTION
Fix: suppress DEPRECATION warning in MainApplication

The release build scan flagged `ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW` as deprecated in API 35. Since the behavior (evict the PDF thumbnail cache) should remain, a `@Suppress("DEPRECATION")` annotation was added to ignore this warning, matching the codebase's existing pattern.

---
*PR created automatically by Jules for task [5772974590066889583](https://jules.google.com/task/5772974590066889583) started by @dogi*