### PR TITLE
gradle: suppress deprecated enableJetifier AGP warning (fixes #16357)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,10 @@ org.gradle.vfs.watch=true
 org.gradle.warning.mode=all
 android.useAndroidX=true
 # below can only be removed with material-dialogs, Circular-Progress-View, materialprogressbar and app/libs/*.aar
+# app/libs ships ChipCloud-3.0.5.aar and flexbox-1.0.0.aar, which still need Jetifier
 android.enableJetifier=true
+# suppress the AGP deprecation warning for enableJetifier; the flag itself must stay (see above)
+android.sync.suppressAgpWarnings=UNSUPPORTED_PROJECT_OPTION_USE
 android.nonTransitiveRClass=false
 android.nonFinalResIds=true
 


### PR DESCRIPTION
## Summary

Every CI stage currently prints `WARNING: The option setting 'android.enableJetifier=true' is deprecated.` The `enableJetifier` flag itself must stay — `app/libs` ships `ChipCloud-3.0.5.aar` and `flexbox-1.0.0.aar`, both of which still require Jetifier — so this change is about silencing the noise, not removing the flag.

## Changes

- `gradle.properties`: add `android.sync.suppressAgpWarnings=UNSUPPORTED_PROJECT_OPTION_USE` so AGP stops emitting the deprecation warning for `android.enableJetifier`.
- Added a brief comment noting *why* `enableJetifier` must stay (the two AARs in `app/libs`).

## Verification

- Confirmed `android.enableJetifier=true` remains at `gradle.properties:27`.
- Confirmed both `app/libs/ChipCloud-3.0.5.aar` and `app/libs/flexbox-1.0.0.aar` are present.

Closes #16357.

---
_This PR was created by an AI agent (OpenHands) on behalf of the repository maintainer._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b59db8fe-90d5-4520-b2d5-302eb2c0fc33)