### PR TITLE
Phase 107 (Lane C): one member, one row — the user identity rule and the health key it protects

### DIFF
--- a/flutter/PHASE_107_NOTES.md
+++ b/flutter/PHASE_107_NOTES.md
@@ -1,9 +1,221 @@
 # Phase 107 — one member, one row: the user identity rule and the health key it protects
 
-*In progress.* Phase 105's audit left this: `UserMapper.fromDoc` keys the cached
-row on the document `_id` unconditionally, where `buildUserFromJson` reuses the
-existing row through `getUserByAnyId` and keeps its local `id`
-(`UserRepositoryImpl.kt:297-308`). A member registered offline who later signs
-in online can therefore end up with two rows — and because health records are
-encrypted with a per-user `key`/`iv`, resolving that member to the wrong row can
-make their records undecryptable.
+Phase 105's parity audit found this and logged it as needing a round of its
+own. Its words:
+
+> `UserMapper.fromDoc` keys the cached row on the document `_id`
+> unconditionally, where `buildUserFromJson` reuses the existing row through
+> `getUserByAnyId` and keeps its local `id` (`UserRepositoryImpl.kt:297-308`).
+
+Everything below was demonstrated failing against the pre-fix code first, one
+defect at a time. Four defects, all in this lane's files.
+
+## 1. The identity rule
+
+Kotlin's `buildUserFromJson` (`UserRepositoryImpl.kt:292-316`) resolves the row
+a document belongs to **before** writing it:
+
+```kotlin
+val id = JsonUtils.getString("_id", jsonDoc).takeIf { it.isNotEmpty() } ?: UUID.randomUUID().toString()
+val existingUser = getUserByAnyId(id)          // WHERE id = :id OR _id = :id LIMIT 1
+val user = existingUser ?: … ?: UserEntity().apply { this.id = id }
+applyJsonToUser(jsonDoc, user, settings)       // reassigns `id` only when blank
+```
+
+The `_id` half of that lookup is the point: a document finds a row through its
+`_id` **column** as readily as through its key, and the row it finds keeps its
+own `id`. `UserMapper.fromDoc` had no lookup at all — it wrote
+`id: Value(couchId)` unconditionally, and `insertOnConflictUpdate` keys on the
+primary key, so a document whose `_id` sat in some row's `couchId` **inserted a
+second row** instead of updating the first.
+
+The member that happens to is the member registered on this device.
+`become_member_screen` mints `id = '<millis>'` with no `couchId`
+(`become_member_screen.dart:258`); the health screens mint `key`/`iv` on that
+row; `UserDao.updateUserSecurityData` records the server-assigned `couchId` on
+that same row when the upload lands. The first online sign-in then produced a
+duplicate keyed on `org.couchdb.user:<name>` — carrying `derived_key` and
+`salt`, and **no `key`/`iv`**.
+
+`fromDoc` now takes the row it is updating; `UserRepository._cacheUserDoc`
+performs the lookup (skipped for a document with no `_id`, matching Kotlin,
+where the id it searches by is a fresh UUID that can never match) and re-reads
+the row by the key it was written under, which is what `upsertUser` does
+(`getById(entity.id)`). That re-read replaces a `getByName(username)`, and the
+replacement matters on its own: a name carries no unique constraint, two
+planets can hold an `ada`, and `LIMIT 1` was picking the session user by scan
+order.
+
+*Failing-first:* "the online login reuses the local row instead of adding one"
+reports 2 rows; "the health key and iv survive the transition" reports a
+`null` key on a row that answers to the member; the same assertion inside the
+end-to-end health test fails at step 5.
+
+### What the consequence actually is — a correction to Phase 105's wording
+
+Phase 105 wrote that `getById(couchId)` "matches both — `limit(1)` then picks
+by scan order, which for this slice can resolve the patient to the row
+*without* the `key`/`iv`". Measured: it does not, today. Both rows are matched
+by `WHERE id = ? OR _id = ?`, `_id` has no index, so SQLite full-scans and
+returns the **older** row — the member's real one — first. The end-to-end test
+in `health_repository_test.dart` was written to catch a failed decryption and
+does not: with the fix reverted it fails on the row count at step 5, and step 6
+still decrypts.
+
+So state it as it is. What was **deterministically** broken:
+
+* two rows for one member, so every list built from the users table showed them
+  twice — the login account picker (`getSavedUsers`), the health patient
+  picker, the survey recipient list;
+* one of those rows carries no `key`/`iv`, and it is reachable by the CouchDB
+  id the health screens address patients with (`patientIdOf` prefers `couchId`);
+* the profile fields and the queued photo below.
+
+What was **latent**: which of the two rows a lookup resolves to. SQLite
+promises no order without `ORDER BY`; an index on `_id`, a `VACUUM`, or rowid
+reuse after a delete flips it, and the health records the wrong row cannot
+decrypt are not recoverable from anywhere — the `key`/`iv` are generated on the
+device and never uploaded, which is why `users` is a preserved table. A
+duplicate row is not a cosmetic defect when one of the two is the only thing
+standing between a patient and their medical history, but it is honest to say
+the loss had not happened yet rather than that it had.
+
+## 2. A document that omits a field wiped the stored one
+
+`applyJsonToUser` guards twelve fields with
+`if (new.isNotEmpty() || old.isNullOrEmpty()) field = new` — `joinDate` with
+`if (newJoinDate != 0L || joinDate == 0L)` — and assigns the rest
+unconditionally. `fromDoc` wrote every field unconditionally, which on an
+*update* is a `Value(null)` over a stored value: the same shape as the Phase 56
+security-data fix and the Phase 74 reactions round trip. A member who filled in
+their profile offline and then signed in online lost every field the `_users`
+document does not carry.
+
+The guarded set, in Kotlin's order: `joinDate`, `firstName`, `lastName`,
+`middleName`, `email`, `phoneNumber`, `level`, `language`, `gender`,
+`dob` (`birthDate`), `birthPlace`, `age`. Unguarded, deliberately: `_rev`,
+`_id`, `name`, `roles`, `isUserAdmin`, `planetCode`, `parentCode`,
+`password_scheme`, `iterations`, `derived_key`, `salt`, `isArchived`. An absent
+`Value` is what "keep the stored one" means to `insertOnConflictUpdate` — the
+column stays out of the `DO UPDATE SET` list — and on an insert there is no
+stored value, so the incoming one is written either way.
+
+`password` is ported too, with its guard: `if (_id?.isEmpty() == true)` reads
+`_id` **after** `_id = newId` is assigned, so the plaintext password is taken
+only for a document with no `_id`, which is the guest shape.
+
+*Failing-first:* with only the two guard helpers reverted to
+`return Value(incoming)`, "a field the document omits keeps its stored value"
+fails and nothing else does.
+
+## 3. An unsynced profile photo was erased by a re-login
+
+`UserEntity.addImageUrl` (`UserEntity.kt:158-166`) writes `userImage` **only**
+when the document has a non-empty `_attachments`. `fromDoc` wrote
+`Value(_attachmentName(doc))` unconditionally, so a document without
+attachments nulled the column — and the value it nulled can be a local file
+path that the user uploader has queued and not yet sent. The photo was gone
+before anything could read it.
+
+*Failing-first:* with only `_imageName` reverted to `Value(name)`, "an unsynced
+profile photo survives a document without attachments" fails and nothing else
+does.
+
+## 4. The two adjacent health items are one rule — and both are ported
+
+The round offered these as separate, optional items. They are not separable.
+
+`HealthExamination.serialize` keys the document on `userId`, not on the row's
+own id, and **omits `_id` entirely** while `userId` is null or empty
+(`HealthExamination.kt:96`). `HealthExaminationDao.getUpdated()` is
+`WHERE isUpdated = 1 AND userId != ''` — and in SQL `userId != ''` is false for
+NULL too, so Kotlin excludes a blank `userId` along with a missing one. The
+guard is what makes serialize's omit-`_id` branch unreachable from the upload
+path: a POST to `/health` with no `_id` makes CouchDB mint a fresh document, so
+one examination would become a **new record on every drain**.
+
+The port had taken neither half — `_id` from `row.id`, and
+`userId.isNotNull()`. Porting only the `_id` half would have opened exactly
+that hazard, which is why both are here.
+
+**The legacy-row decision, stated deliberately.** Phase 105 left this because
+changing `_id` re-keys documents an older build already wrote. Where the two
+ids differ:
+
+* Examinations written by the current build have `userId == id`
+  (`createExamination` defaults `userId` to the row's own id, the invariant
+  `_docToCompanion` maintains for every synced row). No change.
+* The **profile row** is where they differ. `createPojo`
+  (`HealthExaminationActivity.kt:372-378`) writes `_id` = the patient id the
+  screen was opened with and `userId` = `user?._id`, the patient's CouchDB id;
+  `app_providers.dart:396-405` rewrites that `userId` to the couch id once the
+  account uploads (Kotlin's counterpart is `HealthRepositoryImpl.kt:78`). So
+  after the fix the port uploads that row under the couch id, which is both
+  what Kotlin uploads it under and the id the sync-in direction would key the
+  row on.
+* Examination rows written by a **pre-Phase-105** port build carried the
+  *patient's* id in `userId`, so they would now upload under the patient's
+  profile-document id and overwrite it. That is the real exposure, and it is
+  the reason to be explicit: those rows exist only on a development device, the
+  port is not shipped (`app/` remains the shipping app), and Phase 105
+  established that such rows could not be recorded successfully in the first
+  place — they were the invisible ones. Against that, leaving the port keying
+  documents on `row.id` diverges from the specification permanently and in a
+  direction that cannot be corrected later without the same re-keying.
+
+Ported, therefore, and this note is the record of why.
+
+One divergence in the same code found and **deliberately kept**:
+`saveHealthProfileBlob` writes `userId: Value(user?.couchId ?? userId)` where
+Kotlin writes `user?._id` with no fallback. Kotlin's profile row for a member
+whose account has not uploaded therefore has a null `userId`, is excluded by
+`getUpdated()`, and **never uploads at all**. The port's fallback keys it on the
+device-local id instead, which is what the port already does for examinations.
+Matching Kotlin here would mean deleting a working upload path for exactly the
+member class this phase is about, so the fallback stays and the divergence is
+recorded here instead.
+
+## Found and left
+
+* **The guest-user migration is unported and unportable as things stand.**
+  `buildUserFromJson`'s middle branch — when no row matches and the id starts
+  `org.couchdb.user:` with a non-empty name, adopt the guest row of the same
+  name (`getGuestUserByName`, `_id` starting `guest_`), delete it, and reuse it
+  under the new id — has nothing to adopt: no port path creates a guest row.
+  Worth knowing before guest login lands, because the port's own guest tests
+  are inconsistent with Kotlin's: `home_screen`/`settings_screen`/
+  `voices_screen` check `user.id.startsWith('guest')` while
+  `UserEntity.isGuest()` and `insertUsersFromSync` check
+  `_id?.startsWith("guest_")`, and `validateUsername` checks
+  `couchId?.startsWith('guest')`. Three spellings of one predicate.
+* **A guarded field the document omits stores `null` where Kotlin stores `''`.**
+  `JsonUtils.getString` returns `""`, so Kotlin's `field = new` writes an empty
+  string; the port writes `null`. Unchanged: it is how every mapper in the port
+  already reads a missing string, and normalising it is a port-wide change, not
+  a one-file one.
+* **`serialize` writes `creatorId` from `creatorId`; Kotlin writes it from
+  `profileId`** (`addString(object, "creatorId", health.profileId)` — note the
+  field, not a typo in this note). The two are equal for every row either app
+  authors (`saveData` sets both to `health.userKey`), so this only shows up for
+  a synced document whose server-side `creatorId` differs, where Kotlin
+  overwrites it on re-upload and the port preserves it. Left: the port's
+  behaviour is the defensible one and nothing reads the difference.
+* **`serialize` includes an empty-string `profileId`/`gender`/`bp` where
+  `JsonUtils.addString` omits it.** The port's guards are `!= null`, Kotlin's
+  are "non-null and non-empty". Not chased here — it is a sweep across every
+  `serialize` in the port rather than a health-only fix.
+
+## For the integrator
+
+* **No schema change.** Drift stays at v44. `app_database.dart` is edited but
+  only two query bodies (`HealthExaminationDao.getUpdated`, plus the comment on
+  `UserDao.getById`); no table, column or index was touched. I considered
+  asking for an index on `users._id` — it would make the duplicate-row lookup
+  cheap — and did not, because an index there is precisely what would flip
+  SQLite's scan order on a device that still carries a duplicate from an older
+  dev build, turning the latent wrong-row resolution into the real one. The
+  duplicates have to be reconciled before that index is safe.
+* **No new `app_en.arb` keys.** Nothing user-facing changed.
+* Files touched: `lib/data/local/user_mapper.dart`,
+  `lib/repository/user_repository.dart`, `lib/repository/health_repository.dart`,
+  `lib/data/local/app_database.dart`, and the three test files.

--- a/flutter/PHASE_107_NOTES.md
+++ b/flutter/PHASE_107_NOTES.md
@@ -219,3 +219,231 @@ recorded here instead.
 * Files touched: `lib/data/local/user_mapper.dart`,
   `lib/repository/user_repository.dart`, `lib/repository/health_repository.dart`,
   `lib/data/local/app_database.dart`, and the three test files.
+
+---
+
+# A second round, after the parity audit
+
+A `parity-auditor` pass confirmed all five claims above, corrected two of them,
+reviewed the fix, and found three gaps in it plus fourteen divergences nobody
+had claimed. Three more defects are fixed here, each demonstrated failing
+first; the rest are recorded below, because several are outside this lane's
+files and two are more severe than anything this phase set out to fix.
+
+The two corrections are worth keeping. On the headline: the audit reached the
+same conclusion the measurement above did — SQLite full-scans an unindexed
+`users` and returns the older, key-bearing row, so the undecryptable-records
+harm was **latent**. But it named the harm that was *live* and that this phase
+had described only as "a duplicate name", and it is worse than cosmetic:
+
+> **An online login stopped refreshing the member's row.** Everything
+> `applyJsonToUser` writes unguarded — `rolesList`, `derived_key`, `salt`,
+> `password_scheme`, `iterations`, `isArchived`, `userAdmin`, `_rev` — landed
+> on the duplicate, while the session kept resolving the original.
+
+So: a manager grants a role, resets a password, or archives an account in
+Planet; the member signs in online on this device; role-gated UI stays locked,
+and `loginOffline` goes on verifying against the **stale** `derived_key`/`salt`
+— the old password keeps working offline and the new one fails. That is the
+defect the fix actually removed, and it needed no scan-order luck at all.
+
+## 5. The health profile row uploaded under a millisecond timestamp
+
+The second correction overturns a call made above. This note argued that
+`saveHealthProfileBlob`'s `userId: Value(user?.couchId ?? userId)` fallback was
+a harmless improvement on Kotlin's `pojo?.userId = user?._id` and should stay.
+It is not harmless, and the reason is the rule this phase had just finished
+describing: **`userId` is what decides whether `getUpdated()` selects the row
+at all.**
+
+Kotlin writes null for a member whose account has not uploaded, `userId != ''`
+withholds the row, and nothing is sent until the account has a server identity
+— at which point `app_providers`' `updateUserId` stamps the CouchDB id in and
+the row uploads correctly. The port's fallback wrote the device-local
+`'<millis>'` id, which is neither null nor empty, so the row *was* selected and
+POSTed to `/health` keyed on a millisecond timestamp that no server and no
+other device can resolve to a person. Two apps, one recording nothing and one
+recording an unaddressable document, and the port's was the wrong one.
+
+Both `saveHealthProfileBlob` and `saveHealthProfile` now write
+`Value(user?.couchId)`, and both **re-stamp** it on every later save, which is
+what `updateUserHealthProfile` does unconditionally
+(`HealthRepositoryImpl.kt:231`) and the port's update branches did not.
+
+*Failing-first:* "a member with no couchId gets a null userId, so nothing
+uploads" finds the local id in the column and a row in `getUpdated()`. The
+third test in that group ("a later profile save re-stamps the couchId") passes
+either way — `patientIdOf` already prefers the couch id, so the value was
+already right on that path — and is a regression guard, not evidence.
+
+## 6. A rejected manager login cached the account anyway
+
+`checkManagerAndInsert` (`LoginSyncManager.kt:167-175`) tests
+`isManager(jsonDoc)` and returns **before** `saveUser`. The port wrote the row
+and rejected afterwards, leaving behind an account the Kotlin declines to keep.
+The check moved ahead of the cache, and it now reads the document rather than
+the stored row — `UserMapper.docIsManager`, a port of
+`LoginSyncManager.isManager(jsonDoc)`, because at that point there is
+deliberately no row to read.
+
+*Failing-first:* "a rejected manager login caches nothing" finds a row.
+
+## 7. A test that had stopped testing, again
+
+`user_mapper_test`'s "is null when there are no attachments" asserted
+`companion.userImage.value, isNull` — and `Value.absent().value` is *also*
+null, so it passed identically before and after the fix in §3 and could not see
+the distinction that fix exists to make. Both attachment tests now assert
+`.present`, which fails on the pre-fix unconditional write (verified). Twelve
+companion-level tests join them, covering the identity resolution, the
+`generateLocalId` fallback, the `password` guard, and the six guarded fields
+the repository-level tests do not reach (`email`, `middleName`, `gender`,
+`dob`, `age`, and the empty-stored-value branch).
+
+This is the third phase in a row to find a fixture or assertion that had
+absorbed a bug instead of reporting it (Phase 103's achievements uploader,
+Phase 105's `seedHealthRecord`). The tell here was different and worth
+naming: **an assertion that reads `.value` off a drift companion cannot
+distinguish "wrote null" from "wrote nothing"**, and that distinction is the
+entire subject of every preserve-the-stored-value fix this port keeps making.
+Assert `.present`.
+
+## The gap this phase's own fix leaves open
+
+**Legacy health rows are now a live question rather than a deferred one, and
+the integrator has to decide it.** §4 argued that re-keying documents on
+`userId` was safe because the port is unshipped. The audit sharpened the
+outcome and I was wrong about its shape: a pre-Phase-105 examination row
+(`id = 'health-<micros>'`, `userId = <patientId>`) does not merely overwrite
+the patient's profile document — whichever of the two documents is POSTed
+second gets a **409 conflict**, which is not in the outbox's retryable class,
+so that record never reaches the server and nothing logs it. `saveHealthProfileBlob`
+writes before `createExamination`, so the profile usually wins and the
+examination is the record that vanishes.
+
+There is no in-code fix for this: the ambiguity is in the stored rows, not in
+`serialize`, and telling a legacy examination row apart from a profile row
+needs a heuristic on the id prefix that I am not willing to write. The two
+honest options are a one-time data repair in a migration step
+(`UPDATE health_examinations SET user_id = id` for the rows that predate
+Phase 105) — which needs a schema number I have not allocated — or accepting
+the exposure.
+
+**My recommendation is to accept it**, and the reason is specific rather than
+general: for such a row to matter it must be `isUpdated = true` *and* have
+`userId != id`, and Phase 105 established that the rows written that way were
+the ones the port **could not record successfully at all** — invisible to the
+screen, and destroying the profile row on the second save. They exist, if
+anywhere, on a development emulator that has since been wiped. If the
+integrator knows of a device carrying them, ask me for the repair and allocate
+a number; the statement is one line and `health_examinations` is a preserved
+table, so a bump runs it without losing anything else.
+
+**Duplicate rows an older dev build already wrote are not healed either.**
+Kotlin has `cleanupDuplicateUsers` (`UserRepositoryImpl.kt:837-856`: group
+`getDuplicateUsers()` by name, sort `org.couchdb.user:` ahead of `guest_`,
+`deleteByIds` the rest), called from `BecomeMemberActivity.kt:204`. The port
+has neither it nor `UserDao.getDuplicateUsers`/`deleteByIds`. Deliberately not
+written here: its caller is `become_member_screen.dart`, which this lane does
+not own, and an uncalled repository method is exactly the smell Phase 90 went
+back and corrected. It wants the round that also fixes the two registration
+defects below, since that is the same file.
+
+## From the audit — found, verified, and outside this lane
+
+The first two are the severe ones. Both are in `_buildNewUserDoc`
+(`user_repository.dart`, which *is* my file) but neither can be fixed usefully
+without `become_member_screen.dart`, which is not, so they are reported rather
+than half-fixed.
+
+* **A member registered by the port cannot use the app.** `createMember` sends
+  `roles: ["learner"]` (`UserRepositoryImpl.kt:522`); the port sends
+  `<String>[]` and stores `rolesList: const []`
+  (`become_member_screen.dart:265`). `home_screen.dart:351-358` then renders
+  `InactiveDashboardScreen` for `rolesList.isEmpty && !userAdmin`, so
+  registering through the port's own become-member screen and logging in gives
+  "User not activated, please contact administrator" with no path forward on
+  the device. The string `learner` appears nowhere in `flutter/lib`. Fixing
+  only the document half leaves the member inactive until their first *online*
+  login, which is why both halves belong in one change.
+* **The profile the member just typed never reaches Planet.**
+  `_buildNewUserDoc` sends `name`/`password`/`type`/`roles`/`isUserAdmin`/
+  `joinDate`/`planetCode`/`parentCode`. `createMember`
+  (`UserRepositoryImpl.kt:501-526`) also sends firstName, lastName,
+  middleName, email, language, level, phoneNumber, birthDate, gender and
+  `betaEnabled`. The port's local row is written `isUpdated: false`, and
+  `pendingSyncUsers` matches only a blank `couchId` or the dirty flag, so once
+  `uploadNewUser` fills `couchId` nothing ever ships those columns. Register
+  "Ada Lovelace, ada@example.org" and the Planet account has no name and no
+  email, and no other device ever learns them. The values are all on the local
+  row, so `_buildNewUserDoc` reading it by `localId` is the shape of the fix.
+* **Nothing re-queues a dirty health row.** Kotlin re-scans `getUpdated()` on
+  every `AutoSyncWorker` (`:113`) and `UserDataWorker` (`:54`) run, and runs
+  `getUpdatedForUser` during become-member
+  (`ProcessUserDataActivity.kt:175`). In the port `HealthUploader.queuePending`
+  has exactly one caller — `onSaved` after a save
+  (`health_provider.dart:485`) — `HealthQueue.queuePending` returns 0 when
+  `serverConfigProvider` is null, and the sync centre wires health as **pull
+  only** (`dashboard_sync_provider.dart:252`). An examination whose save-time
+  enqueue was skipped stays on the handset indefinitely, and
+  `getUpdatedForUser` has no caller at all. This one matters more after §5,
+  which deliberately makes more rows wait for a server identity: something has
+  to come back for them.
+* **`applyJsonToUser`'s `planetCode` preference write is unported.**
+  `UserRepositoryImpl.kt:273-275` pushes the *document's* `planetCode` into
+  `SharedPreferences` on every login, and `getPlanetCode()` feeds a
+  submission's `source`, the survey filter, the voices planet code and the
+  become-member document. The port only stores the configured community code.
+  They differ for a user whose `_users` document names a different community
+  than the server they signed in against. A pure mapper cannot do this; it
+  needs a side effect in `_cacheUserDoc`, and `UserRepository`'s constructor
+  is `(api, userDao)` — adding `PlanetPrefs` touches `app_providers.dart`.
+* **The become-member → login handoff is dead code.**
+  `become_member_screen.dart:229-236` passes
+  `extra: {username, password, isNewMember}`; nothing reads `state.extra`, and
+  `isNewMember` has one grep hit — its own write. Kotlin's
+  `LoginActivity.handleAutoLogin` (`:214-232`) auto-submits after 500 ms. The
+  port's new member has to retype both.
+* **`user_uploader.dart:171-175` describes behaviour the code does not have.**
+  Its comment says clearing a stale local file path stops `readImageBytes`
+  re-embedding the photo; `markUploaded` writes only `couchId`, `rev` and
+  `isUpdated`. So `userImage` keeps the picker path after a successful upload
+  and every later profile edit re-embeds the same JPEG. Note this is the
+  *other* end of §3: the path must survive a re-login (fixed) and must **not**
+  survive a successful upload (not fixed). Both belong to whoever owns
+  `user_uploader.dart`.
+* **`JsonUtils.getString` coerces where Kotlin refuses.** Kotlin returns `""`
+  unless the primitive `isString` (`JsonUtils.kt:57-61`); the port stringifies
+  anything, so a document with a numeric `age: 42` yields `""` in Kotlin and
+  `"42"` in the port. `json_utils.dart` is not this lane's file.
+* **`serialize`'s remaining field-level differences**, beyond the `creatorId`
+  source already noted above: `JsonUtils.addFloat`/`addInteger`/`addLong` omit
+  **zeros**, so Kotlin drops `temperature`/`pulse`/`height`/`weight`/`date`
+  when they are 0 while the port always sends them; and Kotlin sends
+  `"data": null` where the port omits the key. Left as a deliberate
+  improvement (a real reading of 0 is worth sending) rather than ported, but
+  now written down.
+* **`cacheDocuments` skips rows with `isUpdated == true`
+  (`health_repository.dart:754`) — an undocumented improvement.** Kotlin's
+  `bulkInsertFromSync` (`HealthRepositoryImpl.kt:81-92`) upserts
+  unconditionally with `isUpdated = false`, so a server copy overwrites a
+  pending local edit and clears its dirty flag. The port is right and Kotlin
+  loses data; it belongs in *Faithful quirks* (inverted) in
+  `docs/kotlin-to-flutter-migration.md`, which this round is keeping off.
+  **For the integrator to fold in**, alongside Phase 105's own deferred entry.
+
+## For the integrator — updated
+
+* **Still no schema change**, and still no number requested — but read *The gap
+  this phase's own fix leaves open* first: there is one repair statement that
+  would need a number if the integrator judges any dev device to be carrying
+  pre-Phase-105 health rows. My recommendation is that it does not.
+* **No new `app_en.arb` keys.**
+* Files touched, all within this lane: `lib/data/local/user_mapper.dart`,
+  `lib/repository/user_repository.dart`,
+  `lib/repository/health_repository.dart`, `lib/data/local/app_database.dart`
+  (two query bodies only), and three test files.
+* The follow-up worth scheduling next is the become-member round: `learner`,
+  the profile fields on the creation document, `cleanupDuplicateUsers` with
+  its caller, and the dead auto-login handoff are one file's worth of work and
+  the first of them means a member the port registers cannot currently use it.

--- a/flutter/PHASE_107_NOTES.md
+++ b/flutter/PHASE_107_NOTES.md
@@ -1,0 +1,9 @@
+# Phase 107 — one member, one row: the user identity rule and the health key it protects
+
+*In progress.* Phase 105's audit left this: `UserMapper.fromDoc` keys the cached
+row on the document `_id` unconditionally, where `buildUserFromJson` reuses the
+existing row through `getUserByAnyId` and keeps its local `id`
+(`UserRepositoryImpl.kt:297-308`). A member registered offline who later signs
+in online can therefore end up with two rows — and because health records are
+encrypted with a per-user `key`/`iv`, resolving that member to the wrong row can
+make their records undecryptable.

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -2750,9 +2750,21 @@ class HealthExaminationDao extends DatabaseAccessor<AppDatabase>
   )..where((h) => h.id.equals(id))).getSingleOrNull();
 
   /// Get all updated examinations that need syncing.
