### PR TITLE
login: smoother url utils handling (fixes #16237)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6726
-        versionName = "0.67.26"
+        versionCode = 6727
+        versionName = "0.67.27"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/LoginSyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/LoginSyncManager.kt
@@ -51,7 +51,7 @@ class LoginSyncManager @Inject constructor(
             }
 
             val userUrl = try {
-                String.format("%s/_users/%s", UrlUtils.getUrl(), "org.couchdb.user:$userName")
+                "${UrlUtils.getUrl()}/_users/org.couchdb.user:$userName"
             } catch (e: Exception) {
                 e.printStackTrace()
                 listener.onSyncFailed("Invalid server URL.")

--- a/app/src/main/java/org/ole/planet/myplanet/utils/UrlUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/UrlUtils.kt
@@ -131,7 +131,7 @@ object UrlUtils {
 
     fun getHealthAccessUrl(spm: SharedPrefManager): String {
         val url = baseUrl(spm)
-        return String.format("%s/healthaccess?p=%s", url, spm.getServerPin().ifEmpty { "0000" })
+        return "$url/healthaccess?p=${spm.getServerPin().ifEmpty { "0000" }}"
     }
 
     fun getApkVersionUrl(spm: SharedPrefManager): String {


### PR DESCRIPTION
Replaced plain string concatenations via `String.format` with standard Kotlin string templates for better readability and performance in `UrlUtils.kt` and `LoginSyncManager.kt` as suggested in issue 62.

---
*PR created automatically by Jules for task [5601409954831551306](https://jules.google.com/task/5601409954831551306) started by @dogi*