### PR TITLE
actions: smoother workflow release caching (fixes #16297)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,16 @@ permissions:
   contents: write
   actions: write
 
+# Keyed on github.sha, not github.ref: every master commit carries a unique
+# versionCode (the automerge drain bumps the version per PR), so each commit
+# must produce its own release. A github.ref group keeps only one pending run,
+# so a burst of merges during a drain would cancel the intermediate release --
+# dropping a versionCode with no tag and no Play Store upload, and because a
+# cancelled run is not a failed run, publish_failed/playstore.sh never notices.
+# github.sha still prevents two runs racing the same commit (double tag, double
+# upload, cache/sign collision) while letting distinct commits publish.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   release:
     name: myPlanet release
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,15 @@ permissions:
   contents: write
   actions: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: myPlanet release
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +40,17 @@ jobs:
         uses: gradle/actions/setup-gradle@v6.3.0
         with:
           gradle-version: wrapper
+
+      - name: restore project build dir
+        uses: actions/cache@v6
+        with:
+          path: |
+            app/build
+            .gradle/*
+            !.gradle/configuration-cache
+          key: build-dir-release-${{ matrix.build }}-${{ github.sha }}
+          restore-keys: |
+            build-dir-release-${{ matrix.build }}-
 
       - name: set release version
         run: echo ANDROID_VERSION=$(sed -n 's/.*versionName = "\([^"]*\)".*/\1/p' app/build.gradle) >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           path: |
             app/build
+            !app/build/outputs/**
             .gradle/*
             !.gradle/configuration-cache
           key: build-dir-release-${{ matrix.build }}-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,6 @@ permissions:
   contents: write
   actions: write
 
-# Keyed on github.sha, not github.ref: every master commit carries a unique
-# versionCode (the automerge drain bumps the version per PR), so each commit
-# must produce its own release. A github.ref group keeps only one pending run,
-# so a burst of merges during a drain would cancel the intermediate release --
-# dropping a versionCode with no tag and no Play Store upload, and because a
-# cancelled run is not a failed run, publish_failed/playstore.sh never notices.
-# github.sha still prevents two runs racing the same commit (double tag, double
-# upload, cache/sign collision) while letting distinct commits publish.
 concurrency:
   group: release-${{ github.sha }}
   cancel-in-progress: false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6767
-        versionName = "0.67.67"
+        versionCode = 6768
+        versionName = "0.67.68"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
Hardens `.github/workflows/release.yml` by:
1. Adding top-level `concurrency:` with `group: release-${{ github.ref }}` and `cancel-in-progress: false` to avoid simultaneous release runs without canceling in-flight jobs mid-sign/mid-upload.
2. Adding `timeout-minutes: 30` to the `release` job.
3. Adding a restore project build dir cache step using `actions/cache@v6` for `app/build` and `.gradle/*` (excluding `.gradle/configuration-cache`), matching `build.yml` and `test.yml`.

Fixes #16297

---
*PR created automatically by Jules for task [17093535217027961218](https://jules.google.com/task/17093535217027961218) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release reliability by ensuring each commit can complete its own release without intermediate runs being cancelled.
  * Added a 30-minute time limit to release jobs to prevent stalled workflows.
  * Added build caching to help release workflows complete more efficiently and reduce repeated build work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->