### PR TITLE
community: smoother voices view modelling (fixes #16165)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6684
-        versionName = "0.66.84"
+        versionCode = 6685
+        versionName = "0.66.85"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/VoicesViewModel.kt
@@ -67,7 +67,7 @@ class VoicesViewModel @Inject constructor(
         observeJob?.cancel()
         observeJob = viewModelScope.launch {
             voicesRepository.getCommunityNews(userIdentifier).collect { newsList ->
-                val filtered = newsList.map { it as News? }
+                val filtered: List<News?> = newsList
                 _baseNewsList.value = filtered
                 _labels.value = collectLabels(filtered)
             }


### PR DESCRIPTION
Dropped the unnecessary list allocation map in `VoicesViewModel.observeCommunityNews` when casting from `List<News>` to `List<News?>`. Instead of allocating a new list, simply assign it statically with the explicit generic type.

---
*PR created automatically by Jules for task [11786779846300412122](https://jules.google.com/task/11786779846300412122) started by @dogi*