### PR TITLE
all: smoother notifications load view modelling (fixes #16227)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6716
-        versionName = "0.67.16"
+        versionCode = 6717
+        versionName = "0.67.17"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsViewModel.kt
@@ -59,9 +59,15 @@ class NotificationsViewModel @Inject constructor(
         viewModelScope.launch {
             val payloadNotifications = notificationsRepository.getNotifications(userId, filter, isAdmin)
 
-            val byLoweredType = payloadNotifications.groupBy { it.type.lowercase() }
-            val taskNotifications = byLoweredType["task"] ?: emptyList()
-            val joinRequestNotifications = byLoweredType["join_request"] ?: emptyList()
+            val taskNotifications = mutableListOf<NotificationPayload>()
+            val joinRequestNotifications = mutableListOf<NotificationPayload>()
+            for (notification in payloadNotifications) {
+                if (notification.type.equals("task", ignoreCase = true)) {
+                    taskNotifications.add(notification)
+                } else if (notification.type.equals("join_request", ignoreCase = true)) {
+                    joinRequestNotifications.add(notification)
+                }
+            }
 
             val taskIds = taskNotifications
                 .mapNotNull { it.relatedId }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/notifications/NotificationsViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/notifications/NotificationsViewModelTest.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.ui.notifications
 
 import android.content.Context
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -206,6 +207,26 @@ class NotificationsViewModelTest {
         loadNotifications(payload)
 
         assertEquals("resource", item("1").notification.type)
+    }
+
+    @Test
+    fun testLoadNotificationsExtractsRelevantTypesCaseInsensitivelyInOrder() = runTest(testDispatcher) {
+        val task1 = notification(id = "t1", type = "TaSk", isRead = false, message = "Task 1", subType = null).copy(relatedId = "rel1")
+        val other1 = notification(id = "o1", type = "OTHER", isRead = false, message = "Other 1", subType = null)
+        val join1 = notification(id = "j1", type = "joiN_rEquEst", isRead = false, message = "Join 1", subType = null).copy(relatedId = "rel2")
+        val task2 = notification(id = "t2", type = "task", isRead = false, message = "Task 2", subType = null).copy(relatedId = "rel3")
+
+        loadNotifications(task1, other1, join1, task2)
+
+        coVerify { repository.getTaskTeamNamesByTaskIds(listOf("rel1", "rel3")) }
+        coVerify { repository.getJoinRequestDetailsBatch(listOf("rel2")) }
+
+        val notifs = viewModel.notifications.value
+        assertEquals(4, notifs.size)
+        assertEquals("t1", notifs[0].id)
+        assertEquals("o1", notifs[1].id)
+        assertEquals("j1", notifs[2].id)
+        assertEquals("t2", notifs[3].id)
     }
 
     private fun item(id: String): NotificationListItem.Item =

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,6 @@
+1. **Modify `app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsViewModel.kt`**: Use `replace_with_git_merge_diff` to replace the `groupBy` allocation with a single loop that populates `taskNotifications` and `joinRequestNotifications` directly via `equals("...", ignoreCase = true)`. This eliminates `lowercase()` allocations per notification and avoiding the map allocation.
+2. **Update `app/src/test/java/org/ole/planet/myplanet/ui/notifications/NotificationsViewModelTest.kt`**: Use `replace_with_git_merge_diff` to add a test method `testLoadNotificationsExtractsRelevantTypesCaseInsensitivelyInOrder` that verifies `loadNotifications` logic using mixed-case relevant types (e.g. `TaSk` or `joiN_rEquEst`) and an unrelated type. This test will assert batch-lookup arguments (e.g. `getTaskTeamNamesByTaskIds`, etc.) and final notification order are unchanged.
+3. **Verify changes**: Run `git diff` to verify the applied code changes in both modified files.
+4. **Test**: Run the relevant test command (`./gradlew test --tests "*NotificationsViewModelTest*"`) in the bash session to ensure the changes are correct and haven't introduced regressions.
+5. **Run Pre-commit Checks**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+6. **Submit**: Submit the changes.

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,0 @@
-1. **Modify `app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsViewModel.kt`**: Use `replace_with_git_merge_diff` to replace the `groupBy` allocation with a single loop that populates `taskNotifications` and `joinRequestNotifications` directly via `equals("...", ignoreCase = true)`. This eliminates `lowercase()` allocations per notification and avoiding the map allocation.
-2. **Update `app/src/test/java/org/ole/planet/myplanet/ui/notifications/NotificationsViewModelTest.kt`**: Use `replace_with_git_merge_diff` to add a test method `testLoadNotificationsExtractsRelevantTypesCaseInsensitivelyInOrder` that verifies `loadNotifications` logic using mixed-case relevant types (e.g. `TaSk` or `joiN_rEquEst`) and an unrelated type. This test will assert batch-lookup arguments (e.g. `getTaskTeamNamesByTaskIds`, etc.) and final notification order are unchanged.
-3. **Verify changes**: Run `git diff` to verify the applied code changes in both modified files.
-4. **Test**: Run the relevant test command (`./gradlew test --tests "*NotificationsViewModelTest*"`) in the bash session to ensure the changes are correct and haven't introduced regressions.
-5. **Run Pre-commit Checks**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-6. **Submit**: Submit the changes.


### PR DESCRIPTION
Replaced the `groupBy { it.type.lowercase() }` operation with a single-pass loop using case-insensitive string comparisons.
This prevents allocating a lowercase string for every notification payload and eliminates the allocation of the multimap, while still preserving the insertion order within the two extracted lists.
Added a test to verify correct extraction using mixed-case types while ignoring other types.

---
*PR created automatically by Jules for task [10710371114674323822](https://jules.google.com/task/10710371114674323822) started by @dogi*