### PR TITLE
all: less models android imports is more (fixes #16221)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6709
-        versionName = "0.67.9"
+        versionCode = 6710
+        versionName = "0.67.10"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/Achievement.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Achievement.kt
@@ -1,8 +1,6 @@
 package org.ole.planet.myplanet.model
 
-import android.text.TextUtils
 import android.util.LruCache
-import android.widget.EditText
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
@@ -132,7 +130,7 @@ class Achievement {
         fun serialize(sub: Achievement): JsonObject {
             val `object` = JsonObject()
             `object`.addProperty("_id", sub._id)
-            if (!TextUtils.isEmpty(sub._rev)) `object`.addProperty("_rev", sub._rev)
+            if (!sub._rev.isNullOrEmpty()) `object`.addProperty("_rev", sub._rev)
             `object`.addProperty("goals", sub.goals)
             `object`.addProperty("purpose", sub.purpose)
             `object`.addProperty("achievementsHeader", sub.achievementsHeader)
@@ -149,12 +147,12 @@ class Achievement {
             return `object`
         }
 
-        fun createReference(name: String?, relation: EditText, phone: EditText, email: EditText): JsonObject {
+        fun createReference(name: String?, relation: String, phone: String, email: String): JsonObject {
             val ob = JsonObject()
             ob.addProperty("name", name)
-            ob.addProperty("phone", phone.text.toString())
-            ob.addProperty("relationship", relation.text.toString())
-            ob.addProperty("email", email.text.toString())
+            ob.addProperty("phone", phone)
+            ob.addProperty("relationship", relation)
+            ob.addProperty("email", email)
             return ob
         }
 

--- a/app/src/main/java/org/ole/planet/myplanet/model/Feedback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Feedback.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.model
 
-import android.text.TextUtils
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
@@ -47,7 +46,7 @@ open class Feedback {
     @get:Ignore
     val messageList: List<FeedbackReply>?
         get() {
-            if (TextUtils.isEmpty(messages)) return null
+            if (messages.isNullOrEmpty()) return null
             val feedbackReplies: MutableList<FeedbackReply> = ArrayList()
 
             val stringReader = StringReader(messages)
@@ -73,7 +72,7 @@ open class Feedback {
     @get:Ignore
     val message: String
         get() {
-            if (TextUtils.isEmpty(messages)) return ""
+            if (messages.isNullOrEmpty()) return ""
 
             val stringReader = StringReader(messages)
             val jsonReader = JsonReader(stringReader)

--- a/app/src/main/java/org/ole/planet/myplanet/model/News.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/News.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.model
 
-import android.text.TextUtils
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.Index
@@ -236,7 +235,7 @@ open class News {
 
         fun getViewInJson(map: HashMap<String?, String>): String {
             val viewInArray = JsonArray()
-            if (!TextUtils.isEmpty(map["viewInId"])) {
+            if (!map["viewInId"].isNullOrEmpty()) {
                 val `object` = JsonObject()
                 `object`.addProperty("_id", map["viewInId"])
                 `object`.addProperty("section", map["viewInSection"])

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
@@ -301,7 +301,7 @@ class EditAchievementFragment : BaseContainerFragment(), DatePickerDialog.OnDate
             }
             if (`object` != null) referenceArray?.remove(`object`)
             if (referenceArray == null) referenceArray = JsonArray()
-            referenceArray?.add(createReference(name, alertReferenceBinding.etRelationship, alertReferenceBinding.etPhone, alertReferenceBinding.etEmail))
+            referenceArray?.add(createReference(name, alertReferenceBinding.etRelationship.text.toString(), alertReferenceBinding.etPhone.text.toString(), alertReferenceBinding.etEmail.text.toString()))
             showReference()
             referenceDialog?.dismiss()
         }


### PR DESCRIPTION
Resolves #76

- Swapped all `TextUtils.isEmpty(x)` sites for `x.isNullOrEmpty()` in `News`, `Feedback`, and `Achievement`.
- Retyped `Achievement.createReference` to take `String`s rather than `EditText`s.
- Updated `EditAchievementFragment` to extract text and pass `String`s when creating references.
- Deleted `android.text.TextUtils` and `android.widget.EditText` imports from the models.
- Verified test suite still passes.

---
*PR created automatically by Jules for task [17463864012467986982](https://jules.google.com/task/17463864012467986982) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved saving of achievement references, including relationship, phone, and email details.
  - Improved handling of empty or missing content in feedback messages and news view information.
  - Updated achievement reference entry behavior to reliably capture form values when creating a reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->