### PR TITLE
life: smoother achievements model caching (fixes #16355)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6790
-        versionName = "0.67.90"
+        versionCode = 6791
+        versionName = "0.67.91"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/Achievement.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Achievement.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.model
 
-import android.util.LruCache
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
@@ -91,15 +90,18 @@ class Achievement {
     }
 
     companion object {
-        private val parsedJsonCache = LruCache<String, JsonElement>(1000)
+        private const val CACHE_CAPACITY = 1000
+        private val parsedJsonCache = object : LinkedHashMap<String, JsonElement>(16, 0.75f, true) {
+            override fun removeEldestEntry(eldest: Map.Entry<String, JsonElement>): Boolean = size > CACHE_CAPACITY
+        }
 
         private fun parseStringListToJsonArray(list: List<String>?): JsonArray {
             val array = JsonArray()
             for (s in list ?: emptyList()) {
-                var ob = parsedJsonCache.get(s)
+                var ob = parsedJsonCache[s]
                 if (ob == null) {
                     ob = JsonUtils.gson.fromJson(s, JsonElement::class.java)
-                    parsedJsonCache.put(s, ob)
+                    parsedJsonCache[s] = ob
                 }
                 array.add(ob?.deepCopy())
             }

--- a/app/src/main/java/org/ole/planet/myplanet/model/Achievement.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/Achievement.kt
@@ -6,6 +6,7 @@ import androidx.room.PrimaryKey
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import java.util.Collections
 import org.ole.planet.myplanet.utils.JsonUtils
 
 @Entity(tableName = "achievements", indices = [androidx.room.Index("isUpdated")])
@@ -90,10 +91,12 @@ class Achievement {
     }
 
     companion object {
-        private const val CACHE_CAPACITY = 1000
-        private val parsedJsonCache = object : LinkedHashMap<String, JsonElement>(16, 0.75f, true) {
-            override fun removeEldestEntry(eldest: Map.Entry<String, JsonElement>): Boolean = size > CACHE_CAPACITY
-        }
+        internal const val CACHE_CAPACITY = 1000
+        internal val parsedJsonCache: MutableMap<String, JsonElement> = Collections.synchronizedMap(
+            object : LinkedHashMap<String, JsonElement>(16, 0.75f, true) {
+                override fun removeEldestEntry(eldest: Map.Entry<String, JsonElement>): Boolean = size > CACHE_CAPACITY
+            }
+        )
 
         private fun parseStringListToJsonArray(list: List<String>?): JsonArray {
             val array = JsonArray()

--- a/app/src/test/java/org/ole/planet/myplanet/model/AchievementTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/AchievementTest.kt
@@ -164,15 +164,20 @@ class AchievementTest {
 
     @Test
     fun parsedJsonCache_isBoundedToCapacity() {
-        // The cache is private to the companion object, but its bound is exercised indirectly
-        // through parseStringListToJsonArray. We assert repeated parsing of many distinct
-        // entries never throws and remains correct, confirming the bounded map evicts eldest
-        // entries instead of growing unbounded.
+        // deepCopy() is applied on every read, so cached and freshly parsed elements are
+        // indistinguishable through the public API. The bound is therefore verified by
+        // observing the shared process-wide cache directly. The cache is populated by
+        // parseStringListToJsonArray (reached via the achievementsArray getter, not the
+        // setter), so each distinct entry is read back to fill the cache. Pushing more than
+        // CACHE_CAPACITY distinct entries must evict the eldest and cap the size instead of
+        // growing unbounded.
+        Achievement.parsedJsonCache.clear()
         val achievement = Achievement().apply { _id = "bound_ach" }
-        for (i in 1..1500) {
-            achievement.setAchievements(JsonArray().apply { add("item-$i") })
+        val overCapacity = Achievement.CACHE_CAPACITY + 500
+        for (i in 1..overCapacity) {
+            achievement.setAchievements(JsonArray().apply { add("bound-$i") })
+            achievement.achievementsArray.size()
         }
-        assertEquals(1, achievement.achievementsArray.size())
-        assertEquals("item-1500", achievement.achievementsArray[0].asString)
+        assertEquals(Achievement.CACHE_CAPACITY, Achievement.parsedJsonCache.size)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/model/AchievementTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/AchievementTest.kt
@@ -1,0 +1,178 @@
+package org.ole.planet.myplanet.model
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AchievementTest {
+
+    @Test
+    fun fromJson_setsFieldsAndParsesStringListArrays() {
+        val references = JsonObject().apply {
+            addProperty("name", "Jane Doe")
+            addProperty("relationship", "mentor")
+            addProperty("phone", "555-0100")
+            addProperty("email", "jane@example.com")
+        }
+        val referencesArray = JsonArray().apply { add(references) }
+
+        val achievementsArray = JsonArray().apply {
+            add("completed-course-a")
+            add("completed-course-b")
+        }
+        val linksArray = JsonArray().apply {
+            add("https://example.com/resource-1")
+        }
+        val otherInfoArray = JsonArray().apply {
+            add("extra-info")
+        }
+
+        val act = JsonObject().apply {
+            addProperty("_id", "ach_1")
+            addProperty("_rev", "1-abc")
+            addProperty("purpose", "learning")
+            addProperty("goals", "learn kotlin")
+            addProperty("achievementsHeader", "My Achievements")
+            addProperty("sendToNation", "true")
+            addProperty("dateSortOrder", "desc")
+            addProperty("createdOn", "2026-01-01")
+            addProperty("username", "learner")
+            addProperty("parentCode", "US")
+            addProperty("resumeFileName", "resume.pdf")
+            add("references", referencesArray)
+            add("achievements", achievementsArray)
+            add("links", linksArray)
+            add("otherInfo", otherInfoArray)
+        }
+
+        val achievement = Achievement.fromJson(act)
+
+        assertEquals("ach_1", achievement._id)
+        assertEquals("1-abc", achievement._rev)
+        assertEquals("learning", achievement.purpose)
+        assertEquals("learn kotlin", achievement.goals)
+        assertEquals("My Achievements", achievement.achievementsHeader)
+        assertEquals("true", achievement.sendToNation)
+        assertEquals("desc", achievement.dateSortOrder)
+        assertEquals("2026-01-01", achievement.createdOn)
+        assertEquals("learner", achievement.username)
+        assertEquals("US", achievement.parentCode)
+        assertEquals("resume.pdf", achievement.resumeFileName)
+        assertFalse(achievement.isUpdated)
+
+        assertEquals(2, achievement.achievementsArray.size())
+        assertEquals("completed-course-a", achievement.achievementsArray[0].asString)
+        assertEquals("completed-course-b", achievement.achievementsArray[1].asString)
+
+        assertEquals(1, achievement.getReferencesArray().size())
+        val refObj = achievement.getReferencesArray()[0].asJsonObject
+        assertEquals("Jane Doe", refObj.get("name").asString)
+        assertEquals("mentor", refObj.get("relationship").asString)
+
+        assertEquals(1, achievement.linksArray.size())
+        assertEquals("https://example.com/resource-1", achievement.linksArray[0].asString)
+
+        assertEquals(1, achievement.otherInfoArray.size())
+        assertEquals("extra-info", achievement.otherInfoArray[0].asString)
+    }
+
+    @Test
+    fun parseStringListToJsonArray_returnsCachedElementViaDeepCopy() {
+        // A JsonObject entry is serialized to a string, then parsed back and cached.
+        // deepCopy() produces a fresh JsonObject for each read, so repeated reads of the
+        // same cached entry are not the same instance (mutations of one won't leak to the other).
+        val entry = JsonObject().apply {
+            addProperty("title", "cached-value")
+        }
+        val first = Achievement.fromJson(JsonObject().apply {
+            addProperty("_id", "ach_cache")
+            add("achievements", JsonArray().apply { add(entry) })
+        }).achievementsArray
+
+        val second = Achievement.fromJson(JsonObject().apply {
+            addProperty("_id", "ach_cache_2")
+            add("achievements", JsonArray().apply { add(entry) })
+        }).achievementsArray
+
+        assertEquals("cached-value", first[0].asJsonObject.get("title").asString)
+        assertEquals("cached-value", second[0].asJsonObject.get("title").asString)
+        // deepCopy ensures cached entries aren't shared by identity
+        assertTrue(first[0] !== second[0])
+    }
+
+    @Test
+    fun parseStringListToJsonArray_handlesNullList() {
+        val achievement = Achievement().apply { _id = "empty_ach" }
+        assertEquals(0, achievement.achievementsArray.size())
+        assertEquals(0, achievement.getReferencesArray().size())
+        assertEquals(0, achievement.linksArray.size())
+        assertEquals(0, achievement.otherInfoArray.size())
+    }
+
+    @Test
+    fun serialize_roundTripsFieldsAndArrays() {
+        val original = Achievement.fromJson(JsonObject().apply {
+            addProperty("_id", "ach_serialize")
+            addProperty("_rev", "2-rev")
+            addProperty("purpose", "growth")
+            addProperty("goals", "grow")
+            addProperty("achievementsHeader", "Header")
+            addProperty("sendToNation", "false")
+            addProperty("dateSortOrder", "none")
+            addProperty("createdOn", "2026-02-02")
+            addProperty("username", "user")
+            addProperty("parentCode", "DE")
+            addProperty("resumeFileName", "cv.pdf")
+            add("references", JsonArray().apply {
+                add(Achievement.createReference("Bob", "colleague", "555-2000", "bob@example.com"))
+            })
+            add("achievements", JsonArray().apply { add("course-x") })
+            add("links", JsonArray().apply { add("https://example.com/x") })
+            add("otherInfo", JsonArray().apply { add("info") })
+        })
+
+        val serialized = Achievement.serialize(original)
+
+        assertEquals("ach_serialize", serialized.get("_id").asString)
+        assertEquals("2-rev", serialized.get("_rev").asString)
+        assertEquals("growth", serialized.get("purpose").asString)
+        assertEquals("grow", serialized.get("goals").asString)
+        assertEquals("Header", serialized.get("achievementsHeader").asString)
+        assertEquals(false, serialized.get("sendToNation").asBoolean)
+        assertEquals("none", serialized.get("dateSortOrder").asString)
+        assertEquals("2026-02-02", serialized.get("createdOn").asString)
+        assertEquals("user", serialized.get("username").asString)
+        assertEquals("DE", serialized.get("parentCode").asString)
+        assertEquals("cv.pdf", serialized.get("resumeFileName").asString)
+        assertEquals(1, serialized.getAsJsonArray("achievements").size())
+        assertEquals(1, serialized.getAsJsonArray("links").size())
+        assertEquals(1, serialized.getAsJsonArray("otherInfo").size())
+        assertEquals("Bob", serialized.getAsJsonArray("references")[0].asJsonObject.get("name").asString)
+    }
+
+    @Test
+    fun createReference_buildsExpectedJsonObject() {
+        val ref = Achievement.createReference("Alice", "advisor", "555-3000", "alice@example.com")
+        assertEquals("Alice", ref.get("name").asString)
+        assertEquals("advisor", ref.get("relationship").asString)
+        assertEquals("555-3000", ref.get("phone").asString)
+        assertEquals("alice@example.com", ref.get("email").asString)
+    }
+
+    @Test
+    fun parsedJsonCache_isBoundedToCapacity() {
+        // The cache is private to the companion object, but its bound is exercised indirectly
+        // through parseStringListToJsonArray. We assert repeated parsing of many distinct
+        // entries never throws and remains correct, confirming the bounded map evicts eldest
+        // entries instead of growing unbounded.
+        val achievement = Achievement().apply { _id = "bound_ach" }
+        for (i in 1..1500) {
+            achievement.setAchievements(JsonArray().apply { add("item-$i") })
+        }
+        assertEquals(1, achievement.achievementsArray.size())
+        assertEquals("item-1500", achievement.achievementsArray[0].asString)
+    }
+}


### PR DESCRIPTION
## Summary

`Achievement` pinned its whole model to `android.util` for a 1000-entry JSON parse cache (`LruCache` in the companion object, used only by `parseStringListToJsonArray` in the same file). This replaces `android.util.LruCache` with a pure-Kotlin bounded `LinkedHashMap`-based cache, keeping the same 1000-entry bound and behavior.

The replacement uses an access-order `LinkedHashMap` with `removeEldestEntry` returning `true` once `size > CACHE_CAPACITY` (1000) — the same LRU eviction semantics `LruCache` provides, without the `android.util` dependency on the model.

## Changes

- `model/Achievement.kt`
  - Removed `import android.util.LruCache`.
  - Replaced `private val parsedJsonCache = LruCache<String, JsonElement>(1000)` with a bounded `LinkedHashMap` (access-order, `removeEldestEntry` evicts beyond 1000 entries).
  - Introduced a `CACHE_CAPACITY = 1000` constant for the bound.
  - `parseStringListToJsonArray` now uses map indexing (`parsedJsonCache[s]` / `parsedJsonCache[s] = ob`) instead of `get`/`put`, but the lookup/store/cache-miss semantics are unchanged.
- `app/src/test/.../model/AchievementTest.kt` (new)
  - `fromJson_setsFieldsAndParsesStringListArrays` — covers field mapping plus parsing of the string-list-backed arrays.
  - `parseStringListToJsonArray_returnsCachedElementViaDeepCopy` — verifies the cache returns deep copies (cached entries aren't shared by identity).
  - `parseStringListToJsonArray_handlesNullList` — null/empty list returns an empty array.
  - `parsedJsonCache_isBoundedToCapacity` — exercising 1500 distinct entries through the cache confirms the bounded map evicts eldest entries instead of growing unbounded.
  - `serialize_roundTripsFieldsAndArrays` and `createReference_buildsExpectedJsonObject` — cover the serialize/reference-builder paths.

## Verification

- `./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.model.AchievementTest"` — 6 tests, 0 failures.
- Confirmed no `android.util.LruCache` import or field remains in `Achievement.kt`.

## Related issue

Fixes #16355

---

_This PR was created by an AI agent (OpenHands) on behalf of the repository maintainer._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/16227434-d165-4fe5-9654-4cd481826c57)