### PR TITLE
actions: smoother gradle configuring (fixes #16250)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6738
-        versionName = "0.67.38"
+        versionCode = 6739
+        versionName = "0.67.39"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,9 +22,7 @@ org.gradle.configureondemand=false
 org.gradle.vfs.watch=true
 org.gradle.warning.mode=all
 android.useAndroidX=true
-# Load-bearing: material-dialogs, Circular-Progress-View and materialprogressbar
-# drag in com.android.support:*:28.0.0 transitively, and app/libs/*.aar are
-# pre-AndroidX. Removing this fails checkDuplicateClasses + manifest merger.
+# below can only be removed with material-dialogs, Circular-Progress-View, materialprogressbar and app/libs/*.aar
 android.enableJetifier=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,10 +22,12 @@ org.gradle.configureondemand=false
 org.gradle.vfs.watch=true
 org.gradle.warning.mode=all
 android.useAndroidX=true
+# Load-bearing: material-dialogs, Circular-Progress-View and materialprogressbar
+# drag in com.android.support:*:28.0.0 transitively, and app/libs/*.aar are
+# pre-AndroidX. Removing this fails checkDuplicateClasses + manifest merger.
 android.enableJetifier=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=true
-android.newDsl=false
 
 PLANET_LEARNING_URL=planet.learning.ole.org
 PLANET_LEARNING_PIN=1983


### PR DESCRIPTION
## Summary
Updated Gradle configuration to clarify the necessity of AndroidX Jetifier and removed an obsolete build flag that is no longer supported by the Android Gradle Plugin.

## Changes
- **Added explanatory comment** for `android.enableJetifier=true`: Documents that this flag is load-bearing because transitive dependencies (material-dialogs, Circular-Progress-View, materialprogressbar) drag in pre-AndroidX support library artifacts (com.android.support:*:28.0.0), and pre-AndroidX AAR files in app/libs/ require Jetifier to prevent duplicate class errors and manifest merger failures.
- **Removed `android.newDsl=false`**: This flag is no longer recognized by Android Gradle Plugin 9.3.1 and serves no purpose in the current build configuration.

## Implementation Details
The comment clarifies the architectural constraint that prevents removal of Jetifier despite the app being fully AndroidX-based (Kotlin 100%, Room 2.8.4, etc.). This prevents future maintainers from accidentally removing the flag and breaking the build.

https://claude.ai/code/session_018Peg1CDT9Aoe2AktWY5s5B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Android build configuration by removing an obsolete setting.
  - Added documentation clarifying configuration requirements for compatibility with existing build dependencies.
  - No changes to application features or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->