### PR TITLE
actions: smoother workflow automerging (fixes #16301)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -82,7 +82,7 @@ permissions:
   actions: write
 
 concurrency:
-  group: myPlanet-automerge
+  group: automerge
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -81,6 +81,10 @@ permissions:
   statuses: read
   actions: write
 
+concurrency:
+  group: myPlanet-automerge
+  cancel-in-progress: false
+
 env:
   DEFAULT_BASE: master
   GRADLE_FILE: app/build.gradle
@@ -95,6 +99,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
           token: ${{ secrets.AUTOMERGE_TOKEN || github.token }}
 
       - name: stage helper scripts outside the work tree

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6768
-        versionName = "0.67.68"
+        versionCode = 6769
+        versionName = "0.67.69"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
Add concurrency group 'myPlanet-automerge' to serialize automerge workflow runs and prevent version bump races. Add 'filter: blob:none' to checkout step to prevent downloading all historical blobs.

Fixes #16301

---
*PR created automatically by Jules for task [5279313950849794510](https://jules.google.com/task/5279313950849794510) started by @dogi*