### PR TITLE
Phase 108: first tests for chat_repository_impl.dart (Lane D)

### DIFF
--- a/flutter/PHASE_108_NOTES.md
+++ b/flutter/PHASE_108_NOTES.md
@@ -1,4 +1,302 @@
-# Phase 108 — first tests for `chat_repository_impl.dart`
+# Phase 108 — chat repository and screens: coverage, and the defects it found
 
-Work in progress. This file records what was tested, the defects the tests
-found, and the failing-first evidence for each fix.
+## A correction to the brief before anything else
+
+The task described `lib/repository/chat_repository_impl.dart` as having **no
+tests at all**. It had 22, across `test/repository/chat_repository_test.dart`
+(18) and `test/repository/chat_sync_test.dart` (4), plus 7 for
+`ui/chat/chat_history_screen.dart`. The genuinely uncovered surfaces were
+`savePendingChat`, `sendContinueChatRequest`'s failure paths,
+`fetchAiProviders`, the mapper round trip, and all 240 lines of
+`ui/chat/chat_detail_screen.dart` — and every defect below sits in one of
+those.
+
+The more useful lesson is the *opposite* of "untested code hides defects".
+The worst defect here was in code that **was** tested. The test fixtures
+spelled the server's response key the same wrong way the code read it, so
+both halves agreed with each other and neither agreed with the server.
+
+## Defects fixed, with failing-first evidence
+
+Each was demonstrated failing on the pre-fix code before the fix was written.
+Where a fix could be reverted independently, it was, and the failure
+reproduced.
+
+### 1. The CouchDB write receipt was read under a key the server never sends
+
+`model/ChatResponse.kt:10` declares
+
+```kotlin
+@SerializedName("couchDBResponse") var couchDBResponse: CouchDBResponse? = ...
+```
+
+Gson's `@SerializedName` is the only authority on the wire format, and it says
+the key is `couchDBResponse`. The port read `response['couchdb']`.
+
+Consequences, both silent:
+
+- `sendNewChatRequest` found no object, so no `id`, so it took its
+  "saved without a document id" branch on **every successful answer** — the
+  AI's reply was discarded, nothing was persisted, and the user saw an error
+  banner. New chats could not be created at all.
+- `sendContinueChatRequest` computed `newRev = …?['rev'] ?? rev` and so always
+  kept the old revision. The next follow-up sent a stale `_rev`, which CouchDB
+  rejects as a conflict; a conversation could not get past its second turn.
+
+The port's own comment cites `couchDBResponse.id` two lines above the code that
+reads `couchdb` — the field name was read off the Kotlin correctly and then
+transcribed as a JSON key incorrectly. The three tracked fixtures
+(`chat_repository_test.dart:75,95,129`) used `'couchdb'` too, so the suite
+asserted the bug was correct. Those fixtures are now the real key.
+
+**Failing first:** `a new chat adopts the id from couchDBResponse` →
+`Expected: <Instance of 'ChatSuccess'> Actual: <Instance of 'ChatError'>`;
+`a continuation advances the rev from couchDBResponse` →
+`Expected: '2-b' Actual: '1-a'`.
+
+**This is the round-trip shape the brief asked me to look for**, in a new
+variant: not two halves of one app disagreeing, but the app and its own tests
+agreeing with each other against the server.
+
+### 2. A continuation the server never answered dropped the question
+
+Kotlin calls `continueConversation(id, message, "", rev)` on **both** its
+non-success branch (`ChatRepositoryImpl.kt:113`) and its exception branch
+(`:117`). Only the `catch` had been ported — and `_postChat` converts every
+`NetworkError`/`NetworkException` into `return null` rather than throwing, so
+the offline send, the one case the behaviour exists for, took the unported
+path. The question vanished with no row, no bubble, and no error beyond a
+banner.
+
+`_insertChatsInternal`'s `_hasUnansweredQuery` guard exists specifically to
+stop a later sync overwriting that trailing empty-response row — so as
+written, the guard was protecting something nothing ever wrote.
+
+**Failing first:** `keeps the question when every retry fails` and
+`keeps the question when the server answers a failure`, both
+`Expected: an object with length of <2> … has length of <1>`.
+
+### 3. Every offline chat was queued under the same primary key
+
+```dart
+final id = existingId ?? 'local-chat-\${DateTime.now().microsecondsSinceEpoch}';
+```
+
+Single-quoted with an escaped `$`, so this is not interpolation — the id was
+the literal 51-character string `local-chat-${DateTime.now()…}`, identical for
+every call. `chatDao.upsertAll` is `insertAllOnConflictUpdate`, so the second
+message typed offline **replaced** the first, and since `existing` is only
+looked up when `existingId != null`, the first question was not merged either.
+It was gone before the outbox ever drained.
+
+**Failing first:**
+`Expected: not 'local-chat-${DateTime.now().microsecondsSinceEpoch}' / Actual:
+'local-chat-${DateTime.now().microsecondsSinceEpoch}'`.
+
+### 4. An offline message sorted to the bottom of its own history
+
+`savePendingChat` wrote no `createdDate`/`updatedDate`, so
+`sortChatsByRecency`'s `_maxDate` scored the row 0 and it landed below every
+conversation the user had ever had. Kotlin writes a date on every persistence
+path (`ChatRepositoryImpl.kt:253-254`, `:279-280`). A continuation now keeps
+the created date it already has and moves only its updated date, matching
+`addConversation`.
+
+**Failing first:** `Expected: 'Just now' Actual: 'Capital of Iceland?'`.
+
+### 5. An empty revision could erase a good one
+
+Kotlin's `addConversation` assigns `_rev` only `if (!newRev.isNullOrEmpty())`.
+`ChatDao.updateConversation` writes the column unconditionally, and
+`newRev = …?['rev'] ?? rev` does not fall back on an empty string — so a reply
+carrying `"rev": ""` would overwrite `1-a` with `''`, losing the handle the
+next upload needs and making the row look never-confirmed to `deleteNotIn`.
+The guard is at the call site, because the DAO lives in `app_database.dart`,
+which this lane does not own.
+
+**Failing first, with a caveat worth recording:** this test *passed* on the
+pre-fix code, for the wrong reason — defect 1 meant the `??` always fell back
+to the caller's non-empty rev, so the empty string could never arrive. It
+fails as soon as defect 1 is fixed and the guard is absent (verified:
+`Expected: '1-a' Actual: ''`). A test that passes only because of another
+defect is not evidence of anything.
+
+### 6. Sending could take the screen down on a keystroke
+
+`_sendMessage` called `_scrollController.position.maxScrollExtent`
+unguarded. `ScrollController.position` asserts when nothing is attached, and
+nothing is: the message `ListView` is replaced by an empty-state `Column`
+until there is at least one message, and a rebuild is a frame away rather than
+an `await` away. `onSubmitted` bypasses the disabled send button, so pressing
+enter with no session reached `_sendMessage`, the notifier declined the
+message, no bubble was added, and the assert fired.
+
+Now scrolled from a post-frame callback behind `hasClients`.
+
+**Failing first:** `ScrollController not attached to any scroll views.` at
+`chat_detail_screen.dart:234`, on three tests.
+
+### 7. Tapping any chat in the history list opened an error page
+
+```dart
+context.push('${Routes.chat}/${chat.id}');
+```
+
+`Routes.chat` is already the *template* `/life/chat/:chatId`, so this pushed
+`/life/chat/:chatId/<id>` — three segments where the router defines two. No
+route matched and there is no `errorBuilder`, so every conversation in the
+list opened go_router's error page. The list was decorative. The feedback list
+one route down shows the convention: build the child path from the list's own
+route, which is what this now does.
+
+(The "new chat" button pushes the bare template and matches it *by accident*,
+with `chatId == ':chatId'`. That works only because `loadChat` is broken —
+see the handover items — so it is left alone rather than patched around; it
+needs a route, which is not this lane's file.)
+
+**Failing first:** `Found 0 widgets with text "detail:c1"`.
+
+### 8. A chat with no stored title showed "Untitled chat"
+
+`ChatHistoryAdapter.onBindViewHolder` names a row by
+`conversations[0].query` and falls back to `item.title` only when there is no
+first query. The port read `chat.title` alone — and `ChatMapper.fromDoc`
+writes `null` when the document omits the field, which synced documents do.
+So a row with the question sitting right there in its conversation displayed
+as "Untitled chat". The `?` avatar for a genuinely nameless chat is
+deliberately unchanged; only the title rule moved.
+
+Two existing fixtures set a `title` that disagreed with the first query. Under
+Kotlin's rule the query wins, so those fixtures now keep the two in
+agreement — they were testing the title, not the precedence — and two new
+tests make them disagree on purpose.
+
+**Failing first:** `Found 0 widgets with text "How do I plant maize?"` and
+`Found 0 widgets with text "the real question"`.
+
+### 9. A newline reached the request body
+
+`ChatDetailFragment.kt:288` sends
+`"${binding.editGchatMessage.text}".replace("\n", " ")`. The port trimmed
+only, on a `maxLines: 4` field, so a pasted or soft-keyboard newline survived
+into `content`.
+
+**Failing first:** `Expected: ['first line second line'] Actual: ['first
+line\nsecond line']`.
+
+## Tests added
+
+- `test/repository/chat_write_back_test.dart` (14, new): the response
+  envelope, both continuation failure paths, the revision guard,
+  `savePendingChat`, `fetchAiProviders`, the `buildNewChatDoc` →
+  `fromDoc` → `parseConversations` round trip, `_design` filtering, and the
+  null/empty user-name guard.
+- `test/ui/chat/chat_detail_screen_test.dart` (10, new — the screen had
+  none): empty state, turn rendering, the error banner, the send button's
+  trim/flatten/clear, the blank-message and no-session gates, the keyboard
+  submit that used to crash, and the provider menu including an unavailable
+  entry.
+- `test/ui/chat/chat_history_screen_test.dart` (+3): navigation to the detail
+  route, and title precedence in both directions.
+
+Nothing was skipped or quarantined. No `app_en.arb` keys added; no schema
+change; `schemaVersion` untouched at 44.
+
+## Handover — confirmed defects this lane does not own
+
+Found while auditing the slice (`parity-auditor`, opus/max, which also
+overturned one of my hypotheses — see the end). All are in files assigned to
+nobody this round, so they are reported rather than edited, per the
+one-file-one-owner rule.
+
+**`lib/providers/app_providers.dart` + `lib/core/utils/url_utils.dart` —
+the AI endpoint is never reached.** `ChatApiService.sendChatRequest` POSTs to
+`UrlUtils.hostUrl` *itself*, which is `"$scheme://$hostIp/ml/"` for `.org`/
+`.gt` hosts and `"$scheme://$hostIp:5000/"` otherwise; `fetchAiProviders` GETs
+`"${hostUrl}checkProviders/"`. The port is constructed with
+`serverUrl = credentialFreeDbUrl(config)` — the CouchDB `…/db` URL — and posts
+to `'$serverUrl/chat'`. For `http://10.0.0.5:5000` Kotlin posts to
+`http://10.0.0.5:5000/` and the port to `http://10.0.0.5:5000/db/chat`, a
+CouchDB path. `url_utils.dart` has no `hostUrl` counterpart at all;
+`ServerConfig.serverUrl` keeps the raw typed URL, so one is buildable. Two
+divergences (origin *and* path suffix) that both need fixing. Fixing defect 1
+above is necessary but not sufficient — until this lands, no chat request
+reaches a server that could answer it.
+
+**`lib/providers/chat_provider.dart:205-211` — the queued question is
+replaced by the error text.** `sendMessage(String message)` is shadowed by the
+pattern binding in `case ChatError(message: final message):`, so
+`savePendingChat(query: message)` receives `"Request failed"`. The bubble on
+screen is right; the row written to `chat_history` and handed to the outbox
+carries the error string as the user's question.
+
+**`lib/providers/chat_provider.dart:108-115` — `loadChat` can never find
+anything.** It calls `getChatHistoryForUser(null)`, which correctly returns
+`[]` for a null name (matching `ChatRepositoryImpl.kt:120-125`), so `rows` is
+always empty and the method returns without touching state. Both call sites
+are affected. Because `chatConversationProvider` is not auto-dispose, opening
+an older chat leaves the *previous* conversation on screen and appends the
+next message to the wrong document. This is why fixing defect 7 alone does not
+finish the job — the route now resolves, and the screen it lands on is still
+blank.
+
+**`lib/repository/chat_uploader.dart` — the outbox posts the wrong thing, and
+the next sync then deletes the row.** `_serializeChat` sets
+`'content': row.conversations`, the whole conversations JSON string, where
+`ContentData.content` is the user's plain query; it hardcodes `model: ''`; and
+the handler discards `data['chat']`, so the local turn keeps `response: ''`.
+`markUploaded` sets `docId`/`rev` but leaves the primary key as the local id —
+after which `insertChatHistoryFromSync` skips the server document (its
+`_hasUnansweredQuery` lookup now matches the local row) and `deleteNotIn`
+deletes the local one (it has a `rev` now, and its local id is not in
+`savedIds`). The conversation disappears from the device on the first sync
+after a successful drain. Also `data['couchdb']` at `:78` is the same wrong
+key as defect 1.
+
+**`lib/providers/chat_provider.dart:44-46` — full-conversation search
+defaults to the wrong field.** `ChatHistoryFragment.kt:45-46` sets
+`isFullSearch = false, isQuestion = false` and the layout checks no toggle
+button, so `ChatViewModel.kt:153-159` maps the default to
+`ChatSearchMode.RESPONSE`. The port defaults to `question`.
+
+**`lib/providers/chat_provider.dart:190` — the revision is not re-read before
+a continuation.** `ChatDetailFragment.kt:291-296` calls
+`getLatestRev(_id) ?: _rev` before every send; the port sends
+`currentState.rev`, so a revision advanced by a sync or an outbox drain is
+missed and the send conflicts. `getLatestRev` is correct and has no production
+caller.
+
+Smaller, same rule: the provider auto-selects nothing where
+`ChatDetailFragment.kt:449-455` clicks the first available provider (so the
+port posts `{"name":"default","model":""}`); the search guard is `isEmpty`
+where `ChatViewModel.kt:147` is `isBlank`; a model column would be needed on
+`ChatEntries` to carry `aiProvider.model` through the outbox at all (a schema
+change, hence not attempted).
+
+Unported and undocumented as deferred: chat sharing to voices
+(`extractSharedViewInIds`, the share target tree, `shareChatToVoices` —
+`ChatHistoryAdapter.kt:137-283`), conversation pagination
+(`ChatViewModel.PAGE_SIZE = 20` and `LOAD_MORE`), and the per-send
+alternative-URL mapping.
+
+Also noted, not changed: the port's `sync` runs `deleteNotIn` where the Kotlin
+`chat_history` walk has no delete step at all — the same rule the notifications
+sync follows. Its non-empty-`rev` guard makes it defensible in isolation, but
+it becomes destructive in combination with the uploader item above.
+
+## Two hypotheses of mine that were wrong
+
+Recorded because the audit's most valuable output was the overturning, not the
+confirmations.
+
+- **I suspected the chat calls were missing an `Authorization` header.** They
+  are not. `ApiInterface.chatGpt` and `checkAiProviders` take only
+  `@Url`/`@Body`, and `NetworkModule` installs no auth interceptor — Kotlin
+  sends no header here, and neither does the port. At parity; do not "fix" it.
+- **I suspected `_searchByTitle`'s `isEmpty` skip diverged from Kotlin's
+  `null` skip** (and the same in `_fullConvoSearch`). No behavioural
+  difference for any non-blank query: where Kotlin gets `null` the port gets
+  `''`, and `''` fails both `startsWith` and contains-all-words anyway. The
+  only divergence reachable through it is the blank-query guard, listed above.
+  Likewise Kotlin's `ignoreCase: true` is redundant on both sides, since
+  `normalizeText` lowercases first.

--- a/flutter/PHASE_108_NOTES.md
+++ b/flutter/PHASE_108_NOTES.md
@@ -1,0 +1,4 @@
+# Phase 108 — first tests for `chat_repository_impl.dart`
+
+Work in progress. This file records what was tested, the defects the tests
+found, and the failing-first evidence for each fix.

--- a/flutter/lib/repository/chat_repository_impl.dart
+++ b/flutter/lib/repository/chat_repository_impl.dart
@@ -44,6 +44,19 @@ class ChatRepositoryImpl implements ChatRepository {
   /// page size works well.
   static const int initialBatchSize = 100;
 
+  /// The CouchDB write receipt inside a chat response.
+  ///
+  /// The key is `couchDBResponse`. That is not a guess: `model/ChatResponse.kt`
+  /// declares the field as `@SerializedName("couchDBResponse")`, and the Gson
+  /// mapping is the only authority on what the endpoint puts on the wire.
+  /// Reading it as `couchdb` found nothing on every single response — so a new
+  /// chat always reported "saved without a document id" and stored no row, and
+  /// a continuation always kept its old `_rev` and hit a conflict on the turn
+  /// after. Both halves had tests; both were written against this same wrong
+  /// key, so both passed.
+  static Map<String, dynamic>? _couchResponse(Map<String, dynamic> response) =>
+      response['couchDBResponse'] as Map<String, dynamic>?;
+
   @override
   Future<Map<String, bool>?> fetchAiProviders() async {
     final url = '$serverUrl/checkProviders/';
@@ -88,7 +101,7 @@ class ChatRepositoryImpl implements ChatRepository {
       }
 
       final chatResponse = response['chat'] as String? ?? '';
-      final couchResponse = response['couchdb'] as Map<String, dynamic>?;
+      final couchResponse = _couchResponse(response);
       final rev = couchResponse?['rev'] as String? ?? '';
       // The server creates the CouchDB document and assigns its `_id`; the id
       // must come back from that response, as `couchDBResponse.id` does in the
@@ -120,7 +133,6 @@ class ChatRepositoryImpl implements ChatRepository {
   }
 
   @override
-  @override
   Future<String> savePendingChat({
     required String user,
     required String query,
@@ -132,8 +144,13 @@ class ChatRepositoryImpl implements ChatRepository {
     // outbox drains, `ChatDao.markUploaded` replaces `docId`/`rev` with the
     // server's. That is not true of the success path, which must use the id
     // the server assigned.
-    final id =
-        existingId ?? 'local-chat-\${DateTime.now().microsecondsSinceEpoch}';
+    //
+    // The timestamp has to actually interpolate. Written as '...\$…' inside
+    // single quotes it was an escaped dollar, so every queued chat shared one
+    // literal primary key and `upsertAll` replaced its predecessor: queue two
+    // messages offline and only the second still existed to drain.
+    final now = DateTime.now();
+    final id = existingId ?? 'local-chat-${now.microsecondsSinceEpoch}';
     final existing = existingId == null
         ? null
         : await chatDao.findByDocId(existingId);
@@ -141,6 +158,7 @@ class ChatRepositoryImpl implements ChatRepository {
       ...ChatMapper.parseConversations(existing?.conversations),
       const ChatConversation().copyWith(query: query, response: ''),
     ];
+    final timestamp = now.millisecondsSinceEpoch;
     await chatDao.upsertAll([
       ChatEntriesCompanion(
         id: Value(id),
@@ -150,7 +168,14 @@ class ChatRepositoryImpl implements ChatRepository {
         aiProvider: Value(aiProvider.name),
         title: Value(existing?.title ?? query),
         conversations: Value(ChatMapper.encodeConversations(conversations)),
-        lastUsed: Value(DateTime.now().millisecondsSinceEpoch),
+        // `sortChatsByRecency` scores a row by the newest of these two, so a
+        // row without them lands at 0 — the message the user just typed sorted
+        // below every conversation they had ever had. A continuation keeps the
+        // created date it already has and only moves its updated date, which
+        // is what `addConversation` does in the Kotlin.
+        createdDate: Value(existing?.createdDate ?? '$timestamp'),
+        updatedDate: Value('$timestamp'),
+        lastUsed: Value(timestamp),
         isUploaded: const Value(false),
       ),
     ]);
@@ -178,17 +203,28 @@ class ChatRepositoryImpl implements ChatRepository {
       };
 
       final response = await _postChat(request);
+      // Kotlin's `sendContinueChatRequest` calls
+      // `continueConversation(id, message, "", rev)` on its non-success branch
+      // as well as its `catch`. Only the `catch` had been ported, and
+      // `_postChat` turns a network failure into `null` rather than throwing —
+      // so the offline send, the one case this behaviour exists for, took the
+      // unported path and discarded the user's question outright. The row
+      // written here is also what `_insertChatsInternal` protects from being
+      // overwritten by a later sync, so without it that guard had nothing to
+      // guard.
       if (response == null) {
+        await _continueConversation(id, query, '', rev);
         return const ChatError('Request failed');
       }
 
       final status = response['status'] as String?;
       if (status != 'Success') {
+        await _continueConversation(id, query, '', rev);
         return ChatError(response['message'] as String? ?? 'Request failed');
       }
 
       final chatResponse = response['chat'] as String? ?? '';
-      final newRev = response['couchdb']?['rev'] as String? ?? rev;
+      final newRev = _couchResponse(response)?['rev'] as String? ?? rev;
 
       // Update local database
       await _continueConversation(id, query, chatResponse, newRev);
@@ -305,7 +341,12 @@ class ChatRepositoryImpl implements ChatRepository {
       id,
       ChatMapper.encodeConversations(newConversations),
       updatedDate,
-      rev,
+      // Kotlin's `addConversation` assigns `_rev` only
+      // `if (!newRev.isNullOrEmpty())`. The DAO writes the column
+      // unconditionally, so an empty revision from the server would erase the
+      // handle the next upload needs — and `ChatDao.deleteNotIn` reads a
+      // revision-less row as one the server never confirmed.
+      rev.isEmpty ? (existing.rev ?? '') : rev,
     );
   }
 

--- a/flutter/lib/ui/chat/chat_detail_screen.dart
+++ b/flutter/lib/ui/chat/chat_detail_screen.dart
@@ -220,7 +220,11 @@ class _ChatDetailScreenState extends ConsumerState<ChatDetailScreen> {
   }
 
   Future<void> _sendMessage() async {
-    final message = _messageController.text.trim();
+    // `ChatDetailFragment.kt` flattens the field before sending:
+    // `"${binding.editGchatMessage.text}".replace("\n", " ")`. The field here
+    // is `maxLines: 4`, so a pasted or soft-keyboard newline survived into the
+    // request body where the Kotlin would have sent a space.
+    final message = _messageController.text.replaceAll('\n', ' ').trim();
     if (message.isEmpty) return;
 
     setState(() => _isSending = true);
@@ -228,13 +232,29 @@ class _ChatDetailScreenState extends ConsumerState<ChatDetailScreen> {
 
     await ref.read(chatConversationProvider.notifier).sendMessage(message);
 
-    if (mounted) {
-      setState(() => _isSending = false);
+    if (!mounted) return;
+    setState(() => _isSending = false);
+    _scrollToBottom();
+  }
+
+  /// Scrolls the thread to the newest message once the frame that renders it
+  /// has been laid out.
+  ///
+  /// [ScrollController.position] asserts when nothing is attached, and nothing
+  /// is: the message list is replaced by an empty-state [Column] until there
+  /// is at least one message, and a rebuild is a frame away rather than an
+  /// `await` away. So a send that resolved without adding a bubble — the
+  /// notifier declining it, which is exactly what happens when `onSubmitted`
+  /// fires with no session and bypasses the disabled button — took the whole
+  /// screen down on a keystroke.
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scrollController.hasClients) return;
       _scrollController.animateTo(
         _scrollController.position.maxScrollExtent,
         duration: const Duration(milliseconds: 300),
         curve: Curves.easeOut,
       );
-    }
+    });
   }
 }

--- a/flutter/lib/ui/chat/chat_history_screen.dart
+++ b/flutter/lib/ui/chat/chat_history_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../data/local/app_database.dart';
 import '../../l10n/app_localizations.dart';
 import '../../providers/chat_provider.dart';
 import '../../providers/sync_state.dart';
@@ -139,18 +140,19 @@ class ChatHistoryScreen extends ConsumerWidget {
                     final conversations = chat.conversations;
                     final lastMessage = _extractLastMessage(conversations);
                     final timestamp = _formatTimestamp(chat.updatedDate, l10n);
+                    final heading = _heading(chat);
 
                     return Card(
                       child: ListTile(
                         leading: CircleAvatar(
                           child: Text(
-                            chat.title?.isNotEmpty == true
-                                ? chat.title![0].toUpperCase()
+                            heading?.isNotEmpty == true
+                                ? heading![0].toUpperCase()
                                 : '?',
                           ),
                         ),
                         title: Text(
-                          chat.title ?? l10n.untitledChat,
+                          heading ?? l10n.untitledChat,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
@@ -174,7 +176,13 @@ class ChatHistoryScreen extends ConsumerWidget {
                           ref
                               .read(chatConversationProvider.notifier)
                               .loadChat(chat.id);
-                          context.push('${Routes.chat}/${chat.id}');
+                          // Built from the list's own route, not from
+                          // [Routes.chat] — that constant is already the
+                          // template `/life/chat/:chatId`, so appending an id
+                          // produced a three-segment path the router has no
+                          // route for and every tap landed on go_router's
+                          // error page.
+                          context.push('${Routes.chatHistory}/${chat.id}');
                         },
                       ),
                     );
@@ -186,6 +194,32 @@ class ChatHistoryScreen extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  /// The name this conversation goes by in the list.
+  ///
+  /// `ChatHistoryAdapter.onBindViewHolder` uses `conversations[0].query` and
+  /// falls back to the stored `title` only when there is no first query. That
+  /// order matters: a synced document need not carry a `title` at all, and
+  /// those rows were showing as "Untitled chat" behind a "?" avatar with the
+  /// question sitting unread in the conversation.
+  String? _heading(ChatRow chat) {
+    final conversationsJson = chat.conversations;
+    if (conversationsJson != null && conversationsJson.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(conversationsJson);
+        if (decoded is List && decoded.isNotEmpty) {
+          final first = decoded.first;
+          if (first is Map) {
+            final query = first['query'];
+            if (query is String) return query;
+          }
+        }
+      } catch (_) {
+        // Fall through to the stored title.
+      }
+    }
+    return chat.title;
   }
 
   /// Last turn of the stored conversation, for the list subtitle.

--- a/flutter/test/repository/chat_repository_test.dart
+++ b/flutter/test/repository/chat_repository_test.dart
@@ -72,7 +72,7 @@ void main() {
       stubChatResponse({
         'status': 'Success',
         'chat': 'Reykjavik.',
-        'couchdb': {'id': 'server-doc-1', 'rev': '1-a'},
+        'couchDBResponse': {'id': 'server-doc-1', 'rev': '1-a'},
       });
 
       final result = await repository.sendNewChatRequest(
@@ -92,7 +92,7 @@ void main() {
       stubChatResponse({
         'status': 'Success',
         'chat': 'Reykjavik.',
-        'couchdb': {'rev': '1-a'},
+        'couchDBResponse': {'rev': '1-a'},
       });
 
       final result = await repository.sendNewChatRequest(
@@ -126,7 +126,7 @@ void main() {
           NetworkSuccess<Map<String, dynamic>>({
             'status': 'Success',
             'chat': 'Reykjavik.',
-            'couchdb': {'id': 'server-doc-2', 'rev': '1-b'},
+            'couchDBResponse': {'id': 'server-doc-2', 'rev': '1-b'},
           }),
         ]);
 

--- a/flutter/test/repository/chat_write_back_test.dart
+++ b/flutter/test/repository/chat_write_back_test.dart
@@ -1,0 +1,345 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/chat_mapper.dart';
+import 'package:myplanet/repository/chat_repository.dart';
+import 'package:myplanet/repository/chat_repository_impl.dart';
+
+/// The chat write-back paths: the shape the AI endpoint actually answers with,
+/// what a failed send leaves behind, and the rows `savePendingChat` hands to
+/// the outbox.
+///
+/// The wire format here is taken from the Kotlin `model/ChatResponse.kt`, whose
+/// Gson `@SerializedName` annotations are the only authority on what the server
+/// sends: `couchDBResponse`, not `couchdb`.
+void main() {
+  late AppDatabase database;
+  late ChatRepositoryImpl repository;
+  late MockPlanetApi api;
+
+  const provider = AiProviderConfig(name: 'openai', model: 'gpt-4o');
+
+  setUp(() {
+    database = AppDatabase.memory();
+    api = MockPlanetApi();
+    registerFallbackValue(<String, dynamic>{});
+    repository = ChatRepositoryImpl(
+      planetApi: api,
+      chatDao: database.chatDao,
+      serverUrl: 'https://planet.example',
+      retryDelay: Duration.zero,
+    );
+  });
+  tearDown(() => database.close());
+
+  void stubChat(Map<String, dynamic> body) {
+    when(
+      () => api.sendJsonObject(
+        any(),
+        body: any(named: 'body'),
+        method: any(named: 'method'),
+      ),
+    ).thenAnswer((_) async => NetworkSuccess<Map<String, dynamic>>(body));
+  }
+
+  void stubFailure() {
+    when(
+      () => api.sendJsonObject(
+        any(),
+        body: any(named: 'body'),
+        method: any(named: 'method'),
+      ),
+    ).thenAnswer(
+      (_) async => const NetworkError<Map<String, dynamic>>(503, 'offline'),
+    );
+  }
+
+  Future<void> seedConversation({
+    required String id,
+    String? rev = '1-a',
+    List<Map<String, String>> conversations = const [
+      {'query': 'Capital of Iceland?', 'response': 'Reykjavik.'},
+    ],
+  }) => database.chatDao.upsertAll([
+    ChatEntriesCompanion.insert(
+      id: id,
+      docId: Value(id),
+      rev: Value(rev),
+      user: const Value('ada'),
+      title: const Value('Capital of Iceland?'),
+      createdDate: const Value('1000'),
+      updatedDate: const Value('1000'),
+      conversations: Value(jsonEncode(conversations)),
+    ),
+  ]);
+
+  Future<List<ChatConversation>> turnsOf(String docId) async {
+    final row = await database.chatDao.findByDocId(docId);
+    return ChatMapper.parseConversations(row?.conversations);
+  }
+
+  group('the response envelope the server actually sends', () {
+    test('a new chat adopts the id from couchDBResponse', () async {
+      // `ChatResponse.couchDBResponse` is `@SerializedName("couchDBResponse")`
+      // in the Kotlin, so that — not `couchdb` — is the key on the wire. Read
+      // under the wrong name the object is always absent, the id is always
+      // missing, and every successful answer is reported to the user as
+      // "Chat was saved without a document id" with nothing stored.
+      stubChat({
+        'status': 'Success',
+        'chat': 'Reykjavik.',
+        'couchDBResponse': {'ok': true, 'id': 'server-doc-1', 'rev': '1-a'},
+      });
+
+      final result = await repository.sendNewChatRequest(
+        query: 'Capital of Iceland?',
+        user: 'ada',
+        aiProvider: provider,
+      );
+
+      expect(result, isA<ChatSuccess>());
+      expect((result as ChatSuccess).id, 'server-doc-1');
+      expect(result.rev, '1-a');
+      expect(await database.chatDao.getByDocId('server-doc-1'), hasLength(1));
+    });
+
+    test('a continuation advances the rev from couchDBResponse', () async {
+      // Missing this leaves the row on its old `_rev`. The next follow-up
+      // sends that stale revision as `_rev` and CouchDB rejects it as a
+      // conflict, so a conversation can never get past its second turn.
+      await seedConversation(id: 'chat-1');
+      stubChat({
+        'status': 'Success',
+        'chat': 'About 380,000 people.',
+        'couchDBResponse': {'ok': true, 'id': 'chat-1', 'rev': '2-b'},
+      });
+
+      final result = await repository.sendContinueChatRequest(
+        query: 'How many live there?',
+        user: 'ada',
+        aiProvider: provider,
+        id: 'chat-1',
+        rev: '1-a',
+      );
+
+      expect((result as ChatSuccess).rev, '2-b');
+      expect(await repository.getLatestRev('chat-1'), '2-b');
+    });
+  });
+
+  group('a continuation the server never answered', () {
+    // Kotlin `ChatRepositoryImpl.sendContinueChatRequest` calls
+    // `continueConversation(id, message, "", rev)` on the non-success branch
+    // *and* the exception branch. Only the exception branch was ported — and
+    // `_postChat` swallows network failures into `null` rather than throwing,
+    // so the offline case, the one this exists for, took the unported path and
+    // dropped the user's question entirely.
+
+    test('keeps the question when every retry fails', () async {
+      await seedConversation(id: 'chat-1');
+      stubFailure();
+
+      final result = await repository.sendContinueChatRequest(
+        query: 'How many live there?',
+        user: 'ada',
+        aiProvider: provider,
+        id: 'chat-1',
+        rev: '1-a',
+      );
+
+      expect(result, isA<ChatError>());
+      final turns = await turnsOf('chat-1');
+      expect(turns, hasLength(2));
+      expect(turns.last.query, 'How many live there?');
+      expect(turns.last.response, isEmpty);
+    });
+
+    test('keeps the question when the server answers a failure', () async {
+      await seedConversation(id: 'chat-1');
+      stubChat({'status': 'Error', 'message': 'No provider available'});
+
+      final result = await repository.sendContinueChatRequest(
+        query: 'How many live there?',
+        user: 'ada',
+        aiProvider: provider,
+        id: 'chat-1',
+        rev: '1-a',
+      );
+
+      expect((result as ChatError).message, 'No provider available');
+      final turns = await turnsOf('chat-1');
+      expect(turns, hasLength(2));
+      expect(turns.last.query, 'How many live there?');
+    });
+
+    test('does not overwrite a good revision with an empty one', () async {
+      // Kotlin's `addConversation` assigns `_rev` only
+      // `if (!newRev.isNullOrEmpty())`. Writing the empty string over a real
+      // revision loses the handle the next upload needs, and `deleteNotIn`
+      // treats a revision-less row as never confirmed by the server.
+      await seedConversation(id: 'chat-1');
+      stubChat({
+        'status': 'Success',
+        'chat': 'About 380,000 people.',
+        'couchDBResponse': {'id': 'chat-1', 'rev': ''},
+      });
+
+      await repository.sendContinueChatRequest(
+        query: 'How many live there?',
+        user: 'ada',
+        aiProvider: provider,
+        id: 'chat-1',
+        rev: '1-a',
+      );
+
+      expect(await repository.getLatestRev('chat-1'), '1-a');
+    });
+  });
+
+  group('savePendingChat', () {
+    test('gives each queued chat its own id', () async {
+      // The id was built as '...\${DateTime.now()...}' inside single quotes,
+      // which escapes the `$` instead of interpolating: every call produced the
+      // same literal primary key, so `upsertAll` replaced the previous row and
+      // the earlier message was gone before the outbox ever drained.
+      final first = await repository.savePendingChat(
+        user: 'ada',
+        query: 'First question',
+        aiProvider: provider,
+      );
+      final second = await repository.savePendingChat(
+        user: 'ada',
+        query: 'Second question',
+        aiProvider: provider,
+      );
+
+      expect(first, isNot(second));
+      expect(first, isNot(contains(r'${')));
+      expect(await database.chatDao.getPending(), hasLength(2));
+    });
+
+    test('sorts to the top of the history it was just typed into', () async {
+      // Without a created date `sortChatsByRecency` scores the row 0, so the
+      // message the user just sent appears below every conversation they have
+      // ever had — including the one it belongs after.
+      await seedConversation(id: 'older');
+      await repository.savePendingChat(
+        user: 'ada',
+        query: 'Just now',
+        aiProvider: provider,
+      );
+
+      final history = await repository.getChatHistoryForUser('ada');
+      expect(history.first.title, 'Just now');
+    });
+
+    test('appends to the conversation it continues', () async {
+      await seedConversation(id: 'chat-1');
+
+      final id = await repository.savePendingChat(
+        user: 'ada',
+        query: 'How many live there?',
+        aiProvider: provider,
+        existingId: 'chat-1',
+        existingRev: '1-a',
+      );
+
+      expect(id, 'chat-1');
+      final turns = await turnsOf('chat-1');
+      expect(turns.map((t) => t.query), [
+        'Capital of Iceland?',
+        'How many live there?',
+      ]);
+      expect(await database.chatDao.getPending(), hasLength(1));
+    });
+  });
+
+  group('fetchAiProviders', () {
+    test('decodes the provider availability map', () async {
+      when(() => api.getRaw(any())).thenAnswer(
+        (_) async => const NetworkSuccess<String>(
+          '{"openai": true, "perplexity": false}',
+        ),
+      );
+
+      expect(await repository.fetchAiProviders(), {
+        'openai': true,
+        'perplexity': false,
+      });
+    });
+
+    test('returns null rather than throwing on an unusable body', () async {
+      when(
+        () => api.getRaw(any()),
+      ).thenAnswer((_) async => const NetworkSuccess<String>('not json'));
+
+      expect(await repository.fetchAiProviders(), isNull);
+    });
+
+    test('returns null when the endpoint is unreachable', () async {
+      when(
+        () => api.getRaw(any()),
+      ).thenAnswer((_) async => const NetworkError<String>(null, 'no route'));
+
+      expect(await repository.fetchAiProviders(), isNull);
+    });
+  });
+
+  group('mapper round trip', () {
+    test('a new chat document reads back as the turn it recorded', () async {
+      final doc = ChatMapper.buildNewChatDoc(
+        id: 'doc-1',
+        rev: '1-a',
+        user: 'ada',
+        query: 'Capital of Iceland?',
+        response: 'Reykjavik.',
+        aiProvider: 'openai',
+      );
+
+      await database.chatDao.upsertAll([ChatMapper.fromDoc(doc)]);
+
+      final turns = await turnsOf('doc-1');
+      expect(turns, hasLength(1));
+      expect(turns.single.query, 'Capital of Iceland?');
+      expect(turns.single.response, 'Reykjavik.');
+      final row = await database.chatDao.findByDocId('doc-1');
+      expect(row!.isUploaded, isTrue);
+      expect(row.rev, '1-a');
+    });
+
+    test('a synced document does not queue itself for upload', () async {
+      await repository.insertChatHistoryFromSync([
+        {
+          '_id': 'doc-1',
+          'doc': {
+            '_id': 'doc-1',
+            '_rev': '1-a',
+            'user': 'ada',
+            'conversations': [
+              {'query': 'q', 'response': 'r'},
+            ],
+          },
+        },
+        {'_id': '_design/chats', 'doc': <String, dynamic>{}},
+      ]);
+
+      expect(await database.chatDao.getPending(), isEmpty);
+      expect(await database.chatDao.findByDocId('_design/chats'), isNull);
+      expect(await database.chatDao.findByDocId('doc-1'), isNotNull);
+    });
+  });
+
+  test('history for a missing user is empty, not everyone', () async {
+    await seedConversation(id: 'chat-1');
+
+    expect(await repository.getChatHistoryForUser(null), isEmpty);
+    expect(await repository.getChatHistoryForUser(''), isEmpty);
+  });
+}
+
+class MockPlanetApi extends Mock implements PlanetApi {}

--- a/flutter/test/ui/chat/chat_detail_screen_test.dart
+++ b/flutter/test/ui/chat/chat_detail_screen_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/chat_provider.dart';
+import 'package:myplanet/providers/session_provider.dart';
+import 'package:myplanet/ui/chat/chat_detail_screen.dart';
+
+import '../../support/widget_harness.dart';
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+  final UserRow? user;
+  @override
+  Future<UserRow?> build() async => user;
+}
+
+/// Stands in for the real notifier so the screen can be driven without the
+/// repository, the outbox, or a server. Records what the send button asked for.
+class _TestChatNotifier extends ChatConversationNotifier {
+  _TestChatNotifier(this.initial);
+
+  final ChatConversationState initial;
+  final sent = <String>[];
+
+  @override
+  ChatConversationState build() => initial;
+
+  @override
+  Future<void> sendMessage(String message) async {
+    sent.add(message);
+  }
+}
+
+UserRow _user() => buildUserRow(id: 'u1', name: 'ada');
+
+void main() {
+  Future<_TestChatNotifier> pumpDetail(
+    WidgetTester tester, {
+    ChatConversationState state = const ChatConversationState(),
+    UserRow? user,
+    Map<String, bool>? providers,
+    String? chatId,
+  }) async {
+    final notifier = _TestChatNotifier(state);
+    await tester.pumpWidget(
+      wrapScreen(
+        ChatDetailScreen(chatId: chatId),
+        overrides: [
+          sessionProvider.overrideWith(() => _TestSessionNotifier(user)),
+          chatConversationProvider.overrideWith(() => notifier),
+          aiProvidersProvider.overrideWith((ref) async => providers),
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    return notifier;
+  }
+
+  testWidgets('an unstarted conversation invites one', (tester) async {
+    await pumpDetail(tester, user: _user());
+
+    expect(find.text('New chat'), findsOneWidget);
+    expect(find.text('Start a new conversation'), findsOneWidget);
+  });
+
+  testWidgets('a loaded conversation is titled and rendered in turn order', (
+    tester,
+  ) async {
+    await pumpDetail(
+      tester,
+      user: _user(),
+      state: const ChatConversationState(
+        id: 'chat-1',
+        rev: '1-a',
+        messages: [
+          ChatMessage(content: 'Capital of Iceland?', isUser: true),
+          ChatMessage(content: 'Reykjavik.', isUser: false),
+        ],
+      ),
+    );
+
+    expect(find.text('Conversation'), findsOneWidget);
+    expect(find.text('Capital of Iceland?'), findsOneWidget);
+    expect(find.text('Reykjavik.'), findsOneWidget);
+    expect(find.text('Start a new conversation'), findsNothing);
+  });
+
+  testWidgets('the failure the send reported stays on screen', (tester) async {
+    await pumpDetail(
+      tester,
+      user: _user(),
+      state: const ChatConversationState(error: 'No provider available'),
+    );
+
+    expect(find.text('No provider available'), findsOneWidget);
+  });
+
+  testWidgets('the send button hands the trimmed message over and clears', (
+    tester,
+  ) async {
+    final notifier = await pumpDetail(tester, user: _user());
+
+    await tester.enterText(find.byType(TextField), '  Capital of Iceland?  ');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    expect(notifier.sent, ['Capital of Iceland?']);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller!.text,
+      '',
+    );
+  });
+
+  testWidgets('a blank message is not sent', (tester) async {
+    final notifier = await pumpDetail(tester, user: _user());
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    expect(notifier.sent, isEmpty);
+  });
+
+  testWidgets('without a session there is nobody to send as', (tester) async {
+    await pumpDetail(tester);
+
+    final button = tester.widget<IconButton>(
+      find.ancestor(
+        of: find.byIcon(Icons.send),
+        matching: find.byType(IconButton),
+      ),
+    );
+    expect(button.onPressed, isNull);
+  });
+
+  testWidgets('submitting from the keyboard does not take the screen down', (
+    tester,
+  ) async {
+    // `onSubmitted` bypasses the disabled send button, so pressing enter with
+    // no session reached `_sendMessage` anyway. Nothing was added to the
+    // thread, so the `ListView` was never built — and scrolling to the bottom
+    // of a `ScrollController` with no attached view asserts, taking the screen
+    // down on a keystroke.
+    await pumpDetail(tester);
+
+    await tester.enterText(find.byType(TextField), 'Capital of Iceland?');
+    await tester.testTextInput.receiveAction(TextInputAction.send);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(ChatDetailScreen), findsOneWidget);
+  });
+
+  testWidgets('an unavailable provider is shown but cannot be picked', (
+    tester,
+  ) async {
+    await pumpDetail(
+      tester,
+      user: _user(),
+      providers: const {'openai': true, 'perplexity': false},
+    );
+
+    await tester.tap(find.byIcon(Icons.psychology));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('openai'), findsOneWidget);
+    expect(find.text('perplexity (unavailable)'), findsOneWidget);
+    final disabled = tester.widget<PopupMenuItem<String>>(
+      find.ancestor(
+        of: find.text('perplexity (unavailable)'),
+        matching: find.byType(PopupMenuItem<String>),
+      ),
+    );
+    expect(disabled.enabled, isFalse);
+  });
+
+  testWidgets('no provider menu appears when the server offers none', (
+    tester,
+  ) async {
+    await pumpDetail(tester, user: _user(), providers: const {});
+
+    expect(find.byIcon(Icons.psychology), findsNothing);
+  });
+  testWidgets('a newline in the field is flattened to a space', (tester) async {
+    // `ChatDetailFragment` sends
+    // `"${binding.editGchatMessage.text}".replace("\n", " ")`. Trimming alone
+    // leaves an embedded newline in the request body.
+    final notifier = await pumpDetail(tester, user: _user());
+
+    await tester.enterText(find.byType(TextField), 'first line\nsecond line');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    expect(notifier.sent, ['first line second line']);
+  });
+}

--- a/flutter/test/ui/chat/chat_history_screen_test.dart
+++ b/flutter/test/ui/chat/chat_history_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/chat_provider.dart';
 import 'package:myplanet/ui/chat/chat_history_screen.dart';
@@ -20,7 +21,22 @@ ChatRow _chat({
   isUploaded: false,
 );
 
-const _conversations = '[{"query":"hi","response":"hello there"}]';
+// `ChatHistoryAdapter` names a row by its first query and falls back to the
+// stored title, so a fixture that means to exercise the title keeps the two in
+// agreement. The two tests at the bottom of this file are the ones that make
+// them disagree on purpose.
+/// The tap handler calls `loadChat`, which reaches `chatRepositoryProvider`
+/// and through it `planetPrefsProvider` — `UnimplementedError` under a widget
+/// test. Only the navigation is under test here, so the notifier is stubbed.
+class _StubChatNotifier extends ChatConversationNotifier {
+  @override
+  ChatConversationState build() => const ChatConversationState();
+
+  @override
+  Future<void> loadChat(String chatId) async {}
+}
+
+const _conversations = '[{"query":"Math help","response":"hello there"}]';
 
 void main() {
   testWidgets('shows the empty state when there is no chat history', (
@@ -165,12 +181,12 @@ void main() {
       _chat(
         id: 'c1',
         title: 'greetings',
-        conversations: '[{"query":"hi","response":"hello there"}]',
+        conversations: '[{"query":"greetings","response":"hello there"}]',
       ),
       _chat(
         id: 'c2',
         title: 'science',
-        conversations: '[{"query":"why","response":"because"}]',
+        conversations: '[{"query":"science","response":"because"}]',
       ),
     ];
 
@@ -194,5 +210,94 @@ void main() {
 
     expect(find.text('science'), findsOneWidget);
     expect(find.text('greetings'), findsNothing);
+  });
+  testWidgets('tapping a chat opens that conversation', (tester) async {
+    // The tap built its path from `Routes.chat`, which is already the
+    // *template* `/life/chat/:chatId`, so it pushed
+    // `/life/chat/:chatId/<id>` — three segments where the router defines
+    // two. No route matched, and every conversation in the list opened
+    // go_router's error page instead. The list one route down, feedback,
+    // shows the convention: build the child path from the list's own route.
+    await tester.pumpWidget(
+      wrapScreen(
+        const ChatHistoryScreen(),
+        overrides: [
+          chatHistoryProvider.overrideWith(
+            (ref) async => [
+              _chat(
+                id: 'c1',
+                title: 'Math help',
+                conversations: _conversations,
+              ),
+            ],
+          ),
+          chatConversationProvider.overrideWith(_StubChatNotifier.new),
+        ],
+        pushTargets: {
+          '/life/chat/:chatId': (context) => Text(
+            'detail:${GoRouterState.of(context).pathParameters['chatId']}',
+          ),
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Math help'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('detail:c1'), findsOneWidget);
+  });
+
+  testWidgets('a chat with no title is named by its first question', (
+    tester,
+  ) async {
+    // `ChatHistoryAdapter` prefers `conversations[0].query` and only falls
+    // back to `title`. A synced document need not carry a title at all — the
+    // port showed those rows as "Untitled chat" with a "?" avatar even though
+    // the question was right there in the conversation.
+    await tester.pumpWidget(
+      wrapScreen(
+        const ChatHistoryScreen(),
+        overrides: [
+          chatHistoryProvider.overrideWith(
+            (ref) async => [
+              _chat(
+                id: 'c1',
+                conversations:
+                    '[{"query":"How do I plant maize?","response":"Deeply."}]',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('How do I plant maize?'), findsOneWidget);
+    expect(find.text('Untitled chat'), findsNothing);
+    expect(find.text('H'), findsOneWidget);
+  });
+
+  testWidgets('the first question outranks a stored title', (tester) async {
+    await tester.pumpWidget(
+      wrapScreen(
+        const ChatHistoryScreen(),
+        overrides: [
+          chatHistoryProvider.overrideWith(
+            (ref) async => [
+              _chat(
+                id: 'c1',
+                title: 'stale title',
+                conversations: '[{"query":"the real question","response":"x"}]',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('the real question'), findsOneWidget);
+    expect(find.text('stale title'), findsNothing);
   });
 }


### PR DESCRIPTION
Lane D of the Phase 108 Flutter-port round. Full narrative in `flutter/PHASE_108_NOTES.md`.

## First, a correction to the brief

`lib/repository/chat_repository_impl.dart` was described as having **no tests at all**. It had 22 (`chat_repository_test.dart` 18, `chat_sync_test.dart` 4), plus 7 for the history screen. The uncovered surfaces were `savePendingChat`, `sendContinueChatRequest`'s failure paths, `fetchAiProviders`, the mapper round trip, and all 240 lines of `chat_detail_screen.dart`.

The lesson turned out to be the inverse of the usual one: **the worst defect was in code that was tested.** `model/ChatResponse.kt` declares `@SerializedName("couchDBResponse")`, but the port read `response['couchdb']` — and its own three fixtures spelled it the same wrong way, so the suite asserted the bug was correct.

## Nine defects, each demonstrated failing first

1. **Wrong response key** → a new chat reported "saved without a document id" on **every successful answer** and persisted nothing; a continuation never advanced its `_rev`, so the next turn conflicted. `ChatSuccess` → `ChatError`; rev `2-b` → `1-a`.
2. **A failed continuation dropped the question.** Kotlin saves it locally on its non-success branch *and* its `catch`; only the `catch` was ported, and `_postChat` returns `null` rather than throwing, so the offline case took the unported path. The `_hasUnansweredQuery` sync guard was protecting a row nothing wrote.
3. **`savePendingChat` minted one constant id** — `'...\${...}'` in single quotes is an escaped dollar, not interpolation — so a second offline message replaced the first.
4. **A pending chat had no created/updated date**, so it sorted below every conversation the user had ever had.
5. **An empty revision could erase a good one**, where Kotlin guards on `!newRev.isNullOrEmpty()`. (This test passed pre-fix only *because* of defect 1; it fails the moment that is fixed.)
6. **Sending could crash the screen.** `ScrollController.position` was read unguarded; with no message on screen nothing is attached, and a keyboard submit with no session hit the assert.
7. **Every chat in the history list opened go_router's error page** — the tap path was built from `Routes.chat`, which is already the template `/life/chat/:chatId`.
8. **A titleless chat showed "Untitled chat"**, where `ChatHistoryAdapter` names a row by its first question.
9. **Newlines reached the request body**; `ChatDetailFragment` flattens them to spaces.

## Tests

+27 (1675 → 1702): `chat_write_back_test.dart` (14, new), `chat_detail_screen_test.dart` (10, the screen's first coverage), and 3 for history navigation and title precedence. Gate green: format clean, analyze clean, 1702 passing. No schema change (`schemaVersion` still 44), no new `app_en.arb` keys.

## For the integrator — confirmed defects outside this lane's files

Not edited, per one-file-one-owner. Details and Kotlin citations in the notes.

- **`app_providers.dart` + `url_utils.dart`: the AI endpoint is never reached.** Kotlin posts to `UrlUtils.hostUrl` itself (`host:5000/` or `host/ml/`); the port posts to `<couchdb>/db/chat`. `url_utils.dart` has no `hostUrl` counterpart. Fixing defect 1 is necessary but not sufficient.
- **`chat_provider.dart`: the queued question is replaced by the error text** — `case ChatError(message: final message)` shadows `sendMessage(String message)`, so the outbox carries `"Request failed"` as the user's question.
- **`chat_provider.dart`: `loadChat` can never find anything** — it calls `getChatHistoryForUser(null)`, which correctly returns `[]`. Defect 7 makes the route resolve; this makes the screen it lands on blank.
- **`chat_uploader.dart`: posts the conversations JSON as `content`, drops the model, discards the reply — and the next sync then deletes the row.**
- **`chat_provider.dart`: full-search defaults to `question`; Kotlin defaults to `response`.** And the revision is not re-read before a continuation (`getLatestRev` has no production caller).

Unported and undocumented as deferred: chat sharing to voices, conversation pagination, per-send alternative-URL mapping.

## Two of my own hypotheses the audit overturned

The chat calls are **not** missing an `Authorization` header (Kotlin sends none either — at parity, do not "fix"), and the search functions' `isEmpty`-vs-`null` skip is **not** a divergence for any non-blank query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nD6ae21jE9u2tJQtwL1ja