### PR TITLE
all: less team user dao queries is more (fixes #16341)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6776
-        versionName = "0.67.76"
+        versionCode = 6777
+        versionName = "0.67.77"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamDao.kt
@@ -17,7 +17,6 @@ interface TeamDao {
     @Query("SELECT * FROM teams WHERE teamId = :teamId") suspend fun getAllByTeamId(teamId: String): List<MyTeam>
     @Query("SELECT * FROM teams") fun observeAll(): Flow<List<MyTeam>>
     @Query("SELECT * FROM teams WHERE docType = :docType") suspend fun getByDocType(docType: String): List<MyTeam>
-    @Query("SELECT * FROM teams WHERE docType = :docType") fun observeByDocType(docType: String): Flow<List<MyTeam>>
     @Query("SELECT * FROM teams WHERE teamId = :teamId AND docType = :docType") suspend fun getByTeamIdAndDocType(teamId: String, docType: String): List<MyTeam>
     @Query("SELECT * FROM teams WHERE teamId = :teamId AND docType = 'membership' AND isLeader = 0 AND (status IS NULL OR status != 'archived') AND (:excludeUserId IS NULL OR userId != :excludeUserId)") suspend fun getEligibleNextLeaderCandidates(teamId: String, excludeUserId: String?): List<MyTeam>
     @Query("SELECT * FROM teams WHERE teamId = :teamId AND docType = :docType") fun observeByTeamIdAndDocType(teamId: String, docType: String): Flow<List<MyTeam>>

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserDao.kt
@@ -16,7 +16,6 @@ interface UserDao {
     @Query("SELECT * FROM users WHERE name = :name COLLATE NOCASE LIMIT 1") suspend fun getByNameIgnoreCase(name: String): UserEntity?
     @Query("SELECT * FROM users WHERE name LIKE '%' || :query || '%' OR firstName LIKE '%' || :query || '%' OR lastName LIKE '%' || :query || '%'") suspend fun search(query: String): List<UserEntity>
     @Query("SELECT COUNT(*) FROM users") suspend fun count(): Int
-    @Query("SELECT COUNT(*) FROM users WHERE planetCode = :planetCode") suspend fun countByPlanetCode(planetCode: String): Int
     @Query("DELETE FROM users WHERE id = :id") suspend fun deleteById(id: String): Int
     @Query("DELETE FROM users WHERE id IN (:ids)") suspend fun deleteByIds(ids: List<String>): Int
     @Upsert suspend fun upsert(item: UserEntity)


### PR DESCRIPTION
## Description
Removes two dead (uncalled) Room `@Query` methods that KSP still compiles and validates on every build:

- `TeamDao.observeByDocType` — `data/room/dao/TeamDao.kt`
- `UserDao.countByPlanetCode` — `data/room/dao/UserDao.kt`

Both methods had zero callers in `app/src/main` (verified via grep — matches found only at their declarations). Dead `@Query` methods are still compiled and validated by KSP on every build, so removing them shrinks the DAO surface and avoids maintaining unused SQL.

Fixes #16341

## Changes
- `app/src/main/java/org/ole/planet/myplanet/data/room/dao/TeamDao.kt`: deleted `observeByDocType`
- `app/src/main/java/org/ole/planet/myplanet/data/room/dao/UserDao.kt`: deleted `countByPlanetCode`

No behavioral change — no production or test code referenced either method.

## Verification
- `grep -rn "observeByDocType\|countByPlanetCode" app/src/main` → only declaration matches (now removed)
- `grep -rn "observeByDocType\|countByPlanetCode" app/src/test` → no matches
- `Flow` import retained in `TeamDao.kt` (still used by `observeAll` and `observeByTeamIdAndDocType`)

---
_This PR was created by an AI agent (OpenHands) on behalf of the repository contributor._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0d3bdbaa-f07c-47cf-98e1-24c41f99f5ea)