### PR TITLE
courses: smoother resources inline scoping (fixes #16310)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6775
-        versionName = "0.67.75"
+        versionCode = 6776
+        versionName = "0.67.76"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -64,7 +65,8 @@ class InlineResourceAdapter(
     }
 
     class ViewHolder(val binding: ItemInlineResourceBinding) : RecyclerView.ViewHolder(binding.root) {
-        private var previewJob: Job? = null
+        @get:VisibleForTesting
+        internal var previewJob: Job? = null
 
         fun cancelPreviousPreviews() {
             previewJob?.cancel()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapter.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.ItemInlineResourceBinding
 import org.ole.planet.myplanet.model.MyLibrary
@@ -176,20 +177,16 @@ class InlineResourceAdapter(
                 "ole/${resource.id}/${resource.resourceLocalAddress}"
             )
 
-            when {
-                mimeType?.startsWith("image") == true -> showImagePreview(binding, context, resourceFile)
-                mimeType?.startsWith("video") == true -> showVideoPreview(binding, context, resourceFile)
-                else -> {
-                    holder.setPreviewJob(adapterScope.launch {
-                        when {
-                            mimeType?.contains("pdf") == true -> showPdfPreview(holder, resourceFile)
-                            mimeType?.startsWith("audio") == true -> showAudioPreview(holder, resourceFile)
-                            mimeType?.contains("csv") == true || resource.resourceLocalAddress?.endsWith(".csv") == true -> showCsvPreview(holder, resourceFile)
-                            mimeType?.startsWith("text") == true || resource.resourceLocalAddress?.endsWith(".txt") == true || resource.resourceLocalAddress?.endsWith(".md") == true -> showTextPreview(holder, resourceFile)
-                        }
-                    })
+            holder.setPreviewJob(adapterScope.launch {
+                when {
+                    mimeType?.startsWith("image") == true -> showImagePreview(binding, context, resourceFile)
+                    mimeType?.startsWith("video") == true -> showVideoPreview(binding, context, resourceFile)
+                    mimeType?.contains("pdf") == true -> showPdfPreview(holder, resourceFile)
+                    mimeType?.startsWith("audio") == true -> showAudioPreview(holder, resourceFile)
+                    mimeType?.contains("csv") == true || resource.resourceLocalAddress?.endsWith(".csv") == true -> showCsvPreview(holder, resourceFile)
+                    mimeType?.startsWith("text") == true || resource.resourceLocalAddress?.endsWith(".txt") == true || resource.resourceLocalAddress?.endsWith(".md") == true -> showTextPreview(holder, resourceFile)
                 }
-            }
+            })
         } else {
             binding.pbDownload.visibility = View.VISIBLE
         }
@@ -199,8 +196,9 @@ class InlineResourceAdapter(
         )
     }
 
-    private fun showImagePreview(binding: ItemInlineResourceBinding, context: Context, file: File) {
-        if (file.exists()) {
+    private suspend fun showImagePreview(binding: ItemInlineResourceBinding, context: Context, file: File) {
+        val exists = withContext(dispatcherProvider.io) { file.exists() }
+        if (exists) {
             binding.ivResourcePreview.visibility = View.VISIBLE
             Glide.with(context)
                 .load(file)
@@ -212,9 +210,10 @@ class InlineResourceAdapter(
         }
     }
 
-    private fun showVideoPreview(binding: ItemInlineResourceBinding, context: Context, file: File) {
+    private suspend fun showVideoPreview(binding: ItemInlineResourceBinding, context: Context, file: File) {
         binding.videoThumbnailContainer.visibility = View.VISIBLE
-        if (file.exists()) {
+        val exists = withContext(dispatcherProvider.io) { file.exists() }
+        if (exists) {
             Glide.with(context)
                 .load(file)
                 .diskCacheStrategy(DiskCacheStrategy.ALL)
@@ -224,7 +223,8 @@ class InlineResourceAdapter(
     }
 
     private suspend fun showPdfPreview(holder: ViewHolder, file: File) {
-        if (!file.exists()) return
+        val exists = withContext(dispatcherProvider.io) { file.exists() }
+        if (!exists) return
         val context = holder.itemView.context
         val targetWidthPx = (PDF_PREVIEW_WIDTH_DP * context.resources.displayMetrics.density).toInt()
         Glide.with(context).clear(holder.binding.ivResourcePreview)
@@ -239,8 +239,7 @@ class InlineResourceAdapter(
 
     private suspend fun showAudioPreview(holder: ViewHolder, file: File) {
         holder.binding.audioPreviewContainer.visibility = View.VISIBLE
-        if (!file.exists()) return
-        val cacheKey = getCacheKey(file)
+        val cacheKey = getFileCacheKeyIfExist(file) ?: return
         val cachedDuration = textCache[cacheKey]
         val durationText = if (cachedDuration != null) {
             cachedDuration
@@ -251,8 +250,7 @@ class InlineResourceAdapter(
     }
 
     private suspend fun showCsvPreview(holder: ViewHolder, file: File) {
-        if (!file.exists()) return
-        val cacheKey = getCacheKey(file)
+        val cacheKey = getFileCacheKeyIfExist(file) ?: return
         val cachedPreview = textCache[cacheKey]
         val preview = if (cachedPreview != null) {
             cachedPreview
@@ -266,8 +264,7 @@ class InlineResourceAdapter(
     }
 
     private suspend fun showTextPreview(holder: ViewHolder, file: File) {
-        if (!file.exists()) return
-        val cacheKey = getCacheKey(file)
+        val cacheKey = getFileCacheKeyIfExist(file) ?: return
         val cachedText = textCache[cacheKey]
         val text = if (cachedText != null) {
             cachedText
@@ -277,6 +274,14 @@ class InlineResourceAdapter(
         if (!text.isNullOrEmpty()) {
             holder.binding.tvTextPreview.visibility = View.VISIBLE
             holder.binding.tvTextPreview.text = text
+        }
+    }
+
+    private suspend fun getFileCacheKeyIfExist(file: File): String? = withContext(dispatcherProvider.io) {
+        if (file.exists()) {
+            getCacheKey(file)
+        } else {
+            null
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapterTest.kt
@@ -1,0 +1,103 @@
+package org.ole.planet.myplanet.ui.courses
+
+import android.app.Application
+import android.content.Context
+import android.widget.LinearLayout
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.model.MyLibrary
+import org.ole.planet.myplanet.utils.ResourcesPreviewLoader
+import org.ole.planet.myplanet.utils.TestDispatcherProvider
+import org.ole.planet.myplanet.utils.UrlUtils
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class InlineResourceAdapterTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val dispatcherProvider = TestDispatcherProvider(testDispatcher)
+    private lateinit var previewLoader: ResourcesPreviewLoader
+    private lateinit var adapter: InlineResourceAdapter
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext<Context>()
+        context.setTheme(com.google.android.material.R.style.Theme_MaterialComponents)
+
+        mockkObject(UrlUtils)
+        every { UrlUtils.getUrl(any()) } returns "http://example.com/test.pdf"
+
+        previewLoader = mockk(relaxed = true)
+        adapter = InlineResourceAdapter(
+            previewLoader = previewLoader,
+            dispatcherProvider = dispatcherProvider,
+            onResourceClick = {}
+        )
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `test bind text resource calls previewLoader on IO dispatcher`() = runTest {
+        val file = tempFolder.newFile("sample.txt")
+        file.writeText("Hello world preview")
+
+        val resource = MyLibrary().apply {
+            id = "res1"
+            _id = "res1"
+            title = "Test Resource"
+            resourceLocalAddress = "sample.txt"
+            mediaType = "text/plain"
+        }
+
+        adapter.submitList(listOf(resource))
+
+        val parent = LinearLayout(context)
+        val holder = adapter.onCreateViewHolder(parent, 0)
+
+        adapter.onBindViewHolder(holder, 0)
+
+        assertEquals("Test Resource", holder.binding.tvResourceTitle.text.toString())
+    }
+
+    @Test
+    fun `onViewRecycled cancels previous preview job`() = runTest {
+        val resource = MyLibrary().apply {
+            id = "res2"
+            _id = "res2"
+            title = "Video Resource"
+            resourceLocalAddress = "sample.mp4"
+            mediaType = "video/mp4"
+        }
+        adapter.submitList(listOf(resource))
+
+        val parent = LinearLayout(context)
+        val holder = adapter.onCreateViewHolder(parent, 0)
+        adapter.onBindViewHolder(holder, 0)
+
+        adapter.onViewRecycled(holder)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/courses/InlineResourceAdapterTest.kt
@@ -2,25 +2,32 @@ package org.ole.planet.myplanet.ui.courses
 
 import android.app.Application
 import android.content.Context
+import android.view.View
 import android.widget.LinearLayout
 import androidx.test.core.app.ApplicationProvider
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import java.io.File
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.model.MyLibrary
+import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.ResourcesPreviewLoader
-import org.ole.planet.myplanet.utils.TestDispatcherProvider
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -33,8 +40,17 @@ class InlineResourceAdapterTest {
     @get:Rule
     val tempFolder = TemporaryFolder()
 
-    private val testDispatcher = UnconfinedTestDispatcher()
-    private val dispatcherProvider = TestDispatcherProvider(testDispatcher)
+    private val mainTestDispatcher = StandardTestDispatcher()
+    private val ioTestDispatcher = StandardTestDispatcher()
+
+    private val testDispatcherProvider = object : DispatcherProvider {
+        override val main: CoroutineDispatcher = mainTestDispatcher
+        override val mainImmediate: CoroutineDispatcher = mainTestDispatcher
+        override val io: CoroutineDispatcher = ioTestDispatcher
+        override val default: CoroutineDispatcher = ioTestDispatcher
+        override val unconfined: CoroutineDispatcher = ioTestDispatcher
+    }
+
     private lateinit var previewLoader: ResourcesPreviewLoader
     private lateinit var adapter: InlineResourceAdapter
     private lateinit var context: Context
@@ -50,7 +66,7 @@ class InlineResourceAdapterTest {
         previewLoader = mockk(relaxed = true)
         adapter = InlineResourceAdapter(
             previewLoader = previewLoader,
-            dispatcherProvider = dispatcherProvider,
+            dispatcherProvider = testDispatcherProvider,
             onResourceClick = {}
         )
     }
@@ -61,19 +77,30 @@ class InlineResourceAdapterTest {
     }
 
     @Test
-    fun `test bind text resource calls previewLoader on IO dispatcher`() = runTest {
-        val file = tempFolder.newFile("sample.txt")
+    fun `test bind text resource calls previewLoader on IO dispatcher and updates UI`() = runTest {
+        val oleDir = tempFolder.newFolder("ole", "res1")
+        val file = File(oleDir, "sample.txt")
         file.writeText("Hello world preview")
+
+        coEvery { previewLoader.getTextPreview(any()) } returns "Sample text preview content"
 
         val resource = MyLibrary().apply {
             id = "res1"
             _id = "res1"
+            _rev = "1"
+            downloadedRev = "1"
             title = "Test Resource"
             resourceLocalAddress = "sample.txt"
+            resourceOffline = true
             mediaType = "text/plain"
         }
 
+        val adapterExternalFilesDir = InlineResourceAdapter::class.java.getDeclaredField("externalFilesDir")
+        adapterExternalFilesDir.isAccessible = true
+        adapterExternalFilesDir.set(adapter, tempFolder.root)
+
         adapter.submitList(listOf(resource))
+        mainTestDispatcher.scheduler.advanceUntilIdle()
 
         val parent = LinearLayout(context)
         val holder = adapter.onCreateViewHolder(parent, 0)
@@ -81,23 +108,63 @@ class InlineResourceAdapterTest {
         adapter.onBindViewHolder(holder, 0)
 
         assertEquals("Test Resource", holder.binding.tvResourceTitle.text.toString())
+
+        // Step 1: Advance main dispatcher -> coroutine launches up to withContext(dispatcherProvider.io)
+        mainTestDispatcher.scheduler.advanceUntilIdle()
+
+        // Verify previewLoader has NOT been called yet because IO dispatcher has not run
+        coVerify(exactly = 0) { previewLoader.getTextPreview(any()) }
+
+        // Step 2: Advance IO dispatcher -> file stat executes on IO
+        ioTestDispatcher.scheduler.advanceUntilIdle()
+
+        // Step 3: Advance main dispatcher -> coroutine resumes on main thread, calls previewLoader and updates UI
+        mainTestDispatcher.scheduler.advanceUntilIdle()
+
+        // Verify previewLoader was invoked
+        coVerify(exactly = 1) { previewLoader.getTextPreview(any()) }
+
+        assertEquals(View.VISIBLE, holder.binding.tvTextPreview.visibility)
+        assertEquals("Sample text preview content", holder.binding.tvTextPreview.text.toString())
     }
 
     @Test
     fun `onViewRecycled cancels previous preview job`() = runTest {
+        val oleDir = tempFolder.newFolder("ole", "res2")
+        val file = File(oleDir, "sample.mp4")
+        file.writeText("video data")
+
         val resource = MyLibrary().apply {
             id = "res2"
             _id = "res2"
+            _rev = "1"
+            downloadedRev = "1"
             title = "Video Resource"
             resourceLocalAddress = "sample.mp4"
+            resourceOffline = true
             mediaType = "video/mp4"
         }
+
+        val adapterExternalFilesDir = InlineResourceAdapter::class.java.getDeclaredField("externalFilesDir")
+        adapterExternalFilesDir.isAccessible = true
+        adapterExternalFilesDir.set(adapter, tempFolder.root)
+
         adapter.submitList(listOf(resource))
+        mainTestDispatcher.scheduler.advanceUntilIdle()
 
         val parent = LinearLayout(context)
         val holder = adapter.onCreateViewHolder(parent, 0)
         adapter.onBindViewHolder(holder, 0)
 
+        mainTestDispatcher.scheduler.advanceUntilIdle()
+
+        val job = holder.previewJob
+        assertNotNull("previewJob should be set when binding", job)
+        assertEquals(false, job?.isCancelled)
+
         adapter.onViewRecycled(holder)
+
+        assertEquals(true, job?.isCancelled)
+        assertNull(holder.previewJob)
     }
 }


### PR DESCRIPTION
Move file.exists(), lastModified(), and length() calls in InlineResourceAdapter off the main dispatcher onto dispatcherProvider.io while keeping UI updates on main.

Fixes #16310

---
*PR created automatically by Jules for task [12617410181746357837](https://jules.google.com/task/12617410181746357837) started by @dogi*