### PR TITLE
test: smoother leaders view model loading (fixes #16380)

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/ui/community/LeadersViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/community/LeadersViewModelTest.kt
@@ -1,0 +1,74 @@
+package org.ole.planet.myplanet.ui.community
+
+import android.app.Application
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.services.SharedPrefManager
+import org.ole.planet.myplanet.utils.MainDispatcherRule
+import org.ole.planet.myplanet.utils.TestDispatcherProvider
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class LeadersViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
+    private val sharedPrefManager: SharedPrefManager = mockk(relaxed = true)
+
+    @Test
+    fun `loadLeaders sets an empty list when community leaders string is empty`() = runTest(testDispatcher) {
+        every { sharedPrefManager.getCommunityLeaders() } returns ""
+
+        val viewModel = LeadersViewModel(sharedPrefManager, TestDispatcherProvider(testDispatcher))
+        advanceUntilIdle()
+
+        val leaders = viewModel.leaders.value
+        assertEquals(0, leaders?.size)
+        assertTrue(leaders != null && leaders.isEmpty())
+    }
+
+    @Test
+    fun `loadLeaders parses leaders json into user entities when the string is non-empty`() = runTest(testDispatcher) {
+        val leadersJson = """
+            {
+              "docs": [
+                {
+                  "_id": "user123",
+                  "name": "john_doe",
+                  "firstName": "John",
+                  "lastName": "Doe",
+                  "email": "john@example.com"
+                }
+              ]
+            }
+        """.trimIndent()
+        every { sharedPrefManager.getCommunityLeaders() } returns leadersJson
+
+        val viewModel = LeadersViewModel(sharedPrefManager, TestDispatcherProvider(testDispatcher))
+        advanceUntilIdle()
+
+        val leaders = viewModel.leaders.value
+        assertEquals(1, leaders?.size)
+        val leader = leaders!!.first()
+        assertEquals("user123", leader.id)
+        assertEquals("john_doe", leader.name)
+        assertEquals("John", leader.firstName)
+        assertEquals("Doe", leader.lastName)
+        assertEquals("john@example.com", leader.email)
+    }
+}


### PR DESCRIPTION
## Summary

Adds the missing `LeadersViewModel` unit test. `LeadersViewModel.loadLeaders` runs in `init` and is the entire data source for the Leaders screen, yet it had no test coverage. This covers both of its branches.

## Changes

- **(new)** `app/src/test/java/org/ole/planet/myplanet/ui/community/LeadersViewModelTest.kt`

Two Robolectric tests (Robolectric is required because `UserEntity.parseLeadersJson` parses via `org.json`):

1. **empty-list branch** — when `SharedPrefManager.getCommunityLeaders()` returns `""`, `leaders` resolves to an empty list.
2. **parseLeadersJson branch** — when the leaders string is non-empty, `leaders` is parsed into `UserEntity` instances with the expected `id`/`name`/`firstName`/`lastName`/`email`.

Mirrors existing conventions:
- `MainDispatcherRule` + `TestDispatcherProvider` (`StandardTestDispatcher`) with `runTest(testDispatcher)` + `advanceUntilIdle()` to drive the coroutine launched in `init`, as in `NotificationsViewModelTest` / `UserProfileViewModelTest`.
- `@RunWith(RobolectricTestRunner::class)` + `@Config(application = Application::class)` (a plain `Application`, like `MeetupTest` / `EventsAdapterTest`) so Robolectric does not instantiate `MainApplication`, whose deferred init calls `SecurePrefs.warmUp()` and fails on Robolectric's absent `AndroidKeyStore`.
- The leaders JSON shape matches `UserEntityParseLeadersTest`.

## Verification

```
./gradlew testDefaultDebugUnitTest --tests "org.ole.planet.myplanet.ui.community.LeadersViewModelTest"
```

```
> Task :app:testDefaultDebugUnitTest
BUILD SUCCESSFUL
```

Result: `tests=2 failures=0 errors=0 skipped=0`.

Fixes #16380.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8099f736-a7ef-4c86-b2fc-dfbcfd30787f)