### PR TITLE
Phase 106 (Lane B): exam/survey answer choice shape parity

### DIFF
--- a/flutter/PHASE_106_NOTES.md
+++ b/flutter/PHASE_106_NOTES.md
@@ -1,0 +1,3 @@
+# Phase 106 — the exam path sends choice ids where Kotlin sends choice objects
+
+Work in progress.

--- a/flutter/PHASE_106_NOTES.md
+++ b/flutter/PHASE_106_NOTES.md
@@ -1,3 +1,297 @@
-# Phase 106 — the exam path sends choice ids where Kotlin sends choice objects
+# Phase 106 — the exam path sent choice ids where Kotlin sends choice objects
 
-Work in progress.
+The two gaps Phase 104 logged and deliberately left, plus three defects found
+closing them — one of which would have silently defeated the whole change.
+Each demonstrated failing on the pre-fix code before it was touched.
+
+## 1. What Kotlin actually writes
+
+`ExamTakingFragment` is the **single** Kotlin writer for both exams and
+surveys — `saveExamAnswer`'s `type` only picks the grading, the verdict fields
+and the status, and nothing in `ExamTakingFragment`/`BaseExamFragment` branches
+the answer shape on it. (Grepping `Answer(` construction in `app/` returns two
+sites: `saveExamAnswer` and the sync-in.) So the shape is one thing, and
+`SubmissionsRepositoryImpl.kt:517-541` says what it is:
+
+| question type | `value` | `valueChoices` |
+|---|---|---|
+| `select` | `ansForCheck` — the choice's **display text** via `getChoiceTextById`, whose fallback is `map[id] ?: id` | `[{"id":"<ans>","text":"<ansForCheck>"}]`, or `[]` when nothing is picked |
+| `selectMultiple` | `""` — the **empty string** | one `{"id":"<id>","text":"<text>"}` per `listAns` entry |
+| anything else | the typed text | `null` |
+
+The two halves are not independent. `Answer.createObject` sends `value`
+whenever it is **non-empty** and only falls back to `valueChoicesArray` when it
+is not, so what reaches Planet is: a bare **string** for `select` and for
+text/rating, an **array of objects** for `selectMultiple`, and `[]` for an
+unanswered `select` or an unanswered text question. `valueChoicesArray` is
+never reached for a `select` that has a selection — `ans.isNotEmpty()` gates
+`valueChoices`, and `ansForCheck` is then non-empty either way, so the pair
+(empty `value`, objects present) is unreachable for that type. Kotlin's own
+sync-in (`:707-724`) confirms the round trip: a JSON-array `value` becomes
+`valueChoices`, a primitive becomes `value`.
+
+### What the port did
+
+- **`createExamDraft` stored the bare choice ids** (`valueChoices: ['c1']`) and
+  left `value` null.
+- **`createSurveyDraft`/`updateSurveyAnswers`** stored the objects correctly —
+  Phase 104 fixed that half — but took `value` from the screen, which has no
+  text field on a choice question and so hands over `''`. Kotlin derives it
+  from the question.
+- **`serialize` had the precedence the other way round**: `valueChoices`
+  first, `value` only as the fallback. So even with the write shape aligned, a
+  `select` answer would have uploaded `[{id,text}]` where Kotlin uploads
+  `"Water"`.
+- Three different `value` conventions were in play for one question type:
+  `null` (exam), `''` (`take_survey_screen`), and `null` again from
+  `public_survey_screen`'s select branch.
+
+### The fix
+
+A single `AnswerShape.forQuestion({type, choices, selected, text})` in
+`submissions_repository.dart` — the port of that Kotlin branch, living where
+Kotlin has it (the repository) rather than being re-derived per screen. All
+three question-bound writers go through it:
+
+- `createExamDraft` hands it the choice **ids** the screen records (that is
+  what a radio/checkbox holds and what grading compares against) and it
+  resolves each label from the question, the way `getChoiceTextById` does.
+- `createSurveyDraft`/`updateSurveyAnswers` hand it the stored entries
+  decoded back to `ExamChoice`, and it re-resolves them the same way.
+- `serialize`'s precedence is flipped to value-first, with the condition
+  `isNotEmpty` rather than `!= null` — `!value.isNullOrEmpty()` is what
+  `createObject` tests, so an unanswered row uploads `[]` and not `""`/`null`.
+
+`SubmissionDraftAnswer.choices` therefore becomes an *input* that gets
+re-resolved rather than a value stored verbatim, which is what let
+`public_survey_screen.dart` (owned by another lane this round) stay untouched:
+whatever convention a caller uses for `value`, the repository now normalises it.
+
+`converters.dart` grew the three pieces this needs: `ExamChoice.encode()` (the
+stored entry), `ExamChoice.decode()` (the single reader for one, hoisted out of
+`take_survey_screen`'s private duplicate) and `ExamChoice.textById()` (the port
+of `getChoiceTextById`).
+
+### `_answerChoices`' non-JSON tolerance is gone
+
+It existed only to let the exam path's bare ids past, and Phase 104 asked for
+its removal once the paths agreed. Every entry is now a choice object — both
+write paths go through `AnswerShape`, and the sync-in stores JSON (see §3) —
+so the branch is dead.
+
+It is **not** left to throw the way `gson.fromJson(choice, JsonObject::class
+.java)` does, and that is deliberate: `submission_answers` is in
+`localAuthorityTables`, so a bare-id row an earlier build wrote survives every
+schema bump, and `SubmissionsUploader.queuePending` serializes every pending
+row in one unguarded loop — one such row would block the entire queue for
+good. `ExamChoice.decode` resolves a bare entry to `{id: raw, text: raw}`,
+which is exactly what Kotlin's own unresolvable-id fallback produces
+(`getChoiceTextById` returns `map[id] ?: id`, so `saveExamAnswer` writes the id
+as the text too). Nothing is invented and nothing is silently dropped.
+
+## 2. The detail screen's correctness check
+
+`submission_detail_screen`'s `_AnswerTile` lowercased `[value, ...valueChoices]`
+and required every `correctChoices` entry to be present. `correctChoices` holds
+choice **ids**; a stored entry is the whole `{id, text}` object. So the check
+could only ever match the exam path while it stored bare ids, and matched
+nothing at all once both paths stored objects. It now reduces each entry to its
+id via `ExamChoice.decode` before comparing.
+
+The comment says why it is not a port. Kotlin's `getSubmissionDetail` computes
+`isCorrect = question.getCorrectChoice()?.contains(answer.value) == true`, but
+`QuestionAnswerAdapter.bind` never reads the field and
+`item_question_answer.xml` has no view for it — **the Kotlin detail screen
+shows no correctness indicator at all**, so the icon is the port's own and
+there is no Kotlin rendering to be faithful to. Its comparison is not available
+to copy either: it pits the display text against a list of ids for `select`,
+and `answer.value` is the empty string for `selectMultiple`. (It is not
+literally never-true — a scalar `correctChoice` with `res`-labelled choices
+makes it accidentally right, and a scalar `correctChoice` with `{id,text}`
+choices makes it accidentally true for *any* `selectMultiple` selection,
+because both sides are `""`. Two narrow document shapes, and the output is
+discarded regardless.) Comparing ids is what `ExamGrading` does and follows
+the precedent `ExamMapper._parseCorrectChoices` already set and documented.
+`isPassed` stays the first signal: it is the verdict Kotlin actually computes
+and uploads.
+
+## 3. The defect that would have defeated all of it
+
+`SubmissionsRepository._answerFromJson` — the **sync-in** — did
+`rawValue.map((value) => value.toString())`. Kotlin's counterpart is
+`valueElement.asJsonArray.map { it.toString() }`, and Gson's
+`JsonElement.toString()` emits **JSON**. Dart's `Map.toString()` emits
+`{id: paris, text: Paris}`, which is not JSON.
+
+So every choice answer that came down from the server was cached in a form
+nothing downstream could read back: the re-upload sent that literal as a
+quoted **string** where Planet expects the object, the detail screen and the
+PDF export printed it verbatim, and the id could not be recovered. And after
+this phase it would have been the *only* remaining source of non-decodable
+entries — the new id-based correctness check would have ticked every locally
+authored answer and missed every synced one, which is the sort of split that
+survives a whole test suite. Found by the parity audit, not by me.
+
+A bare-string element is stored **unquoted**, where Gson keeps its quotes.
+That is a deliberate divergence: Kotlin's own `valueChoicesArray` then throws
+casting the `JsonPrimitive` to a `JsonObject`, so the unquoted form is the
+better of two bad options (`SubmissionsRepositoryImplTest` pins that row's
+list size only, so the throw is unnoticed upstream).
+
+## 4. `ExamChoice.fromJson` read `text` alone
+
+An exam document may label a choice with `res` rather than `text` — that is
+why `ExamQuestion.insertCorrectChoice`'s single-id branch reads `res` at all.
+Reading `text` alone gave those choices a blank label *and*, once
+`AnswerShape` derives `value` from the choice, a blank stored value.
+
+`fromJson` now reads `text` first with `res` as the fallback, which is
+`ExamAnswerUtils.choiceDisplayValue` — the function that produces `value` —
+and the rule `SubmissionsRepository._questionFromJson` already used for the
+cached display labels (Phase 104). It diverges from `addCompoundButton`, which
+reads `text` alone and so genuinely draws such a button blank; the two Kotlin
+functions disagree with each other and the port keeps one display rule, the
+same call Phase 104 made.
+
+## Failing-first evidence
+
+Ten new tests, each run against the pre-fix `lib/`:
+
+| test | pre-fix result |
+|---|---|
+| `exam_flow` a select answer is stored as the choice object, not its id | `Actual: ['c1']`, `value` null |
+| `exam_flow` a selectMultiple answer stores objects and an empty value | `Actual: ['c1', 'c2']` |
+| `exam_flow` an unknown choice id falls back to the id as its text | `Actual: ['ghost']` |
+| `exam_flow` a select answer uploads its display text, as Kotlin does | `Actual: ['c1']` — an array where Kotlin sends `'Paris'` |
+| `submissions_repository` a survey select answer carries the choice text as its value | `Actual: ''` |
+| `submissions_repository` a synced choice answer is cached as JSON, not as a Dart map | `Actual: ['{id: paris, text: Paris}']` |
+| `submissions_screen` a choice answer is marked correct by its choice id | `Found 0 widgets with icon "IconData(U+0E159)"` |
+| `converters` reads the label out of `res` when there is no `text` | `ExamChoice(id: 'power', text: '')` |
+| `submissions_repository` a choice pick survives a question with no type | `Actual: []` — the pick discarded (see below) |
+| `submissions_repository` a survey selectMultiple answer uploads objects | passed pre-fix — kept as the regression pin for the half Phase 104 fixed |
+| `submissions_repository` serializes a bare entry as an object, not as a bare id | rewritten from `serializes a bare choice id untouched`, which asserted the removed tolerance |
+
+Three existing assertions were updated to the new shape:
+`exam_flow`'s `records each answer with its verdict` and
+`take_exam_screen`'s partial-multi-select case (both `['c1']` →
+`['{"id":"c1","text":"Paris"}']` / `['{"id":"c1","text":"Red"}']`), and the
+tolerance test above.
+
+### A regression this change nearly introduced
+
+Reviewing the diff turned up one case where routing the survey path through
+`AnswerShape` *lost* data the old code kept: a question that offers choices but
+names **no type**. `take_survey_screen`'s card renders a radio group off
+`choices.isNotEmpty` and reads the type only to pick checkboxes over radios, so
+such a question really does get answered — and the plain-text branch (what
+`saveExamAnswer` does for an unrecognised type) would have written `[]` over
+the pick. It went from stored-and-uploaded to silently discarded, which is the
+exact class of bug this phase exists to close.
+
+`AnswerShape` therefore treats a question with choices and a selection as a
+single-choice question regardless of type. Kotlin needs no such clause and has
+none: `ExamTakingFragment.startExam`'s `when` renders **no input at all** for
+an unrecognised type, so the answer cannot exist there. The clause can never
+fire for the exam path either — `take_exam_screen._buildAnswerInput` defaults a
+type-less question to a text field, so it never produces a selection. It is
+scoped to exactly the screen whose renderer is more permissive than Kotlin's.
+
+One knock-on tidy, recorded because it is a behaviour change with no
+reachable symptom: `take_survey_screen._loadExistingAnswers` seeded the text
+controller from `answer.value` for *every* question, and a `select` answer's
+`value` is now the picked choice's label. It now seeds only a question that
+offers no choices. Nothing observable changes today — a radio group cannot be
+cleared, so `_submit`'s answered-everything guard cannot be fooled by the
+leftover text, and a `selectMultiple` answer's `value` is empty — so it is a
+guard against a later regression rather than a defect, and there is no test
+for it because the case is unobservable from outside the widget.
+
+## Divergences found and deliberately left
+
+All four came out of the parity audit, and none is an answer-*shape* question,
+which is why they are reported rather than folded in. They are the integrator's
+to allocate.
+
+- **`mistakes` is never written by the port** (column default 0), where Kotlin
+  accumulates `(existing?.mistakes ?: 0) + 1` per wrong attempt and **uploads
+  it**. This cannot be ported on its own: `mistakes` is only ever non-zero
+  because a Kotlin exam **refuses to advance past a wrong answer**
+  (`updateAnsDb` returns the verdict and both `btnNext` and `btnSubmit` bail
+  with the `incorrect_ans` snackbar), so the learner retries until right —
+  which is also why every answer in a finished Kotlin submission has
+  `isPassed = true`. The port grades once and computes a percentage. Porting
+  the field without the gate would upload a permanent 0; porting the gate is a
+  different exam model and its own slice.
+- **Per-answer `grade`.** Kotlin sets `grade = 1` for *every* exam answer,
+  right or wrong — a "worth one mark" marker, not a score. The port sets
+  `isCorrect ? 1 : 0`. Not uploaded, and the port's tile renders it as a badge,
+  where Kotlin's adapter renders nothing; adopting Kotlin's value would make
+  the badge meaningless. Left, with the same model caveat as `mistakes`.
+- **Submission status.** `saveExamAnswer` sets `"complete"` only for a survey
+  and `"requires grading"` for an exam's final answer; `createExamDraft` writes
+  `'complete'`, and `requires grading` appears nowhere in `flutter/lib`. That
+  is the status a teacher's grading queue on Planet selects on, so this one is
+  consequential — but it changes what the submissions screen filters show and
+  wants its own audit.
+- **`correctChoices` is populated for non-select questions.**
+  `ExamQuestion.insertExamQuestions` calls `insertCorrectChoice` only when
+  `type?.startsWith("select") == true && question.has("choices")`;
+  `exam_mapper.dart` calls `_parseCorrectChoices` for every question. So
+  `{"type":"input","body":"2+2","correctChoice":"4"}` is gradeable in the port
+  and ungradeable in Kotlin. Replicating the gate would make
+  `ExamGrading.isTextCorrect` dead code and score every text question 0 — the
+  divergence is only tolerable in Kotlin because of the cannot-advance model
+  above. Left deliberately; also note `checkTextAnswer` is substring
+  containment where `isTextCorrect` is exact equality, unobservable in Kotlin
+  today for the same reason.
+- **`hasOtherOption` stays unported**, so `saveExamAnswer`'s
+  `{"id":"other","text":"<otherText>"}` entries never arise and `AnswerShape`
+  has no branch for them. Recorded on `AnswerShape` itself: closing it needs a
+  `hasOtherOption` column on `survey_questions`, which is not a preserved
+  table, so `createAll` rebuilds it and the cost is a schema bump with no
+  hand-written step.
+- **`createDraft` bypasses `AnswerShape`** and writes its entries verbatim. It
+  has no question rows and so cannot resolve a label, and no Kotlin
+  counterpart — nothing in Kotlin creates a submission whose `parent` is a bare
+  title. In production it is only ever called with free text. Named here so
+  `AnswerShape` does not read as authoritative when one caller sits outside it.
+- **The exporter's precedence flip is cosmetic, not a parity finding.** It was
+  choices-first where `formatAnswer` is value-first, but the two are
+  indistinguishable given the writer shape (a `select` row carries the same
+  label in both halves, a `selectMultiple` row has an empty `value`, and a
+  synced row has only one of the two). Flipped anyway for one rule everywhere,
+  and the comment says it is not a fix. `serialize` is the only place the
+  precedence is observable, because there the branches produce different JSON
+  **types**.
+- **Two Kotlin quirks not worth porting**, recorded so a later phase does not
+  read them as gaps. `listAns` is a `HashMap` keyed by the button *text*, so
+  Kotlin's `selectMultiple` entry order is unspecified and two choices sharing
+  a label collapse into one; the port emits question order keyed by id.
+  And a choice object with no `id` records **nothing** in Kotlin
+  (`tag = ""` → `ans = ""` → `ans.isNotEmpty()` false) where the port falls the
+  id back to the text — a divergence in the port's favour with a committed test
+  pinning it.
+- Also worth knowing, though nothing depends on it: after a `select` answer
+  round-trips through the server the local row is `value="Paris",
+  valueChoices=null`, and `populateCacheFromSavedAnswers` reads only
+  `valueChoices` — so **Kotlin cannot restore a single-select selection from a
+  synced row**. The id is deliberately not carried for that type.
+
+## For the integrator
+
+- **No `.arb` key added**, in any locale. The five non-English files are
+  untouched.
+- **No schema bump** (still v44) and no table shape changed. `tables.dart` is
+  not touched at all this round — `AnswerShape` writes into the existing
+  `StringListConverter` column, and the `converters.dart` additions are new
+  methods on `ExamChoice`, not a converter swap.
+- **`public_survey_screen.dart`, `surveys_repository.dart` and
+  `submissions_uploader.dart` are untouched**, deliberately: the first two
+  belong to another lane's surface, and routing everything through
+  `AnswerShape` made a change there unnecessary. `surveys_repository`'s
+  `_buildPublicAnswers` keeps working unchanged and **must not be unified**
+  with `serialize`: `PublicSurveyActivity.buildPublicAnswers` sends the choice
+  *object* for `select` where the `submissions` endpoint takes the string, so
+  the two endpoints genuinely differ and the port already reproduces the split.
+- The **submission status** divergence above is the one item here I would
+  allocate a number to next.

