### PR TITLE
courses: smoother progress steps handling (fixes #16228)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6717
-        versionName = "0.67.17"
+        versionCode = 6718
+        versionName = "0.67.18"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapter.kt
@@ -43,11 +43,10 @@ class CoursesProgressAdapter(private val context: Context) : ListAdapter<Courses
 
         if (stepMistake != null && stepMistake.isNotEmpty()) {
             binding.llHeader.visibility = View.VISIBLE
-            val keys = stepMistake.keys.toList()
             val textColor = ContextCompat.getColor(context, R.color.daynight_textColor)
 
             val currentChildCount = binding.llProgress.childCount
-            val requiredChildCount = keys.size
+            val requiredChildCount = stepMistake.size
 
             if (currentChildCount > requiredChildCount) {
                 binding.llProgress.removeViews(requiredChildCount, currentChildCount - requiredChildCount)
@@ -81,14 +80,15 @@ class CoursesProgressAdapter(private val context: Context) : ListAdapter<Courses
                 }
             }
 
-            for (i in keys.indices) {
-                val stepKey = keys[i]
+            var i = 0
+            stepMistake.forEach { (stepKey, mistakes) ->
                 val row = binding.llProgress.getChildAt(i) as LinearLayout
                 val stepView = row.getChildAt(0) as TextView
                 val mistakeView = row.getChildAt(1) as TextView
 
                 stepView.text = "${stepKey.toInt().plus(1)}"
-                mistakeView.text = "${stepMistake[stepKey]}"
+                mistakeView.text = "$mistakes"
+                i++
             }
         } else {
             binding.llHeader.visibility = View.GONE

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/CoursesProgressAdapterTest.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.ui.courses
 import android.app.Application
 import android.content.Context
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -61,9 +62,21 @@ class CoursesProgressAdapterTest {
 
         adapter.onBindViewHolder(holder, 0)
         assertEquals(3, holder.binding.llProgress.childCount)
+        var row = holder.binding.llProgress.getChildAt(0) as LinearLayout
+        assertEquals("1", (row.getChildAt(0) as TextView).text)
+        assertEquals("1", (row.getChildAt(1) as TextView).text)
+        row = holder.binding.llProgress.getChildAt(1) as LinearLayout
+        assertEquals("2", (row.getChildAt(0) as TextView).text)
+        assertEquals("2", (row.getChildAt(1) as TextView).text)
+        row = holder.binding.llProgress.getChildAt(2) as LinearLayout
+        assertEquals("3", (row.getChildAt(0) as TextView).text)
+        assertEquals("3", (row.getChildAt(1) as TextView).text)
 
         adapter.onBindViewHolder(holder, 1)
         assertEquals(1, holder.binding.llProgress.childCount)
+        row = holder.binding.llProgress.getChildAt(0) as LinearLayout
+        assertEquals("1", (row.getChildAt(0) as TextView).text)
+        assertEquals("5", (row.getChildAt(1) as TextView).text)
 
         adapter.onBindViewHolder(holder, 2)
         assertEquals(0, holder.binding.llProgress.childCount)


### PR DESCRIPTION
Avoid copying `stepMistake.keys.toList()` per recycle and iterating the map with key lookups. Instead, iterate `stepMistake.forEach` natively without extracting the key list to avoid memory and performance bottlenecks on UI re-binding. Tested view recycles.

---
*PR created automatically by Jules for task [5138935647577084094](https://jules.google.com/task/5138935647577084094) started by @dogi*