### PR TITLE
sync: less upload repository query pending is more (fixes #16329)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6787
-        versionName = "0.67.87"
+        versionCode = 6788
+        versionName = "0.67.88"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepository.kt
@@ -4,7 +4,6 @@ import com.google.gson.JsonObject
 import retrofit2.Response
 
 interface UploadRepository {
-    suspend fun <T : Any> queryPending(config: UploadQueryContract<T>): List<T>
     suspend fun markUploaded(
         config: UploadUpdateContract,
         succeeded: List<UploadedItemResult>
@@ -17,19 +16,9 @@ interface UploadRepository {
     suspend fun uploadResource(headerMap: Map<String, String>, url: String, body: okhttp3.RequestBody): Response<JsonObject>
 }
 
-data class UploadQueryContract<T : Any>(
-    val queryType: UploadQueryType
-)
-
 data class UploadUpdateContract(
     val updateType: UploadUpdateType
 )
-
-enum class UploadQueryType {
-    AdoptedSurveys,
-    ExamResults,
-    CompletedSubmissions,
-}
 
 enum class UploadUpdateType {
     Exams,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/UploadRepositoryImpl.kt
@@ -8,12 +8,9 @@ import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.asRequestBody
 import org.ole.planet.myplanet.data.api.ApiInterface
-import org.ole.planet.myplanet.data.room.dao.AnswerDao
 import org.ole.planet.myplanet.data.room.dao.ExamDao
 import org.ole.planet.myplanet.data.room.dao.SubmissionDao
-import org.ole.planet.myplanet.model.MembershipDoc
 import org.ole.planet.myplanet.model.StepExam
-import org.ole.planet.myplanet.model.Submission
 import org.ole.planet.myplanet.services.FileUploader
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.UrlUtils
@@ -24,20 +21,8 @@ class UploadRepositoryImpl @Inject constructor(
     private val apiInterface: ApiInterface,
     private val examDao: ExamDao,
     private val submissionDao: SubmissionDao,
-    private val answerDao: AnswerDao,
     private val dispatcherProvider: DispatcherProvider,
 ) : UploadRepository {
-
-    @Suppress("UNCHECKED_CAST")
-    override suspend fun <T : Any> queryPending(config: UploadQueryContract<T>): List<T> {
-        return when (config.queryType) {
-            UploadQueryType.AdoptedSurveys -> examDao.getPendingAdoptedSurveys() as List<T>
-
-            UploadQueryType.ExamResults -> hydrateSubmissions(submissionDao.getPendingExamResults()) as List<T>
-
-            UploadQueryType.CompletedSubmissions -> hydrateSubmissions(submissionDao.getPendingSubmissions()) as List<T>
-        }
-    }
 
     override suspend fun markUploaded(
         config: UploadUpdateContract,
@@ -73,13 +58,6 @@ class UploadRepositoryImpl @Inject constructor(
 
     override suspend fun fetchExistingDoc(url: String): Response<JsonObject> {
         return apiInterface.getJsonObject(UrlUtils.header, url)
-    }
-
-    private suspend fun hydrateSubmissions(rows: List<Submission>): List<Submission> {
-        if (rows.isEmpty()) return emptyList()
-        val answersBySubmissionId =
-            answerDao.getBySubmissionIds(rows.map { it.id }).groupBy { it.submissionId }
-        return rows.map { row -> row.apply { answers = answersBySubmissionId[id].orEmpty().toMutableList(); teamId?.let { membershipDoc = MembershipDoc().apply { this.teamId = it } } } }
     }
 
     private suspend fun markExamsUploaded(

--- a/app/src/test/java/org/ole/planet/myplanet/repository/UploadRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/UploadRepositoryImplTest.kt
@@ -13,7 +13,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.data.api.ApiInterface
-import org.ole.planet.myplanet.data.room.dao.AnswerDao
 import org.ole.planet.myplanet.data.room.dao.ExamDao
 import org.ole.planet.myplanet.data.room.dao.SubmissionDao
 import org.ole.planet.myplanet.model.StepExam
@@ -35,7 +34,6 @@ class UploadRepositoryImplTest {
     private lateinit var apiInterface: ApiInterface
     private lateinit var examDao: ExamDao
     private lateinit var submissionDao: SubmissionDao
-    private lateinit var answerDao: AnswerDao
     private lateinit var repository: UploadRepositoryImpl
 
     @Before
@@ -43,8 +41,7 @@ class UploadRepositoryImplTest {
         apiInterface = mockk(relaxed = true)
         examDao = mockk(relaxed = true)
         submissionDao = mockk(relaxed = true)
-        answerDao = mockk(relaxed = true)
-        repository = UploadRepositoryImpl(apiInterface, examDao, submissionDao, answerDao, dispatcherProvider)
+        repository = UploadRepositoryImpl(apiInterface, examDao, submissionDao, dispatcherProvider)
 
         val spm = mockk<org.ole.planet.myplanet.services.SharedPrefManager>(relaxed = true)
         every { spm.getUrlUser() } returns "user"
@@ -57,59 +54,6 @@ class UploadRepositoryImplTest {
     @After
     fun tearDown() {
         io.mockk.unmockkAll()
-    }
-
-    @Test
-    fun `queryPending returns adopted surveys from exam dao`() = runTest {
-        coEvery { examDao.getPendingAdoptedSurveys() } returns listOf(
-            StepExam(id = "exam-1", sourceSurveyId = "source-1", type = "surveys")
-        )
-
-        val result: List<StepExam> = repository.queryPending(
-            UploadQueryContract(UploadQueryType.AdoptedSurveys)
-        )
-
-        assertEquals(listOf("exam-1"), result.map { it.id })
-    }
-
-    @Test
-    fun `queryPending returns exam results and hydrates submissions`() = runTest {
-        val submission = org.ole.planet.myplanet.model.Submission(id = "sub-1", teamId = "team-1")
-        val answer = org.ole.planet.myplanet.model.Answer(id = "ans-1", submissionId = "sub-1")
-
-        coEvery { submissionDao.getPendingExamResults() } returns listOf(submission)
-        coEvery { answerDao.getBySubmissionIds(listOf("sub-1")) } returns listOf(answer)
-
-        val result: List<org.ole.planet.myplanet.model.Submission> = repository.queryPending(
-            UploadQueryContract(UploadQueryType.ExamResults)
-        )
-
-        assertEquals(1, result.size)
-        val res = result.first()
-        assertEquals("sub-1", res.id)
-        assertEquals(1, res.answers?.size)
-        assertEquals("ans-1", res.answers?.first()?.id)
-        assertEquals("team-1", res.membershipDoc?.teamId)
-    }
-
-    @Test
-    fun `queryPending returns completed submissions and hydrates submissions`() = runTest {
-        val submission = org.ole.planet.myplanet.model.Submission(id = "sub-2") // no teamId
-        val answer = org.ole.planet.myplanet.model.Answer(id = "ans-2", submissionId = "sub-2")
-
-        coEvery { submissionDao.getPendingSubmissions() } returns listOf(submission)
-        coEvery { answerDao.getBySubmissionIds(listOf("sub-2")) } returns listOf(answer)
-
-        val result: List<org.ole.planet.myplanet.model.Submission> = repository.queryPending(
-            UploadQueryContract(UploadQueryType.CompletedSubmissions)
-        )
-
-        assertEquals(1, result.size)
-        val res = result.first()
-        assertEquals("sub-2", res.id)
-        assertEquals(1, res.answers?.size)
-        assertEquals("ans-2", res.answers?.first()?.id)
-        assertEquals(null, res.membershipDoc)
     }
 
     @Test


### PR DESCRIPTION
Deletes UploadRepository.queryPending, UploadQueryContract, UploadQueryType, hydrateSubmissions helper function, AnswerDao dependency, and associated unit tests.

Fixes #16329

---
*PR created automatically by Jules for task [11487990039575373485](https://jules.google.com/task/11487990039575373485) started by @dogi*