### PR TITLE
courses: smoother inline resources caching (fixes #16225)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6713
-        versionName = "0.67.13"
+        versionCode = 6714
+        versionName = "0.67.14"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -87,7 +87,7 @@ class InlineResourceAdapter(
                 val address = prev.resourceLocalAddress ?: return@forEach
                 val file = FileUtils.getLibraryFile(dir, prev.id, address)
                 val prefix = file.absolutePath
-                textCache.keys.filter { it.startsWith(prefix) }.forEach { textCache.remove(it) }
+                textCache.keys.removeAll { it.startsWith(prefix) }
             }
         }
     }


### PR DESCRIPTION
Optimizes removing stale previews from `InlineResourceAdapter`'s `textCache` by using `removeAll` instead of `filter {}.forEach {}`, avoiding intermediate allocations.

---
*PR created automatically by Jules for task [13242371361612207922](https://jules.google.com/task/13242371361612207922) started by @dogi*