### PR TITLE
actions: smoother dependabot handling (fixes #16302)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     commit-message:
       prefix: "actions:"
     open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: "gradle"
     directories:
       - "/"
@@ -17,3 +21,7 @@ updates:
     commit-message:
       prefix: "all:"
     open-pull-requests-limit: 15
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group Dependabot updates in .github/dependabot.yml for both github-actions and gradle ecosystems using wildcard patterns so updates land in consolidated PRs rather than opening one PR per dependency.

Fixes #16302

---
*PR created automatically by Jules for task [15076691839306247072](https://jules.google.com/task/15076691839306247072) started by @dogi*