-  Future<List<HealthExaminationRow>> getUpdated() => (select(
-    healthExaminations,
-  )..where((h) => h.isUpdated.equals(true) & h.userId.isNotNull())).get();
+  ///
+  /// `WHERE isUpdated = 1 AND userId != ''`, and the second half is not
+  /// `IS NOT NULL`: in SQL `userId != ''` is false for NULL as well, so Kotlin
+  /// excludes a blank `userId` along with a missing one. That is what keeps
+  /// `HealthRepository.serialize`'s omit-`_id` branch off the upload path —
+  /// a POST with no `_id` makes CouchDB mint a fresh document every drain, so
+  /// one examination would become a new record on every sync.
+  Future<List<HealthExaminationRow>> getUpdated() =>
+      (select(healthExaminations)..where(
+            (h) =>
+                h.isUpdated.equals(true) &
+                h.userId.isNotNull() &
+                h.userId.equals('').not(),
+          ))
+          .get();
 
   /// Get updated examinations for a specific user.
   Future<List<HealthExaminationRow>> getUpdatedForUser(String userId) =>

--- a/flutter/lib/data/local/user_mapper.dart
+++ b/flutter/lib/data/local/user_mapper.dart
@@ -13,44 +13,160 @@ import 'app_database.dart';
 class UserMapper {
   const UserMapper._();
 
-  static UsersCompanion fromDoc(Map<String, dynamic> doc) {
+  /// Port of `buildUserFromJson` + `applyJsonToUser`
+  /// (`UserRepositoryImpl.kt:292-316` and `:180-276`).
+  ///
+  /// [existing] is the row the document already belongs to — Kotlin resolves
+  /// it with `getUserByAnyId(_id)`, which is
+  /// `SELECT * FROM users WHERE id = :id OR _id = :id LIMIT 1`, so a document
+  /// finds a row through its `_id` column as readily as through its key. Pass
+  /// it and the row **keeps its own `id`**: `applyJsonToUser` reassigns `id`
+  /// only when it is blank.
+  ///
+  /// That is the whole identity rule, and it is load-bearing. A member
+  /// registered on this device keeps a locally-minted `'<millis>'` id and
+  /// gains a `couchId` only when the upload lands, so keying the cached row on
+  /// the document `_id` gave that member a *second* row the moment they first
+  /// signed in online — one carrying no `key`/`iv`, which
+  /// `UserDao.getById(couchId)` matches as readily as the real one. Since the
+  /// health records are encrypted with those two values and nothing else on
+  /// the device or the server can reproduce them, resolving the member to the
+  /// wrong row does not merely duplicate a name: it makes their medical
+  /// records undecryptable.
+  ///
+  /// [generateLocalId] supplies the key for a document with no `_id` at all —
+  /// Kotlin's `UUID.randomUUID()` fallback. It is only reachable for a
+  /// malformed document; a real `_users` doc is always keyed
+  /// `org.couchdb.user:<name>`.
+  static UsersCompanion fromDoc(
+    Map<String, dynamic> doc, {
+    UserRow? existing,
+    String Function()? generateLocalId,
+  }) {
     final couchId = JsonUtils.getString('_id', doc);
+    final rowId = (existing?.id.isNotEmpty ?? false)
+        ? existing!.id
+        : (couchId.isNotEmpty
+              ? couchId
+              : (generateLocalId ?? _defaultLocalId)());
+
     return UsersCompanion(
-      // The Kotlin keys the row on the document `_id` when there is one, so a
-      // re-login updates the existing row instead of duplicating it.
-      id: Value(couchId),
+      id: Value(rowId),
       couchId: Value(couchId.isEmpty ? null : couchId),
       rev: Value(JsonUtils.getStringOrNull('_rev', doc)),
       name: Value(JsonUtils.getStringOrNull('name', doc)),
       rolesList: Value(JsonUtils.getStringList('roles', doc)),
       userAdmin: Value(JsonUtils.getBool('isUserAdmin', doc)),
-      joinDate: Value(JsonUtils.getLong('joinDate', doc)),
-      firstName: Value(JsonUtils.getStringOrNull('firstName', doc)),
-      lastName: Value(JsonUtils.getStringOrNull('lastName', doc)),
-      middleName: Value(JsonUtils.getStringOrNull('middleName', doc)),
-      email: Value(JsonUtils.getStringOrNull('email', doc)),
+      // Guarded, `if (newJoinDate != 0L || joinDate == 0L)`: a document
+      // without a join date leaves a recorded one alone.
+      joinDate: _keepingStoredInt(
+        JsonUtils.getLong('joinDate', doc),
+        existing?.joinDate,
+      ),
+      // The eleven guarded string fields, in Kotlin's order. Each is
+      // `if (new.isNotEmpty() || old.isNullOrEmpty()) field = new` — a
+      // document that omits one keeps what the row already holds, which is
+      // what stops a re-login wiping a profile the member filled in offline.
+      firstName: _keepingStored(
+        JsonUtils.getStringOrNull('firstName', doc),
+        existing?.firstName,
+      ),
+      lastName: _keepingStored(
+        JsonUtils.getStringOrNull('lastName', doc),
+        existing?.lastName,
+      ),
+      middleName: _keepingStored(
+        JsonUtils.getStringOrNull('middleName', doc),
+        existing?.middleName,
+      ),
+      email: _keepingStored(
+        JsonUtils.getStringOrNull('email', doc),
+        existing?.email,
+      ),
+      phoneNumber: _keepingStored(
+        JsonUtils.getStringOrNull('phoneNumber', doc),
+        existing?.phoneNumber,
+      ),
+      level: _keepingStored(
+        JsonUtils.getStringOrNull('level', doc),
+        existing?.level,
+      ),
+      language: _keepingStored(
+        JsonUtils.getStringOrNull('language', doc),
+        existing?.language,
+      ),
+      gender: _keepingStored(
+        JsonUtils.getStringOrNull('gender', doc),
+        existing?.gender,
+      ),
+      dob: _keepingStored(
+        JsonUtils.getStringOrNull('birthDate', doc),
+        existing?.dob,
+      ),
+      birthPlace: _keepingStored(
+        JsonUtils.getStringOrNull('birthPlace', doc),
+        existing?.birthPlace,
+      ),
+      age: _keepingStored(JsonUtils.getStringOrNull('age', doc), existing?.age),
+      // Unguarded in the Kotlin, and deliberately so: these four are the
+      // credentials PBKDF2 verification reads, and the document is their
+      // authority. (`updateUserSecurityData` is the path that must *not*
+      // overwrite them with null — see `aa24dfa6c`/#15836 — but that is a
+      // response to a POST, not the account document.)
       planetCode: Value(JsonUtils.getStringOrNull('planetCode', doc)),
       parentCode: Value(JsonUtils.getStringOrNull('parentCode', doc)),
-      phoneNumber: Value(JsonUtils.getStringOrNull('phoneNumber', doc)),
       passwordScheme: Value(JsonUtils.getStringOrNull('password_scheme', doc)),
       iterations: Value(JsonUtils.getStringOrNull('iterations', doc)),
       derivedKey: Value(JsonUtils.getStringOrNull('derived_key', doc)),
       salt: Value(JsonUtils.getStringOrNull('salt', doc)),
-      level: Value(JsonUtils.getStringOrNull('level', doc)),
-      language: Value(JsonUtils.getStringOrNull('language', doc)),
-      gender: Value(JsonUtils.getStringOrNull('gender', doc)),
-      dob: Value(JsonUtils.getStringOrNull('birthDate', doc)),
-      age: Value(JsonUtils.getStringOrNull('age', doc)),
-      birthPlace: Value(JsonUtils.getStringOrNull('birthPlace', doc)),
+      // `if (_id?.isEmpty() == true) password = getString("password", jsonDoc)`
+      // — and that reads `_id` *after* `_id = newId`, so the plaintext
+      // password is taken only for a document with no `_id`, which is the
+      // guest shape. Everyone else is verified against `derived_key`/`salt`.
+      password: couchId.isEmpty
+          ? Value(JsonUtils.getStringOrNull('password', doc))
+          : const Value.absent(),
       // Port of `UserEntity.addImageUrl`: a `_users` document stores the
       // profile photo as a CouchDB attachment under `_attachments`, not as a
       // top-level `userImage` field (the Kotlin doc never has one). We store
       // the attachment *name* here and build the full URL at display time via
       // `UrlUtils.userImageUrl`, so the persisted value carries no server
       // credentials and survives a server URL change.
-      userImage: Value(_attachmentName(doc)),
+      //
+      // `addImageUrl` writes nothing when the document has no non-empty
+      // `_attachments`, and the stored value it leaves alone can be a local
+      // file path a queued photo upload has not sent yet — so an absent
+      // attachment must not null the column.
+      userImage: _imageName(doc),
       isArchived: Value(JsonUtils.getBool('isArchived', doc)),
     );
+  }
+
+  static String _defaultLocalId() => '${DateTime.now().microsecondsSinceEpoch}';
+
+  /// `if (new.isNotEmpty() || old.isNullOrEmpty()) field = new`.
+  ///
+  /// An absent [Value] is what "leave the stored one alone" means to
+  /// `insertOnConflictUpdate`: the column stays out of the `DO UPDATE SET`
+  /// list. On an insert there is no stored value to keep, so [stored] is null
+  /// and the incoming one is written either way.
+  static Value<String?> _keepingStored(String? incoming, String? stored) {
+    if (incoming != null && incoming.isNotEmpty) return Value(incoming);
+    if (stored == null || stored.isEmpty) return Value(incoming);
+    return const Value.absent();
+  }
+
+  /// The `joinDate` variant: `0` is the empty value rather than `null`.
+  static Value<int> _keepingStoredInt(int incoming, int? stored) {
+    if (incoming != 0 || (stored ?? 0) == 0) return Value(incoming);
+    return const Value.absent();
+  }
+
+  /// The attachment name to store, or an absent [Value] where `addImageUrl`
+  /// writes nothing.
+  static Value<String?> _imageName(Map<String, dynamic> doc) {
+    final name = _attachmentName(doc);
+    return name == null ? const Value.absent() : Value(name);
   }
 
   /// The first `_attachments` key in [doc], or `null` - the slot Kotlin takes

--- a/flutter/lib/data/local/user_mapper.dart
+++ b/flutter/lib/data/local/user_mapper.dart
@@ -260,6 +260,17 @@ class UserMapper {
     return await file.readAsBytes();
   }
 
+  /// Port of `LoginSyncManager.isManager(jsonDoc)` — the same predicate as
+  /// [isManager], read off the account **document** rather than a stored row.
+  /// `checkManagerAndInsert` applies it before caching anything, so it has to
+  /// be answerable without a row.
+  static bool docIsManager(Map<String, dynamic> doc) =>
+      JsonUtils.getBool('isUserAdmin', doc) ||
+      JsonUtils.getStringList(
+        'roles',
+        doc,
+      ).any((role) => role.toLowerCase() == 'manager');
+
   /// Port of `UserEntity.isManager()` - the manager/admin role check the login
   /// screen applies when `isManagerMode` is set.
   static bool isManager(UserRow user) =>

--- a/flutter/lib/repository/health_repository.dart
+++ b/flutter/lib/repository/health_repository.dart
@@ -281,17 +281,32 @@ class HealthRepository {
       await _dao.upsert(
         HealthExaminationsCompanion(
           id: Value(userId),
-          userId: Value(user?.couchId ?? userId),
+          // `createPojo`: `pojo?.userId = user?._id` — the patient's CouchDB
+          // id, and **null** for a member whose account has not uploaded.
+          // There used to be a `?? userId` fallback here, and it was not
+          // inert: `userId` is what decides whether
+          // [HealthExaminationDao.getUpdated] selects the row, so the local
+          // `'<millis>'` id it fell back to made the port POST a `/health`
+          // document keyed on a millisecond timestamp that no server and no
+          // other device can resolve to a person. Kotlin withholds the row
+          // until the account has a server identity, and
+          // `app_providers`' `updateUserId` stamps it in when the upload
+          // lands.
+          userId: Value(user?.couchId),
           data: Value(encrypted),
           isUpdated: const Value(true),
           date: Value(DateTime.now().millisecondsSinceEpoch),
         ),
       );
     } else {
+      final user = await _userDao.getById(userId);
       await _dao.upsert(
         HealthExaminationsCompanion(
           id: Value(existing.id),
-          userId: Value(existing.userId),
+          // Re-stamped on every save, as `updateUserHealthProfile` does
+          // (`HealthRepositoryImpl.kt:231`): once the account uploads this
+          // becomes the CouchDB id, and while it has not it stays null.
+          userId: Value(user?.couchId ?? existing.userId),
           data: Value(encrypted),
           isUpdated: const Value(true),
         ),
@@ -371,7 +386,9 @@ class HealthRepository {
       await _dao.upsert(
         HealthExaminationsCompanion(
           id: Value(userId),
-          userId: Value(user.couchId ?? user.id),
+          // `healthPojo.userId = userModel?._id` — null until the account
+          // uploads. See the note in [saveHealthProfileBlob].
+          userId: Value(user.couchId),
           data: Value(encrypted),
           isUpdated: const Value(true),
           date: Value(DateTime.now().millisecondsSinceEpoch),
@@ -381,7 +398,8 @@ class HealthRepository {
       await _dao.upsert(
         HealthExaminationsCompanion(
           id: Value(exam.id),
-          userId: Value(exam.userId),
+          // Re-stamped every save, per `HealthRepositoryImpl.kt:231`.
+          userId: Value(user.couchId ?? exam.userId),
           data: Value(encrypted),
           isUpdated: const Value(true),
         ),

--- a/flutter/lib/repository/health_repository.dart
+++ b/flutter/lib/repository/health_repository.dart
@@ -809,9 +809,25 @@ class HealthRepository {
   }
 
   /// Serialize a row to JSON for upload.
+  ///
+  /// The document is keyed on `userId`, not on the row's own id:
+  /// `if (!health.userId.isNullOrEmpty()) object.addProperty("_id", health.userId)`
+  /// (`HealthExamination.kt:96`). The two differ for the profile row of a
+  /// member registered on this device — `createPojo` writes `_id` = the
+  /// patient id the screen was opened with and `userId` = the patient's
+  /// CouchDB id, which `app_providers`' `updateUserId` fills in once the
+  /// account uploads — and `userId` is the id the sync-in direction would key
+  /// the row on (`_docToCompanion`: `userId: doc['_id']`), so it is the
+  /// document's identity in both directions.
+  ///
+  /// A blank `userId` omits `_id` entirely, which would make CouchDB mint a
+  /// fresh document on every drain. That branch is unreachable from the
+  /// upload path because [HealthExaminationDao.getUpdated] excludes those rows
+  /// — `userId != ''` — and the two rules only work as a pair.
   static Map<String, dynamic> serialize(HealthExaminationRow row) {
+    final docId = row.userId ?? '';
     return {
-      if (row.id.isNotEmpty) '_id': row.id,
+      if (docId.isNotEmpty) '_id': docId,
       if (row.rev != null && row.rev!.isNotEmpty) '_rev': row.rev,
       if (row.data != null) 'data': row.data,
       'temperature': row.temperature,

--- a/flutter/lib/repository/user_repository.dart
+++ b/flutter/lib/repository/user_repository.dart
@@ -129,14 +129,20 @@ class UserRepository {
       return const LoginFailure(LoginFailureReason.invalidCredentials);
     }
 
-    // Port of `checkManagerAndInsert`: cache the account so the next sign-in
-    // works offline.
+    // `checkManagerAndInsert` (`LoginSyncManager.kt:167-175`) tests the
+    // **document** and returns before `saveUser`, so a manager-mode sign-in by
+    // a non-manager caches nothing. Reading the stored row instead and
+    // rejecting afterwards left an account behind that the Kotlin declines to
+    // keep.
+    if (isManagerMode && !UserMapper.docIsManager(doc)) {
+      return const LoginFailure(LoginFailureReason.notAManager);
+    }
+
+    // Port of `checkManagerAndInsert`'s `saveUser`: cache the account so the
+    // next sign-in works offline.
     final stored = await _cacheUserDoc(doc);
     if (stored == null) {
       return const LoginFailure(LoginFailureReason.userNotFound);
-    }
-    if (isManagerMode && !UserMapper.isManager(stored)) {
-      return const LoginFailure(LoginFailureReason.notAManager);
     }
     return LoginSuccess(stored);
   }

--- a/flutter/lib/repository/user_repository.dart
+++ b/flutter/lib/repository/user_repository.dart
@@ -131,9 +131,7 @@ class UserRepository {
 
     // Port of `checkManagerAndInsert`: cache the account so the next sign-in
     // works offline.
-    await _userDao.upsert(UserMapper.fromDoc(doc));
-
-    final stored = await _userDao.getByName(username);
+    final stored = await _cacheUserDoc(doc);
     if (stored == null) {
       return const LoginFailure(LoginFailureReason.userNotFound);
     }
@@ -141,6 +139,32 @@ class UserRepository {
       return const LoginFailure(LoginFailureReason.notAManager);
     }
     return LoginSuccess(stored);
+  }
+
+  /// Port of `buildUserFromJson` + `upsertUser`
+  /// (`UserRepositoryImpl.kt:292-322`).
+  ///
+  /// Resolves the row the document belongs to *before* writing it, so a
+  /// document whose `_id` already sits in some row's `couchId` updates that
+  /// row instead of adding a second one keyed on the id. See
+  /// [UserMapper.fromDoc] for why a duplicate here costs a member their health
+  /// records.
+  ///
+  /// The lookup is skipped for a document with no `_id`, matching Kotlin:
+  /// there the id it searches by is a freshly minted UUID, which can never
+  /// match a stored row.
+  ///
+  /// Returns the stored row, re-read by the key it was written under —
+  /// `upsertUser` ends in `userDao.getById(entity.id)`. Re-reading by *name*
+  /// is what this used to do, and a name carries no unique constraint: two
+  /// planets can hold an `ada`, and `LIMIT 1` then picks the session user by
+  /// scan order.
+  Future<UserRow?> _cacheUserDoc(Map<String, dynamic> doc) async {
+    final couchId = JsonUtils.getString('_id', doc);
+    final existing = couchId.isEmpty ? null : await _userDao.getById(couchId);
+    final companion = UserMapper.fromDoc(doc, existing: existing);
+    await _userDao.upsert(companion);
+    return _userDao.getById(companion.id.value);
   }
 
   /// Port of `UserRepositoryImpl.authenticateUser`.

--- a/flutter/test/data/local/user_mapper_test.dart
+++ b/flutter/test/data/local/user_mapper_test.dart
@@ -24,13 +24,19 @@ void main() {
       expect(companion.userImage.value, 'ada.png');
     });
 
-    test('is null when there are no attachments', () {
+    test('writes nothing when there are no attachments', () {
       final companion = UserMapper.fromDoc({
         '_id': 'org.couchdb.user:ada',
         'name': 'ada',
       });
 
-      expect(companion.userImage.value, isNull);
+      // `addImageUrl` touches `userImage` only inside
+      // `if (jsonDoc?.has("_attachments") == true)`, so an absent attachments
+      // block leaves the stored value alone. Asserting on `.value` cannot see
+      // that: `Value.absent().value` is also null, so the assertion passed
+      // identically while the mapper was nulling the column — including a
+      // local file path a queued photo upload had not sent yet.
+      expect(companion.userImage.present, isFalse);
     });
 
     test('ignores a top-level userImage field in favour of attachments', () {
@@ -46,14 +52,16 @@ void main() {
       expect(companion.userImage.value, 'real.png');
     });
 
-    test('is null for an empty attachments object', () {
+    test('writes nothing for an empty attachments object', () {
       final companion = UserMapper.fromDoc({
         '_id': 'org.couchdb.user:ada',
         'name': 'ada',
         '_attachments': <String, dynamic>{},
       });
 
-      expect(companion.userImage.value, isNull);
+      // `firstOrNull()?.key` is null, and the assignment is behind
+      // `if (key1 != null)`.
+      expect(companion.userImage.present, isFalse);
     });
   });
 
@@ -304,6 +312,163 @@ void main() {
       expect(UserMapper.isManager(userWith(roles: ['comanager'])), isFalse);
       expect(UserMapper.isManager(userWith(roles: ['managers'])), isFalse);
       expect(UserMapper.isManager(userWith(roles: ['team manager'])), isFalse);
+    });
+  });
+  group('UserMapper.fromDoc identity and field guards', () {
+    UserRow row({
+      String id = '1700000000000',
+      String? couchId = 'org.couchdb.user:ada',
+      String? email,
+      String? middleName,
+      String? gender,
+      String? dob,
+      String? age,
+    }) {
+      return UserRow(
+        id: id,
+        couchId: couchId,
+        name: 'ada',
+        rolesList: const [],
+        userAdmin: false,
+        joinDate: 0,
+        email: email,
+        middleName: middleName,
+        gender: gender,
+        dob: dob,
+        age: age,
+        isArchived: false,
+        isUpdated: false,
+      );
+    }
+
+    Map<String, dynamic> doc([Map<String, dynamic> extra = const {}]) => {
+      '_id': 'org.couchdb.user:ada',
+      'name': 'ada',
+      ...extra,
+    };
+
+    test('an existing row keeps its own id', () {
+      // `applyJsonToUser` reassigns `id` only `if (id.isNullOrBlank())`.
+      expect(
+        UserMapper.fromDoc(doc(), existing: row()).id.value,
+        '1700000000000',
+      );
+    });
+
+    test('with no existing row the document id is the key', () {
+      expect(UserMapper.fromDoc(doc()).id.value, 'org.couchdb.user:ada');
+    });
+
+    test('a document with no _id falls back to a generated key', () {
+      // Kotlin's `takeIf { it.isNotEmpty() } ?: UUID.randomUUID().toString()`.
+      final companion = UserMapper.fromDoc({
+        'name': 'ada',
+      }, generateLocalId: () => 'generated-1');
+      expect(companion.id.value, 'generated-1');
+      expect(companion.couchId.value, isNull);
+    });
+
+    test('a document with no _id takes the plaintext password', () {
+      // `if (_id?.isEmpty() == true) password = …`, read *after*
+      // `_id = newId` — so the document's `_id`, not the row's prior one.
+      final guest = UserMapper.fromDoc({
+        'name': 'ada',
+        'password': 'plain',
+      }, generateLocalId: () => 'generated-1');
+      expect(guest.password.value, 'plain');
+
+      // A real `_users` document never has its password read.
+      final normal = UserMapper.fromDoc(doc({'password': 'plain'}));
+      expect(normal.password.present, isFalse);
+    });
+
+    test('every guarded field keeps a stored value the document omits', () {
+      final companion = UserMapper.fromDoc(
+        doc(),
+        existing: row(
+          email: 'ada@example.org',
+          middleName: 'Augusta',
+          gender: 'female',
+          dob: '1815-12-10',
+          age: '36',
+        ),
+      );
+
+      // The six the repository-level tests do not reach.
+      expect(companion.email.present, isFalse);
+      expect(companion.middleName.present, isFalse);
+      expect(companion.gender.present, isFalse);
+      expect(companion.dob.present, isFalse);
+      expect(companion.age.present, isFalse);
+    });
+
+    test('a guarded field is written when the stored one is empty', () {
+      // `old.isNullOrEmpty()` — an empty stored value is overwritten with the
+      // document's, even when that is empty too.
+      final companion = UserMapper.fromDoc(doc(), existing: row(email: ''));
+      expect(companion.email.present, isTrue);
+      expect(companion.email.value, isNull);
+    });
+
+    test('an unguarded field is written even when the document omits it', () {
+      // `derived_key`/`salt`/`roles` are assigned unconditionally: the account
+      // document is their authority, and an online login has to be able to
+      // revoke a role or reset a credential.
+      final companion = UserMapper.fromDoc(doc(), existing: row());
+      expect(companion.derivedKey.present, isTrue);
+      expect(companion.derivedKey.value, isNull);
+      expect(companion.rolesList.value, isEmpty);
+    });
+
+    test('joinDate treats 0 as the empty value', () {
+      final stored = UserRow(
+        id: '1700000000000',
+        name: 'ada',
+        rolesList: const [],
+        userAdmin: false,
+        joinDate: 1600000000000,
+        isArchived: false,
+        isUpdated: false,
+      );
+      expect(
+        UserMapper.fromDoc(doc(), existing: stored).joinDate.present,
+        isFalse,
+      );
+      expect(
+        UserMapper.fromDoc(
+          doc({'joinDate': 1700000000001}),
+          existing: stored,
+        ).joinDate.value,
+        1700000000001,
+      );
+    });
+  });
+
+  group('UserMapper.docIsManager', () {
+    test('reads the manager role case-insensitively', () {
+      expect(
+        UserMapper.docIsManager({
+          'roles': ['Manager'],
+        }),
+        isTrue,
+      );
+      expect(
+        UserMapper.docIsManager({
+          'roles': ['learner'],
+        }),
+        isFalse,
+      );
+    });
+
+    test('isUserAdmin alone is enough', () {
+      expect(
+        UserMapper.docIsManager({'roles': <String>[], 'isUserAdmin': true}),
+        isTrue,
+      );
+    });
+
+    test('a document with neither is not a manager', () {
+      expect(UserMapper.docIsManager({'name': 'ada'}), isFalse);
     });
   });
 }

--- a/flutter/test/repository/health_repository_test.dart
+++ b/flutter/test/repository/health_repository_test.dart
@@ -1043,6 +1043,107 @@ void main() {
       expect(await repository.getUpdated(), isEmpty);
     });
   });
+  group('the profile row waits for a server identity', () {
+    // `updateUserHealthProfile` re-stamps `healthPojo.userId = userModel?._id`
+    // on **every** profile save (`HealthRepositoryImpl.kt:231`), and
+    // `createPojo` writes the same value when it creates the row
+    // (`HealthExaminationActivity.kt:377`). For a member whose account has not
+    // uploaded that is null, `getUpdated()`'s `userId != ''` withholds the
+    // row, and Kotlin uploads nothing until the account has a CouchDB id —
+    // at which point `updateUserId` fills it in (`app_providers.dart:399`).
+    //
+    // The port's `?? userId` fallback wrote the device-local `'<millis>'` id
+    // instead, which is neither null nor empty, so the row was selected and
+    // POSTed to `/health` under a millisecond timestamp no server and no
+    // other device can resolve to a person.
+
+    test(
+      'a member with no couchId gets a null userId, so nothing uploads',
+      () async {
+        final repository = createRepository();
+        await database.userDao.upsert(
+          const UsersCompanion(id: Value('1700000000000'), name: Value('ada')),
+        );
+
+        await repository.saveHealthProfile('1700000000000', {
+          'emergencyContact': '555-0100',
+        });
+
+        final row = await database.healthExaminationDao.getByIdOrUserId(
+          '1700000000000',
+        );
+        expect(row?.userId, isNull);
+        expect(
+          await repository.getUpdated(),
+          isEmpty,
+          reason:
+              'Kotlin withholds this row until the account exists on a '
+              'server; the fallback made it upload under a local timestamp',
+        );
+      },
+    );
+
+    test('the couchId is stamped in once the account uploads', () async {
+      final repository = createRepository();
+      await database.userDao.upsert(
+        const UsersCompanion(id: Value('1700000000000'), name: Value('ada')),
+      );
+      await repository.saveHealthProfile('1700000000000', {
+        'emergencyContact': '555-0100',
+      });
+
+      // The upload lands, and `app_providers`' `updateUserId` rewrites the
+      // row — the third part of the rule.
+      await database.userDao.updateUserSecurityData(
+        localId: '1700000000000',
+        couchId: 'org.couchdb.user:ada',
+        rev: '1-a',
+        passwordScheme: null,
+        derivedKey: null,
+        salt: null,
+        iterations: null,
+      );
+      await database.healthExaminationDao.updateUserId(
+        '1700000000000',
+        'org.couchdb.user:ada',
+      );
+
+      final pending = await repository.getUpdated();
+      expect(pending, hasLength(1));
+      expect(
+        HealthRepository.serialize(pending.single)['_id'],
+        'org.couchdb.user:ada',
+      );
+    });
+
+    test(
+      'a later profile save re-stamps the couchId rather than dropping it',
+      () async {
+        final repository = createRepository();
+        await database.userDao.upsert(
+          const UsersCompanion(
+            id: Value('1700000000000'),
+            couchId: Value('org.couchdb.user:ada'),
+            name: Value('ada'),
+          ),
+        );
+
+        // `patientIdOf` prefers the couch id, which is the id the health
+        // screens address a patient by once the account exists.
+        await repository.saveHealthProfile('org.couchdb.user:ada', {
+          'notes': 'first',
+        });
+        await repository.saveHealthProfile('org.couchdb.user:ada', {
+          'notes': 'second',
+        });
+
+        final row = await database.healthExaminationDao.getByIdOrUserId(
+          'org.couchdb.user:ada',
+        );
+        expect(row?.userId, 'org.couchdb.user:ada');
+      },
+    );
+  });
 }
 
 class MockPlanetApi extends Mock implements PlanetApi {}

--- a/flutter/test/repository/health_repository_test.dart
+++ b/flutter/test/repository/health_repository_test.dart
@@ -9,6 +9,7 @@ import 'package:myplanet/core/sync/sync_result.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/repository/health_repository.dart';
+import 'package:myplanet/repository/user_repository.dart';
 
 void main() {
   late AppDatabase database;
@@ -865,6 +866,181 @@ void main() {
         'nonexistent',
       );
       expect(exam, isNull);
+    });
+  });
+  group('a member registered offline who later signs in online', () {
+    // The transition Phase 107 is about, end to end: the account is created on
+    // this device with a local id, health records are encrypted with the
+    // `key`/`iv` minted on that row, the upload records the server-assigned
+    // `couchId`, and only then does the member sign in online. From that point
+    // the health screens address them by `patientIdOf` — the CouchDB id — so
+    // everything below depends on that id resolving to the one row that holds
+    // their key.
+    const localId = '1700000000000';
+    const couchId = 'org.couchdb.user:ada';
+
+    // Generated independently with Python's `hashlib.pbkdf2_hmac` using the
+    // parameters `AndroidDecrypter` pins (SHA1, 10 iterations, 20 bytes).
+    const password = 'correct-horse';
+    const salt = 'a3f1c9d2e5b74806a1c2d3e4f5061728';
+    const derivedKey = 'ddb696f6f34c21547a45f8034c6e41daf63b3ce3';
+
+    test('their examinations are still readable afterwards', () async {
+      final health = createRepository();
+
+      // 1. `become_member_screen`: a local id, no couchId.
+      await database.userDao.upsert(
+        const UsersCompanion(id: Value(localId), name: Value('ada')),
+      );
+
+      // 2. An examination recorded offline, encrypted with the key
+      //    `ensureSecurityKeys` mints on that row.
+      final blob = await health.encryptData(localId, '{"allergies":"peanuts"}');
+      expect(blob, isNotNull);
+      final examId = await health.createExamination(
+        profileId: 'profile-key',
+        temperature: 37,
+        pulse: 72,
+        height: 170,
+        weight: 65,
+        data: blob,
+      );
+
+      // 3. The upload lands and the row gains its server id.
+      await database.userDao.updateUserSecurityData(
+        localId: localId,
+        couchId: couchId,
+        rev: '1-abc',
+        passwordScheme: 'pbkdf2',
+        derivedKey: derivedKey,
+        salt: salt,
+        iterations: '10',
+      );
+
+      // 4. The member signs in online for the first time.
+      final loginApi = MockPlanetApi();
+      const config = ServerConfig(
+        serverUrl: 'https://planet.example.org',
+        pin: '1234',
+        couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+      );
+      when(
+        () =>
+            loginApi.getJsonObject(any(), authHeader: any(named: 'authHeader')),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          '_id': couchId,
+          '_rev': '1-abc',
+          'name': 'ada',
+          'derived_key': derivedKey,
+          'salt': salt,
+          'password_scheme': 'pbkdf2',
+          'iterations': '10',
+        }),
+      );
+      final login = await UserRepository(
+        loginApi,
+        database.userDao,
+      ).loginOnline(config: config, username: 'ada', password: password);
+      expect(login, isA<LoginSuccess>());
+
+      // 5. One row, and the CouchDB id the health screens use resolves to it.
+      expect(await database.userDao.getAllUsers(), hasLength(1));
+      final patient = await database.userDao.getById(couchId);
+      expect(patient?.id, localId);
+
+      // 6. Which is what keeps the record readable.
+      final row = await health.getById(examId);
+      final plain = await health.decryptData(couchId, row!.data);
+      expect(plain, '{"allergies":"peanuts"}');
+    });
+  });
+  group('the upload keys documents the way Kotlin keys them', () {
+    // `HealthExamination.serialize` is
+    // `if (!health.userId.isNullOrEmpty()) object.addProperty("_id", health.userId)`
+    // (`HealthExamination.kt:96`) — the document is keyed on `userId`, not on
+    // the row's own id, and carries no `_id` at all while `userId` is empty.
+    //
+    // `HealthExaminationDao.getUpdated()` is
+    // `WHERE isUpdated = 1 AND userId != ''`, and in SQL `userId != ''` is
+    // false for NULL too, so Kotlin excludes both. The two halves are one
+    // rule: the guard is what makes serialize's omit-`_id` branch unreachable
+    // from the upload path. Porting either half alone is what creates the
+    // hazard — a POST with no `_id` makes CouchDB mint a fresh document on
+    // every drain, so one examination becomes a new record each sync.
+
+    test('the document is keyed on userId, not on the row id', () async {
+      final repository = createRepository();
+      // `createPojo` writes the profile row with `_id` = the patient id the
+      // screen was opened with and `userId` = the patient's CouchDB id, and
+      // `app_providers`' `updateUserId` rewrites that `userId` once the
+      // account uploads. So the two genuinely differ for a member registered
+      // on this device, and Kotlin uploads under the CouchDB id.
+      final id = await repository.createExamination(
+        userId: 'org.couchdb.user:ada',
+        temperature: 37,
+        pulse: 72,
+        height: 170,
+        weight: 65,
+      );
+
+      final payload = HealthRepository.serialize(
+        (await repository.getById(id))!,
+      );
+      expect(payload['_id'], 'org.couchdb.user:ada');
+    });
+
+    test('a row with no userId carries no _id', () async {
+      final repository = createRepository();
+      await repository.createExamination(
+        temperature: 37,
+        pulse: 72,
+        height: 170,
+        weight: 65,
+      );
+      // The row above gets `userId` = its own id; blank it the way an older
+      // build's row would have been.
+      await database.healthExaminationDao.updateUserId('health-local-1', '');
+
+      final row = await repository.getById('health-local-1');
+      expect(
+        HealthRepository.serialize(row!),
+        isNot(contains('_id')),
+        reason: 'addProperty is guarded by !userId.isNullOrEmpty()',
+      );
+    });
+
+    test('getUpdated skips a row whose userId is blank', () async {
+      final repository = createRepository();
+      await repository.createExamination(
+        temperature: 37,
+        pulse: 72,
+        height: 170,
+        weight: 65,
+      );
+      await repository.createExamination(
+        temperature: 38,
+        pulse: 80,
+        height: 170,
+        weight: 65,
+      );
+      await database.healthExaminationDao.updateUserId('health-local-1', '');
+
+      // `userId != ''` excludes the blank row, which is exactly the row
+      // serialize would have POSTed without an `_id`.
+      final pending = await repository.getUpdated();
+      expect(pending.map((r) => r.id), ['health-local-2']);
+    });
+
+    test('getUpdated skips a row whose userId is null', () async {
+      final repository = createRepository();
+      await database.healthExaminationDao.upsert(
+        HealthExaminationsCompanion.insert(
+          id: 'legacy-1',
+          isUpdated: const Value(true),
+        ),
+      );
+      expect(await repository.getUpdated(), isEmpty);
     });
   });
 }

