### PR TITLE
Refactor finance type checks to eliminate redundant string allocations

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesAdapter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.LayerDrawable
-import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,7 +12,6 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import java.util.Locale
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.RowFinanceBinding
 import org.ole.planet.myplanet.model.MyTeam
@@ -41,7 +39,7 @@ class EnterprisesFinancesAdapter(
         val binding = holder.binding
         binding.date.text = item.date?.let { formatDate(it, "MMM dd, yyyy") } ?: ""
         binding.note.text = item.description
-        if (TextUtils.equals(item.type?.lowercase(Locale.getDefault()), "debit")) {
+        if ("debit".equals(item.type, ignoreCase = true)) {
             binding.debit.text = context.getString(R.string.number_placeholder, item.amount)
             binding.credit.text = context.getString(R.string.message_placeholder, " -")
         } else {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/enterprises/EnterprisesFinancesFragment.kt
@@ -22,10 +22,11 @@ import com.bumptech.glide.Glide
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
 import java.time.ZoneId
+import java.util.Locale
+
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.util.Calendar
-import java.util.Locale
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseTeamFragment
@@ -270,7 +271,7 @@ class EnterprisesFinancesFragment : BaseTeamFragment() {
         var debit = 0
         var credit = 0
         for (team in list) {
-            if ("credit".equals(team.type?.lowercase(Locale.getDefault()), ignoreCase = true)) {
+            if ("credit".equals(team.type, ignoreCase = true)) {
                 credit += team.amount
             } else {
                 debit += team.amount


### PR DESCRIPTION
Replaced `TextUtils.equals` and `lowercase()` combinations with `equals(..., ignoreCase = true)` in both `EnterprisesFinancesAdapter` and `EnterprisesFinancesFragment` to avoid redundant string allocations. Also removed unused imports.

---
*PR created automatically by Jules for task [15016540432361080664](https://jules.google.com/task/15016540432361080664) started by @dogi*