### PR TITLE
all: smoother myplanet context handling (fixes #16168)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6687
-        versionName = "0.66.87"
+        versionCode = 6688
+        versionName = "0.66.88"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/MyPlanet.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/MyPlanet.kt
@@ -3,13 +3,11 @@ package org.ole.planet.myplanet.model
 import android.app.usage.UsageStats
 import android.app.usage.UsageStatsManager
 import android.content.Context
-import android.os.Build
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import java.io.Serializable
 import java.util.Calendar
 import java.util.Date
-import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.NetworkUtils
@@ -31,7 +29,7 @@ class MyPlanet : Serializable {
             val postJSON = JsonObject()
             val planet = JsonUtils.gson.fromJson(spm.getVersionDetail() ?: "", MyPlanet::class.java)
             if (planet != null) postJSON.addProperty("planetVersion", planet.planetVersion)
-            postJSON.addProperty("_id", VersionUtils.getAndroidId(MainApplication.context) + "@" + NetworkUtils.getUniqueIdentifier())
+            postJSON.addProperty("_id", VersionUtils.getAndroidId(context) + "@" + NetworkUtils.getUniqueIdentifier())
             postJSON.addProperty("last_synced", spm.getLastSync())
             postJSON.addProperty("parentCode", model.parentCode)
             postJSON.addProperty("createdOn", model.planetCode)
@@ -50,7 +48,7 @@ class MyPlanet : Serializable {
             postJSON.addProperty("version", VersionUtils.getVersionCode(context))
             postJSON.addProperty("versionName", VersionUtils.getVersionName(context))
             postJSON.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
-            postJSON.addProperty("uniqueAndroidId", VersionUtils.getAndroidId(MainApplication.context))
+            postJSON.addProperty("uniqueAndroidId", VersionUtils.getAndroidId(context))
             postJSON.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
             postJSON.addProperty("deviceName", NetworkUtils.getDeviceName())
             postJSON.addProperty("time", Date().time)
@@ -62,18 +60,16 @@ class MyPlanet : Serializable {
             val cal = Calendar.getInstance()
             cal.timeInMillis = spm.getLastUsageUploaded()
             val arr = JsonArray()
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-                val mUsageStatsManager = MainApplication.context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
-                val queryUsageStats = mUsageStatsManager.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, cal.timeInMillis, System.currentTimeMillis())
-                for (s in queryUsageStats) {
-                    addStats(s, arr, context)
-                }
+            val mUsageStatsManager = context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
+            val queryUsageStats = mUsageStatsManager.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, cal.timeInMillis, System.currentTimeMillis())
+            for (s in queryUsageStats) {
+                addStats(s, arr, context)
             }
             return arr
         }
 
         private fun addStats(s: UsageStats, arr: JsonArray, context: Context) {
-            if (s.packageName == MainApplication.context.packageName) {
+            if (s.packageName == context.packageName) {
                 val `object` = JsonObject()
                 `object`.addProperty("lastTimeUsed", if (s.lastTimeUsed > 0) s.lastTimeUsed else 0)
                 `object`.addProperty("firstTimeUsed", if (s.firstTimeStamp > 0) s.lastTimeStamp else 0)


### PR DESCRIPTION
Decouples the `MyPlanet` model companion object functions from the global `MainApplication.context`. It now strictly utilizes the `Context` parameter already provided by callers. The change also eliminates a redundant runtime SDK check (`>= LOLLIPOP_MR1`) since the app's `minSdk` guarantees it will always execute, along with unused imports.

This ensures better modularity and testability by eliminating the hardcoded dependency on the Application class.

---
*PR created automatically by Jules for task [9109943335198190703](https://jules.google.com/task/9109943335198190703) started by @dogi*