### PR TITLE
teams: smoother voices label managing (fixes #16170)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6689
-        versionName = "0.66.89"
+        versionCode = 6690
+        versionName = "0.66.90"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/VoicesLabelManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/VoicesLabelManager.kt
@@ -79,8 +79,7 @@ class VoicesLabelManager(
                 chipCloud.setDeleteListener { _: Int, labelText: String? ->
                     val selectedLabel = when {
                         labelText == null -> null
-                        Constants.LABELS.containsKey(labelText) -> Constants.LABELS[labelText]
-                        else -> labels.firstOrNull { getLabel(it) == labelText }
+                        else -> Constants.LABELS[labelText] ?: labels.firstOrNull { getLabel(it) == labelText }
                     }
                     val voiceId = voice.id
                     if (selectedLabel != null && voiceId != null) {


### PR DESCRIPTION
Collapse the double map lookup in `VoicesLabelManager`'s delete listener.

The `when` block contained `Constants.LABELS.containsKey(labelText) -> Constants.LABELS[labelText]`.
This was changed to directly use `Constants.LABELS[labelText]` and fall back to searching the list of labels if it returns null, avoiding the double lookup.

---
*PR created automatically by Jules for task [5912152280780596553](https://jules.google.com/task/5912152280780596553) started by @dogi*