### PR TITLE
resources: smoother collections view modelling (fixes #16238)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6727
-        versionName = "0.67.27"
+        versionCode = 6728
+        versionName = "0.67.28"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsViewModel.kt
@@ -46,9 +46,12 @@ class CollectionsViewModel @Inject constructor(
             try {
                 val tagsWithChildren = tagsRepository.getTagsWithChildren(dbType)
                 val list = tagsWithChildren.keys.toList()
-                val childMap = tagsWithChildren.entries
-                    .filter { it.value.isNotEmpty() }
-                    .associate { (it.key.id ?: "") to it.value }
+                val childMap = LinkedHashMap<String, List<TagEntity>>()
+                for ((key, value) in tagsWithChildren) {
+                    if (value.isNotEmpty()) {
+                        childMap[key.id ?: ""] = value
+                    }
+                }
 
                 if (list.isEmpty() && childMap.isEmpty()) {
                     _state.value = CollectionsState.Empty


### PR DESCRIPTION
Optimized the construction of `childMap` in `CollectionsViewModel.kt` to avoid intermediate list allocations by replacing `.filter().associate()` with a single-pass `for` loop populating a `LinkedHashMap`. Verified via `CollectionsViewModelTest`.

---
*PR created automatically by Jules for task [12686441124302417797](https://jules.google.com/task/12686441124302417797) started by @dogi*