### PR TITLE
login: smoother teams members view modelling (fixes #16243)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6731
-        versionName = "0.67.31"
+        versionCode = 6732
+        versionName = "0.67.32"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/LoginViewModel.kt
@@ -41,7 +41,7 @@ class LoginViewModel @Inject constructor(
         }
         viewModelScope.launch(dispatcherProvider.io) {
             val teamsList = teamsRepository.getAllActiveTeams()
-            _teams.value = teamsList.toList()
+            _teams.value = teamsList
         }
     }
 
@@ -49,7 +49,7 @@ class LoginViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.io) {
             if (!teamId.isNullOrEmpty()) {
                 val teamMembers = teamsRepository.refreshJoinedMembersForLogin(teamId)
-                _users.value = teamMembers.toList()
+                _users.value = teamMembers
                 loadSavedUsers() // Refresh saved users after joining team
             } else {
                 _users.value = emptyList()


### PR DESCRIPTION
Removed redundant `.toList()` calls in `LoginViewModel` when updating `_teams.value` and `_users.value` as the repository methods already return lists.

---
*PR created automatically by Jules for task [12179777305811454624](https://jules.google.com/task/12179777305811454624) started by @dogi*