### PR TITLE
teams: smoother events describing (fixes #16171)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6690
-        versionName = "0.66.90"
+        versionCode = 6691
+        versionName = "0.66.91"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDescriptionAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/events/EventsDescriptionAdapter.kt
@@ -1,12 +1,10 @@
 package org.ole.planet.myplanet.ui.events
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.databinding.RowDescriptionBinding
 import org.ole.planet.myplanet.utils.DiffUtils
 
 class EventsDescriptionAdapter : ListAdapter<EventsDescriptionAdapter.DescriptionItem, EventsDescriptionAdapter.ViewHolder>(
@@ -18,19 +16,16 @@ class EventsDescriptionAdapter : ListAdapter<EventsDescriptionAdapter.Descriptio
 
     data class DescriptionItem(val key: String, val value: String)
 
-    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val title: TextView = itemView.findViewById(R.id.title)
-        val description: TextView = itemView.findViewById(R.id.description)
-    }
+    class ViewHolder(val binding: RowDescriptionBinding) : RecyclerView.ViewHolder(binding.root)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.row_description, parent, false)
-        return ViewHolder(view)
+        val binding = RowDescriptionBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = getItem(position)
-        holder.title.text = holder.itemView.context.getString(R.string.message_placeholder, "${item.key} : ")
-        holder.description.text = holder.itemView.context.getString(R.string.message_placeholder, item.value)
+        holder.binding.title.text = "${item.key} : "
+        holder.binding.description.text = item.value
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/events/EventsDescriptionAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/events/EventsDescriptionAdapterTest.kt
@@ -47,12 +47,12 @@ class EventsDescriptionAdapterTest {
         val holder = adapter.onCreateViewHolder(parent, 0)
 
         adapter.onBindViewHolder(holder, 0)
-        assertEquals("Date : ", holder.title.text.toString())
-        assertEquals("2023-10-27", holder.description.text.toString())
+        assertEquals("Date : ", holder.binding.title.text.toString())
+        assertEquals("2023-10-27", holder.binding.description.text.toString())
 
         adapter.onBindViewHolder(holder, 1)
-        assertEquals("Time : ", holder.title.text.toString())
-        assertEquals("10:00 AM", holder.description.text.toString())
+        assertEquals("Time : ", holder.binding.title.text.toString())
+        assertEquals("10:00 AM", holder.binding.description.text.toString())
 
         val updatedList = listOf(
             EventsDescriptionAdapter.DescriptionItem("Date", "2023-10-28"),
@@ -71,11 +71,11 @@ class EventsDescriptionAdapterTest {
         assertEquals(2, adapter.itemCount)
 
         adapter.onBindViewHolder(holder, 0)
-        assertEquals("Date : ", holder.title.text.toString())
-        assertEquals("2023-10-28", holder.description.text.toString())
+        assertEquals("Date : ", holder.binding.title.text.toString())
+        assertEquals("2023-10-28", holder.binding.description.text.toString())
 
         adapter.onBindViewHolder(holder, 1)
-        assertEquals("Location : ", holder.title.text.toString())
-        assertEquals("Online", holder.description.text.toString())
+        assertEquals("Location : ", holder.binding.title.text.toString())
+        assertEquals("Online", holder.binding.description.text.toString())
     }
 }


### PR DESCRIPTION
- Updated `EventsDescriptionAdapter` to use `RowDescriptionBinding`.
- Removed reliance on `getString(R.string.message_placeholder)` during `onBindViewHolder` by directly assigning formatted text to binding fields.
- Updated `EventsDescriptionAdapterTest` to reference the newly introduced `binding` property on `ViewHolder` for assertions.

---
*PR created automatically by Jules for task [15111522833610242153](https://jules.google.com/task/15111522833610242153) started by @dogi*