### PR TITLE
Phase 109: l10n placeholder guard + machine-translation marking

### DIFF
--- a/flutter/PHASE_109_NOTES.md
+++ b/flutter/PHASE_109_NOTES.md
@@ -1,3 +1,201 @@
-# Phase 109 — l10n placeholder guard and machine-translation marking
+# Phase 109 — the l10n placeholder guard, and marking the machine translation
 
-Work in progress. See the PR description for status.
+Lane A of the four-lane round. Touches `test/l10n/`, `tool/arb_from_strings_xml.dart`
+and `lib/l10n/*.arb` (metadata only — **no translated text changed**).
+
+## 1. The guard: `test/l10n/placeholder_integrity_test.dart`
+
+The external translation pass that filled the five locale files from ~250 keys to ~850
+tokenised placeholders before translating and never restored them. 58 strings shipped
+broken into the merge: 38 Arabic values carrying a literal `__0____` where a value
+belongs (`ratingOutOfFive` → `'التقييم: __0____ من 5'`), and 20 more across all five
+locales that simply dropped a placeholder the template declares.
+
+`flutter analyze` caught **one** of the 58, and by accident — a dropped placeholder is a
+lint only when `gen-l10n` happens to emit an unused local for it. The other 57 compiled
+and analyzed clean. `test/l10n/locale_coverage_test.dart` could not see them either: it
+guards the locale set and the key set, and never looks inside a value.
+
+Two checks, over every value in every locale file:
+
+**(a) no tokenisation artefact.** Three named patterns, so the failure says which one
+matched: the exact sentinel shape that shipped (`_{2,}\d+_{2,}`), any run of two or more
+underscores (a wider net — the next tokeniser will pick a different sentinel, and no
+legitimate value in any locale contains one today), and Kotlin's printf specifiers
+(`%1$s`/`%1$d`), which ICU never interpolates.
+
+**(b) every placeholder the template declares is present.** The authority is
+`app_en.arb`'s `@<key>.placeholders` metadata, **not** a regex over `{...}` in the
+English text. That distinction is load-bearing: an ICU plural body is full of braces that
+are not placeholders — `{count, plural, =1{one file} other{}}` yields spurious names like
+`1`, `No` and `Are` — and the first pass at this analysis reported 54 "missing"
+placeholders where only 20 were real. Matching is `{name}` and its ICU-qualified forms
+(`{count, plural, …}`), with whitespace allowed inside the braces.
+
+Both collect every defect and assert the whole list is empty, rather than stopping at the
+first: a run tells you the full extent of the damage, named as `locale:key`, with the
+offending value and the missing placeholder inline. Fixing does not require re-deriving
+the analysis.
+
+### Demonstrated catch
+
+Checked out the five locale files as they stood at `c2132ab2f^` — the merge commit before
+the repair, i.e. the broken files as harvested — and ran the new test against them:
+
+```
+91 value(s) carry a placeholder that was tokenised for translation and never restored:
+  ar:questionNumber contains a tokenisation sentinel (__0__) — "سؤال __0____"
+  ar:ratingOutOfFive contains a tokenisation sentinel (__0__) — "التقييم: __0____ من 5"
+  …
+62 value(s) drop a placeholder app_en.arb declares:
+  es:fileNotFound drops "fileName" — "Archivo no encontrado localmente"
+  …
+```
+
+**58 distinct keys flagged — exactly the 58 the repair commit removed, key for key.**
+(153 defect lines rather than 58 because the two artefact patterns overlap on the Arabic
+values and several keys drop more than one placeholder.) The guard passes on the repaired
+files, so it is a catch, not a blanket refusal.
+
+### One thing the guard says that the template will have to answer
+
+`communityEarnings`, `perSurvey` and `yourEarnings` declare ICU placeholders
+(`amount`, `status`) while writing their **English** with Kotlin's `%1$d`/`%1$s`:
+
+```json
+"perSurvey": "%1$s per survey",
+"@perSurvey": { "placeholders": { "status": { "type": "String" } } }
+```
+
+`gen-l10n` therefore emits `String perSurvey(String status)` and never interpolates the
+argument — the value is dropped in *every* language, English included. 15 of the 58
+removals were these three across the five locales. They are absent from all locales now,
+so the guard is green; it will fail the moment one is re-added, which is correct, because
+no translation of that string can be right until `app_en.arb` says `{status}`.
+
+`app_en.arb` is not this lane's file. **Follow-up for whoever owns it:** convert those
+three to ICU placeholders and check their call sites. `tool/arb_from_strings_xml.dart`
+now skips printf-carrying template values so a re-run cannot walk the defect into the
+locale files in the meantime.
+
+## 2. Marking the machine translation
+
+~560 keys per locale are Google Translate output with no human review, sitting
+indistinguishably beside the ~250 Phase 47 strings derived from the Kotlin
+`values-*/strings.xml` — translations already shipping in the Android app.
+
+**Mechanism: a per-key ARB attribute, `"@<key>": {"x-mt": true}`, in the locale file.**
+
+Why that rather than a single list at the top of each file:
+
+- It is the ARB spec's own extension shape (`x-`-prefixed resource attributes), so it is
+  data `gen-l10n` is meant to ignore rather than something it tolerates by luck. Verified
+  on the pinned 3.44.8, including on placeholder-bearing keys, where a locale-side
+  metadata block could plausibly have overridden the template's declaration and stripped
+  a getter's parameters — it does not, and the generated output is byte-identical before
+  and after the marking.
+- **A flag cannot drift from the string it describes.** A central list goes stale exactly
+  the way Phase 69's regeneration did: a key is deleted and the list still names it, or a
+  key is added and nobody updates it — silently, with nothing that reads as data loss.
+  Attached to the key, the only remaining drift is an orphaned block, which one of the
+  new tests forbids outright.
+- Reviewing is then a local edit next to the string being reviewed, so `git diff` shows
+  the review itself. A central list would make every approval an edit to one hot region
+  of the file.
+
+The split, derived from the key sets immediately before the harvest (`3c503f0`) — no
+pre-existing value was altered by the harvest, so key membership is a clean partition:
+
+| locale | machine-translated (unreviewed) | human-reviewed | falls back to English |
+|---|---|---|---|
+| ar | 557 | 259 | 46 |
+| es | 620 | 234 | 8 |
+| fr | 594 | 260 | 8 |
+| ne | 595 | 259 | 8 |
+| so | 595 | 259 | 8 |
+
+Listing them, per locale:
+
+```
+dart tool/arb_from_strings_xml.dart --unreviewed        # every locale
+dart tool/arb_from_strings_xml.dart --unreviewed fr     # one, as key<TAB>value
+```
+
+Four further tests pin the marking: every locale carries some, no flag outlives the
+string it marks, the template declares no review state of its own, and the
+human-reviewed counts are pinned per locale — so a future harvest that adds translations
+without deciding their review state fails here instead of quietly restoring the state
+this phase was opened to end.
+
+## 3. The tool preserves it
+
+`tool/arb_from_strings_xml.dart` already carried non-String values verbatim (Phase 69's
+`@currentCv` fix), so flags survive a merge. Preserving them is not sufficient, though —
+they also have to stay *true*, and the tool is what makes them false:
+
+- a key the tool derives from the Kotlin XML is a human translation already shipping in
+  the Android app, so a flag on one is stale. The documented way to refresh a translation
+  is *delete the key and re-run*, which leaves precisely that stale flag behind;
+- a flag whose key has no value marks nothing, and would attach itself to whatever value
+  is written for that key next.
+
+`_reconcileMachineTranslationFlags` drops both cases, keeping any `placeholders`
+declaration in the same block and deleting only an emptied one. The run summary now
+reports how many strings remain unreviewed and how many flags it cleared, so a run that
+strips the marking is visible instead of silent.
+
+Verified end to end on `fr` by seeding all three shapes — a stale flag on a deleted
+derivable key (`login`), an orphan naming nothing (`@ghostKey`), and a flag beside a
+placeholder declaration (`@currentCv`) — then re-running: `3 flag(s) cleared`, `login`
+re-derived and unflagged, `@ghostKey` gone, `@currentCv` left holding its placeholders
+and nothing else, and all 594 legitimate flags intact.
+
+### One unrelated defect fixed in the same file
+
+`_unquote` stripped Android's whitespace-preserving quotes but not its backslash escapes,
+which the XML parser leaves alone because they are not XML syntax. `values-fr` writes
+`Impossible d\'ajouter un dossier de santé.`, and a re-run would have written that
+backslash into `app_fr.arb` and onto a French screen. Found by running the tool: it is
+one of four keys the XML can now derive into the gaps the repair left. Every escape
+Android documents is undone; an unknown one keeps its backslash rather than being
+silently eaten.
+
+Those four derivable keys (`myGoalsDescription`, `myPurposeDescription`,
+`summaryOfAchievements`, `unableToAddHealthRecord`) are **not** added here — this lane
+changes no translated text. They are a free win for whoever runs the tool next.
+
+## Wording for `CLAUDE.md`
+
+This supersedes the "not yet decided" paragraph in the l10n section (the one beginning
+"**Current l10n state, and one open decision.**"). Suggested replacement:
+
+> **Current l10n state.** The template `app_en.arb` carries 862 keys; the five locale
+> files sit at 816–854, so only 8 keys per locale (46 for Arabic) fall back to English.
+> The Phase 47 derivations came from the Kotlin `strings.xml` — real human translations
+> already shipping in the Android app — but the ~600 keys added by the 2026-09 harvest
+> are Google Translate output with no human review. **The open decision is closed: they
+> are marked.** Phase 109 flags each one in its locale file as
+> `"@<key>": {"x-mt": true}` — the ARB spec's extension shape, ignored by `gen-l10n`,
+> attached to the key so it cannot drift from what it describes the way a central list
+> would. `dart tool/arb_from_strings_xml.dart --unreviewed [locale]` lists what still
+> needs a human: 557 ar, 620 es, 594 fr, 595 ne, 595 so. The tool clears a flag when it
+> derives a human translation over it, and `test/l10n/placeholder_integrity_test.dart`
+> fails if a flag orphans or if the human-reviewed count moves without someone saying so.
+>
+> That same test is the guard the harvest needed and did not have. The translator
+> tokenised placeholders and never restored them: 38 Arabic strings shipped a literal
+> `__0____` where a value belongs, and 20 more across the locales dropped a placeholder
+> the template declares. **`flutter analyze` caught exactly one of the 58**, as an
+> incidental `unused_local_variable`. The guard checks every locale value for a
+> tokenisation artefact and for every placeholder `app_en.arb`'s
+> `@<key>.placeholders` **metadata** declares — metadata, not a regex over `{...}`,
+> because an ICU plural body is full of braces that are not placeholders and a naive scan
+> reports 54 "missing" where 20 are real. Reconstructed against the pre-repair files it
+> flags all 58, key for key. **When a translation and a fact about it have to stay
+> together, attach the fact to the key, not to a list.**
+>
+> Known template defect the guard names: `communityEarnings`, `perSurvey` and
+> `yourEarnings` declare ICU placeholders while writing their English with Kotlin's
+> `%1$d`/`%1$s`, so `gen-l10n` emits a parameter it never interpolates and the value is
+> dropped in every language, English included. They are absent from all five locales
+> until `app_en.arb` is corrected.

--- a/flutter/PHASE_109_NOTES.md
+++ b/flutter/PHASE_109_NOTES.md
@@ -1,0 +1,3 @@
+# Phase 109 — l10n placeholder guard and machine-translation marking
+
+Work in progress. See the PR description for status.

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -2,75 +2,240 @@
   "@@locale": "ar",
   "appTitle": "myPlanet",
   "serverConfigurationTitle": "الاتصال بخادم الكوكب",
+  "@serverConfigurationTitle": {
+    "x-mt": true
+  },
   "serverUrlLabel": "عنوان URL للخادم",
+  "@serverUrlLabel": {
+    "x-mt": true
+  },
   "serverUrlHint": "https://planet.example.org",
+  "@serverUrlHint": {
+    "x-mt": true
+  },
   "serverPinLabel": "رقم التعريف الشخصي للخادم",
+  "@serverPinLabel": {
+    "x-mt": true
+  },
   "connect": "يتصل",
+  "@connect": {
+    "x-mt": true
+  },
   "serverUrlNotConfigured": "لم يتم تكوين عنوان URL للخادم",
   "deviceCouldNotReachLocalServer": "تعذر على الجهاز الوصول إلى الخادم. تحقق مما إذا كنت متصلاً بشبكة Wi-Fi الصحيحة للخادم المحلي (المجتمع).",
+  "@deviceCouldNotReachLocalServer": {
+    "x-mt": true
+  },
   "deviceCouldNotReachNationServer": "لم يتمكن الجهاز من الوصول إلى الخادم. تحقق مما إذا كنت متصلاً بالإنترنت وحاول مرة أخرى.",
   "connectionFailed": "فشل الاتصال!",
   "changeServer": "تغيير الخادم",
+  "@changeServer": {
+    "x-mt": true
+  },
   "login": "تسجيل الدخول",
   "name": "الاسم",
   "password": "كلمة المرور",
   "signInOffline": "تسجيل الدخول حاليا",
+  "@signInOffline": {
+    "x-mt": true
+  },
   "invalidCredentials": "الاسم أو كلمة المرور غير صحيحة.",
+  "@invalidCredentials": {
+    "x-mt": true
+  },
   "userNotFound": "لم يتم العثور على المستخدم.",
+  "@userNotFound": {
+    "x-mt": true
+  },
   "missingAuthData": "استجابة الخادم تفتقد بيانات المصادقة.",
+  "@missingAuthData": {
+    "x-mt": true
+  },
   "serverError": "خطأ في الخادم. يرجى المحاولة مرة أخرى لاحقا.",
+  "@serverError": {
+    "x-mt": true
+  },
   "networkError": "الخادم غير قابل للوصول. تحقق من اتصالك بالإنترنت.",
+  "@networkError": {
+    "x-mt": true
+  },
   "emptyCredentials": "اسم المستخدم وكلمة المرور مطلوبة.",
+  "@emptyCredentials": {
+    "x-mt": true
+  },
   "notAManager": "هذا الحساب ليس مديرا.",
+  "@notAManager": {
+    "x-mt": true
+  },
   "savedAccounts": "الحسابات المحفوظة",
+  "@savedAccounts": {
+    "x-mt": true
+  },
   "resources": "موارد",
   "search": "بحث",
   "sync": "مزامنة",
+  "@sync": {
+    "x-mt": true
+  },
   "cancel": "إلغاء",
   "settings": "الإعدادات",
   "backgroundSync": "مزامنة الخلفية",
+  "@backgroundSync": {
+    "x-mt": true
+  },
   "backgroundSyncDescription": "إرسال التغييرات المعلقة وتحديث بيانات التعلم أثناء إغلاق التطبيق",
+  "@backgroundSyncDescription": {
+    "x-mt": true
+  },
   "syncFrequency": "تردد المزامنة",
+  "@syncFrequency": {
+    "x-mt": true
+  },
   "every15Minutes": "كل 15 دقيقة",
+  "@every15Minutes": {
+    "x-mt": true
+  },
   "every30Minutes": "كل 30 دقيقة",
+  "@every30Minutes": {
+    "x-mt": true
+  },
   "everyHour": "كل ساعة",
+  "@everyHour": {
+    "x-mt": true
+  },
   "every6Hours": "كل 6 ساعات",
+  "@every6Hours": {
+    "x-mt": true
+  },
   "lastBackgroundRun": "آخر تشغيل في الخلفية",
+  "@lastBackgroundRun": {
+    "x-mt": true
+  },
   "backgroundNeverRun": "لم يتم تسجيل أي تشغيل في الخلفية حتى الآن",
+  "@backgroundNeverRun": {
+    "x-mt": true
+  },
   "backgroundSucceeded": "تم الانتهاء بنجاح",
+  "@backgroundSucceeded": {
+    "x-mt": true
+  },
   "backgroundRetryRequested": "غير مكتمل - سيعيد Android المحاولة",
+  "@backgroundRetryRequested": {
+    "x-mt": true
+  },
   "backgroundSkipped": "تم تخطيه",
+  "@backgroundSkipped": {
+    "x-mt": true
+  },
   "backgroundUnknown": "نتيجة غير معروفة",
+  "@backgroundUnknown": {
+    "x-mt": true
+  },
   "backgroundScheduleFailed": "تم حفظ التفضيل، لكن لم يتمكن Android من تحديث الجدول. ستتم إعادة المحاولة عند إعادة تشغيل التطبيق.",
+  "@backgroundScheduleFailed": {
+    "x-mt": true
+  },
   "logOut": "تسجيل الخروج",
+  "@logOut": {
+    "x-mt": true
+  },
   "noDataAvailable": "لا توجد بيانات متاحة",
   "ok": "موافق",
   "home": "الرئيسية",
   "moreOptions": "المزيد من الخيارات",
+  "@moreOptions": {
+    "x-mt": true
+  },
   "appTheme": "موضوع التطبيق",
+  "@appTheme": {
+    "x-mt": true
+  },
   "aiChat": "دردشة الذكاء الاصطناعي",
+  "@aiChat": {
+    "x-mt": true
+  },
   "syncNow": "مزامنة الآن",
+  "@syncNow": {
+    "x-mt": true
+  },
   "syncCenter": "مركز المزامنة",
+  "@syncCenter": {
+    "x-mt": true
+  },
   "syncAll": "مزامنة الكل",
+  "@syncAll": {
+    "x-mt": true
+  },
   "syncing": "جارٍ المزامنة…",
   "waiting": "منتظر",
+  "@waiting": {
+    "x-mt": true
+  },
   "events": "الأحداث",
+  "@events": {
+    "x-mt": true
+  },
   "surveys": "الاستبيانات",
   "syncReady": "جاهز للمزامنة",
+  "@syncReady": {
+    "x-mt": true
+  },
   "syncForegroundNotice": "أبقِ myPlanet مفتوحًا حتى تنتهي المزامنة. تظل عمليات الكتابة المعلقة دون اتصال دائمة في حالة انقطاع الاتصال.",
+  "@syncForegroundNotice": {
+    "x-mt": true
+  },
   "syncProgress": "مزامنة {completed} من {total} المناطق",
+  "@syncProgress": {
+    "x-mt": true
+  },
   "itemsSynced": "{count, plural, =0{Up to date} =1{1 item synced} other{{count} items synced}}",
+  "@itemsSynced": {
+    "x-mt": true
+  },
   "syncResourcesDescription": "قم بتحديث مكتبة التعلم دون اتصال بالإنترنت",
+  "@syncResourcesDescription": {
+    "x-mt": true
+  },
   "syncCoursesDescription": "قم بتحديث الدورات والخطوات وعضوية الرف",
+  "@syncCoursesDescription": {
+    "x-mt": true
+  },
   "syncTeamsDescription": "قم بتحديث الفرق والعضويات وبيانات المؤسسة",
+  "@syncTeamsDescription": {
+    "x-mt": true
+  },
   "syncEventsDescription": "تحديث الاجتماعات والحضور",
+  "@syncEventsDescription": {
+    "x-mt": true
+  },
   "syncSurveysDescription": "تحديث نماذج المسح والواجبات",
+  "@syncSurveysDescription": {
+    "x-mt": true
+  },
   "syncVoicesDescription": "تحديث مناقشات المجتمع والردود",
+  "@syncVoicesDescription": {
+    "x-mt": true
+  },
   "syncFeedbackDescription": "تحديث المواضيع ردود الفعل والردود",
+  "@syncFeedbackDescription": {
+    "x-mt": true
+  },
   "syncChatDescription": "قم بتحديث سجل محادثات الذكاء الاصطناعي",
+  "@syncChatDescription": {
+    "x-mt": true
+  },
   "syncHealthDescription": "تحديث السجلات الصحية المشفرة",
+  "@syncHealthDescription": {
+    "x-mt": true
+  },
   "syncActivitiesDescription": "تحديث سجل تسجيل الدخول من الخادم",
+  "@syncActivitiesDescription": {
+    "x-mt": true
+  },
   "syncNotificationsDescription": "قم بتحديث إشعارات الخادم وتحميل حالات القراءة",
+  "@syncNotificationsDescription": {
+    "x-mt": true
+  },
   "homeMyLibrary": "مكتبتي",
   "homeMyCourses": "دوراتي",
   "homeMyTeams": "فرقي",
@@ -84,94 +249,295 @@
   "subjectLabelSocialStudies": "الدراسات الاجتماعية",
   "subjectLabelTechnology": "التكنولوجيا",
   "surveysToComplete": "You have {count, plural, =1{1 survey} other{{count} surveys}} to complete",
+  "@surveysToComplete": {
+    "x-mt": true
+  },
   "neverSynced": "لم يتم المزامنة أبدا",
   "justNow": "الآن",
   "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@minutesAgo": {
+    "x-mt": true
+  },
   "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@hoursAgo": {
+    "x-mt": true
+  },
   "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@daysAgo": {
+    "x-mt": true
+  },
   "syncedResources": "{count, plural, =0{No resources synced} =1{1 resource synced} other{{count} resources synced}}",
+  "@syncedResources": {
+    "x-mt": true
+  },
   "availableOffline": "متاح حاليا",
+  "@availableOffline": {
+    "x-mt": true
+  },
   "courses": "الدورات",
   "myCourses": "دوراتي",
+  "@myCourses": {
+    "x-mt": true
+  },
   "allCourses": "جميع الدورات",
+  "@allCourses": {
+    "x-mt": true
+  },
   "courseSteps": "{count, plural, =0{No steps} =1{1 step} other{{count} steps}}",
+  "@courseSteps": {
+    "x-mt": true
+  },
   "resourcesInStep": "{count, plural, =0{No resources} =1{1 resource} other{{count} resources}}",
+  "@resourcesInStep": {
+    "x-mt": true
+  },
   "gradeLevel": "مستوى الصف",
+  "@gradeLevel": {
+    "x-mt": true
+  },
   "subjectLevel": "موضوع",
+  "@subjectLevel": {
+    "x-mt": true
+  },
   "allLevels": "الكل",
   "clearFilters": "مسح المرشحات",
+  "@clearFilters": {
+    "x-mt": true
+  },
   "joinCourse": "أضف إلى دوراتي",
+  "@joinCourse": {
+    "x-mt": true
+  },
   "leaveCourse": "إزالة من دوراتي",
+  "@leaveCourse": {
+    "x-mt": true
+  },
   "syncedCourses": "{count, plural, =0{No courses synced} =1{1 course synced} other{{count} courses synced}}",
+  "@syncedCourses": {
+    "x-mt": true
+  },
   "courseNotFound": "لم يتم العثور على الدورة",
+  "@courseNotFound": {
+    "x-mt": true
+  },
   "calendar": "التقويم",
   "profile": "الملف الشخصي",
   "profileUnavailable": "الملف الشخصي غير متاح",
+  "@profileUnavailable": {
+    "x-mt": true
+  },
   "username": "اسم المستخدم",
+  "@username": {
+    "x-mt": true
+  },
   "email": "البريد الإلكتروني",
   "phone": "هاتف",
+  "@phone": {
+    "x-mt": true
+  },
   "level": "مستوى",
+  "@level": {
+    "x-mt": true
+  },
   "levels": "المستويات",
+  "@levels": {
+    "x-mt": true
+  },
   "language": "اللغة",
   "languages": "اللغات",
   "gender": "الجنس",
   "dateOfBirth": "تاريخ الميلاد",
+  "@dateOfBirth": {
+    "x-mt": true
+  },
   "planetCode": "كود الكوكب",
+  "@planetCode": {
+    "x-mt": true
+  },
   "accountDetails": "تفاصيل الحساب",
+  "@accountDetails": {
+    "x-mt": true
+  },
   "noProfileDetails": "لا توجد تفاصيل الملف الشخصي متاحة.",
+  "@noProfileDetails": {
+    "x-mt": true
+  },
   "editProfile": "تحرير الملف الشخصي",
+  "@editProfile": {
+    "x-mt": true
+  },
   "changePhoto": "تغيير الصورة الشخصية",
+  "@changePhoto": {
+    "x-mt": true
+  },
   "photoUpdated": "تم تحديث صورة الملف الشخصي",
+  "@photoUpdated": {
+    "x-mt": true
+  },
   "photoUpdateFailed": "لا يمكن حفظ الصورة",
+  "@photoUpdateFailed": {
+    "x-mt": true
+  },
   "firstName": "الاسم الأول",
+  "@firstName": {
+    "x-mt": true
+  },
   "middleName": "الاسم الأوسط",
+  "@middleName": {
+    "x-mt": true
+  },
   "lastName": "اسم العائلة",
+  "@lastName": {
+    "x-mt": true
+  },
   "save": "حفظ",
   "profileSaved": "تم حفظ الملف الشخصي على هذا الجهاز",
+  "@profileSaved": {
+    "x-mt": true
+  },
   "invalidEmail": "أدخل عنوان بريد إلكتروني صالحًا",
+  "@invalidEmail": {
+    "x-mt": true
+  },
   "appearance": "مظهر",
+  "@appearance": {
+    "x-mt": true
+  },
   "systemTheme": "استخدام موضوع الجهاز",
+  "@systemTheme": {
+    "x-mt": true
+  },
   "lightTheme": "فاتح",
   "darkTheme": "داكن",
   "server": "الخادم",
+  "@server": {
+    "x-mt": true
+  },
   "serverUrl": "عنوان URL للخادم",
+  "@serverUrl": {
+    "x-mt": true
+  },
   "notConfigured": "لم يتم تكوينه",
+  "@notConfigured": {
+    "x-mt": true
+  },
   "communityCode": "رمز المجتمع",
+  "@communityCode": {
+    "x-mt": true
+  },
   "about": "حول",
   "offlineLearningApp": "التعلم دون اتصال بالإنترنت مع Planet",
+  "@offlineLearningApp": {
+    "x-mt": true
+  },
   "learningTools": "أدوات التعلم",
+  "@learningTools": {
+    "x-mt": true
+  },
   "dictionary": "القاموس",
   "dictionaryDescription": "البحث في التعريفات التي تم تنزيلها في وضع عدم الاتصال",
+  "@dictionaryDescription": {
+    "x-mt": true
+  },
   "dictionaryUnavailable": "القاموس غير متاح",
+  "@dictionaryUnavailable": {
+    "x-mt": true
+  },
   "searchDictionary": "ابحث عن كلمة",
+  "@searchDictionary": {
+    "x-mt": true
+  },
   "dictionaryWordCount": "{count, plural, =0{No downloaded words} =1{1 downloaded word} other{{count} downloaded words}}",
+  "@dictionaryWordCount": {
+    "x-mt": true
+  },
   "downloadDictionary": "تحميل القاموس",
+  "@downloadDictionary": {
+    "x-mt": true
+  },
   "retryDownload": "أعد محاولة التنزيل",
+  "@retryDownload": {
+    "x-mt": true
+  },
   "dictionaryDownloadFailed": "لا يمكن تحميل القاموس. لم يتم تغيير بياناتك الحالية دون اتصال بالإنترنت.",
+  "@dictionaryDownloadFailed": {
+    "x-mt": true
+  },
   "wordNotFound": "الكلمة غير متوفرة في القاموس غير المتصل",
+  "@wordNotFound": {
+    "x-mt": true
+  },
   "meaning": "معنى",
+  "@meaning": {
+    "x-mt": true
+  },
   "synonyms": "المرادفات",
+  "@synonyms": {
+    "x-mt": true
+  },
   "antonyms": "المتضادات",
+  "@antonyms": {
+    "x-mt": true
+  },
   "notifications": "إشعارات",
+  "@notifications": {
+    "x-mt": true
+  },
   "notification": "إشعار",
+  "@notification": {
+    "x-mt": true
+  },
   "notificationsUnavailable": "الإخطارات غير متاحة",
+  "@notificationsUnavailable": {
+    "x-mt": true
+  },
   "markAllRead": "وضع علامة على كل قراءة",
+  "@markAllRead": {
+    "x-mt": true
+  },
   "all": "الكل",
   "read": "يقرأ",
+  "@read": {
+    "x-mt": true
+  },
   "unreadCount": "غير مقروءة (_{count})",
+  "@unreadCount": {
+    "x-mt": true
+  },
   "noNotifications": "لا توجد إشعارات",
   "noUnreadNotifications": "لا توجد إشعارات غير مقروءة",
   "noReadNotifications": "لا توجد إشعارات مقروءة",
   "delete": "حذف",
   "deleteNotification": "هل تريد حذف الإشعار؟",
+  "@deleteNotification": {
+    "x-mt": true
+  },
   "deleteNotificationConfirmation": "ستتم إزالة هذا الإشعار من هذا الجهاز.",
+  "@deleteNotificationConfirmation": {
+    "x-mt": true
+  },
   "taskNotification": "مهمة",
+  "@taskNotification": {
+    "x-mt": true
+  },
   "chatNotification": "الدردشة",
   "replyNotification": "رد جديد",
+  "@replyNotification": {
+    "x-mt": true
+  },
   "resourceNotification": "موارد",
   "storageNotification": "تحذير التخزين",
+  "@storageNotification": {
+    "x-mt": true
+  },
   "joinRequestNotification": "طلب الانضمام",
+  "@joinRequestNotification": {
+    "x-mt": true
+  },
   "teamNotification": "تحديث الفريق",
+  "@teamNotification": {
+    "x-mt": true
+  },
   "tasks": "المهام",
   "notifGroupJoinRequests": "طلبات الانضمام",
   "notifGroupTeamUpdates": "تحديثات الفريق",
@@ -180,72 +546,249 @@
   "notificationGroupSystem": "النظام",
   "notificationGroupOther": "أخرى",
   "myLife": "حياتي",
+  "@myLife": {
+    "x-mt": true
+  },
   "myLifeUnavailable": "حياتي غير متوفرة",
+  "@myLifeUnavailable": {
+    "x-mt": true
+  },
   "noLifeItems": "لا عناصر حياتي",
+  "@noLifeItems": {
+    "x-mt": true
+  },
   "shownOnDashboard": "معروض",
+  "@shownOnDashboard": {
+    "x-mt": true
+  },
   "hiddenFromDashboard": "مختفي",
+  "@hiddenFromDashboard": {
+    "x-mt": true
+  },
   "myHealth": "صحتي",
+  "@myHealth": {
+    "x-mt": true
+  },
   "achievements": "الإنجازات",
+  "@achievements": {
+    "x-mt": true
+  },
   "submissions": "التقديمات",
+  "@submissions": {
+    "x-mt": true
+  },
   "submission": "استسلام",
+  "@submission": {
+    "x-mt": true
+  },
   "submissionsUnavailable": "التقديمات غير متوفرة",
+  "@submissionsUnavailable": {
+    "x-mt": true
+  },
   "noSubmissions": "لا يوجد تقديمات حتى الآن",
+  "@noSubmissions": {
+    "x-mt": true
+  },
   "pending": "قيد الانتظار",
+  "@pending": {
+    "x-mt": true
+  },
   "refresh": "ينعش",
+  "@refresh": {
+    "x-mt": true
+  },
   "complete": "مكتمل",
+  "@complete": {
+    "x-mt": true
+  },
   "noMatchingSubmissions": "لا توجد عمليات إرسال تتطابق مع هذا الفلتر",
+  "@noMatchingSubmissions": {
+    "x-mt": true
+  },
   "submissionsSynced": "{count, plural, =0{Submissions are up to date} =1{1 submission synced} other{{count} submissions synced}}",
+  "@submissionsSynced": {
+    "x-mt": true
+  },
   "submissionDetails": "تفاصيل التقديم",
+  "@submissionDetails": {
+    "x-mt": true
+  },
   "submissionNotFound": "لم يتم العثور على الإرسال",
+  "@submissionNotFound": {
+    "x-mt": true
+  },
   "unknown": "مجهول",
+  "@unknown": {
+    "x-mt": true
+  },
   "nA": "لا يوجد",
+  "@nA": {
+    "x-mt": true
+  },
   "otherDiagnosis": "تشخيص آخر",
+  "@otherDiagnosis": {
+    "x-mt": true
+  },
   "add": "يضيف",
+  "@add": {
+    "x-mt": true
+  },
   "status": "الحالة",
   "lastUpdated": "آخر تحديث",
+  "@lastUpdated": {
+    "x-mt": true
+  },
   "grade": "درجة",
+  "@grade": {
+    "x-mt": true
+  },
   "submittedBy": "تم الإرسال بواسطة",
   "submissionType": "النوع",
   "uploadStatus": "حالة التحميل",
+  "@uploadStatus": {
+    "x-mt": true
+  },
   "uploaded": "تم الرفع",
+  "@uploaded": {
+    "x-mt": true
+  },
   "answers": "الإجابات",
+  "@answers": {
+    "x-mt": true
+  },
   "answersUnavailable": "الإجابات غير متوفرة",
+  "@answersUnavailable": {
+    "x-mt": true
+  },
   "noAnswers": "لم يتم حفظ أي إجابات مع هذا الإرسال",
+  "@noAnswers": {
+    "x-mt": true
+  },
   "noAnswer": "لا إجابة",
+  "@noAnswer": {
+    "x-mt": true
+  },
   "newSubmission": "تقديم جديد",
+  "@newSubmission": {
+    "x-mt": true
+  },
   "answer": "إجابة",
+  "@answer": {
+    "x-mt": true
+  },
   "availableChoices": "الاختيارات",
+  "@availableChoices": {
+    "x-mt": true
+  },
   "exportPdf": "تصدير قوات الدفاع الشعبي",
+  "@exportPdf": {
+    "x-mt": true
+  },
   "pdfExportFailed": "لا يمكن إنشاء ملف PDF",
+  "@pdfExportFailed": {
+    "x-mt": true
+  },
   "mySurveys": "استطلاعاتي",
+  "@mySurveys": {
+    "x-mt": true
+  },
   "references": "المراجع",
   "myPersonals": "شخصياتي",
+  "@myPersonals": {
+    "x-mt": true
+  },
   "featureComingSoon": "لم يتم نقل هذه الميزة بعد",
+  "@featureComingSoon": {
+    "x-mt": true
+  },
   "maps": "الخرائط",
   "englishDictionary": "قاموس اللغة الإنجليزية",
+  "@englishDictionary": {
+    "x-mt": true
+  },
   "offlineMapsComingSoon": "لم يتم نقل الخرائط غير المتصلة بالإنترنت حتى الآن",
+  "@offlineMapsComingSoon": {
+    "x-mt": true
+  },
   "addPersonal": "إضافة عنصر شخصي",
+  "@addPersonal": {
+    "x-mt": true
+  },
   "editPersonal": "تحرير العنصر الشخصي",
+  "@editPersonal": {
+    "x-mt": true
+  },
   "deletePersonal": "هل تريد حذف العنصر الشخصي؟",
+  "@deletePersonal": {
+    "x-mt": true
+  },
   "deletePersonalConfirmation": "هل تريد حذف \"_{title}_\" من هذا الجهاز؟",
+  "@deletePersonalConfirmation": {
+    "x-mt": true
+  },
   "personalsUnavailable": "الأغراض الشخصية غير متوفرة",
+  "@personalsUnavailable": {
+    "x-mt": true
+  },
   "noPersonals": "لا توجد أشياء شخصية بعد. أضف ملاحظة خاصة للبدء.",
+  "@noPersonals": {
+    "x-mt": true
+  },
   "duplicateTitle": "يوجد بالفعل عنصر شخصي بهذا العنوان",
+  "@duplicateTitle": {
+    "x-mt": true
+  },
   "attachFile": "إرفاق الملف",
+  "@attachFile": {
+    "x-mt": true
+  },
   "noFileSelected": "No file selected",
+  "@noFileSelected": {
+    "x-mt": true
+  },
   "removeFile": "إزالة الملف",
+  "@removeFile": {
+    "x-mt": true
+  },
   "savedOffline": "تم الحفظ في وضع عدم الاتصال — في انتظار التحميل",
+  "@savedOffline": {
+    "x-mt": true
+  },
   "edit": "تحرير",
   "title": "العنوان",
   "titleRequired": "أدخل عنوانا",
+  "@titleRequired": {
+    "x-mt": true
+  },
   "rateCourse": "دورة معدل",
+  "@rateCourse": {
+    "x-mt": true
+  },
   "ratingsUnavailable": "التقييمات غير متوفرة",
+  "@ratingsUnavailable": {
+    "x-mt": true
+  },
   "ratingSummary": "{average} from {count, plural, =1{1 rating} other{{count} ratings}}",
+  "@ratingSummary": {
+    "x-mt": true
+  },
   "ratingRequired": "اختر التقييم",
+  "@ratingRequired": {
+    "x-mt": true
+  },
   "commentOptional": "تعليق (اختياري)",
+  "@commentOptional": {
+    "x-mt": true
+  },
   "submitRating": "إرسال التقييم",
+  "@submitRating": {
+    "x-mt": true
+  },
   "skip": "تخطي",
   "next": "التالي",
+  "@next": {
+    "x-mt": true
+  },
   "getStarted": "البدء",
   "welcomeToMyPlanet": "مرحبًا بكم في myPlanet",
   "learnOffline": "تعلم بدون اتصال",
@@ -253,285 +796,975 @@
   "unleashLearningPower": "اطلق قوة التعلم",
   "onboardingWelcomeDescription": "بوابتك إلى تعلم لا حدود له",
   "onboardingOfflineDescription": "قم بتنزيل الموارد للتعلم دون الاتصال بالإنترنت. \nالوصول إلى المعرفة أثناء التنقل.",
+  "@onboardingOfflineDescription": {
+    "x-mt": true
+  },
   "onboardingOpenDescription": "اختر اهتماماتك وانغمس في المحتوى التفاعلي. \nصمم رحلتك التعليمية الفريدة.",
+  "@onboardingOpenDescription": {
+    "x-mt": true
+  },
   "onboardingPowerDescription": "اكتشف عالم المعرفة في متناول يدك. \n\n🌍 الوصول دون اتصال بالإنترنت: تعلم بلا حدود، في أي وقت. \n🎯 مخصص: صمم مسار التعلم الخاص بك. \n📚 تفاعلي: تفاعل مع مقاطع الفيديو والكتب والألعاب. \n\nابدأ رحلتك التعليمية اللامحدودة مع myPlanet!",
+  "@onboardingPowerDescription": {
+    "x-mt": true
+  },
   "onboardingServerPrepHint": "قبل تسجيل الدخول، ستحتاج إلى عنوان خادم Planet ورقم التعريف الشخصي (PIN). اسأل مسؤول مجتمعك إذا لم تكن لديك هذه الميزات بعد.",
+  "@onboardingServerPrepHint": {
+    "x-mt": true
+  },
   "meetups": "لقاءات",
+  "@meetups": {
+    "x-mt": true
+  },
   "syncPendingMeetups": "مزامنة الاجتماعات المعلقة",
+  "@syncPendingMeetups": {
+    "x-mt": true
+  },
   "meetupsUnavailable": "اللقاءات غير متوفرة",
+  "@meetupsUnavailable": {
+    "x-mt": true
+  },
   "noMeetups": "لا توجد لقاءات حتى الآن",
+  "@noMeetups": {
+    "x-mt": true
+  },
   "dateNotSet": "التاريخ غير محدد",
+  "@dateNotSet": {
+    "x-mt": true
+  },
   "untitledMeetup": "لقاء بلا عنوان",
+  "@untitledMeetup": {
+    "x-mt": true
+  },
   "addMeetup": "إضافة لقاء",
+  "@addMeetup": {
+    "x-mt": true
+  },
   "meetupDetails": "تفاصيل اللقاء",
+  "@meetupDetails": {
+    "x-mt": true
+  },
   "meetupNotFound": "لم يتم العثور على اللقاء",
+  "@meetupNotFound": {
+    "x-mt": true
+  },
   "createdBy": "تم إنشاؤها بواسطة",
+  "@createdBy": {
+    "x-mt": true
+  },
   "category": "فئة",
+  "@category": {
+    "x-mt": true
+  },
   "location": "الموقع",
   "link": "الرابط",
   "recurring": "يتكرر",
+  "@recurring": {
+    "x-mt": true
+  },
   "description": "وصف",
+  "@description": {
+    "x-mt": true
+  },
   "leaveMeetup": "مغادرة اللقاء",
+  "@leaveMeetup": {
+    "x-mt": true
+  },
   "joinMeetup": "انضم إلى اللقاء",
+  "@joinMeetup": {
+    "x-mt": true
+  },
   "editMeetup": "تحرير اللقاء",
+  "@editMeetup": {
+    "x-mt": true
+  },
   "startTime": "وقت البدء",
+  "@startTime": {
+    "x-mt": true
+  },
   "endTime": "وقت الانتهاء",
+  "@endTime": {
+    "x-mt": true
+  },
   "none": "لا شيء",
   "daily": "يوميًا",
   "weekly": "أسبوعيًا",
   "syncMeetups": "مزامنة اللقاءات",
+  "@syncMeetups": {
+    "x-mt": true
+  },
   "searchMeetups": "بحث عن اللقاءات",
+  "@searchMeetups": {
+    "x-mt": true
+  },
   "sortMeetups": "ترتيب اللقاءات",
+  "@sortMeetups": {
+    "x-mt": true
+  },
   "sortResources": "فرز الموارد",
+  "@sortResources": {
+    "x-mt": true
+  },
   "newestFirst": "الأحدث أولاً",
+  "@newestFirst": {
+    "x-mt": true
+  },
   "oldestFirst": "الأقدم أولاً",
+  "@oldestFirst": {
+    "x-mt": true
+  },
   "titleAscending": "العنوان من الألف إلى الياء",
+  "@titleAscending": {
+    "x-mt": true
+  },
   "titleDescending": "العنوان Z-A",
+  "@titleDescending": {
+    "x-mt": true
+  },
   "startDate": "تاريخ البدء",
+  "@startDate": {
+    "x-mt": true
+  },
   "endDate": "تاريخ الانتهاء",
+  "@endDate": {
+    "x-mt": true
+  },
   "timeNotSet": "لم يتم ضبط الوقت",
+  "@timeNotSet": {
+    "x-mt": true
+  },
   "syncSurveys": "استطلاعات المزامنة",
+  "@syncSurveys": {
+    "x-mt": true
+  },
   "searchSurveys": "بحث المسوحات",
+  "@searchSurveys": {
+    "x-mt": true
+  },
   "sortSurveys": "فرز الاستطلاعات",
+  "@sortSurveys": {
+    "x-mt": true
+  },
   "surveysUnavailable": "الاستطلاعات غير متوفرة",
+  "@surveysUnavailable": {
+    "x-mt": true
+  },
   "noSurveys": "لا توجد استطلاعات متاحة",
+  "@noSurveys": {
+    "x-mt": true
+  },
   "untitledSurvey": "استطلاع بدون عنوان",
+  "@untitledSurvey": {
+    "x-mt": true
+  },
   "takeSurvey": "خذ الاستطلاع",
+  "@takeSurvey": {
+    "x-mt": true
+  },
   "surveyLoadFailed": "لا يمكن تحميل الاستطلاع",
+  "@surveyLoadFailed": {
+    "x-mt": true
+  },
   "surveyHasNoQuestions": "هذا الاستطلاع ليس لديه أسئلة",
+  "@surveyHasNoQuestions": {
+    "x-mt": true
+  },
   "submitSurvey": "إرسال الاستطلاع",
+  "@submitSurvey": {
+    "x-mt": true
+  },
   "answerRequiredQuestions": "الإجابة على جميع الأسئلة المطلوبة",
+  "@answerRequiredQuestions": {
+    "x-mt": true
+  },
   "voices": "أصوات",
+  "@voices": {
+    "x-mt": true
+  },
   "searchVoices": "أصوات البحث",
+  "@searchVoices": {
+    "x-mt": true
+  },
   "syncVoices": "مزامنة الأصوات",
+  "@syncVoices": {
+    "x-mt": true
+  },
   "noVoices": "لا توجد أصوات بعد",
+  "@noVoices": {
+    "x-mt": true
+  },
   "voicesUnavailable": "الأصوات غير متوفرة",
+  "@voicesUnavailable": {
+    "x-mt": true
+  },
   "shareYourVoice": "شارك بصوتك",
+  "@shareYourVoice": {
+    "x-mt": true
+  },
   "postVoice": "بريد",
+  "@postVoice": {
+    "x-mt": true
+  },
   "replyToVoice": "الرد",
   "writeAReply": "اكتب ردا",
+  "@writeAReply": {
+    "x-mt": true
+  },
   "repliesCount": "{count, plural, =0{No replies} =1{1 reply} other{{count} replies}}",
+  "@repliesCount": {
+    "x-mt": true
+  },
   "edited": "تم تحريره",
+  "@edited": {
+    "x-mt": true
+  },
   "editVoice": "تحرير",
   "deleteVoice": "حذف",
   "deleteVoiceConfirm": "هل تريد حذف هذه المشاركة وجميع الردود عليها؟",
+  "@deleteVoiceConfirm": {
+    "x-mt": true
+  },
   "voiceDeleted": "تم حذف المشاركة",
+  "@voiceDeleted": {
+    "x-mt": true
+  },
   "emptyMessageNotAllowed": "اكتب شيئا أولا",
+  "@emptyMessageNotAllowed": {
+    "x-mt": true
+  },
   "thread": "خيط",
+  "@thread": {
+    "x-mt": true
+  },
   "surveySubmitFailed": "لا يمكن حفظ إجاباتك",
+  "@surveySubmitFailed": {
+    "x-mt": true
+  },
   "sendSurveyTo": "حدد المستخدمين لإرسال الاستطلاع إليهم",
+  "@sendSurveyTo": {
+    "x-mt": true
+  },
   "sendSurvey": "إرسال المسح",
+  "@sendSurvey": {
+    "x-mt": true
+  },
   "surveySentToUsers": "Survey sent to selected users",
+  "@surveySentToUsers": {
+    "x-mt": true
+  },
   "noUsersAvailable": "لا يوجد مستخدمين متاحين",
+  "@noUsersAvailable": {
+    "x-mt": true
+  },
   "teams": "الفرق",
   "syncTeams": "فرق المزامنة",
+  "@syncTeams": {
+    "x-mt": true
+  },
   "searchTeams": "فرق البحث",
+  "@searchTeams": {
+    "x-mt": true
+  },
   "teamsUnavailable": "الفرق غير متوفرة",
+  "@teamsUnavailable": {
+    "x-mt": true
+  },
   "noTeams": "لا توجد فرق متاحة",
+  "@noTeams": {
+    "x-mt": true
+  },
   "untitledTeam": "فريق بلا عنوان",
+  "@untitledTeam": {
+    "x-mt": true
+  },
   "teamDetails": "تفاصيل الفريق",
+  "@teamDetails": {
+    "x-mt": true
+  },
   "teamNotFound": "لم يتم العثور على الفريق",
+  "@teamNotFound": {
+    "x-mt": true
+  },
   "publicTeam": "فريق عام",
+  "@publicTeam": {
+    "x-mt": true
+  },
   "privateTeam": "فريق خاص",
+  "@privateTeam": {
+    "x-mt": true
+  },
   "enterprises": "الشركات",
   "searchEnterprises": "البحث عن الشركات",
+  "@searchEnterprises": {
+    "x-mt": true
+  },
   "leader": "قائد",
+  "@leader": {
+    "x-mt": true
+  },
   "leave": "يترك",
+  "@leave": {
+    "x-mt": true
+  },
   "remove": "يزيل",
+  "@remove": {
+    "x-mt": true
+  },
   "makeLeader": "اصنع قائدا",
+  "@makeLeader": {
+    "x-mt": true
+  },
   "leftTeam": "الفريق الأيسر",
+  "@leftTeam": {
+    "x-mt": true
+  },
   "memberRemoved": "تمت إزالة العضو",
+  "@memberRemoved": {
+    "x-mt": true
+  },
   "leaderUpdated": "تم تحديث القائد",
+  "@leaderUpdated": {
+    "x-mt": true
+  },
   "member": "عضو",
+  "@member": {
+    "x-mt": true
+  },
   "teamLeader": "أنت تقود هذا الفريق",
+  "@teamLeader": {
+    "x-mt": true
+  },
   "teamMember": "أنت عضو",
+  "@teamMember": {
+    "x-mt": true
+  },
   "services": "الخدمات",
   "rules": "قواعد",
+  "@rules": {
+    "x-mt": true
+  },
   "teamCourses": "دورات الفريق",
+  "@teamCourses": {
+    "x-mt": true
+  },
   "membersCount": "{count, plural, =0{No members} =1{1 member} other{{count} members}}",
+  "@membersCount": {
+    "x-mt": true
+  },
   "teamTasks": "المهام",
   "tasksUnavailable": "المهام غير متوفرة",
+  "@tasksUnavailable": {
+    "x-mt": true
+  },
   "noTeamTasks": "لا توجد مهام حتى الآن",
+  "@noTeamTasks": {
+    "x-mt": true
+  },
   "noDeadline": "لا يوجد موعد نهائي",
+  "@noDeadline": {
+    "x-mt": true
+  },
   "untitledTask": "مهمة بلا عنوان",
+  "@untitledTask": {
+    "x-mt": true
+  },
   "addTask": "أضف مهمة",
+  "@addTask": {
+    "x-mt": true
+  },
   "editTask": "تحرير المهمة",
+  "@editTask": {
+    "x-mt": true
+  },
   "deleteTask": "حذف المهمة",
+  "@deleteTask": {
+    "x-mt": true
+  },
   "taskTitle": "عنوان المهمة",
+  "@taskTitle": {
+    "x-mt": true
+  },
   "assigneeId": "معرف المكلف",
+  "@assigneeId": {
+    "x-mt": true
+  },
   "teamDiscussions": "المناقشات",
+  "@teamDiscussions": {
+    "x-mt": true
+  },
   "teamMembers": "الأعضاء",
   "members": "الأعضاء",
   "joinRequests": "طلبات الانضمام",
+  "@joinRequests": {
+    "x-mt": true
+  },
   "noMembers": "لا يوجد أعضاء حتى الآن",
+  "@noMembers": {
+    "x-mt": true
+  },
   "membersUnavailable": "الأعضاء غير متوفرين",
+  "@membersUnavailable": {
+    "x-mt": true
+  },
   "unknownMember": "عضو غير معروف",
+  "@unknownMember": {
+    "x-mt": true
+  },
   "noJoinRequests": "لا توجد طلبات معلقة",
+  "@noJoinRequests": {
+    "x-mt": true
+  },
   "accept": "قبول",
   "decline": "انخفاض",
+  "@decline": {
+    "x-mt": true
+  },
   "joinTeam": "طلب الانضمام",
   "leaveTeam": "ترك الفريق",
+  "@leaveTeam": {
+    "x-mt": true
+  },
   "requestPending": "الطلب معلق",
+  "@requestPending": {
+    "x-mt": true
+  },
   "teamResources": "موارد",
   "resourcesUnavailable": "الموارد غير متوفرة",
+  "@resourcesUnavailable": {
+    "x-mt": true
+  },
   "noTeamResources": "لا توجد موارد مرتبطة بهذا الفريق",
+  "@noTeamResources": {
+    "x-mt": true
+  },
   "untitledResource": "مورد بلا عنوان",
+  "@untitledResource": {
+    "x-mt": true
+  },
   "removeFromTeam": "إزالة من الفريق",
+  "@removeFromTeam": {
+    "x-mt": true
+  },
   "addResource": "أضف موردًا",
+  "@addResource": {
+    "x-mt": true
+  },
   "editResource": "تحرير المورد",
+  "@editResource": {
+    "x-mt": true
+  },
   "resourceUpdated": "تم تحديث المورد",
+  "@resourceUpdated": {
+    "x-mt": true
+  },
   "resourceAddedToTeam": "تمت إضافة المورد إلى الفريق",
+  "@resourceAddedToTeam": {
+    "x-mt": true
+  },
   "descriptionIsRequired": "الوصف مطلوب",
+  "@descriptionIsRequired": {
+    "x-mt": true
+  },
   "levelIsRequired": "المستوى مطلوب",
+  "@levelIsRequired": {
+    "x-mt": true
+  },
   "subjectIsRequired": "الموضوع مطلوب",
+  "@subjectIsRequired": {
+    "x-mt": true
+  },
   "selectFile": "حدد ملفًا",
+  "@selectFile": {
+    "x-mt": true
+  },
   "fileSelected": "File selected",
+  "@fileSelected": {
+    "x-mt": true
+  },
   "privateResource": "الموارد الخاصة",
+  "@privateResource": {
+    "x-mt": true
+  },
   "saveChanges": "حفظ التغييرات",
+  "@saveChanges": {
+    "x-mt": true
+  },
   "selectOpenWith": "اختر فتح باستخدام",
+  "@selectOpenWith": {
+    "x-mt": true
+  },
   "selectMedia": "حدد الوسائط",
+  "@selectMedia": {
+    "x-mt": true
+  },
   "selectResourceType": "حدد نوع المورد",
+  "@selectResourceType": {
+    "x-mt": true
+  },
   "linkToLicense": "رابط الترخيص",
+  "@linkToLicense": {
+    "x-mt": true
+  },
   "noResourcesToAdd": "جميع الموارد المتاحة مرتبطة بالفعل",
+  "@noResourcesToAdd": {
+    "x-mt": true
+  },
   "coursesUnavailable": "الدورات غير متوفرة",
+  "@coursesUnavailable": {
+    "x-mt": true
+  },
   "noTeamCourses": "لا توجد دورات مرتبطة بهذا الفريق",
+  "@noTeamCourses": {
+    "x-mt": true
+  },
   "untitledCourse": "دورة بدون عنوان",
+  "@untitledCourse": {
+    "x-mt": true
+  },
   "addCourse": "إضافة دورة",
+  "@addCourse": {
+    "x-mt": true
+  },
   "noCoursesToAdd": "جميع الدورات المتاحة مرتبطة بالفعل",
+  "@noCoursesToAdd": {
+    "x-mt": true
+  },
   "financialReports": "التقارير المالية",
+  "@financialReports": {
+    "x-mt": true
+  },
   "reportsUnavailable": "التقارير غير متوفرة",
+  "@reportsUnavailable": {
+    "x-mt": true
+  },
   "noReports": "لا توجد تقارير مالية حتى الآن",
+  "@noReports": {
+    "x-mt": true
+  },
   "addReport": "إضافة تقرير",
+  "@addReport": {
+    "x-mt": true
+  },
   "editReport": "تحرير التقرير",
+  "@editReport": {
+    "x-mt": true
+  },
   "archiveReport": "الأرشيف",
   "beginningBalance": "رصيد البداية",
+  "@beginningBalance": {
+    "x-mt": true
+  },
   "sales": "المبيعات",
   "otherIncome": "دخل آخر",
+  "@otherIncome": {
+    "x-mt": true
+  },
   "wages": "أجور",
+  "@wages": {
+    "x-mt": true
+  },
   "otherExpenses": "نفقات أخرى",
+  "@otherExpenses": {
+    "x-mt": true
+  },
   "totalIncome": "إجمالي الدخل",
+  "@totalIncome": {
+    "x-mt": true
+  },
   "totalExpenses": "إجمالي النفقات",
+  "@totalExpenses": {
+    "x-mt": true
+  },
   "profitLoss": "الربح / الخسارة",
+  "@profitLoss": {
+    "x-mt": true
+  },
   "endingBalance": "رصيد النهاية",
+  "@endingBalance": {
+    "x-mt": true
+  },
   "negativeBalance": "الرصيد الحالي سلبي!",
+  "@negativeBalance": {
+    "x-mt": true
+  },
   "chatHistory": "تاريخ الدردشة",
+  "@chatHistory": {
+    "x-mt": true
+  },
   "chat": "الدردشة",
   "newChat": "دردشة جديدة",
+  "@newChat": {
+    "x-mt": true
+  },
   "searchChats": "بحث في الدردشات",
+  "@searchChats": {
+    "x-mt": true
+  },
   "noChats": "لا توجد محادثات بعد",
+  "@noChats": {
+    "x-mt": true
+  },
   "noSearchResults": "لا توجد محادثات مطابقة",
+  "@noSearchResults": {
+    "x-mt": true
+  },
   "untitledChat": "دردشة بلا عنوان",
+  "@untitledChat": {
+    "x-mt": true
+  },
   "fullConversationResponse": "الرد الكامل على المحادثة",
+  "@fullConversationResponse": {
+    "x-mt": true
+  },
   "response": "إجابة",
+  "@response": {
+    "x-mt": true
+  },
   "chatConversation": "محادثة",
+  "@chatConversation": {
+    "x-mt": true
+  },
   "newConversation": "محادثة جديدة",
+  "@newConversation": {
+    "x-mt": true
+  },
   "startConversation": "ابدأ محادثة جديدة",
+  "@startConversation": {
+    "x-mt": true
+  },
   "typeMessage": "اكتب رسالة...",
+  "@typeMessage": {
+    "x-mt": true
+  },
   "selectAiProvider": "حدد مزود الذكاء الاصطناعي",
+  "@selectAiProvider": {
+    "x-mt": true
+  },
   "aiProviders": "مزودي الذكاء الاصطناعي",
+  "@aiProviders": {
+    "x-mt": true
+  },
   "feedback": "تغذية راجعة",
   "feedbackNotFound": "لم يتم العثور على ردود الفعل",
+  "@feedbackNotFound": {
+    "x-mt": true
+  },
   "feedbackSaved": "تم حفظ التعليقات",
+  "@feedbackSaved": {
+    "x-mt": true
+  },
   "isUrgent": "هل هذا أمر عاجل؟",
+  "@isUrgent": {
+    "x-mt": true
+  },
   "feedbackType": "نوع ردود الفعل",
+  "@feedbackType": {
+    "x-mt": true
+  },
   "feedbackTypeRequired": "Please select a feedback type",
+  "@feedbackTypeRequired": {
+    "x-mt": true
+  },
   "yourFeedback": "ملاحظاتك",
+  "@yourFeedback": {
+    "x-mt": true
+  },
   "pleaseEnterFeedback": "الرجاء إدخال ملاحظاتك",
+  "@pleaseEnterFeedback": {
+    "x-mt": true
+  },
   "question": "سؤال",
   "bug": "خطأ",
   "suggestion": "اقتراح",
   "priority": "الأولوية",
   "openDate": "تاريخ مفتوح",
+  "@openDate": {
+    "x-mt": true
+  },
   "replies": "الردود",
+  "@replies": {
+    "x-mt": true
+  },
   "pleaseEnterReply": "يرجى إدخال رد",
   "untitledFeedback": "ردود فعل بلا عنوان",
+  "@untitledFeedback": {
+    "x-mt": true
+  },
   "yes": "نعم",
   "no": "لا",
   "submit": "إرسال",
   "takeTest": "خذ الاختبار",
+  "@takeTest": {
+    "x-mt": true
+  },
   "recordSurvey": "سجل المسح",
+  "@recordSurvey": {
+    "x-mt": true
+  },
   "react": "رد فعل",
+  "@react": {
+    "x-mt": true
+  },
   "pickReaction": "اختر رد فعل",
+  "@pickReaction": {
+    "x-mt": true
+  },
   "comments": "تعليقات",
+  "@comments": {
+    "x-mt": true
+  },
   "addComment": "أضف تعليقا",
+  "@addComment": {
+    "x-mt": true
+  },
   "commentsCount": "تعليقات {count}",
+  "@commentsCount": {
+    "x-mt": true
+  },
   "noComments": "لا توجد تعليقات حتى الآن",
+  "@noComments": {
+    "x-mt": true
+  },
   "leaderboard": "المتصدرين",
+  "@leaderboard": {
+    "x-mt": true
+  },
   "allTime": "كل الوقت",
+  "@allTime": {
+    "x-mt": true
+  },
   "thisMonth": "هذا الشهر",
+  "@thisMonth": {
+    "x-mt": true
+  },
   "error": "خطأ",
+  "@error": {
+    "x-mt": true
+  },
   "close": "يغلق",
   "filter": "تصفية",
   "type": "النوع",
   "apply": "يتقدم",
+  "@apply": {
+    "x-mt": true
+  },
   "unavailable": "غير متاح",
+  "@unavailable": {
+    "x-mt": true
+  },
   "chatsUnavailable": "لا يمكن تحميل الدردشات",
+  "@chatsUnavailable": {
+    "x-mt": true
+  },
   "community": "المجتمع",
   "communityLeaders": "قادة المجتمع",
   "nationLeaders": "قادة الأمة",
+  "@nationLeaders": {
+    "x-mt": true
+  },
   "ourVoices": "أصواتنا",
+  "@ourVoices": {
+    "x-mt": true
+  },
   "finances": "المالية",
   "reports": "التقارير",
   "transaction": "عملية",
+  "@transaction": {
+    "x-mt": true
+  },
   "transactions": "المعاملات",
+  "@transactions": {
+    "x-mt": true
+  },
   "addTransaction": "إضافة المعاملة",
   "noTransactions": "لا توجد معاملات حتى الآن",
+  "@noTransactions": {
+    "x-mt": true
+  },
   "debit": "مدين",
   "credit": "دائن",
   "balance": "الرصيد",
   "amount": "المبلغ",
   "note": "ملحوظة",
+  "@note": {
+    "x-mt": true
+  },
   "date": "التاريخ",
   "fromDate": "من تاريخ",
+  "@fromDate": {
+    "x-mt": true
+  },
   "toDate": "حتى الآن",
+  "@toDate": {
+    "x-mt": true
+  },
   "reset": "إعادة ضبط",
+  "@reset": {
+    "x-mt": true
+  },
   "noteRequired": "الملاحظة مطلوبة",
   "amountRequired": "يجب أن يكون المبلغ أكبر من 0",
+  "@amountRequired": {
+    "x-mt": true
+  },
   "transactionAdded": "تمت إضافة المعاملة",
   "addReceipt": "أضف الإيصال",
+  "@addReceipt": {
+    "x-mt": true
+  },
   "receiptSelected": "Receipt selected",
+  "@receiptSelected": {
+    "x-mt": true
+  },
   "noReceipt": "لا يوجد إيصال مرفق",
+  "@noReceipt": {
+    "x-mt": true
+  },
   "receipt": "إيصال",
+  "@receipt": {
+    "x-mt": true
+  },
   "viewReceipt": "عرض الإيصال",
+  "@viewReceipt": {
+    "x-mt": true
+  },
   "noLeadersAvailable": "لا يوجد قادة المتاحة",
+  "@noLeadersAvailable": {
+    "x-mt": true
+  },
   "noServicesAvailable": "لا توجد خدمات متاحة",
+  "@noServicesAvailable": {
+    "x-mt": true
+  },
   "noDescriptionAvailable": "لا تتوفر وصف",
   "takeExam": "خذ الامتحان",
+  "@takeExam": {
+    "x-mt": true
+  },
   "examLoadFailed": "لا يمكن تحميل الامتحان",
+  "@examLoadFailed": {
+    "x-mt": true
+  },
   "examHasNoQuestions": "هذا الامتحان ليس لديه أسئلة",
+  "@examHasNoQuestions": {
+    "x-mt": true
+  },
   "examComplete": "اكتمل الامتحان",
+  "@examComplete": {
+    "x-mt": true
+  },
   "examUnavailable": "الامتحان غير متاح",
+  "@examUnavailable": {
+    "x-mt": true
+  },
   "submitExam": "تقديم الامتحان",
+  "@submitExam": {
+    "x-mt": true
+  },
   "incorrectAnswer": "إجابة غير صحيحة",
+  "@incorrectAnswer": {
+    "x-mt": true
+  },
   "correctAnswers": "صحيح",
+  "@correctAnswers": {
+    "x-mt": true
+  },
   "yourAnswer": "إجابتك",
+  "@yourAnswer": {
+    "x-mt": true
+  },
   "previous": "السابق",
   "finish": "إنهاء",
   "exitExam": "الخروج من الامتحان؟",
+  "@exitExam": {
+    "x-mt": true
+  },
   "exitExamMessage": "سيتم فقدان التقدم المحرز الخاص بك.",
+  "@exitExamMessage": {
+    "x-mt": true
+  },
   "exit": "خروج",
   "download": "تحميل",
   "downloading": "جارٍ التنزيل…",
+  "@downloading": {
+    "x-mt": true
+  },
   "downloadFailed": "فشل التنزيل.",
+  "@downloadFailed": {
+    "x-mt": true
+  },
   "resourceNotDownloaded": "هذا المورد ليس على جهازك بعد.",
+  "@resourceNotDownloaded": {
+    "x-mt": true
+  },
   "retry": "أعد المحاولة",
+  "@retry": {
+    "x-mt": true
+  },
   "fieldRequired": "مطلوب",
+  "@fieldRequired": {
+    "x-mt": true
+  },
   "examSubmitFailed": "تعذر حفظ الاختبار. يرجى المحاولة مرة أخرى.",
+  "@examSubmitFailed": {
+    "x-mt": true
+  },
   "yourInformation": "المعلومات الخاصة بك",
+  "@yourInformation": {
+    "x-mt": true
+  },
   "showAdditionalFields": "إظهار الحقول الإضافية",
+  "@showAdditionalFields": {
+    "x-mt": true
+  },
   "hideAdditionalFields": "إخفاء الحقول الإضافية",
+  "@hideAdditionalFields": {
+    "x-mt": true
+  },
   "phoneNumber": "رقم التليفون",
+  "@phoneNumber": {
+    "x-mt": true
+  },
   "birthDate": "تاريخ الميلاد",
+  "@birthDate": {
+    "x-mt": true
+  },
   "selectDate": "اختر التاريخ",
+  "@selectDate": {
+    "x-mt": true
+  },
   "male": "ذكر",
+  "@male": {
+    "x-mt": true
+  },
   "female": "أنثى",
+  "@female": {
+    "x-mt": true
+  },
   "yearOfBirth": "سنة الميلاد",
   "yearOfBirthRequired": "سنة الميلاد مطلوبة",
+  "@yearOfBirthRequired": {
+    "x-mt": true
+  },
   "invalidYear": "الرجاء إدخال سنة صالحة",
+  "@invalidYear": {
+    "x-mt": true
+  },
   "thankYouForTakingSurvey": "شكرا لك على أخذ هذا الاستطلاع",
+  "@thankYouForTakingSurvey": {
+    "x-mt": true
+  },
   "errorSavingProfile": "حدث خطأ أثناء حفظ الملف الشخصي",
+  "@errorSavingProfile": {
+    "x-mt": true
+  },
   "videoPlayer": "مشغل فيديو",
+  "@videoPlayer": {
+    "x-mt": true
+  },
   "audioPlayer": "مشغل الصوت",
+  "@audioPlayer": {
+    "x-mt": true
+  },
   "videoFileNotFound": "ملف الفيديو غير موجود محليًا",
   "unableToLoadVideo": "تعذر تحميل الفيديو",
   "audioFileNotFound": "ملف الصوت غير موجود محليًا",
@@ -547,68 +1780,227 @@
   "errorOccurred": "خطأ: {error}",
   "openingResource": "فتح: {title}",
   "loadingMedia": "تحميل...",
+  "@loadingMedia": {
+    "x-mt": true
+  },
   "resourceUnavailable": "هذا المورد غير متاح للعرض في وضع عدم الاتصال",
+  "@resourceUnavailable": {
+    "x-mt": true
+  },
   "healthRecordNotAvailable": "السجل الصحي غير متوفر",
+  "@healthRecordNotAvailable": {
+    "x-mt": true
+  },
   "updateHealth": "تحديث الصحة",
+  "@updateHealth": {
+    "x-mt": true
+  },
   "addHealthRecord": "إضافة السجل الصحي",
+  "@addHealthRecord": {
+    "x-mt": true
+  },
   "healthProfile": "الملف الصحي",
+  "@healthProfile": {
+    "x-mt": true
+  },
   "specialNeeds": "احتياجات خاصة",
+  "@specialNeeds": {
+    "x-mt": true
+  },
   "otherNeeds": "احتياجات أخرى",
+  "@otherNeeds": {
+    "x-mt": true
+  },
   "emergencyContact": "الاتصال في حالات الطوارئ",
+  "@emergencyContact": {
+    "x-mt": true
+  },
   "contactNumber": "رقم الاتصال",
+  "@contactNumber": {
+    "x-mt": true
+  },
   "vitalSigns": "العلامات الحيوية",
+  "@vitalSigns": {
+    "x-mt": true
+  },
   "temperature": "درجة حرارة",
+  "@temperature": {
+    "x-mt": true
+  },
   "pulse": "نبض",
+  "@pulse": {
+    "x-mt": true
+  },
   "height": "ارتفاع",
+  "@height": {
+    "x-mt": true
+  },
   "weight": "وزن",
+  "@weight": {
+    "x-mt": true
+  },
   "bloodPressure": "ضغط الدم",
+  "@bloodPressure": {
+    "x-mt": true
+  },
   "vision": "الرؤية",
   "hearing": "السمع",
   "examinationHistory": "تاريخ الامتحان",
+  "@examinationHistory": {
+    "x-mt": true
+  },
   "personalInformation": "معلومات شخصية",
+  "@personalInformation": {
+    "x-mt": true
+  },
   "birthPlace": "مكان الميلاد",
+  "@birthPlace": {
+    "x-mt": true
+  },
   "contactName": "اسم جهة الاتصال",
+  "@contactName": {
+    "x-mt": true
+  },
   "contactType": "نوع الاتصال",
+  "@contactType": {
+    "x-mt": true
+  },
   "healthInformation": "معلومات صحية",
+  "@healthInformation": {
+    "x-mt": true
+  },
   "requiredField": "هذه الخانة مطلوبه",
+  "@requiredField": {
+    "x-mt": true
+  },
   "healthSavedSuccessfully": "تم حفظ البيانات الصحية بنجاح",
+  "@healthSavedSuccessfully": {
+    "x-mt": true
+  },
   "examinationDetails": "تفاصيل الفحص",
+  "@examinationDetails": {
+    "x-mt": true
+  },
   "allergies": "الحساسية",
   "diagnosis": "التشخيص",
   "medications": "الأدوية",
   "immunizations": "التحصينات",
+  "@immunizations": {
+    "x-mt": true
+  },
   "treatments": "العلاجات",
   "observations": "الملاحظات",
+  "@observations": {
+    "x-mt": true
+  },
   "referrals": "الإحالات",
   "labTests": "الاختبارات المعملية",
+  "@labTests": {
+    "x-mt": true
+  },
   "xrays": "الأشعة السينية",
   "conditions": "شروط",
+  "@conditions": {
+    "x-mt": true
+  },
   "selfExamination": "الفحص الذاتي",
+  "@selfExamination": {
+    "x-mt": true
+  },
   "healthRecordAdded": "تمت إضافة السجل الصحي بنجاح",
+  "@healthRecordAdded": {
+    "x-mt": true
+  },
   "selectHealthMember": "اختر عضوا",
+  "@selectHealthMember": {
+    "x-mt": true
+  },
   "newPatient": "مريض جديد",
+  "@newPatient": {
+    "x-mt": true
+  },
   "sortJoinDateDesc": "الأحدث أولاً",
+  "@sortJoinDateDesc": {
+    "x-mt": true
+  },
   "sortJoinDateAsc": "الأقدم أولاً",
+  "@sortJoinDateAsc": {
+    "x-mt": true
+  },
   "sortNameAsc": "الاسم من الألف إلى الياء",
+  "@sortNameAsc": {
+    "x-mt": true
+  },
   "sortNameDesc": "الاسم Z-A",
+  "@sortNameDesc": {
+    "x-mt": true
+  },
   "searchMembers": "أعضاء البحث",
+  "@searchMembers": {
+    "x-mt": true
+  },
   "dismiss": "رفض",
   "addMember": "إضافة عضو",
   "invalidNumber": "رقم غير صالح",
+  "@invalidNumber": {
+    "x-mt": true
+  },
   "tempRangeError": "يجب أن تكون درجة الحرارة بين 30 و 40",
+  "@tempRangeError": {
+    "x-mt": true
+  },
   "pulseRangeError": "يجب أن يكون النبض بين 40 و120",
+  "@pulseRangeError": {
+    "x-mt": true
+  },
   "heightRangeError": "يجب أن يكون الارتفاع بين 1 و 250",
+  "@heightRangeError": {
+    "x-mt": true
+  },
   "weightRangeError": "يجب أن يكون الوزن بين 1 و 150",
+  "@weightRangeError": {
+    "x-mt": true
+  },
   "bloodPressureFormatError": "يجب أن يكون ضغط الدم الانقباضي / الانبساطي",
+  "@bloodPressureFormatError": {
+    "x-mt": true
+  },
   "bloodPressureRangeError": "يجب أن يكون ضغط الدم بين 60/40 و300/200",
+  "@bloodPressureRangeError": {
+    "x-mt": true
+  },
   "bloodPressureNotNumbers": "يجب أن يكون الضغط الانقباضي والانبساطي أرقامًا",
+  "@bloodPressureNotNumbers": {
+    "x-mt": true
+  },
   "temp": "درجة حرارة",
+  "@temp": {
+    "x-mt": true
+  },
   "bp": "بي بي",
+  "@bp": {
+    "x-mt": true
+  },
   "offlineMaps": "خرائط دون اتصال",
+  "@offlineMaps": {
+    "x-mt": true
+  },
   "centerOnDefault": "توسيط على الموقع الافتراضي",
+  "@centerOnDefault": {
+    "x-mt": true
+  },
   "storage": "تخزين",
+  "@storage": {
+    "x-mt": true
+  },
   "storageManagement": "إدارة التخزين",
+  "@storageManagement": {
+    "x-mt": true
+  },
   "storageTotalDownloaded": "إجمالي التنزيلات",
+  "@storageTotalDownloaded": {
+    "x-mt": true
+  },
   "storageVideos": "مقاطع الفيديو",
   "storageAudio": "الصوت",
   "storagePdfs": "ملفات PDF",
@@ -616,13 +2008,22 @@
   "storageOther": "أخرى",
   "fileCountOne": "ملف واحد",
   "storageUnknownResource": "مورد غير معروف",
+  "@storageUnknownResource": {
+    "x-mt": true
+  },
   "areYouSure": "هل أنت متأكد؟",
   "cancelAddingExamination": "Are you sure you want to cancel adding examination? The data will be lost.",
   "yesIWantToExit": "Yes, I want to exit.",
   "inactiveMessage": "User not activated, please contact administrator or manager to activate your account.",
   "submitFeedback": "Submit Feedback",
   "storageDeleteSelectedConfirm": "Delete {count} selected items?",
+  "@storageDeleteSelectedConfirm": {
+    "x-mt": true
+  },
   "storageSelectedCount": "{count} selected",
+  "@storageSelectedCount": {
+    "x-mt": true
+  },
   "deleteSelected": "حذف المحدد",
   "deleteAll": "حذف الكل",
   "selectAll": "تحديد الكل",
@@ -632,60 +2033,159 @@
   "coursesSelected": "{count, plural, =1{تم تحديد عنصر واحد} other{تم تحديد {count} عناصر}}",
   "leaveCoursesConfirm": "{count, plural, =1{هل أنت متأكد أنك تريد إزالة هذا المقرر؟} other{هل أنت متأكد أنك تريد إزالة هذه المقررات؟}}",
   "noStorageUsed": "لم يتم العثور على الملفات التي تم تنزيلها",
+  "@noStorageUsed": {
+    "x-mt": true
+  },
   "availableSpace": "المساحة المتوفرة",
+  "@availableSpace": {
+    "x-mt": true
+  },
   "freeUpSpace": "حرر مساحة",
+  "@freeUpSpace": {
+    "x-mt": true
+  },
   "freeUpSpaceConfirm": "سيؤدي هذا إلى حذف جميع الموارد التي تم تنزيلها لتحرير مساحة التخزين. يكمل؟",
+  "@freeUpSpaceConfirm": {
+    "x-mt": true
+  },
   "storageFreedSummary": "Freed {bytes}. {count, plural, =0{No files removed} =1{1 file removed} other{{count} files removed}}.",
+  "@storageFreedSummary": {
+    "x-mt": true
+  },
   "enterUsername": "أدخل اسم المستخدم",
+  "@enterUsername": {
+    "x-mt": true
+  },
   "enterPassword": "أدخل كلمة المرور",
+  "@enterPassword": {
+    "x-mt": true
+  },
   "retypePassword": "أعد كتابة كلمة المرور",
+  "@retypePassword": {
+    "x-mt": true
+  },
   "becomeMember": "أصبح عضوًا",
   "toAccessThisFeatureBecomeAMember": "أنت حاليًا مستخدم ضيف. للوصول إلى هذه الميزة، كن عضوًا.",
   "creatingMember": "جارٍ إنشاء حساب العضو...",
+  "@creatingMember": {
+    "x-mt": true
+  },
   "passwordsDoNotMatch": "كلمتا المرور غير متطابقتين",
   "pleaseSelectGender": "يرجى تحديد الجنس",
   "pleaseEnterPassword": "يرجى إدخال كلمة المرور",
   "usernameAlreadyExists": "اسم المستخدم موجود بالفعل",
+  "@usernameAlreadyExists": {
+    "x-mt": true
+  },
   "usernameCannotBeEmpty": "اسم المستخدم لا يمكن أن يكون فارغًا",
   "invalidUsername": "اسم مستخدم غير صالح",
   "usernameMustStartWithLetterOrNumber": "يجب أن تبدأ بحرف أو رقم",
   "usernameOnlyLettersNumbers": "يُسمح فقط بالأحرف من a إلى z والأرقام و\"_\"، \".\"، \"-\".",
+  "@usernameOnlyLettersNumbers": {
+    "x-mt": true
+  },
   "usernameTaken": "تم استخدام اسم المستخدم من قبل",
   "memberCreatedOffline": "تم إنشاء حساب العضو دون اتصال",
+  "@memberCreatedOffline": {
+    "x-mt": true
+  },
   "memberCreatedOnline": "تم إنشاء حساب العضو بنجاح",
+  "@memberCreatedOnline": {
+    "x-mt": true
+  },
   "congratulations": "تهانينا! التحدي مكتمل",
   "dailyVoices": "من 5 أصوات يومية",
   "courseNotStarted": "الدورة: لم تبدأ",
+  "@courseNotStarted": {
+    "x-mt": true
+  },
   "syncCompletedChallenge": "اكتملت المزامنة",
+  "@syncCompletedChallenge": {
+    "x-mt": true
+  },
   "rememberSync": "تذكر مزامنة التطبيق المحمول.",
   "challengeDialogTitle": "التحدي اليومي",
+  "@challengeDialogTitle": {
+    "x-mt": true
+  },
   "start": "يبدأ",
+  "@start": {
+    "x-mt": true
+  },
   "continuation": "يكمل",
+  "@continuation": {
+    "x-mt": true
+  },
   "plan": "خطة",
   "mission": "المهمة والخدمات",
   "editPlan": "تعديل الخطة",
   "teamPlan": "ما هي خطة فريقك؟",
+  "@teamPlan": {
+    "x-mt": true
+  },
   "entMission": "ما هي مهمة مؤسستك؟",
+  "@entMission": {
+    "x-mt": true
+  },
   "entServices": "ما هي الخدمات التي تقدمها المؤسسة الخاصة بك؟",
   "entRules": "ما هي قواعد المؤسسة الخاصة بك؟",
   "noMissionDefined": "لا يوجد لدى المؤسسة مهمة وخدمات.",
   "noPlanDefined": "هذا الفريق ليس لديه خطة محددة.",
+  "@noPlanDefined": {
+    "x-mt": true
+  },
   "noDescriptionDefined": "هذا الفريق ليس لديه وصف محدد.",
+  "@noDescriptionDefined": {
+    "x-mt": true
+  },
   "enterpriseName": "اسم المؤسسة",
+  "@enterpriseName": {
+    "x-mt": true
+  },
   "teamName": "اسم الفريق",
+  "@teamName": {
+    "x-mt": true
+  },
   "teamType": "نوع الفريق",
+  "@teamType": {
+    "x-mt": true
+  },
   "local": "محلي",
+  "@local": {
+    "x-mt": true
+  },
   "isPublic": "عام",
   "nameRequired": "الاسم مطلوب",
   "nameIsRequired": "يرجى إدخال الاسم",
   "createdOn": "تم الإنشاء بتاريخ",
+  "@createdOn": {
+    "x-mt": true
+  },
   "courseDetails": "تفاصيل الدورة",
+  "@courseDetails": {
+    "x-mt": true
+  },
   "addedToCourse": "تمت إضافتها إلى دوراتك",
+  "@addedToCourse": {
+    "x-mt": true
+  },
   "removedFromCourse": "تمت إزالتها من الدورات التدريبية الخاصة بك",
+  "@removedFromCourse": {
+    "x-mt": true
+  },
   "pleaseCompleteSurvey": "يرجى إكمال الاستبيان لإنهاء الدورة",
   "takeCourse": "خذ الدورة",
+  "@takeCourse": {
+    "x-mt": true
+  },
   "teamCalendar": "تقويم الفريق",
+  "@teamCalendar": {
+    "x-mt": true
+  },
   "noMeetupsOnDate": "لا يوجد لقاءات في هذا التاريخ",
+  "@noMeetupsOnDate": {
+    "x-mt": true
+  },
   "myProgress": "تقدمي",
   "progress": "التقدم",
   "orderByTitle": "ترتيب حسب العنوان",
@@ -694,41 +2194,128 @@
   "progressFilterNotStarted": "لم يبدأ",
   "progressFilterInProgress": "قيد التنفيذ",
   "progressFilterCompleted": "مكتمل",
+  "@progressFilterCompleted": {
+    "x-mt": true
+  },
   "stepProgress": "{current} من {max} الخطوات",
+  "@stepProgress": {
+    "x-mt": true
+  },
   "noEnrolledCourses": "أنت غير مسجل في أي دورات",
+  "@noEnrolledCourses": {
+    "x-mt": true
+  },
   "mistakes": "الأخطاء",
   "step": "خطوة",
+  "@step": {
+    "x-mt": true
+  },
   "untitledResourceTitle": "مورد بلا عنوان",
+  "@untitledResourceTitle": {
+    "x-mt": true
+  },
   "author": "مؤلف",
+  "@author": {
+    "x-mt": true
+  },
   "publisher": "الناشر",
   "license": "رخصة",
+  "@license": {
+    "x-mt": true
+  },
   "addedBy": "تمت الإضافة بواسطة",
+  "@addedBy": {
+    "x-mt": true
+  },
   "resourceInformation": "معلومات الموارد",
+  "@resourceInformation": {
+    "x-mt": true
+  },
   "resourceFor": "لـ",
+  "@resourceFor": {
+    "x-mt": true
+  },
   "mediaType": "نوع الوسائط",
+  "@mediaType": {
+    "x-mt": true
+  },
   "resourceType": "نوع المورد",
+  "@resourceType": {
+    "x-mt": true
+  },
   "subject": "موضوع",
+  "@subject": {
+    "x-mt": true
+  },
   "year": "السنة",
   "timesRated": "مرات تصنيفها",
+  "@timesRated": {
+    "x-mt": true
+  },
   "addToMyLibrary": "أضف إلى مكتبتي",
+  "@addToMyLibrary": {
+    "x-mt": true
+  },
   "removeFromMyLibrary": "إزالة من مكتبتي",
+  "@removeFromMyLibrary": {
+    "x-mt": true
+  },
   "addedToMyLibrary": "تمت إضافتها إلى مكتبتي",
+  "@addedToMyLibrary": {
+    "x-mt": true
+  },
   "removedFromMyLibrary": "تمت الإزالة من مكتبتي",
+  "@removedFromMyLibrary": {
+    "x-mt": true
+  },
   "myLibrary": "مكتبتي",
+  "@myLibrary": {
+    "x-mt": true
+  },
   "allResources": "جميع الموارد",
+  "@allResources": {
+    "x-mt": true
+  },
   "viewResource": "عرض الموارد",
+  "@viewResource": {
+    "x-mt": true
+  },
   "view": "عرض",
   "linkNotAvailable": "الرابط غير متاح",
   "noRatings": "لا يوجد تقييمات حتى الآن",
+  "@noRatings": {
+    "x-mt": true
+  },
   "basedOnRatings": "based on {count, plural, =1{1 rating} other{{count} ratings}}",
+  "@basedOnRatings": {
+    "x-mt": true
+  },
   "rating": "تصنيف",
+  "@rating": {
+    "x-mt": true
+  },
   "operationFailed": "فشلت العملية",
+  "@operationFailed": {
+    "x-mt": true
+  },
   "filterResources": "تصفية الموارد",
+  "@filterResources": {
+    "x-mt": true
+  },
   "teamSurveys": "استطلاعات الفريق",
   "adoptableSurveys": "الدراسات الاستقصائية المتاحة لاعتمادها",
+  "@adoptableSurveys": {
+    "x-mt": true
+  },
   "noAdoptableSurveys": "لا توجد استطلاعات متاحة لاعتمادها",
+  "@noAdoptableSurveys": {
+    "x-mt": true
+  },
   "adoptSurvey": "تبنَّى الاستبيان",
   "surveyAdopted": "اعتمد المسح",
+  "@surveyAdopted": {
+    "x-mt": true
+  },
   "completedCourse": "دورة مكتملة",
   "remindMeLater": "ذكرني لاحقاً",
   "remindLater": "تذكير لاحقاً",
@@ -737,7 +2324,13 @@
   "hours": "ساعات",
   "days": "أيام",
   "reminderSurveysToComplete": "Reminder: You have {count, plural, =1{1 survey} other{{count} surveys}} to complete",
+  "@reminderSurveysToComplete": {
+    "x-mt": true
+  },
   "myActivities": "أنشطتي",
+  "@myActivities": {
+    "x-mt": true
+  },
   "chartLabel": "عدد مرات تسجيل الدخول",
   "selectLanguage": "اختر اللغة",
   "english": "english",
@@ -747,27 +2340,78 @@
   "arabic": "عربى",
   "french": "français",
   "activitySummary": "نشاط",
+  "@activitySummary": {
+    "x-mt": true
+  },
   "lastLogin": "آخر تسجيل دخول",
+  "@lastLogin": {
+    "x-mt": true
+  },
   "memberDetail": "تفاصيل الأعضاء",
+  "@memberDetail": {
+    "x-mt": true
+  },
   "numberOfVisits": "عدد الزيارات",
+  "@numberOfVisits": {
+    "x-mt": true
+  },
   "noLogoutRecord": "لم يتم العثور على سجل الخروج",
+  "@noLogoutRecord": {
+    "x-mt": true
+  },
   "totalVisits": "إجمالي الزيارات",
+  "@totalVisits": {
+    "x-mt": true
+  },
   "mostOpenedResource": "الموارد الأكثر فتحا",
+  "@mostOpenedResource": {
+    "x-mt": true
+  },
   "numberOfResourcesOpened": "عدد الموارد المفتوحة",
+  "@numberOfResourcesOpened": {
+    "x-mt": true
+  },
   "resourceOpenedTimes": "{title} تم الفتح {count} مرات",
+  "@resourceOpenedTimes": {
+    "x-mt": true
+  },
   "resourcesOpenedTimes": "{count, plural, =1{Resource opened 1 time} other{Resource opened {count} times}}",
+  "@resourcesOpenedTimes": {
+    "x-mt": true
+  },
   "serverReachable": "يمكن الوصول إلى الخادم",
+  "@serverReachable": {
+    "x-mt": true
+  },
   "serverUnreachable": "الخادم غير قابل للوصول",
+  "@serverUnreachable": {
+    "x-mt": true
+  },
   "serverChecking": "فحص الخادم",
+  "@serverChecking": {
+    "x-mt": true
+  },
   "gridView": "عرض شبكي",
   "listView": "عرض قائمة",
   "disclaimer": "تنصل",
   "aboutContent": "### ماي بلانيت \n\nmyPlanet هي أداة تعليمية مصممة للعمل مع تطبيق الويب Planet. وقد تم استخدامه لتحسين التعليم المبكر، والمدارس الثانوية، والصحة القروية، وتنمية القوى العاملة للشباب، والتنمية الاقتصادية والمجتمعية. \n\nتعد Planet Houses مستودعًا للموارد المجانية والمفتوحة ذات الملكية العامة لإفادة جميع المتعلمين. \n\nتم تصميم myPlanet ليكون متاحًا للجميع، في كل مكان، وفي كل وقت. إنها محمولة وبأسعار معقولة وقابلة للتطوير ومستدامة. يعمل على أي جهاز أندرويد مثل الأجهزة اللوحية والهواتف المحمولة. وهو يعمل خارج، وكذلك على شبكة الإنترنت. \n\nيمكّن هذا التطبيق المدارس والمجتمعات من الحصول على مكتبة كاملة متعددة الوسائط ونظام تعليمي يتصل بشكل دوري مع Planet. يمكن أن تحتوي الأجهزة التي تم تكوينها على لوحة المعلومات الشخصية للمتعلمين. ويضمن ذلك أن يتمكن المتعلمون من قراءة الكتب الموجودة على الرفوف الخاصة بهم والحصول على الدورات التدريبية دون الاتصال بالإنترنت - أي دون الاتصال بخادم مركزي. يتم تشجيع المتعلمين على تقييم الموارد التي يستخدمونها والدورات التدريبية التي يأخذونها من نجمة إلى خمس نجوم. يمكن للمتعلمين بشكل دوري المزامنة مع الخادم. يتم تحميل بيانات النشاط وتنزيل الموارد الجديدة في غضون دقائق قليلة إلى myPlanet للاستخدام دون اتصال بالإنترنت. \n\nتحتوي لوحة التحكم أيضًا على سجل الإنجازات وتقويم الأحداث ونظام الدردشة الداخلي للتواصل مع الأعضاء الآخرين. \n\nوقد أثبت موقع myPlanet فعاليته العالية في تحسين فرص التعلم لأكثر من خمسين ألف متعلم في أكثر من 100 موقع، في المدارس في جميع أنحاء نيبال وغانا وكينيا ورواندا، مع اللاجئين السوريين في الأردن، واللاجئين الصوماليين في كينيا، والعاملين الصحيين في القرى في أوغندا.",
+  "@aboutContent": {
+    "x-mt": true
+  },
   "disclaimerContent": "# Disclaimer\n\nLast updated: January 10, 2020\n\n# Interpretation and Definitions\n\n## Interpretation\n\nThe words of which the initial letter is capitalized have meanings defined under the following conditions.\n\nThe following definitions shall have the same meaning regardless of whether they appear in singular or in plural.\n\n## Definitions\n\nFor the purposes of this Disclaimer:\n\n- **Company** (referred to as either \"the Company\", \"We\", \"Us\" or \"Our\" in this Cookies Policy) refers to myPlanet.\n- **You** means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.\n- **Application** means the software program provided by the Company downloaded by You on any electronic device named myPlanet.\n- **Service** refers to the Application.\n\n# Disclaimer\n\nThe information contained on the Service is for general information purposes only.\n\nThe Company assumes no responsibility for errors or omissions in the contents of the Service.\n\nIn no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice.\n\nThe Company does not warrant that the Service is free of viruses or other harmful components.\n\n# Medical Information Disclaimer\n\nThe information about health provided by the Service is not intended to diagnose, treat, cure or prevent disease. Products, services, information, and other content provided by the Service, including information linking to third-party websites are provided for informational purposes only.\n\nInformation offered by the Service is not comprehensive and does not cover all diseases, ailments, physical conditions or their treatment.\n\nIndividuals are different and may react differently to different products. Comments made on the Service by employees or other users are strictly their own personal views made in their own personal capacity and are not claims made by the Company nor do they represent the position or view of the Company.\n\nThe Company is not liable for any information provided by the Service with regard to recommendations regarding supplements for any health purposes.\n\nThe Company makes no guarantee or warranty with respect to any products or services sold. The Company is not responsible for any damages for information or services provided even if the Company has been advised of the possibility of damages.\n\n# External Links Disclaimer\n\nThe Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.\n\nPlease note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.\n\n# Errors and Omissions Disclaimer\n\nThe information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to ensure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules, and regulations, there may be delays, omissions, or inaccuracies in the information contained on the Service.\n\nThe Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.\n\n# Fair Use Disclaimer\n\nThe Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.\n\nThe Company believes this constitutes a \"fair use\" of any such copyrighted material as provided for in section 107 of the United States Copyright law.\n\nIf You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.\n\n# Views Expressed Disclaimer\n\nThe Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer, or company, including the Company.\n\nComments published by users are their sole responsibility and the users will take full responsibility, liability, and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.\n\n# No Responsibility Disclaimer\n\nThe information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal, or other competent advisers.\n\nIn no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.\n\n# \"Use at Your Own Risk\" Disclaimer\n\nAll information in the Service is provided \"as is\", with no guarantee of completeness, accuracy, timeliness, or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability, and fitness for a particular purpose.\n\nThe Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special, or similar damages, even if advised of the possibility of such damages.\n\n## Contact Us\n\nIf you have any questions about this Disclaimer, You can contact Us:\n\n- By email: myplanet@ole.org\n- By visiting this page on our website: [https://ole.org/contact](https://ole.org/contact)",
+  "@disclaimerContent": {
+    "x-mt": true
+  },
   "shareWithCommunity": "مشاركة مع المجتمع",
   "confirmShareCommunity": "هل أنت متأكد أنك تريد مشاركة هذا المحتوى مع المجتمع؟",
   "voiceShared": "مشاركة مشتركة مع المجتمع",
+  "@voiceShared": {
+    "x-mt": true
+  },
   "voiceUnshared": "تمت إزالته من المجتمع",
+  "@voiceUnshared": {
+    "x-mt": true
+  },
   "exportCsv": "تصدير CSV",
   "csvFileSavedSuccessfully": "تم حفظ ملف CSV بنجاح.",
   "failedToSaveCsvFile": "فشل في حفظ ملف CSV.",
@@ -813,14 +2457,41 @@
     }
   },
   "textSize": "حجم النص",
+  "@textSize": {
+    "x-mt": true
+  },
   "selectTextSize": "حدد حجم النص",
+  "@selectTextSize": {
+    "x-mt": true
+  },
   "textSizeSmall": "صغير",
+  "@textSizeSmall": {
+    "x-mt": true
+  },
   "textSizeMedium": "واسطة",
+  "@textSizeMedium": {
+    "x-mt": true
+  },
   "textSizeLarge": "كبير",
+  "@textSizeLarge": {
+    "x-mt": true
+  },
   "resetApp": "إعادة تعيين التطبيق",
+  "@resetApp": {
+    "x-mt": true
+  },
   "clearAllDataConfirm": "هل أنت متأكد أنك تريد مسح كافة البيانات؟",
+  "@clearAllDataConfirm": {
+    "x-mt": true
+  },
   "dataCleared": "تم مسح كافة البيانات",
+  "@dataCleared": {
+    "x-mt": true
+  },
   "dataManagement": "إدارة البيانات",
+  "@dataManagement": {
+    "x-mt": true
+  },
   "resourceTitleAlreadyExists": "يوجد مورد بهذا العنوان بالفعل",
   "failedToUpdateResource": "فشل تحديث المورد"
 }

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -1,81 +1,249 @@
 {
   "@@locale": "es",
   "appTitle": "miPlaneta",
+  "@appTitle": {
+    "x-mt": true
+  },
   "serverConfigurationTitle": "Conéctese a un servidor Planet",
+  "@serverConfigurationTitle": {
+    "x-mt": true
+  },
   "serverUrlLabel": "URL del servidor",
+  "@serverUrlLabel": {
+    "x-mt": true
+  },
   "serverUrlHint": "https://planeta.ejemplo.org",
+  "@serverUrlHint": {
+    "x-mt": true
+  },
   "serverPinLabel": "pin del servidor",
   "connect": "Conectar",
+  "@connect": {
+    "x-mt": true
+  },
   "serverUrlNotConfigured": "URL del servidor no configurada",
   "deviceCouldNotReachLocalServer": "El dispositivo no pudo alcanzar el servidor. Verifique si está conectado a la red Wi-Fi correcta para el servidor local (comunidad).",
   "deviceCouldNotReachNationServer": "El dispositivo no pudo alcanzar el servidor. Verifique si está conectado a Internet e inténtelo de nuevo.",
   "connectionFailed": "¡Conexión fallida!",
   "connectedToCommunity": "Conectado a {code}",
+  "@connectedToCommunity": {
+    "x-mt": true
+  },
   "changeServer": "Cambiar servidor",
+  "@changeServer": {
+    "x-mt": true
+  },
   "login": "Iniciar sesión",
   "name": "Nombre",
   "password": "Contraseña",
   "signInOffline": "Iniciar sesión sin conexión",
+  "@signInOffline": {
+    "x-mt": true
+  },
   "invalidCredentials": "El nombre o la contraseña son incorrectos.",
+  "@invalidCredentials": {
+    "x-mt": true
+  },
   "userNotFound": "Usuario no encontrado.",
+  "@userNotFound": {
+    "x-mt": true
+  },
   "missingAuthData": "A la respuesta del servidor le faltan datos de autenticación.",
+  "@missingAuthData": {
+    "x-mt": true
+  },
   "serverError": "Error del servidor. Inténtelo de nuevo más tarde.",
+  "@serverError": {
+    "x-mt": true
+  },
   "networkError": "Servidor no accesible. Verifique su conexión a Internet.",
+  "@networkError": {
+    "x-mt": true
+  },
   "emptyCredentials": "Se requiere nombre de usuario y contraseña.",
+  "@emptyCredentials": {
+    "x-mt": true
+  },
   "notAManager": "Esta cuenta no es un administrador.",
+  "@notAManager": {
+    "x-mt": true
+  },
   "savedAccounts": "Cuentas guardadas",
+  "@savedAccounts": {
+    "x-mt": true
+  },
   "resources": "Recursos",
   "search": "Buscar",
   "sync": "Sincronizar",
   "cancel": "Cancelar",
   "settings": "Configuraciones",
   "backgroundSync": "Sincronización en segundo plano",
+  "@backgroundSync": {
+    "x-mt": true
+  },
   "backgroundSyncDescription": "Envíe cambios pendientes y actualice los datos de aprendizaje mientras la aplicación está cerrada",
+  "@backgroundSyncDescription": {
+    "x-mt": true
+  },
   "syncFrequency": "Frecuencia de sincronización",
+  "@syncFrequency": {
+    "x-mt": true
+  },
   "every15Minutes": "Cada 15 minutos",
+  "@every15Minutes": {
+    "x-mt": true
+  },
   "every30Minutes": "Cada 30 minutos",
+  "@every30Minutes": {
+    "x-mt": true
+  },
   "everyHour": "Cada hora",
+  "@everyHour": {
+    "x-mt": true
+  },
   "every6Hours": "Cada 6 horas",
+  "@every6Hours": {
+    "x-mt": true
+  },
   "lastBackgroundRun": "Última ejecución en segundo plano",
+  "@lastBackgroundRun": {
+    "x-mt": true
+  },
   "backgroundNeverRun": "Aún no se ha registrado ninguna ejecución en segundo plano",
+  "@backgroundNeverRun": {
+    "x-mt": true
+  },
   "backgroundSucceeded": "Completado con éxito",
+  "@backgroundSucceeded": {
+    "x-mt": true
+  },
   "backgroundRetryRequested": "Incompleto: Android lo volverá a intentar",
+  "@backgroundRetryRequested": {
+    "x-mt": true
+  },
   "backgroundSkipped": "Saltado",
+  "@backgroundSkipped": {
+    "x-mt": true
+  },
   "backgroundUnknown": "Resultado desconocido",
+  "@backgroundUnknown": {
+    "x-mt": true
+  },
   "backgroundScheduleFailed": "La preferencia se guardó, pero Android no pudo actualizar la programación. Se volverá a intentar cuando se reinicie la aplicación.",
+  "@backgroundScheduleFailed": {
+    "x-mt": true
+  },
   "backgroundFailedSteps": "Necesita reintentar: {steps}",
+  "@backgroundFailedSteps": {
+    "x-mt": true
+  },
   "logOut": "Cerrar sesión",
   "noDataAvailable": "No hay datos disponibles.",
   "ok": "OK",
   "home": "Hogar",
+  "@home": {
+    "x-mt": true
+  },
   "moreOptions": "Más opciones",
+  "@moreOptions": {
+    "x-mt": true
+  },
   "appTheme": "Tema de la aplicación",
   "aiChat": "chat de IA",
+  "@aiChat": {
+    "x-mt": true
+  },
   "syncNow": "Sincronizar ahora",
   "syncCenter": "Centro de sincronización",
+  "@syncCenter": {
+    "x-mt": true
+  },
   "syncAll": "Sincronizar todo",
+  "@syncAll": {
+    "x-mt": true
+  },
   "syncing": "Sincronizando…",
+  "@syncing": {
+    "x-mt": true
+  },
   "waiting": "Espera",
+  "@waiting": {
+    "x-mt": true
+  },
   "events": "Eventos",
+  "@events": {
+    "x-mt": true
+  },
   "surveys": "Encuestas",
   "syncReady": "Listo para sincronizar",
+  "@syncReady": {
+    "x-mt": true
+  },
   "syncForegroundNotice": "Mantenga myPlanet abierto hasta que finalice la sincronización. Las escrituras fuera de línea pendientes siguen siendo duraderas si la conexión se interrumpe.",
+  "@syncForegroundNotice": {
+    "x-mt": true
+  },
   "syncProgress": "Sincronizando {completed} de {total} áreas",
+  "@syncProgress": {
+    "x-mt": true
+  },
   "syncAllSuccessful": "Todas las {count} áreas sincronizadas correctamente",
+  "@syncAllSuccessful": {
+    "x-mt": true
+  },
   "syncCompletedWithFailures": "Sincronización finalizada: {success} exitosa, {failed} fallida",
+  "@syncCompletedWithFailures": {
+    "x-mt": true
+  },
   "itemsSynced": "{count, plural, =0{Up to date} =1{1 item synced} other{{count} items synced}}",
+  "@itemsSynced": {
+    "x-mt": true
+  },
   "lastSyncTimestamp": "Última sincronización con el servidor: {date}",
   "syncResourcesDescription": "Actualizar la biblioteca de aprendizaje sin conexión",
+  "@syncResourcesDescription": {
+    "x-mt": true
+  },
   "syncCoursesDescription": "Actualizar cursos, pasos y membresía de estantería",
+  "@syncCoursesDescription": {
+    "x-mt": true
+  },
   "syncTeamsDescription": "Actualizar equipos, membresías y datos empresariales",
+  "@syncTeamsDescription": {
+    "x-mt": true
+  },
   "syncEventsDescription": "Actualizar reuniones y asistencia",
+  "@syncEventsDescription": {
+    "x-mt": true
+  },
   "syncSurveysDescription": "Actualizar formularios de encuesta y tareas",
+  "@syncSurveysDescription": {
+    "x-mt": true
+  },
   "syncVoicesDescription": "Actualizar debates y respuestas de la comunidad",
+  "@syncVoicesDescription": {
+    "x-mt": true
+  },
   "syncFeedbackDescription": "Actualizar hilos de comentarios y respuestas",
+  "@syncFeedbackDescription": {
+    "x-mt": true
+  },
   "syncChatDescription": "Actualizar el historial de conversaciones de IA",
+  "@syncChatDescription": {
+    "x-mt": true
+  },
   "syncHealthDescription": "Actualizar registros médicos cifrados",
+  "@syncHealthDescription": {
+    "x-mt": true
+  },
   "syncActivitiesDescription": "Actualizar el historial de inicio de sesión desde el servidor",
+  "@syncActivitiesDescription": {
+    "x-mt": true
+  },
   "syncNotificationsDescription": "Actualizar notificaciones del servidor y cargar estados de lectura",
+  "@syncNotificationsDescription": {
+    "x-mt": true
+  },
   "homeMyLibrary": "miBiblioteca",
   "homeMyCourses": "misCursos",
   "homeMyTeams": "misEquipos",
@@ -91,19 +259,55 @@
   "surveysToComplete": "Tienes {count, plural, =1{1 encuesta} other{{count} encuestas}} para completar",
   "lastSynced": "Última sincronización: {time}",
   "neverSynced": "Nunca sincronizado",
+  "@neverSynced": {
+    "x-mt": true
+  },
   "justNow": "En este momento",
+  "@justNow": {
+    "x-mt": true
+  },
   "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@minutesAgo": {
+    "x-mt": true
+  },
   "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@hoursAgo": {
+    "x-mt": true
+  },
   "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@daysAgo": {
+    "x-mt": true
+  },
   "syncingResources": "Sincronizando recursos... {completed} de {total}",
+  "@syncingResources": {
+    "x-mt": true
+  },
   "syncedResources": "{count, plural, =0{No resources synced} =1{1 resource synced} other{{count} resources synced}}",
+  "@syncedResources": {
+    "x-mt": true
+  },
   "syncFailed": "Error de sincronización: {message}",
+  "@syncFailed": {
+    "x-mt": true
+  },
   "availableOffline": "Disponible sin conexión",
+  "@availableOffline": {
+    "x-mt": true
+  },
   "courses": "Cursos",
   "myCourses": "misCursos",
   "allCourses": "Todos los cursos",
+  "@allCourses": {
+    "x-mt": true
+  },
   "courseSteps": "{count, plural, =0{No steps} =1{1 step} other{{count} steps}}",
+  "@courseSteps": {
+    "x-mt": true
+  },
   "stepNumber": "Paso {number}",
+  "@stepNumber": {
+    "x-mt": true
+  },
   "resourcesInStep": "{count, plural, =0{Sin recursos} =1{1 recurso} other{{count} recursos}}",
   "@resourcesInStep": {
     "placeholders": {
@@ -114,48 +318,126 @@
   },
   "gradeLevel": "Nivel de grado",
   "subjectLevel": "Sujeto",
+  "@subjectLevel": {
+    "x-mt": true
+  },
   "allLevels": "Todo",
+  "@allLevels": {
+    "x-mt": true
+  },
   "clearFilters": "Limpiar filtros",
+  "@clearFilters": {
+    "x-mt": true
+  },
   "joinCourse": "Añadir a mis cursos",
+  "@joinCourse": {
+    "x-mt": true
+  },
   "leaveCourse": "Quitar de mis cursos",
+  "@leaveCourse": {
+    "x-mt": true
+  },
   "syncedCourses": "{count, plural, =0{No courses synced} =1{1 course synced} other{{count} courses synced}}",
+  "@syncedCourses": {
+    "x-mt": true
+  },
   "courseNotFound": "Curso no encontrado",
+  "@courseNotFound": {
+    "x-mt": true
+  },
   "calendar": "Calendario",
   "profile": "Perfil",
   "profileUnavailable": "Perfil no disponible",
+  "@profileUnavailable": {
+    "x-mt": true
+  },
   "username": "Nombre",
   "email": "Correo electrónico",
   "phone": "Número de teléfono",
   "level": "Nivel",
   "levels": "Niveles",
+  "@levels": {
+    "x-mt": true
+  },
   "language": "Idioma",
   "languages": "Idiomas",
+  "@languages": {
+    "x-mt": true
+  },
   "gender": "Género",
   "dateOfBirth": "Fecha de nacimiento",
   "planetCode": "código de planeta",
+  "@planetCode": {
+    "x-mt": true
+  },
   "accountDetails": "Detalles de la cuenta",
+  "@accountDetails": {
+    "x-mt": true
+  },
   "noProfileDetails": "No hay detalles del perfil disponibles.",
+  "@noProfileDetails": {
+    "x-mt": true
+  },
   "profilePhotoFor": "Foto de perfil de {name}",
+  "@profilePhotoFor": {
+    "x-mt": true
+  },
   "editProfile": "Editar perfil",
   "changePhoto": "Cambiar foto de perfil",
+  "@changePhoto": {
+    "x-mt": true
+  },
   "photoUpdated": "Foto de perfil actualizada",
+  "@photoUpdated": {
+    "x-mt": true
+  },
   "photoUpdateFailed": "No se pudo guardar la foto",
+  "@photoUpdateFailed": {
+    "x-mt": true
+  },
   "firstName": "Nombre de Pila",
   "middleName": "Segundo nombre",
   "lastName": "Apellido",
   "save": "Guardar",
   "profileSaved": "Perfil guardado en este dispositivo",
+  "@profileSaved": {
+    "x-mt": true
+  },
   "invalidEmail": "Introduzca una dirección de correo electrónico válida",
+  "@invalidEmail": {
+    "x-mt": true
+  },
   "appearance": "Apariencia",
+  "@appearance": {
+    "x-mt": true
+  },
   "systemTheme": "Usar tema del dispositivo",
+  "@systemTheme": {
+    "x-mt": true
+  },
   "lightTheme": "Claro",
   "darkTheme": "Oscuro",
   "server": "Servidor",
+  "@server": {
+    "x-mt": true
+  },
   "serverUrl": "URL del servidor",
+  "@serverUrl": {
+    "x-mt": true
+  },
   "notConfigured": "No configurado",
+  "@notConfigured": {
+    "x-mt": true
+  },
   "communityCode": "codigo comunitario",
+  "@communityCode": {
+    "x-mt": true
+  },
   "about": "Acerca de",
   "offlineLearningApp": "Aprendizaje sin conexión con Planet",
+  "@offlineLearningApp": {
+    "x-mt": true
+  },
   "appVersion": "Versión {version}",
   "@appVersion": {
     "placeholders": {
@@ -166,121 +448,409 @@
   },
   "buildNumber": "Compilación {number}",
   "learningTools": "Herramientas de aprendizaje",
+  "@learningTools": {
+    "x-mt": true
+  },
   "dictionary": "Diccionario",
   "dictionaryDescription": "Buscar definiciones descargadas sin conexión",
+  "@dictionaryDescription": {
+    "x-mt": true
+  },
   "dictionaryUnavailable": "Diccionario no disponible",
+  "@dictionaryUnavailable": {
+    "x-mt": true
+  },
   "searchDictionary": "buscar una palabra",
+  "@searchDictionary": {
+    "x-mt": true
+  },
   "dictionaryWordCount": "{count, plural, =0{No downloaded words} =1{1 downloaded word} other{{count} downloaded words}}",
+  "@dictionaryWordCount": {
+    "x-mt": true
+  },
   "downloadDictionary": "Descargar diccionario",
+  "@downloadDictionary": {
+    "x-mt": true
+  },
   "retryDownload": "Reintentar descargar",
+  "@retryDownload": {
+    "x-mt": true
+  },
   "dictionaryDownloadFailed": "No se pudo descargar el diccionario. Sus datos sin conexión existentes no fueron modificados.",
+  "@dictionaryDownloadFailed": {
+    "x-mt": true
+  },
   "wordNotFound": "Palabra no disponible en el diccionario fuera de línea",
+  "@wordNotFound": {
+    "x-mt": true
+  },
   "meaning": "Significado",
+  "@meaning": {
+    "x-mt": true
+  },
   "synonyms": "Sinónimos",
+  "@synonyms": {
+    "x-mt": true
+  },
   "antonyms": "Antónimos",
+  "@antonyms": {
+    "x-mt": true
+  },
   "notifications": "Notificaciones",
+  "@notifications": {
+    "x-mt": true
+  },
   "notification": "Notificación",
+  "@notification": {
+    "x-mt": true
+  },
   "notificationsUnavailable": "Notificaciones no disponibles",
+  "@notificationsUnavailable": {
+    "x-mt": true
+  },
   "markAllRead": "Marcar todo como leído",
   "all": "Todo",
+  "@all": {
+    "x-mt": true
+  },
   "read": "Leer",
+  "@read": {
+    "x-mt": true
+  },
   "unreadCount": "No leído ({count})",
+  "@unreadCount": {
+    "x-mt": true
+  },
   "noNotifications": "Sin notificaciones",
   "noUnreadNotifications": "Sin notificaciones no leídas",
   "noReadNotifications": "Sin notificaciones leídas",
   "delete": "Eliminar",
   "deleteNotification": "¿Eliminar notificación?",
+  "@deleteNotification": {
+    "x-mt": true
+  },
   "deleteNotificationConfirmation": "Esta notificación se eliminará de este dispositivo.",
+  "@deleteNotificationConfirmation": {
+    "x-mt": true
+  },
   "taskNotification": "Tarea",
+  "@taskNotification": {
+    "x-mt": true
+  },
   "chatNotification": "Charlar",
+  "@chatNotification": {
+    "x-mt": true
+  },
   "replyNotification": "Nueva respuesta",
+  "@replyNotification": {
+    "x-mt": true
+  },
   "resourceNotification": "Recursos",
   "storageNotification": "Advertencia de almacenamiento",
+  "@storageNotification": {
+    "x-mt": true
+  },
   "joinRequestNotification": "Solicitud de unión",
+  "@joinRequestNotification": {
+    "x-mt": true
+  },
   "teamNotification": "Actualización del equipo",
+  "@teamNotification": {
+    "x-mt": true
+  },
   "tasks": "Tareas",
+  "@tasks": {
+    "x-mt": true
+  },
   "notifGroupJoinRequests": "Solicitudes de unión",
+  "@notifGroupJoinRequests": {
+    "x-mt": true
+  },
   "notifGroupTeamUpdates": "Actualizaciones del equipo",
+  "@notifGroupTeamUpdates": {
+    "x-mt": true
+  },
   "notifGroupNewVoices": "Nuevas voces",
+  "@notifGroupNewVoices": {
+    "x-mt": true
+  },
   "notifGroupVoiceReplies": "Respuestas de voz",
+  "@notifGroupVoiceReplies": {
+    "x-mt": true
+  },
   "notificationGroupSystem": "Sistema",
+  "@notificationGroupSystem": {
+    "x-mt": true
+  },
   "notificationGroupOther": "Otro",
+  "@notificationGroupOther": {
+    "x-mt": true
+  },
   "myLife": "miVida",
   "myLifeUnavailable": "mi vida no esta disponible",
+  "@myLifeUnavailable": {
+    "x-mt": true
+  },
   "noLifeItems": "No hay artículos de mi vida",
+  "@noLifeItems": {
+    "x-mt": true
+  },
   "shownOnDashboard": "Mostrado",
+  "@shownOnDashboard": {
+    "x-mt": true
+  },
   "hiddenFromDashboard": "Oculto",
+  "@hiddenFromDashboard": {
+    "x-mt": true
+  },
   "hideItem": "Ocultar {title}",
+  "@hideItem": {
+    "x-mt": true
+  },
   "showItem": "Mostrar {title}",
+  "@showItem": {
+    "x-mt": true
+  },
   "reorderItem": "Reordenar {title}",
+  "@reorderItem": {
+    "x-mt": true
+  },
   "myHealth": "miSalud",
   "achievements": "misLogros",
   "submissions": "Envíos",
+  "@submissions": {
+    "x-mt": true
+  },
   "submission": "Envío",
+  "@submission": {
+    "x-mt": true
+  },
   "submissionsUnavailable": "Los envíos no están disponibles",
+  "@submissionsUnavailable": {
+    "x-mt": true
+  },
   "noSubmissions": "Aún no hay presentaciones",
+  "@noSubmissions": {
+    "x-mt": true
+  },
   "pending": "Pendiente",
+  "@pending": {
+    "x-mt": true
+  },
   "submissionGrade": "Grado: {grade}",
+  "@submissionGrade": {
+    "x-mt": true
+  },
   "refresh": "Refrescar",
+  "@refresh": {
+    "x-mt": true
+  },
   "complete": "completa",
   "noMatchingSubmissions": "Ningún envío coincide con este filtro",
+  "@noMatchingSubmissions": {
+    "x-mt": true
+  },
   "submissionsSynced": "{count, plural, =0{Submissions are up to date} =1{1 submission synced} other{{count} submissions synced}}",
+  "@submissionsSynced": {
+    "x-mt": true
+  },
   "submissionDetails": "Detalles de envío",
+  "@submissionDetails": {
+    "x-mt": true
+  },
   "submissionNotFound": "Envío no encontrado",
+  "@submissionNotFound": {
+    "x-mt": true
+  },
   "unknown": "Desconocido",
+  "@unknown": {
+    "x-mt": true
+  },
   "nA": "N / A",
+  "@nA": {
+    "x-mt": true
+  },
   "otherDiagnosis": "Otro diagnóstico",
+  "@otherDiagnosis": {
+    "x-mt": true
+  },
   "add": "Agregar",
+  "@add": {
+    "x-mt": true
+  },
   "status": "Estado",
   "lastUpdated": "Última actualización",
+  "@lastUpdated": {
+    "x-mt": true
+  },
   "grade": "Calificación",
+  "@grade": {
+    "x-mt": true
+  },
   "submittedBy": "Enviado por",
   "submissionType": "Tipo",
   "uploadStatus": "Estado de carga",
+  "@uploadStatus": {
+    "x-mt": true
+  },
   "uploaded": "subido",
+  "@uploaded": {
+    "x-mt": true
+  },
   "answers": "Respuestas",
+  "@answers": {
+    "x-mt": true
+  },
   "answersUnavailable": "Las respuestas no están disponibles",
+  "@answersUnavailable": {
+    "x-mt": true
+  },
   "noAnswers": "No se guardaron respuestas con este envío.",
+  "@noAnswers": {
+    "x-mt": true
+  },
   "noAnswer": "Sin respuesta",
+  "@noAnswer": {
+    "x-mt": true
+  },
   "questionNumber": "Pregunta {number}",
+  "@questionNumber": {
+    "x-mt": true
+  },
   "newSubmission": "Nueva presentación",
+  "@newSubmission": {
+    "x-mt": true
+  },
   "answer": "Respuesta",
+  "@answer": {
+    "x-mt": true
+  },
   "availableChoices": "Opciones",
+  "@availableChoices": {
+    "x-mt": true
+  },
   "exportPdf": "Exportar PDF",
+  "@exportPdf": {
+    "x-mt": true
+  },
   "pdfExportFailed": "No se pudo crear el PDF",
+  "@pdfExportFailed": {
+    "x-mt": true
+  },
   "pdfSaved": "PDF guardado en {path}",
+  "@pdfSaved": {
+    "x-mt": true
+  },
   "mySurveys": "Mis encuestas",
+  "@mySurveys": {
+    "x-mt": true
+  },
   "references": "Referencias",
   "myPersonals": "misPersonales",
   "featureComingSoon": "Esta característica aún no está portada",
+  "@featureComingSoon": {
+    "x-mt": true
+  },
   "maps": "Mapas",
   "englishDictionary": "Diccionario inglés",
   "offlineMapsComingSoon": "Los mapas sin conexión aún no se han transferido",
+  "@offlineMapsComingSoon": {
+    "x-mt": true
+  },
   "addPersonal": "Agregar artículo personal",
+  "@addPersonal": {
+    "x-mt": true
+  },
   "editPersonal": "Editar elemento personal",
+  "@editPersonal": {
+    "x-mt": true
+  },
   "deletePersonal": "¿Eliminar artículo personal?",
+  "@deletePersonal": {
+    "x-mt": true
+  },
   "deletePersonalConfirmation": "¿Eliminar “{title}” de este dispositivo?",
+  "@deletePersonalConfirmation": {
+    "x-mt": true
+  },
   "personalsUnavailable": "Los artículos personales no están disponibles.",
+  "@personalsUnavailable": {
+    "x-mt": true
+  },
   "noPersonals": "Aún no hay artículos personales. Agregue una nota privada para comenzar.",
+  "@noPersonals": {
+    "x-mt": true
+  },
   "duplicateTitle": "Ya existe un objeto personal con este título.",
+  "@duplicateTitle": {
+    "x-mt": true
+  },
   "attachFile": "Adjuntar archivo",
+  "@attachFile": {
+    "x-mt": true
+  },
   "attachedFile": "Adjunto: {name}",
+  "@attachedFile": {
+    "x-mt": true
+  },
   "noFileSelected": "No file selected",
+  "@noFileSelected": {
+    "x-mt": true
+  },
   "removeFile": "Eliminar archivo",
+  "@removeFile": {
+    "x-mt": true
+  },
   "savedOffline": "Guardado sin conexión: carga pendiente",
+  "@savedOffline": {
+    "x-mt": true
+  },
   "edit": "Editar",
   "title": "Título",
   "titleRequired": "Introduce un título",
+  "@titleRequired": {
+    "x-mt": true
+  },
   "rateCourse": "Calificar curso",
+  "@rateCourse": {
+    "x-mt": true
+  },
   "rateTitle": "Tasa {title}",
+  "@rateTitle": {
+    "x-mt": true
+  },
   "ratingsUnavailable": "Las calificaciones no están disponibles",
+  "@ratingsUnavailable": {
+    "x-mt": true
+  },
   "ratingSummary": "{average} from {count, plural, =1{1 rating} other{{count} ratings}}",
+  "@ratingSummary": {
+    "x-mt": true
+  },
   "ratingCompact": "{average} ({count})",
+  "@ratingCompact": {
+    "x-mt": true
+  },
   "ratingOutOfFive": "Calificación: {rating} sobre 5",
+  "@ratingOutOfFive": {
+    "x-mt": true
+  },
   "setRating": "Establecer calificación en {rating}",
+  "@setRating": {
+    "x-mt": true
+  },
   "ratingRequired": "Elige una calificación",
+  "@ratingRequired": {
+    "x-mt": true
+  },
   "commentOptional": "Comentario (opcional)",
+  "@commentOptional": {
+    "x-mt": true
+  },
   "submitRating": "Enviar calificación",
+  "@submitRating": {
+    "x-mt": true
+  },
   "skip": "Omitir",
   "next": "Siguiente",
   "getStarted": "EMPEZAR",
@@ -294,225 +864,864 @@
   "onboardingPowerDescription": "Explora un mundo de conocimiento al alcance de tu mano.\n\n🌍 Acceso sin conexión: Aprende sin fronteras, en cualquier momento.\n🎯 Personalizado: Adapta tu camino de aprendizaje.\n📚 Interactivo: Involúcrate con vídeos, libros, juegos.\n\n¡Comienza tu viaje de aprendizaje ilimitado con myPlanet!",
   "onboardingServerPrepHint": "Antes de iniciar sesión, necesitarás la dirección del servidor de Planet y el PIN. Pregunta a tu administrador comunitario si aún no los tienes.",
   "pageProgress": "Página {current} de {total}",
+  "@pageProgress": {
+    "x-mt": true
+  },
   "meetups": "Reuniones",
+  "@meetups": {
+    "x-mt": true
+  },
   "syncPendingMeetups": "Sincronizar reuniones pendientes",
+  "@syncPendingMeetups": {
+    "x-mt": true
+  },
   "meetupsUnavailable": "Las reuniones no están disponibles",
+  "@meetupsUnavailable": {
+    "x-mt": true
+  },
   "noMeetups": "Aún no hay reuniones",
+  "@noMeetups": {
+    "x-mt": true
+  },
   "dateNotSet": "Fecha no establecida",
+  "@dateNotSet": {
+    "x-mt": true
+  },
   "untitledMeetup": "reunión sin título",
+  "@untitledMeetup": {
+    "x-mt": true
+  },
   "addMeetup": "Agregar reunión",
+  "@addMeetup": {
+    "x-mt": true
+  },
   "meetupDetails": "Detalles de la reunión",
+  "@meetupDetails": {
+    "x-mt": true
+  },
   "meetupNotFound": "Reunión no encontrada",
+  "@meetupNotFound": {
+    "x-mt": true
+  },
   "createdBy": "Creado por",
+  "@createdBy": {
+    "x-mt": true
+  },
   "category": "Categoría",
+  "@category": {
+    "x-mt": true
+  },
   "location": "Ubicación",
+  "@location": {
+    "x-mt": true
+  },
   "link": "Enlace",
+  "@link": {
+    "x-mt": true
+  },
   "recurring": "Periódico",
+  "@recurring": {
+    "x-mt": true
+  },
   "description": "Descripción",
   "leaveMeetup": "Salir de la reunión",
+  "@leaveMeetup": {
+    "x-mt": true
+  },
   "joinMeetup": "Unirse a la reunión",
+  "@joinMeetup": {
+    "x-mt": true
+  },
   "editMeetup": "Editar reunión",
+  "@editMeetup": {
+    "x-mt": true
+  },
   "startTime": "Hora de inicio",
+  "@startTime": {
+    "x-mt": true
+  },
   "endTime": "Hora de finalización",
+  "@endTime": {
+    "x-mt": true
+  },
   "none": "Ninguno",
+  "@none": {
+    "x-mt": true
+  },
   "daily": "A diario",
+  "@daily": {
+    "x-mt": true
+  },
   "weekly": "Semanalmente",
+  "@weekly": {
+    "x-mt": true
+  },
   "syncMeetups": "Sincronizar reuniones",
+  "@syncMeetups": {
+    "x-mt": true
+  },
   "searchMeetups": "Buscar reuniones",
+  "@searchMeetups": {
+    "x-mt": true
+  },
   "sortMeetups": "Ordenar reuniones",
+  "@sortMeetups": {
+    "x-mt": true
+  },
   "sortResources": "Ordenar recursos",
+  "@sortResources": {
+    "x-mt": true
+  },
   "newestFirst": "Lo nuevo primero",
+  "@newestFirst": {
+    "x-mt": true
+  },
   "oldestFirst": "El más viejo primero",
+  "@oldestFirst": {
+    "x-mt": true
+  },
   "titleAscending": "Título A-Z",
+  "@titleAscending": {
+    "x-mt": true
+  },
   "titleDescending": "Título Z-A",
+  "@titleDescending": {
+    "x-mt": true
+  },
   "startDate": "Fecha de inicio",
+  "@startDate": {
+    "x-mt": true
+  },
   "endDate": "Fecha de finalización",
+  "@endDate": {
+    "x-mt": true
+  },
   "timeNotSet": "Hora no establecida",
+  "@timeNotSet": {
+    "x-mt": true
+  },
   "syncSurveys": "Sincronizar encuestas",
+  "@syncSurveys": {
+    "x-mt": true
+  },
   "searchSurveys": "Buscar encuestas",
+  "@searchSurveys": {
+    "x-mt": true
+  },
   "sortSurveys": "Ordenar encuestas",
+  "@sortSurveys": {
+    "x-mt": true
+  },
   "surveysUnavailable": "Las encuestas no están disponibles",
+  "@surveysUnavailable": {
+    "x-mt": true
+  },
   "noSurveys": "No hay encuestas disponibles",
+  "@noSurveys": {
+    "x-mt": true
+  },
   "untitledSurvey": "Encuesta sin título",
+  "@untitledSurvey": {
+    "x-mt": true
+  },
   "takeSurvey": "Tomar encuesta",
+  "@takeSurvey": {
+    "x-mt": true
+  },
   "surveyLoadFailed": "No se pudo cargar la encuesta",
+  "@surveyLoadFailed": {
+    "x-mt": true
+  },
   "surveyHasNoQuestions": "Esta encuesta no tiene preguntas.",
+  "@surveyHasNoQuestions": {
+    "x-mt": true
+  },
   "submitSurvey": "Enviar encuesta",
+  "@submitSurvey": {
+    "x-mt": true
+  },
   "answerRequiredQuestions": "Responda todas las preguntas requeridas",
+  "@answerRequiredQuestions": {
+    "x-mt": true
+  },
   "voices": "Voces",
+  "@voices": {
+    "x-mt": true
+  },
   "searchVoices": "buscar voces",
+  "@searchVoices": {
+    "x-mt": true
+  },
   "syncVoices": "Sincronizar voces",
+  "@syncVoices": {
+    "x-mt": true
+  },
   "noVoices": "Aún no hay voces",
+  "@noVoices": {
+    "x-mt": true
+  },
   "voicesUnavailable": "Las voces no están disponibles",
+  "@voicesUnavailable": {
+    "x-mt": true
+  },
   "shareYourVoice": "Comparte tu voz",
+  "@shareYourVoice": {
+    "x-mt": true
+  },
   "postVoice": "Correo",
+  "@postVoice": {
+    "x-mt": true
+  },
   "replyToVoice": "Responder",
+  "@replyToVoice": {
+    "x-mt": true
+  },
   "writeAReply": "Escribe una respuesta",
+  "@writeAReply": {
+    "x-mt": true
+  },
   "repliesCount": "{count, plural, =0{No replies} =1{1 reply} other{{count} replies}}",
+  "@repliesCount": {
+    "x-mt": true
+  },
   "edited": "Editado",
+  "@edited": {
+    "x-mt": true
+  },
   "editVoice": "Editar",
+  "@editVoice": {
+    "x-mt": true
+  },
   "deleteVoice": "Borrar",
+  "@deleteVoice": {
+    "x-mt": true
+  },
   "deleteVoiceConfirm": "¿Eliminar esta publicación y todas sus respuestas?",
+  "@deleteVoiceConfirm": {
+    "x-mt": true
+  },
   "voiceDeleted": "Publicación eliminada",
+  "@voiceDeleted": {
+    "x-mt": true
+  },
   "emptyMessageNotAllowed": "escribe algo primero",
+  "@emptyMessageNotAllowed": {
+    "x-mt": true
+  },
   "thread": "Hilo",
+  "@thread": {
+    "x-mt": true
+  },
   "surveySubmitFailed": "No se pudieron guardar tus respuestas",
+  "@surveySubmitFailed": {
+    "x-mt": true
+  },
   "sendSurveyTo": "Seleccionar usuarios para enviar encuesta",
   "sendSurvey": "Enviar encuesta",
   "surveySentToUsers": "Encuesta enviada a usuarios seleccionados",
   "noUsersAvailable": "No hay usuarios disponibles",
   "teams": "equipos",
+  "@teams": {
+    "x-mt": true
+  },
   "syncTeams": "Sincronizar equipos",
+  "@syncTeams": {
+    "x-mt": true
+  },
   "searchTeams": "equipos de búsqueda",
+  "@searchTeams": {
+    "x-mt": true
+  },
   "teamsUnavailable": "Los equipos no están disponibles",
+  "@teamsUnavailable": {
+    "x-mt": true
+  },
   "noTeams": "No hay equipos disponibles",
+  "@noTeams": {
+    "x-mt": true
+  },
   "untitledTeam": "Equipo sin título",
+  "@untitledTeam": {
+    "x-mt": true
+  },
   "teamDetails": "Detalles del equipo",
+  "@teamDetails": {
+    "x-mt": true
+  },
   "teamNotFound": "Equipo no encontrado",
+  "@teamNotFound": {
+    "x-mt": true
+  },
   "publicTeam": "equipo publico",
+  "@publicTeam": {
+    "x-mt": true
+  },
   "privateTeam": "equipo privado",
+  "@privateTeam": {
+    "x-mt": true
+  },
   "enterprises": "Empresas",
+  "@enterprises": {
+    "x-mt": true
+  },
   "searchEnterprises": "Buscar empresas",
+  "@searchEnterprises": {
+    "x-mt": true
+  },
   "leader": "Líder",
+  "@leader": {
+    "x-mt": true
+  },
   "leave": "Dejar",
+  "@leave": {
+    "x-mt": true
+  },
   "remove": "Eliminar",
+  "@remove": {
+    "x-mt": true
+  },
   "makeLeader": "Hacer líder",
+  "@makeLeader": {
+    "x-mt": true
+  },
   "leftTeam": "equipo izquierdo",
+  "@leftTeam": {
+    "x-mt": true
+  },
   "memberRemoved": "Miembro eliminado",
+  "@memberRemoved": {
+    "x-mt": true
+  },
   "leaderUpdated": "Líder actualizado",
+  "@leaderUpdated": {
+    "x-mt": true
+  },
   "member": "Miembro",
+  "@member": {
+    "x-mt": true
+  },
   "teamLeader": "Tu lideras este equipo",
+  "@teamLeader": {
+    "x-mt": true
+  },
   "teamMember": "eres miembro",
+  "@teamMember": {
+    "x-mt": true
+  },
   "services": "Servicios",
+  "@services": {
+    "x-mt": true
+  },
   "rules": "Normas",
+  "@rules": {
+    "x-mt": true
+  },
   "teamCourses": "Cursos en equipo",
+  "@teamCourses": {
+    "x-mt": true
+  },
   "membersCount": "{count, plural, =0{No members} =1{1 member} other{{count} members}}",
+  "@membersCount": {
+    "x-mt": true
+  },
   "teamTasks": "Tareas",
+  "@teamTasks": {
+    "x-mt": true
+  },
   "tasksUnavailable": "Las tareas no están disponibles",
+  "@tasksUnavailable": {
+    "x-mt": true
+  },
   "noTeamTasks": "Aún no hay tareas",
+  "@noTeamTasks": {
+    "x-mt": true
+  },
   "noDeadline": "Sin fecha límite",
+  "@noDeadline": {
+    "x-mt": true
+  },
   "untitledTask": "Tarea sin título",
+  "@untitledTask": {
+    "x-mt": true
+  },
   "addTask": "Agregar tarea",
+  "@addTask": {
+    "x-mt": true
+  },
   "editTask": "Editar tarea",
+  "@editTask": {
+    "x-mt": true
+  },
   "deleteTask": "Eliminar tarea",
+  "@deleteTask": {
+    "x-mt": true
+  },
   "taskTitle": "Título de la tarea",
+  "@taskTitle": {
+    "x-mt": true
+  },
   "assigneeId": "ID del cesionario",
+  "@assigneeId": {
+    "x-mt": true
+  },
   "teamDiscussions": "Discusiones",
+  "@teamDiscussions": {
+    "x-mt": true
+  },
   "teamMembers": "Miembros",
+  "@teamMembers": {
+    "x-mt": true
+  },
   "members": "Miembros",
+  "@members": {
+    "x-mt": true
+  },
   "joinRequests": "Solicitudes de unión",
+  "@joinRequests": {
+    "x-mt": true
+  },
   "noMembers": "Aún no hay miembros",
+  "@noMembers": {
+    "x-mt": true
+  },
   "membersUnavailable": "Los miembros no están disponibles",
+  "@membersUnavailable": {
+    "x-mt": true
+  },
   "unknownMember": "Miembro desconocido",
+  "@unknownMember": {
+    "x-mt": true
+  },
   "noJoinRequests": "No hay solicitudes pendientes",
+  "@noJoinRequests": {
+    "x-mt": true
+  },
   "accept": "Aceptar",
+  "@accept": {
+    "x-mt": true
+  },
   "decline": "Rechazar",
+  "@decline": {
+    "x-mt": true
+  },
   "joinTeam": "Solicitar unirse",
+  "@joinTeam": {
+    "x-mt": true
+  },
   "leaveTeam": "dejar el equipo",
+  "@leaveTeam": {
+    "x-mt": true
+  },
   "requestPending": "Solicitud pendiente",
+  "@requestPending": {
+    "x-mt": true
+  },
   "teamResources": "Recursos",
+  "@teamResources": {
+    "x-mt": true
+  },
   "resourcesUnavailable": "Los recursos no están disponibles",
+  "@resourcesUnavailable": {
+    "x-mt": true
+  },
   "noTeamResources": "No hay recursos vinculados a este equipo.",
+  "@noTeamResources": {
+    "x-mt": true
+  },
   "untitledResource": "recurso sin título",
+  "@untitledResource": {
+    "x-mt": true
+  },
   "removeFromTeam": "Quitar del equipo",
+  "@removeFromTeam": {
+    "x-mt": true
+  },
   "addResource": "Agregar recurso",
+  "@addResource": {
+    "x-mt": true
+  },
   "editResource": "Editar recurso",
+  "@editResource": {
+    "x-mt": true
+  },
   "resourceUpdated": "Recurso actualizado",
+  "@resourceUpdated": {
+    "x-mt": true
+  },
   "resourceAddedToTeam": "Recurso agregado al equipo",
+  "@resourceAddedToTeam": {
+    "x-mt": true
+  },
   "descriptionIsRequired": "Se requiere descripción",
+  "@descriptionIsRequired": {
+    "x-mt": true
+  },
   "levelIsRequired": "Se requiere nivel",
+  "@levelIsRequired": {
+    "x-mt": true
+  },
   "subjectIsRequired": "Se requiere sujeto",
+  "@subjectIsRequired": {
+    "x-mt": true
+  },
   "selectFile": "Seleccione un archivo",
+  "@selectFile": {
+    "x-mt": true
+  },
   "fileSelected": "File selected",
+  "@fileSelected": {
+    "x-mt": true
+  },
   "privateResource": "recurso privado",
+  "@privateResource": {
+    "x-mt": true
+  },
   "saveChanges": "Guardar cambios",
+  "@saveChanges": {
+    "x-mt": true
+  },
   "selectOpenWith": "Seleccione abrir con",
+  "@selectOpenWith": {
+    "x-mt": true
+  },
   "selectMedia": "Seleccionar medios",
+  "@selectMedia": {
+    "x-mt": true
+  },
   "selectResourceType": "Seleccionar tipo de recurso",
+  "@selectResourceType": {
+    "x-mt": true
+  },
   "linkToLicense": "Enlace a la licencia",
+  "@linkToLicense": {
+    "x-mt": true
+  },
   "noResourcesToAdd": "Todos los recursos disponibles ya están vinculados.",
+  "@noResourcesToAdd": {
+    "x-mt": true
+  },
   "coursesUnavailable": "Los cursos no están disponibles",
+  "@coursesUnavailable": {
+    "x-mt": true
+  },
   "noTeamCourses": "No hay cursos vinculados a este equipo.",
+  "@noTeamCourses": {
+    "x-mt": true
+  },
   "untitledCourse": "Curso sin título",
+  "@untitledCourse": {
+    "x-mt": true
+  },
   "addCourse": "Agregar curso",
+  "@addCourse": {
+    "x-mt": true
+  },
   "noCoursesToAdd": "Todos los cursos disponibles ya están vinculados.",
+  "@noCoursesToAdd": {
+    "x-mt": true
+  },
   "financialReports": "Informes financieros",
+  "@financialReports": {
+    "x-mt": true
+  },
   "reportsUnavailable": "Los informes no están disponibles",
+  "@reportsUnavailable": {
+    "x-mt": true
+  },
   "noReports": "Aún no hay informes financieros",
+  "@noReports": {
+    "x-mt": true
+  },
   "addReport": "Agregar informe",
+  "@addReport": {
+    "x-mt": true
+  },
   "editReport": "Editar informe",
+  "@editReport": {
+    "x-mt": true
+  },
   "archiveReport": "Archivo",
+  "@archiveReport": {
+    "x-mt": true
+  },
   "beginningBalance": "Saldo inicial",
+  "@beginningBalance": {
+    "x-mt": true
+  },
   "sales": "Ventas",
+  "@sales": {
+    "x-mt": true
+  },
   "otherIncome": "Otros ingresos",
+  "@otherIncome": {
+    "x-mt": true
+  },
   "wages": "Salarios",
+  "@wages": {
+    "x-mt": true
+  },
   "otherExpenses": "Otros gastos",
+  "@otherExpenses": {
+    "x-mt": true
+  },
   "totalIncome": "Ingresos totales",
+  "@totalIncome": {
+    "x-mt": true
+  },
   "totalExpenses": "Gastos totales",
+  "@totalExpenses": {
+    "x-mt": true
+  },
   "profitLoss": "Ganancia/pérdida",
+  "@profitLoss": {
+    "x-mt": true
+  },
   "endingBalance": "Saldo final",
+  "@endingBalance": {
+    "x-mt": true
+  },
   "negativeBalance": "¡El saldo actual es negativo!",
+  "@negativeBalance": {
+    "x-mt": true
+  },
   "reportDateDetails": "Informe creado el: {created} | Actualizado el: {updated}",
+  "@reportDateDetails": {
+    "x-mt": true
+  },
   "chatHistory": "Historial de chat",
+  "@chatHistory": {
+    "x-mt": true
+  },
   "chat": "Charlar",
+  "@chat": {
+    "x-mt": true
+  },
   "newChat": "Nuevo chat",
+  "@newChat": {
+    "x-mt": true
+  },
   "searchChats": "Buscar chats",
+  "@searchChats": {
+    "x-mt": true
+  },
   "noChats": "Aún no hay chats",
+  "@noChats": {
+    "x-mt": true
+  },
   "noSearchResults": "No hay chats coincidentes",
+  "@noSearchResults": {
+    "x-mt": true
+  },
   "untitledChat": "Charla sin título",
+  "@untitledChat": {
+    "x-mt": true
+  },
   "fullConversationResponse": "Respuesta de conversación completa",
+  "@fullConversationResponse": {
+    "x-mt": true
+  },
   "response": "Respuesta",
+  "@response": {
+    "x-mt": true
+  },
   "chatConversation": "Conversación",
+  "@chatConversation": {
+    "x-mt": true
+  },
   "newConversation": "Nueva conversación",
+  "@newConversation": {
+    "x-mt": true
+  },
   "startConversation": "Iniciar una nueva conversación",
+  "@startConversation": {
+    "x-mt": true
+  },
   "typeMessage": "Escribe un mensaje…",
+  "@typeMessage": {
+    "x-mt": true
+  },
   "selectAiProvider": "Seleccione proveedor de IA",
+  "@selectAiProvider": {
+    "x-mt": true
+  },
   "aiProviders": "Proveedores de IA",
+  "@aiProviders": {
+    "x-mt": true
+  },
   "aiProviderAvailable": "{name} (disponible)",
+  "@aiProviderAvailable": {
+    "x-mt": true
+  },
   "aiProviderUnavailable": "{name} (no disponible)",
+  "@aiProviderUnavailable": {
+    "x-mt": true
+  },
   "feedback": "Comentario",
+  "@feedback": {
+    "x-mt": true
+  },
   "feedbackNotFound": "Comentarios no encontrados",
+  "@feedbackNotFound": {
+    "x-mt": true
+  },
   "feedbackSaved": "Comentarios guardados",
+  "@feedbackSaved": {
+    "x-mt": true
+  },
   "isUrgent": "¿Es esto urgente?",
+  "@isUrgent": {
+    "x-mt": true
+  },
   "feedbackType": "Tipo de retroalimentación",
+  "@feedbackType": {
+    "x-mt": true
+  },
   "feedbackTypeRequired": "Please select a feedback type",
+  "@feedbackTypeRequired": {
+    "x-mt": true
+  },
   "yourFeedback": "Tus comentarios",
+  "@yourFeedback": {
+    "x-mt": true
+  },
   "pleaseEnterFeedback": "Por favor ingrese sus comentarios",
+  "@pleaseEnterFeedback": {
+    "x-mt": true
+  },
   "question": "Pregunta",
+  "@question": {
+    "x-mt": true
+  },
   "bug": "Bicho",
+  "@bug": {
+    "x-mt": true
+  },
   "suggestion": "Sugerencia",
+  "@suggestion": {
+    "x-mt": true
+  },
   "priority": "Prioridad",
+  "@priority": {
+    "x-mt": true
+  },
   "openDate": "fecha abierta",
+  "@openDate": {
+    "x-mt": true
+  },
   "replies": "Respuestas",
+  "@replies": {
+    "x-mt": true
+  },
   "pleaseEnterReply": "Por favor ingresa la respuesta",
+  "@pleaseEnterReply": {
+    "x-mt": true
+  },
   "untitledFeedback": "Comentarios sin título",
+  "@untitledFeedback": {
+    "x-mt": true
+  },
   "yes": "Sí",
   "no": "No",
   "submit": "Entregar",
+  "@submit": {
+    "x-mt": true
+  },
   "takeTest": "hacer la prueba",
+  "@takeTest": {
+    "x-mt": true
+  },
   "recordSurvey": "Registro de encuesta",
+  "@recordSurvey": {
+    "x-mt": true
+  },
   "react": "Reaccionar",
+  "@react": {
+    "x-mt": true
+  },
   "pickReaction": "Elige una reacción",
+  "@pickReaction": {
+    "x-mt": true
+  },
   "comments": "Comentarios",
+  "@comments": {
+    "x-mt": true
+  },
   "addComment": "Añadir un comentario",
+  "@addComment": {
+    "x-mt": true
+  },
   "commentsCount": "{count} comentarios",
+  "@commentsCount": {
+    "x-mt": true
+  },
   "noComments": "Aún no hay comentarios",
+  "@noComments": {
+    "x-mt": true
+  },
   "leaderboard": "Tabla de clasificación",
+  "@leaderboard": {
+    "x-mt": true
+  },
   "allTime": "Todo el tiempo",
+  "@allTime": {
+    "x-mt": true
+  },
   "thisMonth": "este mes",
+  "@thisMonth": {
+    "x-mt": true
+  },
   "coursesCompleted": "{completed}/{total} cursos",
+  "@coursesCompleted": {
+    "x-mt": true
+  },
   "surveysCompleted": "{completed}/{total} encuestas",
+  "@surveysCompleted": {
+    "x-mt": true
+  },
   "error": "Error",
+  "@error": {
+    "x-mt": true
+  },
   "close": "Cerca",
+  "@close": {
+    "x-mt": true
+  },
   "filter": "Filtrar",
+  "@filter": {
+    "x-mt": true
+  },
   "type": "Tipo",
+  "@type": {
+    "x-mt": true
+  },
   "apply": "Aplicar",
+  "@apply": {
+    "x-mt": true
+  },
   "unavailable": "indisponible",
+  "@unavailable": {
+    "x-mt": true
+  },
   "chatsUnavailable": "No se pudieron cargar los chats",
+  "@chatsUnavailable": {
+    "x-mt": true
+  },
   "community": "Comunidad",
+  "@community": {
+    "x-mt": true
+  },
   "communityLeaders": "Líderes comunitarios",
+  "@communityLeaders": {
+    "x-mt": true
+  },
   "nationLeaders": "Líderes de la nación",
+  "@nationLeaders": {
+    "x-mt": true
+  },
   "ourVoices": "Nuestras Voces",
+  "@ourVoices": {
+    "x-mt": true
+  },
   "finances": "Finanzas",
   "reports": "Informes",
   "transaction": "Transacción",
@@ -539,41 +1748,149 @@
   "noLeadersAvailable": "No hay líderes disponibles",
   "noServicesAvailable": "No hay servicios disponibles",
   "noDescriptionAvailable": "No hay descripción disponible",
+  "@noDescriptionAvailable": {
+    "x-mt": true
+  },
   "takeExam": "tomar el examen",
+  "@takeExam": {
+    "x-mt": true
+  },
   "examLoadFailed": "No se pudo cargar el examen",
+  "@examLoadFailed": {
+    "x-mt": true
+  },
   "examHasNoQuestions": "Este examen no tiene preguntas.",
+  "@examHasNoQuestions": {
+    "x-mt": true
+  },
   "examComplete": "Examen completo",
+  "@examComplete": {
+    "x-mt": true
+  },
   "examUnavailable": "El examen no está disponible",
+  "@examUnavailable": {
+    "x-mt": true
+  },
   "submitExam": "Enviar examen",
+  "@submitExam": {
+    "x-mt": true
+  },
   "incorrectAnswer": "respuesta incorrecta",
+  "@incorrectAnswer": {
+    "x-mt": true
+  },
   "correctAnswers": "Correcto",
+  "@correctAnswers": {
+    "x-mt": true
+  },
   "yourAnswer": "Tu respuesta",
+  "@yourAnswer": {
+    "x-mt": true
+  },
   "previous": "Anterior",
+  "@previous": {
+    "x-mt": true
+  },
   "finish": "Finalizar",
+  "@finish": {
+    "x-mt": true
+  },
   "exitExam": "¿Examen de salida?",
+  "@exitExam": {
+    "x-mt": true
+  },
   "exitExamMessage": "Tu progreso se perderá.",
+  "@exitExamMessage": {
+    "x-mt": true
+  },
   "exit": "Salida",
+  "@exit": {
+    "x-mt": true
+  },
   "download": "Descargar",
+  "@download": {
+    "x-mt": true
+  },
   "downloading": "Descargando…",
+  "@downloading": {
+    "x-mt": true
+  },
   "downloadFailed": "La descarga falló.",
+  "@downloadFailed": {
+    "x-mt": true
+  },
   "resourceNotDownloaded": "Este recurso aún no está en su dispositivo.",
+  "@resourceNotDownloaded": {
+    "x-mt": true
+  },
   "retry": "Rever",
+  "@retry": {
+    "x-mt": true
+  },
   "fieldRequired": "Requerido",
+  "@fieldRequired": {
+    "x-mt": true
+  },
   "examSubmitFailed": "No se pudo guardar su examen. Por favor inténtalo de nuevo.",
+  "@examSubmitFailed": {
+    "x-mt": true
+  },
   "yourInformation": "Tu información",
+  "@yourInformation": {
+    "x-mt": true
+  },
   "showAdditionalFields": "Mostrar campos adicionales",
+  "@showAdditionalFields": {
+    "x-mt": true
+  },
   "hideAdditionalFields": "Ocultar campos adicionales",
+  "@hideAdditionalFields": {
+    "x-mt": true
+  },
   "phoneNumber": "Número de teléfono",
+  "@phoneNumber": {
+    "x-mt": true
+  },
   "birthDate": "Fecha de nacimiento",
+  "@birthDate": {
+    "x-mt": true
+  },
   "selectDate": "Seleccionar fecha",
+  "@selectDate": {
+    "x-mt": true
+  },
   "male": "Masculino",
+  "@male": {
+    "x-mt": true
+  },
   "female": "Femenino",
+  "@female": {
+    "x-mt": true
+  },
   "yearOfBirth": "año de nacimiento",
+  "@yearOfBirth": {
+    "x-mt": true
+  },
   "yearOfBirthRequired": "Se requiere año de nacimiento",
+  "@yearOfBirthRequired": {
+    "x-mt": true
+  },
   "invalidYear": "Por favor ingrese un año válido",
+  "@invalidYear": {
+    "x-mt": true
+  },
   "yearBetween": "El año debe estar entre {min} y ​​{max}",
+  "@yearBetween": {
+    "x-mt": true
+  },
   "thankYouForTakingSurvey": "Gracias por realizar esta encuesta.",
+  "@thankYouForTakingSurvey": {
+    "x-mt": true
+  },
   "errorSavingProfile": "Error al guardar perfil",
+  "@errorSavingProfile": {
+    "x-mt": true
+  },
   "videoPlayer": "Reproductor de video",
   "audioPlayer": "Reproductor de audio",
   "videoFileNotFound": "Archivo de video no encontrado localmente",
@@ -584,7 +1901,13 @@
   "unableToLoadPdf": "No se puede cargar el PDF",
   "imageFileNotFound": "Imagen no encontrada",
   "attachment": "Adjunto",
+  "@attachment": {
+    "x-mt": true
+  },
   "cannotOpenAttachment": "Este tipo de archivo adjunto no se puede abrir aquí.",
+  "@cannotOpenAttachment": {
+    "x-mt": true
+  },
   "noContent": "Sin contenido",
   "emptyFile": "Archivo vacío",
   "htmlEntryNotFound": "Archivo de entrada HTML no encontrado",
@@ -593,124 +1916,427 @@
   "loadingMedia": "Cargando...",
   "resourceUnavailable": "Este recurso no está disponible para visualización sin conexión",
   "healthRecordNotAvailable": "Historial de salud no disponible",
+  "@healthRecordNotAvailable": {
+    "x-mt": true
+  },
   "updateHealth": "Actualizar salud",
+  "@updateHealth": {
+    "x-mt": true
+  },
   "addHealthRecord": "Agregar registro de salud",
+  "@addHealthRecord": {
+    "x-mt": true
+  },
   "healthProfile": "Perfil de salud",
+  "@healthProfile": {
+    "x-mt": true
+  },
   "specialNeeds": "Necesidades especiales",
+  "@specialNeeds": {
+    "x-mt": true
+  },
   "otherNeeds": "Otras necesidades",
+  "@otherNeeds": {
+    "x-mt": true
+  },
   "emergencyContact": "Contacto de emergencia",
+  "@emergencyContact": {
+    "x-mt": true
+  },
   "contactNumber": "Número de contacto",
+  "@contactNumber": {
+    "x-mt": true
+  },
   "vitalSigns": "Signos vitales",
+  "@vitalSigns": {
+    "x-mt": true
+  },
   "temperature": "Temperatura",
+  "@temperature": {
+    "x-mt": true
+  },
   "pulse": "Legumbres",
+  "@pulse": {
+    "x-mt": true
+  },
   "height": "Altura",
+  "@height": {
+    "x-mt": true
+  },
   "weight": "Peso",
+  "@weight": {
+    "x-mt": true
+  },
   "bloodPressure": "Presión arterial",
+  "@bloodPressure": {
+    "x-mt": true
+  },
   "vision": "Visión",
+  "@vision": {
+    "x-mt": true
+  },
   "hearing": "Audiencia",
+  "@hearing": {
+    "x-mt": true
+  },
   "examinationHistory": "historial de exámenes",
+  "@examinationHistory": {
+    "x-mt": true
+  },
   "personalInformation": "Información personal",
+  "@personalInformation": {
+    "x-mt": true
+  },
   "birthPlace": "lugar de nacimiento",
+  "@birthPlace": {
+    "x-mt": true
+  },
   "contactName": "Nombre de contacto",
+  "@contactName": {
+    "x-mt": true
+  },
   "contactType": "Tipo de contacto",
+  "@contactType": {
+    "x-mt": true
+  },
   "healthInformation": "Información de salud",
+  "@healthInformation": {
+    "x-mt": true
+  },
   "requiredField": "Este campo es obligatorio",
+  "@requiredField": {
+    "x-mt": true
+  },
   "healthSavedSuccessfully": "Datos de salud guardados exitosamente",
+  "@healthSavedSuccessfully": {
+    "x-mt": true
+  },
   "examinationDetails": "Detalles del examen",
+  "@examinationDetails": {
+    "x-mt": true
+  },
   "allergies": "Alergias",
+  "@allergies": {
+    "x-mt": true
+  },
   "diagnosis": "Diagnóstico",
+  "@diagnosis": {
+    "x-mt": true
+  },
   "medications": "Medicamentos",
+  "@medications": {
+    "x-mt": true
+  },
   "immunizations": "Vacunas",
+  "@immunizations": {
+    "x-mt": true
+  },
   "treatments": "Tratos",
+  "@treatments": {
+    "x-mt": true
+  },
   "observations": "Observaciones",
+  "@observations": {
+    "x-mt": true
+  },
   "referrals": "Referencias",
+  "@referrals": {
+    "x-mt": true
+  },
   "labTests": "pruebas de laboratorio",
+  "@labTests": {
+    "x-mt": true
+  },
   "xrays": "rayos x",
+  "@xrays": {
+    "x-mt": true
+  },
   "conditions": "Condiciones",
+  "@conditions": {
+    "x-mt": true
+  },
   "selfExamination": "Autoexamen",
+  "@selfExamination": {
+    "x-mt": true
+  },
   "healthRecordAdded": "Registro de salud agregado exitosamente",
+  "@healthRecordAdded": {
+    "x-mt": true
+  },
   "selectHealthMember": "Seleccionar miembro",
+  "@selectHealthMember": {
+    "x-mt": true
+  },
   "newPatient": "Nuevo paciente",
+  "@newPatient": {
+    "x-mt": true
+  },
   "sortJoinDateDesc": "Lo nuevo primero",
+  "@sortJoinDateDesc": {
+    "x-mt": true
+  },
   "sortJoinDateAsc": "El más viejo primero",
+  "@sortJoinDateAsc": {
+    "x-mt": true
+  },
   "sortNameAsc": "Nombre A–Z",
+  "@sortNameAsc": {
+    "x-mt": true
+  },
   "sortNameDesc": "Nombre Z–A",
+  "@sortNameDesc": {
+    "x-mt": true
+  },
   "searchMembers": "Buscar miembros",
+  "@searchMembers": {
+    "x-mt": true
+  },
   "dismiss": "Despedir",
+  "@dismiss": {
+    "x-mt": true
+  },
   "addMember": "Agregar miembro",
+  "@addMember": {
+    "x-mt": true
+  },
   "invalidNumber": "Número no válido",
+  "@invalidNumber": {
+    "x-mt": true
+  },
   "tempRangeError": "La temperatura debe estar entre 30 y 40",
+  "@tempRangeError": {
+    "x-mt": true
+  },
   "pulseRangeError": "El pulso debe estar entre 40 y 120",
+  "@pulseRangeError": {
+    "x-mt": true
+  },
   "heightRangeError": "La altura debe estar entre 1 y 250.",
+  "@heightRangeError": {
+    "x-mt": true
+  },
   "weightRangeError": "El peso debe estar entre 1 y 150",
+  "@weightRangeError": {
+    "x-mt": true
+  },
   "bloodPressureFormatError": "La presión arterial debe ser sistólica/diastólica.",
+  "@bloodPressureFormatError": {
+    "x-mt": true
+  },
   "bloodPressureRangeError": "La presión arterial debe estar entre 60/40 y 300/200.",
+  "@bloodPressureRangeError": {
+    "x-mt": true
+  },
   "bloodPressureNotNumbers": "La sistólica y la diastólica deben ser números.",
+  "@bloodPressureNotNumbers": {
+    "x-mt": true
+  },
   "temp": "Temperatura",
+  "@temp": {
+    "x-mt": true
+  },
   "bp": "PA",
+  "@bp": {
+    "x-mt": true
+  },
   "offlineMaps": "Mapas sin conexión",
   "centerOnDefault": "Centrar en ubicación predeterminada",
   "storage": "Almacenamiento",
+  "@storage": {
+    "x-mt": true
+  },
   "storageManagement": "Gestión de almacenamiento",
+  "@storageManagement": {
+    "x-mt": true
+  },
   "storageTotalDownloaded": "Total descargado",
+  "@storageTotalDownloaded": {
+    "x-mt": true
+  },
   "storageVideos": "Vídeos",
+  "@storageVideos": {
+    "x-mt": true
+  },
   "storageAudio": "Audio",
+  "@storageAudio": {
+    "x-mt": true
+  },
   "storagePdfs": "PDF",
+  "@storagePdfs": {
+    "x-mt": true
+  },
   "storageImages": "Imágenes",
+  "@storageImages": {
+    "x-mt": true
+  },
   "storageOther": "Otro",
+  "@storageOther": {
+    "x-mt": true
+  },
   "fileCountOne": "1 archivo",
+  "@fileCountOne": {
+    "x-mt": true
+  },
   "fileCountMany": "{count} archivos",
+  "@fileCountMany": {
+    "x-mt": true
+  },
   "storageUnknownResource": "recurso desconocido",
+  "@storageUnknownResource": {
+    "x-mt": true
+  },
   "areYouSure": "¿Estás seguro?",
   "cancelAddingExamination": "Are you sure you want to cancel adding examination? The data will be lost.",
   "yesIWantToExit": "Yes, I want to exit.",
   "inactiveMessage": "User not activated, please contact administrator or manager to activate your account.",
   "submitFeedback": "Submit Feedback",
   "failedToDelete": "No se pudo eliminar: {error}",
+  "@failedToDelete": {
+    "x-mt": true
+  },
   "storageDeleteSelectedConfirm": "Delete {count} selected items?",
+  "@storageDeleteSelectedConfirm": {
+    "x-mt": true
+  },
   "storageDeleteConfirm": "¿Eliminar todos los {category} archivos?",
+  "@storageDeleteConfirm": {
+    "x-mt": true
+  },
   "storageSelectedCount": "{count} selected",
+  "@storageSelectedCount": {
+    "x-mt": true
+  },
   "deleteSelected": "Eliminar seleccionado",
+  "@deleteSelected": {
+    "x-mt": true
+  },
   "deleteAll": "Eliminar todo",
+  "@deleteAll": {
+    "x-mt": true
+  },
   "selectAll": "Seleccionar todo",
+  "@selectAll": {
+    "x-mt": true
+  },
   "unselectAll": "Unselect All",
+  "@unselectAll": {
+    "x-mt": true
+  },
   "addedToMyCourses": "{count, plural, =1{1 course added} other{{count} courses added}}",
+  "@addedToMyCourses": {
+    "x-mt": true
+  },
   "leftCourses": "{count, plural, =1{1 course removed} other{{count} courses removed}}",
+  "@leftCourses": {
+    "x-mt": true
+  },
   "coursesSelected": "{count, plural, =1{1 selected} other{{count} selected}}",
+  "@coursesSelected": {
+    "x-mt": true
+  },
   "leaveCoursesConfirm": "{count, plural, =1{Are you sure you want to remove this course?} other{Are you sure you want to remove these courses?}}",
+  "@leaveCoursesConfirm": {
+    "x-mt": true
+  },
   "noStorageUsed": "No se encontraron archivos descargados",
+  "@noStorageUsed": {
+    "x-mt": true
+  },
   "availableSpace": "Espacio disponible",
   "freeUpSpace": "Liberar espacio",
   "freeUpSpaceConfirm": "Esto eliminará todos los recursos descargados para liberar espacio de almacenamiento. ¿Continuar?",
   "storageFreedSummary": "Liberado {bytes}. {count, plural, =0{No se eliminaron archivos} =1{1 archivo eliminado} other{{count} archivos eliminados}}.",
   "freeUpSpaceFailed": "No se pudo liberar espacio: {error}",
   "enterUsername": "Ingrese el nombre de usuario",
+  "@enterUsername": {
+    "x-mt": true
+  },
   "enterPassword": "Introduce la contraseña",
+  "@enterPassword": {
+    "x-mt": true
+  },
   "retypePassword": "Vuelva a escribir la contraseña",
+  "@retypePassword": {
+    "x-mt": true
+  },
   "becomeMember": "Hazte miembro",
+  "@becomeMember": {
+    "x-mt": true
+  },
   "toAccessThisFeatureBecomeAMember": "Actualmente eres un usuario invitado. Para acceder a esta función, hazte miembro.",
   "creatingMember": "Creando cuenta de miembro...",
+  "@creatingMember": {
+    "x-mt": true
+  },
   "passwordsDoNotMatch": "Las contraseñas no coinciden",
+  "@passwordsDoNotMatch": {
+    "x-mt": true
+  },
   "pleaseSelectGender": "Please select gender",
+  "@pleaseSelectGender": {
+    "x-mt": true
+  },
   "pleaseEnterPassword": "Por favor ingrese una contraseña",
+  "@pleaseEnterPassword": {
+    "x-mt": true
+  },
   "usernameAlreadyExists": "El nombre de usuario ya existe",
+  "@usernameAlreadyExists": {
+    "x-mt": true
+  },
   "usernameCannotBeEmpty": "El nombre de usuario no puede estar vacío",
   "invalidUsername": "Nombre de usuario no válido",
   "usernameMustStartWithLetterOrNumber": "Debe comenzar con letra o número",
   "usernameOnlyLettersNumbers": "Solo se permiten letras a-z, números y \"_\", \".\", \"-\"",
   "usernameTaken": "nombre de usuario en uso",
   "memberCreatedOffline": "Cuenta de miembro creada sin conexión",
+  "@memberCreatedOffline": {
+    "x-mt": true
+  },
   "memberCreatedOnline": "Cuenta de miembro creada exitosamente",
+  "@memberCreatedOnline": {
+    "x-mt": true
+  },
   "congratulations": "¡Felicidades! Desafío completado",
+  "@congratulations": {
+    "x-mt": true
+  },
   "dailyVoices": "de 5 Voces Diarias",
+  "@dailyVoices": {
+    "x-mt": true
+  },
   "voicesProgress": "{count} de 5 Voces Diarias",
+  "@voicesProgress": {
+    "x-mt": true
+  },
   "progressLabel": "Progreso: {percent}%",
+  "@progressLabel": {
+    "x-mt": true
+  },
   "courseNotStarted": "Curso: No iniciado",
+  "@courseNotStarted": {
+    "x-mt": true
+  },
   "syncCompletedChallenge": "Sincronización completada",
+  "@syncCompletedChallenge": {
+    "x-mt": true
+  },
   "rememberSync": "Recuerde sincronizar la aplicación móvil.",
+  "@rememberSync": {
+    "x-mt": true
+  },
   "challengeDialogTitle": "Desafío diario",
+  "@challengeDialogTitle": {
+    "x-mt": true
+  },
   "start": "Comenzar",
+  "@start": {
+    "x-mt": true
+  },
   "continuation": "Continuar",
+  "@continuation": {
+    "x-mt": true
+  },
   "plan": "Plan",
   "mission": "Misión y Servicios",
   "editPlan": "Editar Plan",
@@ -759,38 +2385,116 @@
   "mistakes": "Errores",
   "step": "Paso",
   "untitledResourceTitle": "Recurso sin título",
+  "@untitledResourceTitle": {
+    "x-mt": true
+  },
   "author": "Autor",
+  "@author": {
+    "x-mt": true
+  },
   "publisher": "Editor",
+  "@publisher": {
+    "x-mt": true
+  },
   "license": "Licencia",
+  "@license": {
+    "x-mt": true
+  },
   "addedBy": "Añadido por",
+  "@addedBy": {
+    "x-mt": true
+  },
   "resourceInformation": "Información de recursos",
+  "@resourceInformation": {
+    "x-mt": true
+  },
   "resourceFor": "Para",
+  "@resourceFor": {
+    "x-mt": true
+  },
   "mediaType": "Tipo de medio",
+  "@mediaType": {
+    "x-mt": true
+  },
   "resourceType": "Tipo de recurso",
+  "@resourceType": {
+    "x-mt": true
+  },
   "subject": "Sujeto",
+  "@subject": {
+    "x-mt": true
+  },
   "year": "Año",
+  "@year": {
+    "x-mt": true
+  },
   "timesRated": "Veces clasificados",
+  "@timesRated": {
+    "x-mt": true
+  },
   "addToMyLibrary": "Agregar a mi biblioteca",
+  "@addToMyLibrary": {
+    "x-mt": true
+  },
   "removeFromMyLibrary": "Eliminar de mi biblioteca",
+  "@removeFromMyLibrary": {
+    "x-mt": true
+  },
   "addedToMyLibrary": "Agregado a mi biblioteca",
+  "@addedToMyLibrary": {
+    "x-mt": true
+  },
   "removedFromMyLibrary": "Eliminado de Mi biblioteca",
+  "@removedFromMyLibrary": {
+    "x-mt": true
+  },
   "myLibrary": "Mi biblioteca",
+  "@myLibrary": {
+    "x-mt": true
+  },
   "allResources": "Todos los recursos",
+  "@allResources": {
+    "x-mt": true
+  },
   "viewResource": "Ver recurso",
+  "@viewResource": {
+    "x-mt": true
+  },
   "view": "ver",
   "linkNotAvailable": "Enlace no disponible",
   "noRatings": "Aún no hay valoraciones",
+  "@noRatings": {
+    "x-mt": true
+  },
   "basedOnRatings": "based on {count, plural, =1{1 rating} other{{count} ratings}}",
+  "@basedOnRatings": {
+    "x-mt": true
+  },
   "rating": "Clasificación",
+  "@rating": {
+    "x-mt": true
+  },
   "operationFailed": "Operación fallida",
+  "@operationFailed": {
+    "x-mt": true
+  },
   "filterResources": "Filtrar recursos",
+  "@filterResources": {
+    "x-mt": true
+  },
   "teamSurveys": "Encuestas del equipo",
   "adoptableSurveys": "Encuestas disponibles para adoptar",
   "noAdoptableSurveys": "No hay encuestas disponibles para adoptar",
   "adoptSurvey": "Adoptar encuesta",
   "surveyAdopted": "Encuesta adoptada",
+  "@surveyAdopted": {
+    "x-mt": true
+  },
   "completedCourse": "curso completado",
   "userNameWithLogins": "{name} ({logins})",
+  "@userNameWithLogins": {
+    "x-mt": true
+  },
   "remindMeLater": "Recuérdame más tarde",
   "remindLater": "Recordar más tarde",
   "setReminder": "Establecer recordatorio",
@@ -798,7 +2502,13 @@
   "hours": "horas",
   "days": "Días",
   "reminderSurveysToComplete": "Reminder: You have {count, plural, =1{1 survey} other{{count} surveys}} to complete",
+  "@reminderSurveysToComplete": {
+    "x-mt": true
+  },
   "myActivities": "Mis actividades",
+  "@myActivities": {
+    "x-mt": true
+  },
   "chartLabel": "N.º de inicios de sesión",
   "selectLanguage": "Seleccionar idioma",
   "english": "english",
@@ -808,20 +2518,53 @@
   "arabic": "عربى",
   "french": "français",
   "activitySummary": "Actividad",
+  "@activitySummary": {
+    "x-mt": true
+  },
   "lastLogin": "Último inicio de sesión",
   "memberDetail": "Detalle de miembro",
+  "@memberDetail": {
+    "x-mt": true
+  },
   "numberOfVisits": "Número de visitas",
+  "@numberOfVisits": {
+    "x-mt": true
+  },
   "noLogoutRecord": "No se encontró ningún registro de cierre de sesión",
+  "@noLogoutRecord": {
+    "x-mt": true
+  },
   "totalVisits": "Total de visitas",
   "mostOpenedResource": "Recurso más abierto",
   "numberOfResourcesOpened": "Número de recursos abiertos",
   "resourceOpenedTimes": "{title} abierto {count} veces",
+  "@resourceOpenedTimes": {
+    "x-mt": true
+  },
   "resourcesOpenedTimes": "{count, plural, =1{Resource opened 1 time} other{Resource opened {count} times}}",
+  "@resourcesOpenedTimes": {
+    "x-mt": true
+  },
   "serverReachable": "Servidor accesible",
+  "@serverReachable": {
+    "x-mt": true
+  },
   "serverUnreachable": "Servidor inalcanzable",
+  "@serverUnreachable": {
+    "x-mt": true
+  },
   "serverChecking": "Comprobando el servidor",
+  "@serverChecking": {
+    "x-mt": true
+  },
   "gridView": "Vista de cuadrícula",
+  "@gridView": {
+    "x-mt": true
+  },
   "listView": "Vista de lista",
+  "@listView": {
+    "x-mt": true
+  },
   "disclaimer": "Descargo de responsabilidad",
   "aboutContent": "### MyPlanet\n\nmyPlanet es una herramienta de aprendizaje diseñada para funcionar con la aplicación web de Planet. Se ha utilizado para mejorar la educación temprana, las escuelas secundarias, la salud en las aldeas, el desarrollo de la fuerza laboral juvenil, y el desarrollo económico y comunitario.\n\nPlanet alberga un repositorio de recursos gratuitos, de acceso abierto y de dominio público para beneficiar a todos los estudiantes.\n\nmyPlanet está diseñado para estar disponible para todos, en todas partes, todo el tiempo. Es portátil, asequible, escalable y sostenible. Se ejecuta en cualquier dispositivo Android, como tabletas y teléfonos móviles. Funciona tanto en línea como sin conexión a Internet.\n\nEsta aplicación permite a las escuelas y comunidades tener una biblioteca multimedia completa y un sistema de aprendizaje que se conecta periódicamente con Planet. Los dispositivos configurados pueden contener el panel personal de los estudiantes. Esto garantiza que los estudiantes puedan leer libros en su estante y tomar cursos sin conexión, es decir, sin conexión a un servidor central. Se anima a los estudiantes a calificar con una a cinco estrellas los recursos que utilizan y los cursos que toman. Periódicamente, los estudiantes pueden sincronizarse con un servidor. Los datos de actividad se cargan y se descargan nuevos recursos en cuestión de minutos en myPlanet para su uso sin conexión.\n\nEl panel también contiene un registro de logros, un calendario de eventos y un sistema de chat interno para comunicarse con otros miembros.\n\nmyPlanet ha demostrado ser altamente efectivo para mejorar las oportunidades de aprendizaje de más de cincuenta mil estudiantes en más de 100 ubicaciones, en escuelas de Nepal, Ghana, Kenya y Rwanda, con refugiados Syrian en Jordan, refugiados Somali en Kenya y trabajadores de salud en aldeas de Uganda.",
   "disclaimerContent": "# Renuncia de responsabilidad\n\nÚltima actualización: 10 de enero de 2020\n\n# Interpretación y definiciones\n\n## Interpretación\n\nLas palabras cuya inicial está en mayúscula tienen significados definidos bajo las siguientes condiciones.\n\nLas siguientes definiciones tendrán el mismo significado independientemente de si aparecen en singular o en plural.\n\n## Definiciones\n\nA los efectos de este descargo de responsabilidad:\n\n- **Compañía** (referida como \"la Compañía\", \"Nosotros\", \"Nuestro\" en esta Política de cookies) se refiere a myPlanet.\n- **Tú** significa la persona que accede al Servicio, o la empresa u otra entidad legal en nombre de la cual esa persona accede o utiliza el Servicio, según corresponda.\n- **Aplicación** significa el programa de software proporcionado por la Compañía que tú descargas en cualquier dispositivo electrónico llamado myPlanet.\n- **Servicio** se refiere a la Aplicación.\n\n# Descargo de responsabilidad\n\nLa información contenida en el Servicio se suministra únicamente con fines informativos generales.\n\nLa Compañía no asume ninguna responsabilidad por errores u omisiones en el contenido del Servicio.\n\nEn ningún caso la Compañía será responsable por daños especiales, directos, indirectos, consecuentes o incidentales o cualquier otro tipo de daños, ya sea en una acción contractual, negligencia u otro agravio, que surjan o estén relacionados con el uso del Servicio o el contenido del Servicio. La Compañía se reserva el derecho de hacer adiciones, eliminaciones o modificaciones al contenido del Servicio en cualquier momento y sin previo aviso.\n\nLa Compañía no garantiza que el Servicio esté libre de virus u otros componentes dañinos.\n\n# Descargo de responsabilidad de información médica\n\nLa información sobre salud proporcionada por el Servicio no tiene la intención de diagnosticar, tratar, curar o prevenir enfermedades. Los productos, servicios, información y otros contenidos proporcionados por el Servicio, incluida la información que enlace a sitios web de terceros, se proporcionan únicamente con fines informativos.\n\nLa información ofrecida por el Servicio no es exhaustiva y no abarca todas las enfermedades, dolencias, condiciones físicas o su tratamiento.\n\nLas personas son diferentes y pueden reaccionar de manera diferente a diferentes productos. Los comentarios realizados en el Servicio por empleados u otros usuarios son estrictamente sus propias opiniones personales expresadas en su capacidad personal y no son afirmaciones hechas por la Compañía ni representan la posición o la visión de la Compañía.\n\nLa Compañía no se hace responsable de ninguna información proporcionada por el Servicio con respecto a recomendaciones sobre suplementos para cualquier propósito de salud.\n\nLa Compañía no garantiza ni ofrece garantías con respecto a ningún producto o servicio vendido. La Compañía no es responsable de ningún daño causado por información o servicios proporcionados, incluso si se ha informado de la posibilidad de tales daños.\n\n# Descargo de responsabilidad de enlaces externos\n\nEl Servicio puede contener enlaces a sitios web externos que no son proporcionados ni mantenidos por la Compañía de ninguna manera.\n\nTen en cuenta que la Compañía no garantiza la exactitud, pertinencia, puntualidad o integridad de ninguna información en estos sitios web externos.\n\n# Descargo de responsabilidad por errores y omisiones\n\nLa información proporcionada por el Servicio es solo una guía general sobre temas de interés. Aunque la Compañía toma todas las precauciones para garantizar que el contenido del Servicio sea actual y preciso, pueden producirse errores. Además, debido a la naturaleza cambiante de las leyes, normas y regulaciones, puede haber demoras, omisiones o inexactitudes en la información contenida en el Servicio.\n\nLa Compañía no se hace responsable de ningún error u omisión, ni de los resultados obtenidos del uso de esta información.\n\n# Descargo de responsabilidad de uso justo\n\nLa Compañía puede utilizar material protegido por derechos de autor que no siempre ha sido autorizado específicamente por el propietario de los derechos de autor. La Compañía pone a disposición dicho material para crítica, comentario, informes de noticias, enseñanza, becas o investigación.\n\nLa Compañía cree que esto constituye un \"uso justo\" de cualquier material protegido por derechos de autor según lo establecido en la sección 107 de la ley de derechos de autor de Estados Unidos.\n\nSi deseas utilizar material protegido por derechos de autor del Servicio para tus propios fines que vayan más allá del uso justo, debes obtener permiso del titular de los derechos de autor.\n\n# Descargo de responsabilidad de opiniones expresadas\n\nEl Servicio puede contener opiniones y puntos de vista que son de los autores y no reflejan necesariamente la política oficial o la posición de cualquier otro autor, agencia, organización, empleador o empresa, incluida la Compañía.\n\nLos comentarios publicados por los usuarios son su única responsabilidad y los usuarios asumirán la responsabilidad total, la responsabilidad y la culpa por cualquier difamación o litigio que resulte de algo escrito en un comentario o como resultado directo de algo escrito en un comentario. La Compañía no se hace responsable de ningún comentario publicado por los usuarios y se reserva el derecho de eliminar cualquier comentario por cualquier motivo que sea.\n\n# Descargo de responsabilidad sin responsabilidad\n\nLa información del Servicio se proporciona con el entendimiento de que la Compañía no se dedica aquí a prestar asesoramiento y servicios legales, contables, fiscales u otros servicios profesionales. Como tal, no debe utilizarse como sustituto de la consulta con asesores profesionales de contabilidad, fiscalidad, legal u otros competentes.\n\nEn ningún caso, la Compañía o sus proveedores serán responsables de ningún daño especial, incidental, indirecto o consecuente que surja de o en relación con tu acceso o uso o incapacidad para acceder o usar el Servicio.\n\n# Descargo de responsabilidad de \"Uso bajo tu propio riesgo\"\n\nToda la información en el Servicio se proporciona \"tal cual\", sin garantía de integridad, exactitud, puntualidad o de los resultados obtenidos del uso de esta información, y sin garantía de ningún tipo, expresa o implícita, incluidas, entre otras, las garantías de rendimiento, comerciabilidad y idoneidad para un propósito particular.\n\nLa Compañía no será responsable ante ti ni ante ninguna otra persona por cualquier decisión tomada o acción realizada en confianza en la información proporcionada por el Servicio o por cualquier daño consecuente, especial o similar, incluso si se informa de la posibilidad de tales daños.\n\n## Contáctanos\n\nSi tienes alguna pregunta sobre este descargo de responsabilidad, puedes contactarnos:\n\n- Por correo electrónico: myplanet@ole.org\n- Visitando esta página en nuestro sitio web: [https://ole.org/contact](https://ole.org/contact)",
@@ -838,44 +2581,161 @@
   "selectManyCollections": "Seleccionar varias colecciones",
   "selected": "Seleccionado: ",
   "myAchievements": "Mis logros",
+  "@myAchievements": {
+    "x-mt": true
+  },
   "editAchievement": "Editar logros",
+  "@editAchievement": {
+    "x-mt": true
+  },
   "addAchievement": "Agregar logro",
+  "@addAchievement": {
+    "x-mt": true
+  },
   "addAnAchievement": "Agregar un logro",
+  "@addAnAchievement": {
+    "x-mt": true
+  },
   "addReference": "Agregar referencia",
+  "@addReference": {
+    "x-mt": true
+  },
   "addAReference": "Agregar una referencia",
+  "@addAReference": {
+    "x-mt": true
+  },
   "selectResources": "Seleccionar recursos:",
+  "@selectResources": {
+    "x-mt": true
+  },
   "myGoals": "Mis metas",
+  "@myGoals": {
+    "x-mt": true
+  },
   "myPurpose": "mi propósito",
+  "@myPurpose": {
+    "x-mt": true
+  },
   "noGoalAdded": "Aún no se han fijado objetivos",
+  "@noGoalAdded": {
+    "x-mt": true
+  },
   "noPurposeAdded": "No se agregó ningún propósito",
+  "@noPurposeAdded": {
+    "x-mt": true
+  },
   "noAchievementAdded": "Resumen de logros",
+  "@noAchievementAdded": {
+    "x-mt": true
+  },
   "noReferencesAdded": "No se agregaron referencias",
+  "@noReferencesAdded": {
+    "x-mt": true
+  },
   "sendToNation": "Permita que sus logros sean compartidos con la nación.",
+  "@sendToNation": {
+    "x-mt": true
+  },
   "saving": "Ahorro…",
+  "@saving": {
+    "x-mt": true
+  },
   "achievementSaved": "Logro actualizado",
+  "@achievementSaved": {
+    "x-mt": true
+  },
   "titleIsRequired": "Se requiere título",
+  "@titleIsRequired": {
+    "x-mt": true
+  },
   "selectPdfOnly": "Please select a PDF file",
+  "@selectPdfOnly": {
+    "x-mt": true
+  },
   "viewCv": "Ver CV/Currículum vitae",
+  "@viewCv": {
+    "x-mt": true
+  },
   "deleteCv": "Eliminar CV",
+  "@deleteCv": {
+    "x-mt": true
+  },
   "uploadCvLabel": "Cargue su CV/Currículum vitae a continuación (solo PDF)",
+  "@uploadCvLabel": {
+    "x-mt": true
+  },
   "addMaterials": "Agregue cualquier material que demuestre sus logros a continuación",
+  "@addMaterials": {
+    "x-mt": true
+  },
   "labelAddReferences": "Agregue cualquier referencia a continuación",
+  "@labelAddReferences": {
+    "x-mt": true
+  },
   "cvResume": "CV / Currículum",
+  "@cvResume": {
+    "x-mt": true
+  },
   "relationship": "Relación",
+  "@relationship": {
+    "x-mt": true
+  },
   "noFileChosen": "Ningún archivo elegido",
+  "@noFileChosen": {
+    "x-mt": true
+  },
   "chooseFile": "Elija archivo",
+  "@chooseFile": {
+    "x-mt": true
+  },
   "currentCv": "CV/Currículum vitae actual: {name}",
+  "@currentCv": {
+    "x-mt": true
+  },
   "update": "Actualizar",
+  "@update": {
+    "x-mt": true
+  },
   "fillRequiredFields": "Por favor complete los campos obligatorios: {fields}",
+  "@fillRequiredFields": {
+    "x-mt": true
+  },
   "textSize": "Tamaño del texto",
+  "@textSize": {
+    "x-mt": true
+  },
   "selectTextSize": "Seleccionar tamaño de texto",
+  "@selectTextSize": {
+    "x-mt": true
+  },
   "textSizeSmall": "Pequeño",
+  "@textSizeSmall": {
+    "x-mt": true
+  },
   "textSizeMedium": "Medio",
+  "@textSizeMedium": {
+    "x-mt": true
+  },
   "textSizeLarge": "Grande",
+  "@textSizeLarge": {
+    "x-mt": true
+  },
   "resetApp": "Restablecer aplicación",
+  "@resetApp": {
+    "x-mt": true
+  },
   "clearAllDataConfirm": "¿Está seguro de que desea borrar todos los datos?",
+  "@clearAllDataConfirm": {
+    "x-mt": true
+  },
   "dataCleared": "Todos los datos borrados",
+  "@dataCleared": {
+    "x-mt": true
+  },
   "dataManagement": "Gestión de datos",
+  "@dataManagement": {
+    "x-mt": true
+  },
   "resourceTitleAlreadyExists": "Ya existe un recurso con este título",
   "failedToUpdateResource": "Error al actualizar el recurso"
 }

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -2,80 +2,260 @@
   "@@locale": "fr",
   "appTitle": "myPlanet",
   "serverConfigurationTitle": "Connectez-vous à un serveur Planet",
+  "@serverConfigurationTitle": {
+    "x-mt": true
+  },
   "serverUrlLabel": "URL du serveur",
+  "@serverUrlLabel": {
+    "x-mt": true
+  },
   "serverUrlHint": "https://planet.example.org",
+  "@serverUrlHint": {
+    "x-mt": true
+  },
   "serverPinLabel": "Code PIN du serveur",
+  "@serverPinLabel": {
+    "x-mt": true
+  },
   "connect": "Connecter",
+  "@connect": {
+    "x-mt": true
+  },
   "serverUrlNotConfigured": "URL du serveur non configurée",
   "deviceCouldNotReachLocalServer": "l'appareil n'a pas pu atteindre le serveur. vérifiez si vous êtes connecté au bon réseau Wi-Fi pour le serveur local (communauté).",
+  "@deviceCouldNotReachLocalServer": {
+    "x-mt": true
+  },
   "deviceCouldNotReachNationServer": "l\\'appareil n\\'a pas pu atteindre le serveur. vérifiez si vous êtes connecté à Internet et réessayez.",
   "connectionFailed": "Échec de la connexion !",
   "connectedToCommunity": "Connecté à {code}",
+  "@connectedToCommunity": {
+    "x-mt": true
+  },
   "changeServer": "Changer de serveur",
+  "@changeServer": {
+    "x-mt": true
+  },
   "login": "Connexion",
   "name": "Nom",
   "password": "Mot de passe",
   "signInOffline": "Connectez-vous hors ligne",
+  "@signInOffline": {
+    "x-mt": true
+  },
   "invalidCredentials": "Le nom ou le mot de passe est incorrect.",
+  "@invalidCredentials": {
+    "x-mt": true
+  },
   "userNotFound": "Utilisateur introuvable.",
+  "@userNotFound": {
+    "x-mt": true
+  },
   "missingAuthData": "Réponse du serveur manquant de données d'authentification.",
+  "@missingAuthData": {
+    "x-mt": true
+  },
   "serverError": "Erreur de serveur. Veuillez réessayer plus tard.",
+  "@serverError": {
+    "x-mt": true
+  },
   "networkError": "Serveur inaccessible. Vérifiez votre connexion Internet.",
+  "@networkError": {
+    "x-mt": true
+  },
   "emptyCredentials": "Le nom d'utilisateur et le mot de passe sont requis.",
+  "@emptyCredentials": {
+    "x-mt": true
+  },
   "notAManager": "Ce compte n'est pas un gestionnaire.",
+  "@notAManager": {
+    "x-mt": true
+  },
   "savedAccounts": "Comptes enregistrés",
+  "@savedAccounts": {
+    "x-mt": true
+  },
   "resources": "Ressources",
   "search": "Rechercher",
   "sync": "Synchroniser",
+  "@sync": {
+    "x-mt": true
+  },
   "cancel": "Annuler",
   "settings": "Paramètres",
   "backgroundSync": "Synchronisation en arrière-plan",
+  "@backgroundSync": {
+    "x-mt": true
+  },
   "backgroundSyncDescription": "Envoyez les modifications en attente et actualisez les données d'apprentissage lorsque l'application est fermée",
+  "@backgroundSyncDescription": {
+    "x-mt": true
+  },
   "syncFrequency": "Fréquence de synchronisation",
+  "@syncFrequency": {
+    "x-mt": true
+  },
   "every15Minutes": "Toutes les 15 minutes",
+  "@every15Minutes": {
+    "x-mt": true
+  },
   "every30Minutes": "Toutes les 30 minutes",
+  "@every30Minutes": {
+    "x-mt": true
+  },
   "everyHour": "Toutes les heures",
+  "@everyHour": {
+    "x-mt": true
+  },
   "every6Hours": "Toutes les 6 heures",
+  "@every6Hours": {
+    "x-mt": true
+  },
   "lastBackgroundRun": "Dernière exécution en arrière-plan",
+  "@lastBackgroundRun": {
+    "x-mt": true
+  },
   "backgroundNeverRun": "Aucune exécution en arrière-plan n'a encore été enregistrée",
+  "@backgroundNeverRun": {
+    "x-mt": true
+  },
   "backgroundSucceeded": "Terminé avec succès",
+  "@backgroundSucceeded": {
+    "x-mt": true
+  },
   "backgroundRetryRequested": "Incomplet – Android réessayera",
+  "@backgroundRetryRequested": {
+    "x-mt": true
+  },
   "backgroundSkipped": "Sauté",
+  "@backgroundSkipped": {
+    "x-mt": true
+  },
   "backgroundUnknown": "Résultat inconnu",
+  "@backgroundUnknown": {
+    "x-mt": true
+  },
   "backgroundScheduleFailed": "La préférence a été enregistrée, mais Android n'a pas pu mettre à jour le calendrier. Il sera réessayé au redémarrage de l'application.",
+  "@backgroundScheduleFailed": {
+    "x-mt": true
+  },
   "backgroundFailedSteps": "Il faut réessayer : {steps}",
+  "@backgroundFailedSteps": {
+    "x-mt": true
+  },
   "logOut": "Se déconnecter",
+  "@logOut": {
+    "x-mt": true
+  },
   "noDataAvailable": "Aucune donnée disponible",
   "ok": "OK",
   "home": "Accueil",
   "moreOptions": "Plus d'options",
+  "@moreOptions": {
+    "x-mt": true
+  },
   "appTheme": "Thème de l'application",
+  "@appTheme": {
+    "x-mt": true
+  },
   "aiChat": "Chat IA",
+  "@aiChat": {
+    "x-mt": true
+  },
   "syncNow": "Synchronisez maintenant",
+  "@syncNow": {
+    "x-mt": true
+  },
   "syncCenter": "Centre de synchronisation",
+  "@syncCenter": {
+    "x-mt": true
+  },
   "syncAll": "Synchroniser tout",
+  "@syncAll": {
+    "x-mt": true
+  },
   "syncing": "Synchronisation…",
   "waiting": "En attendant",
+  "@waiting": {
+    "x-mt": true
+  },
   "events": "Événements",
+  "@events": {
+    "x-mt": true
+  },
   "surveys": "Sondages",
   "syncReady": "Prêt à synchroniser",
+  "@syncReady": {
+    "x-mt": true
+  },
   "syncForegroundNotice": "Gardez myPlanet ouvert jusqu'à la fin de la synchronisation. Les écritures hors ligne en attente restent durables si la connexion est interrompue.",
+  "@syncForegroundNotice": {
+    "x-mt": true
+  },
   "syncProgress": "Synchronisation de {completed} de {total} zones",
+  "@syncProgress": {
+    "x-mt": true
+  },
   "syncAllSuccessful": "Toutes les {count} zones ont été synchronisées avec succès",
+  "@syncAllSuccessful": {
+    "x-mt": true
+  },
   "syncCompletedWithFailures": "Synchronisation terminée : {success} réussie, {failed} échouée",
+  "@syncCompletedWithFailures": {
+    "x-mt": true
+  },
   "itemsSynced": "{count, plural, =0{Up to date} =1{1 item synced} other{{count} items synced}}",
+  "@itemsSynced": {
+    "x-mt": true
+  },
   "lastSyncTimestamp": "Dernière synchronisation réussie : {date}",
+  "@lastSyncTimestamp": {
+    "x-mt": true
+  },
   "syncResourcesDescription": "Actualiser la bibliothèque d'apprentissage hors ligne",
+  "@syncResourcesDescription": {
+    "x-mt": true
+  },
   "syncCoursesDescription": "Actualiser les cours, les étapes et les abonnements étagères",
+  "@syncCoursesDescription": {
+    "x-mt": true
+  },
   "syncTeamsDescription": "Actualiser les équipes, les adhésions et les données d'entreprise",
+  "@syncTeamsDescription": {
+    "x-mt": true
+  },
   "syncEventsDescription": "Actualiser les rencontres et la participation",
+  "@syncEventsDescription": {
+    "x-mt": true
+  },
   "syncSurveysDescription": "Actualiser les formulaires et les missions d'enquête",
+  "@syncSurveysDescription": {
+    "x-mt": true
+  },
   "syncVoicesDescription": "Actualiser les discussions et les réponses de la communauté",
+  "@syncVoicesDescription": {
+    "x-mt": true
+  },
   "syncFeedbackDescription": "Actualiser les fils de commentaires et les réponses",
+  "@syncFeedbackDescription": {
+    "x-mt": true
+  },
   "syncChatDescription": "Actualiser l'historique des conversations IA",
+  "@syncChatDescription": {
+    "x-mt": true
+  },
   "syncHealthDescription": "Actualiser les dossiers de santé cryptés",
+  "@syncHealthDescription": {
+    "x-mt": true
+  },
   "syncActivitiesDescription": "Actualiser l'historique de connexion depuis le serveur",
+  "@syncActivitiesDescription": {
+    "x-mt": true
+  },
   "syncNotificationsDescription": "Actualiser les notifications du serveur et télécharger les états de lecture",
+  "@syncNotificationsDescription": {
+    "x-mt": true
+  },
   "homeMyLibrary": "maBibliothèque",
   "homeMyCourses": "mesCours",
   "homeMyTeams": "mesÉquipes",
@@ -89,101 +269,323 @@
   "subjectLabelSocialStudies": "Sciences sociales",
   "subjectLabelTechnology": "Technologie",
   "surveysToComplete": "You have {count, plural, =1{1 survey} other{{count} surveys}} to complete",
+  "@surveysToComplete": {
+    "x-mt": true
+  },
   "lastSynced": "Dernière synchronisation : {time}",
+  "@lastSynced": {
+    "x-mt": true
+  },
   "neverSynced": "jamais synchronisé",
   "justNow": "À l\\'instant",
   "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@minutesAgo": {
+    "x-mt": true
+  },
   "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@hoursAgo": {
+    "x-mt": true
+  },
   "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@daysAgo": {
+    "x-mt": true
+  },
   "syncingResources": "Synchronisation des ressources… {completed} sur {total}",
+  "@syncingResources": {
+    "x-mt": true
+  },
   "syncedResources": "{count, plural, =0{No resources synced} =1{1 resource synced} other{{count} resources synced}}",
+  "@syncedResources": {
+    "x-mt": true
+  },
   "syncFailed": "Échec de la synchronisation : {message}",
+  "@syncFailed": {
+    "x-mt": true
+  },
   "availableOffline": "Disponible hors ligne",
+  "@availableOffline": {
+    "x-mt": true
+  },
   "courses": "Cours",
   "myCourses": "Mes cours",
+  "@myCourses": {
+    "x-mt": true
+  },
   "allCourses": "Tous les cours",
+  "@allCourses": {
+    "x-mt": true
+  },
   "courseSteps": "{count, plural, =0{No steps} =1{1 step} other{{count} steps}}",
+  "@courseSteps": {
+    "x-mt": true
+  },
   "stepNumber": "Étape {number}",
+  "@stepNumber": {
+    "x-mt": true
+  },
   "resourcesInStep": "{count, plural, =0{No resources} =1{1 resource} other{{count} resources}}",
+  "@resourcesInStep": {
+    "x-mt": true
+  },
   "gradeLevel": "Niveau scolaire",
+  "@gradeLevel": {
+    "x-mt": true
+  },
   "subjectLevel": "Sujet",
+  "@subjectLevel": {
+    "x-mt": true
+  },
   "allLevels": "Tous",
   "clearFilters": "Effacer les filtres",
+  "@clearFilters": {
+    "x-mt": true
+  },
   "joinCourse": "Ajouter à mes cours",
+  "@joinCourse": {
+    "x-mt": true
+  },
   "leaveCourse": "Supprimer de mes cours",
+  "@leaveCourse": {
+    "x-mt": true
+  },
   "syncedCourses": "{count, plural, =0{No courses synced} =1{1 course synced} other{{count} courses synced}}",
+  "@syncedCourses": {
+    "x-mt": true
+  },
   "courseNotFound": "Cours introuvable",
+  "@courseNotFound": {
+    "x-mt": true
+  },
   "calendar": "Calendrier",
   "profile": "Profil",
   "profileUnavailable": "Profil indisponible",
+  "@profileUnavailable": {
+    "x-mt": true
+  },
   "username": "Nom d'utilisateur",
+  "@username": {
+    "x-mt": true
+  },
   "email": "E-mail",
   "phone": "Téléphone",
+  "@phone": {
+    "x-mt": true
+  },
   "level": "Niveau",
+  "@level": {
+    "x-mt": true
+  },
   "levels": "Niveaux",
+  "@levels": {
+    "x-mt": true
+  },
   "language": "Langue",
   "languages": "Langues",
   "gender": "Sexe",
   "dateOfBirth": "Date de naissance",
+  "@dateOfBirth": {
+    "x-mt": true
+  },
   "planetCode": "Code de la planète",
+  "@planetCode": {
+    "x-mt": true
+  },
   "accountDetails": "Détails du compte",
+  "@accountDetails": {
+    "x-mt": true
+  },
   "noProfileDetails": "Aucun détail de profil n'est disponible.",
+  "@noProfileDetails": {
+    "x-mt": true
+  },
   "profilePhotoFor": "Photo de profil pour {name}",
+  "@profilePhotoFor": {
+    "x-mt": true
+  },
   "editProfile": "Modifier le profil",
+  "@editProfile": {
+    "x-mt": true
+  },
   "changePhoto": "Changer la photo de profil",
+  "@changePhoto": {
+    "x-mt": true
+  },
   "photoUpdated": "Photo de profil mise à jour",
+  "@photoUpdated": {
+    "x-mt": true
+  },
   "photoUpdateFailed": "Impossible d'enregistrer la photo",
+  "@photoUpdateFailed": {
+    "x-mt": true
+  },
   "firstName": "Prénom",
+  "@firstName": {
+    "x-mt": true
+  },
   "middleName": "Deuxième prénom",
+  "@middleName": {
+    "x-mt": true
+  },
   "lastName": "Nom de famille",
+  "@lastName": {
+    "x-mt": true
+  },
   "save": "Enregistrer",
   "profileSaved": "Profil enregistré sur cet appareil",
+  "@profileSaved": {
+    "x-mt": true
+  },
   "invalidEmail": "Entrez une adresse e-mail valide",
+  "@invalidEmail": {
+    "x-mt": true
+  },
   "appearance": "Apparence",
+  "@appearance": {
+    "x-mt": true
+  },
   "systemTheme": "Utiliser le thème de l'appareil",
+  "@systemTheme": {
+    "x-mt": true
+  },
   "lightTheme": "Clair",
   "darkTheme": "Sombre",
   "server": "Serveur",
+  "@server": {
+    "x-mt": true
+  },
   "serverUrl": "URL du serveur",
+  "@serverUrl": {
+    "x-mt": true
+  },
   "notConfigured": "Non configuré",
+  "@notConfigured": {
+    "x-mt": true
+  },
   "communityCode": "Code communautaire",
+  "@communityCode": {
+    "x-mt": true
+  },
   "about": "À propos de",
   "offlineLearningApp": "Apprentissage hors ligne avec Planet",
+  "@offlineLearningApp": {
+    "x-mt": true
+  },
   "appVersion": "Version {version}",
+  "@appVersion": {
+    "x-mt": true
+  },
   "buildNumber": "Construire {number}",
+  "@buildNumber": {
+    "x-mt": true
+  },
   "learningTools": "Outils d'apprentissage",
+  "@learningTools": {
+    "x-mt": true
+  },
   "dictionary": "Dictionnaire",
   "dictionaryDescription": "Rechercher des définitions téléchargées hors ligne",
+  "@dictionaryDescription": {
+    "x-mt": true
+  },
   "dictionaryUnavailable": "Dictionnaire indisponible",
+  "@dictionaryUnavailable": {
+    "x-mt": true
+  },
   "searchDictionary": "Rechercher un mot",
+  "@searchDictionary": {
+    "x-mt": true
+  },
   "dictionaryWordCount": "{count, plural, =0{No downloaded words} =1{1 downloaded word} other{{count} downloaded words}}",
+  "@dictionaryWordCount": {
+    "x-mt": true
+  },
   "downloadDictionary": "Télécharger le dictionnaire",
+  "@downloadDictionary": {
+    "x-mt": true
+  },
   "retryDownload": "Réessayez le téléchargement",
+  "@retryDownload": {
+    "x-mt": true
+  },
   "dictionaryDownloadFailed": "Le dictionnaire n'a pas pu être téléchargé. Vos données hors ligne existantes n'ont pas été modifiées.",
+  "@dictionaryDownloadFailed": {
+    "x-mt": true
+  },
   "wordNotFound": "Mot non disponible dans le dictionnaire hors ligne",
+  "@wordNotFound": {
+    "x-mt": true
+  },
   "meaning": "Signification",
+  "@meaning": {
+    "x-mt": true
+  },
   "synonyms": "Synonymes",
+  "@synonyms": {
+    "x-mt": true
+  },
   "antonyms": "Antonymes",
+  "@antonyms": {
+    "x-mt": true
+  },
   "notifications": "Notifications",
+  "@notifications": {
+    "x-mt": true
+  },
   "notification": "Notification",
+  "@notification": {
+    "x-mt": true
+  },
   "notificationsUnavailable": "Notifications indisponibles",
+  "@notificationsUnavailable": {
+    "x-mt": true
+  },
   "markAllRead": "Marquer tout comme lu",
+  "@markAllRead": {
+    "x-mt": true
+  },
   "all": "Tous",
   "read": "Lire",
+  "@read": {
+    "x-mt": true
+  },
   "unreadCount": "Non lu ({count})",
+  "@unreadCount": {
+    "x-mt": true
+  },
   "noNotifications": "Aucune notification",
   "noUnreadNotifications": "Aucune notification non lue",
   "noReadNotifications": "Aucune notification lue",
   "delete": "Supprimer",
   "deleteNotification": "Supprimer la notification ?",
+  "@deleteNotification": {
+    "x-mt": true
+  },
   "deleteNotificationConfirmation": "Cette notification sera supprimée de cet appareil.",
+  "@deleteNotificationConfirmation": {
+    "x-mt": true
+  },
   "taskNotification": "Tâche",
+  "@taskNotification": {
+    "x-mt": true
+  },
   "chatNotification": "Discussion",
   "replyNotification": "Nouvelle réponse",
+  "@replyNotification": {
+    "x-mt": true
+  },
   "resourceNotification": "Ressources",
   "storageNotification": "Avertissement de stockage",
+  "@storageNotification": {
+    "x-mt": true
+  },
   "joinRequestNotification": "Demande d'adhésion",
+  "@joinRequestNotification": {
+    "x-mt": true
+  },
   "teamNotification": "Mise à jour de l'équipe",
+  "@teamNotification": {
+    "x-mt": true
+  },
   "tasks": "Tâches",
   "notifGroupJoinRequests": "Demandes d\\'adhésion",
   "notifGroupTeamUpdates": "Mises à jour de l\\'équipe",
@@ -192,83 +594,293 @@
   "notificationGroupSystem": "Système",
   "notificationGroupOther": "Autre",
   "myLife": "Ma vie",
+  "@myLife": {
+    "x-mt": true
+  },
   "myLifeUnavailable": "Ma vie n'est pas disponible",
+  "@myLifeUnavailable": {
+    "x-mt": true
+  },
   "noLifeItems": "Non Articles de ma vie",
+  "@noLifeItems": {
+    "x-mt": true
+  },
   "shownOnDashboard": "Montré",
+  "@shownOnDashboard": {
+    "x-mt": true
+  },
   "hiddenFromDashboard": "Caché",
+  "@hiddenFromDashboard": {
+    "x-mt": true
+  },
   "hideItem": "Masquer {title}",
+  "@hideItem": {
+    "x-mt": true
+  },
   "showItem": "Afficher {title}",
+  "@showItem": {
+    "x-mt": true
+  },
   "reorderItem": "Réorganiser {title}",
+  "@reorderItem": {
+    "x-mt": true
+  },
   "myHealth": "Ma santé",
+  "@myHealth": {
+    "x-mt": true
+  },
   "achievements": "Réalisations",
+  "@achievements": {
+    "x-mt": true
+  },
   "submissions": "Soumissions",
+  "@submissions": {
+    "x-mt": true
+  },
   "submission": "Soumission",
+  "@submission": {
+    "x-mt": true
+  },
   "submissionsUnavailable": "Les soumissions ne sont pas disponibles",
+  "@submissionsUnavailable": {
+    "x-mt": true
+  },
   "noSubmissions": "Aucune soumission pour l'instant",
+  "@noSubmissions": {
+    "x-mt": true
+  },
   "pending": "En attente",
+  "@pending": {
+    "x-mt": true
+  },
   "submissionGrade": "Note : {grade}",
+  "@submissionGrade": {
+    "x-mt": true
+  },
   "refresh": "Rafraîchir",
+  "@refresh": {
+    "x-mt": true
+  },
   "complete": "Complet",
+  "@complete": {
+    "x-mt": true
+  },
   "noMatchingSubmissions": "Aucune soumission ne correspond à ce filtre",
+  "@noMatchingSubmissions": {
+    "x-mt": true
+  },
   "submissionsSynced": "{count, plural, =0{Submissions are up to date} =1{1 submission synced} other{{count} submissions synced}}",
+  "@submissionsSynced": {
+    "x-mt": true
+  },
   "submissionDetails": "Détails de la soumission",
+  "@submissionDetails": {
+    "x-mt": true
+  },
   "submissionNotFound": "Soumission introuvable",
+  "@submissionNotFound": {
+    "x-mt": true
+  },
   "unknown": "Inconnu",
+  "@unknown": {
+    "x-mt": true
+  },
   "nA": "N / A",
+  "@nA": {
+    "x-mt": true
+  },
   "otherDiagnosis": "Autre diagnostic",
+  "@otherDiagnosis": {
+    "x-mt": true
+  },
   "add": "Ajouter",
+  "@add": {
+    "x-mt": true
+  },
   "status": "Statut",
   "lastUpdated": "Dernière mise à jour",
+  "@lastUpdated": {
+    "x-mt": true
+  },
   "grade": "Grade",
+  "@grade": {
+    "x-mt": true
+  },
   "submittedBy": "Soumis par",
   "submissionType": "Type",
   "uploadStatus": "Statut de téléchargement",
+  "@uploadStatus": {
+    "x-mt": true
+  },
   "uploaded": "Téléchargé",
+  "@uploaded": {
+    "x-mt": true
+  },
   "answers": "Réponses",
+  "@answers": {
+    "x-mt": true
+  },
   "answersUnavailable": "Les réponses ne sont pas disponibles",
+  "@answersUnavailable": {
+    "x-mt": true
+  },
   "noAnswers": "Aucune réponse n'a été enregistrée avec cette soumission",
+  "@noAnswers": {
+    "x-mt": true
+  },
   "noAnswer": "Pas de réponse",
+  "@noAnswer": {
+    "x-mt": true
+  },
   "questionNumber": "Question {number}",
+  "@questionNumber": {
+    "x-mt": true
+  },
   "newSubmission": "Nouvelle soumission",
+  "@newSubmission": {
+    "x-mt": true
+  },
   "answer": "Répondre",
+  "@answer": {
+    "x-mt": true
+  },
   "availableChoices": "Choix",
+  "@availableChoices": {
+    "x-mt": true
+  },
   "exportPdf": "Exporter un PDF",
+  "@exportPdf": {
+    "x-mt": true
+  },
   "pdfExportFailed": "Le PDF n'a pas pu être créé",
+  "@pdfExportFailed": {
+    "x-mt": true
+  },
   "pdfSaved": "PDF enregistré dans {path}",
+  "@pdfSaved": {
+    "x-mt": true
+  },
   "mySurveys": "Mes enquêtes",
+  "@mySurveys": {
+    "x-mt": true
+  },
   "references": "Références",
   "myPersonals": "Mes rencontres",
+  "@myPersonals": {
+    "x-mt": true
+  },
   "featureComingSoon": "Cette fonctionnalité n'est pas encore portée",
+  "@featureComingSoon": {
+    "x-mt": true
+  },
   "maps": "Cartes",
   "englishDictionary": "dictionnaire anglais",
+  "@englishDictionary": {
+    "x-mt": true
+  },
   "offlineMapsComingSoon": "Les cartes hors ligne ne sont pas encore portées",
+  "@offlineMapsComingSoon": {
+    "x-mt": true
+  },
   "addPersonal": "Ajouter un objet personnel",
+  "@addPersonal": {
+    "x-mt": true
+  },
   "editPersonal": "Modifier un objet personnel",
+  "@editPersonal": {
+    "x-mt": true
+  },
   "deletePersonal": "Supprimer un objet personnel ?",
+  "@deletePersonal": {
+    "x-mt": true
+  },
   "deletePersonalConfirmation": "Supprimer « {title} » de cet appareil ?",
+  "@deletePersonalConfirmation": {
+    "x-mt": true
+  },
   "personalsUnavailable": "Les objets personnels ne sont pas disponibles",
+  "@personalsUnavailable": {
+    "x-mt": true
+  },
   "noPersonals": "Aucun objet personnel pour l'instant. Ajoutez une note privée pour commencer.",
+  "@noPersonals": {
+    "x-mt": true
+  },
   "duplicateTitle": "Un objet personnel portant ce titre existe déjà",
+  "@duplicateTitle": {
+    "x-mt": true
+  },
   "attachFile": "Joindre un fichier",
+  "@attachFile": {
+    "x-mt": true
+  },
   "attachedFile": "Ci-joint : {name}",
+  "@attachedFile": {
+    "x-mt": true
+  },
   "noFileSelected": "No file selected",
+  "@noFileSelected": {
+    "x-mt": true
+  },
   "removeFile": "Supprimer le fichier",
+  "@removeFile": {
+    "x-mt": true
+  },
   "savedOffline": "Enregistré hors ligne – en attente de téléchargement",
+  "@savedOffline": {
+    "x-mt": true
+  },
   "edit": "Modifier",
   "title": "Titre",
   "titleRequired": "Entrez un titre",
+  "@titleRequired": {
+    "x-mt": true
+  },
   "rateCourse": "Tarifer le cours",
+  "@rateCourse": {
+    "x-mt": true
+  },
   "rateTitle": "Tarifer {title}",
+  "@rateTitle": {
+    "x-mt": true
+  },
   "ratingsUnavailable": "Les notes ne sont pas disponibles",
+  "@ratingsUnavailable": {
+    "x-mt": true
+  },
   "ratingSummary": "{average} from {count, plural, =1{1 rating} other{{count} ratings}}",
+  "@ratingSummary": {
+    "x-mt": true
+  },
   "ratingCompact": "{average} ({count})",
+  "@ratingCompact": {
+    "x-mt": true
+  },
   "ratingOutOfFive": "Note : {rating} sur 5",
+  "@ratingOutOfFive": {
+    "x-mt": true
+  },
   "setRating": "Définir la note sur {rating}",
+  "@setRating": {
+    "x-mt": true
+  },
   "ratingRequired": "Choisissez une note",
+  "@ratingRequired": {
+    "x-mt": true
+  },
   "commentOptional": "Commentaire (facultatif)",
+  "@commentOptional": {
+    "x-mt": true
+  },
   "submitRating": "Soumettre une évaluation",
+  "@submitRating": {
+    "x-mt": true
+  },
   "skip": "Passer",
   "next": "Suivant",
+  "@next": {
+    "x-mt": true
+  },
   "getStarted": "COMMENCER",
   "welcomeToMyPlanet": "Bienvenue sur myPlanet",
   "learnOffline": "Apprendre hors ligne",
@@ -276,292 +888,1003 @@
   "unleashLearningPower": "Libérer le pouvoir d\\'apprendre",
   "onboardingWelcomeDescription": "Votre passerelle vers un apprentissage illimité",
   "onboardingOfflineDescription": "Téléchargez des ressources pour l'apprentissage hors ligne.\nAccédez aux connaissances en déplacement.",
+  "@onboardingOfflineDescription": {
+    "x-mt": true
+  },
   "onboardingOpenDescription": "Choisissez vos intérêts et plongez dans le contenu interactif.\nCréez votre parcours d’apprentissage unique.",
+  "@onboardingOpenDescription": {
+    "x-mt": true
+  },
   "onboardingPowerDescription": "Explorez un monde de connaissances à portée de main.\n\n🌍 Accès hors ligne : apprenez sans frontières, à tout moment.\n🎯 Personnalisé : personnalisez votre parcours d'apprentissage.\n📚 Interactif : interagissez avec des vidéos, des livres et des jeux.\n\nCommencez votre parcours d'apprentissage sans limites avec myPlanet !",
+  "@onboardingPowerDescription": {
+    "x-mt": true
+  },
   "onboardingServerPrepHint": "Avant de vous connecter, vous aurez besoin de votre adresse de serveur Planet et de votre code PIN. Demandez à votre administrateur de communauté si vous ne les avez pas encore.",
+  "@onboardingServerPrepHint": {
+    "x-mt": true
+  },
   "pageProgress": "Page {current} de {total}",
+  "@pageProgress": {
+    "x-mt": true
+  },
   "meetups": "Rencontres",
+  "@meetups": {
+    "x-mt": true
+  },
   "syncPendingMeetups": "Synchroniser les rencontres en attente",
+  "@syncPendingMeetups": {
+    "x-mt": true
+  },
   "meetupsUnavailable": "Les Meetups ne sont pas disponibles",
+  "@meetupsUnavailable": {
+    "x-mt": true
+  },
   "noMeetups": "Pas encore de rencontres",
+  "@noMeetups": {
+    "x-mt": true
+  },
   "dateNotSet": "Date non fixée",
+  "@dateNotSet": {
+    "x-mt": true
+  },
   "untitledMeetup": "Rencontre sans titre",
+  "@untitledMeetup": {
+    "x-mt": true
+  },
   "addMeetup": "Ajouter une rencontre",
+  "@addMeetup": {
+    "x-mt": true
+  },
   "meetupDetails": "Détails du Meetup",
+  "@meetupDetails": {
+    "x-mt": true
+  },
   "meetupNotFound": "Meetup introuvable",
+  "@meetupNotFound": {
+    "x-mt": true
+  },
   "createdBy": "Créé par",
+  "@createdBy": {
+    "x-mt": true
+  },
   "category": "Catégorie",
+  "@category": {
+    "x-mt": true
+  },
   "location": "Emplacement",
   "link": "Lien",
   "recurring": "Récurrent",
+  "@recurring": {
+    "x-mt": true
+  },
   "description": "Description",
+  "@description": {
+    "x-mt": true
+  },
   "leaveMeetup": "Quitter la rencontre",
+  "@leaveMeetup": {
+    "x-mt": true
+  },
   "joinMeetup": "Rejoignez la rencontre",
+  "@joinMeetup": {
+    "x-mt": true
+  },
   "editMeetup": "Modifier la rencontre",
+  "@editMeetup": {
+    "x-mt": true
+  },
   "startTime": "Heure de début",
+  "@startTime": {
+    "x-mt": true
+  },
   "endTime": "Heure de fin",
+  "@endTime": {
+    "x-mt": true
+  },
   "none": "Aucun",
   "daily": "Quotidien",
   "weekly": "Hebdomadaire",
   "syncMeetups": "Synchroniser les rencontres",
+  "@syncMeetups": {
+    "x-mt": true
+  },
   "searchMeetups": "Rechercher des rencontres",
+  "@searchMeetups": {
+    "x-mt": true
+  },
   "sortMeetups": "Trier les rencontres",
+  "@sortMeetups": {
+    "x-mt": true
+  },
   "sortResources": "Trier les ressources",
+  "@sortResources": {
+    "x-mt": true
+  },
   "newestFirst": "Le plus récent en premier",
+  "@newestFirst": {
+    "x-mt": true
+  },
   "oldestFirst": "Le plus ancien en premier",
+  "@oldestFirst": {
+    "x-mt": true
+  },
   "titleAscending": "Titre A à Z",
+  "@titleAscending": {
+    "x-mt": true
+  },
   "titleDescending": "Titre Z-A",
+  "@titleDescending": {
+    "x-mt": true
+  },
   "startDate": "Date de début",
+  "@startDate": {
+    "x-mt": true
+  },
   "endDate": "Date de fin",
+  "@endDate": {
+    "x-mt": true
+  },
   "timeNotSet": "Heure non réglée",
+  "@timeNotSet": {
+    "x-mt": true
+  },
   "syncSurveys": "Synchroniser les enquêtes",
+  "@syncSurveys": {
+    "x-mt": true
+  },
   "searchSurveys": "Rechercher des enquêtes",
+  "@searchSurveys": {
+    "x-mt": true
+  },
   "sortSurveys": "Trier les enquêtes",
+  "@sortSurveys": {
+    "x-mt": true
+  },
   "surveysUnavailable": "Les enquêtes ne sont pas disponibles",
+  "@surveysUnavailable": {
+    "x-mt": true
+  },
   "noSurveys": "Aucune enquête disponible",
+  "@noSurveys": {
+    "x-mt": true
+  },
   "untitledSurvey": "Enquête sans titre",
+  "@untitledSurvey": {
+    "x-mt": true
+  },
   "takeSurvey": "Répondre à l'enquête",
+  "@takeSurvey": {
+    "x-mt": true
+  },
   "surveyLoadFailed": "L'enquête n'a pas pu être chargée",
+  "@surveyLoadFailed": {
+    "x-mt": true
+  },
   "surveyHasNoQuestions": "Cette enquête ne comporte aucune question",
+  "@surveyHasNoQuestions": {
+    "x-mt": true
+  },
   "submitSurvey": "Soumettre l'enquête",
+  "@submitSurvey": {
+    "x-mt": true
+  },
   "answerRequiredQuestions": "Répondez à toutes les questions requises",
+  "@answerRequiredQuestions": {
+    "x-mt": true
+  },
   "voices": "Voix",
+  "@voices": {
+    "x-mt": true
+  },
   "searchVoices": "Rechercher des voix",
+  "@searchVoices": {
+    "x-mt": true
+  },
   "syncVoices": "Synchroniser les voix",
+  "@syncVoices": {
+    "x-mt": true
+  },
   "noVoices": "Pas encore de voix",
+  "@noVoices": {
+    "x-mt": true
+  },
   "voicesUnavailable": "Les voix ne sont pas disponibles",
+  "@voicesUnavailable": {
+    "x-mt": true
+  },
   "shareYourVoice": "Partagez votre voix",
+  "@shareYourVoice": {
+    "x-mt": true
+  },
   "postVoice": "Poste",
+  "@postVoice": {
+    "x-mt": true
+  },
   "replyToVoice": "Répondre",
   "writeAReply": "Écrivez une réponse",
+  "@writeAReply": {
+    "x-mt": true
+  },
   "repliesCount": "{count, plural, =0{No replies} =1{1 reply} other{{count} replies}}",
+  "@repliesCount": {
+    "x-mt": true
+  },
   "edited": "Édité",
+  "@edited": {
+    "x-mt": true
+  },
   "editVoice": "Modifier",
   "deleteVoice": "Supprimer",
   "deleteVoiceConfirm": "Supprimer ce message et toutes ses réponses ?",
+  "@deleteVoiceConfirm": {
+    "x-mt": true
+  },
   "voiceDeleted": "Message supprimé",
+  "@voiceDeleted": {
+    "x-mt": true
+  },
   "emptyMessageNotAllowed": "Écrivez d'abord quelque chose",
+  "@emptyMessageNotAllowed": {
+    "x-mt": true
+  },
   "thread": "Fil",
+  "@thread": {
+    "x-mt": true
+  },
   "surveySubmitFailed": "Impossible d'enregistrer vos réponses",
+  "@surveySubmitFailed": {
+    "x-mt": true
+  },
   "sendSurveyTo": "Sélectionnez les utilisateurs auxquels envoyer l'enquête",
+  "@sendSurveyTo": {
+    "x-mt": true
+  },
   "sendSurvey": "Envoyer le sondage",
+  "@sendSurvey": {
+    "x-mt": true
+  },
   "surveySentToUsers": "Survey sent to selected users",
+  "@surveySentToUsers": {
+    "x-mt": true
+  },
   "noUsersAvailable": "Aucun utilisateur disponible",
+  "@noUsersAvailable": {
+    "x-mt": true
+  },
   "teams": "Équipes",
   "syncTeams": "Synchroniser les équipes",
+  "@syncTeams": {
+    "x-mt": true
+  },
   "searchTeams": "Équipes de recherche",
+  "@searchTeams": {
+    "x-mt": true
+  },
   "teamsUnavailable": "Les équipes ne sont pas disponibles",
+  "@teamsUnavailable": {
+    "x-mt": true
+  },
   "noTeams": "Aucune équipe disponible",
+  "@noTeams": {
+    "x-mt": true
+  },
   "untitledTeam": "Équipe sans titre",
+  "@untitledTeam": {
+    "x-mt": true
+  },
   "teamDetails": "Détails de l'équipe",
+  "@teamDetails": {
+    "x-mt": true
+  },
   "teamNotFound": "Équipe introuvable",
+  "@teamNotFound": {
+    "x-mt": true
+  },
   "publicTeam": "Équipe publique",
+  "@publicTeam": {
+    "x-mt": true
+  },
   "privateTeam": "Équipe privée",
+  "@privateTeam": {
+    "x-mt": true
+  },
   "enterprises": "Entreprises",
   "searchEnterprises": "Rechercher des entreprises",
+  "@searchEnterprises": {
+    "x-mt": true
+  },
   "leader": "Chef",
+  "@leader": {
+    "x-mt": true
+  },
   "leave": "Partir",
+  "@leave": {
+    "x-mt": true
+  },
   "remove": "Retirer",
+  "@remove": {
+    "x-mt": true
+  },
   "makeLeader": "Faire un leader",
+  "@makeLeader": {
+    "x-mt": true
+  },
   "leftTeam": "Équipe de gauche",
+  "@leftTeam": {
+    "x-mt": true
+  },
   "memberRemoved": "Membre supprimé",
+  "@memberRemoved": {
+    "x-mt": true
+  },
   "leaderUpdated": "Leader mis à jour",
+  "@leaderUpdated": {
+    "x-mt": true
+  },
   "member": "Membre",
+  "@member": {
+    "x-mt": true
+  },
   "teamLeader": "Vous dirigez cette équipe",
+  "@teamLeader": {
+    "x-mt": true
+  },
   "teamMember": "Vous êtes membre",
+  "@teamMember": {
+    "x-mt": true
+  },
   "services": "Services",
   "rules": "Règles",
+  "@rules": {
+    "x-mt": true
+  },
   "teamCourses": "Cours en équipe",
+  "@teamCourses": {
+    "x-mt": true
+  },
   "membersCount": "{count, plural, =0{No members} =1{1 member} other{{count} members}}",
+  "@membersCount": {
+    "x-mt": true
+  },
   "teamTasks": "Tâches",
   "tasksUnavailable": "Les tâches ne sont pas disponibles",
+  "@tasksUnavailable": {
+    "x-mt": true
+  },
   "noTeamTasks": "Aucune tâche pour l'instant",
+  "@noTeamTasks": {
+    "x-mt": true
+  },
   "noDeadline": "Pas de date limite",
+  "@noDeadline": {
+    "x-mt": true
+  },
   "untitledTask": "Tâche sans titre",
+  "@untitledTask": {
+    "x-mt": true
+  },
   "addTask": "Ajouter une tâche",
+  "@addTask": {
+    "x-mt": true
+  },
   "editTask": "Modifier la tâche",
+  "@editTask": {
+    "x-mt": true
+  },
   "deleteTask": "Supprimer la tâche",
+  "@deleteTask": {
+    "x-mt": true
+  },
   "taskTitle": "Titre de la tâche",
+  "@taskTitle": {
+    "x-mt": true
+  },
   "assigneeId": "ID du cessionnaire",
+  "@assigneeId": {
+    "x-mt": true
+  },
   "teamDiscussions": "Discussions",
+  "@teamDiscussions": {
+    "x-mt": true
+  },
   "teamMembers": "Membres",
   "members": "Membres",
   "joinRequests": "Demandes d'adhésion",
+  "@joinRequests": {
+    "x-mt": true
+  },
   "noMembers": "Pas encore de membres",
+  "@noMembers": {
+    "x-mt": true
+  },
   "membersUnavailable": "Les membres ne sont pas disponibles",
+  "@membersUnavailable": {
+    "x-mt": true
+  },
   "unknownMember": "Membre inconnu",
+  "@unknownMember": {
+    "x-mt": true
+  },
   "noJoinRequests": "Aucune demande en attente",
+  "@noJoinRequests": {
+    "x-mt": true
+  },
   "accept": "Accepter",
   "decline": "Déclin",
+  "@decline": {
+    "x-mt": true
+  },
   "joinTeam": "Demander à rejoindre",
   "leaveTeam": "Quitter l'équipe",
+  "@leaveTeam": {
+    "x-mt": true
+  },
   "requestPending": "Demande en attente",
+  "@requestPending": {
+    "x-mt": true
+  },
   "teamResources": "Ressources",
   "resourcesUnavailable": "Les ressources ne sont pas disponibles",
+  "@resourcesUnavailable": {
+    "x-mt": true
+  },
   "noTeamResources": "Aucune ressource liée à cette équipe",
+  "@noTeamResources": {
+    "x-mt": true
+  },
   "untitledResource": "Ressource sans titre",
+  "@untitledResource": {
+    "x-mt": true
+  },
   "removeFromTeam": "Supprimer de l'équipe",
+  "@removeFromTeam": {
+    "x-mt": true
+  },
   "addResource": "Ajouter une ressource",
+  "@addResource": {
+    "x-mt": true
+  },
   "editResource": "Modifier la ressource",
+  "@editResource": {
+    "x-mt": true
+  },
   "resourceUpdated": "Ressource mise à jour",
+  "@resourceUpdated": {
+    "x-mt": true
+  },
   "resourceAddedToTeam": "Ressource ajoutée à l'équipe",
+  "@resourceAddedToTeam": {
+    "x-mt": true
+  },
   "descriptionIsRequired": "Une description est requise",
+  "@descriptionIsRequired": {
+    "x-mt": true
+  },
   "levelIsRequired": "Le niveau est requis",
+  "@levelIsRequired": {
+    "x-mt": true
+  },
   "subjectIsRequired": "Le sujet est obligatoire",
+  "@subjectIsRequired": {
+    "x-mt": true
+  },
   "selectFile": "Sélectionnez un fichier",
+  "@selectFile": {
+    "x-mt": true
+  },
   "fileSelected": "File selected",
+  "@fileSelected": {
+    "x-mt": true
+  },
   "privateResource": "Ressource privée",
+  "@privateResource": {
+    "x-mt": true
+  },
   "saveChanges": "Enregistrer les modifications",
+  "@saveChanges": {
+    "x-mt": true
+  },
   "selectOpenWith": "Sélectionnez ouvrir avec",
+  "@selectOpenWith": {
+    "x-mt": true
+  },
   "selectMedia": "Sélectionner un média",
+  "@selectMedia": {
+    "x-mt": true
+  },
   "selectResourceType": "Sélectionnez le type de ressource",
+  "@selectResourceType": {
+    "x-mt": true
+  },
   "linkToLicense": "Lien vers la licence",
+  "@linkToLicense": {
+    "x-mt": true
+  },
   "noResourcesToAdd": "Toutes les ressources disponibles sont déjà liées",
+  "@noResourcesToAdd": {
+    "x-mt": true
+  },
   "coursesUnavailable": "Les cours ne sont pas disponibles",
+  "@coursesUnavailable": {
+    "x-mt": true
+  },
   "noTeamCourses": "Aucun cours lié à cette équipe",
+  "@noTeamCourses": {
+    "x-mt": true
+  },
   "untitledCourse": "Cours sans titre",
+  "@untitledCourse": {
+    "x-mt": true
+  },
   "addCourse": "Ajouter un cours",
+  "@addCourse": {
+    "x-mt": true
+  },
   "noCoursesToAdd": "Tous les cours disponibles sont déjà liés",
+  "@noCoursesToAdd": {
+    "x-mt": true
+  },
   "financialReports": "Rapports financiers",
+  "@financialReports": {
+    "x-mt": true
+  },
   "reportsUnavailable": "Les rapports ne sont pas disponibles",
+  "@reportsUnavailable": {
+    "x-mt": true
+  },
   "noReports": "Pas encore de rapports financiers",
+  "@noReports": {
+    "x-mt": true
+  },
   "addReport": "Ajouter un rapport",
+  "@addReport": {
+    "x-mt": true
+  },
   "editReport": "Modifier le rapport",
+  "@editReport": {
+    "x-mt": true
+  },
   "archiveReport": "Archiver",
   "beginningBalance": "Solde d'ouverture",
+  "@beginningBalance": {
+    "x-mt": true
+  },
   "sales": "Ventes",
   "otherIncome": "Autres revenus",
+  "@otherIncome": {
+    "x-mt": true
+  },
   "wages": "Salaires",
+  "@wages": {
+    "x-mt": true
+  },
   "otherExpenses": "Autres dépenses",
+  "@otherExpenses": {
+    "x-mt": true
+  },
   "totalIncome": "Revenu total",
+  "@totalIncome": {
+    "x-mt": true
+  },
   "totalExpenses": "Dépenses totales",
+  "@totalExpenses": {
+    "x-mt": true
+  },
   "profitLoss": "Bénéfice/perte",
+  "@profitLoss": {
+    "x-mt": true
+  },
   "endingBalance": "Solde final",
+  "@endingBalance": {
+    "x-mt": true
+  },
   "negativeBalance": "Le solde actuel est négatif !",
+  "@negativeBalance": {
+    "x-mt": true
+  },
   "reportDateDetails": "Rapport créé le : {created} | Mis à jour le : {updated}",
+  "@reportDateDetails": {
+    "x-mt": true
+  },
   "chatHistory": "Historique des discussions",
+  "@chatHistory": {
+    "x-mt": true
+  },
   "chat": "Discussion",
   "newChat": "Nouvelle discussion",
+  "@newChat": {
+    "x-mt": true
+  },
   "searchChats": "Rechercher des discussions",
+  "@searchChats": {
+    "x-mt": true
+  },
   "noChats": "Pas encore de chat",
+  "@noChats": {
+    "x-mt": true
+  },
   "noSearchResults": "Aucune discussion correspondante",
+  "@noSearchResults": {
+    "x-mt": true
+  },
   "untitledChat": "Discussion sans titre",
+  "@untitledChat": {
+    "x-mt": true
+  },
   "fullConversationResponse": "Réponse complète à la conversation",
+  "@fullConversationResponse": {
+    "x-mt": true
+  },
   "response": "Réponse",
+  "@response": {
+    "x-mt": true
+  },
   "chatConversation": "Conversation",
+  "@chatConversation": {
+    "x-mt": true
+  },
   "newConversation": "Nouvelle conversation",
+  "@newConversation": {
+    "x-mt": true
+  },
   "startConversation": "Démarrer une nouvelle conversation",
+  "@startConversation": {
+    "x-mt": true
+  },
   "typeMessage": "Tapez un message…",
+  "@typeMessage": {
+    "x-mt": true
+  },
   "selectAiProvider": "Sélectionnez le fournisseur d'IA",
+  "@selectAiProvider": {
+    "x-mt": true
+  },
   "aiProviders": "Fournisseurs d'IA",
+  "@aiProviders": {
+    "x-mt": true
+  },
   "aiProviderAvailable": "{name} (disponible)",
+  "@aiProviderAvailable": {
+    "x-mt": true
+  },
   "aiProviderUnavailable": "{name} (indisponible)",
+  "@aiProviderUnavailable": {
+    "x-mt": true
+  },
   "feedback": "Retour d\\'information",
   "feedbackNotFound": "Commentaires introuvables",
+  "@feedbackNotFound": {
+    "x-mt": true
+  },
   "feedbackSaved": "Commentaires enregistrés",
+  "@feedbackSaved": {
+    "x-mt": true
+  },
   "isUrgent": "Est-ce urgent ?",
+  "@isUrgent": {
+    "x-mt": true
+  },
   "feedbackType": "Type de commentaires",
+  "@feedbackType": {
+    "x-mt": true
+  },
   "feedbackTypeRequired": "Please select a feedback type",
+  "@feedbackTypeRequired": {
+    "x-mt": true
+  },
   "yourFeedback": "Vos commentaires",
+  "@yourFeedback": {
+    "x-mt": true
+  },
   "pleaseEnterFeedback": "Veuillez entrer vos commentaires",
+  "@pleaseEnterFeedback": {
+    "x-mt": true
+  },
   "question": "Question",
   "bug": "Bogue",
   "suggestion": "Suggestion",
   "priority": "Priorité",
   "openDate": "Date d'ouverture",
+  "@openDate": {
+    "x-mt": true
+  },
   "replies": "Réponses",
+  "@replies": {
+    "x-mt": true
+  },
   "pleaseEnterReply": "Veuillez saisir une réponse",
   "untitledFeedback": "Commentaires sans titre",
+  "@untitledFeedback": {
+    "x-mt": true
+  },
   "yes": "Oui",
   "no": "Non",
   "submit": "Soumettre",
   "takeTest": "Faire un test",
+  "@takeTest": {
+    "x-mt": true
+  },
   "recordSurvey": "Enquête record",
+  "@recordSurvey": {
+    "x-mt": true
+  },
   "react": "Réagir",
+  "@react": {
+    "x-mt": true
+  },
   "pickReaction": "Choisissez une réaction",
+  "@pickReaction": {
+    "x-mt": true
+  },
   "comments": "Commentaires",
+  "@comments": {
+    "x-mt": true
+  },
   "addComment": "Ajouter un commentaire",
+  "@addComment": {
+    "x-mt": true
+  },
   "commentsCount": "{count} commentaires",
+  "@commentsCount": {
+    "x-mt": true
+  },
   "noComments": "Pas encore de commentaires",
+  "@noComments": {
+    "x-mt": true
+  },
   "leaderboard": "Classement",
+  "@leaderboard": {
+    "x-mt": true
+  },
   "allTime": "Tout le temps",
+  "@allTime": {
+    "x-mt": true
+  },
   "thisMonth": "Ce mois-ci",
+  "@thisMonth": {
+    "x-mt": true
+  },
   "coursesCompleted": "{completed}/{total} cours",
+  "@coursesCompleted": {
+    "x-mt": true
+  },
   "surveysCompleted": "{completed}/{total} enquêtes",
+  "@surveysCompleted": {
+    "x-mt": true
+  },
   "error": "Erreur",
+  "@error": {
+    "x-mt": true
+  },
   "close": "Fermer",
   "filter": "Filtre",
   "type": "Type",
   "apply": "Appliquer",
+  "@apply": {
+    "x-mt": true
+  },
   "unavailable": "indisponible",
+  "@unavailable": {
+    "x-mt": true
+  },
   "chatsUnavailable": "Les discussions n'ont pas pu être chargées",
+  "@chatsUnavailable": {
+    "x-mt": true
+  },
   "community": "Communauté",
   "communityLeaders": "Dirigeants de communauté",
   "nationLeaders": "Dirigeants nationaux",
+  "@nationLeaders": {
+    "x-mt": true
+  },
   "ourVoices": "Nos voix",
+  "@ourVoices": {
+    "x-mt": true
+  },
   "finances": "Finances",
   "reports": "rapports",
   "transaction": "Transaction",
+  "@transaction": {
+    "x-mt": true
+  },
   "transactions": "Transactions",
+  "@transactions": {
+    "x-mt": true
+  },
   "addTransaction": "Ajouter une transaction",
   "noTransactions": "Aucune transaction pour l'instant",
+  "@noTransactions": {
+    "x-mt": true
+  },
   "debit": "Débit",
   "credit": "Crédit",
   "balance": "Solde",
   "amount": "Montant",
   "note": "Note",
+  "@note": {
+    "x-mt": true
+  },
   "date": "Date",
   "fromDate": "À partir du jour",
+  "@fromDate": {
+    "x-mt": true
+  },
   "toDate": "À ce jour",
+  "@toDate": {
+    "x-mt": true
+  },
   "reset": "Réinitialiser",
+  "@reset": {
+    "x-mt": true
+  },
   "noteRequired": "La note est requise",
   "amountRequired": "Le montant doit être supérieur à 0",
+  "@amountRequired": {
+    "x-mt": true
+  },
   "transactionAdded": "Transaction ajoutée",
   "addReceipt": "Ajouter un reçu",
+  "@addReceipt": {
+    "x-mt": true
+  },
   "receiptSelected": "Receipt selected",
+  "@receiptSelected": {
+    "x-mt": true
+  },
   "noReceipt": "Aucun reçu joint",
+  "@noReceipt": {
+    "x-mt": true
+  },
   "receipt": "Reçu",
+  "@receipt": {
+    "x-mt": true
+  },
   "viewReceipt": "Afficher le reçu",
+  "@viewReceipt": {
+    "x-mt": true
+  },
   "noLeadersAvailable": "Aucun dirigeant disponible",
+  "@noLeadersAvailable": {
+    "x-mt": true
+  },
   "noServicesAvailable": "Aucun service disponible",
+  "@noServicesAvailable": {
+    "x-mt": true
+  },
   "noDescriptionAvailable": "Aucune description disponible",
   "takeExam": "Passer l'examen",
+  "@takeExam": {
+    "x-mt": true
+  },
   "examLoadFailed": "L'examen n'a pas pu être chargé",
+  "@examLoadFailed": {
+    "x-mt": true
+  },
   "examHasNoQuestions": "Cet examen ne comporte pas de questions",
+  "@examHasNoQuestions": {
+    "x-mt": true
+  },
   "examComplete": "Examen terminé",
+  "@examComplete": {
+    "x-mt": true
+  },
   "examUnavailable": "L'examen n'est pas disponible",
+  "@examUnavailable": {
+    "x-mt": true
+  },
   "submitExam": "Soumettre l'examen",
+  "@submitExam": {
+    "x-mt": true
+  },
   "incorrectAnswer": "Réponse incorrecte",
+  "@incorrectAnswer": {
+    "x-mt": true
+  },
   "correctAnswers": "Correct",
+  "@correctAnswers": {
+    "x-mt": true
+  },
   "yourAnswer": "Votre Réponse",
+  "@yourAnswer": {
+    "x-mt": true
+  },
   "previous": "Précédent",
   "finish": "Terminer",
   "exitExam": "Examen de sortie ?",
+  "@exitExam": {
+    "x-mt": true
+  },
   "exitExamMessage": "Votre progression sera perdue.",
+  "@exitExamMessage": {
+    "x-mt": true
+  },
   "exit": "Quitter",
   "download": "Télécharger",
   "downloading": "Téléchargement…",
+  "@downloading": {
+    "x-mt": true
+  },
   "downloadFailed": "Le téléchargement a échoué.",
+  "@downloadFailed": {
+    "x-mt": true
+  },
   "resourceNotDownloaded": "Cette ressource n'est pas encore sur votre appareil.",
+  "@resourceNotDownloaded": {
+    "x-mt": true
+  },
   "retry": "Réessayer",
+  "@retry": {
+    "x-mt": true
+  },
   "fieldRequired": "Requis",
+  "@fieldRequired": {
+    "x-mt": true
+  },
   "examSubmitFailed": "Impossible d'enregistrer votre examen. Veuillez réessayer.",
+  "@examSubmitFailed": {
+    "x-mt": true
+  },
   "yourInformation": "Vos informations",
+  "@yourInformation": {
+    "x-mt": true
+  },
   "showAdditionalFields": "Afficher les champs supplémentaires",
+  "@showAdditionalFields": {
+    "x-mt": true
+  },
   "hideAdditionalFields": "Masquer les champs supplémentaires",
+  "@hideAdditionalFields": {
+    "x-mt": true
+  },
   "phoneNumber": "Numéro de téléphone",
+  "@phoneNumber": {
+    "x-mt": true
+  },
   "birthDate": "Date de naissance",
+  "@birthDate": {
+    "x-mt": true
+  },
   "selectDate": "Sélectionnez une date",
+  "@selectDate": {
+    "x-mt": true
+  },
   "male": "Mâle",
+  "@male": {
+    "x-mt": true
+  },
   "female": "Femelle",
+  "@female": {
+    "x-mt": true
+  },
   "yearOfBirth": "Année de naissance",
   "yearOfBirthRequired": "L'année de naissance est obligatoire",
+  "@yearOfBirthRequired": {
+    "x-mt": true
+  },
   "invalidYear": "Veuillez entrer une année valide",
+  "@invalidYear": {
+    "x-mt": true
+  },
   "yearBetween": "L'année doit être comprise entre {min} et {max}",
+  "@yearBetween": {
+    "x-mt": true
+  },
   "thankYouForTakingSurvey": "Merci d'avoir répondu à cette enquête",
+  "@thankYouForTakingSurvey": {
+    "x-mt": true
+  },
   "errorSavingProfile": "Erreur lors de l'enregistrement du profil",
+  "@errorSavingProfile": {
+    "x-mt": true
+  },
   "videoPlayer": "Lecteur vidéo",
+  "@videoPlayer": {
+    "x-mt": true
+  },
   "audioPlayer": "Lecteur audio",
+  "@audioPlayer": {
+    "x-mt": true
+  },
   "videoFileNotFound": "Fichier vidéo introuvable localement",
   "unableToLoadVideo": "Impossible de charger la vidéo",
   "audioFileNotFound": "Fichier audio introuvable localement",
@@ -577,68 +1900,227 @@
   "errorOccurred": "Erreur : {error}",
   "openingResource": "Ouverture : {title}",
   "loadingMedia": "Chargement...",
+  "@loadingMedia": {
+    "x-mt": true
+  },
   "resourceUnavailable": "Cette ressource n'est pas disponible pour une visualisation hors ligne",
+  "@resourceUnavailable": {
+    "x-mt": true
+  },
   "healthRecordNotAvailable": "Carnet de santé non disponible",
+  "@healthRecordNotAvailable": {
+    "x-mt": true
+  },
   "updateHealth": "Mettre à jour la santé",
+  "@updateHealth": {
+    "x-mt": true
+  },
   "addHealthRecord": "Ajouter un dossier de santé",
+  "@addHealthRecord": {
+    "x-mt": true
+  },
   "healthProfile": "Profil de santé",
+  "@healthProfile": {
+    "x-mt": true
+  },
   "specialNeeds": "Besoins spéciaux",
+  "@specialNeeds": {
+    "x-mt": true
+  },
   "otherNeeds": "Autres besoins",
+  "@otherNeeds": {
+    "x-mt": true
+  },
   "emergencyContact": "Personne à contacter en cas d'urgence",
+  "@emergencyContact": {
+    "x-mt": true
+  },
   "contactNumber": "Numéro de contact",
+  "@contactNumber": {
+    "x-mt": true
+  },
   "vitalSigns": "Signes vitaux",
+  "@vitalSigns": {
+    "x-mt": true
+  },
   "temperature": "Température",
+  "@temperature": {
+    "x-mt": true
+  },
   "pulse": "Impulsion",
+  "@pulse": {
+    "x-mt": true
+  },
   "height": "Hauteur",
+  "@height": {
+    "x-mt": true
+  },
   "weight": "Poids",
+  "@weight": {
+    "x-mt": true
+  },
   "bloodPressure": "Pression artérielle",
+  "@bloodPressure": {
+    "x-mt": true
+  },
   "vision": "Vision",
   "hearing": "Audition",
   "examinationHistory": "Historique des examens",
+  "@examinationHistory": {
+    "x-mt": true
+  },
   "personalInformation": "Informations personnelles",
+  "@personalInformation": {
+    "x-mt": true
+  },
   "birthPlace": "Lieu de naissance",
+  "@birthPlace": {
+    "x-mt": true
+  },
   "contactName": "Nom du contact",
+  "@contactName": {
+    "x-mt": true
+  },
   "contactType": "Type de contact",
+  "@contactType": {
+    "x-mt": true
+  },
   "healthInformation": "Informations sur la santé",
+  "@healthInformation": {
+    "x-mt": true
+  },
   "requiredField": "Ce champ est obligatoire",
+  "@requiredField": {
+    "x-mt": true
+  },
   "healthSavedSuccessfully": "Données de santé enregistrées avec succès",
+  "@healthSavedSuccessfully": {
+    "x-mt": true
+  },
   "examinationDetails": "Détails de l'examen",
+  "@examinationDetails": {
+    "x-mt": true
+  },
   "allergies": "Allergies",
   "diagnosis": "Diagnostic",
   "medications": "Médicaments",
   "immunizations": "Vaccinations",
+  "@immunizations": {
+    "x-mt": true
+  },
   "treatments": "Traitements",
   "observations": "Observations",
+  "@observations": {
+    "x-mt": true
+  },
   "referrals": "Références",
   "labTests": "Tests de laboratoire",
+  "@labTests": {
+    "x-mt": true
+  },
   "xrays": "Radiographies",
   "conditions": "Conditions",
+  "@conditions": {
+    "x-mt": true
+  },
   "selfExamination": "Auto-examen",
+  "@selfExamination": {
+    "x-mt": true
+  },
   "healthRecordAdded": "Dossier de santé ajouté avec succès",
+  "@healthRecordAdded": {
+    "x-mt": true
+  },
   "selectHealthMember": "Sélectionner un membre",
+  "@selectHealthMember": {
+    "x-mt": true
+  },
   "newPatient": "Nouveau patient",
+  "@newPatient": {
+    "x-mt": true
+  },
   "sortJoinDateDesc": "Le plus récent en premier",
+  "@sortJoinDateDesc": {
+    "x-mt": true
+  },
   "sortJoinDateAsc": "Le plus ancien en premier",
+  "@sortJoinDateAsc": {
+    "x-mt": true
+  },
   "sortNameAsc": "Nom A à Z",
+  "@sortNameAsc": {
+    "x-mt": true
+  },
   "sortNameDesc": "Nom Z-A",
+  "@sortNameDesc": {
+    "x-mt": true
+  },
   "searchMembers": "Rechercher des membres",
+  "@searchMembers": {
+    "x-mt": true
+  },
   "dismiss": "Ignorer",
   "addMember": "Ajouter un membre",
   "invalidNumber": "Numéro invalide",
+  "@invalidNumber": {
+    "x-mt": true
+  },
   "tempRangeError": "La température doit être comprise entre 30 et 40",
+  "@tempRangeError": {
+    "x-mt": true
+  },
   "pulseRangeError": "Le pouls doit être compris entre 40 et 120",
+  "@pulseRangeError": {
+    "x-mt": true
+  },
   "heightRangeError": "La hauteur doit être comprise entre 1 et 250",
+  "@heightRangeError": {
+    "x-mt": true
+  },
   "weightRangeError": "Le poids doit être compris entre 1 et 150",
+  "@weightRangeError": {
+    "x-mt": true
+  },
   "bloodPressureFormatError": "La tension artérielle doit être systolique/diastolique",
+  "@bloodPressureFormatError": {
+    "x-mt": true
+  },
   "bloodPressureRangeError": "La tension artérielle doit être comprise entre 60/40 et 300/200",
+  "@bloodPressureRangeError": {
+    "x-mt": true
+  },
   "bloodPressureNotNumbers": "Systolique et diastolique doivent être des nombres",
+  "@bloodPressureNotNumbers": {
+    "x-mt": true
+  },
   "temp": "Température",
+  "@temp": {
+    "x-mt": true
+  },
   "bp": "PA",
+  "@bp": {
+    "x-mt": true
+  },
   "offlineMaps": "Cartes hors ligne",
+  "@offlineMaps": {
+    "x-mt": true
+  },
   "centerOnDefault": "Centrer sur l'emplacement par défaut",
+  "@centerOnDefault": {
+    "x-mt": true
+  },
   "storage": "Stockage",
+  "@storage": {
+    "x-mt": true
+  },
   "storageManagement": "Gestion du stockage",
+  "@storageManagement": {
+    "x-mt": true
+  },
   "storageTotalDownloaded": "Total téléchargé",
+  "@storageTotalDownloaded": {
+    "x-mt": true
+  },
   "storageVideos": "Vidéos",
   "storageAudio": "Audio",
   "storagePdfs": "PDFs",
@@ -646,16 +2128,34 @@
   "storageOther": "Autre",
   "fileCountOne": "1 fichier",
   "fileCountMany": "{count} fichiers",
+  "@fileCountMany": {
+    "x-mt": true
+  },
   "storageUnknownResource": "Ressource inconnue",
+  "@storageUnknownResource": {
+    "x-mt": true
+  },
   "areYouSure": "Êtes-vous sûr ?",
   "cancelAddingExamination": "Are you sure you want to cancel adding examination? The data will be lost.",
   "yesIWantToExit": "Yes, I want to exit.",
   "inactiveMessage": "User not activated, please contact administrator or manager to activate your account.",
   "submitFeedback": "Submit Feedback",
   "failedToDelete": "Échec de la suppression : {error}",
+  "@failedToDelete": {
+    "x-mt": true
+  },
   "storageDeleteSelectedConfirm": "Delete {count} selected items?",
+  "@storageDeleteSelectedConfirm": {
+    "x-mt": true
+  },
   "storageDeleteConfirm": "Supprimer tous les {category} fichiers ?",
+  "@storageDeleteConfirm": {
+    "x-mt": true
+  },
   "storageSelectedCount": "{count} selected",
+  "@storageSelectedCount": {
+    "x-mt": true
+  },
   "deleteSelected": "Supprimer la sélection",
   "deleteAll": "Tout supprimer",
   "selectAll": "Sélectionner tout",
@@ -665,63 +2165,171 @@
   "coursesSelected": "{count, plural, =1{1 sélectionné} other{{count} sélectionnés}}",
   "leaveCoursesConfirm": "{count, plural, =1{Voulez-vous vraiment supprimer ce cours ?} other{Voulez-vous vraiment supprimer ces cours ?}}",
   "noStorageUsed": "Aucun fichier téléchargé trouvé",
+  "@noStorageUsed": {
+    "x-mt": true
+  },
   "availableSpace": "Espace disponible",
+  "@availableSpace": {
+    "x-mt": true
+  },
   "freeUpSpace": "Libérer de l'espace",
+  "@freeUpSpace": {
+    "x-mt": true
+  },
   "freeUpSpaceConfirm": "Cela supprimera toutes les ressources téléchargées pour libérer de l'espace de stockage. Continuer?",
+  "@freeUpSpaceConfirm": {
+    "x-mt": true
+  },
   "storageFreedSummary": "Freed {bytes}. {count, plural, =0{No files removed} =1{1 file removed} other{{count} files removed}}.",
+  "@storageFreedSummary": {
+    "x-mt": true
+  },
   "freeUpSpaceFailed": "Impossible de libérer de l'espace : {error}",
+  "@freeUpSpaceFailed": {
+    "x-mt": true
+  },
   "enterUsername": "Entrez le nom d'utilisateur",
+  "@enterUsername": {
+    "x-mt": true
+  },
   "enterPassword": "Entrez le mot de passe",
+  "@enterPassword": {
+    "x-mt": true
+  },
   "retypePassword": "retaper le mot de passe",
+  "@retypePassword": {
+    "x-mt": true
+  },
   "becomeMember": "devenir membre",
   "toAccessThisFeatureBecomeAMember": "vous êtes actuellement un utilisateur invité. pour accéder à cette fonctionnalité, devenez membre.",
   "creatingMember": "Création d'un compte membre...",
+  "@creatingMember": {
+    "x-mt": true
+  },
   "passwordsDoNotMatch": "Les mots de passe ne correspondent pas",
   "pleaseSelectGender": "Veuillez sélectionner le genre",
   "pleaseEnterPassword": "Veuillez entrer un mot de passe",
   "usernameAlreadyExists": "Le nom d'utilisateur existe déjà",
+  "@usernameAlreadyExists": {
+    "x-mt": true
+  },
   "usernameCannotBeEmpty": "Le nom d\\'utilisateur ne peut pas être vide",
   "invalidUsername": "Nom d\\'utilisateur invalide",
   "usernameMustStartWithLetterOrNumber": "Doit commencer par une lettre ou un chiffre",
   "usernameOnlyLettersNumbers": "Seules les lettres a à z, les chiffres et \"_\", \".\", \"-\" sont autorisés",
+  "@usernameOnlyLettersNumbers": {
+    "x-mt": true
+  },
   "usernameTaken": "Nom d\\'utilisateur déjà pris",
   "memberCreatedOffline": "Compte membre créé hors ligne",
+  "@memberCreatedOffline": {
+    "x-mt": true
+  },
   "memberCreatedOnline": "Compte membre créé avec succès",
+  "@memberCreatedOnline": {
+    "x-mt": true
+  },
   "congratulations": "Félicitations! Défi terminé",
   "dailyVoices": "de 5 Voix quotidiennes",
   "voicesProgress": "{count} sur 5 voix quotidiennes",
+  "@voicesProgress": {
+    "x-mt": true
+  },
   "progressLabel": "Progrès : {percent} %",
+  "@progressLabel": {
+    "x-mt": true
+  },
   "courseNotStarted": "Cours : Non commencé",
+  "@courseNotStarted": {
+    "x-mt": true
+  },
   "syncCompletedChallenge": "Synchronisation terminée",
+  "@syncCompletedChallenge": {
+    "x-mt": true
+  },
   "rememberSync": "N\\'oubliez pas de synchroniser l\\'application mobile.",
   "challengeDialogTitle": "Défi quotidien",
+  "@challengeDialogTitle": {
+    "x-mt": true
+  },
   "start": "Commencer",
+  "@start": {
+    "x-mt": true
+  },
   "continuation": "Continuer",
+  "@continuation": {
+    "x-mt": true
+  },
   "plan": "Plan",
   "mission": "Mission et Services",
   "editPlan": "Modifier le plan",
   "teamPlan": "Quel est le projet de votre équipe ?",
+  "@teamPlan": {
+    "x-mt": true
+  },
   "entMission": "Quelle est la Mission de votre entreprise ?",
+  "@entMission": {
+    "x-mt": true
+  },
   "entServices": "Quels sont les services fournis par votre entreprise ?",
   "entRules": "Quelles sont les règles de votre entreprise ?",
   "noMissionDefined": "L\\'entreprise n\\'a pas de mission et de services.",
   "noPlanDefined": "Cette équipe n'a pas de plan défini.",
+  "@noPlanDefined": {
+    "x-mt": true
+  },
   "noDescriptionDefined": "Cette équipe n'a pas de description définie.",
+  "@noDescriptionDefined": {
+    "x-mt": true
+  },
   "enterpriseName": "Nom de l'entreprise",
+  "@enterpriseName": {
+    "x-mt": true
+  },
   "teamName": "Nom de l'équipe",
+  "@teamName": {
+    "x-mt": true
+  },
   "teamType": "Type d'équipe",
+  "@teamType": {
+    "x-mt": true
+  },
   "local": "Locale",
+  "@local": {
+    "x-mt": true
+  },
   "isPublic": "Public",
   "nameRequired": "Le nom est requis",
   "nameIsRequired": "Veuillez entrer un nom",
   "createdOn": "Créé le",
+  "@createdOn": {
+    "x-mt": true
+  },
   "courseDetails": "Détails du cours",
+  "@courseDetails": {
+    "x-mt": true
+  },
   "addedToCourse": "Ajouté à vos cours",
+  "@addedToCourse": {
+    "x-mt": true
+  },
   "removedFromCourse": "Supprimé de vos cours",
+  "@removedFromCourse": {
+    "x-mt": true
+  },
   "pleaseCompleteSurvey": "veuillez compléter le sondage pour terminer le cours",
   "takeCourse": "Suivre un cours",
+  "@takeCourse": {
+    "x-mt": true
+  },
   "teamCalendar": "Calendrier de l'équipe",
+  "@teamCalendar": {
+    "x-mt": true
+  },
   "noMeetupsOnDate": "Aucune rencontre à cette date",
+  "@noMeetupsOnDate": {
+    "x-mt": true
+  },
   "myProgress": "Ma progression",
   "progress": "Progrès",
   "orderByTitle": "Trier par titre",
@@ -731,42 +2339,129 @@
   "progressFilterInProgress": "En cours",
   "progressFilterCompleted": "Terminé",
   "stepProgress": "{current} étapes sur {max}",
+  "@stepProgress": {
+    "x-mt": true
+  },
   "noEnrolledCourses": "Vous n'êtes inscrit à aucun cours",
+  "@noEnrolledCourses": {
+    "x-mt": true
+  },
   "mistakes": "Erreurs",
   "step": "Étape",
+  "@step": {
+    "x-mt": true
+  },
   "untitledResourceTitle": "Ressource sans titre",
+  "@untitledResourceTitle": {
+    "x-mt": true
+  },
   "author": "Auteur",
+  "@author": {
+    "x-mt": true
+  },
   "publisher": "Éditeur",
   "license": "Licence",
+  "@license": {
+    "x-mt": true
+  },
   "addedBy": "Ajouté par",
+  "@addedBy": {
+    "x-mt": true
+  },
   "resourceInformation": "Informations sur les ressources",
+  "@resourceInformation": {
+    "x-mt": true
+  },
   "resourceFor": "Pour",
+  "@resourceFor": {
+    "x-mt": true
+  },
   "mediaType": "Type de média",
+  "@mediaType": {
+    "x-mt": true
+  },
   "resourceType": "Type de ressource",
+  "@resourceType": {
+    "x-mt": true
+  },
   "subject": "Sujet",
+  "@subject": {
+    "x-mt": true
+  },
   "year": "Année",
   "timesRated": "Temps évalués",
+  "@timesRated": {
+    "x-mt": true
+  },
   "addToMyLibrary": "Ajouter à ma bibliothèque",
+  "@addToMyLibrary": {
+    "x-mt": true
+  },
   "removeFromMyLibrary": "Supprimer de ma bibliothèque",
+  "@removeFromMyLibrary": {
+    "x-mt": true
+  },
   "addedToMyLibrary": "Ajouté à ma bibliothèque",
+  "@addedToMyLibrary": {
+    "x-mt": true
+  },
   "removedFromMyLibrary": "Supprimé de ma bibliothèque",
+  "@removedFromMyLibrary": {
+    "x-mt": true
+  },
   "myLibrary": "Ma bibliothèque",
+  "@myLibrary": {
+    "x-mt": true
+  },
   "allResources": "Toutes les ressources",
+  "@allResources": {
+    "x-mt": true
+  },
   "viewResource": "Afficher la ressource",
+  "@viewResource": {
+    "x-mt": true
+  },
   "view": "afficher",
   "linkNotAvailable": "Lien non disponible",
   "noRatings": "Aucune note pour l'instant",
+  "@noRatings": {
+    "x-mt": true
+  },
   "basedOnRatings": "based on {count, plural, =1{1 rating} other{{count} ratings}}",
+  "@basedOnRatings": {
+    "x-mt": true
+  },
   "rating": "Notation",
+  "@rating": {
+    "x-mt": true
+  },
   "operationFailed": "L'opération a échoué",
+  "@operationFailed": {
+    "x-mt": true
+  },
   "filterResources": "Filtrer les ressources",
+  "@filterResources": {
+    "x-mt": true
+  },
   "teamSurveys": "Enquêtes d\\'équipe",
   "adoptableSurveys": "Enquêtes disponibles à adopter",
+  "@adoptableSurveys": {
+    "x-mt": true
+  },
   "noAdoptableSurveys": "Aucune enquête disponible pour adopter",
+  "@noAdoptableSurveys": {
+    "x-mt": true
+  },
   "adoptSurvey": "Adopter le sondage",
   "surveyAdopted": "Enquête adoptée",
+  "@surveyAdopted": {
+    "x-mt": true
+  },
   "completedCourse": "cours terminé",
   "userNameWithLogins": "{name} ({logins})",
+  "@userNameWithLogins": {
+    "x-mt": true
+  },
   "remindMeLater": "Me rappeler plus tard",
   "remindLater": "Rappeler plus tard",
   "setReminder": "Définir un rappel",
@@ -774,7 +2469,13 @@
   "hours": "heures",
   "days": "Jours",
   "reminderSurveysToComplete": "Reminder: You have {count, plural, =1{1 survey} other{{count} surveys}} to complete",
+  "@reminderSurveysToComplete": {
+    "x-mt": true
+  },
   "myActivities": "Mes activités",
+  "@myActivities": {
+    "x-mt": true
+  },
   "chartLabel": "Nbre de connexions",
   "selectLanguage": "Sélectionner la langue",
   "english": "english",
@@ -784,27 +2485,78 @@
   "arabic": "عربى",
   "french": "français",
   "activitySummary": "Activité",
+  "@activitySummary": {
+    "x-mt": true
+  },
   "lastLogin": "Dernière connexion",
+  "@lastLogin": {
+    "x-mt": true
+  },
   "memberDetail": "Détail du membre",
+  "@memberDetail": {
+    "x-mt": true
+  },
   "numberOfVisits": "Nombre de visites",
+  "@numberOfVisits": {
+    "x-mt": true
+  },
   "noLogoutRecord": "Aucun enregistrement de déconnexion trouvé",
+  "@noLogoutRecord": {
+    "x-mt": true
+  },
   "totalVisits": "Visites totales",
+  "@totalVisits": {
+    "x-mt": true
+  },
   "mostOpenedResource": "Ressource la plus ouverte",
+  "@mostOpenedResource": {
+    "x-mt": true
+  },
   "numberOfResourcesOpened": "Nombre de ressources ouvertes",
+  "@numberOfResourcesOpened": {
+    "x-mt": true
+  },
   "resourceOpenedTimes": "{title} ouvert {count} fois",
+  "@resourceOpenedTimes": {
+    "x-mt": true
+  },
   "resourcesOpenedTimes": "{count, plural, =1{Resource opened 1 time} other{Resource opened {count} times}}",
+  "@resourcesOpenedTimes": {
+    "x-mt": true
+  },
   "serverReachable": "Server reachable",
+  "@serverReachable": {
+    "x-mt": true
+  },
   "serverUnreachable": "Serveur inaccessible",
+  "@serverUnreachable": {
+    "x-mt": true
+  },
   "serverChecking": "Vérification du serveur",
+  "@serverChecking": {
+    "x-mt": true
+  },
   "gridView": "Vue en grille",
   "listView": "Vue en liste",
   "disclaimer": "Avis de non-responsabilité",
   "aboutContent": "### MaPlanète\n\nmyPlanet est un outil d'apprentissage conçu pour fonctionner avec l'application Web Planet. Il a été utilisé pour améliorer l’éducation préscolaire, les écoles secondaires, la santé des villages, le développement de la main-d’œuvre des jeunes et le développement économique et communautaire.\n\nPlanet Houses est un référentiel de ressources gratuites, en libre accès et du domaine public, au profit de tous les apprenants.\n\nmyPlanet est conçu pour être accessible à tous, partout et à tout moment. Il est portable, abordable, évolutif et durable. Il fonctionne sur n'importe quel appareil Android tel que les tablettes et les téléphones mobiles. Il fonctionne aussi bien sur Internet que sur Internet.\n\nCette application permet aux écoles et aux communautés de disposer d'une bibliothèque multimédia complète et d'un système d'apprentissage qui se connecte périodiquement à Planet. Les appareils configurés peuvent contenir le tableau de bord personnel des apprenants. Cela garantit que les apprenants peuvent lire des livres sur leur étagère et suivre des cours hors ligne, c'est-à-dire sans connexion à un serveur central. Les apprenants sont encouragés à noter entre une et cinq étoiles les ressources qu'ils utilisent et les cours qu'ils suivent. Périodiquement, les apprenants peuvent se synchroniser avec un serveur. Les données d'activité sont téléchargées et les nouvelles ressources sont téléchargées en quelques minutes sur myPlanet pour une utilisation hors ligne.\n\nLe tableau de bord contient également un enregistrement des réalisations, un calendrier des événements et un système de discussion interne pour communiquer avec les autres membres.\n\nmyPlanet s'est révélé très efficace pour améliorer les opportunités d'apprentissage pour plus de cinquante mille apprenants dans plus de 100 sites, dans des écoles du Népal, du Ghana, du Kenya et du Rwanda, auprès de réfugiés syriens en Jordanie, de réfugiés somaliens au Kenya et d'agents de santé villageois en Ouganda.",
+  "@aboutContent": {
+    "x-mt": true
+  },
   "disclaimerContent": "# Disclaimer\n\nLast updated: January 10, 2020\n\n# Interpretation and Definitions\n\n## Interpretation\n\nThe words of which the initial letter is capitalized have meanings defined under the following conditions.\n\nThe following definitions shall have the same meaning regardless of whether they appear in singular or in plural.\n\n## Definitions\n\nFor the purposes of this Disclaimer:\n\n- **Company** (referred to as either \"the Company\", \"We\", \"Us\" or \"Our\" in this Cookies Policy) refers to myPlanet.\n- **You** means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.\n- **Application** means the software program provided by the Company downloaded by You on any electronic device named myPlanet.\n- **Service** refers to the Application.\n\n# Disclaimer\n\nThe information contained on the Service is for general information purposes only.\n\nThe Company assumes no responsibility for errors or omissions in the contents of the Service.\n\nIn no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice.\n\nThe Company does not warrant that the Service is free of viruses or other harmful components.\n\n# Medical Information Disclaimer\n\nThe information about health provided by the Service is not intended to diagnose, treat, cure or prevent disease. Products, services, information, and other content provided by the Service, including information linking to third-party websites are provided for informational purposes only.\n\nInformation offered by the Service is not comprehensive and does not cover all diseases, ailments, physical conditions or their treatment.\n\nIndividuals are different and may react differently to different products. Comments made on the Service by employees or other users are strictly their own personal views made in their own personal capacity and are not claims made by the Company nor do they represent the position or view of the Company.\n\nThe Company is not liable for any information provided by the Service with regard to recommendations regarding supplements for any health purposes.\n\nThe Company makes no guarantee or warranty with respect to any products or services sold. The Company is not responsible for any damages for information or services provided even if the Company has been advised of the possibility of damages.\n\n# External Links Disclaimer\n\nThe Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.\n\nPlease note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.\n\n# Errors and Omissions Disclaimer\n\nThe information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to ensure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules, and regulations, there may be delays, omissions, or inaccuracies in the information contained on the Service.\n\nThe Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.\n\n# Fair Use Disclaimer\n\nThe Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.\n\nThe Company believes this constitutes a \"fair use\" of any such copyrighted material as provided for in section 107 of the United States Copyright law.\n\nIf You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.\n\n# Views Expressed Disclaimer\n\nThe Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer, or company, including the Company.\n\nComments published by users are their sole responsibility and the users will take full responsibility, liability, and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.\n\n# No Responsibility Disclaimer\n\nThe information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal, or other competent advisers.\n\nIn no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.\n\n# \"Use at Your Own Risk\" Disclaimer\n\nAll information in the Service is provided \"as is\", with no guarantee of completeness, accuracy, timeliness, or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability, and fitness for a particular purpose.\n\nThe Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special, or similar damages, even if advised of the possibility of such damages.\n\n## Contact Us\n\nIf you have any questions about this Disclaimer, You can contact Us:\n\n- By email: myplanet@ole.org\n- By visiting this page on our website: [https://ole.org/contact](https://ole.org/contact)",
+  "@disclaimerContent": {
+    "x-mt": true
+  },
   "shareWithCommunity": "Partager avec la communauté",
   "confirmShareCommunity": "Êtes-vous sûr de vouloir partager ce contenu avec la communauté ?",
   "voiceShared": "Post partagé avec la communauté",
+  "@voiceShared": {
+    "x-mt": true
+  },
   "voiceUnshared": "Supprimé de la communauté",
+  "@voiceUnshared": {
+    "x-mt": true
+  },
   "exportCsv": "Exporter CSV",
   "csvFileSavedSuccessfully": "fichier CSV enregistré avec succès.",
   "failedToSaveCsvFile": "échec de l'enregistrement du fichier CSV.",
@@ -843,6 +2595,9 @@
   "currentCv": "CV actuel : {name}",
   "update": "Mettre à jour",
   "fillRequiredFields": "Veuillez remplir les champs obligatoires : {fields}",
+  "@fillRequiredFields": {
+    "x-mt": true
+  },
   "@currentCv": {
     "placeholders": {
       "name": {
@@ -851,14 +2606,41 @@
     }
   },
   "textSize": "Taille du texte",
+  "@textSize": {
+    "x-mt": true
+  },
   "selectTextSize": "Sélectionnez la taille du texte",
+  "@selectTextSize": {
+    "x-mt": true
+  },
   "textSizeSmall": "Petit",
+  "@textSizeSmall": {
+    "x-mt": true
+  },
   "textSizeMedium": "Moyen",
+  "@textSizeMedium": {
+    "x-mt": true
+  },
   "textSizeLarge": "Grand",
+  "@textSizeLarge": {
+    "x-mt": true
+  },
   "resetApp": "Réinitialiser l'application",
+  "@resetApp": {
+    "x-mt": true
+  },
   "clearAllDataConfirm": "Êtes-vous sûr de vouloir effacer toutes les données ?",
+  "@clearAllDataConfirm": {
+    "x-mt": true
+  },
   "dataCleared": "Toutes les données effacées",
+  "@dataCleared": {
+    "x-mt": true
+  },
   "dataManagement": "Gestion des données",
+  "@dataManagement": {
+    "x-mt": true
+  },
   "resourceTitleAlreadyExists": "Une ressource avec ce titre existe déjà",
   "failedToUpdateResource": "Échec de la mise à jour de la ressource"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -2,80 +2,260 @@
   "@@locale": "ne",
   "appTitle": "myPlanet",
   "serverConfigurationTitle": "[Nepali] Connect to a Planet server",
+  "@serverConfigurationTitle": {
+    "x-mt": true
+  },
   "serverUrlLabel": "[Nepali] Server URL",
+  "@serverUrlLabel": {
+    "x-mt": true
+  },
   "serverUrlHint": "[Nepali] https://planet.example.org",
+  "@serverUrlHint": {
+    "x-mt": true
+  },
   "serverPinLabel": "[Nepali] Server PIN",
+  "@serverPinLabel": {
+    "x-mt": true
+  },
   "connect": "[Nepali] Connect",
+  "@connect": {
+    "x-mt": true
+  },
   "serverUrlNotConfigured": "सर्भर URL कन्फिगर गरिएको छैन",
   "deviceCouldNotReachLocalServer": "[Nepali] device couldn't reach the server. check if you are connected to the correct Wi-Fi network for the local server (community).",
+  "@deviceCouldNotReachLocalServer": {
+    "x-mt": true
+  },
   "deviceCouldNotReachNationServer": "डिभाइसले सर्भरसम्म पुग्न सकेन। इन्टरनेटमा जडित हुनुहुन्छ कि छैन जाँच गर्नुहोस् र पुन: प्रयास गर्नुहोस्।",
   "connectionFailed": "जडान असफल भयो!",
   "connectedToCommunity": "[Nepali] Connected to {code}",
+  "@connectedToCommunity": {
+    "x-mt": true
+  },
   "changeServer": "[Nepali] Change server",
+  "@changeServer": {
+    "x-mt": true
+  },
   "login": "लगइन",
   "name": "नाम",
   "password": "पासवर्ड",
   "signInOffline": "[Nepali] Sign in offline",
+  "@signInOffline": {
+    "x-mt": true
+  },
   "invalidCredentials": "[Nepali] Name or password is incorrect.",
+  "@invalidCredentials": {
+    "x-mt": true
+  },
   "userNotFound": "[Nepali] User not found.",
+  "@userNotFound": {
+    "x-mt": true
+  },
   "missingAuthData": "[Nepali] Server response missing authentication data.",
+  "@missingAuthData": {
+    "x-mt": true
+  },
   "serverError": "[Nepali] Server error. Please try again later.",
+  "@serverError": {
+    "x-mt": true
+  },
   "networkError": "[Nepali] Server not reachable. Check your internet connection.",
+  "@networkError": {
+    "x-mt": true
+  },
   "emptyCredentials": "[Nepali] Username and password are required.",
+  "@emptyCredentials": {
+    "x-mt": true
+  },
   "notAManager": "[Nepali] This account is not a manager.",
+  "@notAManager": {
+    "x-mt": true
+  },
   "savedAccounts": "[Nepali] Saved accounts",
+  "@savedAccounts": {
+    "x-mt": true
+  },
   "resources": "स्रोतहरू",
   "search": "खोज्नुहोस्",
   "sync": "[Nepali] Sync",
+  "@sync": {
+    "x-mt": true
+  },
   "cancel": "रद्द गर्नुहोस्",
   "settings": "सेटिङ्स",
   "backgroundSync": "[Nepali] Background sync",
+  "@backgroundSync": {
+    "x-mt": true
+  },
   "backgroundSyncDescription": "[Nepali] Send pending changes and refresh learning data while the app is closed",
+  "@backgroundSyncDescription": {
+    "x-mt": true
+  },
   "syncFrequency": "[Nepali] Sync frequency",
+  "@syncFrequency": {
+    "x-mt": true
+  },
   "every15Minutes": "[Nepali] Every 15 minutes",
+  "@every15Minutes": {
+    "x-mt": true
+  },
   "every30Minutes": "[Nepali] Every 30 minutes",
+  "@every30Minutes": {
+    "x-mt": true
+  },
   "everyHour": "[Nepali] Every hour",
+  "@everyHour": {
+    "x-mt": true
+  },
   "every6Hours": "[Nepali] Every 6 hours",
+  "@every6Hours": {
+    "x-mt": true
+  },
   "lastBackgroundRun": "[Nepali] Last background run",
+  "@lastBackgroundRun": {
+    "x-mt": true
+  },
   "backgroundNeverRun": "[Nepali] No background run has been recorded yet",
+  "@backgroundNeverRun": {
+    "x-mt": true
+  },
   "backgroundSucceeded": "[Nepali] Completed successfully",
+  "@backgroundSucceeded": {
+    "x-mt": true
+  },
   "backgroundRetryRequested": "[Nepali] Incomplete — Android will retry",
+  "@backgroundRetryRequested": {
+    "x-mt": true
+  },
   "backgroundSkipped": "[Nepali] Skipped",
+  "@backgroundSkipped": {
+    "x-mt": true
+  },
   "backgroundUnknown": "[Nepali] Unknown result",
+  "@backgroundUnknown": {
+    "x-mt": true
+  },
   "backgroundScheduleFailed": "[Nepali] The preference was saved, but Android could not update the schedule. It will be retried when the app restarts.",
+  "@backgroundScheduleFailed": {
+    "x-mt": true
+  },
   "backgroundFailedSteps": "[Nepali] Needs retry: {steps}",
+  "@backgroundFailedSteps": {
+    "x-mt": true
+  },
   "logOut": "[Nepali] Log out",
+  "@logOut": {
+    "x-mt": true
+  },
   "noDataAvailable": "कुनै डाटा उपलब्ध छैन",
   "ok": "ठिक छ",
   "home": "होम",
   "moreOptions": "[Nepali] More options",
+  "@moreOptions": {
+    "x-mt": true
+  },
   "appTheme": "[Nepali] App theme",
+  "@appTheme": {
+    "x-mt": true
+  },
   "aiChat": "[Nepali] AI chat",
+  "@aiChat": {
+    "x-mt": true
+  },
   "syncNow": "[Nepali] Sync now",
+  "@syncNow": {
+    "x-mt": true
+  },
   "syncCenter": "[Nepali] Sync center",
+  "@syncCenter": {
+    "x-mt": true
+  },
   "syncAll": "[Nepali] Sync all",
+  "@syncAll": {
+    "x-mt": true
+  },
   "syncing": "सिङ्क हुँदैछ…",
   "waiting": "[Nepali] Waiting",
+  "@waiting": {
+    "x-mt": true
+  },
   "events": "[Nepali] Events",
+  "@events": {
+    "x-mt": true
+  },
   "surveys": "सर्वेक्षणहरू",
   "syncReady": "[Nepali] Ready to sync",
+  "@syncReady": {
+    "x-mt": true
+  },
   "syncForegroundNotice": "[Nepali] Keep myPlanet open until the sync finishes. Pending offline writes remain durable if the connection drops.",
+  "@syncForegroundNotice": {
+    "x-mt": true
+  },
   "syncProgress": "[Nepali] Syncing {completed} of {total} areas",
+  "@syncProgress": {
+    "x-mt": true
+  },
   "syncAllSuccessful": "[Nepali] All {count} areas synced successfully",
+  "@syncAllSuccessful": {
+    "x-mt": true
+  },
   "syncCompletedWithFailures": "[Nepali] Sync finished: {success} succeeded, {failed} failed",
+  "@syncCompletedWithFailures": {
+    "x-mt": true
+  },
   "itemsSynced": "{count, plural, =0{Up to date} =1{1 item synced} other{{count} items synced}}",
+  "@itemsSynced": {
+    "x-mt": true
+  },
   "lastSyncTimestamp": "[Nepali] Last successful sync: {date}",
+  "@lastSyncTimestamp": {
+    "x-mt": true
+  },
   "syncResourcesDescription": "[Nepali] Refresh the offline learning library",
+  "@syncResourcesDescription": {
+    "x-mt": true
+  },
   "syncCoursesDescription": "[Nepali] Refresh courses, steps, and shelf membership",
+  "@syncCoursesDescription": {
+    "x-mt": true
+  },
   "syncTeamsDescription": "[Nepali] Refresh teams, memberships, and enterprise data",
+  "@syncTeamsDescription": {
+    "x-mt": true
+  },
   "syncEventsDescription": "[Nepali] Refresh meetups and attendance",
+  "@syncEventsDescription": {
+    "x-mt": true
+  },
   "syncSurveysDescription": "[Nepali] Refresh survey forms and assignments",
+  "@syncSurveysDescription": {
+    "x-mt": true
+  },
   "syncVoicesDescription": "[Nepali] Refresh community discussions and replies",
+  "@syncVoicesDescription": {
+    "x-mt": true
+  },
   "syncFeedbackDescription": "[Nepali] Refresh feedback threads and responses",
+  "@syncFeedbackDescription": {
+    "x-mt": true
+  },
   "syncChatDescription": "[Nepali] Refresh AI conversation history",
+  "@syncChatDescription": {
+    "x-mt": true
+  },
   "syncHealthDescription": "[Nepali] Refresh encrypted health records",
+  "@syncHealthDescription": {
+    "x-mt": true
+  },
   "syncActivitiesDescription": "[Nepali] Refresh login history from the server",
+  "@syncActivitiesDescription": {
+    "x-mt": true
+  },
   "syncNotificationsDescription": "[Nepali] Refresh server notifications and upload read states",
+  "@syncNotificationsDescription": {
+    "x-mt": true
+  },
   "homeMyLibrary": "मेरो पुस्तकालय",
   "homeMyCourses": "मेरो पाठ्यक्रमहरू",
   "homeMyTeams": "मेरो संघ",
@@ -89,101 +269,323 @@
   "subjectLabelSocialStudies": "सामाजिक अध्ययन",
   "subjectLabelTechnology": "प्रविधि",
   "surveysToComplete": "You have {count, plural, =1{1 survey} other{{count} surveys}} to complete",
+  "@surveysToComplete": {
+    "x-mt": true
+  },
   "lastSynced": "[Nepali] Last synced: {time}",
+  "@lastSynced": {
+    "x-mt": true
+  },
   "neverSynced": "कहिले पनि समक्रमित भएन",
   "justNow": "अहिले नै",
   "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@minutesAgo": {
+    "x-mt": true
+  },
   "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@hoursAgo": {
+    "x-mt": true
+  },
   "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@daysAgo": {
+    "x-mt": true
+  },
   "syncingResources": "[Nepali] Syncing resources… {completed} of {total}",
+  "@syncingResources": {
+    "x-mt": true
+  },
   "syncedResources": "{count, plural, =0{No resources synced} =1{1 resource synced} other{{count} resources synced}}",
+  "@syncedResources": {
+    "x-mt": true
+  },
   "syncFailed": "[Nepali] Sync failed: {message}",
+  "@syncFailed": {
+    "x-mt": true
+  },
   "availableOffline": "[Nepali] Available offline",
+  "@availableOffline": {
+    "x-mt": true
+  },
   "courses": "पाठ्यक्रमहरू",
   "myCourses": "[Nepali] My courses",
+  "@myCourses": {
+    "x-mt": true
+  },
   "allCourses": "[Nepali] All courses",
+  "@allCourses": {
+    "x-mt": true
+  },
   "courseSteps": "{count, plural, =0{No steps} =1{1 step} other{{count} steps}}",
+  "@courseSteps": {
+    "x-mt": true
+  },
   "stepNumber": "[Nepali] Step {number}",
+  "@stepNumber": {
+    "x-mt": true
+  },
   "resourcesInStep": "{count, plural, =0{No resources} =1{1 resource} other{{count} resources}}",
+  "@resourcesInStep": {
+    "x-mt": true
+  },
   "gradeLevel": "[Nepali] Grade level",
+  "@gradeLevel": {
+    "x-mt": true
+  },
   "subjectLevel": "[Nepali] Subject",
+  "@subjectLevel": {
+    "x-mt": true
+  },
   "allLevels": "सबै",
   "clearFilters": "[Nepali] Clear filters",
+  "@clearFilters": {
+    "x-mt": true
+  },
   "joinCourse": "[Nepali] Add to my courses",
+  "@joinCourse": {
+    "x-mt": true
+  },
   "leaveCourse": "[Nepali] Remove from my courses",
+  "@leaveCourse": {
+    "x-mt": true
+  },
   "syncedCourses": "{count, plural, =0{No courses synced} =1{1 course synced} other{{count} courses synced}}",
+  "@syncedCourses": {
+    "x-mt": true
+  },
   "courseNotFound": "[Nepali] Course not found",
+  "@courseNotFound": {
+    "x-mt": true
+  },
   "calendar": "पात्रो",
   "profile": "प्रोफाइल",
   "profileUnavailable": "[Nepali] Profile unavailable",
+  "@profileUnavailable": {
+    "x-mt": true
+  },
   "username": "[Nepali] Username",
+  "@username": {
+    "x-mt": true
+  },
   "email": "ईमेल",
   "phone": "[Nepali] Phone",
+  "@phone": {
+    "x-mt": true
+  },
   "level": "[Nepali] Level",
+  "@level": {
+    "x-mt": true
+  },
   "levels": "[Nepali] Levels",
+  "@levels": {
+    "x-mt": true
+  },
   "language": "भाषा",
   "languages": "भाषाहरू",
   "gender": "लिङ्ग",
   "dateOfBirth": "[Nepali] Date of birth",
+  "@dateOfBirth": {
+    "x-mt": true
+  },
   "planetCode": "[Nepali] Planet code",
+  "@planetCode": {
+    "x-mt": true
+  },
   "accountDetails": "[Nepali] Account details",
+  "@accountDetails": {
+    "x-mt": true
+  },
   "noProfileDetails": "[Nepali] No profile details are available.",
+  "@noProfileDetails": {
+    "x-mt": true
+  },
   "profilePhotoFor": "[Nepali] Profile photo for {name}",
+  "@profilePhotoFor": {
+    "x-mt": true
+  },
   "editProfile": "[Nepali] Edit profile",
+  "@editProfile": {
+    "x-mt": true
+  },
   "changePhoto": "[Nepali] Change profile photo",
+  "@changePhoto": {
+    "x-mt": true
+  },
   "photoUpdated": "[Nepali] Profile photo updated",
+  "@photoUpdated": {
+    "x-mt": true
+  },
   "photoUpdateFailed": "[Nepali] Could not save the photo",
+  "@photoUpdateFailed": {
+    "x-mt": true
+  },
   "firstName": "[Nepali] First name",
+  "@firstName": {
+    "x-mt": true
+  },
   "middleName": "[Nepali] Middle name",
+  "@middleName": {
+    "x-mt": true
+  },
   "lastName": "[Nepali] Last name",
+  "@lastName": {
+    "x-mt": true
+  },
   "save": "सुरक्षित गर्नुहोस्",
   "profileSaved": "[Nepali] Profile saved on this device",
+  "@profileSaved": {
+    "x-mt": true
+  },
   "invalidEmail": "[Nepali] Enter a valid email address",
+  "@invalidEmail": {
+    "x-mt": true
+  },
   "appearance": "[Nepali] Appearance",
+  "@appearance": {
+    "x-mt": true
+  },
   "systemTheme": "[Nepali] Use device theme",
+  "@systemTheme": {
+    "x-mt": true
+  },
   "lightTheme": "उज्यालो",
   "darkTheme": "अँध्यारो",
   "server": "[Nepali] Server",
+  "@server": {
+    "x-mt": true
+  },
   "serverUrl": "[Nepali] Server URL",
+  "@serverUrl": {
+    "x-mt": true
+  },
   "notConfigured": "[Nepali] Not configured",
+  "@notConfigured": {
+    "x-mt": true
+  },
   "communityCode": "[Nepali] Community code",
+  "@communityCode": {
+    "x-mt": true
+  },
   "about": "बारेमा",
   "offlineLearningApp": "[Nepali] Offline learning with Planet",
+  "@offlineLearningApp": {
+    "x-mt": true
+  },
   "appVersion": "[Nepali] Version {version}",
+  "@appVersion": {
+    "x-mt": true
+  },
   "buildNumber": "[Nepali] Build {number}",
+  "@buildNumber": {
+    "x-mt": true
+  },
   "learningTools": "[Nepali] Learning tools",
+  "@learningTools": {
+    "x-mt": true
+  },
   "dictionary": "शब्दकोश",
   "dictionaryDescription": "[Nepali] Search downloaded definitions offline",
+  "@dictionaryDescription": {
+    "x-mt": true
+  },
   "dictionaryUnavailable": "[Nepali] Dictionary unavailable",
+  "@dictionaryUnavailable": {
+    "x-mt": true
+  },
   "searchDictionary": "[Nepali] Search for a word",
+  "@searchDictionary": {
+    "x-mt": true
+  },
   "dictionaryWordCount": "{count, plural, =0{No downloaded words} =1{1 downloaded word} other{{count} downloaded words}}",
+  "@dictionaryWordCount": {
+    "x-mt": true
+  },
   "downloadDictionary": "[Nepali] Download dictionary",
+  "@downloadDictionary": {
+    "x-mt": true
+  },
   "retryDownload": "[Nepali] Retry download",
+  "@retryDownload": {
+    "x-mt": true
+  },
   "dictionaryDownloadFailed": "[Nepali] The dictionary could not be downloaded. Your existing offline data was not changed.",
+  "@dictionaryDownloadFailed": {
+    "x-mt": true
+  },
   "wordNotFound": "[Nepali] Word not available in the offline dictionary",
+  "@wordNotFound": {
+    "x-mt": true
+  },
   "meaning": "[Nepali] Meaning",
+  "@meaning": {
+    "x-mt": true
+  },
   "synonyms": "[Nepali] Synonyms",
+  "@synonyms": {
+    "x-mt": true
+  },
   "antonyms": "[Nepali] Antonyms",
+  "@antonyms": {
+    "x-mt": true
+  },
   "notifications": "[Nepali] Notifications",
+  "@notifications": {
+    "x-mt": true
+  },
   "notification": "[Nepali] Notification",
+  "@notification": {
+    "x-mt": true
+  },
   "notificationsUnavailable": "[Nepali] Notifications unavailable",
+  "@notificationsUnavailable": {
+    "x-mt": true
+  },
   "markAllRead": "[Nepali] Mark all read",
+  "@markAllRead": {
+    "x-mt": true
+  },
   "all": "सबै",
   "read": "[Nepali] Read",
+  "@read": {
+    "x-mt": true
+  },
   "unreadCount": "[Nepali] Unread ({count})",
+  "@unreadCount": {
+    "x-mt": true
+  },
   "noNotifications": "कुनै सूचना छैन",
   "noUnreadNotifications": "कुनै अपठित सूचना छैन",
   "noReadNotifications": "कुनै पठित सूचना छैन",
   "delete": "मेट्नुहोस्",
   "deleteNotification": "[Nepali] Delete notification?",
+  "@deleteNotification": {
+    "x-mt": true
+  },
   "deleteNotificationConfirmation": "[Nepali] This notification will be removed from this device.",
+  "@deleteNotificationConfirmation": {
+    "x-mt": true
+  },
   "taskNotification": "[Nepali] Task",
+  "@taskNotification": {
+    "x-mt": true
+  },
   "chatNotification": "च्याट",
   "replyNotification": "[Nepali] New reply",
+  "@replyNotification": {
+    "x-mt": true
+  },
   "resourceNotification": "स्रोतहरू",
   "storageNotification": "[Nepali] Storage warning",
+  "@storageNotification": {
+    "x-mt": true
+  },
   "joinRequestNotification": "[Nepali] Join request",
+  "@joinRequestNotification": {
+    "x-mt": true
+  },
   "teamNotification": "[Nepali] Team update",
+  "@teamNotification": {
+    "x-mt": true
+  },
   "tasks": "कार्यहरू",
   "notifGroupJoinRequests": "सामेल हुने अनुरोधहरू",
   "notifGroupTeamUpdates": "टिम अपडेटहरू",
@@ -192,83 +594,293 @@
   "notificationGroupSystem": "प्रणाली",
   "notificationGroupOther": "अन्य",
   "myLife": "[Nepali] My life",
+  "@myLife": {
+    "x-mt": true
+  },
   "myLifeUnavailable": "[Nepali] My life is unavailable",
+  "@myLifeUnavailable": {
+    "x-mt": true
+  },
   "noLifeItems": "[Nepali] No My life items",
+  "@noLifeItems": {
+    "x-mt": true
+  },
   "shownOnDashboard": "[Nepali] Shown",
+  "@shownOnDashboard": {
+    "x-mt": true
+  },
   "hiddenFromDashboard": "[Nepali] Hidden",
+  "@hiddenFromDashboard": {
+    "x-mt": true
+  },
   "hideItem": "[Nepali] Hide {title}",
+  "@hideItem": {
+    "x-mt": true
+  },
   "showItem": "[Nepali] Show {title}",
+  "@showItem": {
+    "x-mt": true
+  },
   "reorderItem": "[Nepali] Reorder {title}",
+  "@reorderItem": {
+    "x-mt": true
+  },
   "myHealth": "[Nepali] My health",
+  "@myHealth": {
+    "x-mt": true
+  },
   "achievements": "[Nepali] Achievements",
+  "@achievements": {
+    "x-mt": true
+  },
   "submissions": "[Nepali] Submissions",
+  "@submissions": {
+    "x-mt": true
+  },
   "submission": "[Nepali] Submission",
+  "@submission": {
+    "x-mt": true
+  },
   "submissionsUnavailable": "[Nepali] Submissions are unavailable",
+  "@submissionsUnavailable": {
+    "x-mt": true
+  },
   "noSubmissions": "[Nepali] No submissions yet",
+  "@noSubmissions": {
+    "x-mt": true
+  },
   "pending": "[Nepali] Pending",
+  "@pending": {
+    "x-mt": true
+  },
   "submissionGrade": "[Nepali] Grade: {grade}",
+  "@submissionGrade": {
+    "x-mt": true
+  },
   "refresh": "[Nepali] Refresh",
+  "@refresh": {
+    "x-mt": true
+  },
   "complete": "[Nepali] Complete",
+  "@complete": {
+    "x-mt": true
+  },
   "noMatchingSubmissions": "[Nepali] No submissions match this filter",
+  "@noMatchingSubmissions": {
+    "x-mt": true
+  },
   "submissionsSynced": "{count, plural, =0{Submissions are up to date} =1{1 submission synced} other{{count} submissions synced}}",
+  "@submissionsSynced": {
+    "x-mt": true
+  },
   "submissionDetails": "[Nepali] Submission details",
+  "@submissionDetails": {
+    "x-mt": true
+  },
   "submissionNotFound": "[Nepali] Submission not found",
+  "@submissionNotFound": {
+    "x-mt": true
+  },
   "unknown": "[Nepali] Unknown",
+  "@unknown": {
+    "x-mt": true
+  },
   "nA": "[Nepali] N/A",
+  "@nA": {
+    "x-mt": true
+  },
   "otherDiagnosis": "[Nepali] Other diagnosis",
+  "@otherDiagnosis": {
+    "x-mt": true
+  },
   "add": "[Nepali] Add",
+  "@add": {
+    "x-mt": true
+  },
   "status": "स्थिति",
   "lastUpdated": "[Nepali] Last updated",
+  "@lastUpdated": {
+    "x-mt": true
+  },
   "grade": "[Nepali] Grade",
+  "@grade": {
+    "x-mt": true
+  },
   "submittedBy": "पेश गर्ने:",
   "submissionType": "प्रकार",
   "uploadStatus": "[Nepali] Upload status",
+  "@uploadStatus": {
+    "x-mt": true
+  },
   "uploaded": "[Nepali] Uploaded",
+  "@uploaded": {
+    "x-mt": true
+  },
   "answers": "[Nepali] Answers",
+  "@answers": {
+    "x-mt": true
+  },
   "answersUnavailable": "[Nepali] Answers are unavailable",
+  "@answersUnavailable": {
+    "x-mt": true
+  },
   "noAnswers": "[Nepali] No answers were saved with this submission",
+  "@noAnswers": {
+    "x-mt": true
+  },
   "noAnswer": "[Nepali] No answer",
+  "@noAnswer": {
+    "x-mt": true
+  },
   "questionNumber": "[Nepali] Question {number}",
+  "@questionNumber": {
+    "x-mt": true
+  },
   "newSubmission": "[Nepali] New submission",
+  "@newSubmission": {
+    "x-mt": true
+  },
   "answer": "[Nepali] Answer",
+  "@answer": {
+    "x-mt": true
+  },
   "availableChoices": "[Nepali] Choices",
+  "@availableChoices": {
+    "x-mt": true
+  },
   "exportPdf": "[Nepali] Export PDF",
+  "@exportPdf": {
+    "x-mt": true
+  },
   "pdfExportFailed": "[Nepali] The PDF could not be created",
+  "@pdfExportFailed": {
+    "x-mt": true
+  },
   "pdfSaved": "[Nepali] PDF saved to {path}",
+  "@pdfSaved": {
+    "x-mt": true
+  },
   "mySurveys": "[Nepali] My surveys",
+  "@mySurveys": {
+    "x-mt": true
+  },
   "references": "सन्दर्भहरू",
   "myPersonals": "[Nepali] My personals",
+  "@myPersonals": {
+    "x-mt": true
+  },
   "featureComingSoon": "[Nepali] This feature is not ported yet",
+  "@featureComingSoon": {
+    "x-mt": true
+  },
   "maps": "नक्सा",
   "englishDictionary": "[Nepali] English dictionary",
+  "@englishDictionary": {
+    "x-mt": true
+  },
   "offlineMapsComingSoon": "[Nepali] Offline maps are not ported yet",
+  "@offlineMapsComingSoon": {
+    "x-mt": true
+  },
   "addPersonal": "[Nepali] Add personal item",
+  "@addPersonal": {
+    "x-mt": true
+  },
   "editPersonal": "[Nepali] Edit personal item",
+  "@editPersonal": {
+    "x-mt": true
+  },
   "deletePersonal": "[Nepali] Delete personal item?",
+  "@deletePersonal": {
+    "x-mt": true
+  },
   "deletePersonalConfirmation": "[Nepali] Delete “{title}” from this device?",
+  "@deletePersonalConfirmation": {
+    "x-mt": true
+  },
   "personalsUnavailable": "[Nepali] Personal items are unavailable",
+  "@personalsUnavailable": {
+    "x-mt": true
+  },
   "noPersonals": "[Nepali] No personal items yet. Add a private note to get started.",
+  "@noPersonals": {
+    "x-mt": true
+  },
   "duplicateTitle": "[Nepali] A personal item with this title already exists",
+  "@duplicateTitle": {
+    "x-mt": true
+  },
   "attachFile": "[Nepali] Attach file",
+  "@attachFile": {
+    "x-mt": true
+  },
   "attachedFile": "[Nepali] Attached: {name}",
+  "@attachedFile": {
+    "x-mt": true
+  },
   "noFileSelected": "No file selected",
+  "@noFileSelected": {
+    "x-mt": true
+  },
   "removeFile": "[Nepali] Remove file",
+  "@removeFile": {
+    "x-mt": true
+  },
   "savedOffline": "[Nepali] Saved offline — pending upload",
+  "@savedOffline": {
+    "x-mt": true
+  },
   "edit": "सम्पादन गर्नुहोस्",
   "title": "शीर्षक",
   "titleRequired": "[Nepali] Enter a title",
+  "@titleRequired": {
+    "x-mt": true
+  },
   "rateCourse": "[Nepali] Rate course",
+  "@rateCourse": {
+    "x-mt": true
+  },
   "rateTitle": "[Nepali] Rate {title}",
+  "@rateTitle": {
+    "x-mt": true
+  },
   "ratingsUnavailable": "[Nepali] Ratings are unavailable",
+  "@ratingsUnavailable": {
+    "x-mt": true
+  },
   "ratingSummary": "{average} from {count, plural, =1{1 rating} other{{count} ratings}}",
+  "@ratingSummary": {
+    "x-mt": true
+  },
   "ratingCompact": "[Nepali] {average} ({count})",
+  "@ratingCompact": {
+    "x-mt": true
+  },
   "ratingOutOfFive": "[Nepali] Rating: {rating} out of 5",
+  "@ratingOutOfFive": {
+    "x-mt": true
+  },
   "setRating": "[Nepali] Set rating to {rating}",
+  "@setRating": {
+    "x-mt": true
+  },
   "ratingRequired": "[Nepali] Choose a rating",
+  "@ratingRequired": {
+    "x-mt": true
+  },
   "commentOptional": "[Nepali] Comment (optional)",
+  "@commentOptional": {
+    "x-mt": true
+  },
   "submitRating": "[Nepali] Submit rating",
+  "@submitRating": {
+    "x-mt": true
+  },
   "skip": "छोड्नुहोस्",
   "next": "[Nepali] Next",
+  "@next": {
+    "x-mt": true
+  },
   "getStarted": "सुरु गर्नुहोस्",
   "welcomeToMyPlanet": "मेरो प्ल्यानेटमा स्वागत छ",
   "learnOffline": "अफलाइनमा सिक्नुहोस्",
@@ -276,292 +888,1003 @@
   "unleashLearningPower": "सिकाईको शक्ति उत्कृष्ट बनाउनुहोस्",
   "onboardingWelcomeDescription": "सीमित शिक्षा गर्ने गेटवे",
   "onboardingOfflineDescription": "[Nepali] Download resources for offline learning.\nAccess knowledge on the go.",
+  "@onboardingOfflineDescription": {
+    "x-mt": true
+  },
   "onboardingOpenDescription": "[Nepali] Choose your interests and dive into interactive content.\nCraft your unique learning journey.",
+  "@onboardingOpenDescription": {
+    "x-mt": true
+  },
   "onboardingPowerDescription": "[Nepali] Explore a world of knowledge at your fingertips.\n\n🌍 Offline Access: Learn without borders, anytime.\n🎯 Personalized: Tailor your learning path.\n📚 Interactive: Engage with videos, books, games.\n\nBegin your limitless learning journey with myPlanet!",
+  "@onboardingPowerDescription": {
+    "x-mt": true
+  },
   "onboardingServerPrepHint": "[Nepali] Before you sign in, you'll need your Planet server address and PIN. Ask your community administrator if you don't have them yet.",
+  "@onboardingServerPrepHint": {
+    "x-mt": true
+  },
   "pageProgress": "[Nepali] Page {current} of {total}",
+  "@pageProgress": {
+    "x-mt": true
+  },
   "meetups": "[Nepali] Meetups",
+  "@meetups": {
+    "x-mt": true
+  },
   "syncPendingMeetups": "[Nepali] Sync pending meetups",
+  "@syncPendingMeetups": {
+    "x-mt": true
+  },
   "meetupsUnavailable": "[Nepali] Meetups are unavailable",
+  "@meetupsUnavailable": {
+    "x-mt": true
+  },
   "noMeetups": "[Nepali] No meetups yet",
+  "@noMeetups": {
+    "x-mt": true
+  },
   "dateNotSet": "[Nepali] Date not set",
+  "@dateNotSet": {
+    "x-mt": true
+  },
   "untitledMeetup": "[Nepali] Untitled meetup",
+  "@untitledMeetup": {
+    "x-mt": true
+  },
   "addMeetup": "[Nepali] Add meetup",
+  "@addMeetup": {
+    "x-mt": true
+  },
   "meetupDetails": "[Nepali] Meetup details",
+  "@meetupDetails": {
+    "x-mt": true
+  },
   "meetupNotFound": "[Nepali] Meetup not found",
+  "@meetupNotFound": {
+    "x-mt": true
+  },
   "createdBy": "[Nepali] Created by",
+  "@createdBy": {
+    "x-mt": true
+  },
   "category": "[Nepali] Category",
+  "@category": {
+    "x-mt": true
+  },
   "location": "स्थान",
   "link": "लिङ्क",
   "recurring": "[Nepali] Recurring",
+  "@recurring": {
+    "x-mt": true
+  },
   "description": "[Nepali] Description",
+  "@description": {
+    "x-mt": true
+  },
   "leaveMeetup": "[Nepali] Leave meetup",
+  "@leaveMeetup": {
+    "x-mt": true
+  },
   "joinMeetup": "[Nepali] Join meetup",
+  "@joinMeetup": {
+    "x-mt": true
+  },
   "editMeetup": "[Nepali] Edit meetup",
+  "@editMeetup": {
+    "x-mt": true
+  },
   "startTime": "[Nepali] Start time",
+  "@startTime": {
+    "x-mt": true
+  },
   "endTime": "[Nepali] End time",
+  "@endTime": {
+    "x-mt": true
+  },
   "none": "कुनै पनि होइन",
   "daily": "दैनिक",
   "weekly": "साप्ताहिक",
   "syncMeetups": "[Nepali] Sync meetups",
+  "@syncMeetups": {
+    "x-mt": true
+  },
   "searchMeetups": "[Nepali] Search meetups",
+  "@searchMeetups": {
+    "x-mt": true
+  },
   "sortMeetups": "[Nepali] Sort meetups",
+  "@sortMeetups": {
+    "x-mt": true
+  },
   "sortResources": "[Nepali] Sort resources",
+  "@sortResources": {
+    "x-mt": true
+  },
   "newestFirst": "[Nepali] Newest first",
+  "@newestFirst": {
+    "x-mt": true
+  },
   "oldestFirst": "[Nepali] Oldest first",
+  "@oldestFirst": {
+    "x-mt": true
+  },
   "titleAscending": "[Nepali] Title A–Z",
+  "@titleAscending": {
+    "x-mt": true
+  },
   "titleDescending": "[Nepali] Title Z–A",
+  "@titleDescending": {
+    "x-mt": true
+  },
   "startDate": "[Nepali] Start date",
+  "@startDate": {
+    "x-mt": true
+  },
   "endDate": "[Nepali] End date",
+  "@endDate": {
+    "x-mt": true
+  },
   "timeNotSet": "[Nepali] Time not set",
+  "@timeNotSet": {
+    "x-mt": true
+  },
   "syncSurveys": "[Nepali] Sync surveys",
+  "@syncSurveys": {
+    "x-mt": true
+  },
   "searchSurveys": "[Nepali] Search surveys",
+  "@searchSurveys": {
+    "x-mt": true
+  },
   "sortSurveys": "[Nepali] Sort surveys",
+  "@sortSurveys": {
+    "x-mt": true
+  },
   "surveysUnavailable": "[Nepali] Surveys are unavailable",
+  "@surveysUnavailable": {
+    "x-mt": true
+  },
   "noSurveys": "[Nepali] No surveys available",
+  "@noSurveys": {
+    "x-mt": true
+  },
   "untitledSurvey": "[Nepali] Untitled survey",
+  "@untitledSurvey": {
+    "x-mt": true
+  },
   "takeSurvey": "[Nepali] Take survey",
+  "@takeSurvey": {
+    "x-mt": true
+  },
   "surveyLoadFailed": "[Nepali] Survey could not be loaded",
+  "@surveyLoadFailed": {
+    "x-mt": true
+  },
   "surveyHasNoQuestions": "[Nepali] This survey has no questions",
+  "@surveyHasNoQuestions": {
+    "x-mt": true
+  },
   "submitSurvey": "[Nepali] Submit survey",
+  "@submitSurvey": {
+    "x-mt": true
+  },
   "answerRequiredQuestions": "[Nepali] Answer all required questions",
+  "@answerRequiredQuestions": {
+    "x-mt": true
+  },
   "voices": "[Nepali] Voices",
+  "@voices": {
+    "x-mt": true
+  },
   "searchVoices": "[Nepali] Search voices",
+  "@searchVoices": {
+    "x-mt": true
+  },
   "syncVoices": "[Nepali] Sync voices",
+  "@syncVoices": {
+    "x-mt": true
+  },
   "noVoices": "[Nepali] No voices yet",
+  "@noVoices": {
+    "x-mt": true
+  },
   "voicesUnavailable": "[Nepali] Voices are unavailable",
+  "@voicesUnavailable": {
+    "x-mt": true
+  },
   "shareYourVoice": "[Nepali] Share your voice",
+  "@shareYourVoice": {
+    "x-mt": true
+  },
   "postVoice": "[Nepali] Post",
+  "@postVoice": {
+    "x-mt": true
+  },
   "replyToVoice": "उत्तर दिनुहोस्",
   "writeAReply": "[Nepali] Write a reply",
+  "@writeAReply": {
+    "x-mt": true
+  },
   "repliesCount": "{count, plural, =0{No replies} =1{1 reply} other{{count} replies}}",
+  "@repliesCount": {
+    "x-mt": true
+  },
   "edited": "[Nepali] Edited",
+  "@edited": {
+    "x-mt": true
+  },
   "editVoice": "सम्पादन गर्नुहोस्",
   "deleteVoice": "मेट्नुहोस्",
   "deleteVoiceConfirm": "[Nepali] Delete this post and all of its replies?",
+  "@deleteVoiceConfirm": {
+    "x-mt": true
+  },
   "voiceDeleted": "[Nepali] Post deleted",
+  "@voiceDeleted": {
+    "x-mt": true
+  },
   "emptyMessageNotAllowed": "[Nepali] Write something first",
+  "@emptyMessageNotAllowed": {
+    "x-mt": true
+  },
   "thread": "[Nepali] Thread",
+  "@thread": {
+    "x-mt": true
+  },
   "surveySubmitFailed": "[Nepali] Could not save your answers",
+  "@surveySubmitFailed": {
+    "x-mt": true
+  },
   "sendSurveyTo": "[Nepali] Select users to send survey to",
+  "@sendSurveyTo": {
+    "x-mt": true
+  },
   "sendSurvey": "[Nepali] Send survey",
+  "@sendSurvey": {
+    "x-mt": true
+  },
   "surveySentToUsers": "Survey sent to selected users",
+  "@surveySentToUsers": {
+    "x-mt": true
+  },
   "noUsersAvailable": "[Nepali] No users available",
+  "@noUsersAvailable": {
+    "x-mt": true
+  },
   "teams": "टटिमहरू",
   "syncTeams": "[Nepali] Sync teams",
+  "@syncTeams": {
+    "x-mt": true
+  },
   "searchTeams": "[Nepali] Search teams",
+  "@searchTeams": {
+    "x-mt": true
+  },
   "teamsUnavailable": "[Nepali] Teams are unavailable",
+  "@teamsUnavailable": {
+    "x-mt": true
+  },
   "noTeams": "[Nepali] No teams available",
+  "@noTeams": {
+    "x-mt": true
+  },
   "untitledTeam": "[Nepali] Untitled team",
+  "@untitledTeam": {
+    "x-mt": true
+  },
   "teamDetails": "[Nepali] Team details",
+  "@teamDetails": {
+    "x-mt": true
+  },
   "teamNotFound": "[Nepali] Team not found",
+  "@teamNotFound": {
+    "x-mt": true
+  },
   "publicTeam": "[Nepali] Public team",
+  "@publicTeam": {
+    "x-mt": true
+  },
   "privateTeam": "[Nepali] Private team",
+  "@privateTeam": {
+    "x-mt": true
+  },
   "enterprises": "उद्यमहरू",
   "searchEnterprises": "[Nepali] Search enterprises",
+  "@searchEnterprises": {
+    "x-mt": true
+  },
   "leader": "[Nepali] Leader",
+  "@leader": {
+    "x-mt": true
+  },
   "leave": "[Nepali] Leave",
+  "@leave": {
+    "x-mt": true
+  },
   "remove": "[Nepali] Remove",
+  "@remove": {
+    "x-mt": true
+  },
   "makeLeader": "[Nepali] Make leader",
+  "@makeLeader": {
+    "x-mt": true
+  },
   "leftTeam": "[Nepali] Left team",
+  "@leftTeam": {
+    "x-mt": true
+  },
   "memberRemoved": "[Nepali] Member removed",
+  "@memberRemoved": {
+    "x-mt": true
+  },
   "leaderUpdated": "[Nepali] Leader updated",
+  "@leaderUpdated": {
+    "x-mt": true
+  },
   "member": "[Nepali] Member",
+  "@member": {
+    "x-mt": true
+  },
   "teamLeader": "[Nepali] You lead this team",
+  "@teamLeader": {
+    "x-mt": true
+  },
   "teamMember": "[Nepali] You are a member",
+  "@teamMember": {
+    "x-mt": true
+  },
   "services": "सेवाहरू",
   "rules": "[Nepali] Rules",
+  "@rules": {
+    "x-mt": true
+  },
   "teamCourses": "[Nepali] Team courses",
+  "@teamCourses": {
+    "x-mt": true
+  },
   "membersCount": "{count, plural, =0{No members} =1{1 member} other{{count} members}}",
+  "@membersCount": {
+    "x-mt": true
+  },
   "teamTasks": "कार्यहरू",
   "tasksUnavailable": "[Nepali] Tasks are unavailable",
+  "@tasksUnavailable": {
+    "x-mt": true
+  },
   "noTeamTasks": "[Nepali] No tasks yet",
+  "@noTeamTasks": {
+    "x-mt": true
+  },
   "noDeadline": "[Nepali] No deadline",
+  "@noDeadline": {
+    "x-mt": true
+  },
   "untitledTask": "[Nepali] Untitled task",
+  "@untitledTask": {
+    "x-mt": true
+  },
   "addTask": "[Nepali] Add task",
+  "@addTask": {
+    "x-mt": true
+  },
   "editTask": "[Nepali] Edit task",
+  "@editTask": {
+    "x-mt": true
+  },
   "deleteTask": "[Nepali] Delete task",
+  "@deleteTask": {
+    "x-mt": true
+  },
   "taskTitle": "[Nepali] Task title",
+  "@taskTitle": {
+    "x-mt": true
+  },
   "assigneeId": "[Nepali] Assignee ID",
+  "@assigneeId": {
+    "x-mt": true
+  },
   "teamDiscussions": "[Nepali] Discussions",
+  "@teamDiscussions": {
+    "x-mt": true
+  },
   "teamMembers": "सदस्यहरू",
   "members": "सदस्यहरू",
   "joinRequests": "[Nepali] Join requests",
+  "@joinRequests": {
+    "x-mt": true
+  },
   "noMembers": "[Nepali] No members yet",
+  "@noMembers": {
+    "x-mt": true
+  },
   "membersUnavailable": "[Nepali] Members are unavailable",
+  "@membersUnavailable": {
+    "x-mt": true
+  },
   "unknownMember": "[Nepali] Unknown member",
+  "@unknownMember": {
+    "x-mt": true
+  },
   "noJoinRequests": "[Nepali] No pending requests",
+  "@noJoinRequests": {
+    "x-mt": true
+  },
   "accept": "स्वीकार गर्नुहोस्",
   "decline": "[Nepali] Decline",
+  "@decline": {
+    "x-mt": true
+  },
   "joinTeam": "सामेल हुनका लागि अनुरोध गर्नुहोस्",
   "leaveTeam": "[Nepali] Leave team",
+  "@leaveTeam": {
+    "x-mt": true
+  },
   "requestPending": "[Nepali] Request pending",
+  "@requestPending": {
+    "x-mt": true
+  },
   "teamResources": "स्रोतहरू",
   "resourcesUnavailable": "[Nepali] Resources are unavailable",
+  "@resourcesUnavailable": {
+    "x-mt": true
+  },
   "noTeamResources": "[Nepali] No resources linked to this team",
+  "@noTeamResources": {
+    "x-mt": true
+  },
   "untitledResource": "[Nepali] Untitled resource",
+  "@untitledResource": {
+    "x-mt": true
+  },
   "removeFromTeam": "[Nepali] Remove from team",
+  "@removeFromTeam": {
+    "x-mt": true
+  },
   "addResource": "[Nepali] Add resource",
+  "@addResource": {
+    "x-mt": true
+  },
   "editResource": "[Nepali] Edit resource",
+  "@editResource": {
+    "x-mt": true
+  },
   "resourceUpdated": "[Nepali] Resource updated",
+  "@resourceUpdated": {
+    "x-mt": true
+  },
   "resourceAddedToTeam": "[Nepali] Resource added to team",
+  "@resourceAddedToTeam": {
+    "x-mt": true
+  },
   "descriptionIsRequired": "[Nepali] Description is required",
+  "@descriptionIsRequired": {
+    "x-mt": true
+  },
   "levelIsRequired": "[Nepali] Level is required",
+  "@levelIsRequired": {
+    "x-mt": true
+  },
   "subjectIsRequired": "[Nepali] Subject is required",
+  "@subjectIsRequired": {
+    "x-mt": true
+  },
   "selectFile": "[Nepali] Select a file",
+  "@selectFile": {
+    "x-mt": true
+  },
   "fileSelected": "File selected",
+  "@fileSelected": {
+    "x-mt": true
+  },
   "privateResource": "[Nepali] Private resource",
+  "@privateResource": {
+    "x-mt": true
+  },
   "saveChanges": "[Nepali] Save changes",
+  "@saveChanges": {
+    "x-mt": true
+  },
   "selectOpenWith": "[Nepali] Select open with",
+  "@selectOpenWith": {
+    "x-mt": true
+  },
   "selectMedia": "[Nepali] Select media",
+  "@selectMedia": {
+    "x-mt": true
+  },
   "selectResourceType": "[Nepali] Select resource type",
+  "@selectResourceType": {
+    "x-mt": true
+  },
   "linkToLicense": "[Nepali] Link to license",
+  "@linkToLicense": {
+    "x-mt": true
+  },
   "noResourcesToAdd": "[Nepali] All available resources are already linked",
+  "@noResourcesToAdd": {
+    "x-mt": true
+  },
   "coursesUnavailable": "[Nepali] Courses are unavailable",
+  "@coursesUnavailable": {
+    "x-mt": true
+  },
   "noTeamCourses": "[Nepali] No courses linked to this team",
+  "@noTeamCourses": {
+    "x-mt": true
+  },
   "untitledCourse": "[Nepali] Untitled course",
+  "@untitledCourse": {
+    "x-mt": true
+  },
   "addCourse": "[Nepali] Add course",
+  "@addCourse": {
+    "x-mt": true
+  },
   "noCoursesToAdd": "[Nepali] All available courses are already linked",
+  "@noCoursesToAdd": {
+    "x-mt": true
+  },
   "financialReports": "[Nepali] Financial reports",
+  "@financialReports": {
+    "x-mt": true
+  },
   "reportsUnavailable": "[Nepali] Reports are unavailable",
+  "@reportsUnavailable": {
+    "x-mt": true
+  },
   "noReports": "[Nepali] No financial reports yet",
+  "@noReports": {
+    "x-mt": true
+  },
   "addReport": "[Nepali] Add report",
+  "@addReport": {
+    "x-mt": true
+  },
   "editReport": "[Nepali] Edit report",
+  "@editReport": {
+    "x-mt": true
+  },
   "archiveReport": "आर्काइभ",
   "beginningBalance": "[Nepali] Beginning balance",
+  "@beginningBalance": {
+    "x-mt": true
+  },
   "sales": "बिक्री",
   "otherIncome": "[Nepali] Other income",
+  "@otherIncome": {
+    "x-mt": true
+  },
   "wages": "[Nepali] Wages",
+  "@wages": {
+    "x-mt": true
+  },
   "otherExpenses": "[Nepali] Other expenses",
+  "@otherExpenses": {
+    "x-mt": true
+  },
   "totalIncome": "[Nepali] Total income",
+  "@totalIncome": {
+    "x-mt": true
+  },
   "totalExpenses": "[Nepali] Total expenses",
+  "@totalExpenses": {
+    "x-mt": true
+  },
   "profitLoss": "[Nepali] Profit / loss",
+  "@profitLoss": {
+    "x-mt": true
+  },
   "endingBalance": "[Nepali] Ending balance",
+  "@endingBalance": {
+    "x-mt": true
+  },
   "negativeBalance": "[Nepali] The current balance is negative!",
+  "@negativeBalance": {
+    "x-mt": true
+  },
   "reportDateDetails": "[Nepali] Report created on: {created} | Updated on: {updated}",
+  "@reportDateDetails": {
+    "x-mt": true
+  },
   "chatHistory": "[Nepali] Chat History",
+  "@chatHistory": {
+    "x-mt": true
+  },
   "chat": "च्याट",
   "newChat": "[Nepali] New chat",
+  "@newChat": {
+    "x-mt": true
+  },
   "searchChats": "[Nepali] Search chats",
+  "@searchChats": {
+    "x-mt": true
+  },
   "noChats": "[Nepali] No chats yet",
+  "@noChats": {
+    "x-mt": true
+  },
   "noSearchResults": "[Nepali] No matching chats",
+  "@noSearchResults": {
+    "x-mt": true
+  },
   "untitledChat": "[Nepali] Untitled chat",
+  "@untitledChat": {
+    "x-mt": true
+  },
   "fullConversationResponse": "[Nepali] Full conversation response",
+  "@fullConversationResponse": {
+    "x-mt": true
+  },
   "response": "[Nepali] Response",
+  "@response": {
+    "x-mt": true
+  },
   "chatConversation": "[Nepali] Conversation",
+  "@chatConversation": {
+    "x-mt": true
+  },
   "newConversation": "[Nepali] New conversation",
+  "@newConversation": {
+    "x-mt": true
+  },
   "startConversation": "[Nepali] Start a new conversation",
+  "@startConversation": {
+    "x-mt": true
+  },
   "typeMessage": "[Nepali] Type a message…",
+  "@typeMessage": {
+    "x-mt": true
+  },
   "selectAiProvider": "[Nepali] Select AI provider",
+  "@selectAiProvider": {
+    "x-mt": true
+  },
   "aiProviders": "[Nepali] AI providers",
+  "@aiProviders": {
+    "x-mt": true
+  },
   "aiProviderAvailable": "[Nepali] {name} (available)",
+  "@aiProviderAvailable": {
+    "x-mt": true
+  },
   "aiProviderUnavailable": "[Nepali] {name} (unavailable)",
+  "@aiProviderUnavailable": {
+    "x-mt": true
+  },
   "feedback": "प्रतिक्रिया",
   "feedbackNotFound": "[Nepali] Feedback not found",
+  "@feedbackNotFound": {
+    "x-mt": true
+  },
   "feedbackSaved": "[Nepali] Feedback saved",
+  "@feedbackSaved": {
+    "x-mt": true
+  },
   "isUrgent": "[Nepali] Is this urgent?",
+  "@isUrgent": {
+    "x-mt": true
+  },
   "feedbackType": "[Nepali] Feedback type",
+  "@feedbackType": {
+    "x-mt": true
+  },
   "feedbackTypeRequired": "Please select a feedback type",
+  "@feedbackTypeRequired": {
+    "x-mt": true
+  },
   "yourFeedback": "[Nepali] Your feedback",
+  "@yourFeedback": {
+    "x-mt": true
+  },
   "pleaseEnterFeedback": "[Nepali] Please enter your feedback",
+  "@pleaseEnterFeedback": {
+    "x-mt": true
+  },
   "question": "प्रश्न",
   "bug": "बग",
   "suggestion": "सुझाव",
   "priority": "प्राथमिकता",
   "openDate": "[Nepali] Open date",
+  "@openDate": {
+    "x-mt": true
+  },
   "replies": "[Nepali] Replies",
+  "@replies": {
+    "x-mt": true
+  },
   "pleaseEnterReply": "कृपया जवाफ टाइप गर्नुहोस्",
   "untitledFeedback": "[Nepali] Untitled feedback",
+  "@untitledFeedback": {
+    "x-mt": true
+  },
   "yes": "हो",
   "no": "होइन",
   "submit": "पेश गर्नुहोस्",
   "takeTest": "[Nepali] Take test",
+  "@takeTest": {
+    "x-mt": true
+  },
   "recordSurvey": "[Nepali] Record survey",
+  "@recordSurvey": {
+    "x-mt": true
+  },
   "react": "[Nepali] React",
+  "@react": {
+    "x-mt": true
+  },
   "pickReaction": "[Nepali] Pick a reaction",
+  "@pickReaction": {
+    "x-mt": true
+  },
   "comments": "[Nepali] Comments",
+  "@comments": {
+    "x-mt": true
+  },
   "addComment": "[Nepali] Add a comment",
+  "@addComment": {
+    "x-mt": true
+  },
   "commentsCount": "[Nepali] {count} comments",
+  "@commentsCount": {
+    "x-mt": true
+  },
   "noComments": "[Nepali] No comments yet",
+  "@noComments": {
+    "x-mt": true
+  },
   "leaderboard": "[Nepali] Leaderboard",
+  "@leaderboard": {
+    "x-mt": true
+  },
   "allTime": "[Nepali] All time",
+  "@allTime": {
+    "x-mt": true
+  },
   "thisMonth": "[Nepali] This month",
+  "@thisMonth": {
+    "x-mt": true
+  },
   "coursesCompleted": "[Nepali] {completed}/{total} courses",
+  "@coursesCompleted": {
+    "x-mt": true
+  },
   "surveysCompleted": "[Nepali] {completed}/{total} surveys",
+  "@surveysCompleted": {
+    "x-mt": true
+  },
   "error": "[Nepali] Error",
+  "@error": {
+    "x-mt": true
+  },
   "close": "बन्द गर्नुहोस्",
   "filter": "फिल्टर",
   "type": "प्रकार",
   "apply": "[Nepali] Apply",
+  "@apply": {
+    "x-mt": true
+  },
   "unavailable": "[Nepali] unavailable",
+  "@unavailable": {
+    "x-mt": true
+  },
   "chatsUnavailable": "[Nepali] Chats could not be loaded",
+  "@chatsUnavailable": {
+    "x-mt": true
+  },
   "community": "समुदाय",
   "communityLeaders": "सामुदायिक नेताहरू",
   "nationLeaders": "[Nepali] Nation Leaders",
+  "@nationLeaders": {
+    "x-mt": true
+  },
   "ourVoices": "[Nepali] Our Voices",
+  "@ourVoices": {
+    "x-mt": true
+  },
   "finances": "वित्त",
   "reports": "रिपोर्टहरू",
   "transaction": "[Nepali] Transaction",
+  "@transaction": {
+    "x-mt": true
+  },
   "transactions": "[Nepali] Transactions",
+  "@transactions": {
+    "x-mt": true
+  },
   "addTransaction": "लेखा थप्नुहोस्",
   "noTransactions": "[Nepali] No transactions yet",
+  "@noTransactions": {
+    "x-mt": true
+  },
   "debit": "नेलो",
   "credit": "श्रेय",
   "balance": "तल्लोधन",
   "amount": "रकम",
   "note": "[Nepali] Note",
+  "@note": {
+    "x-mt": true
+  },
   "date": "मिति",
   "fromDate": "[Nepali] From date",
+  "@fromDate": {
+    "x-mt": true
+  },
   "toDate": "[Nepali] To date",
+  "@toDate": {
+    "x-mt": true
+  },
   "reset": "[Nepali] Reset",
+  "@reset": {
+    "x-mt": true
+  },
   "noteRequired": "टिप्पणी आवश्यक छ",
   "amountRequired": "[Nepali] Amount must be greater than 0",
+  "@amountRequired": {
+    "x-mt": true
+  },
   "transactionAdded": "लेखा थपियो",
   "addReceipt": "[Nepali] Add receipt",
+  "@addReceipt": {
+    "x-mt": true
+  },
   "receiptSelected": "Receipt selected",
+  "@receiptSelected": {
+    "x-mt": true
+  },
   "noReceipt": "[Nepali] No receipt attached",
+  "@noReceipt": {
+    "x-mt": true
+  },
   "receipt": "[Nepali] Receipt",
+  "@receipt": {
+    "x-mt": true
+  },
   "viewReceipt": "[Nepali] View receipt",
+  "@viewReceipt": {
+    "x-mt": true
+  },
   "noLeadersAvailable": "[Nepali] No leaders available",
+  "@noLeadersAvailable": {
+    "x-mt": true
+  },
   "noServicesAvailable": "[Nepali] No services available",
+  "@noServicesAvailable": {
+    "x-mt": true
+  },
   "noDescriptionAvailable": "विवरण उपलब्ध छैन",
   "takeExam": "[Nepali] Take exam",
+  "@takeExam": {
+    "x-mt": true
+  },
   "examLoadFailed": "[Nepali] Exam could not be loaded",
+  "@examLoadFailed": {
+    "x-mt": true
+  },
   "examHasNoQuestions": "[Nepali] This exam has no questions",
+  "@examHasNoQuestions": {
+    "x-mt": true
+  },
   "examComplete": "[Nepali] Exam Complete",
+  "@examComplete": {
+    "x-mt": true
+  },
   "examUnavailable": "[Nepali] Exam is unavailable",
+  "@examUnavailable": {
+    "x-mt": true
+  },
   "submitExam": "[Nepali] Submit exam",
+  "@submitExam": {
+    "x-mt": true
+  },
   "incorrectAnswer": "[Nepali] Incorrect answer",
+  "@incorrectAnswer": {
+    "x-mt": true
+  },
   "correctAnswers": "[Nepali] Correct",
+  "@correctAnswers": {
+    "x-mt": true
+  },
   "yourAnswer": "[Nepali] Your answer",
+  "@yourAnswer": {
+    "x-mt": true
+  },
   "previous": "अघिल्लो",
   "finish": "समाप्त",
   "exitExam": "[Nepali] Exit exam?",
+  "@exitExam": {
+    "x-mt": true
+  },
   "exitExamMessage": "[Nepali] Your progress will be lost.",
+  "@exitExamMessage": {
+    "x-mt": true
+  },
   "exit": "बाहिर निस्कनुस्",
   "download": "डाउनलोड गर्नुहोस्",
   "downloading": "[Nepali] Downloading…",
+  "@downloading": {
+    "x-mt": true
+  },
   "downloadFailed": "[Nepali] Download failed.",
+  "@downloadFailed": {
+    "x-mt": true
+  },
   "resourceNotDownloaded": "[Nepali] This resource is not on your device yet.",
+  "@resourceNotDownloaded": {
+    "x-mt": true
+  },
   "retry": "[Nepali] Retry",
+  "@retry": {
+    "x-mt": true
+  },
   "fieldRequired": "[Nepali] Required",
+  "@fieldRequired": {
+    "x-mt": true
+  },
   "examSubmitFailed": "[Nepali] Could not save your exam. Please try again.",
+  "@examSubmitFailed": {
+    "x-mt": true
+  },
   "yourInformation": "[Nepali] Your information",
+  "@yourInformation": {
+    "x-mt": true
+  },
   "showAdditionalFields": "[Nepali] Show additional fields",
+  "@showAdditionalFields": {
+    "x-mt": true
+  },
   "hideAdditionalFields": "[Nepali] Hide additional fields",
+  "@hideAdditionalFields": {
+    "x-mt": true
+  },
   "phoneNumber": "[Nepali] Phone number",
+  "@phoneNumber": {
+    "x-mt": true
+  },
   "birthDate": "[Nepali] Birth date",
+  "@birthDate": {
+    "x-mt": true
+  },
   "selectDate": "[Nepali] Select date",
+  "@selectDate": {
+    "x-mt": true
+  },
   "male": "[Nepali] Male",
+  "@male": {
+    "x-mt": true
+  },
   "female": "[Nepali] Female",
+  "@female": {
+    "x-mt": true
+  },
   "yearOfBirth": "जन्म वर्ष",
   "yearOfBirthRequired": "[Nepali] Year of birth is required",
+  "@yearOfBirthRequired": {
+    "x-mt": true
+  },
   "invalidYear": "[Nepali] Please enter a valid year",
+  "@invalidYear": {
+    "x-mt": true
+  },
   "yearBetween": "[Nepali] Year must be between {min} and {max}",
+  "@yearBetween": {
+    "x-mt": true
+  },
   "thankYouForTakingSurvey": "[Nepali] Thank you for taking this survey",
+  "@thankYouForTakingSurvey": {
+    "x-mt": true
+  },
   "errorSavingProfile": "[Nepali] Error saving profile",
+  "@errorSavingProfile": {
+    "x-mt": true
+  },
   "videoPlayer": "[Nepali] Video player",
+  "@videoPlayer": {
+    "x-mt": true
+  },
   "audioPlayer": "[Nepali] Audio player",
+  "@audioPlayer": {
+    "x-mt": true
+  },
   "videoFileNotFound": "भिडियो फाइल स्थानीय रूपमा फेला परेन",
   "unableToLoadVideo": "भिडियो लोड गर्न असमर्थ",
   "audioFileNotFound": "अडियो फाइल स्थानीय रूपमा फेला परेन",
@@ -577,68 +1900,227 @@
   "errorOccurred": "त्रुटि: {error}",
   "openingResource": "खोल्दै: {title}",
   "loadingMedia": "[Nepali] Loading...",
+  "@loadingMedia": {
+    "x-mt": true
+  },
   "resourceUnavailable": "[Nepali] This resource is not available for offline viewing",
+  "@resourceUnavailable": {
+    "x-mt": true
+  },
   "healthRecordNotAvailable": "[Nepali] Health record not available",
+  "@healthRecordNotAvailable": {
+    "x-mt": true
+  },
   "updateHealth": "[Nepali] Update health",
+  "@updateHealth": {
+    "x-mt": true
+  },
   "addHealthRecord": "[Nepali] Add health record",
+  "@addHealthRecord": {
+    "x-mt": true
+  },
   "healthProfile": "[Nepali] Health profile",
+  "@healthProfile": {
+    "x-mt": true
+  },
   "specialNeeds": "[Nepali] Special needs",
+  "@specialNeeds": {
+    "x-mt": true
+  },
   "otherNeeds": "[Nepali] Other needs",
+  "@otherNeeds": {
+    "x-mt": true
+  },
   "emergencyContact": "[Nepali] Emergency contact",
+  "@emergencyContact": {
+    "x-mt": true
+  },
   "contactNumber": "[Nepali] Contact number",
+  "@contactNumber": {
+    "x-mt": true
+  },
   "vitalSigns": "[Nepali] Vital signs",
+  "@vitalSigns": {
+    "x-mt": true
+  },
   "temperature": "[Nepali] Temperature",
+  "@temperature": {
+    "x-mt": true
+  },
   "pulse": "[Nepali] Pulse",
+  "@pulse": {
+    "x-mt": true
+  },
   "height": "[Nepali] Height",
+  "@height": {
+    "x-mt": true
+  },
   "weight": "[Nepali] Weight",
+  "@weight": {
+    "x-mt": true
+  },
   "bloodPressure": "[Nepali] Blood pressure",
+  "@bloodPressure": {
+    "x-mt": true
+  },
   "vision": "दृष्टि",
   "hearing": "श्रवण",
   "examinationHistory": "[Nepali] Examination history",
+  "@examinationHistory": {
+    "x-mt": true
+  },
   "personalInformation": "[Nepali] Personal information",
+  "@personalInformation": {
+    "x-mt": true
+  },
   "birthPlace": "[Nepali] Birth place",
+  "@birthPlace": {
+    "x-mt": true
+  },
   "contactName": "[Nepali] Contact name",
+  "@contactName": {
+    "x-mt": true
+  },
   "contactType": "[Nepali] Contact type",
+  "@contactType": {
+    "x-mt": true
+  },
   "healthInformation": "[Nepali] Health information",
+  "@healthInformation": {
+    "x-mt": true
+  },
   "requiredField": "[Nepali] This field is required",
+  "@requiredField": {
+    "x-mt": true
+  },
   "healthSavedSuccessfully": "[Nepali] Health data saved successfully",
+  "@healthSavedSuccessfully": {
+    "x-mt": true
+  },
   "examinationDetails": "[Nepali] Examination details",
+  "@examinationDetails": {
+    "x-mt": true
+  },
   "allergies": "एलर्जीहरू",
   "diagnosis": "निदान",
   "medications": "औषधि",
   "immunizations": "[Nepali] Immunizations",
+  "@immunizations": {
+    "x-mt": true
+  },
   "treatments": "उपचारहरू",
   "observations": "[Nepali] Observations",
+  "@observations": {
+    "x-mt": true
+  },
   "referrals": "रेफरल",
   "labTests": "[Nepali] Lab tests",
+  "@labTests": {
+    "x-mt": true
+  },
   "xrays": "एक्सरे",
   "conditions": "[Nepali] Conditions",
+  "@conditions": {
+    "x-mt": true
+  },
   "selfExamination": "[Nepali] Self-examination",
+  "@selfExamination": {
+    "x-mt": true
+  },
   "healthRecordAdded": "[Nepali] Health record added successfully",
+  "@healthRecordAdded": {
+    "x-mt": true
+  },
   "selectHealthMember": "[Nepali] Select member",
+  "@selectHealthMember": {
+    "x-mt": true
+  },
   "newPatient": "[Nepali] New patient",
+  "@newPatient": {
+    "x-mt": true
+  },
   "sortJoinDateDesc": "[Nepali] Newest first",
+  "@sortJoinDateDesc": {
+    "x-mt": true
+  },
   "sortJoinDateAsc": "[Nepali] Oldest first",
+  "@sortJoinDateAsc": {
+    "x-mt": true
+  },
   "sortNameAsc": "[Nepali] Name A–Z",
+  "@sortNameAsc": {
+    "x-mt": true
+  },
   "sortNameDesc": "[Nepali] Name Z–A",
+  "@sortNameDesc": {
+    "x-mt": true
+  },
   "searchMembers": "[Nepali] Search members",
+  "@searchMembers": {
+    "x-mt": true
+  },
   "dismiss": "खारेज गर्नुहोस्",
   "addMember": "सदस्य थप्नुहोस्",
   "invalidNumber": "[Nepali] Invalid number",
+  "@invalidNumber": {
+    "x-mt": true
+  },
   "tempRangeError": "[Nepali] Temperature must be between 30 and 40",
+  "@tempRangeError": {
+    "x-mt": true
+  },
   "pulseRangeError": "[Nepali] Pulse must be between 40 and 120",
+  "@pulseRangeError": {
+    "x-mt": true
+  },
   "heightRangeError": "[Nepali] Height must be between 1 and 250",
+  "@heightRangeError": {
+    "x-mt": true
+  },
   "weightRangeError": "[Nepali] Weight must be between 1 and 150",
+  "@weightRangeError": {
+    "x-mt": true
+  },
   "bloodPressureFormatError": "[Nepali] Blood pressure should be systolic/diastolic",
+  "@bloodPressureFormatError": {
+    "x-mt": true
+  },
   "bloodPressureRangeError": "[Nepali] Blood pressure must be between 60/40 and 300/200",
+  "@bloodPressureRangeError": {
+    "x-mt": true
+  },
   "bloodPressureNotNumbers": "[Nepali] Systolic and diastolic must be numbers",
+  "@bloodPressureNotNumbers": {
+    "x-mt": true
+  },
   "temp": "[Nepali] Temp",
+  "@temp": {
+    "x-mt": true
+  },
   "bp": "[Nepali] BP",
+  "@bp": {
+    "x-mt": true
+  },
   "offlineMaps": "[Nepali] Offline Maps",
+  "@offlineMaps": {
+    "x-mt": true
+  },
   "centerOnDefault": "[Nepali] Center on default location",
+  "@centerOnDefault": {
+    "x-mt": true
+  },
   "storage": "[Nepali] Storage",
+  "@storage": {
+    "x-mt": true
+  },
   "storageManagement": "[Nepali] Storage Management",
+  "@storageManagement": {
+    "x-mt": true
+  },
   "storageTotalDownloaded": "[Nepali] Total Downloaded",
+  "@storageTotalDownloaded": {
+    "x-mt": true
+  },
   "storageVideos": "भिडियोहरू",
   "storageAudio": "अडियो",
   "storagePdfs": "PDF हरू",
@@ -646,16 +2128,34 @@
   "storageOther": "अन्य",
   "fileCountOne": "१ फाइल",
   "fileCountMany": "[Nepali] {count} files",
+  "@fileCountMany": {
+    "x-mt": true
+  },
   "storageUnknownResource": "[Nepali] Unknown resource",
+  "@storageUnknownResource": {
+    "x-mt": true
+  },
   "areYouSure": "के तपाईं निश्चित हुनुहुन्छ?",
   "cancelAddingExamination": "Are you sure you want to cancel adding examination? The data will be lost.",
   "yesIWantToExit": "Yes, I want to exit.",
   "inactiveMessage": "User not activated, please contact administrator or manager to activate your account.",
   "submitFeedback": "Submit Feedback",
   "failedToDelete": "[Nepali] Failed to delete: {error}",
+  "@failedToDelete": {
+    "x-mt": true
+  },
   "storageDeleteSelectedConfirm": "Delete {count} selected items?",
+  "@storageDeleteSelectedConfirm": {
+    "x-mt": true
+  },
   "storageDeleteConfirm": "[Nepali] Delete all {category} files?",
+  "@storageDeleteConfirm": {
+    "x-mt": true
+  },
   "storageSelectedCount": "{count} selected",
+  "@storageSelectedCount": {
+    "x-mt": true
+  },
   "deleteSelected": "छानिएका मेटाउनुहोस्",
   "deleteAll": "सबै मेटाउनुहोस्",
   "selectAll": "सबै चयन गर्नुहोस्",
@@ -665,63 +2165,171 @@
   "coursesSelected": "{count, plural, =1{१ चयन भयो} other{{count} चयन भए}}",
   "leaveCoursesConfirm": "{count, plural, =1{के तपाईं यो कोर्स हटाउन निश्चित हुनुहुन्छ?} other{के तपाईं यी कोर्सहरू हटाउन निश्चित हुनुहुन्छ?}}",
   "noStorageUsed": "[Nepali] No downloaded files found",
+  "@noStorageUsed": {
+    "x-mt": true
+  },
   "availableSpace": "[Nepali] Available space",
+  "@availableSpace": {
+    "x-mt": true
+  },
   "freeUpSpace": "[Nepali] Free up space",
+  "@freeUpSpace": {
+    "x-mt": true
+  },
   "freeUpSpaceConfirm": "[Nepali] This will delete all downloaded resources to free up storage space. Continue?",
+  "@freeUpSpaceConfirm": {
+    "x-mt": true
+  },
   "storageFreedSummary": "Freed {bytes}. {count, plural, =0{No files removed} =1{1 file removed} other{{count} files removed}}.",
+  "@storageFreedSummary": {
+    "x-mt": true
+  },
   "freeUpSpaceFailed": "[Nepali] Could not free up space: {error}",
+  "@freeUpSpaceFailed": {
+    "x-mt": true
+  },
   "enterUsername": "[Nepali] Enter username",
+  "@enterUsername": {
+    "x-mt": true
+  },
   "enterPassword": "[Nepali] Enter password",
+  "@enterPassword": {
+    "x-mt": true
+  },
   "retypePassword": "[Nepali] Retype password",
+  "@retypePassword": {
+    "x-mt": true
+  },
   "becomeMember": "सदस्य बन्नुहोस्",
   "toAccessThisFeatureBecomeAMember": "तपाईं हाल अतिथि प्रयोगकर्ता हुनुहुन्छ। यो सुविधा प्रयोग गर्न, सदस्य बन्नुहोस्।",
   "creatingMember": "[Nepali] Creating member account...",
+  "@creatingMember": {
+    "x-mt": true
+  },
   "passwordsDoNotMatch": "पासवर्डहरू मिलेनन्",
   "pleaseSelectGender": "कृपया लिङ्ग चयन गर्नुहोस्",
   "pleaseEnterPassword": "कृपया पासवर्ड लेख्नुहोस्",
   "usernameAlreadyExists": "[Nepali] Username already exists",
+  "@usernameAlreadyExists": {
+    "x-mt": true
+  },
   "usernameCannotBeEmpty": "प्रयोगकर्ता नाम खाली हुनसक्दैन",
   "invalidUsername": "अमान्य प्रयोगकर्ता नाम",
   "usernameMustStartWithLetterOrNumber": "पात्र वा नम्बरसँग सुरु गर्नु पर्दछ",
   "usernameOnlyLettersNumbers": "[Nepali] Only letters a-z, numbers and \"_\", \".\", \"-\" are allowed",
+  "@usernameOnlyLettersNumbers": {
+    "x-mt": true
+  },
   "usernameTaken": "प्रयोगकर्ता नाम पक्रिएको छ",
   "memberCreatedOffline": "[Nepali] Member account created offline",
+  "@memberCreatedOffline": {
+    "x-mt": true
+  },
   "memberCreatedOnline": "[Nepali] Member account created successfully",
+  "@memberCreatedOnline": {
+    "x-mt": true
+  },
   "congratulations": "बधाई छ! चुनौती पूरा भयो",
   "dailyVoices": "५ दैनिक आवाजहरू",
   "voicesProgress": "[Nepali] {count} of 5 Daily Voices",
+  "@voicesProgress": {
+    "x-mt": true
+  },
   "progressLabel": "[Nepali] Progress: {percent}%",
+  "@progressLabel": {
+    "x-mt": true
+  },
   "courseNotStarted": "[Nepali] Course: Not started",
+  "@courseNotStarted": {
+    "x-mt": true
+  },
   "syncCompletedChallenge": "[Nepali] Sync completed",
+  "@syncCompletedChallenge": {
+    "x-mt": true
+  },
   "rememberSync": "मोबाइल एप्लिकेसनलाई समक्रमण गर्न सम्झनुहोस्।",
   "challengeDialogTitle": "[Nepali] Daily Challenge",
+  "@challengeDialogTitle": {
+    "x-mt": true
+  },
   "start": "[Nepali] Start",
+  "@start": {
+    "x-mt": true
+  },
   "continuation": "[Nepali] Continue",
+  "@continuation": {
+    "x-mt": true
+  },
   "plan": "योजना",
   "mission": "मिशन र सेवाहरू",
   "editPlan": "योजना सम्पादन गर्नुहोस्",
   "teamPlan": "[Nepali] What is your team's plan?",
+  "@teamPlan": {
+    "x-mt": true
+  },
   "entMission": "[Nepali] What is your enterprise's Mission?",
+  "@entMission": {
+    "x-mt": true
+  },
   "entServices": "तपाईंको एन्टरप्राइजले के सेवाहरू प्रदान गर्दछ?",
   "entRules": "तपाईंको एन्टरप्राइजको नियमहरू के हुन्छन्?",
   "noMissionDefined": "एन्टरप्राइजमा मिशन र सेवाहरू छैनन्।",
   "noPlanDefined": "[Nepali] This team has no plan defined.",
+  "@noPlanDefined": {
+    "x-mt": true
+  },
   "noDescriptionDefined": "[Nepali] This team has no description defined.",
+  "@noDescriptionDefined": {
+    "x-mt": true
+  },
   "enterpriseName": "[Nepali] Enterprise name",
+  "@enterpriseName": {
+    "x-mt": true
+  },
   "teamName": "[Nepali] Team name",
+  "@teamName": {
+    "x-mt": true
+  },
   "teamType": "[Nepali] Team type",
+  "@teamType": {
+    "x-mt": true
+  },
   "local": "[Nepali] Local",
+  "@local": {
+    "x-mt": true
+  },
   "isPublic": "सार्वजनिक",
   "nameRequired": "नाम आवश्यक छ",
   "nameIsRequired": "कृपया नाम लेख्नुहोस्",
   "createdOn": "[Nepali] Created on",
+  "@createdOn": {
+    "x-mt": true
+  },
   "courseDetails": "[Nepali] Course Details",
+  "@courseDetails": {
+    "x-mt": true
+  },
   "addedToCourse": "[Nepali] Added to your courses",
+  "@addedToCourse": {
+    "x-mt": true
+  },
   "removedFromCourse": "[Nepali] Removed from your courses",
+  "@removedFromCourse": {
+    "x-mt": true
+  },
   "pleaseCompleteSurvey": "कृपया कोर्स समाप्त गर्न सर्वेक्षण पूरा गर्नुहोस्",
   "takeCourse": "[Nepali] Take Course",
+  "@takeCourse": {
+    "x-mt": true
+  },
   "teamCalendar": "[Nepali] Team Calendar",
+  "@teamCalendar": {
+    "x-mt": true
+  },
   "noMeetupsOnDate": "[Nepali] No meetups on this date",
+  "@noMeetupsOnDate": {
+    "x-mt": true
+  },
   "myProgress": "मेरो प्रगति",
   "progress": "प्रगति",
   "orderByTitle": "शीर्षक अनुसार आदेश गर्नुहोस्",
@@ -730,43 +2338,133 @@
   "progressFilterNotStarted": "सुरु भएको छैन",
   "progressFilterInProgress": "प्रगतिमा छ",
   "progressFilterCompleted": "[Nepali] Completed",
+  "@progressFilterCompleted": {
+    "x-mt": true
+  },
   "stepProgress": "[Nepali] {current} of {max} steps",
+  "@stepProgress": {
+    "x-mt": true
+  },
   "noEnrolledCourses": "[Nepali] You are not enrolled in any courses",
+  "@noEnrolledCourses": {
+    "x-mt": true
+  },
   "mistakes": "गल्तीहरू",
   "step": "[Nepali] Step",
+  "@step": {
+    "x-mt": true
+  },
   "untitledResourceTitle": "[Nepali] Untitled Resource",
+  "@untitledResourceTitle": {
+    "x-mt": true
+  },
   "author": "[Nepali] Author",
+  "@author": {
+    "x-mt": true
+  },
   "publisher": "प्रकाशक",
   "license": "[Nepali] License",
+  "@license": {
+    "x-mt": true
+  },
   "addedBy": "[Nepali] Added by",
+  "@addedBy": {
+    "x-mt": true
+  },
   "resourceInformation": "[Nepali] Resource Information",
+  "@resourceInformation": {
+    "x-mt": true
+  },
   "resourceFor": "[Nepali] For",
+  "@resourceFor": {
+    "x-mt": true
+  },
   "mediaType": "[Nepali] Media Type",
+  "@mediaType": {
+    "x-mt": true
+  },
   "resourceType": "[Nepali] Resource Type",
+  "@resourceType": {
+    "x-mt": true
+  },
   "subject": "[Nepali] Subject",
+  "@subject": {
+    "x-mt": true
+  },
   "year": "वर्ष",
   "timesRated": "[Nepali] Times Rated",
+  "@timesRated": {
+    "x-mt": true
+  },
   "addToMyLibrary": "[Nepali] Add to My Library",
+  "@addToMyLibrary": {
+    "x-mt": true
+  },
   "removeFromMyLibrary": "[Nepali] Remove from My Library",
+  "@removeFromMyLibrary": {
+    "x-mt": true
+  },
   "addedToMyLibrary": "[Nepali] Added to My Library",
+  "@addedToMyLibrary": {
+    "x-mt": true
+  },
   "removedFromMyLibrary": "[Nepali] Removed from My Library",
+  "@removedFromMyLibrary": {
+    "x-mt": true
+  },
   "myLibrary": "[Nepali] My Library",
+  "@myLibrary": {
+    "x-mt": true
+  },
   "allResources": "[Nepali] All Resources",
+  "@allResources": {
+    "x-mt": true
+  },
   "viewResource": "[Nepali] View Resource",
+  "@viewResource": {
+    "x-mt": true
+  },
   "view": "हेर्नु",
   "linkNotAvailable": "लिंक उपलब्ध छैन",
   "noRatings": "[Nepali] No ratings yet",
+  "@noRatings": {
+    "x-mt": true
+  },
   "basedOnRatings": "based on {count, plural, =1{1 rating} other{{count} ratings}}",
+  "@basedOnRatings": {
+    "x-mt": true
+  },
   "rating": "[Nepali] Rating",
+  "@rating": {
+    "x-mt": true
+  },
   "operationFailed": "[Nepali] Operation failed",
+  "@operationFailed": {
+    "x-mt": true
+  },
   "filterResources": "[Nepali] Filter Resources",
+  "@filterResources": {
+    "x-mt": true
+  },
   "teamSurveys": "टोली सर्वेक्षणहरू",
   "adoptableSurveys": "[Nepali] Surveys available to adopt",
+  "@adoptableSurveys": {
+    "x-mt": true
+  },
   "noAdoptableSurveys": "[Nepali] No surveys available to adopt",
+  "@noAdoptableSurveys": {
+    "x-mt": true
+  },
   "adoptSurvey": "सर्वेक्षण अपनाउनुहोस्",
   "surveyAdopted": "[Nepali] Survey adopted",
+  "@surveyAdopted": {
+    "x-mt": true
+  },
   "completedCourse": "समाप्त पाठ्यक्रम",
   "userNameWithLogins": "[Nepali] {name} ({logins})",
+  "@userNameWithLogins": {
+    "x-mt": true
+  },
   "remindMeLater": "Xasuusi hadhow",
   "remindLater": "Xasuusi hadhow",
   "setReminder": "Deji xasuusin",
@@ -774,7 +2472,13 @@
   "hours": "घण्टा",
   "days": "Maalmaha",
   "reminderSurveysToComplete": "Reminder: You have {count, plural, =1{1 survey} other{{count} surveys}} to complete",
+  "@reminderSurveysToComplete": {
+    "x-mt": true
+  },
   "myActivities": "[Nepali] My activities",
+  "@myActivities": {
+    "x-mt": true
+  },
   "chartLabel": "लगइनहरूको संख्या",
   "selectLanguage": "भाषा चयन गर्नुहोस्",
   "english": "english",
@@ -784,27 +2488,78 @@
   "arabic": "عربى",
   "french": "français",
   "activitySummary": "[Nepali] Activity",
+  "@activitySummary": {
+    "x-mt": true
+  },
   "lastLogin": "[Nepali] Last login",
+  "@lastLogin": {
+    "x-mt": true
+  },
   "memberDetail": "[Nepali] Member detail",
+  "@memberDetail": {
+    "x-mt": true
+  },
   "numberOfVisits": "[Nepali] Number of visits",
+  "@numberOfVisits": {
+    "x-mt": true
+  },
   "noLogoutRecord": "[Nepali] No logout record found",
+  "@noLogoutRecord": {
+    "x-mt": true
+  },
   "totalVisits": "[Nepali] Total visits",
+  "@totalVisits": {
+    "x-mt": true
+  },
   "mostOpenedResource": "[Nepali] Most opened resource",
+  "@mostOpenedResource": {
+    "x-mt": true
+  },
   "numberOfResourcesOpened": "[Nepali] Number of resources opened",
+  "@numberOfResourcesOpened": {
+    "x-mt": true
+  },
   "resourceOpenedTimes": "[Nepali] {title} opened {count} times",
+  "@resourceOpenedTimes": {
+    "x-mt": true
+  },
   "resourcesOpenedTimes": "{count, plural, =1{Resource opened 1 time} other{Resource opened {count} times}}",
+  "@resourcesOpenedTimes": {
+    "x-mt": true
+  },
   "serverReachable": "[Nepali] Server reachable",
+  "@serverReachable": {
+    "x-mt": true
+  },
   "serverUnreachable": "[Nepali] Server unreachable",
+  "@serverUnreachable": {
+    "x-mt": true
+  },
   "serverChecking": "[Nepali] Checking server",
+  "@serverChecking": {
+    "x-mt": true
+  },
   "gridView": "ग्रिड दृश्य",
   "listView": "सूची दृश्य",
   "disclaimer": "अस्वीकरण",
   "aboutContent": "[Nepali] ### MyPlanet\n\nmyPlanet is a learning tool that is designed to work with Planet web application. It has been used to improve early education, secondary schools, village health, youth workforce development, and economic and community development.\n\nPlanet houses is a repository of free, open access and public domain resources to benefit all learners.\n\nmyPlanet is designed to be available to everyone, everywhere, all the time. It is portable, affordable, scalable and sustainable. It runs on any android device such as tablets and mobile phones. It functions off, as well as on, the Internet.\n\nThis application enables schools and communities to have a complete multi-media library and learning system that periodically connects with Planet. Configured devices can contain the learners' personal dashboard. This ensures learners can read books on their shelf and take courses offline - i.e without connection to a central server. Learners are encouraged to rate from one to five stars the resources they use and the courses they take. Periodically learners can sync with a server. Activity data are uploaded and new resources are downloaded in a matter of a few minutes unto myPlanet for offline use.\n\nThe dashboard also contains a record of achievements, a calendar of events, and an internal chat system for communicating with fellow members.\n\nmyPlanet has been proven highly effective in improving learning opportunities for over fifty thousand learners in more than 100 locations, in schools throughout Nepal, Ghana, Kenya, and Rwanda, with Syrian refugees in Jordan, Somali refugees in Kenya, and village health workers in Uganda.",
+  "@aboutContent": {
+    "x-mt": true
+  },
   "disclaimerContent": "# Disclaimer\n\nLast updated: January 10, 2020\n\n# Interpretation and Definitions\n\n## Interpretation\n\nThe words of which the initial letter is capitalized have meanings defined under the following conditions.\n\nThe following definitions shall have the same meaning regardless of whether they appear in singular or in plural.\n\n## Definitions\n\nFor the purposes of this Disclaimer:\n\n- **Company** (referred to as either \"the Company\", \"We\", \"Us\" or \"Our\" in this Cookies Policy) refers to myPlanet.\n- **You** means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.\n- **Application** means the software program provided by the Company downloaded by You on any electronic device named myPlanet.\n- **Service** refers to the Application.\n\n# Disclaimer\n\nThe information contained on the Service is for general information purposes only.\n\nThe Company assumes no responsibility for errors or omissions in the contents of the Service.\n\nIn no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice.\n\nThe Company does not warrant that the Service is free of viruses or other harmful components.\n\n# Medical Information Disclaimer\n\nThe information about health provided by the Service is not intended to diagnose, treat, cure or prevent disease. Products, services, information, and other content provided by the Service, including information linking to third-party websites are provided for informational purposes only.\n\nInformation offered by the Service is not comprehensive and does not cover all diseases, ailments, physical conditions or their treatment.\n\nIndividuals are different and may react differently to different products. Comments made on the Service by employees or other users are strictly their own personal views made in their own personal capacity and are not claims made by the Company nor do they represent the position or view of the Company.\n\nThe Company is not liable for any information provided by the Service with regard to recommendations regarding supplements for any health purposes.\n\nThe Company makes no guarantee or warranty with respect to any products or services sold. The Company is not responsible for any damages for information or services provided even if the Company has been advised of the possibility of damages.\n\n# External Links Disclaimer\n\nThe Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.\n\nPlease note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.\n\n# Errors and Omissions Disclaimer\n\nThe information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to ensure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules, and regulations, there may be delays, omissions, or inaccuracies in the information contained on the Service.\n\nThe Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.\n\n# Fair Use Disclaimer\n\nThe Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.\n\nThe Company believes this constitutes a \"fair use\" of any such copyrighted material as provided for in section 107 of the United States Copyright law.\n\nIf You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.\n\n# Views Expressed Disclaimer\n\nThe Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer, or company, including the Company.\n\nComments published by users are their sole responsibility and the users will take full responsibility, liability, and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.\n\n# No Responsibility Disclaimer\n\nThe information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal, or other competent advisers.\n\nIn no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.\n\n# \"Use at Your Own Risk\" Disclaimer\n\nAll information in the Service is provided \"as is\", with no guarantee of completeness, accuracy, timeliness, or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability, and fitness for a particular purpose.\n\nThe Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special, or similar damages, even if advised of the possibility of such damages.\n\n## Contact Us\n\nIf you have any questions about this Disclaimer, You can contact Us:\n\n- By email: myplanet@ole.org\n- By visiting this page on our website: [https://ole.org/contact](https://ole.org/contact)",
+  "@disclaimerContent": {
+    "x-mt": true
+  },
   "shareWithCommunity": "समुदायसँग साझा गर्नुहोस्",
   "confirmShareCommunity": "के तपाईं यो सामग्री समुदायसँग साझा गर्न चाहनुहुन्छ?",
   "voiceShared": "[Nepali] Post shared with community",
+  "@voiceShared": {
+    "x-mt": true
+  },
   "voiceUnshared": "[Nepali] Removed from community",
+  "@voiceUnshared": {
+    "x-mt": true
+  },
   "exportCsv": "CSV निर्यात गर्नुहोस्",
   "csvFileSavedSuccessfully": "CSV फाइल सफलतापूर्वक सुरक्षित गरियो।",
   "failedToSaveCsvFile": "CSV फाइल सुरक्षित गर्न असफल।",
@@ -843,6 +2598,9 @@
   "currentCv": "हालको CV/रिज्युमे: {name}",
   "update": "अद्यावधिक गर्नुहोस्",
   "fillRequiredFields": "[Nepali] Please fill required fields: {fields}",
+  "@fillRequiredFields": {
+    "x-mt": true
+  },
   "@currentCv": {
     "placeholders": {
       "name": {
@@ -851,14 +2609,41 @@
     }
   },
   "textSize": "[Nepali] Text size",
+  "@textSize": {
+    "x-mt": true
+  },
   "selectTextSize": "[Nepali] Select text size",
+  "@selectTextSize": {
+    "x-mt": true
+  },
   "textSizeSmall": "[Nepali] Small",
+  "@textSizeSmall": {
+    "x-mt": true
+  },
   "textSizeMedium": "[Nepali] Medium",
+  "@textSizeMedium": {
+    "x-mt": true
+  },
   "textSizeLarge": "[Nepali] Large",
+  "@textSizeLarge": {
+    "x-mt": true
+  },
   "resetApp": "[Nepali] Reset app",
+  "@resetApp": {
+    "x-mt": true
+  },
   "clearAllDataConfirm": "[Nepali] Are you sure you want to clear all data?",
+  "@clearAllDataConfirm": {
+    "x-mt": true
+  },
   "dataCleared": "[Nepali] All data cleared",
+  "@dataCleared": {
+    "x-mt": true
+  },
   "dataManagement": "[Nepali] Data management",
+  "@dataManagement": {
+    "x-mt": true
+  },
   "resourceTitleAlreadyExists": "यस शीर्षकको स्रोत पहिले नै अवस्थित छ",
   "failedToUpdateResource": "स्रोत अद्यावधिक गर्न असफल भयो"
 }

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -2,80 +2,260 @@
   "@@locale": "so",
   "appTitle": "myPlanet",
   "serverConfigurationTitle": "[Somali] Connect to a Planet server",
+  "@serverConfigurationTitle": {
+    "x-mt": true
+  },
   "serverUrlLabel": "[Somali] Server URL",
+  "@serverUrlLabel": {
+    "x-mt": true
+  },
   "serverUrlHint": "[Somali] https://planet.example.org",
+  "@serverUrlHint": {
+    "x-mt": true
+  },
   "serverPinLabel": "[Somali] Server PIN",
+  "@serverPinLabel": {
+    "x-mt": true
+  },
   "connect": "[Somali] Connect",
+  "@connect": {
+    "x-mt": true
+  },
   "serverUrlNotConfigured": "URL-ka server-ka lama dejin",
   "deviceCouldNotReachLocalServer": "[Somali] device couldn't reach the server. check if you are connected to the correct Wi-Fi network for the local server (community).",
+  "@deviceCouldNotReachLocalServer": {
+    "x-mt": true
+  },
   "deviceCouldNotReachNationServer": "qalabku ma uusan gaari karin server-ka. hubi inaad ku xiran tahay internetka oo dib isku day.",
   "connectionFailed": "Xiriirku wuu fashilmay!",
   "connectedToCommunity": "[Somali] Connected to {code}",
+  "@connectedToCommunity": {
+    "x-mt": true
+  },
   "changeServer": "[Somali] Change server",
+  "@changeServer": {
+    "x-mt": true
+  },
   "login": "Giri",
   "name": "Magaca",
   "password": "Furaha Erayga Sirta",
   "signInOffline": "[Somali] Sign in offline",
+  "@signInOffline": {
+    "x-mt": true
+  },
   "invalidCredentials": "[Somali] Name or password is incorrect.",
+  "@invalidCredentials": {
+    "x-mt": true
+  },
   "userNotFound": "[Somali] User not found.",
+  "@userNotFound": {
+    "x-mt": true
+  },
   "missingAuthData": "[Somali] Server response missing authentication data.",
+  "@missingAuthData": {
+    "x-mt": true
+  },
   "serverError": "[Somali] Server error. Please try again later.",
+  "@serverError": {
+    "x-mt": true
+  },
   "networkError": "[Somali] Server not reachable. Check your internet connection.",
+  "@networkError": {
+    "x-mt": true
+  },
   "emptyCredentials": "[Somali] Username and password are required.",
+  "@emptyCredentials": {
+    "x-mt": true
+  },
   "notAManager": "[Somali] This account is not a manager.",
+  "@notAManager": {
+    "x-mt": true
+  },
   "savedAccounts": "[Somali] Saved accounts",
+  "@savedAccounts": {
+    "x-mt": true
+  },
   "resources": "Vifijo",
   "search": "Raadi",
   "sync": "[Somali] Sync",
+  "@sync": {
+    "x-mt": true
+  },
   "cancel": "burin",
   "settings": "Settings",
   "backgroundSync": "[Somali] Background sync",
+  "@backgroundSync": {
+    "x-mt": true
+  },
   "backgroundSyncDescription": "[Somali] Send pending changes and refresh learning data while the app is closed",
+  "@backgroundSyncDescription": {
+    "x-mt": true
+  },
   "syncFrequency": "[Somali] Sync frequency",
+  "@syncFrequency": {
+    "x-mt": true
+  },
   "every15Minutes": "[Somali] Every 15 minutes",
+  "@every15Minutes": {
+    "x-mt": true
+  },
   "every30Minutes": "[Somali] Every 30 minutes",
+  "@every30Minutes": {
+    "x-mt": true
+  },
   "everyHour": "[Somali] Every hour",
+  "@everyHour": {
+    "x-mt": true
+  },
   "every6Hours": "[Somali] Every 6 hours",
+  "@every6Hours": {
+    "x-mt": true
+  },
   "lastBackgroundRun": "[Somali] Last background run",
+  "@lastBackgroundRun": {
+    "x-mt": true
+  },
   "backgroundNeverRun": "[Somali] No background run has been recorded yet",
+  "@backgroundNeverRun": {
+    "x-mt": true
+  },
   "backgroundSucceeded": "[Somali] Completed successfully",
+  "@backgroundSucceeded": {
+    "x-mt": true
+  },
   "backgroundRetryRequested": "[Somali] Incomplete — Android will retry",
+  "@backgroundRetryRequested": {
+    "x-mt": true
+  },
   "backgroundSkipped": "[Somali] Skipped",
+  "@backgroundSkipped": {
+    "x-mt": true
+  },
   "backgroundUnknown": "[Somali] Unknown result",
+  "@backgroundUnknown": {
+    "x-mt": true
+  },
   "backgroundScheduleFailed": "[Somali] The preference was saved, but Android could not update the schedule. It will be retried when the app restarts.",
+  "@backgroundScheduleFailed": {
+    "x-mt": true
+  },
   "backgroundFailedSteps": "[Somali] Needs retry: {steps}",
+  "@backgroundFailedSteps": {
+    "x-mt": true
+  },
   "logOut": "[Somali] Log out",
+  "@logOut": {
+    "x-mt": true
+  },
   "noDataAvailable": "Wax macluumaad ah ayaa lama helin",
   "ok": "Sax",
   "home": "Guriga",
   "moreOptions": "[Somali] More options",
+  "@moreOptions": {
+    "x-mt": true
+  },
   "appTheme": "[Somali] App theme",
+  "@appTheme": {
+    "x-mt": true
+  },
   "aiChat": "[Somali] AI chat",
+  "@aiChat": {
+    "x-mt": true
+  },
   "syncNow": "[Somali] Sync now",
+  "@syncNow": {
+    "x-mt": true
+  },
   "syncCenter": "[Somali] Sync center",
+  "@syncCenter": {
+    "x-mt": true
+  },
   "syncAll": "[Somali] Sync all",
+  "@syncAll": {
+    "x-mt": true
+  },
   "syncing": "La waafajinayaa…",
   "waiting": "[Somali] Waiting",
+  "@waiting": {
+    "x-mt": true
+  },
   "events": "[Somali] Events",
+  "@events": {
+    "x-mt": true
+  },
   "surveys": "Sahaminta",
   "syncReady": "[Somali] Ready to sync",
+  "@syncReady": {
+    "x-mt": true
+  },
   "syncForegroundNotice": "[Somali] Keep myPlanet open until the sync finishes. Pending offline writes remain durable if the connection drops.",
+  "@syncForegroundNotice": {
+    "x-mt": true
+  },
   "syncProgress": "[Somali] Syncing {completed} of {total} areas",
+  "@syncProgress": {
+    "x-mt": true
+  },
   "syncAllSuccessful": "[Somali] All {count} areas synced successfully",
+  "@syncAllSuccessful": {
+    "x-mt": true
+  },
   "syncCompletedWithFailures": "[Somali] Sync finished: {success} succeeded, {failed} failed",
+  "@syncCompletedWithFailures": {
+    "x-mt": true
+  },
   "itemsSynced": "{count, plural, =0{Up to date} =1{1 item synced} other{{count} items synced}}",
+  "@itemsSynced": {
+    "x-mt": true
+  },
   "lastSyncTimestamp": "[Somali] Last successful sync: {date}",
+  "@lastSyncTimestamp": {
+    "x-mt": true
+  },
   "syncResourcesDescription": "[Somali] Refresh the offline learning library",
+  "@syncResourcesDescription": {
+    "x-mt": true
+  },
   "syncCoursesDescription": "[Somali] Refresh courses, steps, and shelf membership",
+  "@syncCoursesDescription": {
+    "x-mt": true
+  },
   "syncTeamsDescription": "[Somali] Refresh teams, memberships, and enterprise data",
+  "@syncTeamsDescription": {
+    "x-mt": true
+  },
   "syncEventsDescription": "[Somali] Refresh meetups and attendance",
+  "@syncEventsDescription": {
+    "x-mt": true
+  },
   "syncSurveysDescription": "[Somali] Refresh survey forms and assignments",
+  "@syncSurveysDescription": {
+    "x-mt": true
+  },
   "syncVoicesDescription": "[Somali] Refresh community discussions and replies",
+  "@syncVoicesDescription": {
+    "x-mt": true
+  },
   "syncFeedbackDescription": "[Somali] Refresh feedback threads and responses",
+  "@syncFeedbackDescription": {
+    "x-mt": true
+  },
   "syncChatDescription": "[Somali] Refresh AI conversation history",
+  "@syncChatDescription": {
+    "x-mt": true
+  },
   "syncHealthDescription": "[Somali] Refresh encrypted health records",
+  "@syncHealthDescription": {
+    "x-mt": true
+  },
   "syncActivitiesDescription": "[Somali] Refresh login history from the server",
+  "@syncActivitiesDescription": {
+    "x-mt": true
+  },
   "syncNotificationsDescription": "[Somali] Refresh server notifications and upload read states",
+  "@syncNotificationsDescription": {
+    "x-mt": true
+  },
   "homeMyLibrary": "maktabadayda",
   "homeMyCourses": "coursyadayda",
   "homeMyTeams": "kooxahayga",
@@ -89,101 +269,323 @@
   "subjectLabelSocialStudies": "Cilmiga Bulshada",
   "subjectLabelTechnology": "Tignoolajiyadda",
   "surveysToComplete": "You have {count, plural, =1{1 survey} other{{count} surveys}} to complete",
+  "@surveysToComplete": {
+    "x-mt": true
+  },
   "lastSynced": "[Somali] Last synced: {time}",
+  "@lastSynced": {
+    "x-mt": true
+  },
   "neverSynced": "waligeyn la isku midayn",
   "justNow": "Hadda uun",
   "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
+  "@minutesAgo": {
+    "x-mt": true
+  },
   "hoursAgo": "{count, plural, =1{1 hour ago} other{{count} hours ago}}",
+  "@hoursAgo": {
+    "x-mt": true
+  },
   "daysAgo": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@daysAgo": {
+    "x-mt": true
+  },
   "syncingResources": "[Somali] Syncing resources… {completed} of {total}",
+  "@syncingResources": {
+    "x-mt": true
+  },
   "syncedResources": "{count, plural, =0{No resources synced} =1{1 resource synced} other{{count} resources synced}}",
+  "@syncedResources": {
+    "x-mt": true
+  },
   "syncFailed": "[Somali] Sync failed: {message}",
+  "@syncFailed": {
+    "x-mt": true
+  },
   "availableOffline": "[Somali] Available offline",
+  "@availableOffline": {
+    "x-mt": true
+  },
   "courses": "Koorsooyin",
   "myCourses": "[Somali] My courses",
+  "@myCourses": {
+    "x-mt": true
+  },
   "allCourses": "[Somali] All courses",
+  "@allCourses": {
+    "x-mt": true
+  },
   "courseSteps": "{count, plural, =0{No steps} =1{1 step} other{{count} steps}}",
+  "@courseSteps": {
+    "x-mt": true
+  },
   "stepNumber": "[Somali] Step {number}",
+  "@stepNumber": {
+    "x-mt": true
+  },
   "resourcesInStep": "{count, plural, =0{No resources} =1{1 resource} other{{count} resources}}",
+  "@resourcesInStep": {
+    "x-mt": true
+  },
   "gradeLevel": "[Somali] Grade level",
+  "@gradeLevel": {
+    "x-mt": true
+  },
   "subjectLevel": "[Somali] Subject",
+  "@subjectLevel": {
+    "x-mt": true
+  },
   "allLevels": "Dhammaan",
   "clearFilters": "[Somali] Clear filters",
+  "@clearFilters": {
+    "x-mt": true
+  },
   "joinCourse": "[Somali] Add to my courses",
+  "@joinCourse": {
+    "x-mt": true
+  },
   "leaveCourse": "[Somali] Remove from my courses",
+  "@leaveCourse": {
+    "x-mt": true
+  },
   "syncedCourses": "{count, plural, =0{No courses synced} =1{1 course synced} other{{count} courses synced}}",
+  "@syncedCourses": {
+    "x-mt": true
+  },
   "courseNotFound": "[Somali] Course not found",
+  "@courseNotFound": {
+    "x-mt": true
+  },
   "calendar": "Calendar",
   "profile": "Profile",
   "profileUnavailable": "[Somali] Profile unavailable",
+  "@profileUnavailable": {
+    "x-mt": true
+  },
   "username": "[Somali] Username",
+  "@username": {
+    "x-mt": true
+  },
   "email": "iimayl",
   "phone": "[Somali] Phone",
+  "@phone": {
+    "x-mt": true
+  },
   "level": "[Somali] Level",
+  "@level": {
+    "x-mt": true
+  },
   "levels": "[Somali] Levels",
+  "@levels": {
+    "x-mt": true
+  },
   "language": "Luuqad",
   "languages": "Luqadaha",
   "gender": "Jinsi",
   "dateOfBirth": "[Somali] Date of birth",
+  "@dateOfBirth": {
+    "x-mt": true
+  },
   "planetCode": "[Somali] Planet code",
+  "@planetCode": {
+    "x-mt": true
+  },
   "accountDetails": "[Somali] Account details",
+  "@accountDetails": {
+    "x-mt": true
+  },
   "noProfileDetails": "[Somali] No profile details are available.",
+  "@noProfileDetails": {
+    "x-mt": true
+  },
   "profilePhotoFor": "[Somali] Profile photo for {name}",
+  "@profilePhotoFor": {
+    "x-mt": true
+  },
   "editProfile": "[Somali] Edit profile",
+  "@editProfile": {
+    "x-mt": true
+  },
   "changePhoto": "[Somali] Change profile photo",
+  "@changePhoto": {
+    "x-mt": true
+  },
   "photoUpdated": "[Somali] Profile photo updated",
+  "@photoUpdated": {
+    "x-mt": true
+  },
   "photoUpdateFailed": "[Somali] Could not save the photo",
+  "@photoUpdateFailed": {
+    "x-mt": true
+  },
   "firstName": "[Somali] First name",
+  "@firstName": {
+    "x-mt": true
+  },
   "middleName": "[Somali] Middle name",
+  "@middleName": {
+    "x-mt": true
+  },
   "lastName": "[Somali] Last name",
+  "@lastName": {
+    "x-mt": true
+  },
   "save": "Keyd",
   "profileSaved": "[Somali] Profile saved on this device",
+  "@profileSaved": {
+    "x-mt": true
+  },
   "invalidEmail": "[Somali] Enter a valid email address",
+  "@invalidEmail": {
+    "x-mt": true
+  },
   "appearance": "[Somali] Appearance",
+  "@appearance": {
+    "x-mt": true
+  },
   "systemTheme": "[Somali] Use device theme",
+  "@systemTheme": {
+    "x-mt": true
+  },
   "lightTheme": "Iftiin",
   "darkTheme": "Madow",
   "server": "[Somali] Server",
+  "@server": {
+    "x-mt": true
+  },
   "serverUrl": "[Somali] Server URL",
+  "@serverUrl": {
+    "x-mt": true
+  },
   "notConfigured": "[Somali] Not configured",
+  "@notConfigured": {
+    "x-mt": true
+  },
   "communityCode": "[Somali] Community code",
+  "@communityCode": {
+    "x-mt": true
+  },
   "about": "ku saabsan",
   "offlineLearningApp": "[Somali] Offline learning with Planet",
+  "@offlineLearningApp": {
+    "x-mt": true
+  },
   "appVersion": "[Somali] Version {version}",
+  "@appVersion": {
+    "x-mt": true
+  },
   "buildNumber": "[Somali] Build {number}",
+  "@buildNumber": {
+    "x-mt": true
+  },
   "learningTools": "[Somali] Learning tools",
+  "@learningTools": {
+    "x-mt": true
+  },
   "dictionary": "Qaamuus",
   "dictionaryDescription": "[Somali] Search downloaded definitions offline",
+  "@dictionaryDescription": {
+    "x-mt": true
+  },
   "dictionaryUnavailable": "[Somali] Dictionary unavailable",
+  "@dictionaryUnavailable": {
+    "x-mt": true
+  },
   "searchDictionary": "[Somali] Search for a word",
+  "@searchDictionary": {
+    "x-mt": true
+  },
   "dictionaryWordCount": "{count, plural, =0{No downloaded words} =1{1 downloaded word} other{{count} downloaded words}}",
+  "@dictionaryWordCount": {
+    "x-mt": true
+  },
   "downloadDictionary": "[Somali] Download dictionary",
+  "@downloadDictionary": {
+    "x-mt": true
+  },
   "retryDownload": "[Somali] Retry download",
+  "@retryDownload": {
+    "x-mt": true
+  },
   "dictionaryDownloadFailed": "[Somali] The dictionary could not be downloaded. Your existing offline data was not changed.",
+  "@dictionaryDownloadFailed": {
+    "x-mt": true
+  },
   "wordNotFound": "[Somali] Word not available in the offline dictionary",
+  "@wordNotFound": {
+    "x-mt": true
+  },
   "meaning": "[Somali] Meaning",
+  "@meaning": {
+    "x-mt": true
+  },
   "synonyms": "[Somali] Synonyms",
+  "@synonyms": {
+    "x-mt": true
+  },
   "antonyms": "[Somali] Antonyms",
+  "@antonyms": {
+    "x-mt": true
+  },
   "notifications": "[Somali] Notifications",
+  "@notifications": {
+    "x-mt": true
+  },
   "notification": "[Somali] Notification",
+  "@notification": {
+    "x-mt": true
+  },
   "notificationsUnavailable": "[Somali] Notifications unavailable",
+  "@notificationsUnavailable": {
+    "x-mt": true
+  },
   "markAllRead": "[Somali] Mark all read",
+  "@markAllRead": {
+    "x-mt": true
+  },
   "all": "Dhammaan",
   "read": "[Somali] Read",
+  "@read": {
+    "x-mt": true
+  },
   "unreadCount": "[Somali] Unread ({count})",
+  "@unreadCount": {
+    "x-mt": true
+  },
   "noNotifications": "Wax ogeysiis ah ma jiro",
   "noUnreadNotifications": "Wax ogeysiis aan la akhiyin ma jiro",
   "noReadNotifications": "Wax ogeysiis la akhiyay ma jiro",
   "delete": "Tirtir",
   "deleteNotification": "[Somali] Delete notification?",
+  "@deleteNotification": {
+    "x-mt": true
+  },
   "deleteNotificationConfirmation": "[Somali] This notification will be removed from this device.",
+  "@deleteNotificationConfirmation": {
+    "x-mt": true
+  },
   "taskNotification": "[Somali] Task",
+  "@taskNotification": {
+    "x-mt": true
+  },
   "chatNotification": "Sawir",
   "replyNotification": "[Somali] New reply",
+  "@replyNotification": {
+    "x-mt": true
+  },
   "resourceNotification": "Vifijo",
   "storageNotification": "[Somali] Storage warning",
+  "@storageNotification": {
+    "x-mt": true
+  },
   "joinRequestNotification": "[Somali] Join request",
+  "@joinRequestNotification": {
+    "x-mt": true
+  },
   "teamNotification": "[Somali] Team update",
+  "@teamNotification": {
+    "x-mt": true
+  },
   "tasks": "Hawlgalaha",
   "notifGroupJoinRequests": "Codsiyada Ku-Biiritaanka",
   "notifGroupTeamUpdates": "Cusboonaysiinta Kooxda",
@@ -192,83 +594,293 @@
   "notificationGroupSystem": "Nidaam",
   "notificationGroupOther": "Kale",
   "myLife": "[Somali] My life",
+  "@myLife": {
+    "x-mt": true
+  },
   "myLifeUnavailable": "[Somali] My life is unavailable",
+  "@myLifeUnavailable": {
+    "x-mt": true
+  },
   "noLifeItems": "[Somali] No My life items",
+  "@noLifeItems": {
+    "x-mt": true
+  },
   "shownOnDashboard": "[Somali] Shown",
+  "@shownOnDashboard": {
+    "x-mt": true
+  },
   "hiddenFromDashboard": "[Somali] Hidden",
+  "@hiddenFromDashboard": {
+    "x-mt": true
+  },
   "hideItem": "[Somali] Hide {title}",
+  "@hideItem": {
+    "x-mt": true
+  },
   "showItem": "[Somali] Show {title}",
+  "@showItem": {
+    "x-mt": true
+  },
   "reorderItem": "[Somali] Reorder {title}",
+  "@reorderItem": {
+    "x-mt": true
+  },
   "myHealth": "[Somali] My health",
+  "@myHealth": {
+    "x-mt": true
+  },
   "achievements": "[Somali] Achievements",
+  "@achievements": {
+    "x-mt": true
+  },
   "submissions": "[Somali] Submissions",
+  "@submissions": {
+    "x-mt": true
+  },
   "submission": "[Somali] Submission",
+  "@submission": {
+    "x-mt": true
+  },
   "submissionsUnavailable": "[Somali] Submissions are unavailable",
+  "@submissionsUnavailable": {
+    "x-mt": true
+  },
   "noSubmissions": "[Somali] No submissions yet",
+  "@noSubmissions": {
+    "x-mt": true
+  },
   "pending": "[Somali] Pending",
+  "@pending": {
+    "x-mt": true
+  },
   "submissionGrade": "[Somali] Grade: {grade}",
+  "@submissionGrade": {
+    "x-mt": true
+  },
   "refresh": "[Somali] Refresh",
+  "@refresh": {
+    "x-mt": true
+  },
   "complete": "[Somali] Complete",
+  "@complete": {
+    "x-mt": true
+  },
   "noMatchingSubmissions": "[Somali] No submissions match this filter",
+  "@noMatchingSubmissions": {
+    "x-mt": true
+  },
   "submissionsSynced": "{count, plural, =0{Submissions are up to date} =1{1 submission synced} other{{count} submissions synced}}",
+  "@submissionsSynced": {
+    "x-mt": true
+  },
   "submissionDetails": "[Somali] Submission details",
+  "@submissionDetails": {
+    "x-mt": true
+  },
   "submissionNotFound": "[Somali] Submission not found",
+  "@submissionNotFound": {
+    "x-mt": true
+  },
   "unknown": "[Somali] Unknown",
+  "@unknown": {
+    "x-mt": true
+  },
   "nA": "[Somali] N/A",
+  "@nA": {
+    "x-mt": true
+  },
   "otherDiagnosis": "[Somali] Other diagnosis",
+  "@otherDiagnosis": {
+    "x-mt": true
+  },
   "add": "[Somali] Add",
+  "@add": {
+    "x-mt": true
+  },
   "status": "xaalad",
   "lastUpdated": "[Somali] Last updated",
+  "@lastUpdated": {
+    "x-mt": true
+  },
   "grade": "[Somali] Grade",
+  "@grade": {
+    "x-mt": true
+  },
   "submittedBy": "La Diyaariyay",
   "submissionType": "Nooca",
   "uploadStatus": "[Somali] Upload status",
+  "@uploadStatus": {
+    "x-mt": true
+  },
   "uploaded": "[Somali] Uploaded",
+  "@uploaded": {
+    "x-mt": true
+  },
   "answers": "[Somali] Answers",
+  "@answers": {
+    "x-mt": true
+  },
   "answersUnavailable": "[Somali] Answers are unavailable",
+  "@answersUnavailable": {
+    "x-mt": true
+  },
   "noAnswers": "[Somali] No answers were saved with this submission",
+  "@noAnswers": {
+    "x-mt": true
+  },
   "noAnswer": "[Somali] No answer",
+  "@noAnswer": {
+    "x-mt": true
+  },
   "questionNumber": "[Somali] Question {number}",
+  "@questionNumber": {
+    "x-mt": true
+  },
   "newSubmission": "[Somali] New submission",
+  "@newSubmission": {
+    "x-mt": true
+  },
   "answer": "[Somali] Answer",
+  "@answer": {
+    "x-mt": true
+  },
   "availableChoices": "[Somali] Choices",
+  "@availableChoices": {
+    "x-mt": true
+  },
   "exportPdf": "[Somali] Export PDF",
+  "@exportPdf": {
+    "x-mt": true
+  },
   "pdfExportFailed": "[Somali] The PDF could not be created",
+  "@pdfExportFailed": {
+    "x-mt": true
+  },
   "pdfSaved": "[Somali] PDF saved to {path}",
+  "@pdfSaved": {
+    "x-mt": true
+  },
   "mySurveys": "[Somali] My surveys",
+  "@mySurveys": {
+    "x-mt": true
+  },
   "references": "Tixraacyo",
   "myPersonals": "[Somali] My personals",
+  "@myPersonals": {
+    "x-mt": true
+  },
   "featureComingSoon": "[Somali] This feature is not ported yet",
+  "@featureComingSoon": {
+    "x-mt": true
+  },
   "maps": "Maps",
   "englishDictionary": "[Somali] English dictionary",
+  "@englishDictionary": {
+    "x-mt": true
+  },
   "offlineMapsComingSoon": "[Somali] Offline maps are not ported yet",
+  "@offlineMapsComingSoon": {
+    "x-mt": true
+  },
   "addPersonal": "[Somali] Add personal item",
+  "@addPersonal": {
+    "x-mt": true
+  },
   "editPersonal": "[Somali] Edit personal item",
+  "@editPersonal": {
+    "x-mt": true
+  },
   "deletePersonal": "[Somali] Delete personal item?",
+  "@deletePersonal": {
+    "x-mt": true
+  },
   "deletePersonalConfirmation": "[Somali] Delete “{title}” from this device?",
+  "@deletePersonalConfirmation": {
+    "x-mt": true
+  },
   "personalsUnavailable": "[Somali] Personal items are unavailable",
+  "@personalsUnavailable": {
+    "x-mt": true
+  },
   "noPersonals": "[Somali] No personal items yet. Add a private note to get started.",
+  "@noPersonals": {
+    "x-mt": true
+  },
   "duplicateTitle": "[Somali] A personal item with this title already exists",
+  "@duplicateTitle": {
+    "x-mt": true
+  },
   "attachFile": "[Somali] Attach file",
+  "@attachFile": {
+    "x-mt": true
+  },
   "attachedFile": "[Somali] Attached: {name}",
+  "@attachedFile": {
+    "x-mt": true
+  },
   "noFileSelected": "No file selected",
+  "@noFileSelected": {
+    "x-mt": true
+  },
   "removeFile": "[Somali] Remove file",
+  "@removeFile": {
+    "x-mt": true
+  },
   "savedOffline": "[Somali] Saved offline — pending upload",
+  "@savedOffline": {
+    "x-mt": true
+  },
   "edit": "Tafatir",
   "title": "Cinwaanka",
   "titleRequired": "[Somali] Enter a title",
+  "@titleRequired": {
+    "x-mt": true
+  },
   "rateCourse": "[Somali] Rate course",
+  "@rateCourse": {
+    "x-mt": true
+  },
   "rateTitle": "[Somali] Rate {title}",
+  "@rateTitle": {
+    "x-mt": true
+  },
   "ratingsUnavailable": "[Somali] Ratings are unavailable",
+  "@ratingsUnavailable": {
+    "x-mt": true
+  },
   "ratingSummary": "{average} from {count, plural, =1{1 rating} other{{count} ratings}}",
+  "@ratingSummary": {
+    "x-mt": true
+  },
   "ratingCompact": "[Somali] {average} ({count})",
+  "@ratingCompact": {
+    "x-mt": true
+  },
   "ratingOutOfFive": "[Somali] Rating: {rating} out of 5",
+  "@ratingOutOfFive": {
+    "x-mt": true
+  },
   "setRating": "[Somali] Set rating to {rating}",
+  "@setRating": {
+    "x-mt": true
+  },
   "ratingRequired": "[Somali] Choose a rating",
+  "@ratingRequired": {
+    "x-mt": true
+  },
   "commentOptional": "[Somali] Comment (optional)",
+  "@commentOptional": {
+    "x-mt": true
+  },
   "submitRating": "[Somali] Submit rating",
+  "@submitRating": {
+    "x-mt": true
+  },
   "skip": "Ka gudub",
   "next": "[Somali] Next",
+  "@next": {
+    "x-mt": true
+  },
   "getStarted": "BILAAB",
   "welcomeToMyPlanet": "Soo dhawoow myPlanet",
   "learnOffline": "Baro horumarinta",
@@ -276,292 +888,1003 @@
   "unleashLearningPower": "Ku Xir Barashada Xoojinta",
   "onboardingWelcomeDescription": "Boggaaga ee Barashada aan dheeraad ahayn",
   "onboardingOfflineDescription": "[Somali] Download resources for offline learning.\nAccess knowledge on the go.",
+  "@onboardingOfflineDescription": {
+    "x-mt": true
+  },
   "onboardingOpenDescription": "[Somali] Choose your interests and dive into interactive content.\nCraft your unique learning journey.",
+  "@onboardingOpenDescription": {
+    "x-mt": true
+  },
   "onboardingPowerDescription": "[Somali] Explore a world of knowledge at your fingertips.\n\n🌍 Offline Access: Learn without borders, anytime.\n🎯 Personalized: Tailor your learning path.\n📚 Interactive: Engage with videos, books, games.\n\nBegin your limitless learning journey with myPlanet!",
+  "@onboardingPowerDescription": {
+    "x-mt": true
+  },
   "onboardingServerPrepHint": "[Somali] Before you sign in, you'll need your Planet server address and PIN. Ask your community administrator if you don't have them yet.",
+  "@onboardingServerPrepHint": {
+    "x-mt": true
+  },
   "pageProgress": "[Somali] Page {current} of {total}",
+  "@pageProgress": {
+    "x-mt": true
+  },
   "meetups": "[Somali] Meetups",
+  "@meetups": {
+    "x-mt": true
+  },
   "syncPendingMeetups": "[Somali] Sync pending meetups",
+  "@syncPendingMeetups": {
+    "x-mt": true
+  },
   "meetupsUnavailable": "[Somali] Meetups are unavailable",
+  "@meetupsUnavailable": {
+    "x-mt": true
+  },
   "noMeetups": "[Somali] No meetups yet",
+  "@noMeetups": {
+    "x-mt": true
+  },
   "dateNotSet": "[Somali] Date not set",
+  "@dateNotSet": {
+    "x-mt": true
+  },
   "untitledMeetup": "[Somali] Untitled meetup",
+  "@untitledMeetup": {
+    "x-mt": true
+  },
   "addMeetup": "[Somali] Add meetup",
+  "@addMeetup": {
+    "x-mt": true
+  },
   "meetupDetails": "[Somali] Meetup details",
+  "@meetupDetails": {
+    "x-mt": true
+  },
   "meetupNotFound": "[Somali] Meetup not found",
+  "@meetupNotFound": {
+    "x-mt": true
+  },
   "createdBy": "[Somali] Created by",
+  "@createdBy": {
+    "x-mt": true
+  },
   "category": "[Somali] Category",
+  "@category": {
+    "x-mt": true
+  },
   "location": "Goobta",
   "link": "Xiriirka",
   "recurring": "[Somali] Recurring",
+  "@recurring": {
+    "x-mt": true
+  },
   "description": "[Somali] Description",
+  "@description": {
+    "x-mt": true
+  },
   "leaveMeetup": "[Somali] Leave meetup",
+  "@leaveMeetup": {
+    "x-mt": true
+  },
   "joinMeetup": "[Somali] Join meetup",
+  "@joinMeetup": {
+    "x-mt": true
+  },
   "editMeetup": "[Somali] Edit meetup",
+  "@editMeetup": {
+    "x-mt": true
+  },
   "startTime": "[Somali] Start time",
+  "@startTime": {
+    "x-mt": true
+  },
   "endTime": "[Somali] End time",
+  "@endTime": {
+    "x-mt": true
+  },
   "none": "Midna",
   "daily": "Maalinle",
   "weekly": "Toddobaad",
   "syncMeetups": "[Somali] Sync meetups",
+  "@syncMeetups": {
+    "x-mt": true
+  },
   "searchMeetups": "[Somali] Search meetups",
+  "@searchMeetups": {
+    "x-mt": true
+  },
   "sortMeetups": "[Somali] Sort meetups",
+  "@sortMeetups": {
+    "x-mt": true
+  },
   "sortResources": "[Somali] Sort resources",
+  "@sortResources": {
+    "x-mt": true
+  },
   "newestFirst": "[Somali] Newest first",
+  "@newestFirst": {
+    "x-mt": true
+  },
   "oldestFirst": "[Somali] Oldest first",
+  "@oldestFirst": {
+    "x-mt": true
+  },
   "titleAscending": "[Somali] Title A–Z",
+  "@titleAscending": {
+    "x-mt": true
+  },
   "titleDescending": "[Somali] Title Z–A",
+  "@titleDescending": {
+    "x-mt": true
+  },
   "startDate": "[Somali] Start date",
+  "@startDate": {
+    "x-mt": true
+  },
   "endDate": "[Somali] End date",
+  "@endDate": {
+    "x-mt": true
+  },
   "timeNotSet": "[Somali] Time not set",
+  "@timeNotSet": {
+    "x-mt": true
+  },
   "syncSurveys": "[Somali] Sync surveys",
+  "@syncSurveys": {
+    "x-mt": true
+  },
   "searchSurveys": "[Somali] Search surveys",
+  "@searchSurveys": {
+    "x-mt": true
+  },
   "sortSurveys": "[Somali] Sort surveys",
+  "@sortSurveys": {
+    "x-mt": true
+  },
   "surveysUnavailable": "[Somali] Surveys are unavailable",
+  "@surveysUnavailable": {
+    "x-mt": true
+  },
   "noSurveys": "[Somali] No surveys available",
+  "@noSurveys": {
+    "x-mt": true
+  },
   "untitledSurvey": "[Somali] Untitled survey",
+  "@untitledSurvey": {
+    "x-mt": true
+  },
   "takeSurvey": "[Somali] Take survey",
+  "@takeSurvey": {
+    "x-mt": true
+  },
   "surveyLoadFailed": "[Somali] Survey could not be loaded",
+  "@surveyLoadFailed": {
+    "x-mt": true
+  },
   "surveyHasNoQuestions": "[Somali] This survey has no questions",
+  "@surveyHasNoQuestions": {
+    "x-mt": true
+  },
   "submitSurvey": "[Somali] Submit survey",
+  "@submitSurvey": {
+    "x-mt": true
+  },
   "answerRequiredQuestions": "[Somali] Answer all required questions",
+  "@answerRequiredQuestions": {
+    "x-mt": true
+  },
   "voices": "[Somali] Voices",
+  "@voices": {
+    "x-mt": true
+  },
   "searchVoices": "[Somali] Search voices",
+  "@searchVoices": {
+    "x-mt": true
+  },
   "syncVoices": "[Somali] Sync voices",
+  "@syncVoices": {
+    "x-mt": true
+  },
   "noVoices": "[Somali] No voices yet",
+  "@noVoices": {
+    "x-mt": true
+  },
   "voicesUnavailable": "[Somali] Voices are unavailable",
+  "@voicesUnavailable": {
+    "x-mt": true
+  },
   "shareYourVoice": "[Somali] Share your voice",
+  "@shareYourVoice": {
+    "x-mt": true
+  },
   "postVoice": "[Somali] Post",
+  "@postVoice": {
+    "x-mt": true
+  },
   "replyToVoice": "jawaab",
   "writeAReply": "[Somali] Write a reply",
+  "@writeAReply": {
+    "x-mt": true
+  },
   "repliesCount": "{count, plural, =0{No replies} =1{1 reply} other{{count} replies}}",
+  "@repliesCount": {
+    "x-mt": true
+  },
   "edited": "[Somali] Edited",
+  "@edited": {
+    "x-mt": true
+  },
   "editVoice": "Tafatir",
   "deleteVoice": "Tirtir",
   "deleteVoiceConfirm": "[Somali] Delete this post and all of its replies?",
+  "@deleteVoiceConfirm": {
+    "x-mt": true
+  },
   "voiceDeleted": "[Somali] Post deleted",
+  "@voiceDeleted": {
+    "x-mt": true
+  },
   "emptyMessageNotAllowed": "[Somali] Write something first",
+  "@emptyMessageNotAllowed": {
+    "x-mt": true
+  },
   "thread": "[Somali] Thread",
+  "@thread": {
+    "x-mt": true
+  },
   "surveySubmitFailed": "[Somali] Could not save your answers",
+  "@surveySubmitFailed": {
+    "x-mt": true
+  },
   "sendSurveyTo": "[Somali] Select users to send survey to",
+  "@sendSurveyTo": {
+    "x-mt": true
+  },
   "sendSurvey": "[Somali] Send survey",
+  "@sendSurvey": {
+    "x-mt": true
+  },
   "surveySentToUsers": "Survey sent to selected users",
+  "@surveySentToUsers": {
+    "x-mt": true
+  },
   "noUsersAvailable": "[Somali] No users available",
+  "@noUsersAvailable": {
+    "x-mt": true
+  },
   "teams": "Kooxaha",
   "syncTeams": "[Somali] Sync teams",
+  "@syncTeams": {
+    "x-mt": true
+  },
   "searchTeams": "[Somali] Search teams",
+  "@searchTeams": {
+    "x-mt": true
+  },
   "teamsUnavailable": "[Somali] Teams are unavailable",
+  "@teamsUnavailable": {
+    "x-mt": true
+  },
   "noTeams": "[Somali] No teams available",
+  "@noTeams": {
+    "x-mt": true
+  },
   "untitledTeam": "[Somali] Untitled team",
+  "@untitledTeam": {
+    "x-mt": true
+  },
   "teamDetails": "[Somali] Team details",
+  "@teamDetails": {
+    "x-mt": true
+  },
   "teamNotFound": "[Somali] Team not found",
+  "@teamNotFound": {
+    "x-mt": true
+  },
   "publicTeam": "[Somali] Public team",
+  "@publicTeam": {
+    "x-mt": true
+  },
   "privateTeam": "[Somali] Private team",
+  "@privateTeam": {
+    "x-mt": true
+  },
   "enterprises": "Shirkado",
   "searchEnterprises": "[Somali] Search enterprises",
+  "@searchEnterprises": {
+    "x-mt": true
+  },
   "leader": "[Somali] Leader",
+  "@leader": {
+    "x-mt": true
+  },
   "leave": "[Somali] Leave",
+  "@leave": {
+    "x-mt": true
+  },
   "remove": "[Somali] Remove",
+  "@remove": {
+    "x-mt": true
+  },
   "makeLeader": "[Somali] Make leader",
+  "@makeLeader": {
+    "x-mt": true
+  },
   "leftTeam": "[Somali] Left team",
+  "@leftTeam": {
+    "x-mt": true
+  },
   "memberRemoved": "[Somali] Member removed",
+  "@memberRemoved": {
+    "x-mt": true
+  },
   "leaderUpdated": "[Somali] Leader updated",
+  "@leaderUpdated": {
+    "x-mt": true
+  },
   "member": "[Somali] Member",
+  "@member": {
+    "x-mt": true
+  },
   "teamLeader": "[Somali] You lead this team",
+  "@teamLeader": {
+    "x-mt": true
+  },
   "teamMember": "[Somali] You are a member",
+  "@teamMember": {
+    "x-mt": true
+  },
   "services": "adeegyo",
   "rules": "[Somali] Rules",
+  "@rules": {
+    "x-mt": true
+  },
   "teamCourses": "[Somali] Team courses",
+  "@teamCourses": {
+    "x-mt": true
+  },
   "membersCount": "{count, plural, =0{No members} =1{1 member} other{{count} members}}",
+  "@membersCount": {
+    "x-mt": true
+  },
   "teamTasks": "Hawlgalaha",
   "tasksUnavailable": "[Somali] Tasks are unavailable",
+  "@tasksUnavailable": {
+    "x-mt": true
+  },
   "noTeamTasks": "[Somali] No tasks yet",
+  "@noTeamTasks": {
+    "x-mt": true
+  },
   "noDeadline": "[Somali] No deadline",
+  "@noDeadline": {
+    "x-mt": true
+  },
   "untitledTask": "[Somali] Untitled task",
+  "@untitledTask": {
+    "x-mt": true
+  },
   "addTask": "[Somali] Add task",
+  "@addTask": {
+    "x-mt": true
+  },
   "editTask": "[Somali] Edit task",
+  "@editTask": {
+    "x-mt": true
+  },
   "deleteTask": "[Somali] Delete task",
+  "@deleteTask": {
+    "x-mt": true
+  },
   "taskTitle": "[Somali] Task title",
+  "@taskTitle": {
+    "x-mt": true
+  },
   "assigneeId": "[Somali] Assignee ID",
+  "@assigneeId": {
+    "x-mt": true
+  },
   "teamDiscussions": "[Somali] Discussions",
+  "@teamDiscussions": {
+    "x-mt": true
+  },
   "teamMembers": "Xubinayaasha",
   "members": "Xubinayaasha",
   "joinRequests": "[Somali] Join requests",
+  "@joinRequests": {
+    "x-mt": true
+  },
   "noMembers": "[Somali] No members yet",
+  "@noMembers": {
+    "x-mt": true
+  },
   "membersUnavailable": "[Somali] Members are unavailable",
+  "@membersUnavailable": {
+    "x-mt": true
+  },
   "unknownMember": "[Somali] Unknown member",
+  "@unknownMember": {
+    "x-mt": true
+  },
   "noJoinRequests": "[Somali] No pending requests",
+  "@noJoinRequests": {
+    "x-mt": true
+  },
   "accept": "Qabto",
   "decline": "[Somali] Decline",
+  "@decline": {
+    "x-mt": true
+  },
   "joinTeam": "Codso Inaad Ku Dhaqmeyso",
   "leaveTeam": "[Somali] Leave team",
+  "@leaveTeam": {
+    "x-mt": true
+  },
   "requestPending": "[Somali] Request pending",
+  "@requestPending": {
+    "x-mt": true
+  },
   "teamResources": "Vifijo",
   "resourcesUnavailable": "[Somali] Resources are unavailable",
+  "@resourcesUnavailable": {
+    "x-mt": true
+  },
   "noTeamResources": "[Somali] No resources linked to this team",
+  "@noTeamResources": {
+    "x-mt": true
+  },
   "untitledResource": "[Somali] Untitled resource",
+  "@untitledResource": {
+    "x-mt": true
+  },
   "removeFromTeam": "[Somali] Remove from team",
+  "@removeFromTeam": {
+    "x-mt": true
+  },
   "addResource": "[Somali] Add resource",
+  "@addResource": {
+    "x-mt": true
+  },
   "editResource": "[Somali] Edit resource",
+  "@editResource": {
+    "x-mt": true
+  },
   "resourceUpdated": "[Somali] Resource updated",
+  "@resourceUpdated": {
+    "x-mt": true
+  },
   "resourceAddedToTeam": "[Somali] Resource added to team",
+  "@resourceAddedToTeam": {
+    "x-mt": true
+  },
   "descriptionIsRequired": "[Somali] Description is required",
+  "@descriptionIsRequired": {
+    "x-mt": true
+  },
   "levelIsRequired": "[Somali] Level is required",
+  "@levelIsRequired": {
+    "x-mt": true
+  },
   "subjectIsRequired": "[Somali] Subject is required",
+  "@subjectIsRequired": {
+    "x-mt": true
+  },
   "selectFile": "[Somali] Select a file",
+  "@selectFile": {
+    "x-mt": true
+  },
   "fileSelected": "File selected",
+  "@fileSelected": {
+    "x-mt": true
+  },
   "privateResource": "[Somali] Private resource",
+  "@privateResource": {
+    "x-mt": true
+  },
   "saveChanges": "[Somali] Save changes",
+  "@saveChanges": {
+    "x-mt": true
+  },
   "selectOpenWith": "[Somali] Select open with",
+  "@selectOpenWith": {
+    "x-mt": true
+  },
   "selectMedia": "[Somali] Select media",
+  "@selectMedia": {
+    "x-mt": true
+  },
   "selectResourceType": "[Somali] Select resource type",
+  "@selectResourceType": {
+    "x-mt": true
+  },
   "linkToLicense": "[Somali] Link to license",
+  "@linkToLicense": {
+    "x-mt": true
+  },
   "noResourcesToAdd": "[Somali] All available resources are already linked",
+  "@noResourcesToAdd": {
+    "x-mt": true
+  },
   "coursesUnavailable": "[Somali] Courses are unavailable",
+  "@coursesUnavailable": {
+    "x-mt": true
+  },
   "noTeamCourses": "[Somali] No courses linked to this team",
+  "@noTeamCourses": {
+    "x-mt": true
+  },
   "untitledCourse": "[Somali] Untitled course",
+  "@untitledCourse": {
+    "x-mt": true
+  },
   "addCourse": "[Somali] Add course",
+  "@addCourse": {
+    "x-mt": true
+  },
   "noCoursesToAdd": "[Somali] All available courses are already linked",
+  "@noCoursesToAdd": {
+    "x-mt": true
+  },
   "financialReports": "[Somali] Financial reports",
+  "@financialReports": {
+    "x-mt": true
+  },
   "reportsUnavailable": "[Somali] Reports are unavailable",
+  "@reportsUnavailable": {
+    "x-mt": true
+  },
   "noReports": "[Somali] No financial reports yet",
+  "@noReports": {
+    "x-mt": true
+  },
   "addReport": "[Somali] Add report",
+  "@addReport": {
+    "x-mt": true
+  },
   "editReport": "[Somali] Edit report",
+  "@editReport": {
+    "x-mt": true
+  },
   "archiveReport": "Arsiif",
   "beginningBalance": "[Somali] Beginning balance",
+  "@beginningBalance": {
+    "x-mt": true
+  },
   "sales": "Iibka",
   "otherIncome": "[Somali] Other income",
+  "@otherIncome": {
+    "x-mt": true
+  },
   "wages": "[Somali] Wages",
+  "@wages": {
+    "x-mt": true
+  },
   "otherExpenses": "[Somali] Other expenses",
+  "@otherExpenses": {
+    "x-mt": true
+  },
   "totalIncome": "[Somali] Total income",
+  "@totalIncome": {
+    "x-mt": true
+  },
   "totalExpenses": "[Somali] Total expenses",
+  "@totalExpenses": {
+    "x-mt": true
+  },
   "profitLoss": "[Somali] Profit / loss",
+  "@profitLoss": {
+    "x-mt": true
+  },
   "endingBalance": "[Somali] Ending balance",
+  "@endingBalance": {
+    "x-mt": true
+  },
   "negativeBalance": "[Somali] The current balance is negative!",
+  "@negativeBalance": {
+    "x-mt": true
+  },
   "reportDateDetails": "[Somali] Report created on: {created} | Updated on: {updated}",
+  "@reportDateDetails": {
+    "x-mt": true
+  },
   "chatHistory": "[Somali] Chat History",
+  "@chatHistory": {
+    "x-mt": true
+  },
   "chat": "Sawir",
   "newChat": "[Somali] New chat",
+  "@newChat": {
+    "x-mt": true
+  },
   "searchChats": "[Somali] Search chats",
+  "@searchChats": {
+    "x-mt": true
+  },
   "noChats": "[Somali] No chats yet",
+  "@noChats": {
+    "x-mt": true
+  },
   "noSearchResults": "[Somali] No matching chats",
+  "@noSearchResults": {
+    "x-mt": true
+  },
   "untitledChat": "[Somali] Untitled chat",
+  "@untitledChat": {
+    "x-mt": true
+  },
   "fullConversationResponse": "[Somali] Full conversation response",
+  "@fullConversationResponse": {
+    "x-mt": true
+  },
   "response": "[Somali] Response",
+  "@response": {
+    "x-mt": true
+  },
   "chatConversation": "[Somali] Conversation",
+  "@chatConversation": {
+    "x-mt": true
+  },
   "newConversation": "[Somali] New conversation",
+  "@newConversation": {
+    "x-mt": true
+  },
   "startConversation": "[Somali] Start a new conversation",
+  "@startConversation": {
+    "x-mt": true
+  },
   "typeMessage": "[Somali] Type a message…",
+  "@typeMessage": {
+    "x-mt": true
+  },
   "selectAiProvider": "[Somali] Select AI provider",
+  "@selectAiProvider": {
+    "x-mt": true
+  },
   "aiProviders": "[Somali] AI providers",
+  "@aiProviders": {
+    "x-mt": true
+  },
   "aiProviderAvailable": "[Somali] {name} (available)",
+  "@aiProviderAvailable": {
+    "x-mt": true
+  },
   "aiProviderUnavailable": "[Somali] {name} (unavailable)",
+  "@aiProviderUnavailable": {
+    "x-mt": true
+  },
   "feedback": "Rajayn",
   "feedbackNotFound": "[Somali] Feedback not found",
+  "@feedbackNotFound": {
+    "x-mt": true
+  },
   "feedbackSaved": "[Somali] Feedback saved",
+  "@feedbackSaved": {
+    "x-mt": true
+  },
   "isUrgent": "[Somali] Is this urgent?",
+  "@isUrgent": {
+    "x-mt": true
+  },
   "feedbackType": "[Somali] Feedback type",
+  "@feedbackType": {
+    "x-mt": true
+  },
   "feedbackTypeRequired": "Please select a feedback type",
+  "@feedbackTypeRequired": {
+    "x-mt": true
+  },
   "yourFeedback": "[Somali] Your feedback",
+  "@yourFeedback": {
+    "x-mt": true
+  },
   "pleaseEnterFeedback": "[Somali] Please enter your feedback",
+  "@pleaseEnterFeedback": {
+    "x-mt": true
+  },
   "question": "Su\\'aal",
   "bug": "Bug",
   "suggestion": "talo soo jeedin",
   "priority": "mudnaanta",
   "openDate": "[Somali] Open date",
+  "@openDate": {
+    "x-mt": true
+  },
   "replies": "[Somali] Replies",
+  "@replies": {
+    "x-mt": true
+  },
   "pleaseEnterReply": "Fadlan geli jawaab",
   "untitledFeedback": "[Somali] Untitled feedback",
+  "@untitledFeedback": {
+    "x-mt": true
+  },
   "yes": "Haa",
   "no": "Maya",
   "submit": "Ku Dir",
   "takeTest": "[Somali] Take test",
+  "@takeTest": {
+    "x-mt": true
+  },
   "recordSurvey": "[Somali] Record survey",
+  "@recordSurvey": {
+    "x-mt": true
+  },
   "react": "[Somali] React",
+  "@react": {
+    "x-mt": true
+  },
   "pickReaction": "[Somali] Pick a reaction",
+  "@pickReaction": {
+    "x-mt": true
+  },
   "comments": "[Somali] Comments",
+  "@comments": {
+    "x-mt": true
+  },
   "addComment": "[Somali] Add a comment",
+  "@addComment": {
+    "x-mt": true
+  },
   "commentsCount": "[Somali] {count} comments",
+  "@commentsCount": {
+    "x-mt": true
+  },
   "noComments": "[Somali] No comments yet",
+  "@noComments": {
+    "x-mt": true
+  },
   "leaderboard": "[Somali] Leaderboard",
+  "@leaderboard": {
+    "x-mt": true
+  },
   "allTime": "[Somali] All time",
+  "@allTime": {
+    "x-mt": true
+  },
   "thisMonth": "[Somali] This month",
+  "@thisMonth": {
+    "x-mt": true
+  },
   "coursesCompleted": "[Somali] {completed}/{total} courses",
+  "@coursesCompleted": {
+    "x-mt": true
+  },
   "surveysCompleted": "[Somali] {completed}/{total} surveys",
+  "@surveysCompleted": {
+    "x-mt": true
+  },
   "error": "[Somali] Error",
+  "@error": {
+    "x-mt": true
+  },
   "close": "Xir",
   "filter": "Gaaji",
   "type": "Nooca",
   "apply": "[Somali] Apply",
+  "@apply": {
+    "x-mt": true
+  },
   "unavailable": "[Somali] unavailable",
+  "@unavailable": {
+    "x-mt": true
+  },
   "chatsUnavailable": "[Somali] Chats could not be loaded",
+  "@chatsUnavailable": {
+    "x-mt": true
+  },
   "community": "Bulshada",
   "communityLeaders": "Hogaamiyayaasha bulshada",
   "nationLeaders": "[Somali] Nation Leaders",
+  "@nationLeaders": {
+    "x-mt": true
+  },
   "ourVoices": "[Somali] Our Voices",
+  "@ourVoices": {
+    "x-mt": true
+  },
   "finances": "Maaliyadda",
   "reports": "warbixino",
   "transaction": "[Somali] Transaction",
+  "@transaction": {
+    "x-mt": true
+  },
   "transactions": "[Somali] Transactions",
+  "@transactions": {
+    "x-mt": true
+  },
   "addTransaction": "Ku daray Hawlaha",
   "noTransactions": "[Somali] No transactions yet",
+  "@noTransactions": {
+    "x-mt": true
+  },
   "debit": "Debit",
   "credit": "Credit",
   "balance": "Baaki",
   "amount": "Masaafad",
   "note": "[Somali] Note",
+  "@note": {
+    "x-mt": true
+  },
   "date": "Taariikhda",
   "fromDate": "[Somali] From date",
+  "@fromDate": {
+    "x-mt": true
+  },
   "toDate": "[Somali] To date",
+  "@toDate": {
+    "x-mt": true
+  },
   "reset": "[Somali] Reset",
+  "@reset": {
+    "x-mt": true
+  },
   "noteRequired": "Fariin waa loo baahan yahay",
   "amountRequired": "[Somali] Amount must be greater than 0",
+  "@amountRequired": {
+    "x-mt": true
+  },
   "transactionAdded": "Hawlasha lagu daray",
   "addReceipt": "[Somali] Add receipt",
+  "@addReceipt": {
+    "x-mt": true
+  },
   "receiptSelected": "Receipt selected",
+  "@receiptSelected": {
+    "x-mt": true
+  },
   "noReceipt": "[Somali] No receipt attached",
+  "@noReceipt": {
+    "x-mt": true
+  },
   "receipt": "[Somali] Receipt",
+  "@receipt": {
+    "x-mt": true
+  },
   "viewReceipt": "[Somali] View receipt",
+  "@viewReceipt": {
+    "x-mt": true
+  },
   "noLeadersAvailable": "[Somali] No leaders available",
+  "@noLeadersAvailable": {
+    "x-mt": true
+  },
   "noServicesAvailable": "[Somali] No services available",
+  "@noServicesAvailable": {
+    "x-mt": true
+  },
   "noDescriptionAvailable": "Sharaxaad lama heli karo",
   "takeExam": "[Somali] Take exam",
+  "@takeExam": {
+    "x-mt": true
+  },
   "examLoadFailed": "[Somali] Exam could not be loaded",
+  "@examLoadFailed": {
+    "x-mt": true
+  },
   "examHasNoQuestions": "[Somali] This exam has no questions",
+  "@examHasNoQuestions": {
+    "x-mt": true
+  },
   "examComplete": "[Somali] Exam Complete",
+  "@examComplete": {
+    "x-mt": true
+  },
   "examUnavailable": "[Somali] Exam is unavailable",
+  "@examUnavailable": {
+    "x-mt": true
+  },
   "submitExam": "[Somali] Submit exam",
+  "@submitExam": {
+    "x-mt": true
+  },
   "incorrectAnswer": "[Somali] Incorrect answer",
+  "@incorrectAnswer": {
+    "x-mt": true
+  },
   "correctAnswers": "[Somali] Correct",
+  "@correctAnswers": {
+    "x-mt": true
+  },
   "yourAnswer": "[Somali] Your answer",
+  "@yourAnswer": {
+    "x-mt": true
+  },
   "previous": "Hore",
   "finish": "Dhammaad",
   "exitExam": "[Somali] Exit exam?",
+  "@exitExam": {
+    "x-mt": true
+  },
   "exitExamMessage": "[Somali] Your progress will be lost.",
+  "@exitExamMessage": {
+    "x-mt": true
+  },
   "exit": "Ka Bax",
   "download": "Download",
   "downloading": "[Somali] Downloading…",
+  "@downloading": {
+    "x-mt": true
+  },
   "downloadFailed": "[Somali] Download failed.",
+  "@downloadFailed": {
+    "x-mt": true
+  },
   "resourceNotDownloaded": "[Somali] This resource is not on your device yet.",
+  "@resourceNotDownloaded": {
+    "x-mt": true
+  },
   "retry": "[Somali] Retry",
+  "@retry": {
+    "x-mt": true
+  },
   "fieldRequired": "[Somali] Required",
+  "@fieldRequired": {
+    "x-mt": true
+  },
   "examSubmitFailed": "[Somali] Could not save your exam. Please try again.",
+  "@examSubmitFailed": {
+    "x-mt": true
+  },
   "yourInformation": "[Somali] Your information",
+  "@yourInformation": {
+    "x-mt": true
+  },
   "showAdditionalFields": "[Somali] Show additional fields",
+  "@showAdditionalFields": {
+    "x-mt": true
+  },
   "hideAdditionalFields": "[Somali] Hide additional fields",
+  "@hideAdditionalFields": {
+    "x-mt": true
+  },
   "phoneNumber": "[Somali] Phone number",
+  "@phoneNumber": {
+    "x-mt": true
+  },
   "birthDate": "[Somali] Birth date",
+  "@birthDate": {
+    "x-mt": true
+  },
   "selectDate": "[Somali] Select date",
+  "@selectDate": {
+    "x-mt": true
+  },
   "male": "[Somali] Male",
+  "@male": {
+    "x-mt": true
+  },
   "female": "[Somali] Female",
+  "@female": {
+    "x-mt": true
+  },
   "yearOfBirth": "Sannadka dhalashada",
   "yearOfBirthRequired": "[Somali] Year of birth is required",
+  "@yearOfBirthRequired": {
+    "x-mt": true
+  },
   "invalidYear": "[Somali] Please enter a valid year",
+  "@invalidYear": {
+    "x-mt": true
+  },
   "yearBetween": "[Somali] Year must be between {min} and {max}",
+  "@yearBetween": {
+    "x-mt": true
+  },
   "thankYouForTakingSurvey": "[Somali] Thank you for taking this survey",
+  "@thankYouForTakingSurvey": {
+    "x-mt": true
+  },
   "errorSavingProfile": "[Somali] Error saving profile",
+  "@errorSavingProfile": {
+    "x-mt": true
+  },
   "videoPlayer": "[Somali] Video player",
+  "@videoPlayer": {
+    "x-mt": true
+  },
   "audioPlayer": "[Somali] Audio player",
+  "@audioPlayer": {
+    "x-mt": true
+  },
   "videoFileNotFound": "Faylka fiidyowga lama helin gudaha",
   "unableToLoadVideo": "Lama helin fiidyowga",
   "audioFileNotFound": "Faylka maqalka lama helin gudaha",
@@ -577,68 +1900,227 @@
   "errorOccurred": "Khalad: {error}",
   "openingResource": "Furaya: {title}",
   "loadingMedia": "[Somali] Loading...",
+  "@loadingMedia": {
+    "x-mt": true
+  },
   "resourceUnavailable": "[Somali] This resource is not available for offline viewing",
+  "@resourceUnavailable": {
+    "x-mt": true
+  },
   "healthRecordNotAvailable": "[Somali] Health record not available",
+  "@healthRecordNotAvailable": {
+    "x-mt": true
+  },
   "updateHealth": "[Somali] Update health",
+  "@updateHealth": {
+    "x-mt": true
+  },
   "addHealthRecord": "[Somali] Add health record",
+  "@addHealthRecord": {
+    "x-mt": true
+  },
   "healthProfile": "[Somali] Health profile",
+  "@healthProfile": {
+    "x-mt": true
+  },
   "specialNeeds": "[Somali] Special needs",
+  "@specialNeeds": {
+    "x-mt": true
+  },
   "otherNeeds": "[Somali] Other needs",
+  "@otherNeeds": {
+    "x-mt": true
+  },
   "emergencyContact": "[Somali] Emergency contact",
+  "@emergencyContact": {
+    "x-mt": true
+  },
   "contactNumber": "[Somali] Contact number",
+  "@contactNumber": {
+    "x-mt": true
+  },
   "vitalSigns": "[Somali] Vital signs",
+  "@vitalSigns": {
+    "x-mt": true
+  },
   "temperature": "[Somali] Temperature",
+  "@temperature": {
+    "x-mt": true
+  },
   "pulse": "[Somali] Pulse",
+  "@pulse": {
+    "x-mt": true
+  },
   "height": "[Somali] Height",
+  "@height": {
+    "x-mt": true
+  },
   "weight": "[Somali] Weight",
+  "@weight": {
+    "x-mt": true
+  },
   "bloodPressure": "[Somali] Blood pressure",
+  "@bloodPressure": {
+    "x-mt": true
+  },
   "vision": "Ruuxa",
   "hearing": "Gurinaan",
   "examinationHistory": "[Somali] Examination history",
+  "@examinationHistory": {
+    "x-mt": true
+  },
   "personalInformation": "[Somali] Personal information",
+  "@personalInformation": {
+    "x-mt": true
+  },
   "birthPlace": "[Somali] Birth place",
+  "@birthPlace": {
+    "x-mt": true
+  },
   "contactName": "[Somali] Contact name",
+  "@contactName": {
+    "x-mt": true
+  },
   "contactType": "[Somali] Contact type",
+  "@contactType": {
+    "x-mt": true
+  },
   "healthInformation": "[Somali] Health information",
+  "@healthInformation": {
+    "x-mt": true
+  },
   "requiredField": "[Somali] This field is required",
+  "@requiredField": {
+    "x-mt": true
+  },
   "healthSavedSuccessfully": "[Somali] Health data saved successfully",
+  "@healthSavedSuccessfully": {
+    "x-mt": true
+  },
   "examinationDetails": "[Somali] Examination details",
+  "@examinationDetails": {
+    "x-mt": true
+  },
   "allergies": "Alargada",
   "diagnosis": "Baaris",
   "medications": "Daaweynaha",
   "immunizations": "[Somali] Immunizations",
+  "@immunizations": {
+    "x-mt": true
+  },
   "treatments": "Dib u dhiska",
   "observations": "[Somali] Observations",
+  "@observations": {
+    "x-mt": true
+  },
   "referrals": "Dabaqyo",
   "labTests": "[Somali] Lab tests",
+  "@labTests": {
+    "x-mt": true
+  },
   "xrays": "X-ray",
   "conditions": "[Somali] Conditions",
+  "@conditions": {
+    "x-mt": true
+  },
   "selfExamination": "[Somali] Self-examination",
+  "@selfExamination": {
+    "x-mt": true
+  },
   "healthRecordAdded": "[Somali] Health record added successfully",
+  "@healthRecordAdded": {
+    "x-mt": true
+  },
   "selectHealthMember": "[Somali] Select member",
+  "@selectHealthMember": {
+    "x-mt": true
+  },
   "newPatient": "[Somali] New patient",
+  "@newPatient": {
+    "x-mt": true
+  },
   "sortJoinDateDesc": "[Somali] Newest first",
+  "@sortJoinDateDesc": {
+    "x-mt": true
+  },
   "sortJoinDateAsc": "[Somali] Oldest first",
+  "@sortJoinDateAsc": {
+    "x-mt": true
+  },
   "sortNameAsc": "[Somali] Name A–Z",
+  "@sortNameAsc": {
+    "x-mt": true
+  },
   "sortNameDesc": "[Somali] Name Z–A",
+  "@sortNameDesc": {
+    "x-mt": true
+  },
   "searchMembers": "[Somali] Search members",
+  "@searchMembers": {
+    "x-mt": true
+  },
   "dismiss": "saar",
   "addMember": "Ku Dar Xubin",
   "invalidNumber": "[Somali] Invalid number",
+  "@invalidNumber": {
+    "x-mt": true
+  },
   "tempRangeError": "[Somali] Temperature must be between 30 and 40",
+  "@tempRangeError": {
+    "x-mt": true
+  },
   "pulseRangeError": "[Somali] Pulse must be between 40 and 120",
+  "@pulseRangeError": {
+    "x-mt": true
+  },
   "heightRangeError": "[Somali] Height must be between 1 and 250",
+  "@heightRangeError": {
+    "x-mt": true
+  },
   "weightRangeError": "[Somali] Weight must be between 1 and 150",
+  "@weightRangeError": {
+    "x-mt": true
+  },
   "bloodPressureFormatError": "[Somali] Blood pressure should be systolic/diastolic",
+  "@bloodPressureFormatError": {
+    "x-mt": true
+  },
   "bloodPressureRangeError": "[Somali] Blood pressure must be between 60/40 and 300/200",
+  "@bloodPressureRangeError": {
+    "x-mt": true
+  },
   "bloodPressureNotNumbers": "[Somali] Systolic and diastolic must be numbers",
+  "@bloodPressureNotNumbers": {
+    "x-mt": true
+  },
   "temp": "[Somali] Temp",
+  "@temp": {
+    "x-mt": true
+  },
   "bp": "[Somali] BP",
+  "@bp": {
+    "x-mt": true
+  },
   "offlineMaps": "[Somali] Offline Maps",
+  "@offlineMaps": {
+    "x-mt": true
+  },
   "centerOnDefault": "[Somali] Center on default location",
+  "@centerOnDefault": {
+    "x-mt": true
+  },
   "storage": "[Somali] Storage",
+  "@storage": {
+    "x-mt": true
+  },
   "storageManagement": "[Somali] Storage Management",
+  "@storageManagement": {
+    "x-mt": true
+  },
   "storageTotalDownloaded": "[Somali] Total Downloaded",
+  "@storageTotalDownloaded": {
+    "x-mt": true
+  },
   "storageVideos": "Fiidiyowyada",
   "storageAudio": "Codka",
   "storagePdfs": "Dukumentiyada PDF",
@@ -646,16 +2128,34 @@
   "storageOther": "Kale",
   "fileCountOne": "1 fayl",
   "fileCountMany": "[Somali] {count} files",
+  "@fileCountMany": {
+    "x-mt": true
+  },
   "storageUnknownResource": "[Somali] Unknown resource",
+  "@storageUnknownResource": {
+    "x-mt": true
+  },
   "areYouSure": "Ma hubtaa?",
   "cancelAddingExamination": "Are you sure you want to cancel adding examination? The data will be lost.",
   "yesIWantToExit": "Yes, I want to exit.",
   "inactiveMessage": "User not activated, please contact administrator or manager to activate your account.",
   "submitFeedback": "Submit Feedback",
   "failedToDelete": "[Somali] Failed to delete: {error}",
+  "@failedToDelete": {
+    "x-mt": true
+  },
   "storageDeleteSelectedConfirm": "Delete {count} selected items?",
+  "@storageDeleteSelectedConfirm": {
+    "x-mt": true
+  },
   "storageDeleteConfirm": "[Somali] Delete all {category} files?",
+  "@storageDeleteConfirm": {
+    "x-mt": true
+  },
   "storageSelectedCount": "{count} selected",
+  "@storageSelectedCount": {
+    "x-mt": true
+  },
   "deleteSelected": "Tirtir Kuwa La Doortay",
   "deleteAll": "Tirtir Dhammaan",
   "selectAll": "Dhammaad Dhammaadee",
@@ -665,63 +2165,171 @@
   "coursesSelected": "{count, plural, =1{1 la doortay} other{{count} la doortay}}",
   "leaveCoursesConfirm": "{count, plural, =1{Ma hubtaa inaad ka saarayso koorsan?} other{Ma hubtaa inaad ka saaraysid koorsasyadaan?}}",
   "noStorageUsed": "[Somali] No downloaded files found",
+  "@noStorageUsed": {
+    "x-mt": true
+  },
   "availableSpace": "[Somali] Available space",
+  "@availableSpace": {
+    "x-mt": true
+  },
   "freeUpSpace": "[Somali] Free up space",
+  "@freeUpSpace": {
+    "x-mt": true
+  },
   "freeUpSpaceConfirm": "[Somali] This will delete all downloaded resources to free up storage space. Continue?",
+  "@freeUpSpaceConfirm": {
+    "x-mt": true
+  },
   "storageFreedSummary": "Freed {bytes}. {count, plural, =0{No files removed} =1{1 file removed} other{{count} files removed}}.",
+  "@storageFreedSummary": {
+    "x-mt": true
+  },
   "freeUpSpaceFailed": "[Somali] Could not free up space: {error}",
+  "@freeUpSpaceFailed": {
+    "x-mt": true
+  },
   "enterUsername": "[Somali] Enter username",
+  "@enterUsername": {
+    "x-mt": true
+  },
   "enterPassword": "[Somali] Enter password",
+  "@enterPassword": {
+    "x-mt": true
+  },
   "retypePassword": "[Somali] Retype password",
+  "@retypePassword": {
+    "x-mt": true
+  },
   "becomeMember": "noqo xubin",
   "toAccessThisFeatureBecomeAMember": "hadda waxaad tahay isticmaale marti ah. si aad u hesho helitaanka astaamahan, noqo xubin.",
   "creatingMember": "[Somali] Creating member account...",
+  "@creatingMember": {
+    "x-mt": true
+  },
   "passwordsDoNotMatch": "Furayaasha sirta isma waafaqsana",
   "pleaseSelectGender": "Fadlan xulo jinsiga",
   "pleaseEnterPassword": "Fadlan geli ereyga sirta ah",
   "usernameAlreadyExists": "[Somali] Username already exists",
+  "@usernameAlreadyExists": {
+    "x-mt": true
+  },
   "usernameCannotBeEmpty": "Magaca isticmaasha waa in lagu jiro waxaan kusoo haysano",
   "invalidUsername": "Magac isticmaalaha aan sax ahayn",
   "usernameMustStartWithLetterOrNumber": "Waa in la bilaabo lambarka ama tirada",
   "usernameOnlyLettersNumbers": "[Somali] Only letters a-z, numbers and \"_\", \".\", \"-\" are allowed",
+  "@usernameOnlyLettersNumbers": {
+    "x-mt": true
+  },
   "usernameTaken": "Magaca isticmaalaha laga qaadsiyey",
   "memberCreatedOffline": "[Somali] Member account created offline",
+  "@memberCreatedOffline": {
+    "x-mt": true
+  },
   "memberCreatedOnline": "[Somali] Member account created successfully",
+  "@memberCreatedOnline": {
+    "x-mt": true
+  },
   "congratulations": "Hambalyo! Tartanka waa la dhameeyay",
   "dailyVoices": "5 Cod maalinle ah",
   "voicesProgress": "[Somali] {count} of 5 Daily Voices",
+  "@voicesProgress": {
+    "x-mt": true
+  },
   "progressLabel": "[Somali] Progress: {percent}%",
+  "@progressLabel": {
+    "x-mt": true
+  },
   "courseNotStarted": "[Somali] Course: Not started",
+  "@courseNotStarted": {
+    "x-mt": true
+  },
   "syncCompletedChallenge": "[Somali] Sync completed",
+  "@syncCompletedChallenge": {
+    "x-mt": true
+  },
   "rememberSync": "Xusuusnow inaad la socodsiiso codsiga mobilka.",
   "challengeDialogTitle": "[Somali] Daily Challenge",
+  "@challengeDialogTitle": {
+    "x-mt": true
+  },
   "start": "[Somali] Start",
+  "@start": {
+    "x-mt": true
+  },
   "continuation": "[Somali] Continue",
+  "@continuation": {
+    "x-mt": true
+  },
   "plan": "Qorshe",
   "mission": "Mission & Adeegyada",
   "editPlan": "Wax ka beddel qorshaha",
   "teamPlan": "[Somali] What is your team's plan?",
+  "@teamPlan": {
+    "x-mt": true
+  },
   "entMission": "[Somali] What is your enterprise's Mission?",
+  "@entMission": {
+    "x-mt": true
+  },
   "entServices": "Xidhiidhka Beelahaada waxay bixisaa?",
   "entRules": "Qawaanada Beelahaada waa maxay?",
   "noMissionDefined": "Beelaha waa maxay & adeegyadooda ma jirto.",
   "noPlanDefined": "[Somali] This team has no plan defined.",
+  "@noPlanDefined": {
+    "x-mt": true
+  },
   "noDescriptionDefined": "[Somali] This team has no description defined.",
+  "@noDescriptionDefined": {
+    "x-mt": true
+  },
   "enterpriseName": "[Somali] Enterprise name",
+  "@enterpriseName": {
+    "x-mt": true
+  },
   "teamName": "[Somali] Team name",
+  "@teamName": {
+    "x-mt": true
+  },
   "teamType": "[Somali] Team type",
+  "@teamType": {
+    "x-mt": true
+  },
   "local": "[Somali] Local",
+  "@local": {
+    "x-mt": true
+  },
   "isPublic": "Ciidamo",
   "nameRequired": "Magacu waa loo baahan yahay",
   "nameIsRequired": "Fadlan geli magac",
   "createdOn": "[Somali] Created on",
+  "@createdOn": {
+    "x-mt": true
+  },
   "courseDetails": "[Somali] Course Details",
+  "@courseDetails": {
+    "x-mt": true
+  },
   "addedToCourse": "[Somali] Added to your courses",
+  "@addedToCourse": {
+    "x-mt": true
+  },
   "removedFromCourse": "[Somali] Removed from your courses",
+  "@removedFromCourse": {
+    "x-mt": true
+  },
   "pleaseCompleteSurvey": "fadlan dhameystir sahanka si aad u dhameystirto koorsada",
   "takeCourse": "[Somali] Take Course",
+  "@takeCourse": {
+    "x-mt": true
+  },
   "teamCalendar": "[Somali] Team Calendar",
+  "@teamCalendar": {
+    "x-mt": true
+  },
   "noMeetupsOnDate": "[Somali] No meetups on this date",
+  "@noMeetupsOnDate": {
+    "x-mt": true
+  },
   "myProgress": "Halistaaga",
   "progress": "Horumar",
   "orderByTitle": "Ku qoraalka Cinwaanka",
@@ -730,43 +2338,133 @@
   "progressFilterNotStarted": "Lama bilaaban",
   "progressFilterInProgress": "Socda",
   "progressFilterCompleted": "[Somali] Completed",
+  "@progressFilterCompleted": {
+    "x-mt": true
+  },
   "stepProgress": "[Somali] {current} of {max} steps",
+  "@stepProgress": {
+    "x-mt": true
+  },
   "noEnrolledCourses": "[Somali] You are not enrolled in any courses",
+  "@noEnrolledCourses": {
+    "x-mt": true
+  },
   "mistakes": "Khalad",
   "step": "[Somali] Step",
+  "@step": {
+    "x-mt": true
+  },
   "untitledResourceTitle": "[Somali] Untitled Resource",
+  "@untitledResourceTitle": {
+    "x-mt": true
+  },
   "author": "[Somali] Author",
+  "@author": {
+    "x-mt": true
+  },
   "publisher": "Daabace",
   "license": "[Somali] License",
+  "@license": {
+    "x-mt": true
+  },
   "addedBy": "[Somali] Added by",
+  "@addedBy": {
+    "x-mt": true
+  },
   "resourceInformation": "[Somali] Resource Information",
+  "@resourceInformation": {
+    "x-mt": true
+  },
   "resourceFor": "[Somali] For",
+  "@resourceFor": {
+    "x-mt": true
+  },
   "mediaType": "[Somali] Media Type",
+  "@mediaType": {
+    "x-mt": true
+  },
   "resourceType": "[Somali] Resource Type",
+  "@resourceType": {
+    "x-mt": true
+  },
   "subject": "[Somali] Subject",
+  "@subject": {
+    "x-mt": true
+  },
   "year": "Sannad",
   "timesRated": "[Somali] Times Rated",
+  "@timesRated": {
+    "x-mt": true
+  },
   "addToMyLibrary": "[Somali] Add to My Library",
+  "@addToMyLibrary": {
+    "x-mt": true
+  },
   "removeFromMyLibrary": "[Somali] Remove from My Library",
+  "@removeFromMyLibrary": {
+    "x-mt": true
+  },
   "addedToMyLibrary": "[Somali] Added to My Library",
+  "@addedToMyLibrary": {
+    "x-mt": true
+  },
   "removedFromMyLibrary": "[Somali] Removed from My Library",
+  "@removedFromMyLibrary": {
+    "x-mt": true
+  },
   "myLibrary": "[Somali] My Library",
+  "@myLibrary": {
+    "x-mt": true
+  },
   "allResources": "[Somali] All Resources",
+  "@allResources": {
+    "x-mt": true
+  },
   "viewResource": "[Somali] View Resource",
+  "@viewResource": {
+    "x-mt": true
+  },
   "view": "eeg",
   "linkNotAvailable": "Xogta lama helin",
   "noRatings": "[Somali] No ratings yet",
+  "@noRatings": {
+    "x-mt": true
+  },
   "basedOnRatings": "based on {count, plural, =1{1 rating} other{{count} ratings}}",
+  "@basedOnRatings": {
+    "x-mt": true
+  },
   "rating": "[Somali] Rating",
+  "@rating": {
+    "x-mt": true
+  },
   "operationFailed": "[Somali] Operation failed",
+  "@operationFailed": {
+    "x-mt": true
+  },
   "filterResources": "[Somali] Filter Resources",
+  "@filterResources": {
+    "x-mt": true
+  },
   "teamSurveys": "Sahaminta kooxda",
   "adoptableSurveys": "[Somali] Surveys available to adopt",
+  "@adoptableSurveys": {
+    "x-mt": true
+  },
   "noAdoptableSurveys": "[Somali] No surveys available to adopt",
+  "@noAdoptableSurveys": {
+    "x-mt": true
+  },
   "adoptSurvey": "Sahaminta qaado",
   "surveyAdopted": "[Somali] Survey adopted",
+  "@surveyAdopted": {
+    "x-mt": true
+  },
   "completedCourse": "koorso la dhammaaday",
   "userNameWithLogins": "[Somali] {name} ({logins})",
+  "@userNameWithLogins": {
+    "x-mt": true
+  },
   "remindMeLater": "मलाई पछि सम्झाउनुहोस्",
   "remindLater": "पछि सम्झाउनुहोस्",
   "setReminder": "रिमाइन्डर सेट गर्नुहोस्",
@@ -774,7 +2472,13 @@
   "hours": "saacadood",
   "days": "दिनहरू",
   "reminderSurveysToComplete": "Reminder: You have {count, plural, =1{1 survey} other{{count} surveys}} to complete",
+  "@reminderSurveysToComplete": {
+    "x-mt": true
+  },
   "myActivities": "[Somali] My activities",
+  "@myActivities": {
+    "x-mt": true
+  },
   "chartLabel": "Tirada galitaanka",
   "selectLanguage": "Xulo luqadda",
   "english": "english",
@@ -784,27 +2488,78 @@
   "arabic": "عربى",
   "french": "français",
   "activitySummary": "[Somali] Activity",
+  "@activitySummary": {
+    "x-mt": true
+  },
   "lastLogin": "[Somali] Last login",
+  "@lastLogin": {
+    "x-mt": true
+  },
   "memberDetail": "[Somali] Member detail",
+  "@memberDetail": {
+    "x-mt": true
+  },
   "numberOfVisits": "[Somali] Number of visits",
+  "@numberOfVisits": {
+    "x-mt": true
+  },
   "noLogoutRecord": "[Somali] No logout record found",
+  "@noLogoutRecord": {
+    "x-mt": true
+  },
   "totalVisits": "[Somali] Total visits",
+  "@totalVisits": {
+    "x-mt": true
+  },
   "mostOpenedResource": "[Somali] Most opened resource",
+  "@mostOpenedResource": {
+    "x-mt": true
+  },
   "numberOfResourcesOpened": "[Somali] Number of resources opened",
+  "@numberOfResourcesOpened": {
+    "x-mt": true
+  },
   "resourceOpenedTimes": "[Somali] {title} opened {count} times",
+  "@resourceOpenedTimes": {
+    "x-mt": true
+  },
   "resourcesOpenedTimes": "{count, plural, =1{Resource opened 1 time} other{Resource opened {count} times}}",
+  "@resourcesOpenedTimes": {
+    "x-mt": true
+  },
   "serverReachable": "[Somali] Server reachable",
+  "@serverReachable": {
+    "x-mt": true
+  },
   "serverUnreachable": "[Somali] Server unreachable",
+  "@serverUnreachable": {
+    "x-mt": true
+  },
   "serverChecking": "[Somali] Checking server",
+  "@serverChecking": {
+    "x-mt": true
+  },
   "gridView": "Muuqaal shabag",
   "listView": "Muuqaal liis",
   "disclaimer": "soo Celinta",
   "aboutContent": "[Somali] ### MyPlanet\n\nmyPlanet is a learning tool that is designed to work with Planet web application. It has been used to improve early education, secondary schools, village health, youth workforce development, and economic and community development.\n\nPlanet houses is a repository of free, open access and public domain resources to benefit all learners.\n\nmyPlanet is designed to be available to everyone, everywhere, all the time. It is portable, affordable, scalable and sustainable. It runs on any android device such as tablets and mobile phones. It functions off, as well as on, the Internet.\n\nThis application enables schools and communities to have a complete multi-media library and learning system that periodically connects with Planet. Configured devices can contain the learners' personal dashboard. This ensures learners can read books on their shelf and take courses offline - i.e without connection to a central server. Learners are encouraged to rate from one to five stars the resources they use and the courses they take. Periodically learners can sync with a server. Activity data are uploaded and new resources are downloaded in a matter of a few minutes unto myPlanet for offline use.\n\nThe dashboard also contains a record of achievements, a calendar of events, and an internal chat system for communicating with fellow members.\n\nmyPlanet has been proven highly effective in improving learning opportunities for over fifty thousand learners in more than 100 locations, in schools throughout Nepal, Ghana, Kenya, and Rwanda, with Syrian refugees in Jordan, Somali refugees in Kenya, and village health workers in Uganda.",
+  "@aboutContent": {
+    "x-mt": true
+  },
   "disclaimerContent": "# Disclaimer\n\nLast updated: January 10, 2020\n\n# Interpretation and Definitions\n\n## Interpretation\n\nThe words of which the initial letter is capitalized have meanings defined under the following conditions.\n\nThe following definitions shall have the same meaning regardless of whether they appear in singular or in plural.\n\n## Definitions\n\nFor the purposes of this Disclaimer:\n\n- **Company** (referred to as either \"the Company\", \"We\", \"Us\" or \"Our\" in this Cookies Policy) refers to myPlanet.\n- **You** means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.\n- **Application** means the software program provided by the Company downloaded by You on any electronic device named myPlanet.\n- **Service** refers to the Application.\n\n# Disclaimer\n\nThe information contained on the Service is for general information purposes only.\n\nThe Company assumes no responsibility for errors or omissions in the contents of the Service.\n\nIn no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice.\n\nThe Company does not warrant that the Service is free of viruses or other harmful components.\n\n# Medical Information Disclaimer\n\nThe information about health provided by the Service is not intended to diagnose, treat, cure or prevent disease. Products, services, information, and other content provided by the Service, including information linking to third-party websites are provided for informational purposes only.\n\nInformation offered by the Service is not comprehensive and does not cover all diseases, ailments, physical conditions or their treatment.\n\nIndividuals are different and may react differently to different products. Comments made on the Service by employees or other users are strictly their own personal views made in their own personal capacity and are not claims made by the Company nor do they represent the position or view of the Company.\n\nThe Company is not liable for any information provided by the Service with regard to recommendations regarding supplements for any health purposes.\n\nThe Company makes no guarantee or warranty with respect to any products or services sold. The Company is not responsible for any damages for information or services provided even if the Company has been advised of the possibility of damages.\n\n# External Links Disclaimer\n\nThe Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.\n\nPlease note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.\n\n# Errors and Omissions Disclaimer\n\nThe information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to ensure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules, and regulations, there may be delays, omissions, or inaccuracies in the information contained on the Service.\n\nThe Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.\n\n# Fair Use Disclaimer\n\nThe Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.\n\nThe Company believes this constitutes a \"fair use\" of any such copyrighted material as provided for in section 107 of the United States Copyright law.\n\nIf You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.\n\n# Views Expressed Disclaimer\n\nThe Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer, or company, including the Company.\n\nComments published by users are their sole responsibility and the users will take full responsibility, liability, and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.\n\n# No Responsibility Disclaimer\n\nThe information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal, or other competent advisers.\n\nIn no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.\n\n# \"Use at Your Own Risk\" Disclaimer\n\nAll information in the Service is provided \"as is\", with no guarantee of completeness, accuracy, timeliness, or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability, and fitness for a particular purpose.\n\nThe Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special, or similar damages, even if advised of the possibility of such damages.\n\n## Contact Us\n\nIf you have any questions about this Disclaimer, You can contact Us:\n\n- By email: myplanet@ole.org\n- By visiting this page on our website: [https://ole.org/contact](https://ole.org/contact)",
+  "@disclaimerContent": {
+    "x-mt": true
+  },
   "shareWithCommunity": "Waxbaridii Bulshada la Wadaag",
   "confirmShareCommunity": "Ma hubtaa inaad rabto inaad la wadaagto macluumaadkan bulshada?",
   "voiceShared": "[Somali] Post shared with community",
+  "@voiceShared": {
+    "x-mt": true
+  },
   "voiceUnshared": "[Somali] Removed from community",
+  "@voiceUnshared": {
+    "x-mt": true
+  },
   "exportCsv": "Dhoofinta CSV",
   "csvFileSavedSuccessfully": "faylka CSV si guul leh ayaa loo keydiyay.",
   "failedToSaveCsvFile": "waa lagu guuldareystay in la badbaadiyo faylka CSV.",
@@ -843,6 +2598,9 @@
   "currentCv": "CV-ga hadda: {name}",
   "update": "Cusbooneysiin",
   "fillRequiredFields": "[Somali] Please fill required fields: {fields}",
+  "@fillRequiredFields": {
+    "x-mt": true
+  },
   "@currentCv": {
     "placeholders": {
       "name": {
@@ -851,14 +2609,41 @@
     }
   },
   "textSize": "[Somali] Text size",
+  "@textSize": {
+    "x-mt": true
+  },
   "selectTextSize": "[Somali] Select text size",
+  "@selectTextSize": {
+    "x-mt": true
+  },
   "textSizeSmall": "[Somali] Small",
+  "@textSizeSmall": {
+    "x-mt": true
+  },
   "textSizeMedium": "[Somali] Medium",
+  "@textSizeMedium": {
+    "x-mt": true
+  },
   "textSizeLarge": "[Somali] Large",
+  "@textSizeLarge": {
+    "x-mt": true
+  },
   "resetApp": "[Somali] Reset app",
+  "@resetApp": {
+    "x-mt": true
+  },
   "clearAllDataConfirm": "[Somali] Are you sure you want to clear all data?",
+  "@clearAllDataConfirm": {
+    "x-mt": true
+  },
   "dataCleared": "[Somali] All data cleared",
+  "@dataCleared": {
+    "x-mt": true
+  },
   "dataManagement": "[Somali] Data management",
+  "@dataManagement": {
+    "x-mt": true
+  },
   "resourceTitleAlreadyExists": "Kheyraad leh cinwaankan hore ayuu u jiray",
   "failedToUpdateResource": "Cusbooneysiin kheyraadka waxay ku guuldareysatay"
 }

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -1,0 +1,248 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myplanet/providers/settings_provider.dart';
+
+/// Guards the *values* in the locale files, which nothing checked before.
+///
+/// `test/l10n/locale_coverage_test.dart` guards the locale set and the key set:
+/// that every language the picker offers has an `.arb`, that no locale invents
+/// a key, that none is blank or declared twice. All of it is structural — it
+/// looks at which keys exist, never at what is inside them.
+///
+/// That gap shipped a real regression. An external translation pass filled the
+/// five locale files from ~250 keys to ~850, and it tokenised placeholders
+/// before translating without restoring them afterwards: Arabic carried 38
+/// strings with a literal `__0____` where a value belongs
+/// (`ratingOutOfFive` → `'التقييم: __0____ من 5'`), and 20 more across all five
+/// locales simply dropped a placeholder the template declares. 58 strings that
+/// could not render their own data.
+///
+/// `flutter analyze` caught **one** of the 58, and only by accident: a dropped
+/// placeholder is a lint solely when `gen-l10n` happens to emit an unused local
+/// for it. The other 57 compiled, analyzed clean, and would have shipped. These
+/// tests are what should have caught them.
+void main() {
+  final template = _readArb('en');
+
+  /// Every locale that ships a translation file. `en` is the template, so it
+  /// is the authority here rather than a subject.
+  final locales = LocaleNotifier.supportedLanguageCodes
+      .where((code) => code != 'en')
+      .toList();
+
+  test('no locale value carries a tokenisation artefact', () {
+    // The failure this exists for. A translator that swaps `{count}` for a
+    // sentinel and never swaps it back leaves text that renders literally —
+    // the user sees `__0____`, not their rating.
+    //
+    // No value in any locale legitimately contains a doubled underscore or a
+    // printf specifier today, so the nets are deliberately wider than the one
+    // shape that got through: the next tokeniser will use a different sentinel.
+    final defects = <String>[];
+    for (final code in locales) {
+      final arb = _readArb(code);
+      for (final key in _messageKeys(arb)) {
+        final value = arb[key] as String;
+        for (final artefact in _artefacts) {
+          if (RegExp(artefact.pattern).hasMatch(value)) {
+            defects.add('$code:$key contains ${artefact.name} — "$value"');
+          }
+        }
+      }
+    }
+
+    // Every defect at once, not just the first: the point of this guard is that
+    // one run tells you the whole extent of the damage.
+    expect(
+      defects,
+      isEmpty,
+      reason:
+          '${defects.length} value(s) carry a placeholder that was tokenised '
+          'for translation and never restored:\n${defects.join("\n")}\n'
+          'Put the ICU placeholder back, or drop the key so it falls back to '
+          'English.',
+    );
+  });
+
+  test('every locale value keeps the placeholders the template declares', () {
+    // The other half of the same regression, and the half nothing could see:
+    // a value that quietly omits `{count}` renders as a grammatical sentence
+    // with the number missing.
+    //
+    // The authority is `app_en.arb`'s `@<key>.placeholders` metadata, **not** a
+    // regex over `{...}` in the English text. An ICU plural body is full of
+    // braces that are not placeholders — `{count, plural, =1{one file} other{}}`
+    // yields spurious names like `1`, `No` and `Are`, and the first pass at
+    // this analysis reported 54 "missing" placeholders where only 20 were real.
+    // The metadata says exactly which names are values.
+    final defects = <String>[];
+    for (final code in locales) {
+      final arb = _readArb(code);
+      for (final key in _messageKeys(arb)) {
+        final value = arb[key] as String;
+        for (final name in _declaredPlaceholders(template, key)) {
+          if (!_usesPlaceholder(value, name)) {
+            defects.add('$code:$key drops "$name" — "$value"');
+          }
+        }
+      }
+    }
+
+    expect(
+      defects,
+      isEmpty,
+      reason:
+          '${defects.length} value(s) drop a placeholder app_en.arb declares:'
+          '\n${defects.join("\n")}\n'
+          'The generated getter still takes the argument, so the value it was '
+          'given is silently discarded at render time.',
+    );
+  });
+
+  // ---------------------------------------------------------------------
+  // Machine-translation marking (Phase 109).
+  //
+  // ~560 keys per locale are Google-Translate output with no human review,
+  // sitting indistinguishably beside the ~250 Phase 47 strings derived from the
+  // Kotlin `values-*/strings.xml` — translations already shipping in the
+  // Android app. `"@<key>": {"x-mt": true}` in the locale file marks the
+  // unreviewed ones, so a reviewer can list precisely what still needs a human.
+  // ---------------------------------------------------------------------
+
+  test('every locale marks its machine-translated strings', () {
+    for (final code in locales) {
+      expect(
+        _machineTranslatedKeys(_readArb(code)),
+        isNotEmpty,
+        reason:
+            'app_$code.arb carries no "x-mt" flags at all. Either every string '
+            'has been human-reviewed — in which case say so in the phase notes '
+            '— or a regeneration stripped the marking.',
+      );
+    }
+  });
+
+  test('no x-mt flag outlives the string it marks', () {
+    // A flag is attached to its key rather than kept in a central list
+    // precisely so the two cannot drift apart. This is the one way they still
+    // can: delete the translation, leave the `@key` block behind, and the flag
+    // then lands on whatever value is added for that key next — mislabelling a
+    // human translation as unreviewed.
+    for (final code in locales) {
+      final arb = _readArb(code);
+      final translated = _messageKeys(arb).toSet();
+      for (final key in _machineTranslatedKeys(arb)) {
+        expect(
+          translated,
+          contains(key),
+          reason:
+              'app_$code.arb flags "$key" as machine-translated but has no '
+              '"$key" value — delete the orphaned "@$key" block',
+        );
+      }
+    }
+  });
+
+  test('the template declares no review state of its own', () {
+    // `app_en.arb` is the source text, not a translation of anything. An
+    // `x-mt` flag there would mean the English itself is machine output.
+    expect(_machineTranslatedKeys(template), isEmpty);
+  });
+
+  test('the human-reviewed string counts are what the notes claim', () {
+    // Pins the marking against silent staleness. A future harvest that adds
+    // translations without deciding their review state shows up here as a
+    // count that moved, rather than as several hundred unreviewed strings
+    // indistinguishable from the reviewed ones — which is exactly the state
+    // this phase was opened to end.
+    //
+    // Adding a *reviewed* translation is meant to move these numbers: update
+    // the map and say in the commit message who reviewed it. Adding an
+    // unreviewed one means flagging it `x-mt`, which leaves them alone.
+    const humanReviewed = {
+      'ar': 259,
+      'es': 234,
+      'fr': 260,
+      'ne': 259,
+      'so': 259,
+    };
+
+    for (final code in locales) {
+      final arb = _readArb(code);
+      final unflagged =
+          _messageKeys(arb).length - _machineTranslatedKeys(arb).length;
+      expect(
+        unflagged,
+        humanReviewed[code],
+        reason:
+            'app_$code.arb has $unflagged strings with no "x-mt" flag, i.e. '
+            '$unflagged claimed as human-reviewed, but the pinned count is '
+            '${humanReviewed[code]}. If you reviewed strings or added a '
+            'reviewed translation, update this map. If you added a translation '
+            'nobody has reviewed, flag it "x-mt" instead.',
+      );
+    }
+  });
+}
+
+/// Patterns that mean "a value was substituted out and never substituted back".
+const _artefacts = [
+  (
+    name: 'a tokenisation sentinel (__0__)',
+    // The exact shape that shipped: `__0____`, `__1__`.
+    pattern: r'_{2,}\d+_{2,}',
+  ),
+  (
+    name: 'a run of underscores',
+    // Wider net for the same class of failure with a different sentinel. No
+    // legitimate value in any locale contains one.
+    pattern: r'_{2,}',
+  ),
+  (
+    name: 'a printf format specifier',
+    // Kotlin's `%1$s`/`%1$d`, which ICU does not interpolate. Three template
+    // keys (`communityEarnings`, `perSurvey`, `yourEarnings`) still carry these
+    // in their *English* text while declaring ICU placeholders, so they render
+    // the literal specifier and drop the argument in every language. Deriving a
+    // translation for one of them from the Kotlin XML would carry the defect
+    // into the locale files; `tool/arb_from_strings_xml.dart` skips them for
+    // that reason, and this fails if anything else reintroduces one.
+    pattern: r'%\d*\$?[sd]',
+  ),
+];
+
+Map<String, Object?> _readArb(String locale) =>
+    jsonDecode(File('lib/l10n/app_$locale.arb').readAsStringSync())
+        as Map<String, Object?>;
+
+/// Translatable entries — everything that is not `@@locale` or an `@key` block.
+Iterable<String> _messageKeys(Map<String, Object?> arb) =>
+    arb.keys.where((key) => !key.startsWith('@') && arb[key] is String);
+
+/// Placeholder names `app_en.arb` declares for [key], in declaration order.
+Iterable<String> _declaredPlaceholders(Map<String, Object?> arb, String key) {
+  final meta = arb['@$key'];
+  if (meta is! Map<String, Object?>) return const [];
+  final placeholders = meta['placeholders'];
+  if (placeholders is! Map<String, Object?>) return const [];
+  return placeholders.keys;
+}
+
+/// Keys the locale file flags as unreviewed machine output.
+Iterable<String> _machineTranslatedKeys(Map<String, Object?> arb) => arb.keys
+    .where((key) => key.startsWith('@') && key != '@@locale')
+    .where((key) {
+      final meta = arb[key];
+      return meta is Map<String, Object?> && meta['x-mt'] == true;
+    })
+    .map((key) => key.substring(1));
+
+/// Whether [value] interpolates [name].
+///
+/// `{name}` and the ICU forms that qualify it — `{count, plural, ...}`,
+/// `{choice, select, ...}` — all count; whitespace inside the braces is legal
+/// ICU and appears in the wild.
+bool _usesPlaceholder(String value, String name) =>
+    RegExp('\\{\\s*${RegExp.escape(name)}\\s*[,}]').hasMatch(value);

--- a/flutter/tool/arb_from_strings_xml.dart
+++ b/flutter/tool/arb_from_strings_xml.dart
@@ -38,6 +38,25 @@
 // A consequence worth knowing: because existing values win, the script cannot
 // *correct* a translation already in the .arb. Delete the key first, then
 // re-run, if the XML has a better one.
+//
+// Machine-translation flags (Phase 109) survive a re-run too, and are kept
+// *honest* across one. `"@<key>": {"x-mt": true}` in a locale file marks a
+// string as unreviewed machine output; ~560 keys per locale carry it. The merge
+// carries those blocks over verbatim, and then reconciles them, because merely
+// preserving them is not enough:
+//
+//   * a key this script derives from the Kotlin XML is a human translation
+//     already shipping in the Android app, so if a stale `x-mt` block is
+//     sitting there — the workflow above, delete the key and re-run to pick up
+//     a better translation, leaves exactly that — the flag is dropped;
+//   * a flag whose key has no value at all is dropped, so it cannot land on
+//     whatever value is written for that key next and mislabel it.
+//
+// `test/l10n/placeholder_integrity_test.dart` pins both ends of this.
+//
+// Usage, again from `flutter/`:
+//   dart tool/arb_from_strings_xml.dart --unreviewed        # list what needs a
+//   dart tool/arb_from_strings_xml.dart --unreviewed fr     # human, per locale
 
 import 'dart:convert';
 import 'dart:io';
@@ -47,7 +66,18 @@ import 'package:xml/xml.dart';
 /// Locales with a `values-<code>` directory in the Kotlin app.
 const defaultLocales = ['ar', 'fr', 'ne', 'so'];
 
+/// Every locale that ships an `.arb`. `es` has no Kotlin `values-es`, so it is
+/// not derivable — but it does carry machine-translated strings to review.
+const allLocales = ['ar', 'es', 'fr', 'ne', 'so'];
+
+/// The ARB attribute marking a string as unreviewed machine translation.
+const machineTranslatedFlag = 'x-mt';
+
 void main(List<String> args) {
+  if (args.isNotEmpty && args.first == '--unreviewed') {
+    _reportUnreviewed(args.skip(1).toList());
+    return;
+  }
   final locales = args.isEmpty ? defaultLocales : args;
   final resDir = Directory('../app/src/main/res');
   if (!resDir.existsSync()) {
@@ -88,6 +118,14 @@ void main(List<String> args) {
       if (templateValue is! String) continue;
       // ICU syntax of any kind is out of scope — see the header.
       if (templateValue.contains('{')) continue;
+      // So is Kotlin's printf syntax. Three template keys — `communityEarnings`,
+      // `perSurvey`, `yourEarnings` — declare ICU placeholders but write their
+      // English with `%1$d`/`%1$s`, which ICU never interpolates: the generated
+      // getter takes the argument and drops it, in every language including
+      // English. Deriving a translation would spread that defect into the
+      // locale files, where the placeholder guard then fails on it. Leave them
+      // absent until `app_en.arb` is corrected to `{amount}`/`{status}`.
+      if (_printfSpecifier.hasMatch(templateValue)) continue;
       final wanted = templateValue.trim();
 
       final named = byCamelCase[key] ?? const [];
@@ -143,19 +181,99 @@ void main(List<String> args) {
       if (!derived.containsKey(entry.key)) preserved++;
     }
     var added = 0;
+    final humanDerived = <String>{};
     for (final key in keys) {
       final value = derived[key];
       if (value == null || merged.containsKey(key)) continue;
       merged[key] = value;
+      humanDerived.add(key);
       added++;
     }
 
+    final cleared = _reconcileMachineTranslationFlags(merged, humanDerived);
+
     file.writeAsStringSync('${_encodeArb(merged)}\n');
     stdout.writeln(
-      'app_$locale.arb: ${merged.length - 1} strings '
+      'app_$locale.arb: ${_messageKeys(merged).length} strings '
       '($byName by name, $byText by shared English) of ${keys.length} keys'
-      ' — $added added, $preserved kept that the XML does not derive',
+      ' — $added added, $preserved kept that the XML does not derive,'
+      ' ${_machineTranslatedKeys(merged).length} still unreviewed'
+      '${cleared == 0 ? '' : ' ($cleared flag(s) cleared)'}',
     );
+  }
+}
+
+/// Kotlin's `%s`/`%d`/`%1$s` format specifiers, which ICU does not interpolate.
+final _printfSpecifier = RegExp(r'%\d*\$?[sd]');
+
+/// Translatable entries — not `@@locale`, not an `@key` metadata block.
+Iterable<String> _messageKeys(Map<String, Object?> arb) =>
+    arb.keys.where((key) => !key.startsWith('@') && arb[key] is String);
+
+/// Keys flagged as unreviewed machine translation.
+Iterable<String> _machineTranslatedKeys(Map<String, Object?> arb) => arb.keys
+    .where((key) => key.startsWith('@') && key != '@@locale')
+    .where((key) {
+      final meta = arb[key];
+      return meta is Map && meta[machineTranslatedFlag] == true;
+    })
+    .map((key) => key.substring(1));
+
+/// Drops `x-mt` flags that have stopped being true, and returns how many.
+///
+/// Two cases, both of which this script itself creates:
+///
+///   * [humanDerived] is what this run carried across from the Kotlin
+///     `strings.xml` — translations already shipping in the Android app. A flag
+///     on one of those is stale by definition.
+///   * a flag whose key carries no value marks nothing. Left in place it would
+///     attach itself to the next value written for that key.
+///
+/// A metadata block that also declares placeholders keeps them: only the flag
+/// is removed, and only an emptied block is deleted outright.
+int _reconcileMachineTranslationFlags(
+  Map<String, Object?> merged,
+  Set<String> humanDerived,
+) {
+  final translated = _messageKeys(merged).toSet();
+  var cleared = 0;
+
+  for (final key in _machineTranslatedKeys(merged).toList()) {
+    if (!humanDerived.contains(key) && translated.contains(key)) continue;
+    final meta = Map<String, Object?>.from(merged['@$key']! as Map);
+    meta.remove(machineTranslatedFlag);
+    if (meta.isEmpty) {
+      merged.remove('@$key');
+    } else {
+      merged['@$key'] = meta;
+    }
+    cleared++;
+  }
+
+  return cleared;
+}
+
+/// Prints the strings still awaiting a human, per locale.
+///
+/// This is the whole point of the marking: ~560 keys per locale are Google
+/// Translate output sitting indistinguishably beside translations derived from
+/// the Kotlin app. A reviewer needs to see exactly which.
+void _reportUnreviewed(List<String> args) {
+  for (final locale in args.isEmpty ? allLocales : args) {
+    final file = File('lib/l10n/app_$locale.arb');
+    if (!file.existsSync()) {
+      stderr.writeln('No app_$locale.arb — skipped.');
+      continue;
+    }
+    final arb = _readArb(file.path);
+    final unreviewed = _machineTranslatedKeys(arb).toList();
+    stdout.writeln(
+      '# $locale — ${unreviewed.length} unreviewed of '
+      '${_messageKeys(arb).length} translated',
+    );
+    for (final key in unreviewed) {
+      stdout.writeln('$key\t${arb[key]}');
+    }
   }
 }
 
@@ -176,16 +294,48 @@ Map<String, String> _readStringsXml(String path) {
   return result;
 }
 
-/// Strips Android's whitespace-preserving quoting.
+/// Strips Android's whitespace-preserving quoting and backslash escapes.
 ///
 /// `<string name="x">"Select resources: "</string>` is the XML way to keep a
 /// trailing space; the quotes are not part of the value. Reading `innerText`
 /// verbatim carried them into the `.arb`, and the app then displayed them.
+///
+/// Android also escapes apostrophes and quotes with a backslash, which the XML
+/// parser leaves alone because they are not XML syntax: `values-fr` writes
+/// `Impossible d\'ajouter un dossier de santé.` The backslash is Android's, not
+/// the string's, and carrying it across would put a literal `d\'ajouter` on a
+/// French screen. Every escape Android documents is undone here; an unknown one
+/// keeps its backslash rather than being silently eaten.
 String _unquote(String raw) {
-  if (raw.length > 1 && raw.startsWith('"') && raw.endsWith('"')) {
-    return raw.substring(1, raw.length - 1);
+  final quoted = raw.length > 1 && raw.startsWith('"') && raw.endsWith('"')
+      ? raw.substring(1, raw.length - 1)
+      : raw;
+
+  final buffer = StringBuffer();
+  for (var i = 0; i < quoted.length; i++) {
+    if (quoted[i] != r'\' || i + 1 == quoted.length) {
+      buffer.write(quoted[i]);
+      continue;
+    }
+    final escaped = quoted[i + 1];
+    switch (escaped) {
+      case "'":
+      case '"':
+      case '@':
+      case '?':
+      case r'\':
+        buffer.write(escaped);
+      case 'n':
+        buffer.write('\n');
+      case 't':
+        buffer.write('\t');
+      default:
+        buffer.write(quoted[i]);
+        continue; // not an escape — keep the backslash and re-read the next char
+    }
+    i++;
   }
-  return raw;
+  return buffer.toString();
 }
 
 String _camelCase(String snakeCase) {


### PR DESCRIPTION
Lane A of the Phase 109 parallel round. Head: `d7e9a6d`. Gate green locally — format clean, analyze clean, **1746 tests pass** (1740 baseline + 6 new).

Full write-up, including the exact wording proposed for `CLAUDE.md`'s l10n section, is in `flutter/PHASE_109_NOTES.md`.

## 1. The guard — `flutter/test/l10n/placeholder_integrity_test.dart`

Two checks over every value in every locale file:

- **no tokenisation artefact** — three named patterns, so the failure says which matched: the sentinel shape that shipped (`_{2,}\d+_{2,}`), any run of 2+ underscores (a wider net; no legitimate value has one today), and Kotlin's printf specifiers, which ICU never interpolates.
- **every placeholder the template declares.** The authority is the `placeholders` map inside `app_en.arb`'s `@KEY` **metadata block**, not a regex over `{...}` — an ICU plural body is full of braces that are not placeholders (`{count, plural, =1{…}}` yields spurious `1`, `No`, `Are`), which is why the first pass reported 54 "missing" where 20 were real.

Both **collect every defect** rather than stopping at the first, and name `locale:key`, the offending value, and the missing placeholder — so fixing does not mean re-deriving the analysis.

### Demonstrated catch

Ran against the five locale files as they stood at `c2132ab2f^` (the harvested, pre-repair state):

```
91 value(s) carry a placeholder that was tokenised for translation and never restored:
  ar:ratingOutOfFive contains a tokenisation sentinel (__0__) — "التقييم: __0____ من 5"
  …
62 value(s) drop a placeholder app_en.arb declares:
  es:fileNotFound drops "fileName" — "Archivo no encontrado localmente"
  …
```

**58 distinct keys flagged — exactly the 58 the repair commit removed, key for key.** Green on the repaired files, so it is a catch and not a blanket refusal.

### A template defect it names

`communityEarnings`, `perSurvey`, `yourEarnings` declare ICU placeholders while writing their **English** with Kotlin's `%1$d`/`%1$s`, so `gen-l10n` emits `String perSurvey(String status)` and never interpolates it — the value is dropped in every language, English included. 15 of the 58 removals were these three. `app_en.arb` is not this lane's file; **follow-up for whoever owns it.** The tool now skips printf-carrying template values so a re-run cannot walk the defect into the locale files meanwhile.

## 2. Marking — a per-key `x-mt` attribute

Each unreviewed key gets a metadata block beside it in the locale file:

```json
"ratingOutOfFive": "…",
"@ratingOutOfFive": { "x-mt": true },
```

| locale | unreviewed (MT) | human-reviewed | falls back to English |
|---|---|---|---|
| ar | 557 | 259 | 46 |
| es | 620 | 234 | 8 |
| fr | 594 | 260 | 8 |
| ne | 595 | 259 | 8 |
| so | 595 | 259 | 8 |

Per-key rather than a central list, because **a flag then cannot drift from the string it describes** — a list goes stale exactly the way Phase 69's regeneration did, silently. Verified ignored by `gen-l10n` on the pinned 3.44.8: generated output byte-identical before and after, including on placeholder-bearing keys where a locale-side block could plausibly have stripped a getter's parameters.

`dart tool/arb_from_strings_xml.dart --unreviewed [locale]` lists them. Four further tests pin the marking (present, no orphans, template unflagged, counts pinned).

**No translated text changed** — the `.arb` diffs are pure insertions, verified by comparing the non-metadata maps against `HEAD`.

## 3. Tool preservation

Flags already survived the merge; keeping them *true* is the new part. `_reconcileMachineTranslationFlags` drops a flag when the tool derives a human translation from the Kotlin XML over it (the documented "delete the key and re-run" refresh leaves precisely that stale flag), and when a flag's key has no value at all. A `placeholders` declaration in the same block is kept; only an emptied block is deleted. Verified end to end on `fr` with all three shapes seeded: `3 flag(s) cleared`, `login` re-derived unflagged, the orphan gone, `@currentCv` left holding its placeholders, all 594 legitimate flags intact.

Also fixes `_unquote`, which stripped Android's whitespace-preserving quotes but not its backslash escapes — a re-run would have written `Impossible d\'ajouter un dossier de santé.` into `app_fr.arb` and onto a French screen.

## Scope

Touched only this lane's files: `flutter/test/l10n/`, `flutter/tool/arb_from_strings_xml.dart`, `flutter/lib/l10n/*.arb` (metadata only), `flutter/PHASE_109_NOTES.md`. No `app_en.arb` text, no `schemaVersion`, no `CLAUDE.md`.

## Left undone, deliberately

- The 8 keys per locale (46 for Arabic) still untranslated fall back to English, as intended — nothing machine-translated here.
- Four keys the XML *can* now derive into the gaps the repair left (`myGoalsDescription`, `myPurposeDescription`, `summaryOfAchievements`, `unableToAddHealthRecord`) are **not** added, because this lane changes no translated text. Free win for whoever runs the tool next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShTeKTfGiovxu6jBp9oqNy