### PR TITLE
all: smoother file utils checking (fixes #16312)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6774
-        versionName = "0.67.74"
+        versionCode = 6775
+        versionName = "0.67.75"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -363,6 +363,7 @@ class DownloadService : Service() {
     private fun downloadFile(body: ResponseBody, url: String) {
         val fileSize = body.contentLength()
         val finalFile = FileUtils.getSDPathFromUrl(this@DownloadService, url)
+        finalFile.parentFile?.mkdirs()
         val tempFile = File(finalFile.parentFile, "${finalFile.name}.tmp")
         tempFile.delete()
         outputFile = finalFile

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadWorker.kt
@@ -112,6 +112,7 @@ class DownloadWorker @AssistedInject constructor(
     private suspend fun downloadFileBody(body: ResponseBody, url: String, index: Int, total: Int) {
         val fileSize = body.contentLength()
         val outputFile: File = FileUtils.getSDPathFromUrl(context, url)
+        outputFile.parentFile?.mkdirs()
         var totalBytes: Long = 0
         var lastUpdateTime = 0L
 

--- a/app/src/main/java/org/ole/planet/myplanet/utils/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/FileUtils.kt
@@ -48,39 +48,21 @@ object FileUtils {
         return File(externalFilesDir, "ole/$libraryId/$address")
     }
 
-    private fun createFilePath(context: Context, folder: String, filename: String): File {
+    private fun resolveFilePath(context: Context, folder: String, filename: String): File {
         val baseDirectory = File(getExternalFilesDir(context), folder)
 
-        if (filename.contains("/")) {
+        return if (filename.contains("/")) {
             val subDirPath = filename.substring(0, filename.lastIndexOf('/'))
             val fullDir = File(baseDirectory, subDirPath)
-
-            try {
-                if (!fullDir.exists() && !fullDir.mkdirs()) {
-                    throw IOException("Failed to create directory: ${fullDir.absolutePath}")
-                }
-            } catch (e: IOException) {
-                e.printStackTrace()
-                throw RuntimeException("Failed to create directory: ${fullDir.absolutePath}", e)
-            }
-
             val actualFilename = filename.substring(filename.lastIndexOf('/') + 1)
-            return File(fullDir, actualFilename)
+            File(fullDir, actualFilename)
         } else {
-            try {
-                if (!baseDirectory.exists() && !baseDirectory.mkdirs()) {
-                    throw IOException("Failed to create directory: ${baseDirectory.absolutePath}")
-                }
-            } catch (e: IOException) {
-                e.printStackTrace()
-                throw RuntimeException("Failed to create directory: ${baseDirectory.absolutePath}", e)
-            }
-            return File(baseDirectory, filename)
+            File(baseDirectory, filename)
         }
     }
 
     fun getSDPathFromUrl(context: Context, url: String?): File {
-        return createFilePath(context, "/ole/${getIdFromUrl(url)}", getResourceRelativePathFromUrl(url))
+        return resolveFilePath(context, "/ole/${getIdFromUrl(url)}", getResourceRelativePathFromUrl(url))
     }
 
     private fun getResourceRelativePathFromUrl(url: String?): String {
@@ -345,14 +327,12 @@ object FileUtils {
     fun totalAvailableMemory(context: Context): Long = getStorageStats(context).second
 
     fun totalAvailableMemoryRatio(context: Context): Long {
-        val total = totalMemoryCapacity(context)
-        val available = totalAvailableMemory(context)
+        val (total, available) = getStorageStats(context)
         return (available.toDouble() / total.toDouble() * 100).roundToLong()
     }
 
     fun availableOverTotalMemoryFormattedString(context: Context): String {
-        val available = totalAvailableMemory(context)
-        val total = totalMemoryCapacity(context)
+        val (total, available) = getStorageStats(context)
         return formatSize(context, available) + "/" + formatSize(context, total)
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/utils/FileUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/FileUtilsTest.kt
@@ -80,7 +80,13 @@ class FileUtilsTest {
     @Test
     fun checkFileExist_returnsFalseWhenFileDoesNotExist() {
         val url = "http://example.com/resources/123/nonexistent.txt"
+        val expectedFile = FileUtils.getSDPathFromUrl(context, url)
+        val parentDir = expectedFile.parentFile
+
         assertFalse(FileUtils.checkFileExist(context, url))
+        if (parentDir != null) {
+            assertFalse("Parent directory should not be created by existence check", parentDir.exists())
+        }
     }
 
     @Test


### PR DESCRIPTION
Optimized storage stats fetching in FileUtils by querying StorageStatsManager once per helper method call. Removed automatic directory creation from path resolution and file existence checks.

Fixes #16312

---
*PR created automatically by Jules for task [4940451286417140931](https://jules.google.com/task/4940451286417140931) started by @dogi*