### PR TITLE
login: smoother activities repository serializing (fixes #16281)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6762
-        versionName = "0.67.62"
+        versionCode = 6763
+        versionName = "0.67.63"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ActivitiesRepositoryImpl.kt
@@ -303,7 +303,7 @@ class ActivitiesRepositoryImpl @Inject constructor(
         ob.addProperty("deviceName", NetworkUtils.getDeviceName())
         ob.addProperty("customDeviceName", NetworkUtils.getCustomDeviceName(context))
         if (activity._id != null) {
-            ob.addProperty("_id", activity.logoutTime)
+            ob.addProperty("_id", activity._id)
         }
         if (activity._rev != null) {
             ob.addProperty("_rev", activity._rev)


### PR DESCRIPTION
fixes #16281 
The _id property was incorrectly set to activity.logoutTime instead of activity._id when building the activity JSON object.