### PR TITLE
all: less hilt entry point accessors is more (fixes #16298)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6771
-        versionName = "0.67.71"
+        versionCode = 6772
+        versionName = "0.67.72"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/CoreDependenciesEntryPoint.kt
@@ -5,9 +5,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import org.ole.planet.myplanet.repository.DiagnosticsRepository
-import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
-import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.TimeProvider
@@ -17,10 +15,8 @@ import org.ole.planet.myplanet.utils.TimeProvider
 interface CoreDependenciesEntryPoint {
     @ApplicationScope fun applicationScope(): CoroutineScope
     fun sharedPrefManager(): SharedPrefManager
-    fun userSessionManager(): UserSessionManager
     fun serverUrlMapper(): ServerUrlMapper
     fun dispatcherProvider(): DispatcherProvider
     fun diagnosticsRepository(): DiagnosticsRepository
     fun timeProvider(): TimeProvider
-    fun resourcesRepository(): ResourcesRepository
 }

--- a/app/src/main/java/org/ole/planet/myplanet/di/ServiceDependenciesEntryPoint.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/ServiceDependenciesEntryPoint.kt
@@ -5,21 +5,13 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
-import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.services.BroadcastService
-import org.ole.planet.myplanet.services.UploadManager
-import org.ole.planet.myplanet.services.UploadToShelfService
 import org.ole.planet.myplanet.services.retry.RetryQueue
-import org.ole.planet.myplanet.services.sync.SyncManager
 
 @EntryPoint
 @InstallIn(SingletonComponent::class)
 interface ServiceDependenciesEntryPoint {
     fun broadcastService(): BroadcastService
-    fun apiInterface(): ApiInterface
-    fun syncManager(): SyncManager
-    fun uploadManager(): UploadManager
-    fun uploadToShelfService(): UploadToShelfService
     fun retryQueue(): RetryQueue
 }
 


### PR DESCRIPTION
This change deletes six unused Hilt entry-point accessors (`apiInterface()`, `syncManager()`, `uploadManager()`, `uploadToShelfService()`, `userSessionManager()`, and `resourcesRepository()`) from `ServiceDependenciesEntryPoint.kt` and `CoreDependenciesEntryPoint.kt`, along with their unused imports.

Fixes #16298

---
*PR created automatically by Jules for task [13969260321779749803](https://jules.google.com/task/13969260321779749803) started by @dogi*