### PR TITLE
all: smoother notification list item html caching (fixes #16334)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6786
-        versionName = "0.67.86"
+        versionCode = 6787
+        versionName = "0.67.87"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/NotificationListItem.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/NotificationListItem.kt
@@ -1,7 +1,5 @@
 package org.ole.planet.myplanet.model
 
-import android.text.Html
-
 sealed class NotificationListItem {
     data class Header(
         val type: String,
@@ -14,9 +12,5 @@ sealed class NotificationListItem {
         val notification: Notification,
         val isSelected: Boolean = false,
         val isSelectionMode: Boolean = false
-    ) : NotificationListItem() {
-        val parsedText: CharSequence by lazy(LazyThreadSafetyMode.NONE) {
-            Html.fromHtml(notification.formattedText.toString(), Html.FROM_HTML_MODE_LEGACY)
-        }
-    }
+    ) : NotificationListItem()
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapter.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.ui.notifications
 
+import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -110,7 +111,10 @@ class NotificationsAdapter(
 
         fun bind(item: NotificationListItem.Item) {
             val notification = item.notification
-            binding.title.text = item.parsedText
+            binding.title.text = Html.fromHtml(
+                notification.formattedText.toString(),
+                Html.FROM_HTML_MODE_LEGACY
+            )
             binding.timestamp.text = formatRelativeTime(notification.createdAt)
             binding.root.alpha = if (notification.isRead) 0.6f else 1.0f
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapter.kt
@@ -38,6 +38,7 @@ class NotificationsAdapter(
 
     private var dateFormatter: DateTimeFormatter? = null
     private var lastLocale: Locale? = null
+    private val parsedHtmlCache = LruCache<String, CharSequence>(100)
 
     private fun getDateFormatter(): DateTimeFormatter {
         val currentLocale = Locale.getDefault()
@@ -54,7 +55,6 @@ class NotificationsAdapter(
     companion object {
         private const val VIEW_TYPE_HEADER = 0
         private const val VIEW_TYPE_ITEM = 1
-        private val parsedHtmlCache = LruCache<String, CharSequence>(100)
     }
 
     override fun getItemViewType(position: Int): Int = when (getItem(position)) {
@@ -113,13 +113,14 @@ class NotificationsAdapter(
 
         fun bind(item: NotificationListItem.Item) {
             val notification = item.notification
-            var titleText = parsedHtmlCache.get(notification.id)
+            val rawText = notification.formattedText.toString()
+            var titleText = parsedHtmlCache.get(rawText)
             if (titleText == null) {
                 titleText = Html.fromHtml(
-                    notification.formattedText.toString(),
+                    rawText,
                     Html.FROM_HTML_MODE_LEGACY
                 )
-                parsedHtmlCache.put(notification.id, titleText)
+                parsedHtmlCache.put(rawText, titleText)
             }
             binding.title.text = titleText
             binding.timestamp.text = formatRelativeTime(notification.createdAt)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapter.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.ui.notifications
 
 import android.text.Html
+import android.util.LruCache
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -53,6 +54,7 @@ class NotificationsAdapter(
     companion object {
         private const val VIEW_TYPE_HEADER = 0
         private const val VIEW_TYPE_ITEM = 1
+        private val parsedHtmlCache = LruCache<String, CharSequence>(100)
     }
 
     override fun getItemViewType(position: Int): Int = when (getItem(position)) {
@@ -111,10 +113,15 @@ class NotificationsAdapter(
 
         fun bind(item: NotificationListItem.Item) {
             val notification = item.notification
-            binding.title.text = Html.fromHtml(
-                notification.formattedText.toString(),
-                Html.FROM_HTML_MODE_LEGACY
-            )
+            var titleText = parsedHtmlCache.get(notification.id)
+            if (titleText == null) {
+                titleText = Html.fromHtml(
+                    notification.formattedText.toString(),
+                    Html.FROM_HTML_MODE_LEGACY
+                )
+                parsedHtmlCache.put(notification.id, titleText)
+            }
+            binding.title.text = titleText
             binding.timestamp.text = formatRelativeTime(notification.createdAt)
             binding.root.alpha = if (notification.isRead) 0.6f else 1.0f
 

--- a/app/src/test/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/notifications/NotificationsAdapterTest.kt
@@ -82,4 +82,19 @@ class NotificationsAdapterTest {
         val expectedString = SimpleDateFormat("MMM d, yyyy", Locale.getDefault()).format(expectedDate)
         assertEquals(expectedString, bindAndGetTimestamp(diff))
     }
+
+    @Test
+    fun `test bind updates title when formattedText changes for same notification id`() {
+        val parent = FrameLayout(context)
+        val viewHolder = adapter.onCreateViewHolder(parent, 1) as NotificationsAdapter.ItemViewHolder
+        val titleTextView = viewHolder.itemView.findViewById<TextView>(R.id.title)
+
+        val initialNotif = Notification("1", "<b>Initial</b> text", false, "test", "test", System.currentTimeMillis(), "")
+        viewHolder.bind(NotificationListItem.Item(initialNotif))
+        assertEquals("Initial text", titleTextView.text.toString())
+
+        val updatedNotif = Notification("1", "<b>Updated</b> text", false, "test", "test", System.currentTimeMillis(), "")
+        viewHolder.bind(NotificationListItem.Item(updatedNotif))
+        assertEquals("Updated text", titleTextView.text.toString())
+    }
 }


### PR DESCRIPTION
Moved Html.fromHtml parsing from NotificationListItem model into NotificationsAdapter.ItemViewHolder.bind, leaving the model platform-free.

Fixes #16334

---
*PR created automatically by Jules for task [17284592860637804382](https://jules.google.com/task/17284592860637804382) started by @dogi*