--- a/flutter/test/repository/user_repository_test.dart
+++ b/flutter/test/repository/user_repository_test.dart
@@ -1321,4 +1321,219 @@ void main() {
       expect(user?.key, isNull);
     });
   });
+  group('one member, one row', () {
+    // `become_member_screen` writes the account with a locally-minted
+    // `'<millis>'` id and no `couchId`; the health screens mint `key`/`iv` on
+    // that row; the user uploader then records the server-assigned `couchId`
+    // on the same row (`UserDao.updateUserSecurityData`). Every test here
+    // starts from that state and then signs the member in online, which is
+    // the transition `buildUserFromJson`'s identity rule exists to survive.
+    const localId = '1700000000000';
+
+    Future<void> seedLocallyRegisteredMember({
+      String? firstName = 'Ada',
+      String? userImage,
+      bool isUpdated = false,
+    }) async {
+      await db.userDao.upsert(
+        UsersCompanion(
+          id: const Value(localId),
+          name: const Value('ada'),
+          firstName: Value(firstName),
+          lastName: const Value('Lovelace'),
+          phoneNumber: const Value('555-0100'),
+          level: const Value('intermediate'),
+          language: const Value('en'),
+          birthPlace: const Value('London'),
+          joinDate: const Value(1600000000000),
+          userImage: Value(userImage),
+          isUpdated: Value(isUpdated),
+          key: const Value('the-key'),
+          iv: const Value('the-iv'),
+        ),
+      );
+      await db.userDao.updateUserSecurityData(
+        localId: localId,
+        couchId: 'org.couchdb.user:ada',
+        rev: '1-abc',
+        passwordScheme: 'pbkdf2',
+        derivedKey: _derivedKey,
+        salt: _salt,
+        iterations: '10',
+      );
+    }
+
+    void serverReturns(Map<String, dynamic> doc) {
+      when(
+        () =>
+            api.getJsonObject(userDocUrl, authHeader: any(named: 'authHeader')),
+      ).thenAnswer((_) async => NetworkSuccess<Map<String, dynamic>>(doc));
+    }
+
+    Future<LoginResult> signIn() => repository.loginOnline(
+      config: config,
+      username: 'ada',
+      password: _password,
+    );
+
+    test(
+      'the online login reuses the local row instead of adding one',
+      () async {
+        await seedLocallyRegisteredMember();
+        serverReturns(userDoc());
+
+        expect(await signIn(), isA<LoginSuccess>());
+
+        // `buildUserFromJson` resolves the row through `getUserByAnyId(_id)` —
+        // `WHERE id = :id OR _id = :id` — and `applyJsonToUser` reassigns `id`
+        // only when it is blank, so the member keeps the one row they had.
+        final rows = await db.userDao.getAllUsers();
+        expect(
+          rows,
+          hasLength(1),
+          reason:
+              'the CouchDB _id already resolves to this member through '
+              'their couchId; keying a second row on it duplicates the member',
+        );
+        expect(rows.single.id, localId);
+        expect(rows.single.couchId, 'org.couchdb.user:ada');
+        // The deterministic, user-visible half: every list built from the users
+        // table — the login account picker, the health patient picker, the
+        // survey recipient list — showed the member twice.
+        expect(await db.userDao.getSavedUsers(), hasLength(1));
+      },
+    );
+
+    test('the health key and iv survive the transition', () async {
+      await seedLocallyRegisteredMember();
+      serverReturns(userDoc());
+
+      await signIn();
+
+      // The consequence that makes this more than a duplicate name: health
+      // records are encrypted with the row's `key`/`iv`, which live only on
+      // this device. A row keyed on the CouchDB `_id` carries neither, and
+      // `getById(couchId)` matches it as readily as the real one.
+      for (final row in await db.userDao.getAllUsers()) {
+        expect(
+          row.key,
+          'the-key',
+          reason:
+              'a row that answers to this member carries no health key, '
+              'so the records it encrypted cannot be decrypted',
+        );
+        expect(row.iv, 'the-iv');
+      }
+      final resolved = await db.userDao.getById('org.couchdb.user:ada');
+      expect(resolved?.id, localId);
+      expect(resolved?.key, 'the-key');
+    });
+
+    test('the session is the row the member already had', () async {
+      await seedLocallyRegisteredMember();
+      serverReturns(userDoc());
+
+      final result = await signIn();
+
+      // `upsertUser` returns `userDao.getById(entity.id)`, so the signed-in
+      // user is the row the document was applied to. Re-reading by name is
+      // scan-ordered and picks by luck once two rows carry the name.
+      expect((result as LoginSuccess).user.id, localId);
+      expect(result.user.key, 'the-key');
+    });
+
+    test('a field the document omits keeps its stored value', () async {
+      await seedLocallyRegisteredMember();
+      // `applyJsonToUser` guards these with
+      // `if (new.isNotEmpty() || old.isNullOrEmpty()) field = new`, so a
+      // document that omits one leaves the stored value alone. Writing every
+      // field unconditionally nulls a profile the member filled in offline.
+      final doc = userDoc()
+        ..remove('firstName')
+        ..remove('lastName')
+        ..remove('phoneNumber')
+        ..remove('level')
+        ..remove('language')
+        ..remove('birthPlace')
+        ..remove('joinDate');
+      serverReturns(doc);
+
+      await signIn();
+
+      final row = (await db.userDao.getAllUsers()).single;
+      expect(row.firstName, 'Ada');
+      expect(row.lastName, 'Lovelace');
+      expect(row.phoneNumber, '555-0100');
+      expect(row.level, 'intermediate');
+      expect(row.language, 'en');
+      expect(row.birthPlace, 'London');
+      expect(row.joinDate, 1600000000000);
+    });
+
+    test('a non-empty document field still wins', () async {
+      await seedLocallyRegisteredMember();
+      serverReturns(
+        userDoc()
+          ..['firstName'] = 'Augusta'
+          ..['joinDate'] = 1700000000001,
+      );
+
+      await signIn();
+
+      final row = (await db.userDao.getAllUsers()).single;
+      expect(row.firstName, 'Augusta');
+      expect(row.joinDate, 1700000000001);
+    });
+
+    test(
+      'an unsynced profile photo survives a document without attachments',
+      () async {
+        await seedLocallyRegisteredMember(
+          userImage: '/tmp/queued-photo.jpg',
+          isUpdated: true,
+        );
+        serverReturns(userDoc());
+
+        await signIn();
+
+        // `addImageUrl` only touches `userImage` when the document carries a
+        // non-empty `_attachments`. The photo here is a local path the user
+        // uploader has not sent yet; nulling it loses the photo outright.
+        final row = (await db.userDao.getAllUsers()).single;
+        expect(row.userImage, '/tmp/queued-photo.jpg');
+      },
+    );
+
+    test(
+      'an attachment in the document does replace the stored name',
+      () async {
+        await seedLocallyRegisteredMember(userImage: 'old.jpg');
+        serverReturns(
+          userDoc()
+            ..['_attachments'] = {
+              'img': {'content_type': 'image/jpeg'},
+            },
+        );
+
+        await signIn();
+
+        expect((await db.userDao.getAllUsers()).single.userImage, 'img');
+      },
+    );
+
+    test('a first sign-in still keys the row on the document id', () async {
+      // No local row: `buildUserFromJson` falls through to
+      // `UserEntity().apply { this.id = id }`, so the CouchDB `_id` is the
+      // row's id. This is the case the pre-fix mapper handled correctly and
+      // it has to keep working.
+      serverReturns(userDoc());
+
+      final result = await signIn();
+
+      final rows = await db.userDao.getAllUsers();
+      expect(rows, hasLength(1));
+      expect(rows.single.id, 'org.couchdb.user:ada');
+      expect((result as LoginSuccess).user.id, 'org.couchdb.user:ada');
+    });
+  });
 }

