### PR TITLE
all: smoother notifications repository dao querying (fixes #16325)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6780
-        versionName = "0.67.80"
+        versionCode = 6781
+        versionName = "0.67.81"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NotificationDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/NotificationDao.kt
@@ -36,6 +36,12 @@ interface NotificationDao {
     @Query("SELECT * FROM notifications WHERE id IN (:ids)")
     suspend fun getByIds(ids: List<String>): List<AppNotification>
 
+    @Query("SELECT id FROM notifications WHERE id IN (:ids)")
+    suspend fun getIdsByIds(ids: List<String>): List<String>
+
+    @Query("SELECT id FROM notifications WHERE userId = :userId AND isRead = 0")
+    suspend fun getUnreadIds(userId: String): List<String>
+
     @Query("UPDATE notifications SET isRead = 1, createdAt = :createdAt, needsSync = CASE WHEN isFromServer = 1 THEN 1 ELSE needsSync END WHERE id IN (:ids)")
     suspend fun markAsRead(ids: List<String>, createdAt: Date): Int
 

--- a/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImpl.kt
@@ -113,7 +113,7 @@ class NotificationsRepositoryImpl @Inject constructor(
     override suspend fun markNotificationsAsRead(notificationIds: Set<String>): Set<String> {
         if (notificationIds.isEmpty()) return emptySet()
 
-        val existingIds = notificationDao.getByIds(notificationIds.toList()).map { it.id }
+        val existingIds = notificationDao.getIdsByIds(notificationIds.toList())
         if (existingIds.isEmpty()) return emptySet()
         notificationDao.markAsRead(existingIds, Date())
         return existingIds.toSet()
@@ -121,7 +121,7 @@ class NotificationsRepositoryImpl @Inject constructor(
 
     override suspend fun markAllUnreadAsRead(userId: String?): Set<String> {
         val actualUserId = userId ?: return emptySet()
-        val unreadIds = notificationDao.getNotifications(actualUserId, "unread", false).map { it.id }.toSet()
+        val unreadIds = notificationDao.getUnreadIds(actualUserId).toSet()
         if (unreadIds.isEmpty()) return emptySet()
         notificationDao.markAllUnreadAsRead(actualUserId, Date())
         return unreadIds
@@ -403,7 +403,7 @@ class NotificationsRepositoryImpl @Inject constructor(
 
     override suspend fun deleteNotifications(ids: Set<String>): Set<String> {
         if (ids.isEmpty()) return emptySet()
-        val deletedIds = notificationDao.getByIds(ids.toList()).map { it.id }
+        val deletedIds = notificationDao.getIdsByIds(ids.toList())
         if (deletedIds.isNotEmpty()) {
             notificationDao.deleteByIds(deletedIds)
         }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/NotificationsRepositoryImplTest.kt
@@ -371,28 +371,67 @@ class NotificationsRepositoryImplTest {
     }
 
     @Test
+    fun `markNotificationsAsRead with empty set does nothing`() = runTest {
+        val result = repository.markNotificationsAsRead(emptySet())
+
+        assertTrue(result.isEmpty())
+        coVerify(exactly = 0) { notificationDao.getIdsByIds(any()) }
+        coVerify(exactly = 0) { notificationDao.markAsRead(any<List<String>>(), any()) }
+    }
+
+    @Test
+    fun `markNotificationsAsRead marks existing notifications as read and returns ids`() = runTest {
+        val ids = setOf("id1", "id2", "id3")
+        coEvery { notificationDao.getIdsByIds(any()) } returns listOf("id1", "id2")
+        coEvery { notificationDao.markAsRead(any<List<String>>(), any()) } returns 2
+
+        val result = repository.markNotificationsAsRead(ids)
+
+        assertEquals(setOf("id1", "id2"), result)
+        coVerify { notificationDao.getIdsByIds(ids.toList()) }
+        coVerify { notificationDao.markAsRead(listOf("id1", "id2"), any()) }
+    }
+
+    @Test
+    fun `markAllUnreadAsRead with null userId returns empty set`() = runTest {
+        val result = repository.markAllUnreadAsRead(null)
+
+        assertTrue(result.isEmpty())
+        coVerify(exactly = 0) { notificationDao.getUnreadIds(any()) }
+        coVerify(exactly = 0) { notificationDao.markAllUnreadAsRead(any(), any()) }
+    }
+
+    @Test
+    fun `markAllUnreadAsRead fetches unread ids and updates all unread`() = runTest {
+        coEvery { notificationDao.getUnreadIds("user1") } returns listOf("id1", "id2")
+        coEvery { notificationDao.markAllUnreadAsRead("user1", any()) } returns 2
+
+        val result = repository.markAllUnreadAsRead("user1")
+
+        assertEquals(setOf("id1", "id2"), result)
+        coVerify { notificationDao.getUnreadIds("user1") }
+        coVerify { notificationDao.markAllUnreadAsRead("user1", any()) }
+    }
+
+    @Test
     fun `deleteNotifications with empty set does nothing`() = runTest {
         val result = repository.deleteNotifications(emptySet())
 
         assertTrue(result.isEmpty())
-        coVerify(exactly = 0) { notificationDao.getByIds(any()) }
+        coVerify(exactly = 0) { notificationDao.getIdsByIds(any()) }
         coVerify(exactly = 0) { notificationDao.deleteByIds(any()) }
     }
 
     @Test
     fun `deleteNotifications deletes existing notifications and returns deleted ids`() = runTest {
         val ids = setOf("id1", "id2", "id3")
-        val notifications = listOf(
-            AppNotification().apply { id = "id1" },
-            AppNotification().apply { id = "id2" }
-        )
-        coEvery { notificationDao.getByIds(any()) } returns notifications
+        coEvery { notificationDao.getIdsByIds(any()) } returns listOf("id1", "id2")
         coEvery { notificationDao.deleteByIds(any()) } returns 2
 
         val result = repository.deleteNotifications(ids)
 
         assertEquals(setOf("id1", "id2"), result)
-        coVerify { notificationDao.getByIds(ids.toList()) }
+        coVerify { notificationDao.getIdsByIds(ids.toList()) }
         coVerify { notificationDao.deleteByIds(listOf("id1", "id2")) }
     }
 


### PR DESCRIPTION
Replaced full-row notification loads with id-only projections in NotificationDao and NotificationsRepositoryImpl for markNotificationsAsRead, markAllUnreadAsRead, and deleteNotifications. Updated unit tests in NotificationsRepositoryImplTest to verify id-only projection queries.

Fixes #16325

---
*PR created automatically by Jules for task [4091770736283420069](https://jules.google.com/task/4091770736283420069) started by @dogi*