### PR TITLE
sync: smoother importing (fixes #16563)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6766
-        versionName = "0.67.66"
+        versionCode = 6767
+        versionName = "0.67.67"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -32,6 +32,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Date
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
@@ -74,7 +75,6 @@ import org.ole.planet.myplanet.utils.TimeUtils
 import org.ole.planet.myplanet.utils.UrlUtils
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
-import kotlin.time.Duration.Companion.milliseconds
 
 @AndroidEntryPoint
 abstract class SyncActivity : ProcessUserDataActivity(), ConfigurationsRepository.CheckVersionCallback {


### PR DESCRIPTION
## Summary

Ran the kotlin-importing skill across the source tree (`app/src/main/java` and `app/src/test/java`). The cleanup sorted imports and removed unused ones where safe to do so.

## Changes

- **`SyncActivity.kt`** — moved the out-of-order `kotlin.time.Duration.Companion.milliseconds` import into its correct alphabetical position among the other `kotlin.*` imports. Pure import-sort fix; no functional change.

## Notes

- No unused imports were removed anywhere (the only candidate — a wildcard `org.junit.Assert.*` in `UserDaoTest.kt` — is actively used via `assertEquals`/`assertTrue`/`assertNotNull`, so it was kept).
- No wildcard imports were reported elsewhere.

## Testing

No functional changes; existing CI build and unit tests should pass unchanged.

_This PR was created by an AI agent (OpenHands) on behalf of the maintainer._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/66e68b2d-02c4-4070-a28a-7bd9b51996b8)