### PR TITLE
all: smoother notifications view modelling (fixes #16248)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6736
-        versionName = "0.67.36"
+        versionCode = 6737
+        versionName = "0.67.37"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsViewModel.kt
@@ -353,7 +353,7 @@ class NotificationsViewModel @Inject constructor(
                 )
             }
             "join_request" -> {
-                if (notification.type.lowercase() != "join_request") {
+                if (!notification.type.equals("join_request", ignoreCase = true)) {
                     // Server notification with pre-formatted message
                     notification.message
                 } else {


### PR DESCRIPTION
Fix allocation in NotificationsViewModel string comparison

Change `notification.type.lowercase() != "join_request"` to `!notification.type.equals("join_request", ignoreCase = true)` to avoid unnecessary String allocations in the loop.

---
*PR created automatically by Jules for task [8742605278862837109](https://jules.google.com/task/8742605278862837109) started by @dogi*