### PR TITLE
teams: smoother base voices members selecting (fixes #16223)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6711
-        versionName = "0.67.11"
+        versionCode = 6712
+        versionName = "0.67.12"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseVoicesFragment.kt
@@ -102,8 +102,9 @@ abstract class BaseVoicesFragment : BaseContainerFragment(), OnNewsItemClickList
     override fun onMemberSelected(userModel: UserEntity?) {
         if (!isAdded) return
 
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             val fragment = VoicesActions.showMemberDetails(userModel, activitiesRepository) ?: return@launch
+            if (!isAdded) return@launch
             FragmentNavigator.replaceFragment(
                 requireActivity().supportFragmentManager,
                 R.id.fragment_container,


### PR DESCRIPTION
Fixed a potential crash in `BaseVoicesFragment.kt` by replacing `lifecycleScope` with `viewLifecycleOwner.lifecycleScope` for `onMemberSelected` navigation and ensuring fragment attachment is checked after a suspend function returns.

---
*PR created automatically by Jules for task [5927909977432968346](https://jules.google.com/task/5927909977432968346) started by @dogi*