### PR TITLE
community : smoother tab pager adapting (fixes #16308)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6763
-        versionName = "0.67.63"
+        versionCode = 6764
+        versionName = "0.67.64"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityPagerAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityPagerAdapter.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.ui.community
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.ui.enterprises.EnterprisesFinancesFragment
@@ -10,7 +9,7 @@ import org.ole.planet.myplanet.ui.enterprises.EnterprisesReportsFragment
 import org.ole.planet.myplanet.ui.teams.TeamCalendarFragment
 import org.ole.planet.myplanet.ui.voices.VoicesFragment
 
-class CommunityPagerAdapter(private val fm: FragmentActivity, private val id: String, private var fromLogin: Boolean, private val planetType: String?) : FragmentStateAdapter(fm) {
+class CommunityPagerAdapter(private val hostFragment: Fragment, private val id: String, private var fromLogin: Boolean, private val planetType: String?) : FragmentStateAdapter(hostFragment) {
     override fun createFragment(position: Int): Fragment {
         val fragment: Fragment = when (position) {
             0 -> {
@@ -46,17 +45,17 @@ class CommunityPagerAdapter(private val fm: FragmentActivity, private val id: St
 
     fun getPageTitle(position: Int): CharSequence {
         val leaders = if (planetType == "community") {
-            fm.getString(R.string.community_leaders)
+            hostFragment.getString(R.string.community_leaders)
         } else {
-            fm.getString(R.string.nation_leaders)
+            hostFragment.getString(R.string.nation_leaders)
         }
         return when (position) {
-            0 -> fm.getString(R.string.our_voices)
+            0 -> hostFragment.getString(R.string.our_voices)
             1 -> leaders
-            2 -> fm.getString(R.string.calendar)
-            3 -> if (!fromLogin) fm.getString(R.string.services) else ""
-            4 -> if (!fromLogin) fm.getString(R.string.finances) else ""
-            5 -> if (!fromLogin) fm.getString(R.string.reports) else ""
+            2 -> hostFragment.getString(R.string.calendar)
+            3 -> if (!fromLogin) hostFragment.getString(R.string.services) else ""
+            4 -> if (!fromLogin) hostFragment.getString(R.string.finances) else ""
+            5 -> if (!fromLogin) hostFragment.getString(R.string.reports) else ""
             else -> ""
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/CommunityTabFragment.kt
@@ -29,7 +29,7 @@ class CommunityTabFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         viewLifecycleOwner.lifecycleScope.launch {
             val state = viewModel.state.filterNotNull().first()
-            binding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), "${state.planetCode}@${state.parentCode}", false, state.planetType)
+            binding.viewPager2.adapter = CommunityPagerAdapter(this@CommunityTabFragment, "${state.planetCode}@${state.parentCode}", false, state.planetType)
             TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->
                 tab.text = (binding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
             }.attach()

--- a/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/community/HomeCommunityDialogFragment.kt
@@ -96,7 +96,7 @@ class HomeCommunityDialogFragment : BottomSheetDialogFragment() {
         val sParentcode = sharedPrefManager.getParentCode()
         val communityName = sharedPrefManager.getCommunityName()
         val planetType = configurationsRepository.getPlanetType()
-        binding.viewPager2.adapter = CommunityPagerAdapter(requireActivity(), "$communityName@$sParentcode", true, planetType)
+        binding.viewPager2.adapter = CommunityPagerAdapter(this, "$communityName@$sParentcode", true, planetType)
         tabLayoutMediator = TabLayoutMediator(binding.tabLayout, binding.viewPager2) { tab, position ->
             tab.text = (binding.viewPager2.adapter as CommunityPagerAdapter).getPageTitle(position)
         }


### PR DESCRIPTION
fixes #16308
Pass the host Fragment instead of FragmentActivity to CommunityPagerAdapter's FragmentStateAdapter, ensuring child fragments follow the host fragment's lifecycle.
[Screen_recording_20260827_162827.webm](https://github.com/user-attachments/assets/3ddf7269-827c-4f1b-8e70-56260c915396)
