### PR TITLE
sync: smoother upload coordinating (fixes #16229)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6718
-        versionName = "0.67.18"
+        versionCode = 6719
+        versionName = "0.67.19"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
@@ -57,22 +57,9 @@ class UploadCoordinator @Inject constructor(
                 var dbFailedErrors = emptyList<UploadError>()
                 if (succeeded.isNotEmpty()) {
                     val dbFailed = updateDatabaseBatch(succeeded, config)
-
-                    dbFailedErrors = dbFailed.map { failedItem ->
-                        UploadError(
-                            itemId = failedItem.localId,
-                            exception = Exception("Local DB update failed"),
-                            retryable = false
-                        )
-                    }
-
-                    if (dbFailed.isEmpty()) {
-                        allSucceeded.addAll(succeeded)
-                    } else {
-                        val dbFailedIds = dbFailed.map { it.localId }.toHashSet()
-                        val actuallySucceeded = succeeded.filter { it.localId !in dbFailedIds }
-                        allSucceeded.addAll(actuallySucceeded)
-                    }
+                    val (actuallySucceeded, dbErrors) = reconcileDbFailures(succeeded, dbFailed)
+                    dbFailedErrors = dbErrors
+                    allSucceeded.addAll(actuallySucceeded)
                 }
 
                 allFailed.addAll(failed)
@@ -293,6 +280,28 @@ class UploadCoordinator @Inject constructor(
             }
         }
     }
+    private fun reconcileDbFailures(
+        succeeded: List<UploadedItem>,
+        dbFailed: List<UploadedItem>
+    ): Pair<List<UploadedItem>, List<UploadError>> {
+        val dbFailedErrors = dbFailed.map { failedItem ->
+            UploadError(
+                itemId = failedItem.localId,
+                exception = Exception("Local DB update failed"),
+                retryable = false
+            )
+        }
+
+        val actuallySucceeded = if (dbFailed.isEmpty()) {
+            succeeded
+        } else {
+            val dbFailedIds = dbFailed.map { it.localId }.toHashSet()
+            succeeded.filter { it.localId !in dbFailedIds }
+        }
+
+        return actuallySucceeded to dbFailedErrors
+    }
+
 
     private fun normalizeUploadResult(localId: String, responseBody: JsonObject, idField: String, revField: String): UploadedItem {
         return UploadedItem(
@@ -328,15 +337,9 @@ class UploadCoordinator @Inject constructor(
                 var dbFailedErrors = emptyList<UploadError>()
                 if (succeeded.isNotEmpty()) {
                     val dbFailed = updateDatabaseBatchRoom(succeeded, config)
-                    dbFailedErrors = dbFailed.map { failedItem ->
-                        UploadError(failedItem.localId, Exception("Local DB update failed"), retryable = false)
-                    }
-                    if (dbFailed.isEmpty()) {
-                        allSucceeded.addAll(succeeded)
-                    } else {
-                        val dbFailedIds = dbFailed.map { it.localId }.toHashSet()
-                        allSucceeded.addAll(succeeded.filter { it.localId !in dbFailedIds })
-                    }
+                    val (actuallySucceeded, dbErrors) = reconcileDbFailures(succeeded, dbFailed)
+                    dbFailedErrors = dbErrors
+                    allSucceeded.addAll(actuallySucceeded)
                 }
 
                 allFailed.addAll(failed)


### PR DESCRIPTION
Extract duplicate DB reconciliation logic into a shared helper

This removes the duplicated logic between the `upload` and `uploadRoom` methods in `UploadCoordinator.kt` by extracting it into a single private helper function `reconcileDbFailures()`. This prevents code drift while ensuring exception text, retry policies, and ID ordering remain completely preserved.

---
*PR created automatically by Jules for task [16051839481271271282](https://jules.google.com/task/16051839481271271282) started by @dogi*