### PR TITLE
actions: smoother workflow test timing (fixes #16239)

### DIFF
--- a/.github/scripts/test_timing_summary.py
+++ b/.github/scripts/test_timing_summary.py
@@ -14,11 +14,26 @@ has grown past what one CI job should carry gets noticed.
 """
 import argparse
 import glob
+import math
 import os
 import sys
 import xml.etree.ElementTree as ET
 
 TOP_N = 15
+
+
+def _parse_time(time_str: str | None, path: str) -> float:
+    try:
+        if time_str is None:
+            return 0.0
+        val = float(time_str)
+        if not math.isfinite(val) or val < 0.0:
+            print(f"Warning: malformed time '{time_str}' in {os.path.basename(path)}, defaulting to 0.0", file=sys.stderr)
+            return 0.0
+        return val
+    except ValueError:
+        print(f"Warning: malformed time '{time_str}' in {os.path.basename(path)}, defaulting to 0.0", file=sys.stderr)
+        return 0.0
 
 
 def main() -> int:
@@ -45,12 +60,12 @@ def main() -> int:
         except ET.ParseError as exc:
             print(f"Skipping unreadable result file `{path}`: {exc}", file=sys.stderr)
             continue
-        elapsed = float(root.get("time") or 0)
+        elapsed = _parse_time(root.get("time"), path)
         classes.append((elapsed, root.get("name") or "?"))
         total += elapsed
         for case in root.iter("testcase"):
             owner = (case.get("classname") or "?").rsplit(".", 1)[-1]
-            cases.append((float(case.get("time") or 0), f"{owner}.{case.get('name') or '?'}"))
+            cases.append((_parse_time(case.get("time"), path), f"{owner}.{case.get('name') or '?'}"))
 
     classes.sort(reverse=True)
     cases.sort(reverse=True)

--- a/.github/scripts/test_timing_summary.py
+++ b/.github/scripts/test_timing_summary.py
@@ -21,7 +21,6 @@ import xml.etree.ElementTree as ET
 
 TOP_N = 15
 
-
 def _parse_time(time_str: str | None, path: str) -> float:
     try:
         if time_str is None:
@@ -34,7 +33,6 @@ def _parse_time(time_str: str | None, path: str) -> float:
     except ValueError:
         print(f"Warning: malformed time '{time_str}' in {os.path.basename(path)}, defaulting to 0.0", file=sys.stderr)
         return 0.0
-
 
 def main() -> int:
     parser = argparse.ArgumentParser()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6728
-        versionName = "0.67.28"
+        versionCode = 6729
+        versionName = "0.67.29"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
Safely parses the `time` attributes in JUnit XML files to handle `NaN`, `inf`, and malformed strings gracefully by defaulting to `0.0` and emitting a warning to stderr, preventing the `test_timing_summary.py` CI step from crashing.

---
*PR created automatically by Jules for task [9958875739411169087](https://jules.google.com/task/9958875739411169087) started by @dogi*