### PR TITLE
Initialize Codex Cloud skill submodules with .codex/setup.sh and update AGENTS.md

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Codex Cloud runs this once when it creates the repository environment. Make
+# the shared agent skills available before Codex starts working. Keep setup
+# non-fatal so a transient network outage does not prevent a task from running.
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || {
+  echo "setup.sh: cannot locate workspace root" >&2
+  exit 1
+}
+
+git submodule update --init --recursive ||
+  echo "setup.sh: submodule init failed (offline?) — continuing without uninitialized skills" >&2
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Skills (auto-loaded from .agents/skills/)
 
-Skill repos are git submodules. `.openhands/setup.sh` initializes them at
-session start, before skill discovery runs. In any other context (fresh
-manual clone, other agents), initialize them yourself:
+Skill repos are git submodules. `.openhands/setup.sh` and `.codex/setup.sh`
+initialize them at session start, before skill discovery runs. In any other
+context (fresh manual clone, other agents), initialize them yourself:
 
 ```bash
 git submodule update --init --recursive


### PR DESCRIPTION
### Motivation

- Ensure the Codex Cloud environment bootstraps the repository's shared agent skills (git submodules) the same way `.openhands/setup.sh` does. 
- Keep environment setup non-fatal so transient network or proxy issues do not block Codex tasks from starting.

### Description

- Add an executable `./.codex/setup.sh` script that locates the workspace root and runs `git submodule update --init --recursive`, and emits a warning but exits successfully if submodule initialization fails. 
- Update `AGENTS.md` to document that both `.openhands/setup.sh` and `.codex/setup.sh` initialize the `.agents/skills` submodules at session start.

### Testing

- Ran `bash -n .codex/setup.sh` to validate script syntax, which succeeded. 
- Executed `./.codex/setup.sh`, which attempted `git submodule update --init --recursive` and handled remote access failures gracefully by printing a warning and exiting `0`. 
- Ran `git diff --check` and `git status --short --branch` to validate the working tree state, which returned clean results.
- Verified the new script file is executable with `chmod +x .codex/setup.sh` and that the repository documentation change is present in `AGENTS.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8eec7be250833089f294fd943681ee)