### PR TITLE
actions: smoother workflow automerge pr picking (fixes #16379)

### DIFF
--- a/.github/scripts/automerge.sh
+++ b/.github/scripts/automerge.sh
@@ -68,8 +68,9 @@ pick_pr() {
         --json number,title,isDraft,headRefName,headRefOid,headRepositoryOwner,labels \
       | jq -c --arg skip "$skip_numbers" --arg prio "$PRIORITY_LABEL" '
             [ $skip | split(" ")[] | select(length > 0) | tonumber ] as $done
+            | ($done | map({ key: tostring, value: true }) | from_entries) as $doneSet
             | map(select(.isDraft | not))
-            | map(select(.number as $n | $done | index($n) | not))
+            | map(select(.number as $n | $doneSet | has($n | tostring) | not))
             | map(. + { priority: (
                   ($prio | length > 0)
                   and (((.labels // []) | map(.name) | index($prio)) != null)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6789
-        versionName = "0.67.89"
+        versionCode = 6790
+        versionName = "0.67.90"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
## Summary

`pick_pr` in `.github/scripts/automerge.sh` used `index()` over a rebuilt `$done` array to test PR-number membership on every drain-loop iteration — a linear scan that made the loop quadratic in queue size.

This replaces the linear `index()` scan with an O(1) membership check:

- `$done` (the skip list) is now converted once into a jq object/set, `$doneSet`, via `map({ key: tostring, value: true }) | from_entries`.
- The membership test becomes `$doneSet | has($n | tostring) | not` instead of `$done | index($n) | not`.

The behavioral result is identical: a PR is filtered out when its number appears in the skip set. The change only affects the lookup complexity, dropping each iteration from O(n) to O(1) so the whole drain is O(n log n) (the `sort_by`) instead of O(n²).

## Verification

Confirmed the exact filter at `automerge.sh:72` before the change. Verified the new filter with a standalone `jq` test harness covering:

- no skip → picks lowest non-draft PR
- skip one → picks next non-draft
- skip the two lowest → skips a draft and picks the next non-draft
- skip all non-drafts → returns `null`

All four cases produce the same output as the original `index()`-based filter.

## Test plan

- [x] `jq` filter equivalence verified against the original behavior with a standalone test
- [ ] CI `build.yml` / `test.yml` pass on this branch

fixes #16379

---

_This PR was created by an AI agent (OpenHands) on behalf of the repository maintainer._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c44b7fd3-f44c-4f50-9ff8-02b8b8fb40db)