### PR TITLE
all: smoother diagnostics repository log building (fixes #16342)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6781
-        versionName = "0.67.81"
+        versionCode = 6782
+        versionName = "0.67.82"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImpl.kt
@@ -27,7 +27,9 @@ class DiagnosticsRepositoryImpl @Inject constructor(
     }
 
     private fun buildApkLog(
-        spm: SharedPrefManager,
+        parentCode: String,
+        planetCode: String,
+        versionName: String?,
         modelId: String?,
         time: String,
         type: String,
@@ -35,12 +37,12 @@ class DiagnosticsRepositoryImpl @Inject constructor(
     ): ApkLog {
         return ApkLog().apply {
             id = "${UUID.randomUUID()}"
-            parentCode = spm.getParentCode()
-            createdOn = spm.getPlanetCode()
+            this.parentCode = parentCode
+            createdOn = planetCode
             modelId?.let { userId = it }
             this.time = time
             page = ""
-            version = VersionUtils.getVersionName(context)
+            version = versionName
             this.type = type
             if (error.isNotEmpty()) {
                 this.error = error
@@ -51,7 +53,15 @@ class DiagnosticsRepositoryImpl @Inject constructor(
     override suspend fun saveLogToRoom(type: String, error: String, time: String): Boolean {
         return try {
             val model = userSessionManager.getUserModel()
-            val log = buildApkLog(sharedPrefManager, model?.id, time, type, error)
+            val log = buildApkLog(
+                sharedPrefManager.getParentCode(),
+                sharedPrefManager.getPlanetCode(),
+                VersionUtils.getVersionName(context),
+                model?.id,
+                time,
+                type,
+                error,
+            )
             apkLogDao.insert(log)
             true
         } catch (e: Exception) {
@@ -64,8 +74,11 @@ class DiagnosticsRepositoryImpl @Inject constructor(
         if (pendingLogs.isEmpty()) return true
         return try {
             val model = userSessionManager.getUserModel()
+            val parentCode = sharedPrefManager.getParentCode()
+            val planetCode = sharedPrefManager.getPlanetCode()
+            val versionName = VersionUtils.getVersionName(context)
             val logsToInsert = pendingLogs.map { pending ->
-                buildApkLog(sharedPrefManager, model?.id, pending.time, pending.type, pending.error)
+                buildApkLog(parentCode, planetCode, versionName, model?.id, pending.time, pending.type, pending.error)
             }
             apkLogDao.insertAll(logsToInsert)
             true

--- a/app/src/main/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImpl.kt
@@ -64,24 +64,8 @@ class DiagnosticsRepositoryImpl @Inject constructor(
         if (pendingLogs.isEmpty()) return true
         return try {
             val model = userSessionManager.getUserModel()
-            val versionName = VersionUtils.getVersionName(context)
-            val parentCode = sharedPrefManager.getParentCode()
-            val planetCode = sharedPrefManager.getPlanetCode()
-
             val logsToInsert = pendingLogs.map { pending ->
-                ApkLog().apply {
-                    id = "${UUID.randomUUID()}"
-                    this.parentCode = parentCode
-                    this.createdOn = planetCode
-                    model?.let { userId = it.id }
-                    this.time = pending.time
-                    page = ""
-                    version = versionName
-                    this.type = pending.type
-                    if (pending.error.isNotEmpty()) {
-                        this.error = pending.error
-                    }
-                }
+                buildApkLog(sharedPrefManager, model?.id, pending.time, pending.type, pending.error)
             }
             apkLogDao.insertAll(logsToInsert)
             true

--- a/app/src/test/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImplTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.unmockkObject
+import io.mockk.verify
 import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -152,6 +153,13 @@ class DiagnosticsRepositoryImplTest {
 
         // Each log gets its own generated id.
         assertFalse(first.id == second.id)
+
+        // The three context lookups are hoisted above the map, so each runs once
+        // for the whole batch regardless of size (VersionUtils.getVersionName is
+        // a PackageManager IPC — the batch path flushes pending logs at startup).
+        verify(exactly = 1) { VersionUtils.getVersionName(any()) }
+        verify(exactly = 1) { sharedPrefManager.getParentCode() }
+        verify(exactly = 1) { sharedPrefManager.getPlanetCode() }
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImplTest.kt
@@ -1,0 +1,185 @@
+package org.ole.planet.myplanet.repository
+
+import android.content.Context
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.unmockkObject
+import java.io.File
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.data.room.dao.ApkLogDao
+import org.ole.planet.myplanet.model.ApkLog
+import org.ole.planet.myplanet.model.UserEntity
+import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.CrashLogStore
+import org.ole.planet.myplanet.utils.VersionUtils
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DiagnosticsRepositoryImplTest {
+    private lateinit var context: Context
+    private lateinit var apkLogDao: ApkLogDao
+    private lateinit var sharedPrefManager: SharedPrefManager
+    private lateinit var userSessionManager: UserSessionManager
+    private lateinit var repository: DiagnosticsRepositoryImpl
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Before
+    fun setUp() {
+        context = mockk()
+        apkLogDao = mockk(relaxed = true)
+        sharedPrefManager = mockk()
+        userSessionManager = mockk()
+
+        every { sharedPrefManager.getParentCode() } returns "parent-123"
+        every { sharedPrefManager.getPlanetCode() } returns "planet-456"
+
+        mockkObject(VersionUtils)
+        every { VersionUtils.getVersionName(any()) } returns "0.63.42"
+
+        repository = DiagnosticsRepositoryImpl(context, apkLogDao, sharedPrefManager, userSessionManager)
+    }
+
+    @Test
+    fun `saveLogToRoom builds a log reusing buildApkLog fields`() = runTest {
+        val user = UserEntity(id = "user-1")
+        coEvery { userSessionManager.getUserModel() } returns user
+
+        val inserted = slot<ApkLog>()
+        coEvery { apkLogDao.insert(capture(inserted)) } returns Unit
+
+        val result = repository.saveLogToRoom("crash", "boom", "1700000000000")
+
+        assertTrue(result)
+        val log = inserted.captured
+        assertEquals("crash", log.type)
+        assertEquals("boom", log.error)
+        assertEquals("1700000000000", log.time)
+        assertEquals("", log.page)
+        assertEquals("parent-123", log.parentCode)
+        assertEquals("planet-456", log.createdOn)
+        assertEquals("0.63.42", log.version)
+        assertEquals("user-1", log.userId)
+        assertNotNull(log.id)
+        assertTrue(log.id.isNotEmpty())
+    }
+
+    @Test
+    fun `saveLogToRoom leaves userId null when no user is logged in`() = runTest {
+        coEvery { userSessionManager.getUserModel() } returns null
+
+        val inserted = slot<ApkLog>()
+        coEvery { apkLogDao.insert(capture(inserted)) } returns Unit
+
+        repository.saveLogToRoom("anr", "stuck", "1700000000000")
+
+        assertNull(inserted.captured.userId)
+    }
+
+    @Test
+    fun `saveLogToRoom returns false on exception`() = runTest {
+        coEvery { userSessionManager.getUserModel() } throws RuntimeException("db down")
+
+        val result = repository.saveLogToRoom("crash", "boom", "1700000000000")
+
+        assertFalse(result)
+        coVerify(exactly = 0) { apkLogDao.insert(any()) }
+    }
+
+    @Test
+    fun `saveLogsToRoom returns true and inserts nothing for an empty list`() = runTest {
+        val result = repository.saveLogsToRoom(emptyList())
+
+        assertTrue(result)
+        coVerify(exactly = 0) { apkLogDao.insertAll(any()) }
+    }
+
+    @Test
+    fun `saveLogsToRoom builds each log reusing buildApkLog fields`() = runTest {
+        val user = UserEntity(id = "user-1")
+        coEvery { userSessionManager.getUserModel() } returns user
+
+        val inserted = slot<List<ApkLog>>()
+        coEvery { apkLogDao.insertAll(capture(inserted)) } returns Unit
+
+        val pending = listOf(
+            CrashLogStore.PendingLog(File("/tmp/a.log"), "crash", "1700000000001", "err1"),
+            CrashLogStore.PendingLog(File("/tmp/b.log"), "anr", "1700000000002", "err2")
+        )
+
+        val result = repository.saveLogsToRoom(pending)
+
+        assertTrue(result)
+        val logs = inserted.captured
+        assertEquals(2, logs.size)
+
+        val first = logs[0]
+        assertEquals("crash", first.type)
+        assertEquals("err1", first.error)
+        assertEquals("1700000000001", first.time)
+        assertEquals("", first.page)
+        assertEquals("parent-123", first.parentCode)
+        assertEquals("planet-456", first.createdOn)
+        assertEquals("0.63.42", first.version)
+        assertEquals("user-1", first.userId)
+        assertNotNull(first.id)
+        assertTrue(first.id.isNotEmpty())
+
+        val second = logs[1]
+        assertEquals("anr", second.type)
+        assertEquals("err2", second.error)
+        assertEquals("1700000000002", second.time)
+        assertEquals("user-1", second.userId)
+        assertNotNull(second.id)
+        assertTrue(second.id.isNotEmpty())
+
+        // Each log gets its own generated id.
+        assertFalse(first.id == second.id)
+    }
+
+    @Test
+    fun `saveLogsToRoom leaves userId null when no user is logged in`() = runTest {
+        coEvery { userSessionManager.getUserModel() } returns null
+
+        val inserted = slot<List<ApkLog>>()
+        coEvery { apkLogDao.insertAll(capture(inserted)) } returns Unit
+
+        val pending = listOf(
+            CrashLogStore.PendingLog(File("/tmp/a.log"), "crash", "1700000000001", "err1")
+        )
+
+        repository.saveLogsToRoom(pending)
+
+        assertEquals(1, inserted.captured.size)
+        assertNull(inserted.captured[0].userId)
+    }
+
+    @Test
+    fun `saveLogsToRoom returns false on exception`() = runTest {
+        coEvery { userSessionManager.getUserModel() } throws RuntimeException("db down")
+
+        val result = repository.saveLogsToRoom(
+            listOf(CrashLogStore.PendingLog(File("/tmp/a.log"), "crash", "1700000000001", "err1"))
+        )
+
+        assertFalse(result)
+        coVerify(exactly = 0) { apkLogDao.insertAll(any()) }
+    }
+}


### PR DESCRIPTION
## Summary

`DiagnosticsRepositoryImpl` built the same `ApkLog` fields twice: once in `buildApkLog` (used by `saveLogToRoom`) and again as an inline `ApkLog().apply {}` inside `saveLogsToRoom`, with precomputed `versionName`/`parentCode`/`planetCode`. The two had already drifted — `buildApkLog` used `modelId?.let { userId = it }` while the inline path used `model?.let { userId = it.id }`.

This makes `saveLogsToRoom` reuse `buildApkLog`, so both save paths share a single field-construction path and the drift is resolved. The resolved behavior keeps `userId = model?.id` (the value both expressions reduce to), now expressed through `buildApkLog`'s `modelId` parameter.

## Files changed

- `repository/DiagnosticsRepositoryImpl.kt` — `saveLogsToRoom` now maps each `PendingLog` through `buildApkLog` instead of constructing `ApkLog` inline.
- `app/src/test/.../repository/DiagnosticsRepositoryImplTest.kt` — new test covering both `saveLogToRoom` and `saveLogsToRoom`, asserting the shared field-construction (type, error, time, page, parentCode, createdOn, version, userId, generated id) plus the no-user and exception edge cases.

## Verification

```
./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.repository.DiagnosticsRepositoryImplTest"
```

Result: `tests="7" skipped="0" failures="0" errors="0"` — all passing.

Closes #16342.

---

_This PR was created by an AI agent (OpenHands) on behalf of the maintainer._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3e029501-b764-46f5-8d40-28529d3710d1)