--- a/flutter/lib/data/local/converters.dart
+++ b/flutter/lib/data/local/converters.dart
@@ -48,7 +48,17 @@ class ExamChoice {
       return raw.isEmpty ? null : ExamChoice(id: raw, text: raw);
     }
     if (raw is Map) {
-      final text = raw['text']?.toString() ?? '';
+      // `text` first with `res` only as a fallback, which is
+      // `ExamAnswerUtils.choiceDisplayValue` and what
+      // `SubmissionsRepository._questionFromJson` already does for the
+      // display column. Exam documents really do label choices with `res` —
+      // `ExamQuestion.insertCorrectChoice`'s single-id branch reads it — and
+      // reading `text` alone left those with a blank label *and* recorded a
+      // blank value on the answer. Kotlin's `addCompoundButton` does read
+      // `text` alone and so draws them blank; the port keeps one display rule
+      // instead, the same call Phase 104 made for the cached choice labels.
+      var text = raw['text']?.toString() ?? '';
+      if (text.isEmpty) text = raw['res']?.toString() ?? '';
       final id = raw['id']?.toString() ?? text;
       if (id.isEmpty && text.isEmpty) return null;
       return ExamChoice(id: id.isEmpty ? text : id, text: text);
@@ -57,6 +67,40 @@ class ExamChoice {
   }
 
   Map<String, dynamic> toJson() => {'id': id, 'text': text};
+
+  /// This choice as one stored answer entry.
+  ///
+  /// `saveExamAnswer` writes `"""{"id":"\$id","text":"\$text"}"""` into
+  /// `valueChoices`, and `Answer.valueChoicesArray` parses it straight back
+  /// with `gson.fromJson(choice, JsonObject::class.java)`.
+  String encode() => jsonEncode(toJson());
+
+  /// Reads one stored answer entry back.
+  ///
+  /// The single reader for a `valueChoices` entry, wherever it came from: the
+  /// choice object both write paths store, or a bare id an earlier build of
+  /// the exam path wrote. A bare entry resolves to `{id: raw, text: raw}`,
+  /// which is exactly what Kotlin's own unresolvable-id fallback produces —
+  /// `getChoiceTextById` returns `map[id] ?: id`, so `saveExamAnswer` writes
+  /// the id as the text too.
+  static ExamChoice? decode(String raw) {
+    try {
+      return ExamChoice.fromJson(jsonDecode(raw));
+    } on FormatException {
+      return ExamChoice.fromJson(raw);
+    }
+  }
+
+  /// Port of `ExamAnswerUtils.getChoiceTextById`: the display text of the
+  /// choice [id] names, or [id] itself when the question no longer offers it
+  /// (`map[id] ?: id`). A choice with no display value is left out of the
+  /// lookup, so it too falls back to its id.
+  static String textById(Iterable<ExamChoice> choices, String id) {
+    for (final choice in choices) {
+      if (choice.id == id && choice.text.isNotEmpty) return choice.text;
+    }
+    return id;
+  }
 
   /// Parses a document's `choices` array. Anything that is neither an object
   /// nor a non-empty string is dropped, matching `ExamTakingFragment`, which

--- a/flutter/lib/repository/submissions_exporter.dart
+++ b/flutter/lib/repository/submissions_exporter.dart
@@ -160,10 +160,21 @@ class SubmissionsExporter {
   /// Port of `SubmissionsRepositoryExporter.formatAnswer`: each stored choice
   /// is the `{id, text}` object as a JSON string, so the label has to be
   /// decoded out of it — joining the entries verbatim printed raw JSON.
+  ///
+  /// `value` is read first and the choices only when it is empty, which is
+  /// `formatAnswer`'s own order and the same precedence `Answer.createObject`
+  /// uses for the upload. The two orders are not actually distinguishable
+  /// here — a `select` row carries the same label in both halves, a
+  /// `selectMultiple` row has an empty `value`, and a synced row has only one
+  /// of the two — so this is one rule everywhere rather than a fix. The one
+  /// place the precedence *is* observable is `SubmissionsRepository.serialize`,
+  /// where the two branches produce different JSON types.
   String _answerValue(SubmissionAnswerRow answer) =>
-      answer.valueChoices.isNotEmpty
+      (answer.value?.isNotEmpty ?? false)
+      ? answer.value!
+      : answer.valueChoices.isNotEmpty
       ? ExamChoice.labelsFor(answer.valueChoices)
-      : answer.value ?? 'No answer';
+      : 'No answer';
 
   /// Recovers the raw question id from the `submissionId:rawQuestionId` row id.
   ///

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -10,6 +10,7 @@ import '../core/utils/json_utils.dart';
 import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
+import '../data/local/converters.dart';
 
 /// Offline list portion of `repository/SubmissionsRepositoryImpl.kt`.
 class SubmissionsRepository {
@@ -136,17 +137,39 @@ class SubmissionsRepository {
       answers: {
         id: [
           for (final question in questions)
-            SubmissionAnswersCompanion.insert(
-              id: '$id:${_rawQuestionId(question)}',
+            _surveyAnswer(
               submissionId: id,
-              questionId: Value(_rawQuestionId(question)),
-              value: Value(answers[question.id]?.value),
-              valueChoices: Value(answers[question.id]?.choices ?? const []),
+              question: question,
+              draft: answers[question.id],
             ),
         ],
       },
     );
     return id;
+  }
+
+  /// One survey answer row, shaped by [AnswerShape] so it matches what the
+  /// exam path writes — Kotlin has a single `saveExamAnswer` for both.
+  SubmissionAnswersCompanion _surveyAnswer({
+    required String submissionId,
+    required SurveyQuestionRow question,
+    required SubmissionDraftAnswer? draft,
+  }) {
+    final shape = AnswerShape.forQuestion(
+      type: question.type,
+      choices: question.choices,
+      selected: (draft?.choices ?? const <String>[])
+          .map(ExamChoice.decode)
+          .whereType<ExamChoice>(),
+      text: draft?.value,
+    );
+    return SubmissionAnswersCompanion.insert(
+      id: '$submissionId:${_rawQuestionId(question)}',
+      submissionId: submissionId,
+      questionId: Value(_rawQuestionId(question)),
+      value: Value(shape.value),
+      valueChoices: Value(shape.valueChoices),
+    );
   }
 
   /// Replaces the answer rows on an existing survey submission (resuming a
@@ -172,12 +195,10 @@ class SubmissionsRepository {
       answers: {
         submissionId: [
           for (final question in questions)
-            SubmissionAnswersCompanion.insert(
-              id: '$submissionId:${_rawQuestionId(question)}',
+            _surveyAnswer(
               submissionId: submissionId,
-              questionId: Value(_rawQuestionId(question)),
-              value: Value(answers[question.id]?.value),
-              valueChoices: Value(answers[question.id]?.choices ?? const []),
+              question: question,
+              draft: answers[question.id],
             ),
         ],
       },
@@ -255,20 +276,51 @@ class SubmissionsRepository {
       answers: {
         id: [
           for (final question in questions)
-            SubmissionAnswersCompanion.insert(
-              id: '$id:${question.id}',
+            _examAnswer(
               submissionId: id,
-              examId: Value(exam.id),
-              questionId: Value(question.id),
-              value: Value(answers[question.id]?.value),
-              valueChoices: Value(answers[question.id]?.choiceIds ?? const []),
-              isPassed: Value(answers[question.id]?.isCorrect ?? false),
-              grade: Value((answers[question.id]?.isCorrect ?? false) ? 1 : 0),
+              examId: exam.id,
+              question: question,
+              draft: answers[question.id],
             ),
         ],
       },
     );
     return id;
+  }
+
+  /// One graded exam answer row.
+  ///
+  /// The screen hands over choice **ids** — that is what a radio/checkbox
+  /// records and what grading compares against — and [AnswerShape] turns them
+  /// into the `{id, text}` objects `saveExamAnswer` stores, resolving each
+  /// label from the question the way `getChoiceTextById` does. The port used to
+  /// store the bare ids, so a choice answer reached Planet as a list of ids
+  /// where Kotlin sends objects (or, for a single choice, the display text).
+  SubmissionAnswersCompanion _examAnswer({
+    required String submissionId,
+    required String examId,
+    required ExamQuestionRow question,
+    required ExamDraftAnswer? draft,
+  }) {
+    final shape = AnswerShape.forQuestion(
+      type: question.type,
+      choices: question.choices,
+      selected: (draft?.choiceIds ?? const <String>[]).map(
+        (id) => ExamChoice(id: id, text: ''),
+      ),
+      text: draft?.value,
+    );
+    final isCorrect = draft?.isCorrect ?? false;
+    return SubmissionAnswersCompanion.insert(
+      id: '$submissionId:${question.id}',
+      submissionId: submissionId,
+      examId: Value(examId),
+      questionId: Value(question.id),
+      value: Value(shape.value),
+      valueChoices: Value(shape.valueChoices),
+      isPassed: Value(isCorrect),
+      grade: Value(isCorrect ? 1 : 0),
+    );
   }
 
   /// Attaches the profile collected by `UserInformationFragment` to an attempt.
@@ -533,9 +585,15 @@ class SubmissionsRepository {
         for (final answer in answers)
           {
             if (answer.questionId != null) 'questionId': answer.questionId,
-            'value': answer.valueChoices.isNotEmpty
-                ? _answerChoices(answer.valueChoices)
-                : answer.value,
+            // `Answer.createObject` sends `value` whenever it is non-empty
+            // and only falls back to `valueChoicesArray` when it is not — so
+            // a `select` answer reaches Planet as the bare display text and
+            // the object array is what a `selectMultiple` (whose `value` is
+            // the empty string) sends. The port had this precedence the other
+            // way round, which sent an array where Kotlin sends a string.
+            'value': (answer.value?.isNotEmpty ?? false)
+                ? answer.value
+                : _answerChoices(answer.valueChoices),
             'mistakes': answer.mistakes,
             'passed': answer.isPassed,
           },
@@ -544,24 +602,24 @@ class SubmissionsRepository {
   }
 
   /// Port of `Answer.valueChoicesArray`, which sends each stored choice as the
-  /// object it came from (`gson.fromJson(choice, JsonObject::class.java)`) —
+  /// object it came from (`gson.fromJson(choice, JsonObject::class.java)`):
   /// Planet expects `answers[].value` to be `{id, text}` objects for a choice
-  /// question, not strings. An entry that is not JSON is sent as it stands,
-  /// which is how the exam path's bare choice ids survive; Kotlin has no such
-  /// entries and would throw on one.
+  /// question, not strings.
+  ///
+  /// Every entry is now a choice object — both write paths go through
+  /// [AnswerShape], and the sync-in stores the server's own objects — so the
+  /// "send a non-JSON entry through untouched" branch this used to carry for
+  /// the exam path's bare ids is gone. A bare entry an earlier build left
+  /// behind still uploads as an object rather than poisoning the whole queue
+  /// (`SubmissionsUploader.queuePending` serializes every pending row in one
+  /// unguarded loop, so throwing the way `gson.fromJson` does would block
+  /// every other submission): [ExamChoice.decode] resolves it to
+  /// `{id: raw, text: raw}`, which is what Kotlin's own unresolvable-id
+  /// fallback produces.
   static List<Object?> _answerChoices(List<String> raw) => [
-    for (final choice in raw) _parseChoice(choice),
+    for (final entry in raw)
+      if (ExamChoice.decode(entry) case final choice?) choice.toJson(),
   ];
-
-  static Object? _parseChoice(String raw) {
-    try {
-      final decoded = jsonDecode(raw);
-      if (decoded is Map<String, dynamic>) return decoded;
-    } on FormatException {
-      // Not JSON — send the entry through untouched.
-    }
-    return raw;
-  }
 
   /// `parent` and `user` are stored locally as JSON *text*, but Kotlin uploads
   /// them as nested objects — `object.add("parent", ...)` and
@@ -707,8 +765,20 @@ class SubmissionsRepository {
     required String? examId,
   }) {
     final rawValue = json['value'];
+    // Kotlin stores `valueElement.asJsonArray.map { it.toString() }`, and
+    // Gson's `JsonElement.toString()` emits **JSON**. Dart's `Map.toString()`
+    // emits `{id: paris, text: Paris}`, which is not JSON — so a synced choice
+    // answer was cached in a form nothing downstream could read back: the
+    // re-upload sent that literal as a quoted string where Planet expects the
+    // object, the detail screen and the PDF export printed it verbatim, and
+    // the correctness check could not recover the id. A bare-string element
+    // is stored unquoted; Gson keeps its quotes there, but then Kotlin's own
+    // `valueChoicesArray` throws casting the primitive to a `JsonObject`, so
+    // the unquoted form is the better of the two.
     final choices = rawValue is List
-        ? rawValue.map((value) => value.toString()).toList(growable: false)
+        ? rawValue
+              .map((value) => value is Map ? jsonEncode(value) : '$value')
+              .toList(growable: false)
         : const <String>[];
     final questionId = JsonUtils.getStringOrNull('questionId', json);
     return SubmissionAnswersCompanion.insert(
@@ -799,7 +869,103 @@ class SubmissionDraftAnswer {
   });
   final String? questionId;
   final String? value;
+
+  /// The picked choices as stored answer entries — see [ExamChoice.encode].
+  /// [AnswerShape.forQuestion] re-resolves them against the question, so a
+  /// caller that only has ids may pass those instead.
   final List<String> choices;
+}
+
+/// The `value` / `valueChoices` pair one answered question is stored as.
+///
+/// Port of the branch at the top of `SubmissionsRepositoryImpl.saveExamAnswer`,
+/// which is the **single** writer for both exams and surveys in the Kotlin app
+/// (`ExamTakingFragment` runs both; its `type` only picks the grading and the
+/// status). The port has three writers — [SubmissionsRepository.createExamDraft],
+/// [SubmissionsRepository.createSurveyDraft] and
+/// [SubmissionsRepository.updateSurveyAnswers] — so the shape lives here, once,
+/// rather than being re-derived per screen.
+///
+/// The two halves are not independent: `Answer.createObject` sends `value`
+/// whenever it is non-empty and only falls back to `valueChoicesArray` when it
+/// is not, so which of them Kotlin fills decides what reaches Planet.
+class AnswerShape {
+  const AnswerShape({required this.value, required this.valueChoices});
+
+  final String? value;
+  final List<String> valueChoices;
+
+  /// [selected] are the picked choices; [text] is whatever a text field,
+  /// textarea or rating scale holds.
+  ///
+  /// * `select` — `value` is the choice's display text (`ansForCheck`, i.e.
+  ///   `getChoiceTextById`) and `valueChoices` the one choice object, or `[]`
+  ///   when nothing is picked. Kotlin's radio group records a single id, so
+  ///   only the first selection is read.
+  /// * `selectMultiple` — `value` is the **empty string**, which is what makes
+  ///   `createObject` send the object array, and `valueChoices` one object per
+  ///   pick.
+  /// * anything else — `value` is [text] and `valueChoices` is empty
+  ///   (`valueChoices = null` in Kotlin; the column here is not nullable).
+  ///
+  /// The `hasOtherOption` branches are not ported: the port renders no "Other"
+  /// choice on either screen, so `otherVisible` is never true and there is
+  /// nothing to carry. It stays part of the open `hasOtherOption` gap — and
+  /// closing it needs a `hasOtherOption` column on `survey_questions`, which
+  /// `ExamQuestions` has but `SurveyQuestions` does not. That table is not in
+  /// `localAuthorityTables`, so `createAll` rebuilds it and the column costs
+  /// only a schema bump, no hand-written step.
+  static AnswerShape forQuestion({
+    required String? type,
+    required List<ExamChoice> choices,
+    required Iterable<ExamChoice> selected,
+    String? text,
+  }) {
+    final normalized = type?.toLowerCase();
+    // `ExamTakingFragment.startExam` and `saveExamAnswer` both compare the
+    // type with `ignoreCase = true`.
+    if (normalized == 'selectmultiple') {
+      return AnswerShape(
+        value: '',
+        valueChoices: [
+          for (final choice in selected) _resolve(choices, choice).encode(),
+        ],
+      );
+    }
+    // A question that offers choices and got a pick is a choice question even
+    // when its type says nothing. `saveExamAnswer` has no such clause and
+    // needs none — `ExamTakingFragment.startExam` renders no input at all for
+    // an unrecognised type, so the answer cannot exist — but the port's survey
+    // card renders a radio group off `choices.isNotEmpty` and reads the type
+    // only to pick checkboxes over radios. Falling through to the plain-text
+    // branch here would discard a pick the screen had just accepted.
+    if (normalized == 'select' || (choices.isNotEmpty && selected.isNotEmpty)) {
+      final picked = selected.isEmpty
+          ? null
+          : _resolve(choices, selected.first);
+      return AnswerShape(
+        value: picked?.text ?? '',
+        valueChoices: picked == null ? const [] : [picked.encode()],
+      );
+    }
+    return AnswerShape(value: text, valueChoices: const []);
+  }
+
+  /// The choice as the question defines it.
+  ///
+  /// `saveExamAnswer` resolves the text from the question
+  /// (`getChoiceTextById`), not from whatever the screen was holding, and
+  /// falls back to the id when the question no longer offers the choice. An
+  /// entry that carries its own text is honoured before that last fallback —
+  /// that only happens for a stored answer whose question has since changed,
+  /// where the recorded label is better than the raw id.
+  static ExamChoice _resolve(List<ExamChoice> choices, ExamChoice selected) {
+    final text = ExamChoice.textById(choices, selected.id);
+    if (text != selected.id) return ExamChoice(id: selected.id, text: text);
+    return selected.text.isEmpty
+        ? ExamChoice(id: selected.id, text: selected.id)
+        : selected;
+  }
 }
 
 /// One question's answer on an exam attempt.
@@ -817,7 +983,11 @@ class ExamDraftAnswer {
   final String? value;
 
   /// Ids of the selected choices — ids, not labels, because that is what
-  /// `correctChoices` holds and what the server's answer documents store.
+  /// `correctChoices` holds and what a radio/checkbox records
+  /// (`addCompoundButton` puts the choice's `id` in the button's tag).
+  /// [AnswerShape] pairs each one with the label the question gives it, which
+  /// is the `{id, text}` object a stored answer and an uploaded document
+  /// actually carry.
   final List<String> choiceIds;
 
   final bool isCorrect;

--- a/flutter/lib/ui/submissions/submission_detail_screen.dart
+++ b/flutter/lib/ui/submissions/submission_detail_screen.dart
@@ -136,10 +136,33 @@ class _AnswerTile extends StatelessWidget {
         // paths decode the label out rather than printing the entry.
         ? ExamChoice.labelsFor(answer.valueChoices)
         : l10n.noAnswer;
-    final normalized = [
-      answer.value,
-      ...answer.valueChoices,
-    ].whereType<String>().map((value) => value.toLowerCase()).toSet();
+    // `correctChoices` holds choice **ids**, lowercased — both from
+    // `ExamMapper._parseCorrectChoices` and from the `correctChoice` array a
+    // synced question carries. A stored answer entry is the whole
+    // `{id, text}` object, so it has to be reduced to its id before the
+    // comparison; comparing the entries verbatim only ever matched the exam
+    // path while it stored bare ids, and matched nothing once both paths
+    // stored objects the way `saveExamAnswer` does.
+    //
+    // This indicator is the port's own: Kotlin's `getSubmissionDetail`
+    // computes `isCorrect = question.getCorrectChoice()?.contains(answer
+    // .value) == true`, but `QuestionAnswerAdapter.bind` never reads the
+    // field and `item_question_answer.xml` has no view for it, so the Kotlin
+    // detail screen shows no correctness at all. There is therefore no Kotlin
+    // rendering to be faithful to, and its comparison is not available to
+    // copy either: it pits the display *text* against a list of ids for
+    // `select`, and for `selectMultiple` `answer.value` is the empty string.
+    // Comparing ids is what `ExamGrading` does and follows the precedent
+    // `ExamMapper._parseCorrectChoices` already set and documented.
+    //
+    // `isPassed` stays the first signal: it is the verdict Kotlin actually
+    // computes and uploads.
+    final normalized = {
+      if (answer.value?.isNotEmpty ?? false) answer.value!.toLowerCase(),
+      for (final entry in answer.valueChoices)
+        if (ExamChoice.decode(entry) case final choice?)
+          choice.id.toLowerCase(),
+    };
     final correct =
         question != null &&
         question!.correctChoices.isNotEmpty &&

--- a/flutter/lib/ui/surveys/take_survey_screen.dart
+++ b/flutter/lib/ui/surveys/take_survey_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -63,13 +61,21 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
         }
       }
       if (question == null) continue;
-      if (answer.value?.isNotEmpty == true) {
+      // Only a question that offers no choices has a text field to seed. A
+      // choice answer's `value` is now the picked choice's display text (the
+      // one `saveExamAnswer` derives), and seeding it would put that label in
+      // a controller the card never renders for such a question. No symptom
+      // is reachable today — a radio group cannot be cleared, so `_submit`'s
+      // answered-everything guard cannot be fooled by the leftover text, and
+      // a `selectMultiple` answer's `value` is empty — but seeding a field
+      // that is not on screen is how that guard would come apart later.
+      if (question.choices.isEmpty && answer.value?.isNotEmpty == true) {
         textAnswers[question.id]?.text = answer.value!;
       }
       if (answer.valueChoices.isNotEmpty) {
         choiceAnswers[question.id]?.addAll(
           answer.valueChoices
-              .map(_decodeChoice)
+              .map(ExamChoice.decode)
               .whereType<ExamChoice>()
               // Only a choice the question still offers can be re-selected;
               // `ExamChoice` is a value type, so this is set membership.
@@ -81,17 +87,6 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
   }
 
   static String _rawId(SurveyQuestionRow q) => q.questionId ?? q.id;
-
-  /// A stored answer choice is the choice object as a JSON string; a row
-  /// written before that was fixed carries a bare label instead, which
-  /// [ExamChoice.fromJson] keeps as its own id.
-  static ExamChoice? _decodeChoice(String raw) {
-    try {
-      return ExamChoice.fromJson(jsonDecode(raw));
-    } on FormatException {
-      return ExamChoice.fromJson(raw);
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -172,7 +167,7 @@ class _TakeSurveyScreenState extends ConsumerState<TakeSurveyScreen> {
           questionId: question.id,
           value: textAnswers[question.id]!.text.trim(),
           choices: choiceAnswers[question.id]!
-              .map((choice) => jsonEncode(choice.toJson()))
+              .map((choice) => choice.encode())
               .toList(growable: false),
         ),
     };

--- a/flutter/test/data/local/converters_test.dart
+++ b/flutter/test/data/local/converters_test.dart
@@ -28,6 +28,20 @@ void main() {
       expect(ExamChoice.listFromJson(null), isEmpty);
     });
 
+    test('reads the label out of `res` when there is no `text`', () {
+      // `ExamAnswerUtils.choiceDisplayValue` is `text` first with `res` only
+      // as a fallback, and `insertCorrectChoice`'s single-id branch reads
+      // `res` — so exam documents do carry choices labelled that way.
+      // Reading `text` alone left them with a blank label, which is also what
+      // the answer then recorded as its value.
+      expect(
+        ExamChoice.listFromJson([
+          {'id': 'power', 'res': 'Power'},
+        ]),
+        [const ExamChoice(id: 'power', text: 'Power')],
+      );
+    });
+
     test('falls back to the text when a choice carries no id', () {
       expect(
         ExamChoice.listFromJson([

--- a/flutter/test/repository/exam_flow_test.dart
+++ b/flutter/test/repository/exam_flow_test.dart
@@ -242,10 +242,110 @@ void main() {
       final answers = await database.submissionDao.answersFor(id);
       expect(answers, hasLength(2));
       final byQuestion = {for (final a in answers) a.questionId: a};
-      expect(byQuestion['q1']!.valueChoices, ['c1']);
+      expect(byQuestion['q1']!.valueChoices, ['{"id":"c1","text":"Paris"}']);
       expect(byQuestion['q1']!.isPassed, isTrue);
       expect(byQuestion['q2']!.value, 'blue');
       expect(byQuestion['q2']!.examId, 'exam-1');
+    });
+
+    test(
+      'a select answer is stored as the choice object, not its id',
+      () async {
+        // `SubmissionsRepositoryImpl.saveExamAnswer` writes
+        // `listOf("""{"id":"$ans","text":"$ansForCheck"}""")` for a `select`
+        // question and sets `value` to `ansForCheck`, the choice's display text
+        // via `ExamAnswerUtils.getChoiceTextById`. The port stored the bare id
+        // and left `value` null.
+        final exam = await seedExam();
+        final id = await submissions.createExamDraft(
+          exam: exam,
+          questions: twoQuestions(),
+          userId: 'ada',
+          answers: const {
+            'q1': ExamDraftAnswer(choiceIds: ['c1'], isCorrect: true),
+          },
+        );
+        final answers = await database.submissionDao.answersFor(id);
+        final q1 = answers.firstWhere((a) => a.questionId == 'q1');
+        expect(q1.valueChoices, ['{"id":"c1","text":"Paris"}']);
+        expect(q1.value, 'Paris');
+      },
+    );
+
+    test('a selectMultiple answer stores objects and an empty value', () async {
+      // Kotlin's `selectMultiple` branch sets `value = ""` and maps `listAns`
+      // (text -> id) to `{"id":"$id","text":"$text"}` per entry.
+      final exam = await seedExam();
+      final questions = [
+        ExamQuestionRow(
+          id: 'q1',
+          examId: 'exam-1',
+          type: 'selectMultiple',
+          correctChoices: const ['c1', 'c2'],
+          choices: const [
+            ExamChoice(id: 'c1', text: 'Paris'),
+            ExamChoice(id: 'c2', text: 'Lyon'),
+          ],
+          hasOtherOption: false,
+          scaleMax: 9,
+          position: 0,
+        ),
+      ];
+      final id = await submissions.createExamDraft(
+        exam: exam,
+        questions: questions,
+        userId: 'ada',
+        answers: const {
+          'q1': ExamDraftAnswer(choiceIds: ['c1', 'c2'], isCorrect: true),
+        },
+      );
+      final answers = await database.submissionDao.answersFor(id);
+      expect(answers.single.valueChoices, [
+        '{"id":"c1","text":"Paris"}',
+        '{"id":"c2","text":"Lyon"}',
+      ]);
+      expect(answers.single.value, '');
+    });
+
+    test('an unknown choice id falls back to the id as its text', () async {
+      // `getChoiceTextById` returns `map[id] ?: id`.
+      final exam = await seedExam();
+      final id = await submissions.createExamDraft(
+        exam: exam,
+        questions: twoQuestions(),
+        userId: 'ada',
+        answers: const {
+          'q1': ExamDraftAnswer(choiceIds: ['ghost']),
+        },
+      );
+      final answers = await database.submissionDao.answersFor(id);
+      final q1 = answers.firstWhere((a) => a.questionId == 'q1');
+      expect(q1.valueChoices, ['{"id":"ghost","text":"ghost"}']);
+      expect(q1.value, 'ghost');
+    });
+
+    test('a select answer uploads its display text, as Kotlin does', () async {
+      // `Answer.createObject` sends `value` whenever it is non-empty and only
+      // falls back to `valueChoicesArray` when it is not — so a `select`
+      // answer reaches Planet as a bare string, and `valueChoicesArray` is
+      // reached only for `selectMultiple` (and an unanswered select).
+      final exam = await seedExam();
+      final id = await submissions.createExamDraft(
+        exam: exam,
+        questions: twoQuestions(),
+        userId: 'ada',
+        answers: const {
+          'q1': ExamDraftAnswer(choiceIds: ['c1'], isCorrect: true),
+        },
+      );
+      final payload = await submissions.serialize(
+        (await submissions.getById(id))!,
+      );
+      final byQuestion = {
+        for (final answer in payload['answers'] as List)
+          (answer as Map)['questionId']: answer['value'],
+      };
+      expect(byQuestion['q1'], 'Paris');
     });
 
     test('an unanswered exam scores zero rather than failing', () async {

--- a/flutter/test/repository/submissions_repository_test.dart
+++ b/flutter/test/repository/submissions_repository_test.dart
@@ -6,6 +6,7 @@ import 'package:myplanet/core/network/network_result.dart';
 import 'package:myplanet/core/sync/sync_result.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/converters.dart';
 import 'package:myplanet/repository/submissions_repository.dart';
 
 class MockPlanetApi extends Mock implements PlanetApi {}
@@ -226,6 +227,184 @@ void main() {
     expect(questions.single.choices, ['Water', 'Power', 'Other']);
   });
 
+  test('a survey select answer carries the choice text as its value', () async {
+    // `saveExamAnswer`'s `select` branch sets `value = ansForCheck`, the
+    // choice's display text — and `Answer.createObject` sends `value`
+    // whenever it is non-empty. The survey screen has no text field on a
+    // choice question, so it hands the repository an empty string; deriving
+    // the value from the question is where Kotlin does it.
+    await database.surveyDao.upsertAll(
+      [SurveysCompanion.insert(id: 'survey-1', name: const Value('Services'))],
+      {
+        'survey-1': [
+          SurveyQuestionsCompanion.insert(
+            id: 'survey-1:q-1',
+            surveyId: 'survey-1',
+            questionId: const Value('q-1'),
+            type: const Value('select'),
+            choices: const Value([
+              ExamChoice(id: 'water', text: 'Water'),
+              ExamChoice(id: 'power', text: 'Power'),
+            ]),
+            position: 0,
+          ),
+        ],
+      },
+    );
+    final survey = (await database.surveyDao.getById('survey-1'))!;
+    final questions = await database.surveyDao.questionsFor('survey-1');
+
+    final id = await repository.createSurveyDraft(
+      survey: survey,
+      questions: questions,
+      userId: 'user-1',
+      answers: const {
+        'survey-1:q-1': SubmissionDraftAnswer(
+          questionId: 'q-1',
+          value: '',
+          choices: ['{"id":"water","text":"Water"}'],
+        ),
+      },
+      now: DateTime.fromMillisecondsSinceEpoch(1000),
+    );
+
+    final answers = await database.submissionDao.answersFor(id);
+    expect(answers.single.value, 'Water');
+    expect(answers.single.valueChoices, ['{"id":"water","text":"Water"}']);
+
+    final payload = await repository.serialize((await repository.getById(id))!);
+    expect((payload['answers'] as List).single, containsPair('value', 'Water'));
+  });
+
+  test('a survey selectMultiple answer uploads objects', () async {
+    await database.surveyDao.upsertAll(
+      [SurveysCompanion.insert(id: 'survey-2', name: const Value('Services'))],
+      {
+        'survey-2': [
+          SurveyQuestionsCompanion.insert(
+            id: 'survey-2:q-1',
+            surveyId: 'survey-2',
+            questionId: const Value('q-1'),
+            type: const Value('selectMultiple'),
+            choices: const Value([
+              ExamChoice(id: 'water', text: 'Water'),
+              ExamChoice(id: 'power', text: 'Power'),
+            ]),
+            position: 0,
+          ),
+        ],
+      },
+    );
+    final survey = (await database.surveyDao.getById('survey-2'))!;
+    final questions = await database.surveyDao.questionsFor('survey-2');
+
+    final id = await repository.createSurveyDraft(
+      survey: survey,
+      questions: questions,
+      userId: 'user-1',
+      answers: const {
+        'survey-2:q-1': SubmissionDraftAnswer(
+          questionId: 'q-1',
+          value: '',
+          choices: [
+            '{"id":"water","text":"Water"}',
+            '{"id":"power","text":"Power"}',
+          ],
+        ),
+      },
+      now: DateTime.fromMillisecondsSinceEpoch(1000),
+    );
+
+    // Kotlin's `selectMultiple` branch sets `value = ""`, which is what sends
+    // `valueChoicesArray` instead of a string.
+    final answers = await database.submissionDao.answersFor(id);
+    expect(answers.single.value, '');
+
+    final payload = await repository.serialize((await repository.getById(id))!);
+    expect((payload['answers'] as List).single['value'], [
+      {'id': 'water', 'text': 'Water'},
+      {'id': 'power', 'text': 'Power'},
+    ]);
+  });
+
+  test('a choice pick survives a question with no type', () async {
+    // `take_survey_screen` renders choices whenever the question offers any,
+    // reading only `selectmultiple` off the type to pick checkboxes over
+    // radios — so a document that names no type still gets a radio group and
+    // a real answer. Shaping that answer through the plain-text branch (which
+    // is what `saveExamAnswer` does for an unrecognised type) would discard
+    // the pick silently. Kotlin never faces the case: `startExam` renders
+    // *nothing* for a type-less question, so it is unanswerable there.
+    await database.surveyDao.upsertAll(
+      [SurveysCompanion.insert(id: 'survey-3', name: const Value('Services'))],
+      {
+        'survey-3': [
+          SurveyQuestionsCompanion.insert(
+            id: 'survey-3:q-1',
+            surveyId: 'survey-3',
+            questionId: const Value('q-1'),
+            choices: const Value([ExamChoice(id: 'water', text: 'Water')]),
+            position: 0,
+          ),
+        ],
+      },
+    );
+    final survey = (await database.surveyDao.getById('survey-3'))!;
+
+    final id = await repository.createSurveyDraft(
+      survey: survey,
+      questions: await database.surveyDao.questionsFor('survey-3'),
+      userId: 'user-1',
+      answers: const {
+        'survey-3:q-1': SubmissionDraftAnswer(
+          questionId: 'q-1',
+          value: '',
+          choices: ['{"id":"water","text":"Water"}'],
+        ),
+      },
+      now: DateTime.fromMillisecondsSinceEpoch(1000),
+    );
+
+    final answers = await database.submissionDao.answersFor(id);
+    expect(answers.single.valueChoices, ['{"id":"water","text":"Water"}']);
+    expect(answers.single.value, 'Water');
+  });
+
+  test('a synced choice answer is cached as JSON, not as a Dart map', () async {
+    // Kotlin stores `valueElement.asJsonArray.map { it.toString() }`, and
+    // Gson's `JsonElement.toString()` emits JSON. Dart's `Map.toString()`
+    // emits `{id: paris, text: Paris}` — not JSON, so nothing downstream can
+    // read it back: the re-upload sent that literal as a *string* where
+    // Planet expects the object, and the detail screen and the PDF export
+    // printed it verbatim.
+    await repository.upsertDocuments([
+      {
+        '_id': 'synced-1',
+        'userId': 'user-1',
+        'status': 'complete',
+        'answers': [
+          {
+            'questionId': 'q-1',
+            'value': [
+              {'id': 'paris', 'text': 'Paris'},
+            ],
+          },
+        ],
+      },
+    ]);
+
+    final answers = await repository.answersFor('synced-1');
+    expect(answers.single.valueChoices, ['{"id":"paris","text":"Paris"}']);
+    // And it round-trips: the entry the sync stored is one the uploader can
+    // send back as an object.
+    final payload = await repository.serialize(
+      (await repository.getById('synced-1'))!,
+    );
+    expect((payload['answers'] as List).single['value'], [
+      {'id': 'paris', 'text': 'Paris'},
+    ]);
+  });
+
   test('serializes an answer choice as the object it was stored as', () async {
     // Port of `Answer.valueChoicesArray`, which sends each entry back through
     // `gson.fromJson(choice, JsonObject::class.java)`: Planet expects
@@ -252,10 +431,16 @@ void main() {
     ]);
   });
 
-  test('serializes a bare choice id untouched', () async {
-    // The exam path stores plain choice ids in `valueChoices`; Kotlin has no
-    // such entries and `gson.fromJson` would throw on one, so they are passed
-    // through rather than dropped.
+  test('serializes a bare entry as an object, not as a bare id', () async {
+    // The exam path used to store plain choice ids and `_answerChoices`
+    // carried a "send a non-JSON entry untouched" branch to let them past.
+    // Both write paths go through `AnswerShape` now, so that tolerance is
+    // gone: an entry an earlier build left behind resolves to
+    // `{id: raw, text: raw}`, which is what Kotlin's own unresolvable-id
+    // fallback produces (`getChoiceTextById` returns `map[id] ?: id`).
+    // It is not left to throw the way `gson.fromJson` would, because
+    // `SubmissionsUploader.queuePending` serializes every pending row in one
+    // unguarded loop and one such row would block the whole queue.
     final id = await repository.createDraft(
       userId: 'user-1',
       type: 'exam',
@@ -268,7 +453,9 @@ void main() {
 
     final payload = await repository.serialize((await repository.getById(id))!);
     final answer = (payload['answers'] as List).single as Map;
-    expect(answer['value'], ['choice-a']);
+    expect(answer['value'], [
+      {'id': 'choice-a', 'text': 'choice-a'},
+    ]);
   });
 
   test(

--- a/flutter/test/ui/exam/take_exam_screen_test.dart
+++ b/flutter/test/ui/exam/take_exam_screen_test.dart
@@ -476,7 +476,8 @@ void main() {
 
       // Adding the second correct choice would have passed it.
       final answers = await db.select(db.submissionAnswers).get();
-      expect(answers.single.valueChoices, ['c1']);
+      // Stored as the choice object `saveExamAnswer` writes, not the bare id.
+      expect(answers.single.valueChoices, ['{"id":"c1","text":"Red"}']);
       expect(answers.single.isPassed, isFalse);
     });
 

--- a/flutter/test/ui/submissions_screen_test.dart
+++ b/flutter/test/ui/submissions_screen_test.dart
@@ -199,4 +199,69 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Water, Power'), findsOneWidget);
   });
+
+  testWidgets('a choice answer is marked correct by its choice id', (
+    tester,
+  ) async {
+    // The tile's own correctness check compares the stored answer against the
+    // question's `correctChoices`, which are choice **ids**
+    // (`ExamMapper._parseCorrectChoices`, and the `correctChoice` array a
+    // synced question carries). A stored answer entry is the whole
+    // `{id, text}` object, so comparing the entries verbatim could only ever
+    // match the exam path's bare ids — and once both paths store objects, as
+    // Kotlin's `saveExamAnswer` does, it matched nothing at all.
+    const row = SubmissionRow(
+      id: 'submission-4',
+      userId: 'user-1',
+      type: 'exam',
+      startTime: 0,
+      lastUpdateTime: 0,
+      grade: 0,
+      status: 'complete',
+      uploaded: false,
+      isUpdated: true,
+    );
+    await tester.pumpWidget(
+      wrapScreen(
+        const SubmissionDetailScreen(submissionId: 'submission-4'),
+        overrides: [
+          submissionProvider(
+            'submission-4',
+          ).overrideWith((ref) => Stream.value(row)),
+          submissionAnswersProvider('submission-4').overrideWith(
+            (ref) => Stream.value([
+              const SubmissionAnswerRow(
+                id: 'submission-4:q-1',
+                submissionId: 'submission-4',
+                questionId: 'q-1',
+                valueChoices: ['{"id":"paris","text":"Paris"}'],
+                mistakes: 0,
+                // Not pre-graded — the tile's own check is what is under test.
+                isPassed: false,
+                grade: 0,
+              ),
+            ]),
+          ),
+          submissionQuestionsProvider('submission-4').overrideWith(
+            (ref) => Stream.value([
+              const SubmissionQuestionRow(
+                id: 'submission-4:q-1',
+                submissionId: 'submission-4',
+                header: 'Capital city',
+                type: 'select',
+                correctChoices: ['paris'],
+                choices: ['Paris', 'Rome'],
+                position: 0,
+              ),
+            ]),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -500));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Lane B of the Phase 106 Flutter-port round. Closes both gaps `flutter/PHASE_104_NOTES.md` logged and left.

## What changed

`ExamTakingFragment` is the **single** Kotlin writer for both exams and surveys — `saveExamAnswer`'s `type` only picks the grading, the verdict fields and the status. So the answer shape is one thing:

| type | `value` | `valueChoices` | uploaded `answers[].value` |
|---|---|---|---|
| `select` | the choice's display text (`getChoiceTextById`) | `[{"id":…,"text":…}]` | a bare **string** |
| `selectMultiple` | `""` | one object per pick | an **array of objects** |
| else | the typed text | `null` | a string, or `[]` when blank |

`Answer.createObject` sends `value` whenever it is non-empty, so `valueChoicesArray` is only ever reached for `selectMultiple` and for an unanswered question.

The port had three problems: `createExamDraft` stored bare ids with a null `value`; the survey writers stored objects but took `value` from a screen that has no text field on a choice question (`''`); and `serialize` had the precedence backwards. A single `AnswerShape.forQuestion` now shapes every question-bound answer, living in the repository where Kotlin has it, and `_answerChoices`' non-JSON tolerance is gone with the ids that needed it.

`submission_detail_screen`'s correctness check now reduces each entry to its **id** before comparing. The code says why that is not a port: `QuestionAnswerAdapter.bind` never reads `isCorrect` and `item_question_answer.xml` has no view for it, so Kotlin's detail screen shows no correctness at all — the icon is the port's own.

## Defects found, each demonstrated failing first

1. **The sync-in cached synced choice answers in a form nothing could read.** `_answerFromJson` did `value.toString()`; Dart's `Map.toString()` is `{id: paris, text: Paris}`, not JSON, where Gson's `JsonElement.toString()` emits JSON. Pre-fix: `Actual: ['{id: paris, text: Paris}']`. It would have been the one remaining source of undecodable entries after this change — the new id-based check would have ticked every local answer and missed every synced one. Found by the parity audit, not by me.
2. **`ExamChoice.fromJson` read `text` alone**, so a choice labelled with `res` (which exam documents carry — `insertCorrectChoice` reads it) had a blank label and a blank stored value. Now `text` then `res`, matching `choiceDisplayValue`.
3. **A regression the diff review caught**: a survey question with choices but no `type` is answerable in the port (the card renders radios off `choices.isNotEmpty`), and the plain-text branch would have written `[]` over the pick. `AnswerShape` treats choices-plus-a-selection as single-choice regardless of type; Kotlin needs no such clause because `startExam` renders no input at all for an unrecognised type.

11 new tests (10 failing pre-fix), 3 existing assertions updated to the new shape.

## Left deliberately, reported not folded in

None is an answer-*shape* question: `mistakes` never written and per-answer `grade` differing (both tied to Kotlin's unported "cannot advance past a wrong answer" model), the submission status (`requires grading` vs `complete` — the consequential one), `correctChoices` populated for non-select questions, and `hasOtherOption`. Reasoning for each is in the notes.

## Notes

- **No schema bump** (still v44), no table shape change — `tables.dart` untouched.
- **No `.arb` key added** in any locale.
- `public_survey_screen.dart` and `surveys_repository.dart` are untouched by design (another lane's surface); routing through `AnswerShape` made a change there unnecessary. `_buildPublicAnswers` must **not** be unified with `serialize` — `PublicSurveyActivity.buildPublicAnswers` sends the choice object where the `submissions` endpoint takes the string, and the port already reproduces that split.
- 1685 tests pass; `dart format` and `flutter analyze` clean on Flutter 3.44.8.

Full write-up in `flutter/PHASE_106_NOTES.md`.