### PR TITLE
all: smoother storage category view model testing (fixes #16376)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6791
-        versionName = "0.67.91"
+        versionCode = 6792
+        versionName = "0.67.92"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/settings/StorageCategoryViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/settings/StorageCategoryViewModelTest.kt
@@ -1,0 +1,136 @@
+package org.ole.planet.myplanet.ui.settings
+
+import android.content.Context
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.ole.planet.myplanet.model.OfflineResourceItem
+import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.utils.FileUtils
+import org.ole.planet.myplanet.utils.MainDispatcherRule
+import org.ole.planet.myplanet.utils.TestDispatcherProvider
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StorageCategoryViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
+    private val resourcesRepository = mockk<ResourcesRepository>(relaxed = true)
+    private val context = mockk<Context>(relaxed = true)
+    private val dispatcherProvider = TestDispatcherProvider(testDispatcher)
+
+    private lateinit var viewModel: StorageCategoryViewModel
+    private val olePath = "/tmp/ole/"
+
+    @Before
+    fun setUp() {
+        mockkObject(FileUtils)
+        every { FileUtils.getOlePath(any()) } returns olePath
+        viewModel = StorageCategoryViewModel(resourcesRepository, dispatcherProvider, context)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `toggleItemChecked flips only the matching item's checked state`() = runTest(testDispatcher) {
+        val items = listOf(
+            OfflineResourceItem("res1", "Book", listOf("/p/b.pdf"), 100L, false),
+            OfflineResourceItem("res2", "Video", listOf("/p/v.mp4"), 200L, false)
+        )
+        loadItems(items)
+
+        viewModel.toggleItemChecked("res1")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.items.first { it.resourceId == "res1" }.isChecked)
+        assertFalse(state.items.first { it.resourceId == "res2" }.isChecked)
+
+        viewModel.toggleItemChecked("res1")
+        advanceUntilIdle()
+        assertFalse(viewModel.uiState.value.items.first { it.resourceId == "res1" }.isChecked)
+    }
+
+    @Test
+    fun `toggleAllChecked checks all items when not all checked and unchecks when all checked`() = runTest(testDispatcher) {
+        val items = listOf(
+            OfflineResourceItem("res1", "Book", listOf("/p/b.pdf"), 100L, false),
+            OfflineResourceItem("res2", "Video", listOf("/p/v.mp4"), 200L, true)
+        )
+        loadItems(items)
+
+        viewModel.toggleAllChecked()
+        advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.items.all { it.isChecked })
+
+        viewModel.toggleAllChecked()
+        advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.items.none { it.isChecked })
+    }
+
+    @Test
+    fun `deleteItems re-entry guard prevents a second deletion while one is in flight`() = runTest(testDispatcher) {
+        val items = listOf(
+            OfflineResourceItem("res1", "Book", listOf("/p/b.pdf"), 100L, true)
+        )
+        loadItems(items)
+
+        coEvery { resourcesRepository.deleteOfflineResources(olePath, items) } just Runs
+
+        viewModel.deleteItems(items)
+        // The first call sets isDeleting synchronously; without advancing, a second call hits the guard.
+        assertTrue(viewModel.uiState.value.isDeleting)
+
+        viewModel.deleteItems(items)
+        advanceUntilIdle()
+
+        assertFalse("isDeleting should be cleared after deletion completes", viewModel.uiState.value.isDeleting)
+        coVerify(exactly = 1) { resourcesRepository.deleteOfflineResources(olePath, items) }
+    }
+
+    @Test
+    fun `deleteItems emits a complete event after deleting`() = runTest(testDispatcher) {
+        val items = listOf(
+            OfflineResourceItem("res1", "Book", listOf("/p/b.pdf"), 100L, true)
+        )
+        loadItems(items)
+
+        coEvery { resourcesRepository.deleteOfflineResources(olePath, items) } just Runs
+
+        viewModel.deleteItems(items)
+        advanceUntilIdle()
+
+        assertEquals(Unit, viewModel.deleteCompleteEvent.first())
+    }
+
+    private fun loadItems(items: List<OfflineResourceItem>) {
+        coEvery {
+            resourcesRepository.getOfflineResourceItems(olePath, any(), any())
+        } returns items
+        viewModel.loadResources(emptySet(), emptySet())
+        advanceUntilIdle()
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/settings/StorageCategoryViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/settings/StorageCategoryViewModelTest.kt
@@ -12,6 +12,7 @@ import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -126,7 +127,7 @@ class StorageCategoryViewModelTest {
         assertEquals(Unit, viewModel.deleteCompleteEvent.first())
     }
 
-    private fun loadItems(items: List<OfflineResourceItem>) {
+    private suspend fun TestScope.loadItems(items: List<OfflineResourceItem>) {
         coEvery {
             resourcesRepository.getOfflineResourceItems(olePath, any(), any())
         } returns items


### PR DESCRIPTION
## What & Why

`StorageCategoryViewModel` had no test coverage. `toggleItemChecked`, `toggleAllChecked`, and the `deleteItems` re-entry guard (`if (_uiState.value.isDeleting) return`) are the load-bearing logic of the storage cleanup screen, so add a test that exercises all three.

Closes #16376

## Changes

- `(new) app/src/test/java/org/ole/planet/myplanet/ui/settings/StorageCategoryViewModelTest.kt` — adds unit tests covering:
  - `toggleItemChecked` flips only the matching item's `isChecked` state (and flips back on a second toggle)
  - `toggleAllChecked` checks all items when not all checked, and unchecks all when all are checked
  - `deleteItems` re-entry guard — a second `deleteItems` call made while the first is in flight is dropped, so `deleteOfflineResources` runs exactly once
  - `deleteItems` emits the `deleteCompleteEvent` after deleting and clears `isDeleting`

The test follows existing project conventions: MockK, `MainDispatcherRule` with `StandardTestDispatcher`, `TestDispatcherProvider`, and `mockkObject(FileUtils)` for `getOlePath` — matching the patterns in `ResourcesViewModelTest`, `CourseDetailViewModelTest`, and `FreeSpaceWorkerTest`.

## Verification

No JDK 17 / Android SDK is available in this sandbox, so the Gradle `testDefaultDebugUnitTest` task could not be run locally. CI (`test.yml`) will run `./gradlew testDefaultDebugUnitTest`, which fails the build on any unit-test failure. The test logic was validated against `StorageCategoryViewModel`'s source:
- `toggleItemChecked` / `toggleAllChecked` are synchronous `_uiState.update` operations verified after `advanceUntilIdle()`.
- The re-entry-guard test relies on the first `deleteItems` setting `isDeleting = true` synchronously before the launched coroutine runs (with `StandardTestDispatcher`, the body is suspended until `advanceUntilIdle()`), so the second call observes `isDeleting == true` and returns early.

---

_This PR was created by an AI agent (OpenHands) on behalf of dogi._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/11c79f76-c4b9-4245-bd01-875ff9194d07)