### PR TITLE
all: smoother network monitor working (fixes #16299)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6769
-        versionName = "0.67.69"
+        versionCode = 6770
+        versionName = "0.67.70"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/NetworkMonitorWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/NetworkMonitorWorker.kt
@@ -2,17 +2,17 @@ package org.ole.planet.myplanet.services
 
 import android.content.Context
 import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.flow.first
-import org.ole.planet.myplanet.utils.NetworkUtils
 
 @HiltWorker
 class NetworkMonitorWorker @AssistedInject constructor(
@@ -26,8 +26,13 @@ class NetworkMonitorWorker @AssistedInject constructor(
         private const val UPLOAD_DELAY_SECONDS = 30L
 
         fun start(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
             val workRequest = OneTimeWorkRequestBuilder<NetworkMonitorWorker>()
                 .addTag(WORK_TAG)
+                .setConstraints(constraints)
                 .build()
 
             WorkManager.getInstance(context)
@@ -37,7 +42,6 @@ class NetworkMonitorWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         return try {
-            NetworkUtils.isNetworkConnectedFlow.first { it }
             scheduleServerReachabilityCheck()
 
             Result.success()

--- a/app/src/test/java/org/ole/planet/myplanet/services/NetworkMonitorWorkerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/NetworkMonitorWorkerTest.kt
@@ -1,0 +1,127 @@
+package org.ole.planet.myplanet.services
+
+import android.content.Context
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ListenableWorker.Result
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.impl.WorkManagerImpl
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NetworkMonitorWorkerTest {
+
+    @MockK(relaxed = true)
+    lateinit var workManagerImpl: WorkManagerImpl
+
+    @MockK(relaxed = true)
+    lateinit var context: Context
+
+    @MockK(relaxed = true)
+    lateinit var workerParams: WorkerParameters
+
+    private lateinit var worker: NetworkMonitorWorker
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        every { context.applicationContext } returns context
+
+        mockkStatic(WorkManagerImpl::class)
+        every { WorkManagerImpl.getInstance(any()) } returns workManagerImpl
+
+        mockkStatic(WorkManager::class)
+        every { WorkManager.getInstance(any()) } returns workManagerImpl
+
+        worker = NetworkMonitorWorker(context, workerParams)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun start_enqueuesUniqueWorkWithConnectedNetworkConstraint() {
+        val slot = slot<OneTimeWorkRequest>()
+        every {
+            workManagerImpl.enqueueUniqueWork(
+                "network_monitor_work",
+                ExistingWorkPolicy.KEEP,
+                capture(slot)
+            )
+        } returns mockk(relaxed = true)
+
+        NetworkMonitorWorker.start(context)
+
+        verify(exactly = 1) {
+            workManagerImpl.enqueueUniqueWork(
+                "network_monitor_work",
+                ExistingWorkPolicy.KEEP,
+                any<OneTimeWorkRequest>()
+            )
+        }
+
+        val workRequest = slot.captured
+        assertEquals(NetworkType.CONNECTED, workRequest.workSpec.constraints.requiredNetworkType)
+        assertTrue(workRequest.tags.contains("network_monitor_work"))
+    }
+
+    @Test
+    fun doWork_schedulesServerReachabilityCheckAndReturnsSuccess() = runTest {
+        val slot = slot<OneTimeWorkRequest>()
+        every {
+            workManagerImpl.enqueueUniqueWork(
+                "server_reachability_work",
+                ExistingWorkPolicy.REPLACE,
+                capture(slot)
+            )
+        } returns mockk(relaxed = true)
+
+        val result = worker.doWork()
+
+        assertEquals(Result.success(), result)
+        verify(exactly = 1) {
+            workManagerImpl.enqueueUniqueWork(
+                "server_reachability_work",
+                ExistingWorkPolicy.REPLACE,
+                any<OneTimeWorkRequest>()
+            )
+        }
+        val workRequest = slot.captured
+        assertTrue(workRequest.tags.contains("server_reachability_work"))
+        assertEquals(true, workRequest.workSpec.input.getBoolean("network_reconnection_trigger", false))
+    }
+
+    @Test
+    fun doWork_returnsRetryOnException() = runTest {
+        every {
+            workManagerImpl.enqueueUniqueWork(
+                "server_reachability_work",
+                any(),
+                any<OneTimeWorkRequest>()
+            )
+        } throws RuntimeException("WorkManager error")
+
+        val result = worker.doWork()
+
+        assertEquals(Result.retry(), result)
+    }
+}


### PR DESCRIPTION
Add NetworkType.CONNECTED constraint to NetworkMonitorWorker start request to let WorkManager wait for network connectivity rather than blocking inside doWork. Added corresponding unit tests in NetworkMonitorWorkerTest.

Fixes #16299

---
*PR created automatically by Jules for task [3520844021269107969](https://jules.google.com/task/3520844021269107969) started by @dogi*