### PR TITLE
login: smoother auth session updating (fixes #16222)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6710
-        versionName = "0.67.10"
+        versionCode = 6711
+        versionName = "0.67.11"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/auth/AuthSessionUpdater.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/auth/AuthSessionUpdater.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.data.auth
 
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
+import android.util.Log
 import dagger.assisted.AssistedInject
 import java.io.DataOutputStream
 import java.net.HttpURLConnection
@@ -62,24 +63,26 @@ class AuthSessionUpdater @AssistedInject constructor(
         try {
             withContext(dispatcherProvider.io) {
                 val conn = getSessionUrl()?.openConnection() as HttpURLConnection? ?: throw Exception("Unable to get session URL")
-                conn.requestMethod = "GET"
-                conn.setRequestProperty("Content-Type", "application/json")
-                conn.setRequestProperty("Accept", "application/json")
-                conn.doOutput = true
-                conn.doInput = true
+                try {
+                    conn.requestMethod = "GET"
+                    conn.setRequestProperty("Content-Type", "application/json")
+                    conn.setRequestProperty("Accept", "application/json")
+                    conn.doOutput = true
+                    conn.doInput = true
 
-                val os = DataOutputStream(conn.outputStream)
-                os.writeBytes(getJsonObject().toString())
+                    DataOutputStream(conn.outputStream).use { os ->
+                        os.writeBytes(getJsonObject().toString())
+                        os.flush()
+                    }
 
-                os.flush()
-                os.close()
-
-                callback.setAuthSession(conn.headerFields)
-                conn.disconnect()
+                    callback.setAuthSession(conn.headerFields)
+                } finally {
+                    conn.disconnect()
+                }
             }
         } catch (e: Exception) {
             callback.onError(e.message.orEmpty())
-            e.printStackTrace()
+            Log.w("AuthSessionUpdater", "Error in sendPost", e)
         }
     }
 
@@ -90,7 +93,7 @@ class AuthSessionUpdater @AssistedInject constructor(
             jsonParam.put("password", sharedPrefManager.getUrlPwd())
             jsonParam
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.w("AuthSessionUpdater", "Error in getJsonObject", e)
             null
         }
     }
@@ -102,7 +105,7 @@ class AuthSessionUpdater @AssistedInject constructor(
             val serverUrl = URL(urlString)
             serverUrl
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.w("AuthSessionUpdater", "Error in getSessionUrl", e)
             null
         }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/data/auth/AuthSessionUpdaterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/auth/AuthSessionUpdaterTest.kt
@@ -14,9 +14,11 @@ import org.junit.After
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
+import io.mockk.mockkStatic
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.UrlUtils
+import android.util.Log
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AuthSessionUpdaterTest {
@@ -38,6 +40,8 @@ class AuthSessionUpdaterTest {
         every { mockDispatcherProvider.main } returns testDispatcher
         every { mockDispatcherProvider.default } returns testDispatcher
         every { mockDispatcherProvider.unconfined } returns testDispatcher
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), any<String>(), any<Throwable>()) } returns 0
     }
 
     @After


### PR DESCRIPTION
Fixes a resource leak in `AuthSessionUpdater.sendPost` by properly closing the `DataOutputStream` and ensuring `HttpURLConnection.disconnect()` is called on exceptions. Also replaces `printStackTrace()` with `Log.w`.

---
*PR created automatically by Jules for task [1382469628494991791](https://jules.google.com/task/1382469628494991791) started by @dogi*