### PR TITLE
life: smoother dashboard plugin view modelling (fixes #16231)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6720
-        versionName = "0.67.20"
+        versionCode = 6721
+        versionName = "0.67.21"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/MyLife.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/MyLife.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.model
 
-import android.content.Context
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.Index
@@ -55,14 +54,19 @@ class MyLife {
     }
 
     companion object {
-        fun defaultItems(context: Context, userId: String?): List<MyLife> = listOf(
-            MyLife("ic_myhealth", userId, context.getString(R.string.myhealth)),
-            MyLife("my_achievement", userId, context.getString(R.string.achievements)),
-            MyLife("ic_submissions", userId, context.getString(R.string.submission)),
-            MyLife("ic_my_survey", userId, context.getString(R.string.my_survey)),
-            MyLife("ic_references", userId, context.getString(R.string.references)),
-            MyLife("ic_calendar", userId, context.getString(R.string.calendar)),
-            MyLife("ic_mypersonals", userId, context.getString(R.string.mypersonals))
+        private val defaultItemPairs = listOf(
+            "ic_myhealth" to R.string.myhealth,
+            "my_achievement" to R.string.achievements,
+            "ic_submissions" to R.string.submission,
+            "ic_my_survey" to R.string.my_survey,
+            "ic_references" to R.string.references,
+            "ic_calendar" to R.string.calendar,
+            "ic_mypersonals" to R.string.mypersonals
         )
+
+        fun defaultItems(userId: String?, resolveLabel: (Int) -> String): List<MyLife> =
+            defaultItemPairs.map { (imageId, stringRes) ->
+                MyLife(imageId, userId, resolveLabel(stringRes))
+            }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardPluginFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardPluginFragment.kt
@@ -120,5 +120,5 @@ open class DashboardPluginFragment : BaseContainerFragment() {
         return v
     }
 
-    fun getMyLifeListBase(userId: String?): List<MyLife> = MyLife.defaultItems(requireContext(), userId)
+    fun getMyLifeListBase(userId: String?): List<MyLife> = MyLife.defaultItems(userId, requireContext()::getString)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/life/LifeViewModel.kt
@@ -35,7 +35,7 @@ class LifeViewModel @Inject constructor(
                 val userId = sharedPrefManager.getUserId().ifEmpty { userRepository.getUserModel()?.id }
                 var myLifeList = lifeRepository.getMyLifeByUserId(userId)
                 if (myLifeList.isEmpty()) {
-                    lifeRepository.seedMyLifeIfEmpty(userId, MyLife.defaultItems(context, userId))
+                    lifeRepository.seedMyLifeIfEmpty(userId, MyLife.defaultItems(userId, context::getString))
                     myLifeList = lifeRepository.getMyLifeByUserId(userId)
                 }
                 myLifeList.distinctBy { it.imageId ?: it.title }


### PR DESCRIPTION
This commit modifies the `MyLife.defaultItems` function to resolve string resources via a provided resolver function `(Int) -> String` rather than depending directly on an Android `Context`. This strictly separates the Android framework presentation layer from the data model.

---
*PR created automatically by Jules for task [3189559195291767378](https://jules.google.com/task/3189559195291767378) started by @dogi*