### PR TITLE
Refactor: Deduplicate showZoomableImage implementation

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/ImageViewerUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/ImageViewerUtils.kt
@@ -4,36 +4,53 @@ import android.app.Dialog
 import android.content.Context
 import android.graphics.Color
 import android.view.LayoutInflater
-import android.widget.ImageView
 import androidx.core.graphics.drawable.toDrawable
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
-import com.github.chrisbanes.photoview.PhotoView
 import java.io.File
 import java.util.Locale
 import org.ole.planet.myplanet.R
+import org.ole.planet.myplanet.databinding.DialogZoomableImageBinding
 
 object ImageViewerUtils {
-    fun showZoomableImage(context: Context, imagePath: String) {
-        val dialog = Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen)
-        val view = LayoutInflater.from(context).inflate(R.layout.dialog_zoomable_image, null)
-        val photoView = view.findViewById<PhotoView>(R.id.photoView)
-        val closeButton = view.findViewById<ImageView>(R.id.closeButton)
+    private var activeDialog: Dialog? = null
 
-        dialog.setContentView(view)
+    fun showZoomableImage(context: Context, imagePath: String) {
+        activeDialog?.dismiss()
+
+        val dialog = Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen)
+        activeDialog = dialog
+
+        val binding = DialogZoomableImageBinding.inflate(LayoutInflater.from(context))
+        dialog.setContentView(binding.root)
         dialog.window?.setBackgroundDrawable(Color.BLACK.toDrawable())
 
-        val request = Glide.with(photoView.context)
-        val file = File(imagePath)
-        val target = if (imagePath.lowercase(Locale.getDefault()).endsWith(".gif")) {
-            request.asGif().load(file).error(request.asGif().load(imagePath))
-        } else {
-            request.load(file).error(request.load(imagePath))
-        }
-        target.diskCacheStrategy(DiskCacheStrategy.ALL).fitCenter()
-            .error(R.drawable.ic_loading).into(photoView)
+        val request = Glide.with(binding.photoView.context)
+        val isHttp = imagePath.startsWith("http", ignoreCase = true)
 
-        closeButton.setOnClickListener { dialog.dismiss() }
+        val target = if (isHttp) {
+            request.load(imagePath)
+        } else {
+            val file = File(imagePath)
+            if (imagePath.lowercase(Locale.getDefault()).endsWith(".gif")) {
+                request.asGif().load(file).error(request.asGif().load(imagePath))
+            } else {
+                request.load(file).error(request.load(imagePath))
+            }
+        }
+
+        target.diskCacheStrategy(DiskCacheStrategy.ALL).fitCenter()
+            .error(R.drawable.ic_loading).into(binding.photoView)
+
+        binding.closeButton.setOnClickListener {
+            dialog.dismiss()
+            activeDialog = null
+        }
+
+        dialog.setOnDismissListener {
+            activeDialog = null
+        }
+
         dialog.show()
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/MarkdownUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/MarkdownUtils.kt
@@ -1,23 +1,16 @@
 package org.ole.planet.myplanet.utils
 
-import android.app.Dialog
 import android.content.Context
-import android.graphics.Color
 import android.text.Layout
 import android.text.Spannable
 import android.text.TextPaint
 import android.text.method.LinkMovementMethod
 import android.text.style.AlignmentSpan
 import android.text.style.ClickableSpan
-import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
-import android.widget.ImageView
 import android.widget.TextView
-import androidx.core.graphics.drawable.toDrawable
 import com.bumptech.glide.Glide
-import com.bumptech.glide.load.engine.DiskCacheStrategy
-import com.github.chrisbanes.photoview.PhotoView
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonConfiguration
@@ -37,7 +30,6 @@ import org.commonmark.node.Image
 import org.ole.planet.myplanet.R
 
 object MarkdownUtils {
-    private var currentZoomDialog: Dialog? = null
     @Volatile private var markwonInstance: Markwon? = null
     private val imagePattern = Pattern.compile("!\\[.*?]\\((.*?)\\)")
 
@@ -79,44 +71,12 @@ object MarkdownUtils {
 
     private class CustomImageSpan(private val theme: MarkwonTheme, private val url: String) : ClickableSpan() {
         override fun onClick(widget: View) {
-            showZoomableImage(widget.context, url)
+            ImageViewerUtils.showZoomableImage(widget.context, url)
         }
 
         override fun updateDrawState(ds: TextPaint) {
             theme.applyLinkStyle(ds)
         }
-    }
-
-    private fun showZoomableImage(context: Context, imageUrl: String) {
-        currentZoomDialog?.dismiss()
-
-        val dialog = Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen)
-        currentZoomDialog = dialog
-
-        val view = LayoutInflater.from(context).inflate(R.layout.dialog_zoomable_image, null)
-        val photoView = view.findViewById<PhotoView>(R.id.photoView)
-        val closeButton = view.findViewById<ImageView>(R.id.closeButton)
-
-        dialog.setContentView(view)
-        dialog.window?.setBackgroundDrawable(Color.BLACK.toDrawable())
-
-        Glide.with(photoView.context)
-            .load(imageUrl)
-            .diskCacheStrategy(DiskCacheStrategy.ALL)
-            .fitCenter()
-            .error(R.drawable.ic_loading)
-            .into(photoView)
-
-        closeButton.setOnClickListener {
-            dialog.dismiss()
-            currentZoomDialog = null
-        }
-
-        dialog.setOnDismissListener {
-            currentZoomDialog = null
-        }
-
-        dialog.show()
     }
 
     fun prependBaseUrlToImages(


### PR DESCRIPTION
- Centralized `showZoomableImage` in `ImageViewerUtils` using ViewBinding.
- Replaced custom layout lookup with `DialogZoomableImageBinding`.
- Added support for tracking `activeDialog` to prevent multiple zooms simultaneously opening.
- Dynamically detect and handle HTTP(S) paths versus local file paths within the same method.
- Removed duplicate `showZoomableImage` logic and `currentZoomDialog` from `MarkdownUtils`, routing `CustomImageSpan.onClick` straight to the unified util.
- Pruned redundant imports.

---
*PR created automatically by Jules for task [1287135684813282195](https://jules.google.com/task/1287135684813282195) started by @dogi*