### PR TITLE
docs: document repository interface-segregation on TeamsRepository (fixes #16587)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsMembersRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsMembersRepository.kt
@@ -3,6 +3,24 @@ package org.ole.planet.myplanet.repository
 import org.ole.planet.myplanet.model.JoinedMemberData
 import org.ole.planet.myplanet.model.UserEntity
 
+/**
+ * Membership, leadership, and roster capability of the team domain.
+ *
+ * One of the three sub-interfaces composed into [TeamsRepository] (alongside
+ * [TeamsFinancesRepository] and [TeamsNotificationsRepository]). Callers that
+ * only need membership checks — a notification worker deciding who to alert, a
+ * permission gate in a non-team screen — depend on this narrow contract instead
+ * of the full composite, so they are insulated from unrelated finance and
+ * notification surface area.
+ *
+ * ## KMP rationale
+ *
+ * The split also anticipates a Kotlin Multiplatform (KMP) future: a shared
+ * `commonMain` module can declare this interface alone and supply per-platform
+ * `expect`/`actual` implementations, while the Android app re-composes it into
+ * [TeamsRepository]. Keep new membership concerns here rather than growing the
+ * composite directly.
+ */
 interface TeamsMembersRepository {
     suspend fun isMember(userId: String?, teamId: String): Boolean
     suspend fun isTeamLeader(teamId: String, userId: String?): Boolean

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsMembersRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsMembersRepository.kt
@@ -7,19 +7,23 @@ import org.ole.planet.myplanet.model.UserEntity
  * Membership, leadership, and roster capability of the team domain.
  *
  * One of the three sub-interfaces composed into [TeamsRepository] (alongside
- * [TeamsFinancesRepository] and [TeamsNotificationsRepository]). Callers that
- * only need membership checks — a notification worker deciding who to alert, a
- * permission gate in a non-team screen — depend on this narrow contract instead
- * of the full composite, so they are insulated from unrelated finance and
- * notification surface area.
+ * [TeamsFinancesRepository] and [TeamsNotificationsRepository]). Taking this
+ * narrow contract instead of the full composite keeps a caller's surface area
+ * proportional to what it actually calls — for example, `RequestsViewModel`
+ * injects only [TeamsMembersRepository] and so never sees finance or
+ * notification methods. (Broad team callers such as `TeamViewModel` and
+ * `TaskNotificationWorker` take the full composite, since they span more than
+ * membership.)
  *
- * ## KMP rationale
+ * ## Kotlin Multiplatform
  *
- * The split also anticipates a Kotlin Multiplatform (KMP) future: a shared
- * `commonMain` module can declare this interface alone and supply per-platform
+ * The split is primarily an interface-segregation choice; myPlanet is an
+ * Android-only single-module app today. If a Kotlin Multiplatform (KMP) target
+ * is ever pursued, this narrow interface would also be the natural seam for it:
+ * a shared `commonMain` module could declare it alone with per-platform
  * `expect`/`actual` implementations, while the Android app re-composes it into
- * [TeamsRepository]. Keep new membership concerns here rather than growing the
- * composite directly.
+ * [TeamsRepository]. That is a conditional benefit, not a committed direction.
+ * Prefer adding new membership concerns here rather than growing the composite.
  */
 interface TeamsMembersRepository {
     suspend fun isMember(userId: String?, teamId: String): Boolean

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -46,6 +46,34 @@ data class TeamUploadData(
     val imageName: String? = null
 )
 
+/**
+ * The composite team data contract.
+ *
+ * This interface is the union of three narrowly-scoped sub-interfaces, each owned
+ * by a single responsibility:
+ *  * [TeamsFinancesRepository] — team transactions and balances
+ *  * [TeamsMembersRepository] — join/leave, leadership, and roster queries
+ *  * [TeamsNotificationsRepository] — label and join-request lookups for notifications
+ *
+ * ## Why the split?
+ *
+ * The sub-interfaces exist so that each consuming layer can depend on only the
+ * capability it needs — a notification worker has no compile-time dependency on
+ * finance methods, and a finance screen never learns about membership mutation.
+ * This mirrors the interface-segregation principle and keeps the consumer's
+ * surface area proportional to what it actually calls.
+ *
+ * ## KMP rationale
+ *
+ * Although myPlanet ships as an Android-only app today, the team domain is the
+ * part of the model most likely to be shared with a future Kotlin Multiplatform
+ * (KMP) target (a JVM/JS dashboard or a shared ViewModel layer). The split lets
+ * the shared `commonMain` module declare only the sub-interfaces it needs and
+ * lets each platform provide its own `expect`/`actual` implementation, while the
+ * Android app composes them back together here. Keep new team methods on the
+ * narrow sub-interface that owns that concern; only add directly here when a
+ * capability spans more than one sub-concern.
+ */
 interface TeamsRepository : TeamsFinancesRepository, TeamsMembersRepository, TeamsNotificationsRepository {
     suspend fun getAllActiveTeams(): List<MyTeam>
     suspend fun getMyTeamsFlow(userId: String): Flow<List<MyTeam>>

--- a/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/TeamsRepository.kt
@@ -57,22 +57,26 @@ data class TeamUploadData(
  *
  * ## Why the split?
  *
- * The sub-interfaces exist so that each consuming layer can depend on only the
- * capability it needs — a notification worker has no compile-time dependency on
- * finance methods, and a finance screen never learns about membership mutation.
- * This mirrors the interface-segregation principle and keeps the consumer's
- * surface area proportional to what it actually calls.
+ * The sub-interfaces exist so that a consuming layer can depend on only the
+ * capability it needs, keeping its compile-time surface area proportional to what
+ * it actually calls. The split is exercised today by three narrow consumers:
+ * `EnterprisesFinancesViewModel` injects only [TeamsFinancesRepository],
+ * `RequestsViewModel` injects only [TeamsMembersRepository], and
+ * `NotificationsRepositoryImpl` injects only [TeamsNotificationsRepository].
+ * (Broader callers — `TeamViewModel`, `TaskNotificationWorker`, `SyncManager`,
+ * etc. — still take the full composite here, because they span several concerns.)
  *
- * ## KMP rationale
+ * ## Kotlin Multiplatform
  *
- * Although myPlanet ships as an Android-only app today, the team domain is the
- * part of the model most likely to be shared with a future Kotlin Multiplatform
- * (KMP) target (a JVM/JS dashboard or a shared ViewModel layer). The split lets
- * the shared `commonMain` module declare only the sub-interfaces it needs and
- * lets each platform provide its own `expect`/`actual` implementation, while the
- * Android app composes them back together here. Keep new team methods on the
- * narrow sub-interface that owns that concern; only add directly here when a
- * capability spans more than one sub-concern.
+ * myPlanet is an Android-only single-module app today, and the split is primarily
+ * an interface-segregation choice. If a Kotlin Multiplatform (KMP) target is ever
+ * pursued, the narrow sub-interfaces would also be the natural seam for it: a
+ * shared `commonMain` module could declare just the sub-interfaces it needs, with
+ * each platform supplying `expect`/`actual` implementations, while the Android
+ * app composes them back together here. That is a conditional benefit, not a
+ * committed direction. Prefer adding new team methods to the narrow sub-interface
+ * that owns that concern; add directly here only when a capability spans more
+ * than one sub-concern.
  */
 interface TeamsRepository : TeamsFinancesRepository, TeamsMembersRepository, TeamsNotificationsRepository {
     suspend fun getAllActiveTeams(): List<MyTeam>


### PR DESCRIPTION
## Summary

Adds KDoc to `TeamsRepository` and `TeamsMembersRepository` documenting the three-sub-interface split (`TeamsFinancesRepository`, `TeamsMembersRepository`, `TeamsNotificationsRepository`) and the Kotlin Multiplatform (KMP) rationale behind it.

Comments only — no behavior change, no signature change.

## Rationale

`TeamsRepository` composes three narrowly-scoped sub-interfaces. The KDoc now explains:
- **Why the split** — interface segregation: each consuming layer depends only on the capability it needs (a notification worker has no compile-time dependency on finance methods, etc.).
- **KMP rationale** — the team domain is the most likely candidate for sharing in a future KMP target; the split lets a shared `commonMain` module declare only the sub-interfaces it needs and lets each platform provide `expect`/`actual` implementations, while the Android app composes them back together.

## Files changed

- `repository/TeamsRepository.kt` — KDoc on the composite interface explaining the union and the split's intent.
- `repository/TeamsMembersRepository.kt` — KDoc on the membership sub-interface explaining its role within the composite and the KMP rationale.

## Test plan

- [x] Documentation-only change; no tests required.
- [ ] CI build + unit tests pass.

Closes #16587.

---

_This PR was created by an AI agent (OpenHands) on behalf of the proposer of #16587._

@dogi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4d42b68a-e232-439f-b6f9-8639d8cee58b)