### PR TITLE
teams: smoother tasks copy uploading (fixes #16242)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6730
-        versionName = "0.67.30"
+        versionCode = 6731
+        versionName = "0.67.31"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/tasks/TeamsTasksFragment.kt
@@ -297,7 +297,7 @@ class TeamsTasksFragment : BaseTeamFragment(), OnTaskCompletedListener {
         refreshJob?.cancel()
         refreshJob = viewLifecycleOwner.lifecycleScope.launch {
             val knownAssigneeIds = adapterTask.getKnownAssigneeIds()
-            val tasksSnapshot = teamViewModel.taskList.value.toList()
+            val tasksSnapshot = teamViewModel.taskList.value
 
             val (taskList, fetchedNames, currentSnapshot) = withContext(dispatcherProvider.io) {
                 val list = when (currentTab) {


### PR DESCRIPTION
Removes an unnecessary `.toList()` copy when reading `teamViewModel.taskList.value` in `TeamsTasksFragment`.
Since `taskList` is a `StateFlow<List<TeamTask>>` that receives fresh lists from a Room DAO flow, the list instances are replaced wholesale rather than mutated. Therefore, directly reading `.value` is safe for cross-thread use and avoids a redundant allocation.

---
*PR created automatically by Jules for task [9513973787740678493](https://jules.google.com/task/9513973787740678493) started by @dogi*