### PR TITLE
courses: smoother submissions repository pdf exporting (fixes #16236)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6725
-        versionName = "0.67.25"
+        versionCode = 6726
+        versionName = "0.67.26"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/SubmissionsRepositoryExporter.kt
@@ -11,6 +11,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
+import org.json.JSONObject
 import org.ole.planet.myplanet.data.room.dao.AnswerDao
 import org.ole.planet.myplanet.data.room.dao.ExamDao
 import org.ole.planet.myplanet.data.room.dao.QuestionDao
@@ -120,7 +121,6 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
                 document.close()
             }
         } catch (e: Exception) {
-                e.printStackTrace()
                 null
             }
     }
@@ -238,7 +238,6 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
                 document.close()
             }
         } catch (e: Exception) {
-                e.printStackTrace()
                 null
             }
     }
@@ -246,23 +245,31 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
     private fun drawMultilineText(canvas: Canvas, text: String, x: Float, y: Float, paint: Paint, maxWidth: Float): Float {
         var currentY = y
         val words = text.split(" ")
-        var line = ""
+        val line = java.lang.StringBuilder()
+        var lineWidth = 0f
 
         words.forEach { word ->
-            val testLine = if (line.isEmpty()) word else "$line $word"
-            val width = paint.measureText(testLine)
-
-            if (width > maxWidth && line.isNotEmpty()) {
-                canvas.drawText(line, x, currentY, paint)
-                currentY += LINE_HEIGHT
-                line = word
+            if (line.isEmpty()) {
+                line.append(word)
+                lineWidth = paint.measureText(word)
             } else {
-                line = testLine
+                val addition = " $word"
+                val additionWidth = paint.measureText(addition)
+                if (lineWidth + additionWidth > maxWidth) {
+                    canvas.drawText(line.toString(), x, currentY, paint)
+                    currentY += LINE_HEIGHT
+                    line.clear()
+                    line.append(word)
+                    lineWidth = paint.measureText(word)
+                } else {
+                    line.append(addition)
+                    lineWidth += additionWidth
+                }
             }
         }
 
         if (line.isNotEmpty()) {
-            canvas.drawText(line, x, currentY, paint)
+            canvas.drawText(line.toString(), x, currentY, paint)
             currentY += LINE_HEIGHT
         }
 
@@ -278,7 +285,7 @@ internal class SubmissionsRepositoryExporter @Inject constructor(
             !choices.isNullOrEmpty() -> {
                 choices.joinToString(", ") { choice ->
                     try {
-                        val choiceObj = org.json.JSONObject(choice)
+                        val choiceObj = JSONObject(choice)
                         choiceObj.optString("text", choice)
                     } catch (e: Exception) {
                         choice


### PR DESCRIPTION
Fix O(N^2) performance issue in PDF text wrapping

Optimized `drawMultilineText` in `SubmissionsRepositoryExporter` to avoid measuring the entire accumulated string repeatedly for every word. It now accumulates text in a `StringBuilder`, keeps a running `lineWidth`, and only measures the newly added word (and space).

Also cleaned up by removing a noisy `printStackTrace` inside a catch block that deliberately returned null, and moved `JSONObject` fully-qualified instantiation to a top-level import.

---
*PR created automatically by Jules for task [3997099282363232018](https://jules.google.com/task/3997099282363232018) started by @dogi*