### PR TITLE
all: smoother network module connection pooling (fixes #16305)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6773
-        versionName = "0.67.73"
+        versionCode = 6774
+        versionName = "0.67.74"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/di/NetworkModule.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 import javax.inject.Singleton
 import javax.net.SocketFactory
+import okhttp3.ConnectionPool
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.data.api.ApiInterface
@@ -72,8 +73,10 @@ object NetworkModule {
         val dispatcher = Dispatcher().apply {
             maxRequestsPerHost = MAX_REQUESTS_PER_HOST
         }
+        val connectionPool = ConnectionPool(MAX_REQUESTS_PER_HOST, 5, TimeUnit.MINUTES)
         val builder = OkHttpClient.Builder()
             .dispatcher(dispatcher)
+            .connectionPool(connectionPool)
             .connectTimeout(connect, TimeUnit.SECONDS)
             .readTimeout(read, TimeUnit.SECONDS)
             .writeTimeout(write, TimeUnit.SECONDS)

--- a/app/src/test/java/org/ole/planet/myplanet/di/NetworkModuleTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/di/NetworkModuleTest.kt
@@ -1,10 +1,13 @@
 package org.ole.planet.myplanet.di
 
 import com.google.gson.Gson
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.ole.planet.myplanet.data.api.RetryInterceptor
 
 class NetworkModuleTest {
 
@@ -35,5 +38,15 @@ class NetworkModuleTest {
         assertFalse("JSON should NOT contain transientField", json.contains("transientField"))
         assertFalse("JSON should NOT contain staticField", json.contains("staticField"))
         assertFalse("JSON should NOT contain finalField", json.contains("finalField"))
+    }
+
+    @Test
+    fun `provideStandardOkHttpClient returns OkHttpClient configured with ConnectionPool and Dispatcher`() {
+        val mockRetryInterceptor = mockk<RetryInterceptor>(relaxed = true)
+        val okHttpClient = NetworkModule.provideStandardOkHttpClient(mockRetryInterceptor)
+
+        assertNotNull(okHttpClient)
+        assertEquals(20, okHttpClient.dispatcher.maxRequestsPerHost)
+        assertNotNull(okHttpClient.connectionPool)
     }
 }


### PR DESCRIPTION
Sized the OkHttp ConnectionPool in NetworkModule to match MAX_REQUESTS_PER_HOST (20) with a 5-minute keep-alive duration, ensuring up to 20 idle connections can be reused across concurrent CouchDB requests without incurring unnecessary TCP+TLS handshake overhead. Added a unit test in NetworkModuleTest to verify client dispatcher and connection pool configuration.

Fixes #16305

---
*PR created automatically by Jules for task [18404190358324513234](https://jules.google.com/task/18404190358324513234) started by @dogi*