### PR TITLE
dashboard: smoother bell sync status refreshing (fixes #16272)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6765
-        versionName = "0.67.65"
+        versionCode = 6766
+        versionName = "0.67.66"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/BellDashboardFragment.kt
@@ -13,7 +13,9 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
@@ -47,6 +49,7 @@ class BellDashboardFragment : BaseDashboardFragment() {
     private var _binding: FragmentHomeBellBinding? = null
     private val binding get() = _binding!!
     private var networkStatusJob: Job? = null
+    private var lastSyncStatusJob: Job? = null
     private val viewModel: BellDashboardViewModel by viewModels()
     var user: UserEntity? = null
     private var surveyListDialog: AlertDialog? = null
@@ -67,6 +70,7 @@ class BellDashboardFragment : BaseDashboardFragment() {
         super.onViewCreated(view, savedInstanceState)
         initView(view)
         setupNetworkStatusMonitoring()
+        startLastSyncStatusTicker()
         (activity as DashboardActivity?)?.supportActionBar?.hide()
         observeCompletedCourses()
         observeSurveyReminders()
@@ -371,6 +375,18 @@ class BellDashboardFragment : BaseDashboardFragment() {
         railSyncStatus.text = getString(R.string.dashboard_sync_status, timeText)
     }
 
+    private fun startLastSyncStatusTicker() {
+        lastSyncStatusJob?.cancel()
+        lastSyncStatusJob = viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                while (true) {
+                    delay(LAST_SYNC_STATUS_REFRESH_INTERVAL_MS)
+                    updateRailSyncStatus()
+                }
+            }
+        }
+    }
+
     private fun openHelperFragment(f: Fragment) {
         val b = Bundle()
         b.putBoolean("isMyCourseLib", true)
@@ -398,6 +414,7 @@ class BellDashboardFragment : BaseDashboardFragment() {
         surveyListDialog?.dismiss()
         surveyListDialog = null
         networkStatusJob?.cancel()
+        lastSyncStatusJob?.cancel()
         super.onDestroyView()
         _binding = null
     }
@@ -421,5 +438,9 @@ class BellDashboardFragment : BaseDashboardFragment() {
         } else {
             super.handleClick(id, title, f, v)
         }
+    }
+
+    companion object {
+        private const val LAST_SYNC_STATUS_REFRESH_INTERVAL_MS = 60_000L
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/dashboard/DashboardActivity.kt
@@ -31,7 +31,9 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.navigation.NavigationBarView
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
@@ -158,6 +160,7 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
         if (isFirstLaunch) handleInitialFragment()
         addBackPressCallback()
         collectUiState()
+        startLastSyncStatusTicker()
 
         lifecycleScope.launch {
             user = userSessionManager.getUserModel()
@@ -598,6 +601,17 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
             TimeUtils.getRelativeTime(lastSyncMillis, timeProvider)
         }
         binding.dashboardLastSyncStatus.text = getString(R.string.dashboard_sync_status, timeText)
+    }
+
+    private fun startLastSyncStatusTicker() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                while (true) {
+                    delay(LAST_SYNC_STATUS_REFRESH_INTERVAL_MS)
+                    updateLastSyncStatus()
+                }
+            }
+        }
     }
 
     private fun onRealmDataChange() {
@@ -1124,5 +1138,6 @@ class DashboardActivity : DashboardElementActivity(), OnHomeItemClickListener, N
     companion object {
         const val MESSAGE_PROGRESS = "message_progress"
         var isFromNotificationAction = false
+        private const val LAST_SYNC_STATUS_REFRESH_INTERVAL_MS = 60_000L
     }
 }


### PR DESCRIPTION
fixes #16272 
Adds a 60-second ticker to BellDashboardFragment and DashboardActivity that updates the relative sync timestamp display while the UI is resumed.
[sync time update.webm](https://github.com/user-attachments/assets/6af6229c-020f-4f42-a1ea-8e6d447f0645)
