### PR TITLE
courses: smoother steps label formatting (fixes #16244)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6732
-        versionName = "0.67.32"
+        versionCode = 6733
+        versionName = "0.67.33"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/TakeCourseFragment.kt
@@ -185,12 +185,15 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
         })
     }
 
+    private fun setStepText(currentStep: Int, totalSteps: Int) {
+        binding.tvStep.text = String.format(Locale.getDefault(), "${getString(R.string.step)} %d/%d", currentStep, totalSteps)
+    }
+
     private fun updateStepDisplay(position: Int) {
         if (position == 0) {
             binding.tvStep.text = "Course Details"
         } else {
-            val stepNumber = position
-            binding.tvStep.text = String.format(getString(R.string.step) + " %d/%d", stepNumber, steps.size)
+            setStepText(position, steps.size)
         }
         binding.nextStep.text = if (position == 0) getString(R.string.start) else getString(R.string.next)
         binding.courseStepProgressBar.max = steps.size
@@ -336,7 +339,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     override fun onPageScrollStateChanged(state: Int) {}
 
     private fun onClickNext() {
-        binding.tvStep.text = String.format(Locale.getDefault(), "${getString(R.string.step)} %d/%d", binding.viewPager2.currentItem, steps.size)
+        setStepText(binding.viewPager2.currentItem, steps.size)
         if (binding.viewPager2.currentItem >= steps.size) {
             binding.nextStep.visibility = View.GONE
             binding.finishStep.visibility = View.VISIBLE
@@ -347,7 +350,7 @@ class TakeCourseFragment : Fragment(), ViewPager.OnPageChangeListener, View.OnCl
     }
 
     private fun onClickPrevious() {
-        binding.tvStep.text = String.format(Locale.getDefault(), "${getString(R.string.step)} %d/%d", binding.viewPager2.currentItem - 1, steps.size)
+        setStepText(binding.viewPager2.currentItem - 1, steps.size)
         if (binding.viewPager2.currentItem - 1 == 0) {
             binding.previousStep.visibility = View.GONE
             binding.nextStep.visibility = View.VISIBLE


### PR DESCRIPTION
Centralize the formatting of `binding.tvStep.text` into a single helper method `setStepText`. This replaces three disparate String.format calls with a unified `String.format(Locale.getDefault(), ...)` usage, adhering to lint requirements and preserving correct locale-specific digit rendering for locales like Arabic and Nepali, avoiding regressions that plain Kotlin string templates would cause.

---
*PR created automatically by Jules for task [8790181314535772783](https://jules.google.com/task/8790181314535772783) started by @dogi*