### PR TITLE
teams: smoother repository member querying (fixes #16300)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6770
-        versionName = "0.67.70"
+        versionCode = 6771
+        versionName = "0.67.71"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -961,7 +961,9 @@ class TeamsRepositoryImpl @Inject constructor(
             .filter { !it.isDeletePending } // Filter so only the not pending members get query
             .mapNotNull { it.userId }
             .distinct()
-        return teamMembers.mapNotNull { userRepository.getUserById(it) }
+        if (teamMembers.isEmpty()) return emptyList()
+        val userMap = userRepository.getUsersByIds(teamMembers).associateBy { it.id }
+        return teamMembers.mapNotNull { userMap[it] }
     }
 
     override suspend fun getJoinedMembersWithVisitInfo(teamId: String): List<JoinedMemberData> {
@@ -1050,7 +1052,9 @@ class TeamsRepositoryImpl @Inject constructor(
         val requestedMemberIds = teamDao.getByTeamIdAndDocType(teamId, "request")
             .mapNotNull { it.userId }
             .distinct()
-        return requestedMemberIds.mapNotNull { userRepository.getUserById(it) }
+        if (requestedMemberIds.isEmpty()) return emptyList()
+        val userMap = userRepository.getUsersByIds(requestedMemberIds).associateBy { it.id }
+        return requestedMemberIds.mapNotNull { userMap[it] }
     }
 
     override suspend fun isTeamNameExists(name: String, type: String, excludeTeamId: String?): Boolean {

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepositoryImpl.kt
@@ -962,7 +962,12 @@ class TeamsRepositoryImpl @Inject constructor(
             .mapNotNull { it.userId }
             .distinct()
         if (teamMembers.isEmpty()) return emptyList()
-        val userMap = userRepository.getUsersByIds(teamMembers).associateBy { it.id }
+        val users = userRepository.getUsersByIds(teamMembers)
+        val userMap = HashMap<String, UserEntity>(users.size * 2)
+        users.forEach { user ->
+            userMap[user.id] = user
+            user._id?.let { userMap[it] = user }
+        }
         return teamMembers.mapNotNull { userMap[it] }
     }
 
@@ -1053,7 +1058,12 @@ class TeamsRepositoryImpl @Inject constructor(
             .mapNotNull { it.userId }
             .distinct()
         if (requestedMemberIds.isEmpty()) return emptyList()
-        val userMap = userRepository.getUsersByIds(requestedMemberIds).associateBy { it.id }
+        val users = userRepository.getUsersByIds(requestedMemberIds)
+        val userMap = HashMap<String, UserEntity>(users.size * 2)
+        users.forEach { user ->
+            userMap[user.id] = user
+            user._id?.let { userMap[it] = user }
+        }
         return requestedMemberIds.mapNotNull { userMap[it] }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
@@ -562,7 +562,7 @@ class TeamsRepositoryImplTest {
     }
 
     @Test
-    fun `getJoinedMembers uses getUsersByIds and preserves order`() = runTest(testDispatcher) {
+    fun `getJoinedMembers uses getUsersByIds and preserves order including _id match`() = runTest(testDispatcher) {
         val teamId = "team1"
         val member1 = MyTeam().apply { userId = "user1"; isDeletePending = false }
         val member2 = MyTeam().apply { userId = "user2"; isDeletePending = false }
@@ -571,7 +571,7 @@ class TeamsRepositoryImplTest {
 
         coEvery { teamDao.getByTeamIdAndDocType(teamId, "membership") } returns listOf(member1, member2, deletePendingMember, member3)
 
-        val user1 = UserEntity().apply { id = "user1"; name = "Alice" }
+        val user1 = UserEntity().apply { id = "org.couchdb.user:alice"; _id = "user1"; name = "Alice" }
         val user2 = UserEntity().apply { id = "user2"; name = "Bob" }
         val user3 = UserEntity().apply { id = "user3"; name = "Charlie" }
 
@@ -585,14 +585,14 @@ class TeamsRepositoryImplTest {
     }
 
     @Test
-    fun `getRequestedMembers uses getUsersByIds and preserves order`() = runTest(testDispatcher) {
+    fun `getRequestedMembers uses getUsersByIds and preserves order including _id match`() = runTest(testDispatcher) {
         val teamId = "team1"
         val req1 = MyTeam().apply { userId = "user1" }
         val req2 = MyTeam().apply { userId = "user2" }
 
         coEvery { teamDao.getByTeamIdAndDocType(teamId, "request") } returns listOf(req1, req2)
 
-        val user1 = UserEntity().apply { id = "user1"; name = "Alice" }
+        val user1 = UserEntity().apply { id = "org.couchdb.user:alice"; _id = "user1"; name = "Alice" }
         val user2 = UserEntity().apply { id = "user2"; name = "Bob" }
 
         coEvery { userRepository.getUsersByIds(listOf("user1", "user2")) } returns listOf(user2, user1)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
@@ -64,6 +64,7 @@ class TeamsRepositoryImplTest {
     private val courseDao: CourseDao = mockk(relaxed = true)
     private val courseStepDao: CourseStepDao = mockk(relaxed = true)
     private val appDatabase: AppDatabase = mockk(relaxed = true)
+    private val userRepository: UserRepository = mockk(relaxed = true)
 
     private val testDispatcher = StandardTestDispatcher()
 
@@ -82,8 +83,6 @@ class TeamsRepositoryImplTest {
         coEvery { serverUrlMapper.processUrl(any()) } returns serverUrlMapping
         every { sharedPrefManager.getServerUrl() } returns "http://test.com"
 
-        val mockUserRepository = mockk<UserRepository>(relaxed = true)
-
         teamsRepository = TeamsRepositoryImpl(
             mockk<android.content.Context>(relaxed = true),
             activitiesRepository,
@@ -94,7 +93,7 @@ class TeamsRepositoryImplTest {
             sharedPrefManager,
             serverUrlMapper,
             dispatcherProvider,
-            mockUserRepository,
+            userRepository,
             dagger.Lazy { mockk<ResourcesRepository>(relaxed = true) },
             TestTimeProvider(),
             teamLogDao,
@@ -560,5 +559,48 @@ class TeamsRepositoryImplTest {
 
         val result = teamsRepository.getMyTeamDetailsFlow("user1", "team").first()
         assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `getJoinedMembers uses getUsersByIds and preserves order`() = runTest(testDispatcher) {
+        val teamId = "team1"
+        val member1 = MyTeam().apply { userId = "user1"; isDeletePending = false }
+        val member2 = MyTeam().apply { userId = "user2"; isDeletePending = false }
+        val member3 = MyTeam().apply { userId = "user3"; isDeletePending = false }
+        val deletePendingMember = MyTeam().apply { userId = "user4"; isDeletePending = true }
+
+        coEvery { teamDao.getByTeamIdAndDocType(teamId, "membership") } returns listOf(member1, member2, deletePendingMember, member3)
+
+        val user1 = UserEntity().apply { id = "user1"; name = "Alice" }
+        val user2 = UserEntity().apply { id = "user2"; name = "Bob" }
+        val user3 = UserEntity().apply { id = "user3"; name = "Charlie" }
+
+        coEvery { userRepository.getUsersByIds(listOf("user1", "user2", "user3")) } returns listOf(user3, user1, user2)
+
+        val result = teamsRepository.getJoinedMembers(teamId)
+
+        assertEquals(listOf(user1, user2, user3), result)
+        coVerify(exactly = 1) { userRepository.getUsersByIds(listOf("user1", "user2", "user3")) }
+        coVerify(exactly = 0) { userRepository.getUserById(any()) }
+    }
+
+    @Test
+    fun `getRequestedMembers uses getUsersByIds and preserves order`() = runTest(testDispatcher) {
+        val teamId = "team1"
+        val req1 = MyTeam().apply { userId = "user1" }
+        val req2 = MyTeam().apply { userId = "user2" }
+
+        coEvery { teamDao.getByTeamIdAndDocType(teamId, "request") } returns listOf(req1, req2)
+
+        val user1 = UserEntity().apply { id = "user1"; name = "Alice" }
+        val user2 = UserEntity().apply { id = "user2"; name = "Bob" }
+
+        coEvery { userRepository.getUsersByIds(listOf("user1", "user2")) } returns listOf(user2, user1)
+
+        val result = teamsRepository.getRequestedMembers(teamId)
+
+        assertEquals(listOf(user1, user2), result)
+        coVerify(exactly = 1) { userRepository.getUsersByIds(listOf("user1", "user2")) }
+        coVerify(exactly = 0) { userRepository.getUserById(any()) }
     }
 }


### PR DESCRIPTION
Batched per-member user lookups in getJoinedMembers and getRequestedMembers in TeamsRepositoryImpl to avoid N+1 queries while preserving original ordering and deduplication semantics.

Fixes #16300

---
*PR created automatically by Jules for task [16832460847586196363](https://jules.google.com/task/16832460847586196363) started by @dogi*