### PR TITLE
resources: smoother collections parent tagging (fixes #16246)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6734
-        versionName = "0.67.34"
+        versionCode = 6735
+        versionName = "0.67.35"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/CollectionsFragment.kt
@@ -153,7 +153,7 @@ class CollectionsFragment : DialogFragment(), OnTagClickListener, CompoundButton
     override fun onParentTagClicked(parent: TagData.Parent) {
         parent.isExpanded = !parent.isExpanded
         currentTagDataList = buildTagDataList(list).toMutableList()
-        adapter.submitList(currentTagDataList.toList())
+        adapter.submitList(currentTagDataList)
     }
 
     override fun onCheckboxTagSelected(tag: TagEntity) {


### PR DESCRIPTION
Removed the extra list copy in `CollectionsFragment.onParentTagClicked` by removing `.toList()` when submitting the newly created mutable list to the adapter.

---
*PR created automatically by Jules for task [9849415319212219547](https://jules.google.com/task/9849415319212219547) started by @dogi*