### PR TITLE
resources: smoother viewer text truncating (fixes #673)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6747
-        versionName = "0.67.47"
+        versionCode = 6748
+        versionName = "0.67.48"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ResourceViewerFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/viewer/ResourceViewerFragment.kt
@@ -52,6 +52,7 @@ import java.io.File
 import java.util.regex.Pattern
 import javax.inject.Inject
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnAudioRecordListener
 import org.ole.planet.myplanet.data.auth.AuthSessionUpdater
@@ -458,20 +459,33 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
             .into(imageViewer)
     }
 
-    private fun setupTextViewer() {
+    private suspend fun setupTextViewer() {
         binding.stubText.visibility = View.VISIBLE
         val textFileTitle = binding.root.findViewById<TextView>(R.id.textFileTitle)
         val textContent = binding.root.findViewById<TextView>(R.id.textContent)
         textFileTitle.text = title
 
         val file = File(externalFilesDir, "ole/$filePath")
-        if (file.exists()) {
-            val text = file.readText()
-            if (type == ResourceType.MARKDOWN) {
-                MarkdownUtils.setMarkdownText(textContent, text)
+        if (!file.exists()) return
+
+        val (text, truncated) = withContext(dispatcherProvider.io) {
+            val raw = file.readText()
+            if (raw.length > MAX_TEXT_VIEWER_CHARS) {
+                raw.substring(0, MAX_TEXT_VIEWER_CHARS) to true
             } else {
-                textContent.text = text
+                raw to false
             }
+        }
+
+        if (!isAdded) return
+
+        if (type == ResourceType.MARKDOWN) {
+            MarkdownUtils.setMarkdownText(textContent, text)
+        } else {
+            textContent.text = text
+        }
+        if (truncated) {
+            Utilities.toast(requireContext(), getString(R.string.text_content_truncated))
         }
     }
 
@@ -577,6 +591,7 @@ class ResourceViewerFragment : Fragment(), AuthSessionUpdater.AuthCallback {
         private const val PIP_ASPECT_RATIO_DENOMINATOR = 1000
         private const val DRAG_SLOP_DP = 24f
         private const val DRAG_THRESHOLD_DP = 150f
+        private const val MAX_TEXT_VIEWER_CHARS = 500_000
         private const val ARG_RESOURCE_ID = "resourceId"
         private const val ARG_FILE_PATH = "filePath"
         private const val ARG_TITLE = "title"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1280,6 +1280,7 @@
     <string name="current_cv">السيرة الذاتية الحالية: %s</string>
     <string name="select_pdf_only">يرجى اختيار ملف PDF</string>
     <string name="file_not_found">الملف غير موجود: %s</string>
+    <string name="text_content_truncated">الملف كبير جدًا لعرضه بالكامل — يتم عرض الجزء الأول فقط</string>
     <string name="chat_already_shared_to_destination">تمت مشاركة هذه الدردشة بالفعل إلى هذه الوجهة</string>
     <string name="load_earlier_messages">تحميل الرسائل السابقة</string>
     <string name="already_shared">تمت المشاركة بالفعل</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1267,6 +1267,7 @@
     <string name="current_cv">CV/Currículum actual: %s</string>
     <string name="select_pdf_only">Por favor selecciona un archivo PDF</string>
     <string name="file_not_found">Archivo no encontrado: %s</string>
+    <string name="text_content_truncated">El archivo es demasiado grande para mostrarlo completo — se muestra solo la primera parte</string>
     <string name="chat_already_shared_to_destination">Este chat ya ha sido compartido a este destino</string>
     <string name="load_earlier_messages">Cargar mensajes anteriores</string>
     <string name="already_shared">Ya compartido</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1268,6 +1268,7 @@
     <string name="current_cv">CV actuel : %s</string>
     <string name="select_pdf_only">Veuillez sélectionner un fichier PDF</string>
     <string name="file_not_found">Fichier introuvable : %s</string>
+    <string name="text_content_truncated">Le fichier est trop volumineux pour être affiché en entier — seule la première partie est affichée</string>
     <string name="chat_already_shared_to_destination">Cette discussion a déjà été partagée vers cette destination</string>
     <string name="load_earlier_messages">Charger les messages précédents</string>
     <string name="already_shared">Déjà partagé</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -1264,6 +1264,7 @@
     <string name="current_cv">हालको CV/रिज्युमे: %s</string>
     <string name="select_pdf_only">कृपया PDF फाइल छान्नुहोस्</string>
     <string name="file_not_found">फाइल फेला परेन: %s</string>
+    <string name="text_content_truncated">फाइल पूरै देखाउनका लागि धेरै ठूलो छ — पहिलो भाग मात्र देखाइँदैछ</string>
     <string name="chat_already_shared_to_destination">यो च्याट पहिले नै यस गन्तव्यमा साझेदारी गरिएको छ</string>
     <string name="load_earlier_messages">पहिलेका सन्देशहरू लोड गर्नुहोस्</string>
     <string name="already_shared">पहिले नै साझा गरिएको</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -1264,6 +1264,7 @@
     <string name="current_cv">CV-ga hadda: %s</string>
     <string name="select_pdf_only">Fadlan dooro fayl PDF ah</string>
     <string name="file_not_found">Faylka lama helin: %s</string>
+    <string name="text_content_truncated">Faylku waa mid aad u weyn si loo muujiyo oo dhan — waxaa la muujinayaa qaybta ugu horreysa oo keliya</string>
     <string name="chat_already_shared_to_destination">Wadahadalkan hore ayaa loogu wadaagay goobtan</string>
     <string name="load_earlier_messages">Soo geli fariimaha hore</string>
     <string name="already_shared">Hore loo wadaagay</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1275,6 +1275,7 @@
     <string name="current_cv">Current CV/Resume: %s</string>
     <string name="select_pdf_only">Please select a PDF file</string>
     <string name="file_not_found">File not found: %s</string>
+    <string name="text_content_truncated">File is too large to display in full — showing the first part only</string>
     <string name="chat_already_shared_to_destination">This chat has already been shared to this destination</string>
     <string name="load_earlier_messages">Load earlier messages</string>
     <string name="already_shared">Already shared</string>


### PR DESCRIPTION
fixes #673
Read text files on the IO dispatcher and cap display at 500K characters to prevent UI freezes. Shows a toast when content is truncated. Adds translated strings for all supported languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying large text files by showing the first 500,000 characters.
  * Added a notification when file content has been truncated.
  * Preserved appropriate rendering for Markdown and plain-text files.

* **Localization**
  * Added truncation messages in Arabic, Spanish, French, Nepali, Somali, and English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->