### PR TITLE
sync: smoother retry queue working (fixes #16234)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6723
-        versionName = "0.67.23"
+        versionCode = 6724
+        versionName = "0.67.24"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueueWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/retry/RetryQueueWorker.kt
@@ -114,6 +114,9 @@ class RetryQueueWorker @AssistedInject constructor(
 
             Log.i(TAG, "RETRY_QUEUE: Processing ${pendingOperations.size} pending operations")
 
+            val baseUrl = UrlUtils.getUrl()
+            val authHeader = UrlUtils.header
+
             var successCount = 0
             var failureCount = 0
 
@@ -127,7 +130,7 @@ class RetryQueueWorker @AssistedInject constructor(
                     }
 
                     batch.forEach { operation ->
-                        val success = processOperation(operation)
+                        val success = processOperation(operation, baseUrl, authHeader)
                         if (success) successCount++ else failureCount++
                     }
                 }
@@ -149,11 +152,15 @@ class RetryQueueWorker @AssistedInject constructor(
         }
     }
 
-    private suspend fun processOperation(operation: RetryOperation): Boolean {
+    private suspend fun processOperation(
+        operation: RetryOperation,
+        baseUrl: String,
+        authHeader: String
+    ): Boolean {
         return try {
             // Timeout for individual operation (30 seconds)
             withTimeout(30_000L) {
-                processOperationInternal(operation)
+                processOperationInternal(operation, baseUrl, authHeader)
             }
         } catch (e: TimeoutCancellationException) {
             Log.w(TAG, "Operation ${operation.id} timed out")
@@ -166,7 +173,11 @@ class RetryQueueWorker @AssistedInject constructor(
         }
     }
 
-    private suspend fun processOperationInternal(operation: RetryOperation): Boolean {
+    private suspend fun processOperationInternal(
+        operation: RetryOperation,
+        baseUrl: String,
+        authHeader: String
+    ): Boolean {
         return try {
             retryQueue.markInProgress(operation.id)
 
@@ -178,21 +189,21 @@ class RetryQueueWorker @AssistedInject constructor(
                 return false
             }
             val requestUrl = if (operation.dbId.isNullOrEmpty()) {
-                "${UrlUtils.getUrl()}/${operation.endpoint}"
+                "$baseUrl/${operation.endpoint}"
             } else {
-                "${UrlUtils.getUrl()}/${operation.endpoint}/${operation.dbId}"
+                "$baseUrl/${operation.endpoint}/${operation.dbId}"
             }
 
             val response = if (operation.httpMethod == "PUT" && !operation.dbId.isNullOrEmpty()) {
                 apiInterface.putDoc(
-                    UrlUtils.header,
+                    authHeader,
                     "application/json",
                     requestUrl,
                     payload
                 )
             } else {
                 apiInterface.postDoc(
-                    UrlUtils.header,
+                    authHeader,
                     "application/json",
                     requestUrl,
                     payload

--- a/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueWorkerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/retry/RetryQueueWorkerTest.kt
@@ -70,6 +70,10 @@ class RetryQueueWorkerTest {
         mockkStatic(WorkManager::class)
         every { WorkManager.getInstance(any()) } returns workManagerImpl
 
+        mockkObject(org.ole.planet.myplanet.utils.UrlUtils)
+        every { org.ole.planet.myplanet.utils.UrlUtils.getUrl() } returns "http://mock.url"
+        every { org.ole.planet.myplanet.utils.UrlUtils.header } returns "mockHeader"
+
         worker = RetryQueueWorker(context, workerParams, retryQueue, apiInterface)
 
         mockkObject(MainApplication)


### PR DESCRIPTION
Hoist `baseUrl` and `authHeader` in `RetryQueueWorker` out of the inner loop to prevent them from being evaluated per-operation, saving potentially up to 50 redundant prefs reads and base64 encodings per batch. Test coverage has been updated and passes.

---
*PR created automatically by Jules for task [18065150421663874000](https://jules.google.com/task/18065150421663874000) started by @dogi*