### PR TITLE
login: smoother onboarding (fixes #16232)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6721
-        versionName = "0.67.21"
+        versionCode = 6722
+        versionName = "0.67.22"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/onboarding/OnboardingActivity.kt
@@ -37,6 +37,8 @@ class OnboardingActivity : AppCompatActivity() {
     private val onBoardItems = ArrayList<OnboardingItem>()
     private var dotsCount = 0
     private lateinit var dots: Array<ImageView?>
+    private val selectedDot by lazy { ContextCompat.getDrawable(this, R.drawable.selected_item_dot) }
+    private val unselectedDot by lazy { ContextCompat.getDrawable(this, R.drawable.non_selected_item_dot) }
     @Inject
     lateinit var prefData: SharedPrefManager
     @Inject
@@ -114,9 +116,9 @@ class OnboardingActivity : AppCompatActivity() {
 
             override fun onPageSelected(position: Int) {
                 for (i in dots.indices) {
-                    dots[i]?.setImageDrawable(ContextCompat.getDrawable(this@OnboardingActivity, R.drawable.non_selected_item_dot))
+                    dots[i]?.setImageDrawable(unselectedDot)
                 }
-                dots[position]?.setImageDrawable(ContextCompat.getDrawable(this@OnboardingActivity, R.drawable.selected_item_dot))
+                dots[position]?.setImageDrawable(selectedDot)
 
                 if (position == mAdapter.count - 1) {
                     binding.skip.visibility = View.GONE
@@ -187,7 +189,7 @@ class OnboardingActivity : AppCompatActivity() {
 
         for (i in dots.indices) {
             dots[i] = ImageView(this)
-            dots[i]?.setImageDrawable(ContextCompat.getDrawable(this, R.drawable.non_selected_item_dot))
+            dots[i]?.setImageDrawable(unselectedDot)
 
             val params = LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.WRAP_CONTENT,
@@ -197,7 +199,7 @@ class OnboardingActivity : AppCompatActivity() {
             params.setMargins(6, 0, 6, 0)
             binding.viewPagerCountDots.addView(dots[i], params)
         }
-        dots[0]?.setImageDrawable(ContextCompat.getDrawable(this, R.drawable.selected_item_dot))
+        dots[0]?.setImageDrawable(selectedDot)
     }
 
     override fun onNewIntent(intent: Intent) {


### PR DESCRIPTION
Replaced repeated calls to `ContextCompat.getDrawable` in `OnboardingActivity` with `by lazy` properties to cache the drawables.

---
*PR created automatically by Jules for task [7969056712951555634](https://jules.google.com/task/7969056712951555634) started by @dogi*