### PR TITLE
refactor: reuse coreEntryPoint for sharedPrefManager in NetworkUtils

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt
@@ -31,8 +31,7 @@ object NetworkUtils {
 
     // Safe because NetworkUtils is only accessed after MainApplication.onCreate sets the context
     private val sharedPrefManager: SharedPrefManager by lazy {
-        val entryPoint = EntryPointAccessors.fromApplication(context, CoreDependenciesEntryPoint::class.java)
-        entryPoint.sharedPrefManager()
+        coreEntryPoint.sharedPrefManager()
     }
 
     // Safe because NetworkUtils is only accessed after MainApplication.onCreate sets the context


### PR DESCRIPTION
`NetworkUtils` previously resolved a `CoreDependenciesEntryPoint` into `coreEntryPoint` but then the `sharedPrefManager` lazy delegate called `EntryPointAccessors.fromApplication(...)` a second time for the same entry point.
This commit refactors the initialization to reuse the existing `coreEntryPoint` to avoid redundant lookups and object allocations.

---
*PR created automatically by Jules for task [14417042744961476501](https://jules.google.com/task/14417042744961476501) started by @dogi*