### PR TITLE
all: less notifications repository task team name is more (fixes #16338)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6777
-        versionName = "0.67.77"
+        versionCode = 6778
+        versionName = "0.67.78"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepository.kt
@@ -21,7 +21,6 @@ interface NotificationsRepository {
     suspend fun getJoinRequestDetails(relatedId: String?): Pair<String, String>
     suspend fun getTaskTeamNamesByTaskIds(taskIds: List<String>): Map<String, String>
     suspend fun getJoinRequestDetailsBatch(relatedIds: List<String>): Map<String, Pair<String, String>>
-    suspend fun getTaskTeamName(taskTitle: String): String?
     suspend fun getTeamNotifications(teamIds: List<String>, userId: String): Map<String, TeamNotificationInfo>
     suspend fun updateTeamNotification(teamId: String, count: Int)
     suspend fun getTaskTeamNamesByTaskTitles(taskTitles: List<String>): Map<String, String>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -249,12 +249,6 @@ class NotificationsRepositoryImpl @Inject constructor(
         return map
     }
 
-    override suspend fun getTaskTeamName(taskTitle: String): String? {
-        val taskObj = teamTaskDao.getByTitle(taskTitle)
-        val teamInfo = taskObj?.teamId?.let { teamsRepository.get().getTeamLabelInfo(it) }
-        return teamInfo?.name
-    }
-
     override suspend fun getTaskTeamNamesByTaskTitles(taskTitles: List<String>): Map<String, String> {
         if (taskTitles.isEmpty()) return emptyMap()
         val map = mutableMapOf<String, String>()


### PR DESCRIPTION
## Summary

`NotificationsRepository.getTaskTeamName(taskTitle)` and its `NotificationsRepositoryImpl` override had no callers in `app/src/main` or `app/src/test` — `NotificationsViewModel` moved to the batched `getTaskTeamNamesByTaskTitles` / `getTaskTeamNamesByTaskIds`. The method kept a one-row-per-title query pattern alive in an otherwise fully batched interface.

This deletes the unused method and its implementation.

## Changes

- `repository/NotificationsRepository.kt`: removed `suspend fun getTaskTeamName(taskTitle: String): String?` from the interface.
- `repository/NotificationsRepositoryImpl.kt`: removed the matching `override`.

## Verification

- `grep -rn "getTaskTeamName\b" app/src/main app/src/test` now finds zero matches (previously only the declaration and the override).
- `./gradlew testDefaultDebugUnitTest --tests "...NotificationsRepositoryImplTest" --rerun-tasks` → BUILD SUCCESSFUL, 24 tests, 0 failures, 0 errors.
- `./gradlew testDefaultDebugUnitTest --tests "...NotificationsViewModelTest"` → BUILD SUCCESSFUL, 19 tests, 0 failures, 0 errors.

Fixes #16338

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bb46d836-d2d4-497a-914b-c9481bc88693)