### PR TITLE
sync: smoother photo url utils uploading (fixes #16159)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6679
-        versionName = "0.66.79"
+        versionCode = 6680
+        versionName = "0.66.80"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/PhotoUploader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/PhotoUploader.kt
@@ -33,13 +33,15 @@ class PhotoUploader @Inject constructor(
         withContext(dispatcherProvider.io) {
             data class UploadedPhotoInfo(val photoId: String, val rev: String, val id: String)
 
+            val baseUrl = UrlUtils.getUrl()
+
             photosToUpload.chunked(BATCH_SIZE).forEach { batch ->
                 val successfulUploads = mutableListOf<UploadedPhotoInfo>()
 
                 batch.forEach { (photoId, serialized) ->
                     try {
                         val `object` = uploadRepository.postUpload(
-                            "${UrlUtils.getUrl()}/submissions", serialized
+                            "$baseUrl/submissions", serialized
                         ).body()
 
                         if (`object` != null) {


### PR DESCRIPTION
Hoists the `UrlUtils.getUrl()` call out of the `PhotoUploader` per-photo `forEach` loop. This avoids unnecessary IO/SP lookups since the base URL is static per session.

---
*PR created automatically by Jules for task [7932366732563818232](https://jules.google.com/task/7932366732563818232) started by @dogi*