### PR TITLE
enterprises: smoother repository report flowing (fixes #16354)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6782
-        versionName = "0.67.82"
+        versionCode = 6783
+        versionName = "0.67.83"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/EnterprisesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/EnterprisesRepositoryImpl.kt
@@ -92,9 +92,6 @@ class EnterprisesRepositoryImpl @Inject constructor(
                 }.sortedByDescending { it.createdDate }
             }
             .distinctByContent { old, new ->
-                // Compare CouchDB sync markers alongside the financial fields edited locally
-                // via updateReport/archiveReport, since _rev stays fixed for a local edit and the
-                // report's displayed values must refresh immediately without waiting for a sync.
                 old._id == new._id && old._rev == new._rev && old.status == new.status &&
                     old.description == new.description && old.beginningBalance == new.beginningBalance &&
                     old.sales == new.sales && old.otherIncome == new.otherIncome &&

--- a/app/src/main/java/org/ole/planet/myplanet/repository/EnterprisesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/EnterprisesRepositoryImpl.kt
@@ -4,7 +4,6 @@ import com.google.gson.JsonObject
 import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -15,6 +14,7 @@ import org.ole.planet.myplanet.model.MyTeam
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils
+import org.ole.planet.myplanet.utils.distinctByContent
 
 class EnterprisesRepositoryImpl @Inject constructor(
     private val teamDao: TeamDao,
@@ -91,9 +91,17 @@ class EnterprisesRepositoryImpl @Inject constructor(
                     it.status != "archived"
                 }.sortedByDescending { it.createdDate }
             }
-            .distinctUntilChanged { old, new ->
-                if (old.size != new.size) return@distinctUntilChanged false
-                old.zip(new).all { (o, n) -> o._id == n._id && o._rev == n._rev }
+            .distinctByContent { old, new ->
+                // Compare CouchDB sync markers alongside the financial fields edited locally
+                // via updateReport/archiveReport, since _rev stays fixed for a local edit and the
+                // report's displayed values must refresh immediately without waiting for a sync.
+                old._id == new._id && old._rev == new._rev && old.status == new.status &&
+                    old.description == new.description && old.beginningBalance == new.beginningBalance &&
+                    old.sales == new.sales && old.otherIncome == new.otherIncome &&
+                    old.wages == new.wages && old.otherExpenses == new.otherExpenses &&
+                    old.startDate == new.startDate && old.endDate == new.endDate &&
+                    old.updatedDate == new.updatedDate && old.updated == new.updated &&
+                    old.imageName == new.imageName
             }
             .flowOn(dispatcherProvider.default)
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/EnterprisesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/EnterprisesRepositoryImplTest.kt
@@ -1,22 +1,26 @@
 package org.ole.planet.myplanet.repository
 
+import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.ole.planet.myplanet.data.room.dao.TeamDao
 import org.ole.planet.myplanet.model.MyTeam
 import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.TestDispatcherProvider
 import org.ole.planet.myplanet.utils.TimeProvider
 import org.ole.planet.myplanet.utils.TimeUtils
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EnterprisesRepositoryImplTest {
 
-    private val teamDao: TeamDao = mockk()
-    private val timeProvider: TimeProvider = mockk()
-    private val dispatcherProvider: DispatcherProvider = mockk()
+    private val teamDao: TeamDao = mockk(relaxed = true)
+    private val timeProvider: TimeProvider = mockk(relaxed = true)
+    private val dispatcherProvider: DispatcherProvider = TestDispatcherProvider(UnconfinedTestDispatcher())
 
     private val repository = EnterprisesRepositoryImpl(
         teamDao, timeProvider, dispatcherProvider
@@ -65,5 +69,95 @@ class EnterprisesRepositoryImplTest {
             .toString()
 
         assertEquals(expectedCsv, result)
+    }
+
+    @Test
+    fun `getReportsFlow deduplicates byte-identical emissions`() = runTest {
+        val r1 = report("r1", "rev1", sales = 10)
+        val r2 = report("r1", "rev1", sales = 10)
+        coEvery { teamDao.observeByTeamIdAndDocType("team1", "report") } returns
+            flowOf(listOf(r1), listOf(r2))
+
+        val emissions = mutableListOf<List<MyTeam>>()
+        repository.getReportsFlow("team1").collect { emissions.add(it) }
+
+        assertEquals(1, emissions.size)
+    }
+
+    @Test
+    fun `getReportsFlow emits when a locally-edited financial field changes with rev unchanged`() = runTest {
+        val before = report("r1", "rev1", sales = 10)
+        val after = report("r1", "rev1", sales = 25)
+        coEvery { teamDao.observeByTeamIdAndDocType("team1", "report") } returns
+            flowOf(listOf(before), listOf(after))
+
+        val emissions = mutableListOf<List<MyTeam>>()
+        repository.getReportsFlow("team1").collect { emissions.add(it) }
+
+        assertEquals(2, emissions.size)
+        assertEquals(10, emissions[0][0].sales)
+        assertEquals(25, emissions[1][0].sales)
+    }
+
+    @Test
+    fun `getReportsFlow emits when description changes with id and rev unchanged`() = runTest {
+        val before = report("r1", "rev1", description = "old")
+        val after = report("r1", "rev1", description = "new")
+        coEvery { teamDao.observeByTeamIdAndDocType("team1", "report") } returns
+            flowOf(listOf(before), listOf(after))
+
+        val emissions = mutableListOf<List<MyTeam>>()
+        repository.getReportsFlow("team1").collect { emissions.add(it) }
+
+        assertEquals(2, emissions.size)
+        assertEquals("old", emissions[0][0].description)
+        assertEquals("new", emissions[1][0].description)
+    }
+
+    @Test
+    fun `getReportsFlow emits when a report is added`() = runTest {
+        val r1 = report("r1", "rev1", createdDate = 100L)
+        val r2 = report("r2", "rev2", createdDate = 200L)
+        coEvery { teamDao.observeByTeamIdAndDocType("team1", "report") } returns
+            flowOf(listOf(r1), listOf(r1, r2))
+
+        val emissions = mutableListOf<List<MyTeam>>()
+        repository.getReportsFlow("team1").collect { emissions.add(it) }
+
+        assertEquals(2, emissions.size)
+        assertEquals(1, emissions[0].size)
+        assertEquals(2, emissions[1].size)
+    }
+
+    @Test
+    fun `getReportsFlow filters archived reports and sorts by createdDate descending`() = runTest {
+        val r1 = report("r1", "rev1", createdDate = 100L)
+        val archived = report("ra", "reva", createdDate = 300L, status = "archived")
+        val r2 = report("r2", "rev2", createdDate = 200L)
+        coEvery { teamDao.observeByTeamIdAndDocType("team1", "report") } returns
+            flowOf(listOf(r1, archived, r2))
+
+        val emissions = mutableListOf<List<MyTeam>>()
+        repository.getReportsFlow("team1").collect { emissions.add(it) }
+
+        assertEquals(1, emissions.size)
+        assertEquals(listOf("r2", "r1"), emissions[0].map { it._id })
+    }
+
+    private fun report(
+        id: String,
+        rev: String,
+        description: String? = null,
+        sales: Int = 0,
+        createdDate: Long = 0L,
+        status: String? = null,
+    ) = MyTeam().apply {
+        _id = id
+        _rev = rev
+        docType = "report"
+        this.description = description
+        this.sales = sales
+        this.createdDate = createdDate
+        this.status = status
     }
 }


### PR DESCRIPTION
## Summary

`getReportsFlow`'s `distinctUntilChanged` compared only `_id` and `_rev` (`EnterprisesRepositoryImpl.kt:94-97`). Locally edited report fields change while `_rev` stays fixed, so the repository suppressed a user-visible update — editing a report did not refresh its displayed financial values until a server sync.

This is a real correctness bug, not just an efficiency trim: the financial values a user sees go stale the moment they edit a report, with no signal until the next sync round-trip.

## Changes

`repository/EnterprisesRepositoryImpl.kt`
- Replaced the `_id`/`_rev`-only comparison with a content-aware one that also covers the financial fields edited locally via `updateReport`/`archiveReport`: `status`, `description`, `beginningBalance`, `sales`, `otherIncome`, `wages`, `otherExpenses`, `startDate`, `endDate`, `updatedDate`, `updated`, and `imageName`.
- Switched to the shared `distinctByContent` helper (already used by `PersonalsRepositoryImpl`), which compares by index instead of `zip`, so it correctly de-duplicates reordered lists too.
- Swapped the now-unused `distinctUntilChanged` import for `distinctByContent`.

## Verification

Added unit tests to `EnterprisesRepositoryImplTest` covering the flow semantics:
- byte-identical emissions are de-duplicated (1 emission),
- a locally-edited financial field (`sales`) with `_id`/`_rev` unchanged emits a refresh (the regression this issue describes),
- a `description` edit with `_id`/`_rev` unchanged emits,
- adding a report emits,
- archived reports are filtered and results sorted by `createdDate` descending.

Note: I could not run the test suite locally — no JDK is installed in this environment. The tests mirror the established pattern in `PersonalsRepositoryImplTest` (relaxed `TeamDao` mock + `flowOf` + `UnconfinedTestDispatcher` + collect), which is exercised by CI.

Fixes #16354.

---
_This pull request was created by an AI agent (OpenHands) on behalf of the repository maintainers._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d25cc3c4-d5af-46ab-9d81-9d9c6a9db698)