### PR TITLE
Optimize CommunityServicesFragment link list rendering

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
@@ -81,15 +81,6 @@ class CommunityServicesFragment : BaseTeamFragment() {
     private fun setRecyclerView(links: List<MyTeam>) {
         val parent = binding?.llServices ?: return
 
-        val currentTitles = (0 until parent.childCount).mapNotNull { i ->
-            (parent.getChildAt(i) as? TextView)?.text?.toString()
-        }
-        val incomingTitles = links.map { it.title }
-
-        if (currentTitles == incomingTitles) {
-            return
-        }
-
         links.forEachIndexed { index, team ->
             val b: TextView
             if (index < parent.childCount) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
@@ -80,17 +80,10 @@ class CommunityServicesFragment : BaseTeamFragment() {
 
     private fun setRecyclerView(links: List<MyTeam>) {
         val parent = binding?.llServices ?: return
-
-        links.forEachIndexed { index, team ->
-            val b: TextView
-            if (index < parent.childCount) {
-                b = parent.getChildAt(index) as TextView
-            } else {
-                b = LayoutInflater.from(activity).inflate(R.layout.button_single, parent, false) as TextView
-                b.setPadding(8, 8, 8, 8)
-                parent.addView(b)
-            }
-
+        parent.removeAllViews()
+        links.forEach { team ->
+            val b: TextView = LayoutInflater.from(activity).inflate(R.layout.button_single, parent, false) as TextView
+            b.setPadding(8, 8, 8, 8)
             b.text = team.title
             b.setOnClickListener {
                 val rawRoute = team.route ?: return@setOnClickListener
@@ -126,11 +119,7 @@ class CommunityServicesFragment : BaseTeamFragment() {
                     })
                 }
             }
-        }
-
-        val childCount = parent.childCount
-        if (links.size < childCount) {
-            parent.removeViews(links.size, childCount - links.size)
+            parent.addView(b)
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
@@ -80,10 +80,17 @@ class CommunityServicesFragment : BaseTeamFragment() {
 
     private fun setRecyclerView(links: List<MyTeam>) {
         val parent = binding?.llServices ?: return
-        parent.removeAllViews()
-        links.forEach { team ->
-            val b: TextView = LayoutInflater.from(activity).inflate(R.layout.button_single, parent, false) as TextView
-            b.setPadding(8, 8, 8, 8)
+
+        links.forEachIndexed { index, team ->
+            val b: TextView
+            if (index < parent.childCount) {
+                b = parent.getChildAt(index) as TextView
+            } else {
+                b = LayoutInflater.from(activity).inflate(R.layout.button_single, parent, false) as TextView
+                b.setPadding(8, 8, 8, 8)
+                parent.addView(b)
+            }
+
             b.text = team.title
             b.setOnClickListener {
                 val rawRoute = team.route ?: return@setOnClickListener
@@ -119,7 +126,11 @@ class CommunityServicesFragment : BaseTeamFragment() {
                     })
                 }
             }
-            parent.addView(b)
+        }
+
+        val childCount = parent.childCount
+        if (links.size < childCount) {
+            parent.removeViews(links.size, childCount - links.size)
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityServicesFragment.kt
@@ -80,10 +80,26 @@ class CommunityServicesFragment : BaseTeamFragment() {
 
     private fun setRecyclerView(links: List<MyTeam>) {
         val parent = binding?.llServices ?: return
-        parent.removeAllViews()
-        links.forEach { team ->
-            val b: TextView = LayoutInflater.from(activity).inflate(R.layout.button_single, parent, false) as TextView
-            b.setPadding(8, 8, 8, 8)
+
+        val currentTitles = (0 until parent.childCount).mapNotNull { i ->
+            (parent.getChildAt(i) as? TextView)?.text?.toString()
+        }
+        val incomingTitles = links.map { it.title }
+
+        if (currentTitles == incomingTitles) {
+            return
+        }
+
+        links.forEachIndexed { index, team ->
+            val b: TextView
+            if (index < parent.childCount) {
+                b = parent.getChildAt(index) as TextView
+            } else {
+                b = LayoutInflater.from(activity).inflate(R.layout.button_single, parent, false) as TextView
+                b.setPadding(8, 8, 8, 8)
+                parent.addView(b)
+            }
+
             b.text = team.title
             b.setOnClickListener {
                 val rawRoute = team.route ?: return@setOnClickListener
@@ -119,7 +135,11 @@ class CommunityServicesFragment : BaseTeamFragment() {
                     })
                 }
             }
-            parent.addView(b)
+        }
+
+        val childCount = parent.childCount
+        if (links.size < childCount) {
+            parent.removeViews(links.size, childCount - links.size)
         }
     }
 }


### PR DESCRIPTION
Optimized the link list rendering in `CommunityServicesFragment` to reuse existing views and avoid full rebuilds on every refresh.

---
*PR created automatically by Jules for task [8102992331690761976](https://jules.google.com/task/8102992331690761976) started by @dogi*