### PR TITLE
community: smoother configurations repository tab views modelling (fixes #16326)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6881
-        versionName = "0.68.81"
+        versionCode = 6882
+        versionName = "0.68.82"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepository.kt
@@ -12,6 +12,10 @@ interface ConfigurationsRepository {
     suspend fun clearAllData()
     suspend fun getMinApk(url: String, pin: String): ConfigurationResult
     fun getPlanetType(): String?
+    fun getParentCode(): String
+    fun getCommunityName(): String
+    fun getCommunityLeaders(): String
+    fun clearPreferences()
     suspend fun ensureServerUrlUpdated()
     suspend fun clearFirstRunStorageAndSetFlag(hasWritePermission: Boolean)
     suspend fun getQueuedDownloads(): List<String>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImpl.kt
@@ -393,6 +393,22 @@ class ConfigurationsRepositoryImpl @Inject constructor(
         return sharedPrefManager.getRawString("planetType")
     }
 
+    override fun getParentCode(): String {
+        return sharedPrefManager.getParentCode()
+    }
+
+    override fun getCommunityName(): String {
+        return sharedPrefManager.getCommunityName()
+    }
+
+    override fun getCommunityLeaders(): String {
+        return sharedPrefManager.getCommunityLeaders()
+    }
+
+    override fun clearPreferences() {
+        sharedPrefManager.clearPreferences()
+    }
+
     override suspend fun clearFirstRunStorageAndSetFlag(hasWritePermission: Boolean) {
         withContext(dispatcherProvider.io) {
             if (hasWritePermission && sharedPrefManager.getFirstRun()) {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.repository.ConfigurationsRepository
-import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 
 data class CommunityTabState(
@@ -21,7 +20,6 @@ data class CommunityTabState(
 
 @HiltViewModel
 class CommunityTabViewModel @Inject constructor(
-    private val sharedPrefManager: SharedPrefManager,
     private val configurationsRepository: ConfigurationsRepository,
     private val userSessionManager: UserSessionManager
 ) : ViewModel() {
@@ -31,8 +29,8 @@ class CommunityTabViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val parentCode = sharedPrefManager.getParentCode()
-            val communityName = sharedPrefManager.getCommunityName()
+            val parentCode = configurationsRepository.getParentCode()
+            val communityName = configurationsRepository.getCommunityName()
             val planetType = configurationsRepository.getPlanetType()
             val user = userSessionManager.getUserModel()
             val planetCode = user?.planetCode.orEmpty()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
@@ -14,7 +14,6 @@ import javax.inject.Inject
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 import org.ole.planet.myplanet.repository.ConfigurationsRepository
-import org.ole.planet.myplanet.services.SharedPrefManager
 
 @AndroidEntryPoint
 class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
@@ -23,9 +22,6 @@ class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
     private var bottomSheetBehavior: BottomSheetBehavior<View>? = null
     private var bottomSheetCallback: BottomSheetBehavior.BottomSheetCallback? = null
     private var tabLayoutMediator: TabLayoutMediator? = null
-
-    @Inject
-    lateinit var sharedPrefManager: SharedPrefManager
 
     @Inject
     lateinit var configurationsRepository: ConfigurationsRepository
@@ -93,8 +89,8 @@ class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
 
     private fun initCommunityTab() {
         binding.llActionButtons.visibility = View.GONE
-        val sParentcode = sharedPrefManager.getParentCode()
-        val communityName = sharedPrefManager.getCommunityName()
+        val sParentcode = configurationsRepository.getParentCode()
+        val communityName = configurationsRepository.getCommunityName()
         val planetType = configurationsRepository.getPlanetType()
         binding.viewPager2.adapter = CommunityPagerAdapter(this, "$communityName@$sParentcode", true, planetType)
         tabLayoutMediator = TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/LeadersViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/LeadersViewModel.kt
@@ -9,12 +9,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.model.UserEntity
-import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.repository.ConfigurationsRepository
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class LeadersViewModel @Inject constructor(
-    private val sharedPrefManager: SharedPrefManager,
+    private val configurationsRepository: ConfigurationsRepository,
     private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
 
@@ -27,7 +27,7 @@ class LeadersViewModel @Inject constructor(
 
     private fun loadLeaders() {
         viewModelScope.launch(dispatcherProvider.default) {
-            val leadersString = sharedPrefManager.getCommunityLeaders()
+            val leadersString = configurationsRepository.getCommunityLeaders()
             if (leadersString.isNotEmpty()) {
                 _leaders.value = UserEntity.parseLeadersJson(leadersString)
             } else {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/settings/SettingsViewModel.kt
@@ -13,13 +13,11 @@ import org.ole.planet.myplanet.repository.ConfigurationsRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
 import org.ole.planet.myplanet.repository.RetryQueueDetails
 import org.ole.planet.myplanet.repository.RetryRepository
-import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.DispatcherProvider
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val configurationsRepository: ConfigurationsRepository,
-    private val sharedPrefManager: SharedPrefManager,
     private val retryRepository: RetryRepository,
     private val resourcesRepository: ResourcesRepository,
     private val dispatcherProvider: DispatcherProvider
@@ -44,7 +42,7 @@ class SettingsViewModel @Inject constructor(
     fun clearAllData() {
         viewModelScope.launch(dispatcherProvider.io) {
             configurationsRepository.clearAllData()
-            sharedPrefManager.clearPreferences()
+            configurationsRepository.clearPreferences()
             _clearDataEvent.send(Unit)
         }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ConfigurationsRepositoryImplTest.kt
@@ -783,4 +783,37 @@ class ConfigurationsRepositoryImplTest {
 
         assertEquals(listOf("link1", "link2"), repository.getQueuedDownloads())
     }
+
+    @Test
+    fun `getParentCode delegates to sharedPrefManager`() {
+        every { sharedPrefManager.getParentCode() } returns "parent_123"
+
+        assertEquals("parent_123", repository.getParentCode())
+        verify { sharedPrefManager.getParentCode() }
+    }
+
+    @Test
+    fun `getCommunityName delegates to sharedPrefManager`() {
+        every { sharedPrefManager.getCommunityName() } returns "test_community"
+
+        assertEquals("test_community", repository.getCommunityName())
+        verify { sharedPrefManager.getCommunityName() }
+    }
+
+    @Test
+    fun `getCommunityLeaders delegates to sharedPrefManager`() {
+        every { sharedPrefManager.getCommunityLeaders() } returns "leaders_json"
+
+        assertEquals("leaders_json", repository.getCommunityLeaders())
+        verify { sharedPrefManager.getCommunityLeaders() }
+    }
+
+    @Test
+    fun `clearPreferences delegates to sharedPrefManager`() {
+        every { sharedPrefManager.clearPreferences() } just runs
+
+        repository.clearPreferences()
+
+        verify { sharedPrefManager.clearPreferences() }
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityTabViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/community/CommunityTabViewModelTest.kt
@@ -1,0 +1,56 @@
+package org.ole.planet.myplanet.ui.community
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.ole.planet.myplanet.model.UserEntity
+import org.ole.planet.myplanet.repository.ConfigurationsRepository
+import org.ole.planet.myplanet.services.UserSessionManager
+import org.ole.planet.myplanet.utils.MainDispatcherRule
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommunityTabViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val configurationsRepository: ConfigurationsRepository = mockk()
+    private val userSessionManager: UserSessionManager = mockk()
+
+    @Before
+    fun setup() {
+        every { configurationsRepository.getParentCode() } returns "parent_code_123"
+        every { configurationsRepository.getCommunityName() } returns "community_abc"
+        every { configurationsRepository.getPlanetType() } returns "planet_xyz"
+    }
+
+    @Test
+    fun `init populates state with values from configurationsRepository and userSessionManager`() = runTest {
+        val user = UserEntity().apply { planetCode = "planet_code_999" }
+        coEvery { userSessionManager.getUserModel() } returns user
+
+        val viewModel = CommunityTabViewModel(configurationsRepository, userSessionManager)
+        advanceUntilIdle()
+
+        val state = viewModel.state.first()
+        assertEquals("planet_code_999", state?.planetCode)
+        assertEquals("parent_code_123", state?.parentCode)
+        assertEquals("community_abc", state?.communityName)
+        assertEquals("planet_xyz", state?.planetType)
+
+        verify { configurationsRepository.getParentCode() }
+        verify { configurationsRepository.getCommunityName() }
+        verify { configurationsRepository.getPlanetType() }
+        coVerify { userSessionManager.getUserModel() }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/community/LeadersViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/community/LeadersViewModelTest.kt
@@ -1,0 +1,72 @@
+package org.ole.planet.myplanet.ui.community
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.repository.ConfigurationsRepository
+import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.MainDispatcherRule
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = android.app.Application::class)
+class LeadersViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val dispatcherProvider = object : DispatcherProvider {
+        override val main = testDispatcher
+        override val mainImmediate = testDispatcher
+        override val io = testDispatcher
+        override val default = testDispatcher
+        override val unconfined = testDispatcher
+    }
+
+    private val configurationsRepository: ConfigurationsRepository = mockk()
+
+
+    @Test
+    fun `loadLeaders parses non-empty community leaders from configurationsRepository`() = runTest {
+        val leadersJson = """{"docs":[{"_id":"leader_1","name":"Alice"}]}"""
+        every { configurationsRepository.getCommunityLeaders() } returns leadersJson
+
+        val viewModel = LeadersViewModel(configurationsRepository, dispatcherProvider)
+        advanceUntilIdle()
+
+        val result = viewModel.leaders.first()
+        assertEquals(1, result?.size)
+        assertEquals("leader_1", result?.get(0)?.id)
+        verify { configurationsRepository.getCommunityLeaders() }
+    }
+
+    @Test
+    fun `loadLeaders returns empty list when community leaders is empty`() = runTest {
+        every { configurationsRepository.getCommunityLeaders() } returns ""
+
+        val viewModel = LeadersViewModel(configurationsRepository, dispatcherProvider)
+        advanceUntilIdle()
+
+        val result = viewModel.leaders.first()
+        assertEquals(emptyList<Any>(), result)
+        verify { configurationsRepository.getCommunityLeaders() }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,64 @@
+package org.ole.planet.myplanet.ui.settings
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.ole.planet.myplanet.repository.ConfigurationsRepository
+import org.ole.planet.myplanet.repository.ResourcesRepository
+import org.ole.planet.myplanet.repository.RetryRepository
+import org.ole.planet.myplanet.utils.DispatcherProvider
+import org.ole.planet.myplanet.utils.MainDispatcherRule
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val dispatcherProvider = object : DispatcherProvider {
+        override val main = testDispatcher
+        override val mainImmediate = testDispatcher
+        override val io = testDispatcher
+        override val default = testDispatcher
+        override val unconfined = testDispatcher
+    }
+
+    private val configurationsRepository: ConfigurationsRepository = mockk(relaxed = true)
+    private val retryRepository: RetryRepository = mockk(relaxed = true)
+    private val resourcesRepository: ResourcesRepository = mockk(relaxed = true)
+
+    @Test
+    fun `clearAllData calls clearAllData and clearPreferences on configurationsRepository and emits clearDataEvent`() = runTest {
+        coEvery { configurationsRepository.clearAllData() } just runs
+        every { configurationsRepository.clearPreferences() } just runs
+
+        val viewModel = SettingsViewModel(
+            configurationsRepository,
+            retryRepository,
+            resourcesRepository,
+            dispatcherProvider
+        )
+
+        viewModel.clearAllData()
+        advanceUntilIdle()
+
+        val event = viewModel.clearDataEvent.first()
+        assertNotNull(event)
+
+        coVerify { configurationsRepository.clearAllData() }
+        verify { configurationsRepository.clearPreferences() }
+    }
+}


### PR DESCRIPTION
Routed community/parent-code config reads and clearPreferences through ConfigurationsRepository instead of accessing SharedPrefManager directly across UI components.

Fixes #16326

---
*PR created automatically by Jules for task [18126929720452606005](https://jules.google.com/task/18126929720452606005) started by @dogi*