### PR TITLE
actions: smoother workflows skipping (fixes #16166)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**'
       - '!master'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
 
 concurrency:
   group: build-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '**'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6685
-        versionName = "0.66.85"
+        versionCode = 6686
+        versionName = "0.66.86"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
Resolves issue 76 by skipping the test and build workflows when a push contains only documentation changes (specifically, changes to markdown files or the `docs/` directory).

---
*PR created automatically by Jules for task [14847412013709997533](https://jules.google.com/task/14847412013709997533) started by @dogi*