### PR TITLE
Refactor MyLife to remove Context dependency

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/model/MyLife.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/MyLife.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.model
 
-import android.content.Context
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.Index
@@ -55,14 +54,14 @@ class MyLife {
     }
 
     companion object {
-        fun defaultItems(context: Context, userId: String?): List<MyLife> = listOf(
-            MyLife("ic_myhealth", userId, context.getString(R.string.myhealth)),
-            MyLife("my_achievement", userId, context.getString(R.string.achievements)),
-            MyLife("ic_submissions", userId, context.getString(R.string.submission)),
-            MyLife("ic_my_survey", userId, context.getString(R.string.my_survey)),
-            MyLife("ic_references", userId, context.getString(R.string.references)),
-            MyLife("ic_calendar", userId, context.getString(R.string.calendar)),
-            MyLife("ic_mypersonals", userId, context.getString(R.string.mypersonals))
+        fun defaultItems(userId: String?, resolveLabel: (Int) -> String): List<MyLife> = listOf(
+            MyLife("ic_myhealth", userId, resolveLabel(R.string.myhealth)),
+            MyLife("my_achievement", userId, resolveLabel(R.string.achievements)),
+            MyLife("ic_submissions", userId, resolveLabel(R.string.submission)),
+            MyLife("ic_my_survey", userId, resolveLabel(R.string.my_survey)),
+            MyLife("ic_references", userId, resolveLabel(R.string.references)),
+            MyLife("ic_calendar", userId, resolveLabel(R.string.calendar)),
+            MyLife("ic_mypersonals", userId, resolveLabel(R.string.mypersonals))
         )
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardPluginFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardPluginFragment.kt
@@ -120,5 +120,5 @@ open class DashboardPluginFragment : BaseContainerFragment() {
         return v
     }
 
-    fun getMyLifeListBase(userId: String?): List<MyLife> = MyLife.defaultItems(requireContext(), userId)
+    fun getMyLifeListBase(userId: String?): List<MyLife> = MyLife.defaultItems(userId, requireContext()::getString)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeViewModel.kt
@@ -35,7 +35,7 @@ class LifeViewModel @Inject constructor(
                 val userId = sharedPrefManager.getUserId().ifEmpty { userRepository.getUserModel()?.id }
                 var myLifeList = lifeRepository.getMyLifeByUserId(userId)
                 if (myLifeList.isEmpty()) {
-                    lifeRepository.seedMyLifeIfEmpty(userId, MyLife.defaultItems(context, userId))
+                    lifeRepository.seedMyLifeIfEmpty(userId, MyLife.defaultItems(userId, context::getString))
                     myLifeList = lifeRepository.getMyLifeByUserId(userId)
                 }
                 myLifeList.distinctBy { it.imageId ?: it.title }


### PR DESCRIPTION
This change removes the `android.content.Context` dependency from the `MyLife` data model, shifting the responsibility of resolving string resources to the caller. This aligns the data model better with pure Kotlin architecture by removing Android framework imports and presentation work from the entity class.

---
*PR created automatically by Jules for task [16317228685270544540](https://jules.google.com/task/16317228685270544540) started by @dogi*