### PR TITLE
sync: smoother download auth header working (fixes #16161)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6681
-        versionName = "0.66.81"
+        versionCode = 6682
+        versionName = "0.66.82"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
@@ -58,9 +58,11 @@ class DownloadWorker @AssistedInject constructor(
             var completedCount = 0
             val results = mutableListOf<Boolean>()
 
+            val authHeader = UrlUtils.header
+
             urls.forEachIndexed { index, url ->
                 try {
-                    val success = downloadFile(url, index, urls.size)
+                    val success = downloadFile(url, authHeader, index, urls.size)
                     results.add(success)
                     completedCount++
 
@@ -81,7 +83,7 @@ class DownloadWorker @AssistedInject constructor(
         }
     }
 
-    private suspend fun downloadFile(url: String, index: Int, total: Int): Boolean {
+    private suspend fun downloadFile(url: String, authHeader: String, index: Int, total: Int): Boolean {
         if (FileUtils.checkFileExist(context, url)) {
             try {
                 resourcesRepository.markResourceOfflineByUrl(url)
@@ -91,7 +93,7 @@ class DownloadWorker @AssistedInject constructor(
             return true
         }
         return try {
-            val response = downloadRepository.downloadFileResponse(url, UrlUtils.header)
+            val response = downloadRepository.downloadFileResponse(url, authHeader)
             when (response) {
                 is DownloadResult.Success -> {
                     downloadFileBody(response.body, url, index, total)


### PR DESCRIPTION
Hoist the auth header out of the per-file loop in DownloadWorker and pass it down to downloadFile so the Basic auth is not re-encoded for every file.

---
*PR created automatically by Jules for task [10326784632570692069](https://jules.google.com/task/10326784632570692069) started by @dogi*