### PR TITLE
all: less services submissions hilt injections is more (fixes #16307)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6772
-        versionName = "0.67.72"
+        versionCode = 6773
+        versionName = "0.67.73"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -55,9 +55,6 @@ import org.ole.planet.myplanet.utils.UrlUtils.header
 @AndroidEntryPoint
 class DownloadService : Service() {
     @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
-
-    @Inject
     lateinit var downloadRepository: DownloadRepository
 
     @Inject

--- a/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/sync/SyncManager.kt
@@ -41,7 +41,6 @@ import org.ole.planet.myplanet.model.Rows
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.SyncRepository
-import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.repository.UserSyncRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
@@ -67,7 +66,6 @@ class SyncManager @Inject constructor(
     private val activitiesRepository: ActivitiesRepository,
     private val dispatcherProvider: DispatcherProvider,
     private val timeProvider: TimeProvider,
-    private val teamsRepository: TeamsRepository,
     private val userSyncRepository: UserSyncRepository,
     private val syncRepository: SyncRepository,
     private val syncTimeLogger: SyncTimeLogger

--- a/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/upload/UploadCoordinator.kt
@@ -1,9 +1,7 @@
 package org.ole.planet.myplanet.services.upload
 
-import android.content.Context
 import android.util.Log
 import com.google.gson.JsonObject
-import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import java.util.concurrent.CancellationException
 import javax.inject.Inject
@@ -25,7 +23,6 @@ import org.ole.planet.myplanet.utils.UrlUtils
 @Singleton
 class UploadCoordinator @Inject constructor(
     private val uploadRepository: UploadRepository,
-    @ApplicationContext private val context: Context,
     private val retryQueue: RetryQueue,
     private val dispatcherProvider: DispatcherProvider
 ) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/submissions/SubmissionsFragment.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
@@ -19,7 +18,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
 import org.ole.planet.myplanet.databinding.FragmentMySubmissionBinding
-import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
 import org.ole.planet.myplanet.utils.textChanges
 
@@ -29,9 +27,6 @@ class SubmissionsFragment : Fragment(), CompoundButton.OnCheckedChangeListener {
     private var _binding: FragmentMySubmissionBinding? = null
     private val binding get() = _binding!!
     private val viewModel: SubmissionViewModel by viewModels()
-
-    @Inject
-    lateinit var userSessionManager: UserSessionManager
 
     private lateinit var adapter: SubmissionsAdapter
     var type: String? = ""

--- a/app/src/test/java/org/ole/planet/myplanet/services/sync/SyncManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/sync/SyncManagerTest.kt
@@ -22,7 +22,6 @@ import org.ole.planet.myplanet.callback.OnSyncListener
 import org.ole.planet.myplanet.data.api.ApiInterface
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
-import org.ole.planet.myplanet.repository.TeamsRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
@@ -42,7 +41,6 @@ class SyncManagerTest {
     private val testScope = TestScope(testDispatcher)
     private val activitiesRepository: ActivitiesRepository = mockk(relaxed = true)
     private val dispatcherProvider: DispatcherProvider = TestDispatcherProvider(testDispatcher)
-    private val teamsRepository: TeamsRepository = mockk(relaxed = true)
     private val listener: OnSyncListener = mockk(relaxed = true)
 
     @Before
@@ -61,7 +59,6 @@ class SyncManagerTest {
             activitiesRepository,
             dispatcherProvider,
             TestTimeProvider(),
-            teamsRepository,
             mockk(),
             mockk(),
             mockk(relaxed = true)


### PR DESCRIPTION
Removed four unused Hilt injections across SyncManager, UploadCoordinator, DownloadService, and SubmissionsFragment, and updated SyncManagerTest to match constructor signature changes.

Fixes #16307

---
*PR created automatically by Jules for task [11810403442557964676](https://jules.google.com/task/11810403442557964676) started by @dogi*