### PR TITLE
perf(courses): avoid allocating map key list on every bind

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapter.kt
@@ -43,11 +43,10 @@ class CoursesProgressAdapter(private val context: Context) : ListAdapter<Courses
 
         if (stepMistake != null && stepMistake.isNotEmpty()) {
             binding.llHeader.visibility = View.VISIBLE
-            val keys = stepMistake.keys.toList()
             val textColor = ContextCompat.getColor(context, R.color.daynight_textColor)
 
             val currentChildCount = binding.llProgress.childCount
-            val requiredChildCount = keys.size
+            val requiredChildCount = stepMistake.size
 
             if (currentChildCount > requiredChildCount) {
                 binding.llProgress.removeViews(requiredChildCount, currentChildCount - requiredChildCount)
@@ -81,14 +80,15 @@ class CoursesProgressAdapter(private val context: Context) : ListAdapter<Courses
                 }
             }
 
-            for (i in keys.indices) {
-                val stepKey = keys[i]
+            var i = 0
+            for ((stepKey, mistakeCount) in stepMistake) {
                 val row = binding.llProgress.getChildAt(i) as LinearLayout
                 val stepView = row.getChildAt(0) as TextView
                 val mistakeView = row.getChildAt(1) as TextView
 
                 stepView.text = "${stepKey.toInt().plus(1)}"
-                mistakeView.text = "${stepMistake[stepKey]}"
+                mistakeView.text = "$mistakeCount"
+                i++
             }
         } else {
             binding.llHeader.visibility = View.GONE

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapterTest.kt
@@ -61,9 +61,21 @@ class CoursesProgressAdapterTest {
 
         adapter.onBindViewHolder(holder, 0)
         assertEquals(3, holder.binding.llProgress.childCount)
+        var row = holder.binding.llProgress.getChildAt(0) as LinearLayout
+        assertEquals("1", (row.getChildAt(0) as android.widget.TextView).text)
+        assertEquals("1", (row.getChildAt(1) as android.widget.TextView).text)
+        row = holder.binding.llProgress.getChildAt(1) as LinearLayout
+        assertEquals("2", (row.getChildAt(0) as android.widget.TextView).text)
+        assertEquals("2", (row.getChildAt(1) as android.widget.TextView).text)
+        row = holder.binding.llProgress.getChildAt(2) as LinearLayout
+        assertEquals("3", (row.getChildAt(0) as android.widget.TextView).text)
+        assertEquals("3", (row.getChildAt(1) as android.widget.TextView).text)
 
         adapter.onBindViewHolder(holder, 1)
         assertEquals(1, holder.binding.llProgress.childCount)
+        row = holder.binding.llProgress.getChildAt(0) as LinearLayout
+        assertEquals("1", (row.getChildAt(0) as android.widget.TextView).text)
+        assertEquals("5", (row.getChildAt(1) as android.widget.TextView).text)
 
         adapter.onBindViewHolder(holder, 2)
         assertEquals(0, holder.binding.llProgress.childCount)


### PR DESCRIPTION
Refactored `showStepMistakes` in `CoursesProgressAdapter` to directly iterate over `stepMistake` entries rather than extracting `keys.toList()`, eliminating avoidable map allocation and secondary `stepMistake[stepKey]` lookups per step during `onBindViewHolder`.
Updated `CoursesProgressAdapterTest` to explicitly verify text values inside layout children, ensuring stale data is properly overwritten upon rebinding.

---
*PR created automatically by Jules for task [4642710095273456428](https://jules.google.com/task/4642710095273456428) started by @dogi*