### PR TITLE
all: smoother importing (fixes #15711)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6918
-        versionName = "0.69.18"
+        versionCode = 6919
+        versionName = "0.69.19"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/model/HealthRecord.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/model/HealthRecord.kt
@@ -1,8 +1,5 @@
 package org.ole.planet.myplanet.model
 
-import org.ole.planet.myplanet.model.HealthExamination
-import org.ole.planet.myplanet.model.MyHealth
-import org.ole.planet.myplanet.model.UserEntity
 
 data class HealthRecord(
     val healthPojo: HealthExamination,

--- a/app/src/main/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImpl.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/repository/DiagnosticsRepositoryImpl.kt
@@ -7,7 +7,6 @@ import javax.inject.Inject
 import org.ole.planet.myplanet.data.room.dao.ApkLogDao
 import org.ole.planet.myplanet.model.ApkLog
 import org.ole.planet.myplanet.model.UserEntity
-import org.ole.planet.myplanet.repository.UserRepository
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.CrashLogStore
 import org.ole.planet.myplanet.utils.VersionUtils

--- a/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/DownloadService.kt
@@ -42,10 +42,7 @@ import org.ole.planet.myplanet.model.Download
 import org.ole.planet.myplanet.model.DownloadResult
 import org.ole.planet.myplanet.repository.DownloadRepository
 import org.ole.planet.myplanet.repository.ResourcesRepository
-import org.ole.planet.myplanet.services.DownloadWorker
-import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
-import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.DownloadUtils
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.FileUtils.availableExternalMemorySize

--- a/app/src/main/java/org/ole/planet/myplanet/services/SubmissionsUploader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/services/SubmissionsUploader.kt
@@ -8,9 +8,6 @@ import javax.inject.Singleton
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withTimeoutOrNull
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.services.SharedPrefManager
-import org.ole.planet.myplanet.services.SubmissionUploadExecutor
-import org.ole.planet.myplanet.services.UploadManager
 import org.ole.planet.myplanet.services.sync.ServerUrlMapper
 
 @Singleton

--- a/app/src/main/java/org/ole/planet/myplanet/ui/components/MarkdownDialogFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/components/MarkdownDialogFragment.kt
@@ -18,7 +18,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnHomeItemClickListener
 import org.ole.planet.myplanet.databinding.DialogCampaignChallengeBinding
 import org.ole.planet.myplanet.ui.community.CommunityTabFragment
-import org.ole.planet.myplanet.ui.components.CustomClickableSpan
 import org.ole.planet.myplanet.ui.courses.TakeCourseFragment
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
 import org.ole.planet.myplanet.ui.dashboard.DashboardElementActivity

--- a/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/courses/CourseStepFragment.kt
@@ -10,7 +10,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.withResumed
 import androidx.lifecycle.withStarted

--- a/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/sync/SyncActivity.kt
@@ -32,8 +32,8 @@ import com.afollestad.materialdialogs.MaterialDialog
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Date
 import javax.inject.Inject
-import kotlinx.coroutines.FlowPreview
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn

--- a/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/user/EditAchievementFragment.kt
@@ -6,8 +6,8 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.OpenableColumns
-import android.view.ContextThemeWrapper
 import android.text.TextUtils
+import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
@@ -35,8 +35,6 @@ import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.ole.planet.myplanet.services.VoicesLabelManager
 import org.ole.planet.myplanet.ui.components.FragmentNavigator
-import org.ole.planet.myplanet.ui.voices.VoicesActions
-import org.ole.planet.myplanet.ui.voices.VoicesViewModel
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.FileUtils.getFileNameFromUrl

--- a/app/src/main/java/org/ole/planet/myplanet/utils/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/FileUtils.kt
@@ -26,7 +26,6 @@ import java.nio.charset.StandardCharsets
 import java.util.Locale
 import java.util.UUID
 import kotlin.math.roundToLong
-import org.ole.planet.myplanet.utils.TimeProvider
 
 object FileUtils {
     private const val TAG = "FileUtils"

--- a/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/NetworkUtils.kt
@@ -9,7 +9,6 @@ import android.net.NetworkCapabilities
 import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
 import android.os.Build
-import android.provider.Settings
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import dagger.hilt.android.EntryPointAccessors

--- a/app/src/main/java/org/ole/planet/myplanet/utils/NotificationUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/NotificationUtils.kt
@@ -19,7 +19,6 @@ import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.di.CoreDependenciesEntryPoint
 import org.ole.planet.myplanet.services.NotificationActionReceiver
 import org.ole.planet.myplanet.ui.dashboard.DashboardActivity
-import org.ole.planet.myplanet.utils.TimeProvider
 
 data class NotificationConfig(
     val id: String,

--- a/app/src/test/java/org/ole/planet/myplanet/MainApplicationTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/MainApplicationTest.kt
@@ -2,20 +2,20 @@ package org.ole.planet.myplanet
 
 import android.content.Context
 import android.net.TrafficStats
+import com.sun.net.httpserver.HttpServer
 import dagger.hilt.android.EntryPointAccessors
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.net.InetSocketAddress
+import java.util.Collections
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import com.sun.net.httpserver.HttpServer
-import java.net.InetSocketAddress
-import java.util.Collections
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/app/src/test/java/org/ole/planet/myplanet/data/room/dao/UserDaoTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/data/room/dao/UserDaoTest.kt
@@ -5,7 +5,9 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/org/ole/planet/myplanet/model/MyCourseTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/MyCourseTest.kt
@@ -1,7 +1,6 @@
 package org.ole.planet.myplanet.model
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 class MyCourseTest {

--- a/app/src/test/java/org/ole/planet/myplanet/model/StepExamTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/StepExamTest.kt
@@ -12,8 +12,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.ole.planet.myplanet.model.ExamQuestion
-import org.ole.planet.myplanet.model.StepExam
 
 class StepExamTest {
 

--- a/app/src/test/java/org/ole/planet/myplanet/model/UserEntityEncodeImageTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/UserEntityEncodeImageTest.kt
@@ -20,7 +20,6 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.model.UserEntity
 
 class UserEntityEncodeImageTest {
 

--- a/app/src/test/java/org/ole/planet/myplanet/model/UserEntityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/model/UserEntityTest.kt
@@ -18,7 +18,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.MainApplication
-import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.utils.Utilities
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/CoursesRepositoryImplTest.kt
@@ -15,8 +15,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -36,7 +34,6 @@ import org.ole.planet.myplanet.data.room.dao.TagDao
 import org.ole.planet.myplanet.model.CourseStep
 import org.ole.planet.myplanet.model.MyCourse
 import org.ole.planet.myplanet.model.SearchActivity
-import org.ole.planet.myplanet.repository.RatingSummary
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.Utilities
 

--- a/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryLibrarySyncTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/ResourcesRepositoryLibrarySyncTest.kt
@@ -16,10 +16,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.data.room.AppDatabase
 import org.ole.planet.myplanet.data.room.dao.MyLibraryDao
-import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.data.room.dao.RemovedLogDao
 import org.ole.planet.myplanet.data.room.dao.ResourceActivityDao
 import org.ole.planet.myplanet.data.room.dao.SearchActivityDao
+import org.ole.planet.myplanet.model.MyLibrary
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.services.UserSessionManager
 import org.robolectric.RobolectricTestRunner

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamChatBadgeIntegrationTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamChatBadgeIntegrationTest.kt
@@ -13,13 +13,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import org.ole.planet.myplanet.data.room.AppDatabase
-import org.ole.planet.myplanet.di.PlainGson
 import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.services.SharedPrefManager
 import org.ole.planet.myplanet.utils.TestDispatcherProvider
 import org.ole.planet.myplanet.utils.TestTimeProvider
+import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class TeamChatBadgeIntegrationTest {

--- a/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/repository/TeamsRepositoryImplTest.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test

--- a/app/src/test/java/org/ole/planet/myplanet/services/DownloadServiceOnDownloadCompleteTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/services/DownloadServiceOnDownloadCompleteTest.kt
@@ -16,8 +16,6 @@ import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
-import java.lang.reflect.Field
-import javax.inject.Provider
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/test/java/org/ole/planet/myplanet/ui/community/LeadersViewModelTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/community/LeadersViewModelTest.kt
@@ -1,20 +1,14 @@
 package org.ole.planet.myplanet.ui.community
 
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/org/ole/planet/myplanet/ui/components/FragmentNavigatorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/components/FragmentNavigatorTest.kt
@@ -5,7 +5,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivityNavigationTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/dashboard/DashboardElementActivityNavigationTest.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.ui.dashboard
 
 import android.os.Bundle
 import android.widget.FrameLayout
-import androidx.fragment.app.Fragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.testing.HiltAndroidRule

--- a/app/src/test/java/org/ole/planet/myplanet/ui/sync/ServerAddressAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/sync/ServerAddressAdapterTest.kt
@@ -3,16 +3,15 @@ package org.ole.planet.myplanet.ui.sync
 import android.app.Application
 import android.content.Context
 import android.widget.LinearLayout
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.ole.planet.myplanet.model.ServerAddress
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.ole.planet.myplanet.model.ServerAddress
 
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class, sdk = [34])

--- a/app/src/test/java/org/ole/planet/myplanet/ui/teams/members/MembersAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/teams/members/MembersAdapterTest.kt
@@ -5,6 +5,8 @@ import android.widget.FrameLayout
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.mockk
+import java.util.Locale
+import java.util.TimeZone
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -14,9 +16,6 @@ import org.ole.planet.myplanet.callback.OnMemberActionListener
 import org.ole.planet.myplanet.model.JoinedMemberData
 import org.ole.planet.myplanet.model.UserEntity
 import org.ole.planet.myplanet.ui.teams.members.MembersAdapter.Companion.PAYLOAD_KEY_LOGGED_IN_USER_LEADER_CHANGED
-import org.ole.planet.myplanet.utils.TimeUtils
-import java.util.Locale
-import java.util.TimeZone
 
 @RunWith(AndroidJUnit4::class)
 class MembersAdapterTest {

--- a/app/src/test/java/org/ole/planet/myplanet/ui/voices/VoicesActionsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/ui/voices/VoicesActionsTest.kt
@@ -2,7 +2,6 @@ package org.ole.planet.myplanet.ui.voices
 
 import android.app.Application
 import android.content.Context
-import android.widget.LinearLayout
 import androidx.test.core.app.ApplicationProvider
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -15,7 +14,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.R
 import org.ole.planet.myplanet.callback.OnNewsItemClickListener
-import org.ole.planet.myplanet.model.News
 import org.ole.planet.myplanet.repository.ActivitiesRepository
 import org.ole.planet.myplanet.repository.VoicesEditActions
 import org.robolectric.RobolectricTestRunner


### PR DESCRIPTION
## Summary
This PR removes unused imports throughout the codebase to improve code cleanliness and maintainability. No functional changes are made.

## Key Changes
- **Wildcard import**: expanded the last star import in the tree — `org.junit.Assert.*` in `UserDaoTest.kt` — to the three symbols it uses, so no Kotlin source uses a wildcard import
- **Test files**: Removed unused imports from test classes including mockk utilities (`just`, `runs`, `mockkObject`, `unmockkObject`), JUnit annotations (`@Before`, `@After`), and unused model/utility imports
- **Main source files**: Removed redundant or unused imports from:
  - `HealthRecord.kt` — removed duplicate model imports
  - `DownloadService.kt` — removed unused service and utility imports
  - `SubmissionsUploader.kt` — removed unused service imports
  - `DiagnosticsRepositoryImpl.kt` — removed unused repository import
  - `MarkdownDialogFragment.kt` — removed unused component import
  - `CourseStepFragment.kt` — removed unused `Lifecycle` import
  - `FileUtils.kt` — removed unused `TimeProvider` import
  - `NetworkUtils.kt` — removed unused `Settings` import
  - `NotificationUtils.kt` — removed unused `TimeProvider` import
  - `ReplyActivity.kt` — removed duplicate voice-related imports
  - `EditAchievementFragment.kt` — reordered imports alphabetically
  - `SyncActivity.kt` — reordered imports alphabetically
- **Import organization**: Standardized import ordering to follow Kotlin conventions (stdlib, then third-party, then project imports) in several files

## Implementation Details
- All changes are import-only; no code logic or behavior is modified
- Imports were identified as unused by IDE analysis and removed
- Some files had duplicate imports (e.g., `assertNotNull`, `assertEquals`) which were deduplicated
- Import ordering was corrected to match project conventions where applicable

https://claude.ai/code/session_01GyAXPpzw2AVuvEGQ44p9Zc

Fixes #15711