### PR TITLE
sync: smoother retry interceptor backoff time providing (fixes #16330)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6788
-        versionName = "0.67.88"
+        versionCode = 6789
+        versionName = "0.67.89"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/data/api/RetryInterceptor.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/api/RetryInterceptor.kt
@@ -85,7 +85,7 @@ class RetryInterceptor @Inject constructor(
                 if (remaining <= 0) {
                     return
                 }
-                Thread.sleep(minOf(remaining, MAX_BACKOFF_SLICE_MS))
+                timeProvider.sleep(minOf(remaining, MAX_BACKOFF_SLICE_MS))
             }
         } catch (e: InterruptedException) {
             Thread.currentThread().interrupt()

--- a/app/src/main/java/org/ole/planet/myplanet/utils/TimeProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/TimeProvider.kt
@@ -10,8 +10,14 @@ package org.ole.planet.myplanet.utils
  */
 interface TimeProvider {
     fun now(): Long
+    fun sleep(millis: Long) {
+        Thread.sleep(millis)
+    }
 }
 
 class SystemTimeProvider : TimeProvider {
     override fun now(): Long = System.currentTimeMillis()
+    override fun sleep(millis: Long) {
+        Thread.sleep(millis)
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/data/api/RetryInterceptorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/api/RetryInterceptorTest.kt
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.services.BroadcastService
 import org.ole.planet.myplanet.utils.SystemTimeProvider
+import org.ole.planet.myplanet.utils.TestTimeProvider
 import org.ole.planet.myplanet.utils.TimeProvider
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -34,7 +35,7 @@ class RetryInterceptorTest {
     @Before
     fun setUp() {
         broadcastService = mockk(relaxed = true)
-        timeProvider = SystemTimeProvider()
+        timeProvider = TestTimeProvider()
         retryInterceptor = RetryInterceptor(broadcastService, timeProvider)
         retryInterceptor.initialDelay = 10L
     }
@@ -213,8 +214,8 @@ class RetryInterceptorTest {
         every { chain.proceed(request) } returns errorResponse
         every { chain.call() } returns notCancelledCall()
 
-        // Use a longer delay to ensure the other thread has time to interrupt
-        retryInterceptor.initialDelay = 2000L
+        val systemRetryInterceptor = RetryInterceptor(broadcastService, SystemTimeProvider())
+        systemRetryInterceptor.initialDelay = 2000L
 
         val currentThread = Thread.currentThread()
         val interrupterThread = Thread {
@@ -224,7 +225,7 @@ class RetryInterceptorTest {
         interrupterThread.start()
 
         try {
-            retryInterceptor.intercept(chain)
+            systemRetryInterceptor.intercept(chain)
             fail("Expected IOException due to interruption")
         } catch (e: IOException) {
             assertEquals("Interrupted during retry delay", e.message)

--- a/app/src/test/java/org/ole/planet/myplanet/utils/TestTimeProvider.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/TestTimeProvider.kt
@@ -4,6 +4,10 @@ package org.ole.planet.myplanet.utils
 class TestTimeProvider(var currentTime: Long = 0L) : TimeProvider {
     override fun now(): Long = currentTime
 
+    override fun sleep(millis: Long) {
+        advanceBy(millis)
+    }
+
     fun advanceBy(millis: Long) {
         currentTime += millis
     }


### PR DESCRIPTION
Routed RetryInterceptor's backoff sleep through TimeProvider instead of calling Thread.sleep directly against real wall-clock time. Added sleep method to TimeProvider interface with implementations in SystemTimeProvider (Thread.sleep) and TestTimeProvider (advances virtual time). Updated RetryInterceptorTest to use TestTimeProvider so unit tests run instantly without sleeping real seconds.

Fixes #16330

---
*PR created automatically by Jules for task [3308411598340943660](https://jules.google.com/task/3308411598340943660) started by @dogi*