### PR TITLE
life: smoother personals repository serializing (fixes #16224)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6712
-        versionName = "0.67.12"
+        versionCode = 6713
+        versionName = "0.67.13"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/Personal.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Personal.kt
@@ -1,6 +1,6 @@
 package org.ole.planet.myplanet.model
 
-import android.content.Context
+
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -33,7 +33,7 @@ open class Personal {
     var path: String? = null
 
     companion object {
-        fun serialize(personal: Personal, context: Context): JsonObject {
+        fun serialize(personal: Personal, customDeviceName: String): JsonObject {
             val `object` = JsonObject()
             `object`.addProperty("title", personal.title)
             `object`.addProperty("uploadDate", Date().time)
@@ -47,7 +47,7 @@ open class Personal {
             val object1 = JsonObject()
             `object`.addProperty("androidId", NetworkUtils.getUniqueIdentifier())
             `object`.addProperty("deviceName", NetworkUtils.getDeviceName())
-            `object`.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
+            `object`.addProperty("customDeviceName", customDeviceName)
             object1.addProperty("users", personal.userId)
             `object`.add("privateFor", object1)
             return `object`

--- a/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/PersonalsRepositoryImpl.kt
@@ -13,6 +13,7 @@ import org.ole.planet.myplanet.data.room.dao.PersonalDao
 import org.ole.planet.myplanet.model.Personal
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.JsonUtils.getString
+import org.ole.planet.myplanet.utils.NetworkUtils
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.distinctByContent
 
@@ -85,7 +86,7 @@ class PersonalsRepositoryImpl @Inject constructor(
     override suspend fun uploadPersonalDocument(personal: Personal): Pair<String, String>? {
         val response = apiInterface.postDoc(
             UrlUtils.header, "application/json",
-            "${UrlUtils.getUrl()}/resources", Personal.serialize(personal, context)
+            "${UrlUtils.getUrl()}/resources", Personal.serialize(personal, NetworkUtils.getCustomDeviceName(context))
         )
 
         val `object` = response.body()

--- a/app/src/test/java/org/ole/planet/myplanet/model/PersonalTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/PersonalTest.kt
@@ -1,6 +1,6 @@
 package org.ole.planet.myplanet.model
 
-import android.content.Context
+
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -15,11 +15,9 @@ import org.ole.planet.myplanet.utils.NetworkUtils
 
 class PersonalTest {
 
-    private lateinit var mockContext: Context
 
     @Before
     fun setup() {
-        mockContext = mockk<Context>(relaxed = true)
 
         // FileUtils and NetworkUtils are Kotlin objects, so mockkObject (not mockkStatic)
         // is required to intercept their member functions
@@ -47,9 +45,8 @@ class PersonalTest {
 
         every { NetworkUtils.getUniqueIdentifier() } returns "unique_id"
         every { NetworkUtils.getDeviceName() } returns "device_name"
-        every { NetworkUtils.getCustomDeviceName(any()) } returns "custom_device_name"
 
-        val serialized = Personal.serialize(personal, mockContext)
+        val serialized = Personal.serialize(personal, "custom_device_name")
 
         assertEquals("My Personal Title", serialized.get("title").asString)
         assertTrue(serialized.has("uploadDate"))
@@ -76,9 +73,8 @@ class PersonalTest {
         every { FileUtils.getFileNameFromUrl(null) } returns ""
         every { NetworkUtils.getUniqueIdentifier() } returns "unique_id"
         every { NetworkUtils.getDeviceName() } returns "device_name"
-        every { NetworkUtils.getCustomDeviceName(any()) } returns "custom_device_name"
 
-        val serialized = Personal.serialize(personal, mockContext)
+        val serialized = Personal.serialize(personal, "custom_device_name")
 
         assertTrue(serialized.get("title").isJsonNull)
         assertTrue(serialized.has("uploadDate"))


### PR DESCRIPTION
Decouples `Personal.serialize` from `android.content.Context` by passing the custom device name as a string parameter. Updated the caller in `PersonalsRepositoryImpl` and refactored the related tests in `PersonalTest`.

---
*PR created automatically by Jules for task [17339944783912537619](https://jules.google.com/task/17339944783912537619) started by @dogi*