### PR TITLE
all: smoother version utils android id caching (fixes #16317)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6783
-        versionName = "0.67.83"
+        versionCode = 6784
+        versionName = "0.67.84"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt
@@ -170,7 +170,7 @@ object NetworkUtils {
     }
 
     fun getUniqueIdentifier(): String {
-        val androidId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+        val androidId = VersionUtils.getAndroidId(context)
         val buildId = Build.ID
         return androidId + "_" + buildId
     }
@@ -186,8 +186,7 @@ object NetworkUtils {
     }
 
     fun getCustomDeviceName(context: Context): String {
-        val spm = coreEntryPoint.sharedPrefManager()
-        return spm.getCustomDeviceName()
+        return sharedPrefManager.getCustomDeviceName()
     }
 
     fun extractProtocol(url: String): String? {

--- a/app/src/main/java/org/ole/planet/myplanet/utils/VersionUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/VersionUtils.kt
@@ -4,9 +4,13 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.provider.Settings
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.pm.PackageInfoCompat.getLongVersionCode
 
 object VersionUtils {
+    @Volatile
+    private var cachedAndroidId: String? = null
+
     fun getVersionCode(context: Context): Int {
         try {
             val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
@@ -32,8 +36,18 @@ object VersionUtils {
         return ""
     }
 
-    fun getAndroidId(context: Context): String {
-        return Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+    fun getAndroidId(context: Context): String? {
+        cachedAndroidId?.let { return it }
+        val id = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+        if (id != null) {
+            cachedAndroidId = id
+        }
+        return id
+    }
+
+    @VisibleForTesting
+    internal fun resetAndroidIdCacheForTesting() {
+        cachedAndroidId = null
     }
 
     fun isVersionAllowed(currentVersion: String, minApkVersion: String): Boolean {

--- a/app/src/test/java/org/ole/planet/myplanet/utils/NetworkUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/NetworkUtilsTest.kt
@@ -36,6 +36,7 @@ class NetworkUtilsTest {
         // Initialize MainApplication.context which is required by NetworkUtils to avoid UninitializedPropertyAccessException
         // It is needed here because NetworkUtils gets system service from it directly
         org.ole.planet.myplanet.MainApplication.testContext = ApplicationProvider.getApplicationContext()
+        VersionUtils.resetAndroidIdCacheForTesting()
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/utils/VersionUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/VersionUtilsTest.kt
@@ -5,12 +5,15 @@ import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -19,6 +22,11 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class)
 class VersionUtilsTest {
+
+    @Before
+    fun setUp() {
+        VersionUtils.resetAndroidIdCacheForTesting()
+    }
 
     @Test
     fun compareVersions_should_return_0_for_equal_versions() {
@@ -213,5 +221,51 @@ class VersionUtilsTest {
 
         val versionName = VersionUtils.getVersionName(mockContext)
         assertNull(versionName)
+    }
+
+    @Test
+    fun getAndroidId_caches_non_null_id() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        Settings.Secure.putString(
+            context.contentResolver,
+            Settings.Secure.ANDROID_ID,
+            "initial_android_id"
+        )
+
+        val firstCallId = VersionUtils.getAndroidId(context)
+        assertEquals("initial_android_id", firstCallId)
+
+        Settings.Secure.putString(
+            context.contentResolver,
+            Settings.Secure.ANDROID_ID,
+            "changed_android_id"
+        )
+
+        val secondCallId = VersionUtils.getAndroidId(context)
+        assertEquals("initial_android_id", secondCallId)
+    }
+
+    @Test
+    fun getAndroidId_does_not_cache_null_value() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        Settings.Secure.putString(
+            context.contentResolver,
+            Settings.Secure.ANDROID_ID,
+            null
+        )
+
+        val firstCallId = VersionUtils.getAndroidId(context)
+        assertNull(firstCallId)
+
+        Settings.Secure.putString(
+            context.contentResolver,
+            Settings.Secure.ANDROID_ID,
+            "valid_android_id"
+        )
+
+        val secondCallId = VersionUtils.getAndroidId(context)
+        assertEquals("valid_android_id", secondCallId)
     }
 }


### PR DESCRIPTION
Cache process-lifetime Android ID in VersionUtils to prevent content resolver round trips per serialized document, delegate getUniqueIdentifier to VersionUtils.getAndroidId, reuse memoized sharedPrefManager in NetworkUtils.getCustomDeviceName, and add comprehensive unit tests.

Fixes #16317

---
*PR created automatically by Jules for task [12205646375015651849](https://jules.google.com/task/12205646375015651849) started by @dogi*