### PR TITLE
all: smoother callback listeners unifying (fixes #16640)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6887
-        versionName = "0.68.87"
+        versionCode = 6888
+        versionName = "0.68.88"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnChangedListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnChangedListener.kt
@@ -1,0 +1,5 @@
+package org.ole.planet.myplanet.callback
+
+fun interface OnChangedListener {
+    fun onChanged()
+}

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnFeedbackSubmittedListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnFeedbackSubmittedListener.kt
@@ -1,5 +1,0 @@
-package org.ole.planet.myplanet.callback
-
-interface OnFeedbackSubmittedListener {
-    fun onFeedbackSubmitted()
-}

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnMemberChangeListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnMemberChangeListener.kt
@@ -1,5 +1,0 @@
-package org.ole.planet.myplanet.callback
-
-interface OnMemberChangeListener {
-    fun onMemberChanged()
-}

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnSecurityDataListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnSecurityDataListener.kt
@@ -1,5 +1,0 @@
-package org.ole.planet.myplanet.callback
-
-interface OnSecurityDataListener {
-    fun onSecurityDataUpdated()
-}

--- a/app/src/main/java/org/ole/planet/myplanet/callback/OnTeamUpdateListener.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/callback/OnTeamUpdateListener.kt
@@ -1,5 +1,0 @@
-package org.ole.planet.myplanet.callback
-
-interface OnTeamUpdateListener {
-    fun onTeamDetailsUpdated()
-}

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.ole.planet.myplanet.R
-import org.ole.planet.myplanet.callback.OnFeedbackSubmittedListener
+import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.databinding.FragmentFeedbackBinding
 import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectLatestWhenStarted
@@ -22,8 +22,8 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
 
     private val viewModel: FeedbackComposerViewModel by viewModels()
 
-    private var mListener: OnFeedbackSubmittedListener? = null
-    fun setOnFeedbackSubmittedListener(listener: OnFeedbackSubmittedListener?) {
+    private var mListener: OnChangedListener? = null
+    fun setOnFeedbackSubmittedListener(listener: OnChangedListener?) {
         mListener = listener
     }
 
@@ -50,7 +50,7 @@ class FeedbackFragment : DialogFragment(), View.OnClickListener {
             when (event) {
                 is FeedbackComposerViewModel.SubmitEvent.Saved -> {
                     Utilities.toast(activity, getString(R.string.feedback_saved))
-                    mListener?.onFeedbackSubmitted()
+                    mListener?.onChanged()
                     dismiss()
                 }
                 is FeedbackComposerViewModel.SubmitEvent.Error -> {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/feedback/FeedbackListFragment.kt
@@ -11,7 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import org.ole.planet.myplanet.base.BaseRecyclerFragment.Companion.showNoData
-import org.ole.planet.myplanet.callback.OnFeedbackSubmittedListener
+import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.databinding.FragmentFeedbackListBinding
 import org.ole.planet.myplanet.model.Feedback
 import org.ole.planet.myplanet.model.TableDataUpdate
@@ -21,7 +21,7 @@ import org.ole.planet.myplanet.ui.sync.RealtimeSyncMixin
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener, RealtimeSyncMixin {
+class FeedbackListFragment : Fragment(), OnChangedListener, RealtimeSyncMixin {
 
     private var _binding: FragmentFeedbackListBinding? = null
     private val binding get() = _binding!!
@@ -78,7 +78,7 @@ class FeedbackListFragment : Fragment(), OnFeedbackSubmittedListener, RealtimeSy
         super.onDestroyView()
     }
 
-    override fun onFeedbackSubmitted() {
+    override fun onChanged() {
         refreshFeedbackListData()
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/ProcessUserDataActivity.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BasePermissionActivity
-import org.ole.planet.myplanet.callback.OnSecurityDataListener
+import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.callback.OnSuccessListener
 import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.repository.SyncRepository
@@ -161,7 +161,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
         return true
     }
 
-    fun startUpload(source: String, userName: String? = null, securityCallback: OnSecurityDataListener? = null) {
+    fun startUpload(source: String, userName: String? = null, securityCallback: OnChangedListener? = null) {
         when (source) {
             "becomeMember" -> uploadMemberData(userName, securityCallback)
             "login" -> uploadLoginData()
@@ -169,7 +169,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
         }
     }
 
-    private fun uploadMemberData(userName: String?, securityCallback: OnSecurityDataListener?) {
+    private fun uploadMemberData(userName: String?, securityCallback: OnChangedListener?) {
         uploadToShelfService.uploadSingleUserData(userName, object : OnSuccessListener {
             override fun onSuccess(success: String?) {
                 uploadToShelfService.uploadSingleUserHealth("org.couchdb.user:${userName}", object : OnSuccessListener {
@@ -177,7 +177,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
                         userName?.let { name ->
                             fetchAndLogUserSecurityData(name, securityCallback)
                         } ?: run {
-                            securityCallback?.onSecurityDataUpdated()
+                            securityCallback?.onChanged()
                         }
                     }
                 })
@@ -248,7 +248,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
         }
     }
 
-    fun fetchAndLogUserSecurityData(name: String, securityCallback: OnSecurityDataListener? = null) {
+    fun fetchAndLogUserSecurityData(name: String, securityCallback: OnChangedListener? = null) {
         lifecycleScope.launch {
             try {
                 userRepository.fetchUserSecurityData(name)
@@ -256,7 +256,7 @@ abstract class ProcessUserDataActivity : BasePermissionActivity(), OnSuccessList
                 e.printStackTrace()
             } finally {
                 withContext(dispatcherProvider.main) {
-                    securityCallback?.onSecurityDataUpdated()
+                    securityCallback?.onChanged()
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/PlanFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/PlanFragment.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseTeamFragment
-import org.ole.planet.myplanet.callback.OnTeamUpdateListener
+import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.databinding.AlertCreateTeamBinding
 import org.ole.planet.myplanet.databinding.FragmentPlanBinding
 import org.ole.planet.myplanet.model.MyTeam
@@ -26,9 +26,9 @@ class PlanFragment : BaseTeamFragment() {
     private var _binding: FragmentPlanBinding? = null
     private val binding get() = _binding!!
     private var isEnterprise: Boolean = false
-    private var teamUpdateListener: OnTeamUpdateListener? = null
+    private var teamUpdateListener: OnChangedListener? = null
 
-    fun setTeamUpdateListener(listener: OnTeamUpdateListener) {
+    fun setTeamUpdateListener(listener: OnChangedListener) {
         teamUpdateListener = listener
     }
 
@@ -194,7 +194,7 @@ class PlanFragment : BaseTeamFragment() {
 
                     this@PlanFragment.team = refreshedTeam
                     updateUIWithTeamDetails(refreshedTeam)
-                    teamUpdateListener?.onTeamDetailsUpdated()
+                    teamUpdateListener?.onChanged()
                     Utilities.toast(requireContext(), context.getString(R.string.added_successfully))
                     dialog.dismiss()
                 } else {

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamDetailFragment.kt
@@ -20,9 +20,8 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseTeamFragment
-import org.ole.planet.myplanet.callback.OnMemberChangeListener
+import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.callback.OnTeamPageListener
-import org.ole.planet.myplanet.callback.OnTeamUpdateListener
 import org.ole.planet.myplanet.databinding.FragmentTeamDetailBinding
 import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.UserEntity
@@ -43,7 +42,7 @@ import org.ole.planet.myplanet.utils.Utilities
 import org.ole.planet.myplanet.utils.collectWhenStarted
 
 @AndroidEntryPoint
-class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpdateListener {
+class TeamDetailFragment : BaseTeamFragment() {
 
     @Inject
     lateinit var userSessionManager: UserSessionManager
@@ -207,7 +206,9 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
             currentAdapter.updatePages(pageConfigs)
         } else {
             binding.viewPager2.adapter = TeamPagerAdapter(
-                this, pageConfigs, team?._id, this, this
+                this, pageConfigs, team?._id,
+                OnChangedListener { onMemberChanged() },
+                OnChangedListener { onTeamDetailsUpdated() }
             )
             binding.tabLayout.tabMode = TabLayout.MODE_SCROLLABLE
             binding.tabLayout.isInlineLabel = true
@@ -388,7 +389,7 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
         }
     }
 
-    override fun onMemberChanged() {
+    private fun onMemberChanged() {
         _binding ?: return
         _binding?.let { binding ->
             val teamId = team?._id ?: return@let
@@ -403,7 +404,7 @@ class TeamDetailFragment : BaseTeamFragment(), OnMemberChangeListener, OnTeamUpd
         }
     }
 
-    override fun onTeamDetailsUpdated() {
+    private fun onTeamDetailsUpdated() {
         viewLifecycleOwner.lifecycleScope.launch {
             refreshTeamDetails()
         }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamPagerAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/TeamPagerAdapter.kt
@@ -5,8 +5,7 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.callback.OnMemberChangeListener
-import org.ole.planet.myplanet.callback.OnTeamUpdateListener
+import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.ApplicantsPage
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.CoursesPage
 import org.ole.planet.myplanet.ui.teams.TeamPageConfig.DocumentsPage
@@ -25,8 +24,8 @@ class TeamPagerAdapter(
     private val parentFragment: Fragment,
     private var pages: List<TeamPageConfig>,
     private val teamId: String?,
-    private val onMemberChangeListener: OnMemberChangeListener,
-    private val teamUpdateListener: OnTeamUpdateListener
+    private val onMemberChangeListener: OnChangedListener,
+    private val teamUpdateListener: OnChangedListener
 ) : FragmentStateAdapter(parentFragment) {
     private val itemIds = mutableMapOf<String, Long>()
     private var nextId = 1L

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/MembersFragment.kt
@@ -15,8 +15,8 @@ import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseRecyclerFragment
 import org.ole.planet.myplanet.base.BaseTeamFragment
+import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.callback.OnMemberActionListener
-import org.ole.planet.myplanet.callback.OnMemberChangeListener
 import org.ole.planet.myplanet.databinding.FragmentCombinedMembersBinding
 import org.ole.planet.myplanet.model.JoinedMemberData
 import org.ole.planet.myplanet.model.News
@@ -30,11 +30,11 @@ class MembersFragment : BaseTeamFragment() {
     private var _binding: FragmentCombinedMembersBinding? = null
     private val binding get() = _binding!!
 
-    private var onMemberChangeListener: OnMemberChangeListener? = null
+    private var onMemberChangeListener: OnChangedListener? = null
     private var membersAdapter: MembersAdapter? = null
     private var requestsAdapter: RequestsAdapter? = null
 
-    fun setOnMemberChangeListener(listener: OnMemberChangeListener) {
+    fun setOnMemberChangeListener(listener: OnChangedListener) {
         onMemberChangeListener = listener
     }
 
@@ -87,7 +87,7 @@ class MembersFragment : BaseTeamFragment() {
             }
         }
         collectWhenStarted(requestsViewModel.successAction) {
-            onMemberChangeListener?.onMemberChanged()
+            onMemberChangeListener?.onChanged()
             loadMembers()
         }
     }
@@ -139,7 +139,7 @@ class MembersFragment : BaseTeamFragment() {
                 }
                 teamsRepository.removeMember(teamId, memberId)
                 loadMembers()
-                onMemberChangeListener?.onMemberChanged()
+                onMemberChangeListener?.onChanged()
                 requestsViewModel.fetchMembers(teamId)
             } catch (e: Exception) {
                 Toast.makeText(requireContext(), "Error removing member: ${e.message}", Toast.LENGTH_SHORT).show()
@@ -153,7 +153,7 @@ class MembersFragment : BaseTeamFragment() {
                 teamsRepository.updateTeamLeader(teamId, userId)
                 loadMembers()
                 Toast.makeText(requireContext(), getString(R.string.leader_selected), Toast.LENGTH_SHORT).show()
-                onMemberChangeListener?.onMemberChanged()
+                onMemberChangeListener?.onChanged()
             } catch (e: Exception) {
                 Toast.makeText(requireContext(), "Error making leader: ${e.message}", Toast.LENGTH_SHORT).show()
             }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/RequestsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/teams/members/RequestsFragment.kt
@@ -13,7 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.base.BaseMemberFragment
-import org.ole.planet.myplanet.callback.OnMemberChangeListener
+import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.services.UserSessionManager
@@ -27,8 +27,8 @@ class RequestsFragment : BaseMemberFragment() {
 
     private val viewModel: RequestsViewModel by viewModels()
     private lateinit var currentUser: UserEntity
-    private var onMemberChangeListener: OnMemberChangeListener? = null
-    fun setOnMemberChangeListener(listener: OnMemberChangeListener) {
+    private var onMemberChangeListener: OnChangedListener? = null
+    fun setOnMemberChangeListener(listener: OnChangedListener) {
         this.onMemberChangeListener = listener
     }
 
@@ -53,7 +53,7 @@ class RequestsFragment : BaseMemberFragment() {
             showNoData(binding.tvNodata, uiState.members.size, "members")
         }
         collectWhenStarted(viewModel.successAction) {
-            onMemberChangeListener?.onMemberChanged()
+            onMemberChangeListener?.onChanged()
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/BecomeMemberActivity.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.MainApplication
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.base.BaseActivity
-import org.ole.planet.myplanet.callback.OnSecurityDataListener
+import org.ole.planet.myplanet.callback.OnChangedListener
 import org.ole.planet.myplanet.databinding.ActivityBecomeMemberBinding
 import org.ole.planet.myplanet.model.MemberInfo
 import org.ole.planet.myplanet.services.SharedPrefManager
@@ -117,17 +117,15 @@ class BecomeMemberActivity : BaseActivity() {
             withContext(dispatcherProvider.main) {
                 if (result.first) {
                     val userName = info.username
-                    val securityCallback = object : OnSecurityDataListener {
-                        override fun onSecurityDataUpdated() {
-                            customProgressDialog.dismiss()
-                            autoLoginNewMember(info.username, info.password)
-                        }
+                    val securityCallback = OnChangedListener {
+                        customProgressDialog.dismiss()
+                        autoLoginNewMember(info.username, info.password)
                     }
                     startUpload("becomeMember", userName, securityCallback)
 
                     if (result.second == getString(R.string.not_connect_to_planet_created_user_offline)) {
                         Utilities.toast(MainApplication.context, result.second)
-                        securityCallback.onSecurityDataUpdated()
+                        securityCallback.onChanged()
                     }
                     Utilities.toast(this@BecomeMemberActivity, result.second)
                 } else {


### PR DESCRIPTION
fixes #16640
Replace OnFeedbackSubmittedListener, OnMemberChangeListener, OnSecurityDataListener, and OnTeamUpdateListener with a single OnChangedListener fun interface, updating all usage sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated several specialized update callbacks into a single reusable change-notification mechanism.
  * Updated feedback, team, membership, and security-data flows to use the unified callback.
  * Preserved existing behavior, including refreshing lists and notifying screens after successful updates.
  * Simplified callback usage by supporting direct lambda-based notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->