### PR TITLE
all: smoother utilities hex mapping (fixes #16547)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6884
-        versionName = "0.68.84"
+        versionCode = 6885
+        versionName = "0.68.85"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/utils/Utilities.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/Utilities.kt
@@ -85,7 +85,7 @@ object Utilities {
     }
 
     fun toHex(arg: String?): String {
-        return arg?.toByteArray()?.let { String.format("%x", BigInteger(1, it)) } ?: ""
+        return arg?.toByteArray()?.let { BigInteger(1, it).toString(16) } ?: ""
     }
 
     fun normalizeText(str: String): String {

--- a/app/src/test/java/org/ole/planet/myplanet/utils/UtilitiesTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/UtilitiesTest.kt
@@ -69,4 +69,11 @@ class UtilitiesTest {
         verify(exactly = 1) { mockToast.show() }
         verify(exactly = 1) { anyConstructed<Handler>().post(any()) }
     }
+
+    @Test
+    fun `toHex returns hex representation for valid strings and empty string for null`() {
+        org.junit.Assert.assertEquals("68656c6c6f", Utilities.toHex("hello"))
+        org.junit.Assert.assertEquals("0", Utilities.toHex(""))
+        org.junit.Assert.assertEquals("", Utilities.toHex(null))
+    }
 }


### PR DESCRIPTION
Replaced String.format("%x", BigInteger(1, it)) with BigInteger(1, it).toString(16) in Utilities.toHex to avoid Formatter overhead. Added unit tests for Utilities.toHex.

Fixes #16547

---
*PR created automatically by Jules for task [16132280190545842137](https://jules.google.com/task/16132280190545842137) started by @dogi*