### PR TITLE
feedback: smoother pending query documenting no count variant (fixes #16580)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/FeedbackDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/FeedbackDao.kt
@@ -17,9 +17,9 @@ interface FeedbackDao {
     @Query("SELECT * FROM feedback WHERE owner IS :owner ORDER BY openTime DESC")
     fun getByOwnerFlow(owner: String?): Flow<List<Feedback>>
 
-    // No count variant by design: the only caller (UploadCoordinator via
-    // FeedbackRepository.getPendingFeedback) needs the full rows to serialize and upload each
-    // one, so a COUNT(*) here would be dead API.
+    // No count variant by design: consumers (UploadCoordinator via
+    // FeedbackRepository.getPendingFeedback) serialize and upload each returned row, so they
+    // need the full list — a COUNT(*) here would be dead API.
     @Query("SELECT * FROM feedback WHERE isUploaded = 0")
     suspend fun getPending(): List<Feedback>
 

--- a/app/src/main/java/org/ole/planet/myplanet/data/room/dao/FeedbackDao.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/dao/FeedbackDao.kt
@@ -17,6 +17,9 @@ interface FeedbackDao {
     @Query("SELECT * FROM feedback WHERE owner IS :owner ORDER BY openTime DESC")
     fun getByOwnerFlow(owner: String?): Flow<List<Feedback>>
 
+    // No count variant by design: the only caller (UploadCoordinator via
+    // FeedbackRepository.getPendingFeedback) needs the full rows to serialize and upload each
+    // one, so a COUNT(*) here would be dead API.
     @Query("SELECT * FROM feedback WHERE isUploaded = 0")
     suspend fun getPending(): List<Feedback>
 


### PR DESCRIPTION
fixes #16580

## Summary

Investigated whether `FeedbackDao` and `RetryDao` need a count variant of their `getPending()` queries, per the issue's two load-bearing caveats. Conclusion: **no count queries are added** — adding them would be dead API, exactly the outcome the issue anticipates and instructs ("close this without adding an unused query rather than adding dead API").

## Investigation

### FeedbackDao.getPending() — no count-only caller (caveat 1)

The sole production call chain:

```
FeedbackDao.getPending()
  -> FeedbackRepositoryImpl.getPendingFeedback()
    -> UploadConfigs.kt:201  fetchPendingItems = { feedbackRepository.getPendingFeedback() }
      -> UploadCoordinator.queryItemsToUpload() / queryItemsToUploadRoom()
```

`UploadCoordinator` invokes `fetchPendingItems` to get the **full list** of pending feedback rows, then `mapNotNull { ... }` each row into a `PreparedUpload` to serialize and HTTP-upload it. The only size-like use is `itemsToUpload.isEmpty()` (an early-return guard), performed **after** loading rows the coordinator needs anyway. No caller only needs a `.size`, so a `COUNT(*)` would never replace the row fetch — it would be unused. Per caveat 1, no count variant is added.

A short KDoc is added on `FeedbackDao.getPending()` recording this deliberate omission so the same non-issue isn't reopened by a future contributor/agent.

### RetryDao — left untouched (caveat 2)

- `RetryDao.getPending(now)` is consumed by `RetryQueueWorker.doWork()`, which `chunked(BATCH_SIZE).forEach { processOperation(...) }` — it iterates and processes every returned op. It needs the full list; a count would not replace it.
- `RetryDao` **already** has `getActiveCount()` (`COUNT(*) WHERE status='pending' OR status='in_progress'`), which backs the one genuine count need: the Settings retry-queue snapshot (`getRetryQueueSnapshot` → `SettingsActivity`, where the count drives the "...and N more" line and button enable state). So the real count need is already satisfied.
- Per caveat 2, no retry surface is re-added: #16337 ("Drop the dead retry-queue API surface") is actively **removing** retry API. Adding a new `RetryDao` count query now would collide with that in-flight removal.

## Changes

- `data/room/dao/FeedbackDao.kt`: added a 3-line KDoc on `getPending()` documenting why no count variant exists.

No behavior change; no test needed (documentation-only, per the contribution guidelines).

## Why not add the queries

| DAO | Genuine count-only caller? | Action |
|-----|----------------------------|--------|
| FeedbackDao | No — only caller needs full rows to upload | None (documented) |
| RetryDao | Already served by existing `getActiveCount()`; `getPending` callers need rows | None (collides with #16337) |

This PR was created by an AI agent (OpenHands) on behalf of the repository maintainers.

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/05b697da-84a3-4862-a536-d929775f3499)