### PR TITLE
all: smoother feedback json parsing (fixes #16247)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6735
-        versionName = "0.67.35"
+        versionCode = 6736
+        versionName = "0.67.36"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/Feedback.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Feedback.kt
@@ -7,8 +7,6 @@ import androidx.room.PrimaryKey
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import com.google.gson.stream.JsonReader
-import java.io.StringReader
 import org.ole.planet.myplanet.utils.JsonUtils
 
 /**
@@ -50,11 +48,7 @@ open class Feedback {
             if (TextUtils.isEmpty(messages)) return null
             val feedbackReplies: MutableList<FeedbackReply> = ArrayList()
 
-            val stringReader = StringReader(messages)
-            val jsonReader = JsonReader(stringReader)
-
-            val e = JsonParser.parseReader(jsonReader)
-            val ar = e.asJsonArray
+            val ar = JsonParser.parseString(messages).asJsonArray
             if (ar.size() > 0) {
                 for (i in 1 until ar.size()) {
                     val ob = ar[i].asJsonObject
@@ -75,11 +69,7 @@ open class Feedback {
         get() {
             if (TextUtils.isEmpty(messages)) return ""
 
-            val stringReader = StringReader(messages)
-            val jsonReader = JsonReader(stringReader)
-
-            val e = JsonParser.parseReader(jsonReader)
-            val ar = e.asJsonArray
+            val ar = JsonParser.parseString(messages).asJsonArray
             if (ar.size() > 0) {
                 val ob = ar[0].asJsonObject
                 return ob["message"].asString


### PR DESCRIPTION
Simplified the JSON parsing logic in the `Feedback` model by removing unnecessary `StringReader` and `JsonReader` wrappers. Used `JsonParser.parseString()` directly to parse feedback messages. Removed unused imports. Verified via `*FeedbackTest` that all message extraction logic still functions correctly.

---
*PR created automatically by Jules for task [13920900859228092499](https://jules.google.com/task/13920900859228092499) started by @dogi*