### PR TITLE
courses: smoother submissions repository list flowing (fixes #16163)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6683
-        versionName = "0.66.83"
+        versionCode = 6684
+        versionName = "0.66.84"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryImpl.kt
@@ -76,11 +76,11 @@ class SubmissionsRepositoryImpl @Inject internal constructor(
     }
 
     override fun getPendingSurveysFlow(userId: String?): Flow<List<Submission>> {
-        return submissionDao.observePendingSurveys(userId).map { rows -> rows.map { it } }
+        return submissionDao.observePendingSurveys(userId)
     }
 
     override fun getSubmissionsFlow(userId: String): Flow<List<Submission>> {
-        return submissionDao.observeByUserId(userId).map { rows -> rows.map { it } }.distinctUntilChanged { old, new ->
+        return submissionDao.observeByUserId(userId).distinctUntilChanged { old, new ->
             // Assuming any meaningful mutation bumps lastUpdateTime.
             old.size == new.size && old.zip(new).all { (o, n) -> o.id == n.id && o.lastUpdateTime == n.lastUpdateTime }
         }


### PR DESCRIPTION
Removes unnecessary `.map { rows -> rows.map { it } }` copies from flows in SubmissionsRepositoryImpl which were needlessly duplicating lists upon every database emission.

---
*PR created automatically by Jules for task [2175795098407888625](https://jules.google.com/task/2175795098407888625) started by @dogi*