--- a/flutter/test/repository/user_repository_test.dart
+++ b/flutter/test/repository/user_repository_test.dart
@@ -1521,6 +1521,25 @@ void main() {
       },
     );
 
+    test('a rejected manager login caches nothing', () async {
+      // `checkManagerAndInsert` (`LoginSyncManager.kt:167-175`) tests
+      // `isManager(jsonDoc)` and returns **before** `saveUser`, so a
+      // manager-mode sign-in by a non-manager leaves the table untouched.
+      // Writing the row first and rejecting afterwards cached an account the
+      // Kotlin declines to cache.
+      serverReturns(userDoc());
+
+      final result = await repository.loginOnline(
+        config: config,
+        username: 'ada',
+        password: _password,
+        isManagerMode: true,
+      );
+
+      expect((result as LoginFailure).reason, LoginFailureReason.notAManager);
+      expect(await db.userDao.getAllUsers(), isEmpty);
+    });
+
     test('a first sign-in still keys the row on the document id', () async {
       // No local row: `buildUserFromJson` falls through to
       // `UserEntity().apply { this.id = id }`, so the CouchDB `_id` is the


### PR DESCRIPTION
Lane C of the Phase 107 round. **Draft** — CI reports here, and a comment on this PR is the integrator's inbound channel.

Full write-up in `flutter/PHASE_107_NOTES.md`. Head: `4176e1d`. Gate locally: `dart format` clean, `flutter analyze` clean, **1703 tests passing** (branch head was 1675, +28).

## Seven defects, each demonstrated failing first

**1. The identity rule (`UserMapper.fromDoc` → `UserRepository._cacheUserDoc`).** Kotlin's `buildUserFromJson` (`UserRepositoryImpl.kt:292-316`) resolves the row a document belongs to with `getUserByAnyId(_id)` = `WHERE id = :id OR _id = :id LIMIT 1`, and `applyJsonToUser` reassigns `id` only when blank. The mapper had no lookup, so a document whose `_id` sat in a row's `couchId` **inserted a second row** — for the member registered on this device, whose row keeps a local `'<millis>'` id and gains a `couchId` when the upload lands. The duplicate carries `derived_key`/`salt` and no `key`/`iv`. The re-read after the upsert also moved from `getByName` to `getById`, which is what `upsertUser` does.

**2. Guarded fields.** `applyJsonToUser` guards twelve fields with `if (new.isNotEmpty() || old.isNullOrEmpty())`; writing them unconditionally was a `Value(null)` over a profile the member filled in offline.

**3. `userImage`.** `addImageUrl` writes only when the doc carries `_attachments`; the port was nulling a queued local photo path.

**4. The two adjacent health items, which are one rule.** `serialize` keys the document on `userId` (`HealthExamination.kt:96`) and `getUpdated`'s `userId != ''` excludes NULL too; that guard is what keeps the omit-`_id` branch (a POST CouchDB answers with a fresh document every drain) off the upload path. Both ported.

**5. The profile health row uploaded under a millisecond timestamp.** This is the audit **overturning a call I made in the first round.** I had argued `saveHealthProfileBlob`'s `userId: user?.couchId ?? userId` fallback was a harmless improvement on Kotlin's `pojo?.userId = user?._id`. It is not — and the reason is the rule §4 had just ported: `userId` decides whether `getUpdated()` selects the row. Kotlin withholds a member's profile row until their account has a server identity; the port POSTed it to `/health` keyed on a device-local `'<millis>'` id no server or other device can resolve to a person. Both write paths now write `Value(user?.couchId)` and both **re-stamp** on every later save, which `updateUserHealthProfile` does unconditionally (`HealthRepositoryImpl.kt:231`) and the port's update branches did not.

**6. A rejected manager login cached the account anyway.** `checkManagerAndInsert` (`LoginSyncManager.kt:167-175`) tests the *document* and returns before `saveUser`.

**7. A test that had stopped testing.** `user_mapper_test` asserted `companion.userImage.value, isNull`, and `Value.absent().value` is *also* null — so it passed identically before and after the fix it was meant to pin. **An assertion that reads `.value` off a drift companion cannot distinguish "wrote null" from "wrote nothing"**, and that distinction is the whole subject of every preserve-the-stored-value fix this port keeps making. Assert `.present`.

## Two corrections to how the harm was framed

Phase 105 wrote that `getById(couchId)` matching both rows "can resolve the patient to the row *without* the `key`/`iv`". Measured, and the audit agrees: it does not today — `users` has no index, SQLite full-scans, and the older key-bearing row comes back first. The undecryptable-records harm was **latent** (an added index, a future `ORDER BY`, or deleting the older row flips it).

What *was* live is worse than the "duplicate name" I first called it, and needed no scan-order luck: **an online login stopped refreshing the member's row.** Everything `applyJsonToUser` writes unguarded — `rolesList`, `derived_key`, `salt`, `password_scheme`, `iterations`, `isArchived`, `userAdmin`, `_rev` — landed on the duplicate while the session kept resolving the original. A manager grants a role or resets a password in Planet, the member signs in online, role-gated UI stays locked and `loginOffline` keeps verifying against the **stale** credentials — the old password works offline, the new one fails.

## Decisions the integrator should read

- **The legacy health-row question is now live rather than deferred, and I recommend accepting it.** §4's re-keying means a pre-Phase-105 examination row (`userId = patientId ≠ id`) collides with the patient's profile document — a **409**, not an overwrite, and 409 is not in the outbox's retryable class, so that record silently never ships. There is no in-code fix (the ambiguity is in the rows, and telling a legacy examination from a profile row needs an id-prefix heuristic I won't write). A one-time `UPDATE health_examinations SET user_id = id` in a migration step would need a **schema number I have not allocated**. My recommendation: don't — for such a row to matter it must be `isUpdated` *and* have `userId != id`, and Phase 105 established those were exactly the rows the port **could not record successfully at all**. If you know of a device carrying them, ask and allocate a number.
- **Duplicates an older dev build already wrote are not healed.** Kotlin has `cleanupDuplicateUsers` (`UserRepositoryImpl.kt:837-856`), called from `BecomeMemberActivity.kt:204`. Not written here on purpose: its caller is `become_member_screen.dart`, which this lane does not own, and an uncalled repository method is the smell Phase 90 went back to correct.
- **No index on `users._id`**, though it would make the lookup cheap: an index there is exactly what would flip SQLite's scan order on a device still carrying a duplicate, turning the latent case into the real one. Reconcile duplicates first.

## Two severe defects found outside this lane — recommend scheduling next

Both are in `_buildNewUserDoc` (my file) but neither is useful without `become_member_screen.dart` (not mine), so they are reported, not half-fixed:

- **A member the port registers cannot use the app.** `createMember` sends `roles: ["learner"]` (`UserRepositoryImpl.kt:522`); the port sends `<String>[]` and stores `rolesList: const []`, and `home_screen.dart:351-358` renders `InactiveDashboardScreen` for `rolesList.isEmpty && !userAdmin`. Register through the port's own become-member screen, log in, get "User not activated, please contact administrator" with no on-device path forward. `learner` appears nowhere in `flutter/lib`.
- **The profile the member just typed never reaches Planet.** `_buildNewUserDoc` omits firstName/lastName/middleName/email/language/level/phoneNumber/birthDate/gender, and since the row is written `isUpdated: false` and `pendingSyncUsers` matches only a blank `couchId` or the dirty flag, nothing ever ships them. The Planet account has no name and no email.

Nine more (health rows never re-queued, the unported `planetCode` pref write, the dead auto-login handoff, `user_uploader`'s comment describing behaviour it doesn't have, `JsonUtils` coercion, `serialize`'s zero-omission, `cacheDocuments`' undocumented improvement for *Faithful quirks*, `migrateGuestUser`, `getUpdatedForUser` having no caller) are itemised with citations in the notes.

## Housekeeping

- **No schema number needed** for what is here; v44 stands. `app_database.dart` is edited but only two query bodies.
- **No new `app_en.arb` keys.**
- Files: `lib/data/local/user_mapper.dart`, `lib/repository/user_repository.dart`, `lib/repository/health_repository.dart`, `lib/data/local/app_database.dart`, `flutter/PHASE_107_NOTES.md`, and three test files. Nothing outside this lane's ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyS7jfupHLGZSH817JxHY8