### PR TITLE
all: smoother configurations repository sha256 utils checking (fixes #16352)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6778
-        versionName = "0.67.78"
+        versionCode = 6779
+        versionName = "0.67.79"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.repository
 
 import android.content.Context
+import android.util.Log
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import com.google.gson.Gson
@@ -53,6 +54,10 @@ class ConfigurationsRepositoryImpl @Inject constructor(
     @PlainGson private val gson: Gson
 ) : ConfigurationsRepository {
     private val serverAvailabilityCache = ConcurrentHashMap<String, Pair<Boolean, Long>>()
+
+    companion object {
+        private const val TAG = "ConfigurationsRepository"
+    }
 
     override suspend fun checkHealth(): String {
         return try {
@@ -233,6 +238,10 @@ class ConfigurationsRepositoryImpl @Inject constructor(
                     if (f.exists()) {
                         val sha256 = withContext(dispatcherProvider.io) {
                             Sha256Utils().getCheckSumFromFile(f)
+                        }
+                        if (sha256 == null) {
+                            Log.w(TAG, "Could not compute checksum for $path")
+                            return false
                         }
                         return checksum.contains(sha256)
                     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Sha256Utils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Sha256Utils.kt
@@ -9,11 +9,6 @@ class Sha256Utils {
         private val HEX_CHARS = "0123456789abcdef".toCharArray()
     }
 
-    /**
-     * Returns the SHA-512 hex digest of [file], or `null` when the file cannot be read
-     * or the digest cannot be computed. The class is named Sha256Utils for historical
-     * reasons but computes a SHA-512 hash.
-     */
     fun getCheckSumFromFile(file: File): String? {
         return try {
             val digest = MessageDigest.getInstance("SHA-512")

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Sha256Utils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Sha256Utils.kt
@@ -9,7 +9,12 @@ class Sha256Utils {
         private val HEX_CHARS = "0123456789abcdef".toCharArray()
     }
 
-    fun getCheckSumFromFile(file: File): String {
+    /**
+     * Returns the SHA-512 hex digest of [file], or `null` when the file cannot be read
+     * or the digest cannot be computed. The class is named Sha256Utils for historical
+     * reasons but computes a SHA-512 hash.
+     */
+    fun getCheckSumFromFile(file: File): String? {
         return try {
             val digest = MessageDigest.getInstance("SHA-512")
             FileInputStream(file).use { fis ->
@@ -27,8 +32,8 @@ class Sha256Utils {
                 result[i * 2 + 1] = HEX_CHARS[v and 0x0F]
             }
             String(result)
-        } catch (e: Exception) {
-            ""
+        } catch (_: Exception) {
+            null
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Sha256Utils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Sha256Utils.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.utils
 
-import android.util.Log
 import java.io.File
 import java.io.FileInputStream
 import java.security.MessageDigest
@@ -29,7 +28,6 @@ class Sha256Utils {
             }
             String(result)
         } catch (e: Exception) {
-            Log.w("Sha256Utils", "Failed to get checksum for file: ${file.absolutePath}", e)
             ""
         }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
@@ -431,6 +431,41 @@ class ConfigurationsRepositoryImplTest {
     }
 
     @Test
+    fun `checkCheckSum returns false when checksum cannot be computed`() = runTest(testDispatcher) {
+        val path = "test_path"
+        val expectedChecksum = "expected_checksum"
+
+        every { sharedPrefManager.getServerUrl() } returns "http://test.url"
+        every { sharedPrefManager.isAlternativeUrl() } returns false
+        every { sharedPrefManager.getCouchdbUrl() } returns "http://test.url"
+        UrlUtils.init(sharedPrefManager)
+
+        // Mock api response
+        val mockBody = expectedChecksum.toResponseBody("text/plain".toMediaTypeOrNull())
+        val response = Response.success(200, mockBody)
+        coEvery { apiInterface.getChecksum(any()) } returns response
+
+        io.mockk.mockkStatic(android.util.Log::class)
+        every { android.util.Log.w(any(), any<String>()) } returns 0
+
+        io.mockk.mockkObject(FileUtils)
+        val mockFile = mockk<java.io.File>()
+        every { FileUtils.getSDPathFromUrl(context, path) } returns mockFile
+        every { mockFile.exists() } returns true
+
+        io.mockk.mockkConstructor(Sha256Utils::class)
+        every { anyConstructed<Sha256Utils>().getCheckSumFromFile(mockFile) } returns null
+
+        val result = repository.checkCheckSum(path)
+
+        assertFalse(result)
+
+        io.mockk.unmockkStatic(android.util.Log::class)
+        io.mockk.unmockkObject(FileUtils)
+        io.mockk.unmockkConstructor(Sha256Utils::class)
+    }
+
+    @Test
     fun `checkCheckSum returns false when file does not exist`() = runTest(testDispatcher) {
         val path = "test_path"
         val checksumUrl = "http://test.url/checksum"

--- a/app/src/test/java/org/ole/planet/myplanet/utils/Sha256UtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/Sha256UtilsTest.kt
@@ -1,8 +1,9 @@
 package org.ole.planet.myplanet.utils
 
 import java.io.File
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeFalse
 import org.junit.Test
@@ -17,23 +18,24 @@ class Sha256UtilsTest {
 
         val checksum = Sha256Utils().getCheckSumFromFile(file)
 
+        assertNotNull(checksum)
         assertNotEquals("", checksum)
         // Note: The class is named Sha256Utils, but the underlying implementation uses SHA-512.
         // A SHA-512 hex string length is 128 characters.
-        assertTrue(checksum.length == 128)
+        assertTrue(checksum!!.length == 128)
     }
 
     @Test
-    fun getCheckSumFromFile_fileNotFound_returnsEmptyString() {
+    fun getCheckSumFromFile_fileNotFound_returnsNull() {
         val file = File("non_existent_file.txt")
 
         val checksum = Sha256Utils().getCheckSumFromFile(file)
 
-        assertEquals("", checksum)
+        assertNull(checksum)
     }
 
     @Test
-    fun getCheckSumFromFile_invalidFilePermissions_returnsEmptyString() {
+    fun getCheckSumFromFile_invalidFilePermissions_returnsNull() {
         val file = File.createTempFile("no_read_permission", ".txt")
         file.writeText("test data")
         file.deleteOnExit()
@@ -46,7 +48,7 @@ class Sha256UtilsTest {
 
         val checksum = Sha256Utils().getCheckSumFromFile(file)
 
-        assertEquals("", checksum)
+        assertNull(checksum)
 
         // Restore read permission so it can be deleted
         file.setReadable(true)

--- a/app/src/test/java/org/ole/planet/myplanet/utils/Sha256UtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/Sha256UtilsTest.kt
@@ -1,30 +1,13 @@
 package org.ole.planet.myplanet.utils
 
-import android.util.Log
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import java.io.File
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeFalse
-import org.junit.Before
 import org.junit.Test
 
 class Sha256UtilsTest {
-
-    @Before
-    fun setUp() {
-        mockkStatic(Log::class)
-        every { Log.w(any<String>(), any<String>(), any()) } returns 0
-    }
-
-    @After
-    fun tearDown() {
-        unmockkStatic(Log::class)
-    }
 
     @Test
     fun getCheckSumFromFile_validFile_returnsChecksum() {


### PR DESCRIPTION
## Summary

`Sha256Utils.getCheckSumFromFile` was pure `MessageDigest` over a `File` except for a single `Log.w` on the failure path — the class's only `android` import, blocking an otherwise platform-free checksum helper.

This removes the `android.util.Log` dependency from the helper **and** closes a pre-existing fail-open on the integrity path that surfaced while doing so. The helper now returns `null` on failure instead of an empty string, so the sole caller no longer treats an unverifiable file as passing.

## Changes

- `utils/Sha256Utils.kt` — removed the `android.util.Log` import and the `Log.w(...)` call; `getCheckSumFromFile` now returns `String?` (`null` on failure) instead of an empty string. The helper stays platform-free.
- `repository/ConfigurationsRepositoryImpl.kt` — `checkCheckSum` now treats `null` as "cannot verify" → `false` (fail-closed), closing the `checksum.contains("")` hole that previously returned `true` for an unverifiable file. The lost `Log.w` diagnostic is re-surfaced here, where an Android dependency is already present.
- `test/.../Sha256UtilsTest.kt` — dropped the `mockkStatic(Log::class)` scaffolding (the helper no longer touches `Log`); failure-path tests now assert `null`.
- `test/.../ConfigurationsRepositoryImplTest.kt` — added `checkCheckSum returns false when checksum cannot be computed` covering the new fail-closed behavior.

## Test plan

- [x] `Sha256UtilsTest` updated to assert `null` on the failure paths (no `Log` mock needed).
- [x] `ConfigurationsRepositoryImplTest` added a fail-closed case for the `null` checksum.
- [ ] `./gradlew testDefaultDebugUnitTest` passes in CI.

_Note: the test suite could not be executed locally — no JDK/Gradle toolchain in this environment. CI will confirm._

fixes #16352