### PR TITLE
all: smoother map tile utils handling (fixes #16241)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6742
-        versionName = "0.67.42"
+        versionCode = 6743
+        versionName = "0.67.43"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import org.ole.planet.myplanet.ui.sync.SyncActivity
 import org.ole.planet.myplanet.utils.LocaleUtils
+import android.util.Log
 
 abstract class BaseActivity : SyncActivity() {
     override fun attachBaseContext(newBase: Context) {
@@ -32,7 +33,7 @@ abstract class BaseActivity : SyncActivity() {
                 setTitle(label)
             }
         } catch (e: PackageManager.NameNotFoundException) {
-            e.printStackTrace()
+            Log.w("BaseActivity", "Failed to find activity label for: ${componentName.className}", e)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/data/api/ChatApiService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/api/ChatApiService.kt
@@ -12,6 +12,7 @@ import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.UrlUtils
 import retrofit2.Response
+import android.util.Log
 
 @Singleton
 class ChatApiService @Inject constructor(
@@ -45,7 +46,7 @@ class ChatApiService @Inject constructor(
                 object : TypeToken<Map<String, Boolean>>() {}.type
             )
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.w("ChatApiService", "Failed to fetch AI providers from: ${UrlUtils.hostUrl}checkProviders/", e)
             null
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/MapTileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/MapTileUtils.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.utils
 
 import android.content.Context
 import android.os.Environment
+import android.util.Log
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -28,7 +29,7 @@ object MapTileUtils {
                     }
                 }
             } catch (e: Exception) {
-                e.printStackTrace()
+                Log.w("MapTileUtils", "Failed to copy map tile: $s", e)
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Sha256Utils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Sha256Utils.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.utils
 
 import java.io.File
 import java.io.FileInputStream
+import android.util.Log
 import java.security.MessageDigest
 
 class Sha256Utils {
@@ -28,7 +29,7 @@ class Sha256Utils {
             }
             String(result)
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.w("Sha256Utils", "Failed to get checksum for file: ${file.absolutePath}", e)
             ""
         }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/data/api/ChatApiServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/api/ChatApiServiceTest.kt
@@ -18,6 +18,9 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import android.util.Log
 import org.ole.planet.myplanet.model.ChatResponse
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
 import org.ole.planet.myplanet.utils.UrlUtils
@@ -39,11 +42,14 @@ class ChatApiServiceTest {
         // Parallel tests would be flaky due to this shared state.
         // It's a limitation due to the production code using the static/singleton UrlUtils directly.
         mockkObject(UrlUtils)
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), any<String>(), any()) } returns 0
     }
 
     @After
     fun tearDown() {
         unmockkObject(UrlUtils)
+        unmockkStatic(Log::class)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/utils/Sha256UtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/Sha256UtilsTest.kt
@@ -6,8 +6,25 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeFalse
 import org.junit.Test
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.Before
+import org.junit.After
+import io.mockk.every
+import android.util.Log
 
 class Sha256UtilsTest {
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), any<String>(), any()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
 
     @Test
     fun getCheckSumFromFile_validFile_returnsChecksum() {


### PR DESCRIPTION
Replaced untagged `printStackTrace()` calls with structured `Log.w` statements
including appropriate tags and specific error messages. Affected files include:
- MapTileUtils.kt
- Sha256Utils.kt
- BaseActivity.kt
- ChatApiService.kt

Also updated the `Sha256UtilsTest` and `ChatApiServiceTest` test classes to
mock `android.util.Log` correctly. This change prevents silent swallows of
real errors without altering any return values or control-flow paths.

---
*PR created automatically by Jules for task [2868337696302024629](https://jules.google.com/task/2868337696302024629) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic reporting when activity labels, provider checks, map tiles, or checksum generation fail.
  * Warning messages now include relevant error context while preserving existing fallback behavior.

* **Tests**
  * Updated automated tests to accommodate the improved warning-level error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->