### PR TITLE
courses: filter stays active (fixes #16271)

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/data/room/AppDatabase.kt
@@ -125,7 +125,7 @@ import org.ole.planet.myplanet.model.UserEntity
         Answer::class,
         MyTeam::class,
     ],
-    version = 9,
+    version = 10,
     exportSchema = false,
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseFilterController.kt
@@ -91,6 +91,48 @@ class CourseFilterController(
         onScrollToTop()
     }
 
+    fun restoreFilterState(state: FilterState, tags: List<TagEntity> = emptyList()) {
+        if (::etSearch.isInitialized && etSearch.text.toString() != state.searchText) {
+            etSearch.setText(state.searchText)
+        }
+        if (::spnGrade.isInitialized) {
+            val gradeAdapter = spnGrade.adapter
+            if (gradeAdapter != null) {
+                var found = false
+                for (i in 0 until gradeAdapter.count) {
+                    if (gradeAdapter.getItem(i).toString() == state.grade || (state.grade.isEmpty() && i == 0)) {
+                        spnGrade.setSelection(i)
+                        found = true
+                        break
+                    }
+                }
+            }
+        }
+        if (::spnSubject.isInitialized) {
+            val subjectAdapter = spnSubject.adapter
+            if (subjectAdapter != null) {
+                for (i in 0 until subjectAdapter.count) {
+                    if (subjectAdapter.getItem(i).toString() == state.subject || (state.subject.isEmpty() && i == 0)) {
+                        spnSubject.setSelection(i)
+                        break
+                    }
+                }
+            }
+        }
+        searchTags.clear()
+        val seenNames = HashSet<String?>()
+        tags.forEach { tag ->
+            if (seenNames.add(tag.name)) {
+                searchTags.add(tag)
+            }
+        }
+        progressFilter = state.progressFilter
+        if (::tvSelected.isInitialized) {
+            refreshTagText()
+        }
+        _filterState.value = currentState()
+    }
+
     private fun setupSearchWatcher() {
         searchTextWatcher = object : TextWatcher {
             @Suppress("EmptyMethod")

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesFragment.kt
@@ -222,12 +222,17 @@ class CoursesFragment : BaseRecyclerFragment<MyCourse?>(), OnCourseItemSelectedL
         )
         filterController.setup()
 
-        var lastState: FilterState? = null
+        val savedFilter = viewModel.currentFilterState
+        if (savedFilter.isActive) {
+            filterController.restoreFilterState(savedFilter)
+        }
+
+        var lastState: FilterState? = savedFilter.takeIf { it.isActive }
         var isFirstEmission = true
         collectLatestWhenStarted(filterController.filterState) { state ->
             if (isFirstEmission) {
                 isFirstEmission = false
-                if (!state.isActive) {
+                if (savedFilter.isActive || !state.isActive) {
                     lastState = state
                     return@collectLatestWhenStarted
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CoursesViewModel.kt
@@ -41,6 +41,9 @@ class CoursesViewModel @Inject constructor(
     private var activeSort: SortType? = null
     private var sortJob: Job? = null
 
+    var currentFilterState: FilterState = FilterState("", "", "", emptyList())
+        private set
+
     enum class SortType { TITLE, DATE }
 
     fun toggleTitleSort() {
@@ -129,7 +132,16 @@ class CoursesViewModel @Inject constructor(
                     val tagsMap = coursesRepository.getCourseTagsBulk(allCourseIds)
                         .mapValues { entry -> entry.value.map { it.toTag() } }
 
-                    processCourses(isMyCourseLib, userId, validCourses, myCourses, progressMap, tagsMap)
+                    if (currentFilterState.isActive) {
+                        filterCoursesInternal(
+                            isMyCourseLib, userId, currentFilterState.searchText,
+                            currentFilterState.grade, currentFilterState.subject,
+                            currentFilterState.tagNames, currentFilterState.progressFilter,
+                            allCourses, progressMap, tagsMap
+                        )
+                    } else {
+                        processCourses(isMyCourseLib, userId, validCourses, myCourses, progressMap, tagsMap)
+                    }
                 } catch (e: Exception) {
                     e.printStackTrace()
                     null
@@ -150,6 +162,7 @@ class CoursesViewModel @Inject constructor(
         tagNames: List<String>,
         progressFilter: String = ""
     ) {
+        currentFilterState = FilterState(searchText, selectedGrade, selectedSubject, tagNames, progressFilter)
         viewModelScope.launch {
             val newState = withContext(dispatcherProvider.io) {
                 val filteredCourses = coursesRepository.filterCourses(searchText, selectedGrade, selectedSubject, tagNames)
@@ -157,34 +170,54 @@ class CoursesViewModel @Inject constructor(
                 val progressMap = _coursesState.value.progressMap
                 val tagsMap = _coursesState.value.tagsMap
 
-                val baseCourses = if (isMyCourseLib) myCourses else filteredCourses
-
-                val progressFilteredCourses = if (progressFilter.isEmpty() || progressMap == null) {
-                    baseCourses
-                } else {
-                    baseCourses.filter { course ->
-                        val courseKey = course.courseId.takeIf { !it.isNullOrBlank() }
-                            ?: course.id.takeIf { !it.isNullOrBlank() }
-                            ?: course._id
-                        val p = progressMap[courseKey] ?: progressMap[course.courseId] ?: progressMap[course.id]
-                        val current = p?.current ?: 0
-                        val max = p?.max?.takeIf { it > 0 } ?: course.getNumberOfSteps()
-                        when (progressFilter) {
-                            "Not Started" -> current == 0
-                            "In Progress" -> current > 0 && (max == 0 || current < max)
-                            "Completed"   -> max > 0 && current >= max
-                            else -> true
-                        }
-                    }
-                }
-
-                if (isMyCourseLib) {
-                    processCourses(isMyCourseLib, userId, filteredCourses, progressFilteredCourses, progressMap, tagsMap)
-                } else {
-                    processCourses(isMyCourseLib, userId, progressFilteredCourses, myCourses, progressMap, tagsMap)
-                }
+                filterCoursesInternal(
+                    isMyCourseLib, userId, searchText, selectedGrade, selectedSubject,
+                    tagNames, progressFilter, null, progressMap, tagsMap
+                )
             }
             _coursesState.value = newState
+        }
+    }
+
+    private suspend fun filterCoursesInternal(
+        isMyCourseLib: Boolean,
+        userId: String?,
+        searchText: String,
+        selectedGrade: String,
+        selectedSubject: String,
+        tagNames: List<String>,
+        progressFilter: String,
+        cachedAllCourses: List<MyCourse>?,
+        progressMap: Map<String, CourseProgressState>?,
+        tagsMap: Map<String, List<Tag>>
+    ): CoursesUiState {
+        val filteredCourses = coursesRepository.filterCourses(searchText, selectedGrade, selectedSubject, tagNames)
+        val myCourses = coursesRepository.getMyCourses(userId, filteredCourses)
+
+        val baseCourses = if (isMyCourseLib) myCourses else filteredCourses
+        val progressFilteredCourses = if (progressFilter.isEmpty() || progressMap == null) {
+            baseCourses
+        } else {
+            baseCourses.filter { course ->
+                val courseKey = course.courseId.takeIf { !it.isNullOrBlank() }
+                    ?: course.id.takeIf { !it.isNullOrBlank() }
+                    ?: course._id
+                val p = progressMap[courseKey] ?: progressMap[course.courseId] ?: progressMap[course.id]
+                val current = p?.current ?: 0
+                val max = p?.max?.takeIf { it > 0 } ?: course.getNumberOfSteps()
+                when (progressFilter) {
+                    "Not Started" -> current == 0
+                    "In Progress" -> current > 0 && (max == 0 || current < max)
+                    "Completed"   -> max > 0 && current >= max
+                    else -> true
+                }
+            }
+        }
+
+         return if (isMyCourseLib) {
+            processCourses(isMyCourseLib, userId, filteredCourses, progressFilteredCourses, progressMap, tagsMap)
+        } else {
+            processCourses(isMyCourseLib, userId, progressFilteredCourses, myCourses, progressMap, tagsMap)
         }
     }
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/75b81a64-f367-438f-8c68-8f2ba3affe53



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Course filters now persist and are automatically restored when returning to the Courses screen.
  * Previously selected search text, grade, subject, tags, and progress filters remain applied after course data reloads.
* **Bug Fixes**
  * Prevented restored filter settings from being cleared or triggering duplicate filtering when the Courses screen initializes.
  * Added a database schema revision to support reliable data resynchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->