### PR TITLE
courses: smoother exam answer utils caching (fixes #16220)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6708
-        versionName = "0.67.8"
+        versionCode = 6709
+        versionName = "0.67.9"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/ExamAnswerUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ExamAnswerUtils.kt
@@ -1,8 +1,9 @@
 package org.ole.planet.myplanet.utils
 
-import android.util.LruCache
 import com.google.gson.JsonObject
 import java.util.Arrays
+import java.util.Collections
+import java.util.LinkedHashMap
 import java.util.Locale
 import org.ole.planet.myplanet.model.ExamQuestion
 import org.ole.planet.myplanet.utils.JsonUtils.getStringAsJsonArray
@@ -10,7 +11,13 @@ import org.ole.planet.myplanet.utils.JsonUtils.getStringAsJsonArray
 object ExamAnswerUtils {
     // Process-lifetime cache mapping a stringified choices JSON to a Map of id -> text.
     // Using choices as the key prevents stale mapping if the question's choices are updated from the server.
-    private val choicesCache = LruCache<String, Map<String, String>>(100)
+    private val choicesCache = Collections.synchronizedMap(
+        object : LinkedHashMap<String, Map<String, String>>(100, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Map<String, String>>): Boolean {
+                return size > 100
+            }
+        }
+    )
 
     fun choiceDisplayValue(choice: JsonObject): String? {
         return JsonUtils.getString("text", choice).ifBlank {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/ExamAnswerUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ExamAnswerUtils.kt
@@ -1,9 +1,9 @@
 package org.ole.planet.myplanet.utils
 
+import androidx.annotation.VisibleForTesting
 import com.google.gson.JsonObject
 import java.util.Arrays
 import java.util.Collections
-import java.util.LinkedHashMap
 import java.util.Locale
 import org.ole.planet.myplanet.model.ExamQuestion
 import org.ole.planet.myplanet.utils.JsonUtils.getStringAsJsonArray
@@ -12,12 +12,15 @@ object ExamAnswerUtils {
     // Process-lifetime cache mapping a stringified choices JSON to a Map of id -> text.
     // Using choices as the key prevents stale mapping if the question's choices are updated from the server.
     private val choicesCache = Collections.synchronizedMap(
-        object : LinkedHashMap<String, Map<String, String>>(100, 0.75f, true) {
+        object : LinkedHashMap<String, Map<String, String>>(134, 0.75f, true) {
             override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Map<String, String>>): Boolean {
                 return size > 100
             }
         }
     )
+
+    @VisibleForTesting
+    internal fun cacheSize(): Int = choicesCache.size
 
     fun choiceDisplayValue(choice: JsonObject): String? {
         return JsonUtils.getString("text", choice).ifBlank {

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ExamAnswerUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ExamAnswerUtilsTest.kt
@@ -66,4 +66,78 @@ class ExamAnswerUtilsTest {
         val inputQuestion = createQuestion("input", listOf("A"))
         assertFalse(ExamAnswerUtils.checkCorrectAnswer("", null, inputQuestion))
     }
+
+    @Test
+    fun testChoiceCachingAndChangedJson() {
+        val json1 = "[{\"id\":\"1\",\"text\":\"Choice A\"},{\"id\":\"2\",\"text\":\"Choice B\"}]"
+        val mockQuestion1 = mockk<ExamQuestion>()
+        every { mockQuestion1.choices } returns json1
+
+        // First call populates cache
+        val text1 = ExamAnswerUtils.getChoiceTextById(mockQuestion1, "1")
+        org.junit.Assert.assertEquals("Choice A", text1)
+
+        // Second call hits cache (returns same value)
+        val text2 = ExamAnswerUtils.getChoiceTextById(mockQuestion1, "2")
+        org.junit.Assert.assertEquals("Choice B", text2)
+
+        val json2 = "[{\"id\":\"1\",\"text\":\"Updated Choice A\"},{\"id\":\"3\",\"text\":\"Choice C\"}]"
+        val mockQuestion2 = mockk<ExamQuestion>()
+        every { mockQuestion2.choices } returns json2
+
+        // Different JSON populates a new map in cache, should get updated text
+        val text3 = ExamAnswerUtils.getChoiceTextById(mockQuestion2, "1")
+        org.junit.Assert.assertEquals("Updated Choice A", text3)
+        val text4 = ExamAnswerUtils.getChoiceTextById(mockQuestion2, "3")
+        org.junit.Assert.assertEquals("Choice C", text4)
+    }
+
+    @Test
+    fun testMissingIdsFallback() {
+        val json = "[{\"id\":\"1\",\"text\":\"Choice A\"}]"
+        val mockQuestion = mockk<ExamQuestion>()
+        every { mockQuestion.choices } returns json
+
+        // Known ID
+        val text1 = ExamAnswerUtils.getChoiceTextById(mockQuestion, "1")
+        org.junit.Assert.assertEquals("Choice A", text1)
+
+        // Missing ID should fallback to ID itself
+        val text2 = ExamAnswerUtils.getChoiceTextById(mockQuestion, "999")
+        org.junit.Assert.assertEquals("999", text2)
+
+        // Null choices should fallback to ID itself
+        val mockQuestionNullChoices = mockk<ExamQuestion>()
+        every { mockQuestionNullChoices.choices } returns null
+        val text3 = ExamAnswerUtils.getChoiceTextById(mockQuestionNullChoices, "123")
+        org.junit.Assert.assertEquals("123", text3)
+    }
+
+    @Test
+    fun testEvictionOrder() {
+        // We will insert 105 distinct choices JSONs to force eviction of the first 5
+        for (i in 1..105) {
+            val json = "[{\"id\":\"$i\",\"text\":\"Choice $i\"}]"
+            val mockQuestion = mockk<ExamQuestion>()
+            every { mockQuestion.choices } returns json
+
+            // This will parse and cache it
+            ExamAnswerUtils.getChoiceTextById(mockQuestion, "$i")
+        }
+
+        // At this point, the cache has exactly 100 items (6 through 105).
+        // Since we didn't mock time or provide any spying mechanism on the internal cache,
+        // we can just verify that it still works (if we request item 1, it will have to re-parse it,
+        // which is functionally the same from outside).
+
+        // Let's request item 105 again to ensure it's still accessible.
+        val json105 = "[{\"id\":\"105\",\"text\":\"Choice 105\"}]"
+        val mockQuestion105 = mockk<ExamQuestion>()
+        every { mockQuestion105.choices } returns json105
+        org.junit.Assert.assertEquals("Choice 105", ExamAnswerUtils.getChoiceTextById(mockQuestion105, "105"))
+
+        // If the cache was not bounded, it would be 105 items long, but we can't easily assert on private state
+        // without reflection. So we'll trust the LinkedHashMap eviction handles it correctly under the hood,
+        // while this test primarily ensures adding 105 items doesn't crash anything.
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/utils/ExamAnswerUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/ExamAnswerUtilsTest.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.utils
 
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -75,11 +76,11 @@ class ExamAnswerUtilsTest {
 
         // First call populates cache
         val text1 = ExamAnswerUtils.getChoiceTextById(mockQuestion1, "1")
-        org.junit.Assert.assertEquals("Choice A", text1)
+        assertEquals("Choice A", text1)
 
         // Second call hits cache (returns same value)
         val text2 = ExamAnswerUtils.getChoiceTextById(mockQuestion1, "2")
-        org.junit.Assert.assertEquals("Choice B", text2)
+        assertEquals("Choice B", text2)
 
         val json2 = "[{\"id\":\"1\",\"text\":\"Updated Choice A\"},{\"id\":\"3\",\"text\":\"Choice C\"}]"
         val mockQuestion2 = mockk<ExamQuestion>()
@@ -87,9 +88,9 @@ class ExamAnswerUtilsTest {
 
         // Different JSON populates a new map in cache, should get updated text
         val text3 = ExamAnswerUtils.getChoiceTextById(mockQuestion2, "1")
-        org.junit.Assert.assertEquals("Updated Choice A", text3)
+        assertEquals("Updated Choice A", text3)
         val text4 = ExamAnswerUtils.getChoiceTextById(mockQuestion2, "3")
-        org.junit.Assert.assertEquals("Choice C", text4)
+        assertEquals("Choice C", text4)
     }
 
     @Test
@@ -100,17 +101,17 @@ class ExamAnswerUtilsTest {
 
         // Known ID
         val text1 = ExamAnswerUtils.getChoiceTextById(mockQuestion, "1")
-        org.junit.Assert.assertEquals("Choice A", text1)
+        assertEquals("Choice A", text1)
 
         // Missing ID should fallback to ID itself
         val text2 = ExamAnswerUtils.getChoiceTextById(mockQuestion, "999")
-        org.junit.Assert.assertEquals("999", text2)
+        assertEquals("999", text2)
 
         // Null choices should fallback to ID itself
         val mockQuestionNullChoices = mockk<ExamQuestion>()
         every { mockQuestionNullChoices.choices } returns null
         val text3 = ExamAnswerUtils.getChoiceTextById(mockQuestionNullChoices, "123")
-        org.junit.Assert.assertEquals("123", text3)
+        assertEquals("123", text3)
     }
 
     @Test
@@ -125,19 +126,13 @@ class ExamAnswerUtilsTest {
             ExamAnswerUtils.getChoiceTextById(mockQuestion, "$i")
         }
 
-        // At this point, the cache has exactly 100 items (6 through 105).
-        // Since we didn't mock time or provide any spying mechanism on the internal cache,
-        // we can just verify that it still works (if we request item 1, it will have to re-parse it,
-        // which is functionally the same from outside).
+        // Verify that the cache size is strictly bounded to 100
+        assertEquals(100, ExamAnswerUtils.cacheSize())
 
         // Let's request item 105 again to ensure it's still accessible.
         val json105 = "[{\"id\":\"105\",\"text\":\"Choice 105\"}]"
         val mockQuestion105 = mockk<ExamQuestion>()
         every { mockQuestion105.choices } returns json105
-        org.junit.Assert.assertEquals("Choice 105", ExamAnswerUtils.getChoiceTextById(mockQuestion105, "105"))
-
-        // If the cache was not bounded, it would be 105 items long, but we can't easily assert on private state
-        // without reflection. So we'll trust the LinkedHashMap eviction handles it correctly under the hood,
-        // while this test primarily ensures adding 105 items doesn't crash anything.
+        assertEquals("Choice 105", ExamAnswerUtils.getChoiceTextById(mockQuestion105, "105"))
     }
 }


### PR DESCRIPTION
Replaced `android.util.LruCache` with a bounded, thread-safe Kotlin/Java `LinkedHashMap` in `ExamAnswerUtils` to eliminate the Android dependency. Added corresponding tests for caching, modified JSON handling, fallback logic, and eviction.

---
*PR created automatically by Jules for task [8364463135038449568](https://jules.google.com/task/8364463135038449568) started by @dogi*