### PR TITLE
refactor: walk version parts with a cursor in compareVersions

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/utils/VersionUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/VersionUtils.kt
@@ -7,6 +7,9 @@ import android.provider.Settings
 import androidx.core.content.pm.PackageInfoCompat.getLongVersionCode
 
 object VersionUtils {
+    private const val VERSION_PREFIX = "v"
+    private const val LITE_SUFFIX = "-lite"
+
     fun getVersionCode(context: Context): Int {
         try {
             val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
@@ -41,15 +44,43 @@ object VersionUtils {
     }
 
     fun compareVersions(version1: String, version2: String): Int {
-        val parts1 = version1.removeSuffix("-lite").removePrefix("v").split(".").map { it.toInt() }
-        val parts2 = version2.removePrefix("v").split(".").map { it.toInt() }
+        val parts1 = VersionParts(version1, stripLiteSuffix = true)
+        val parts2 = VersionParts(version2, stripLiteSuffix = false)
+        var result = 0
 
-        for (i in 0 until kotlin.math.min(parts1.size, parts2.size)) {
-            if (parts1[i] != parts2[i]) {
-                return parts1[i].compareTo(parts2[i])
+        // Every part of both strings is read, even once the order is decided, so a
+        // non-numeric part still throws NumberFormatException the way splitting did.
+        while (parts1.hasNext || parts2.hasNext) {
+            val comparison = when {
+                parts1.hasNext && parts2.hasNext -> parts1.next().compareTo(parts2.next())
+                parts1.hasNext -> { parts1.next(); 1 }
+                else -> { parts2.next(); -1 }
+            }
+            if (result == 0) {
+                result = comparison
             }
         }
-        return parts1.size.compareTo(parts2.size)
+        return result
+    }
+
+    /** Walks the dot-separated parts of a version string in place, without splitting it. */
+    private class VersionParts(private val version: String, stripLiteSuffix: Boolean) {
+        private val end =
+            if (stripLiteSuffix && version.endsWith(LITE_SUFFIX)) version.length - LITE_SUFFIX.length
+            else version.length
+        private var cursor = if (version.startsWith(VERSION_PREFIX)) VERSION_PREFIX.length else 0
+
+        /** A cursor past [end] means the last part has been consumed; an empty string still has one. */
+        val hasNext: Boolean
+            get() = cursor <= end
+
+        fun next(): Int {
+            val dot = version.indexOf('.', cursor)
+            val stop = if (dot in cursor until end) dot else end
+            val part = version.substring(cursor, stop).toInt()
+            cursor = stop + 1
+            return part
+        }
     }
 
     fun parseApkVersionString(raw: String?): Int? {


### PR DESCRIPTION
## Summary

A readability/allocation refactor of `VersionUtils.compareVersions`, with **no behaviour change**. The tests that were here have moved to [#16217](https://github.com/open-learning-exchange/myplanet/pull/16217), which stands on its own and passes against master unmodified — this PR is now the implementation only, rebased on current master.

### Correcting the previous description

The auto-generated title and body claimed this "validates format" and makes the function "stricter about format violations". That was wrong, and I should have corrected it when the PR was opened. Master's `split(".").map { it.toInt() }` already parsed every part eagerly and already threw on every malformed one. This change **preserves** that; it adds no validation and no new format check.

## What actually changes

`removeSuffix`/`removePrefix`/`split`/`map { it.toInt() }` becomes a small private `VersionParts` helper that walks the dot-separated parts with a cursor. What that buys:

- Two intermediate `ArrayList`s and their boxed `Int`s go away.
- The per-part `substring` **stays** — it's what keeps `toInt()`'s exact semantics (unicode digits, `+` sign, overflow), so this is not an allocation-free parse.

Cost: roughly 30 lines against master's 8, plus one invariant a reader has to hold (`cursor <= end` means a part is still pending; an empty string still has one).

## Why the value is modest

`compareVersions` → `isVersionAllowed` → `ConfigurationsRepositoryImpl:300`, reached from three sites, each behind an `apiInterface.checkVersion` round-trip. So this saves a handful of small objects a few times per session, already gated on HTTP. It is a readability and tidiness argument, not a performance one — reviewers should weigh it on that basis, and closing this in favour of [#16217](https://github.com/open-learning-exchange/myplanet/pull/16217) alone is a reasonable call.

## Behaviour preserved

- Same signature; `v` prefix stripped from both arguments, `-lite` from the first only.
- First differing part decides; when the shared parts match, the shorter version sorts lower. The "one side exhausted" branch *is* that size comparison, which is why latching the first non-zero result reproduces master exactly.
- Both strings are still consumed to the end after the order is decided, so a malformed part anywhere still throws `NumberFormatException`.

## Verification

`testDefaultDebugUnitTest` can't run in this container (no Android SDK). Instead I compiled master's implementation and this one side by side and ran a differential test over 39×39 = 1521 input pairs — valid versions, `v`/`-lite` variants, empty strings, double and trailing dots, `2147483648` overflow, whitespace, `+`/`-` signs, Arabic-Indic digits. **Zero mismatches** in result sign or exception type. The only difference is which malformed part is named in the exception message when *both* strings are malformed, since parsing now interleaves. CI runs the real suite.