### PR TITLE
Phase 111: repair legacy health rows (schema 45) and make the silent 409 visible

### DIFF
--- a/flutter/PHASE_111_NOTES.md
+++ b/flutter/PHASE_111_NOTES.md
@@ -49,6 +49,8 @@ UPDATE health_examinations SET user_id = id
    AND _id IS NULL AND _rev IS NULL
    AND id NOT IN (SELECT id FROM users)
    AND id NOT IN (SELECT _id FROM users WHERE _id IS NOT NULL)
+   AND EXISTS (SELECT 1 FROM health_examinations AS p
+                WHERE p.id = health_examinations.user_id)
 ```
 
 `user_id = id` is not an invention: it is what Phase 105 made every new
@@ -72,11 +74,6 @@ Each remaining conjunct excludes something real, and there is a test for each:
   collision. Phase 107 drew the same boundary.
 * `user_id <> id` — the post-Phase-105 shape and every synced row have them
   equal.
-* `_id IS NULL AND _rev IS NULL` — a row that already uploaded owns a revision
-  of the document its old `userId` names. Re-keying it while keeping that
-  `_rev` would post a revision of a document that does not exist under the new
-  id: **the same 409, newly caused by us.** Those rows are left alone. See the
-  limits below.
 * `id NOT IN (users)` — a profile row's id is the patient's user-row key
   (`saveHealthProfileBlob`), and `UserDao.getById` matches `_id` as well as
   `id`, so both columns are checked. This is the conjunct that protects the
@@ -86,14 +83,88 @@ Each remaining conjunct excludes something real, and there is a test for each:
   millisecond timestamp no server can resolve to a person — precisely the
   mistake `saveHealthProfileBlob`'s own comment records having already been
   made once.
+* `_rev IS NULL` — a row that already uploaded owns a revision, and **nothing
+  on the row records which document it is a revision of.** See below; this one
+  had a wrong justification in the first cut of these notes. `_id IS NULL`
+  rides along and excludes nothing: `couchId` is only ever written by
+  `_docToCompanion`, whose rows have `userId == id` and are already out. It is
+  kept to say plainly that a row with a server identity is not repairable.
+* `EXISTS (… p.id = user_id)` — the collision must actually exist. **This is
+  the conjunct the first cut lacked, and its absence was the phase's own worst
+  defect.** See below.
 
-**Confidence.** High that the predicate matches nothing it should not — every
-excluded shape is pinned by a test in `migration_test.dart`. Moderate that it
-catches *every* legacy row, and the gap is deliberate: a legacy row that
-already uploaded is excluded, because there is no safe repair for it. That row
-overwrote the patient's profile document on the server with an examination, and
-a migration cannot unpick that; it needs a sync-in, which is a different
-problem.
+### The false positive a `parity-auditor` pass found, and I had claimed could not exist
+
+The first cut of these notes said *"High that the predicate matches nothing it
+should not."* That was wrong, and the shape it missed is reachable through the
+port's own ordinary write path rather than through anything exotic.
+
+`saveHealthProfileBlob` resolves the profile row with `getByIdOrUserId`, whose
+predicate is `id = ? OR userId = ?` — and a legacy examination row satisfies
+the second half, because its `userId` **is** the patient's id. The else-branch
+then keeps `id: Value(existing.id)` and writes the encrypted `MyHealth` blob
+into it. So on a device that has a legacy examination row and no separate
+profile row, the first save on a post-Phase-105 build turns the examination row
+**into** the patient's profile row, keeping its `health-…` id. Measured, with
+the profile row absent or written second:
+
+```
+PROBE[legacy-first]    [{id: health-1725000000000000, user_id: org.couchdb.user:ada, hasdata: 1}]
+PROBE[no-profile-row]  [{id: health-1725000000000000, user_id: org.couchdb.user:ada, hasdata: 1}]
+```
+
+One row, holding the health profile, keyed on an examination id. Every other
+conjunct of the repair matches it — `is_updated = 1`, `user_id <> id`,
+`profile_id IS NULL`, no `_id`/`_rev`, and `id NOT IN (users)` most of all. The
+repair would have re-keyed it and published the patient's emergency contact,
+special needs and `userKey` under a millisecond timestamp: **the exact harm
+this phase exists to prevent, caused by the phase.**
+
+The `EXISTS` conjunct is the narrowing. It says the row must be colliding with
+something: some row is keyed on the `user_id` about to be replaced. A converted
+row is the only row for its patient, so it is excluded; the true positive keeps
+its profile row, so it is not. `leaves a legacy row that became the profile row
+alone` fails on the pre-fix predicate with
+`Actual: 'health-1725000000000005'`.
+
+The cost of the narrowing, stated plainly: a legacy examination row whose
+patient has no profile row at all is no longer repaired. It does not 409 — it
+posts under the patient's id and quietly becomes their profile document on the
+server, which is a different and older bug. Repairing that shape needs to know
+which of the two rows is the examination, and after the conversion above the
+answer is destroyed rather than merely unknown.
+
+**Confidence, restated.** The predicate is now pinned against eight shapes in
+`migration_test.dart`, including the one that caught me. What I will not claim
+again is that no ninth exists: the reason this one was invisible is that I
+reasoned about the rows a *migration* would see rather than about what the
+app's own write paths do to those rows between Phase 105 shipping and the
+upgrade running.
+
+### What the `_rev` exclusion actually excludes
+
+The first cut justified it as *"a row that already uploaded owns a revision of
+the document its old `userId` names."* It does not. Before Phase 107,
+`serialize` keyed the upload on the row's **own `id`** — commit `713c5ad` is
+the line that changed it:
+
+```
+-      if (row.id.isNotEmpty) '_id': row.id,
++      if (docId.isNotEmpty) '_id': docId,     // docId = row.userId ?? ''
+```
+
+and `markUploaded` writes `rev` and `is_updated`, never `couchId`. So an old
+`_rev` may belong to the `health-…` document or to the patient's, and nothing
+on the row says which. For half of them the repair is exactly right and
+excluding them is what keeps them broken. They are still left alone, because a
+guess here writes a revision of a document that may not exist — but the reason
+is *ambiguity*, not the confident story the first cut told. **These rows remain
+a silent loss path**, and the banner in §3 will now report them without being
+able to fix them.
+
+The first cut also said such a row *"overwrote the patient's profile document
+on the server with an examination."* It did not: under the pre-107 keying it
+created its own document under `health-…` and overwrote nothing.
 
 **What a user with pending local health records loses to this bump: nothing.**
 `health_examinations` and `users` are both in `localAuthorityTables`, so the
@@ -118,12 +189,26 @@ false for a 409, returns null, and `markHealthExaminationsUploaded` simply
 does not include the row — leaving `isUpdated` set so the next sync tries
 again, forever, with the same stale `_rev`. Nothing is logged; the `catch` only
 runs for a throw. So Kotlin is not *handling* the conflict either. It differs
-in one way worth recording: **Kotlin retries indefinitely where the port
-abandons.** In practice the port also retries, because
-`OutboxRepository.enqueue` only looks for an *open* operation and an abandoned
-row is not one — so each save queues the doomed record afresh and leaves one
-more abandoned row behind. The rows accumulate; `cleanup()` exists and has no
-caller.
+in one way worth recording, and the first cut of these notes understated it.
+
+**Kotlin retries automatically and free; the port did not retry at all unless
+the clinician re-saved.** `HealthQueue.queuePending` has exactly one caller —
+`onSaved` on the examination form. The health screen's sync button and the sync
+centre both run `HealthSyncNotifier`, which is `HealthRepository.sync`, a
+**pull**. And `OutboxDrainer` only selects `pending` rows, so no resume-drain or
+background job ever touches an abandoned one. Kotlin's `uploadHealth` runs from
+`AutoSyncWorker` and `UserDataWorker` on every sync and re-attempts everything
+still flagged `isUpdated`. So the port's abandonment was not merely louder than
+Kotlin's silence — for a transient 4xx (a momentarily wrong PIN earns a 401,
+which `code < 500` calls permanent) it was **worse**. That is the divergence
+worth naming, not the abandonment itself.
+
+Hence the banner carries a **Retry**, using the existing `retry` key: it calls
+`queuePending` and drains. `enqueue` ignores the abandoned row and writes a
+fresh pending one, so it is a real re-attempt rather than a nudge. Wiring the
+same re-queue into the health sync area would be the fuller fix — Kotlin's sync
+does both directions — but that is a shared surface and this is a parallel
+round; logged rather than taken.
 
 What was missing was not retrying but *saying so*. `OutboxDao` gains
 `abandoned(uploadType)` and `forItem(uploadType, itemId)` — before this,
@@ -134,6 +219,20 @@ silently discarded". `rejectedHealthRecordCountProvider` counts them by
 than of attempts, and `MyHealthScreen` opens with a caution card when it is
 non-zero: *"N health records could not be sent to the server. They are still
 stored on this device."* One new `app_en.arb` key, `healthRecordsRejected`.
+The card renders on the no-patient branch too — "no patient resolves" is
+exactly the state a clinician might be in while wondering where a reading went
+— and the count is device-wide rather than per-patient, which the wording says.
+
+**The banner had to be able to clear, and in the first cut it could not.** An
+abandoned row is never reused, `markCompleted` deletes only the row that
+succeeded, and `cleanup()` has no caller — so a record refused once would have
+been reported as stranded for the life of the install, *including after the v45
+repair delivered it*, with no action offered and nothing true about the
+warning. `HealthUploader.handler` now withdraws the abandoned rows for an item
+when the server accepts it, which is the only event that makes an old refusal
+untrue. `a delivered record stops being reported as stranded` runs the real
+upgrade sequence — refused first, repaired second — which is what the earlier
+test missed by migrating before the first drain.
 
 It is a `FutureProvider`, not a stream, and that is not a style preference: a
 live drift query held open for the life of the screen leaves a pending timer
@@ -150,7 +249,7 @@ it with.
 
 ## 4. `creatorId` — a Kotlin quirk, now ported
 
-`HealthExamination.kt:109-110`:
+`HealthExamination.kt:110-111`:
 
 ```kotlin
 JsonUtils.addString(`object`, "profileId", health.profileId)
@@ -186,7 +285,10 @@ The audit item was stale.
 Owned by this lane, except where noted:
 
 * `lib/data/local/app_database.dart` — `schemaVersion` 45, the repair step,
-  `OutboxDao.forItem`/`abandoned`.
+  `OutboxDao.forItem`/`abandoned`/`clearAbandonedFor`.
+* `lib/repository/health_uploader.dart`, and two methods on
+  `lib/repository/outbox_repository.dart` (`clearAbandoned`). Neither file is
+  named in another lane's set; the outbox change is purely additive.
 * `lib/repository/health_repository.dart` — the `creatorId` serializer.
 * `lib/providers/health_provider.dart` — `rejectedHealthRecordCountProvider`.
 * `lib/ui/health/my_health_screen.dart` — the caution banner, and the refresh

--- a/flutter/PHASE_111_NOTES.md
+++ b/flutter/PHASE_111_NOTES.md
@@ -1,8 +1,199 @@
 # Phase 111 — the legacy health row, the 409 that eats a record, and making it visible
 
-*In progress.* Picking up the decision Phase 107 handed to the integrator:
-do the one-time data repair for pre-Phase-105 examination rows, at
-`schemaVersion` 45, and make an unretryable outbox conflict observable
-rather than silent.
+Phase 107 found the defect and handed the decision on: a pre-Phase-105
+examination row collides with the patient's profile document, and the loser of
+that collision takes a **409** the outbox classifies as permanent, so a
+clinician's reading never reaches the server and nothing anywhere says so. It
+named two honest options — a one-time data repair needing a schema number, or
+accepting the exposure — and recommended accepting.
 
-Notes land here as the work does.
+The integrator chose the repair and allocated `schemaVersion` **45**. This is
+that repair, plus the observability half, which is independent of it and
+matters more.
+
+## 1. What actually goes wrong
+
+`HealthRepository.serialize` keys the uploaded document on the row's `userId`,
+not on its own id — `if (!health.userId.isNullOrEmpty()) object.addProperty("_id", health.userId)`
+(`HealthExamination.kt:96`). Two rows with the same `userId` therefore claim
+the same CouchDB document.
+
+Before Phase 105 the examination form wrote the **patient's** id into a new
+row's `userId` (`createExamination(userId: _userId, …)`), so on a device that
+recorded an examination then, `health_examinations` holds:
+
+| row | `id` | `userId` | serialized `_id` |
+|---|---|---|---|
+| profile | `org.couchdb.user:ada` | `org.couchdb.user:ada` | `org.couchdb.user:ada` |
+| examination | `health-1725000000000000` | `org.couchdb.user:ada` | `org.couchdb.user:ada` |
+
+`saveHealthProfileBlob` writes before `createExamination`, so on the drain the
+profile is POSTed first and wins. The examination gets a 409.
+`OutboxDrainer._send` treats every `code < 500` as permanent, so the operation
+is abandoned on its first attempt, `markUploaded` never runs, `isUpdated` stays
+true, and the row sits on the handset looking, to every screen, exactly like a
+record that was filed.
+
+`health_legacy_conflict_test.dart` holds that whole path against a fake CouchDB
+that enforces `_id` uniqueness the way the real one does — the assertion is the
+**record loss** (`couch.documents.keys` is `[patientId]` and nothing else), not
+the status code.
+
+## 2. The repair, and how narrow it is
+
+```sql
+UPDATE health_examinations SET user_id = id
+ WHERE is_updated = 1
+   AND user_id IS NOT NULL AND user_id <> id
+   AND profile_id IS NULL
+   AND _id IS NULL AND _rev IS NULL
+   AND id NOT IN (SELECT id FROM users)
+   AND id NOT IN (SELECT _id FROM users WHERE _id IS NOT NULL)
+```
+
+`user_id = id` is not an invention: it is what Phase 105 made every new
+examination do (`createExamination`: `userId ?? id`), what `_docToCompanion`
+maintains for every synced row (`userId: doc['_id']`), and what Kotlin's
+`saveData` writes (`_id` and `userId` are the same `generateIv()`). A repaired
+row is indistinguishable from one recorded today and posts as its own document.
+
+**Phase 107 declined to write an id-prefix heuristic and was right to.** The
+rule here is not one. `profile_id IS NULL` is a *positive* identification, and
+it comes from the port's own history rather than from the shape of a string:
+Phase 105's headline finding was that the pre-Phase-105 form "wrote no
+`profileId`, which is the only link `getPatientHealthRecords` looks examinations
+up by" (commit `a5dd24d`). Every row from the server carries the `profileId`
+Planet stored; every row written since Phase 105 carries `health.userKey`. Only
+the broken generation has none.
+
+Each remaining conjunct excludes something real, and there is a test for each:
+
+* `is_updated = 1` — a clean row is never queued, so it is not in the
+  collision. Phase 107 drew the same boundary.
+* `user_id <> id` — the post-Phase-105 shape and every synced row have them
+  equal.
+* `_id IS NULL AND _rev IS NULL` — a row that already uploaded owns a revision
+  of the document its old `userId` names. Re-keying it while keeping that
+  `_rev` would post a revision of a document that does not exist under the new
+  id: **the same 409, newly caused by us.** Those rows are left alone. See the
+  limits below.
+* `id NOT IN (users)` — a profile row's id is the patient's user-row key
+  (`saveHealthProfileBlob`), and `UserDao.getById` matches `_id` as well as
+  `id`, so both columns are checked. This is the conjunct that protects the
+  profile row of a member registered *on this device*, whose `id` is a local
+  `'<millis>'` and whose `userId` is legitimately the CouchDB id it was later
+  given. Re-keying that one would publish the health profile under a
+  millisecond timestamp no server can resolve to a person — precisely the
+  mistake `saveHealthProfileBlob`'s own comment records having already been
+  made once.
+
+**Confidence.** High that the predicate matches nothing it should not — every
+excluded shape is pinned by a test in `migration_test.dart`. Moderate that it
+catches *every* legacy row, and the gap is deliberate: a legacy row that
+already uploaded is excluded, because there is no safe repair for it. That row
+overwrote the patient's profile document on the server with an examination, and
+a migration cannot unpick that; it needs a sync-in, which is a different
+problem.
+
+**What a user with pending local health records loses to this bump: nothing.**
+`health_examinations` and `users` are both in `localAuthorityTables`, so the
+upgrade steps over them — the drop-and-recreate loop is for CouchDB caches
+only. The repair changes one column on rows that could not upload anyway, and
+`the repair does not cost the record it repairs` asserts the reading, its
+ciphertext and its `isUpdated` flag all survive. There is no shape change, so
+`tables.dart` is untouched and there is no `_addColumnIfMissing` step to write.
+
+## 3. Making the 409 visible — the half that is not about legacy rows
+
+The repair only reaches rows that already exist. A conflict can still happen
+tomorrow: the profile row's `_rev` goes stale when another device updates the
+same patient, and `cacheDocuments` deliberately skips a locally-edited row
+(`if (current?.isUpdated == true) continue`), so a dirty profile row never
+learns the new revision. Every one of those ends the same way — abandoned,
+silent.
+
+**Kotlin has nothing to port here.** `uploadHealthData`
+(`HealthRepositoryImpl.kt:111-141`) reads `res.body()?.has("id")`, which is
+false for a 409, returns null, and `markHealthExaminationsUploaded` simply
+does not include the row — leaving `isUpdated` set so the next sync tries
+again, forever, with the same stale `_rev`. Nothing is logged; the `catch` only
+runs for a throw. So Kotlin is not *handling* the conflict either. It differs
+in one way worth recording: **Kotlin retries indefinitely where the port
+abandons.** In practice the port also retries, because
+`OutboxRepository.enqueue` only looks for an *open* operation and an abandoned
+row is not one — so each save queues the doomed record afresh and leaves one
+more abandoned row behind. The rows accumulate; `cleanup()` exists and has no
+caller.
+
+What was missing was not retrying but *saying so*. `OutboxDao` gains
+`abandoned(uploadType)` and `forItem(uploadType, itemId)` — before this,
+nothing selected an abandoned row at all, and keeping the row **was** the whole
+of what `OutboxOutcome.abandoned`'s doc comment calls "inspectable rather than
+silently discarded". `rejectedHealthRecordCountProvider` counts them by
+**distinct `itemId`**, not by row, so the number is of stranded records rather
+than of attempts, and `MyHealthScreen` opens with a caution card when it is
+non-zero: *"N health records could not be sent to the server. They are still
+stored on this device."* One new `app_en.arb` key, `healthRecordsRejected`.
+
+It is a `FutureProvider`, not a stream, and that is not a style preference: a
+live drift query held open for the life of the screen leaves a pending timer
+that fails *every* widget test in `my_health_screen_test.dart` with "A Timer is
+still pending even after the widget tree was disposed". The screen re-reads it
+on build, and pull-to-refresh invalidates it — which is when a clinician would
+look.
+
+This banner is the port's own addition; Kotlin has no counterpart, because it
+has no permanent-failure state to report. It is kept anyway on the grounds the
+brief states: a record that silently never reaches the server is the worst
+failure this app can produce, and a health record is the worst one to produce
+it with.
+
+## 4. `creatorId` — a Kotlin quirk, now ported
+
+`HealthExamination.kt:109-110`:
+
+```kotlin
+JsonUtils.addString(`object`, "profileId", health.profileId)
+JsonUtils.addString(`object`, "creatorId", health.profileId)
+```
+
+Both wire fields come from `profileId`. It reads like a copy-paste slip and may
+be one, but it is the shape Planet has always been sent by myPlanet, and the
+brief's question — does "equal for every row either app writes" stay true? —
+has a *no* in it. Both apps set the two columns to the same `health.userKey`
+when authoring (`HealthExaminationActivity.kt:248-249`, and the port's form),
+and Kotlin's own serializer guarantees a myPlanet-authored server document has
+them equal. But `_docToCompanion` copies the two independently from the
+document, so a record **Planet itself wrote** with `creatorId ≠ profileId`,
+pulled in and edited on the device, went back out with the port preserving the
+server's `creatorId` where Kotlin replaces it. That is the one case the field
+is load-bearing, and it is the one where the two apps disagreed. `serialize`
+now writes `profileId` into both, including the null case — `addString` skips a
+null, so a row with no `profileId` sends no `creatorId` at all.
+
+## 5. `getUpdated()` — already correct, no change
+
+The other audit item was `getUpdated()`'s `userId.isNotNull()` against Kotlin's
+`userId != ''`. It has already been fixed and pinned: the port reads
+`isUpdated.equals(true) & userId.isNotNull() & userId.equals('').not()`
+(`app_database.dart`), whose doc comment spells out that `userId != ''` is
+false for NULL as well, so Kotlin excludes a blank `userId` along with a
+missing one. `health_repository_test.dart:1013` and `:1035` pin both halves.
+The audit item was stale.
+
+## 6. Files touched, for the integrator
+
+Owned by this lane, except where noted:
+
+* `lib/data/local/app_database.dart` — `schemaVersion` 45, the repair step,
+  `OutboxDao.forItem`/`abandoned`.
+* `lib/repository/health_repository.dart` — the `creatorId` serializer.
+* `lib/providers/health_provider.dart` — `rejectedHealthRecordCountProvider`.
+* `lib/ui/health/my_health_screen.dart` — the caution banner, and the refresh
+  handler now invalidating it.
+* `test/data/local/migration_test.dart`, `test/ui/health/my_health_screen_test.dart`,
+  and the new `test/repository/health_legacy_conflict_test.dart`.
+* **`lib/l10n/app_en.arb` — one key, `healthRecordsRejected`, inserted directly
+  after `healthRecordNotAvailable`.** Lane A owns `lib/l10n/`; this is the only
+  line of theirs this branch touches, and it is a pure insertion.
+* **`lib/data/local/tables.dart` is NOT touched.** The repair needs no column.

--- a/flutter/PHASE_111_NOTES.md
+++ b/flutter/PHASE_111_NOTES.md
@@ -1,0 +1,8 @@
+# Phase 111 — the legacy health row, the 409 that eats a record, and making it visible
+
+*In progress.* Picking up the decision Phase 107 handed to the integrator:
+do the one-time data repair for pre-Phase-105 examination rows, at
+`schemaVersion` 45, and make an unretryable outbox conflict observable
+rather than silent.
+
+Notes land here as the work does.

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -339,12 +339,33 @@ class AppDatabase extends _$AppDatabase {
       //    the server carries the one Planet stored. This is the positive
       //    identification, not an id-prefix guess: Phase 107 declined to write
       //    the guess, and it was right to.
-      //  * `_id IS NULL AND _rev IS NULL` — a row that already uploaded owns a
-      //    revision of the document its old `userId` names. Re-keying it while
-      //    keeping that `_rev` would post a revision of a document that does
-      //    not exist under the new id: the same 409, newly caused by us. Those
-      //    rows are left alone; the mess they made on the server predates this
-      //    and a migration cannot unpick it.
+      //  * `_rev IS NULL` — a row that already uploaded owns a revision, and
+      //    nothing on the row records *which document* it is a revision of.
+      //    Before Phase 107 `serialize` keyed the upload on the row's own `id`
+      //    (`713c5ad` is the line that changed it to `userId`), and
+      //    `markUploaded` writes `rev` and nothing else — so an old `_rev` may
+      //    belong to the `health-…` document or to the patient's, and the
+      //    repair is right for one and wrong for the other. Left alone rather
+      //    than guessed at; these rows remain a loss path, recorded in
+      //    `PHASE_111_NOTES.md`. `_id IS NULL` rides along: `couchId` is only
+      //    ever written by `_docToCompanion`, whose rows have `userId == id`
+      //    and are already excluded, so it adds nothing and is kept only to
+      //    say plainly that a row with a server identity is not repairable.
+      //  * `EXISTS (… p.id = user_id)` — the collision must actually exist.
+      //    This is the conjunct the first cut of the repair lacked, and its
+      //    absence was not theoretical: `saveHealthProfileBlob` resolves the
+      //    profile row with `getByIdOrUserId`, which matches a legacy
+      //    examination row *through its `userId` column*, and the else-branch
+      //    then keeps `id: Value(existing.id)` — so on a device with no
+      //    separate profile row the first post-Phase-105 save turns the legacy
+      //    examination row into the patient's profile row, `id = 'health-…'`
+      //    and all. Every other conjunct here still matches it, and re-keying
+      //    it would publish the health profile under a millisecond timestamp
+      //    no server can resolve to a person: the exact harm this repair
+      //    exists to prevent, caused by the repair. A converted row is the
+      //    only row for its patient, so requiring a row keyed on the `userId`
+      //    being replaced excludes it and keeps the true positive, where the
+      //    profile row is what the examination is colliding with.
       //  * `id NOT IN (users)` — a *profile* row's id is the patient's user
       //    row key (`saveHealthProfileBlob`), and `UserDao.getById` matches
       //    `_id` as well as `id`, so both columns are checked. This is what
@@ -361,7 +382,9 @@ class AppDatabase extends _$AppDatabase {
           'AND _id IS NULL '
           'AND _rev IS NULL '
           'AND id NOT IN (SELECT id FROM users) '
-          'AND id NOT IN (SELECT _id FROM users WHERE _id IS NOT NULL)',
+          'AND id NOT IN (SELECT _id FROM users WHERE _id IS NOT NULL) '
+          'AND EXISTS (SELECT 1 FROM health_examinations AS p '
+          'WHERE p.id = health_examinations.user_id)',
         );
       }
     },
@@ -1761,6 +1784,22 @@ class OutboxDao extends DatabaseAccessor<AppDatabase> with _$OutboxDaoMixin {
             )
             ..orderBy([(row) => OrderingTerm(expression: row.createdAt)]))
           .get();
+
+  /// Drops the abandoned rows recorded against one item.
+  ///
+  /// An abandoned row is never reused — [findOpen] ignores it — and `cleanup()`
+  /// has no caller, so without this a record that is refused once is reported
+  /// as stranded for the life of the install, including after a later attempt
+  /// delivers it. The uploader calls this when the server finally accepts the
+  /// record, which is the only event that makes the old refusals untrue.
+  Future<int> clearAbandonedFor(String uploadType, String itemId) =>
+      (delete(outboxEntries)..where(
+            (row) =>
+                row.uploadType.equals(uploadType) &
+                row.itemId.equals(itemId) &
+                row.status.equals(statusAbandoned),
+          ))
+          .go();
 
   /// Operations of [uploadType] the queue has given up on.
   ///

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -109,7 +109,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.memory() : super(NativeDatabase.memory());
 
   @override
-  int get schemaVersion => 44;
+  int get schemaVersion => 45;
 
   /// Tables holding local intent the server cannot give back.
   ///
@@ -309,6 +309,60 @@ class AppDatabase extends _$AppDatabase {
       // reactions, so the nullable column's default is correct.
       if (from < 42) {
         await _addColumnIfMissing(m, newsEntries, newsEntries.reactions);
+      }
+
+      // v45 is a one-time data repair, not a shape change: see
+      // `PHASE_111_NOTES.md`. Before Phase 105 the examination form wrote the
+      // *patient's* id into a new examination row's `userId`, and
+      // `HealthRepository.serialize` keys the uploaded document on `userId` —
+      // so such a row claims the same CouchDB `_id` as the patient's own
+      // profile row. The profile is written first, wins, and the examination
+      // takes a 409, which [OutboxDrainer] classifies as permanent. The
+      // clinician's reading then never reaches the server.
+      //
+      // Setting `userId` to the row's own id is what Phase 105 made every new
+      // examination do (`createExamination`: `userId ?? id`), and what
+      // `_docToCompanion` maintains for every synced row — so the repaired row
+      // is indistinguishable from one recorded today, and posts as its own
+      // document.
+      //
+      // The predicate is deliberately narrow, because re-keying the wrong row
+      // would create the same conflict in the other direction. Every conjunct
+      // excludes something real:
+      //
+      //  * `is_updated = 1` — a clean row is not queued for upload at all, so
+      //    it cannot be in the collision. Phase 107 drew the same boundary.
+      //  * `user_id <> id` — the post-Phase-105 shape and every synced row
+      //    have them equal, and are untouched.
+      //  * `profile_id IS NULL` — the pre-Phase-105 form wrote no `profileId`
+      //    (that was the same phase's headline finding), while every row from
+      //    the server carries the one Planet stored. This is the positive
+      //    identification, not an id-prefix guess: Phase 107 declined to write
+      //    the guess, and it was right to.
+      //  * `_id IS NULL AND _rev IS NULL` — a row that already uploaded owns a
+      //    revision of the document its old `userId` names. Re-keying it while
+      //    keeping that `_rev` would post a revision of a document that does
+      //    not exist under the new id: the same 409, newly caused by us. Those
+      //    rows are left alone; the mess they made on the server predates this
+      //    and a migration cannot unpick it.
+      //  * `id NOT IN (users)` — a *profile* row's id is the patient's user
+      //    row key (`saveHealthProfileBlob`), and `UserDao.getById` matches
+      //    `_id` as well as `id`, so both columns are checked. This is what
+      //    keeps the repair off the profile row of a member registered on this
+      //    device, whose `userId` is legitimately the CouchDB id its own key
+      //    is not.
+      if (from < 45) {
+        await customStatement(
+          'UPDATE health_examinations SET user_id = id '
+          'WHERE is_updated = 1 '
+          'AND user_id IS NOT NULL '
+          'AND user_id <> id '
+          'AND profile_id IS NULL '
+          'AND _id IS NULL '
+          'AND _rev IS NULL '
+          'AND id NOT IN (SELECT id FROM users) '
+          'AND id NOT IN (SELECT _id FROM users WHERE _id IS NOT NULL)',
+        );
       }
     },
   );
@@ -1692,6 +1746,38 @@ class OutboxDao extends DatabaseAccessor<AppDatabase> with _$OutboxDaoMixin {
           ..limit(1))
         .getSingleOrNull();
   }
+
+  /// Every operation recorded for one item, whatever its status.
+  ///
+  /// [findOpen] deliberately ignores an `abandoned` row so a fresh enqueue is
+  /// never blocked by one; the consequence is that a permanently-refused write
+  /// leaves a row behind that nothing else selects. This is how the record of
+  /// that refusal is read back.
+  Future<List<OutboxRow>> forItem(String uploadType, String itemId) =>
+      (select(outboxEntries)
+            ..where(
+              (row) =>
+                  row.uploadType.equals(uploadType) & row.itemId.equals(itemId),
+            )
+            ..orderBy([(row) => OrderingTerm(expression: row.createdAt)]))
+          .get();
+
+  /// Operations of [uploadType] the queue has given up on.
+  ///
+  /// A 409 is `permanent` to [OutboxDrainer] — `code < 500` — so a conflicting
+  /// write is abandoned on its first attempt and never retried under that row.
+  /// Nothing read these until now, which is why a health record the server
+  /// refused could vanish with no error anywhere: the row was kept, and the
+  /// keeping was the whole of the "observability".
+  Future<List<OutboxRow>> abandoned(String uploadType) =>
+      (select(outboxEntries)
+            ..where(
+              (row) =>
+                  row.uploadType.equals(uploadType) &
+                  row.status.equals(statusAbandoned),
+            )
+            ..orderBy([(row) => OrderingTerm(expression: row.createdAt)]))
+          .get();
 
   /// Pending operations whose backoff has elapsed, oldest first.
   Future<List<OutboxRow>> due(int now) {

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -956,6 +956,14 @@
   "loadingMedia": "Loading...",
   "resourceUnavailable": "This resource is not available for offline viewing",
   "healthRecordNotAvailable": "Health record not available",
+  "healthRecordsRejected": "{count, plural, =1{1 health record could not be sent to the server. It is still stored on this device.} other{{count} health records could not be sent to the server. They are still stored on this device.}}",
+  "@healthRecordsRejected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "updateHealth": "Update health",
   "addHealthRecord": "Add health record",
   "healthProfile": "Health profile",

--- a/flutter/lib/providers/health_provider.dart
+++ b/flutter/lib/providers/health_provider.dart
@@ -10,6 +10,7 @@ import 'sync_state.dart';
 import '../data/local/app_database.dart';
 import '../data/local/health_models.dart';
 import '../repository/health_repository.dart';
+import '../repository/health_uploader.dart';
 import 'app_providers.dart';
 import 'session_provider.dart';
 
@@ -176,6 +177,33 @@ class HealthQueue {
 }
 
 final healthQueueProvider = Provider<HealthQueue>(HealthQueue.new);
+
+/// How many health records the server has refused for good.
+///
+/// [OutboxDrainer] treats any `code < 500` as permanent, so a 409 — the
+/// conflict a legacy row's `_id` collision produces — abandons the operation on
+/// its first attempt. The row is kept rather than deleted, and until now that
+/// keeping *was* the whole of the observability: nothing selected an abandoned
+/// row, nothing counted one, and no screen said a word. A reading a clinician
+/// took stayed on the handset while the app behaved as though it had been
+/// filed.
+///
+/// Counted by distinct `itemId`, not by row: [OutboxRepository.enqueue] only
+/// looks for an *open* operation, so a record refused again on every save
+/// leaves one abandoned row per attempt. What the clinician needs to know is
+/// how many records are stranded, not how many times the app has tried.
+///
+/// A [FutureProvider] rather than a stream: the count only moves when a drain
+/// finishes, and holding a live drift query open for the life of the screen
+/// leaves a pending timer that fails every widget test in the file — the
+/// screen re-reads it on build and on pull-to-refresh, which is when a
+/// clinician would look.
+final rejectedHealthRecordCountProvider = FutureProvider<int>((ref) async {
+  final rows = await ref
+      .watch(outboxDaoProvider)
+      .abandoned(HealthUploader.type);
+  return rows.map((row) => row.itemId).toSet().length;
+});
 
 /// Pull of the `health` database, giving `HealthRepository.sync` its first
 /// caller — it was written and never invoked, so a device that had not

--- a/flutter/lib/repository/health_repository.dart
+++ b/flutter/lib/repository/health_repository.dart
@@ -862,7 +862,7 @@ class HealthRepository {
       if (row.profileId != null) 'profileId': row.profileId,
       // Both wire fields come from `profileId`:
       // `addString(object, "creatorId", health.profileId)`
-      // (`HealthExamination.kt:110`). It reads like a copy-paste slip and may
+      // (`HealthExamination.kt:111`). It reads like a copy-paste slip and may
       // well be one, but it is the shape Planet has always been sent, and the
       // two columns are equal by construction in anything either app authors
       // — `saveData` sets both to `health.userKey`, and so does the port's

--- a/flutter/lib/repository/health_repository.dart
+++ b/flutter/lib/repository/health_repository.dart
@@ -860,7 +860,17 @@ class HealthRepository {
       if (row.planetCode != null) 'planetCode': row.planetCode,
       'hasInfo': row.hasInfo,
       if (row.profileId != null) 'profileId': row.profileId,
-      if (row.creatorId != null) 'creatorId': row.creatorId,
+      // Both wire fields come from `profileId`:
+      // `addString(object, "creatorId", health.profileId)`
+      // (`HealthExamination.kt:110`). It reads like a copy-paste slip and may
+      // well be one, but it is the shape Planet has always been sent, and the
+      // two columns are equal by construction in anything either app authors
+      // — `saveData` sets both to `health.userKey`, and so does the port's
+      // form. Where they can differ is a document Planet itself wrote, pulled
+      // in and then edited here: Kotlin overwrites the server's `creatorId`
+      // with `profileId` on the way back out and the port used to preserve it,
+      // which is a divergence in the one case the field is load-bearing.
+      if (row.profileId != null) 'creatorId': row.profileId,
       if (row.gender != null) 'gender': row.gender,
       'age': row.age,
       // `addJson(object, "conditions", gson.fromJson(conditions, JsonObject))`

--- a/flutter/lib/repository/health_uploader.dart
+++ b/flutter/lib/repository/health_uploader.dart
@@ -70,6 +70,12 @@ class HealthUploader {
       // same document instead of conflicting against a stale `_rev`; clearing
       // `isUpdated` is what stops it being queued a second time.
       await _dao.markUploaded(row.itemId, rev);
+      // And the record is no longer stranded, so the refusals that said it was
+      // must go with it. An abandoned row is never reused and nothing sweeps
+      // them, so leaving them would have `MyHealthScreen` warn about a record
+      // that is on the server — for the life of the install, with no action to
+      // offer. This is the only event that makes an old refusal untrue.
+      await _outbox.clearAbandoned(type, row.itemId);
     }
     return result;
   };

--- a/flutter/lib/repository/outbox_repository.dart
+++ b/flutter/lib/repository/outbox_repository.dart
@@ -150,6 +150,14 @@ class OutboxRepository {
   /// succeeded carried the superseded body.
   Future<void> markCompleted(String id) => _dao.deleteIfInProgress(id);
 
+  /// Forgets the permanent failures recorded against one item.
+  ///
+  /// Called when a later attempt succeeds: [enqueue] never reuses an abandoned
+  /// row and [cleanup] has no caller, so the record of a refusal outlives the
+  /// refusal itself unless something withdraws it.
+  Future<int> clearAbandoned(String uploadType, String itemId) =>
+      _dao.clearAbandonedFor(uploadType, itemId);
+
   /// Records a failed attempt and schedules the next one.
   ///
   /// Returns `true` if the operation was abandoned — attempts exhausted, or the

--- a/flutter/lib/ui/health/my_health_screen.dart
+++ b/flutter/lib/ui/health/my_health_screen.dart
@@ -143,10 +143,16 @@ class _HealthContent extends ConsumerWidget {
       // gesture is the port's own addition — which is why its handler was
       // left empty, advertising a refresh that did nothing. Re-reading the
       // selected patient is what the affordance already promises.
-      onRefresh: () => ref.read(patientDetailProvider.notifier).refresh(),
+      onRefresh: () async {
+        // The banner is a `FutureProvider`, so the pull that re-reads the
+        // patient is also what re-reads whether anything is still stranded.
+        ref.invalidate(rejectedHealthRecordCountProvider);
+        await ref.read(patientDetailProvider.notifier).refresh();
+      },
       child: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          const _RejectedUploadsBanner(),
           // User profile card
           Card(
             child: Padding(
@@ -385,6 +391,47 @@ String resolveCreatorName(String createdBy, Map<String, UserRow> userMap) {
     return createdBy.substring(colonIndex + 1).trim();
   }
   return createdBy;
+}
+
+/// Says so when the server has permanently refused a health record.
+///
+/// The port's own addition — Kotlin has no counterpart, because it has no
+/// permanent-failure state to report: `uploadHealthData` swallows the response
+/// and leaves `isUpdated` set, so the next sync tries again forever. The outbox
+/// classifies a 409 as permanent instead, which is a better model of what a
+/// conflict means and a worse one to keep silent about. A reading that never
+/// reached the server, on a screen that shows it as recorded, is the failure
+/// this app can least afford.
+class _RejectedUploadsBanner extends ConsumerWidget {
+  const _RejectedUploadsBanner();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(rejectedHealthRecordCountProvider).valueOrNull ?? 0;
+    if (count == 0) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    return Card(
+      color: theme.colorScheme.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Icon(Icons.cloud_off, color: theme.colorScheme.onErrorContainer),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                AppLocalizations.of(context).healthRecordsRejected(count),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _InfoRow extends StatelessWidget {

--- a/flutter/lib/ui/health/my_health_screen.dart
+++ b/flutter/lib/ui/health/my_health_screen.dart
@@ -10,6 +10,7 @@ import '../../l10n/app_localizations.dart';
 import '../../providers/app_providers.dart';
 import '../../providers/health_provider.dart';
 import '../../providers/sync_state.dart';
+import '../../repository/personals_uploader.dart';
 import '../components/profile_avatar.dart';
 import '../router.dart';
 
@@ -101,7 +102,16 @@ class MyHealthScreen extends ConsumerWidget {
     final user = detail.user;
     final record = detail.record;
     if (user == null) {
-      return Center(child: Text(l10n.healthRecordNotAvailable));
+      // The banner rides above this branch as well: a record the server refused
+      // is a device-level fact, and "no patient resolves" is exactly the state
+      // a clinician might be in while wondering where a reading went.
+      return ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const _RejectedUploadsBanner(),
+          Center(child: Text(l10n.healthRecordNotAvailable)),
+        ],
+      );
     }
     final data = HealthData(
       user: user,
@@ -411,6 +421,7 @@ class _RejectedUploadsBanner extends ConsumerWidget {
     if (count == 0) return const SizedBox.shrink();
 
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     return Card(
       color: theme.colorScheme.errorContainer,
       child: Padding(
@@ -421,16 +432,35 @@ class _RejectedUploadsBanner extends ConsumerWidget {
             const SizedBox(width: 12),
             Expanded(
               child: Text(
-                AppLocalizations.of(context).healthRecordsRejected(count),
+                l10n.healthRecordsRejected(count),
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onErrorContainer,
                 ),
               ),
             ),
+            // Without this the banner names a problem and offers nothing to do
+            // about it. Kotlin re-attempts every failed health upload on every
+            // sync (`UploadToShelfService.uploadHealth`, run from
+            // `AutoSyncWorker`); the port re-queues only from the examination
+            // form's own save, so a stranded record has no other way back onto
+            // the wire. `enqueue` ignores the abandoned row and writes a fresh
+            // pending one, so this is a real retry rather than a nudge.
+            TextButton(onPressed: () => _retry(ref), child: Text(l10n.retry)),
           ],
         ),
       ),
     );
+  }
+
+  Future<void> _retry(WidgetRef ref) async {
+    await ref.read(healthQueueProvider).queuePending();
+    final config = ref.read(serverConfigProvider);
+    if (config != null) {
+      await ref
+          .read(outboxDrainerProvider)
+          .drain(authHeader: PersonalsUploader.authHeaderFor(config));
+    }
+    ref.invalidate(rejectedHealthRecordCountProvider);
   }
 }
 

--- a/flutter/test/data/local/migration_test.dart
+++ b/flutter/test/data/local/migration_test.dart
@@ -297,8 +297,20 @@ void main() {
       ),
     );
 
+    /// The patient's profile row — the document a legacy examination collides
+    /// with, and the reason the collision exists at all.
+    Future<void> seedProfileRow() => database.healthExaminationDao.upsert(
+      HealthExaminationsCompanion.insert(
+        id: 'org.couchdb.user:ada',
+        userId: const Value('org.couchdb.user:ada'),
+        data: const Value('profile-ciphertext'),
+        isUpdated: const Value(true),
+      ),
+    );
+
     test('re-keys a legacy examination onto its own id', () async {
       await seedUser();
+      await seedProfileRow();
       await database.healthExaminationDao.upsert(
         HealthExaminationsCompanion.insert(
           id: 'health-1725000000000000',
@@ -315,6 +327,37 @@ void main() {
       );
       expect(row!.userId, 'health-1725000000000000');
       expect(row.pulse, 72, reason: 'the reading itself is untouched');
+    });
+
+    test('leaves a legacy row that became the profile row alone', () async {
+      // `saveHealthProfileBlob` resolves the profile row with
+      // `getByIdOrUserId`, which matches a legacy examination row through its
+      // `userId` column — and then keeps `id: Value(existing.id)`. So on a
+      // device with no separate profile row, the first post-Phase-105 save
+      // turns the legacy examination row *into* the patient's profile row,
+      // keeping its `health-…` id. Every other conjunct of the repair matches
+      // that row; re-keying it would publish the health profile under a
+      // millisecond timestamp no server can resolve to a person, which is the
+      // harm this repair exists to prevent.
+      await seedUser();
+      await database.healthExaminationDao.upsert(
+        HealthExaminationsCompanion.insert(
+          id: 'health-1725000000000005',
+          userId: const Value('org.couchdb.user:ada'),
+          data: const Value('profile-ciphertext'),
+          isUpdated: const Value(true),
+        ),
+      );
+
+      await runUpgrade(from: 44);
+
+      expect(
+        (await database.healthExaminationDao.getById(
+          'health-1725000000000005',
+        ))!.userId,
+        'org.couchdb.user:ada',
+        reason: 'no row is keyed on that userId, so there is no collision',
+      );
     });
 
     test("leaves a locally-registered member's profile row alone", () async {
@@ -372,6 +415,7 @@ void main() {
       // it while keeping that revision would post a revision of a document
       // that does not exist under the new id — the same 409, newly ours.
       await seedUser();
+      await seedProfileRow();
       await database.healthExaminationDao.upsert(
         HealthExaminationsCompanion.insert(
           id: 'health-1725000000000001',
@@ -396,6 +440,7 @@ void main() {
       // A row with a `profileId` is either recorded after Phase 105 or pulled
       // from the server; neither is the shape being repaired.
       await seedUser();
+      await seedProfileRow();
       await database.healthExaminationDao.upsert(
         HealthExaminationsCompanion.insert(
           id: 'health-1725000000000002',
@@ -418,6 +463,7 @@ void main() {
     test('leaves a clean row alone', () async {
       // Nothing queues it, so it is not in the collision.
       await seedUser();
+      await seedProfileRow();
       await database.healthExaminationDao.upsert(
         HealthExaminationsCompanion.insert(
           id: 'health-1725000000000003',
@@ -439,6 +485,7 @@ void main() {
       // `health_examinations` is preserved, so the upgrade that carries the
       // repair must not be the thing that discards the reading.
       await seedUser();
+      await seedProfileRow();
       await database.healthExaminationDao.upsert(
         HealthExaminationsCompanion.insert(
           id: 'health-1725000000000004',

--- a/flutter/test/data/local/migration_test.dart
+++ b/flutter/test/data/local/migration_test.dart
@@ -282,6 +282,184 @@ void main() {
     expect((await database.healthExaminationDao.getById('exam-1'))?.pulse, 72);
   });
 
+  group('the v45 legacy-examination repair', () {
+    // Before Phase 105 the examination form wrote the *patient's* id into a new
+    // row's `userId`, which is the column `HealthRepository.serialize` keys the
+    // uploaded document on — so the row claimed the patient's profile document
+    // and took a 409 nothing surfaced. `health_legacy_conflict_test.dart` holds
+    // the end-to-end loss; these pin the predicate's edges, because re-keying
+    // the wrong row would cause the same conflict in the other direction.
+    Future<void> seedUser() => database.userDao.upsert(
+      UsersCompanion.insert(
+        id: 'local-9',
+        name: const Value('ada'),
+        couchId: const Value('org.couchdb.user:ada'),
+      ),
+    );
+
+    test('re-keys a legacy examination onto its own id', () async {
+      await seedUser();
+      await database.healthExaminationDao.upsert(
+        HealthExaminationsCompanion.insert(
+          id: 'health-1725000000000000',
+          userId: const Value('org.couchdb.user:ada'),
+          pulse: const Value(72),
+          isUpdated: const Value(true),
+        ),
+      );
+
+      await runUpgrade(from: 44);
+
+      final row = await database.healthExaminationDao.getById(
+        'health-1725000000000000',
+      );
+      expect(row!.userId, 'health-1725000000000000');
+      expect(row.pulse, 72, reason: 'the reading itself is untouched');
+    });
+
+    test("leaves a locally-registered member's profile row alone", () async {
+      // The row this predicate exists to protect: its id is the member's local
+      // user key and its `userId` is the CouchDB id the account was given, so
+      // the two legitimately differ. Re-keying it would post the profile under
+      // a millisecond timestamp no server can resolve to a person.
+      await seedUser();
+      await database.healthExaminationDao.upsert(
+        HealthExaminationsCompanion.insert(
+          id: 'local-9',
+          userId: const Value('org.couchdb.user:ada'),
+          isUpdated: const Value(true),
+        ),
+      );
+
+      await runUpgrade(from: 44);
+
+      expect(
+        (await database.healthExaminationDao.getById('local-9'))!.userId,
+        'org.couchdb.user:ada',
+      );
+    });
+
+    test('leaves a profile row keyed on the CouchDB id alone', () async {
+      // `UserDao.getById` matches `_id` as well as `id`, so a profile row can
+      // be keyed on either. Both columns are checked.
+      await database.userDao.upsert(
+        UsersCompanion.insert(
+          id: 'local-8',
+          name: const Value('bea'),
+          couchId: const Value('org.couchdb.user:bea'),
+        ),
+      );
+      await database.healthExaminationDao.upsert(
+        HealthExaminationsCompanion.insert(
+          id: 'org.couchdb.user:bea',
+          userId: const Value('local-8'),
+          isUpdated: const Value(true),
+        ),
+      );
+
+      await runUpgrade(from: 44);
+
+      expect(
+        (await database.healthExaminationDao.getById(
+          'org.couchdb.user:bea',
+        ))!.userId,
+        'local-8',
+      );
+    });
+
+    test('leaves a row that already uploaded alone', () async {
+      // Its `_rev` belongs to the document its old `userId` names. Re-keying
+      // it while keeping that revision would post a revision of a document
+      // that does not exist under the new id — the same 409, newly ours.
+      await seedUser();
+      await database.healthExaminationDao.upsert(
+        HealthExaminationsCompanion.insert(
+          id: 'health-1725000000000001',
+          userId: const Value('org.couchdb.user:ada'),
+          couchId: const Value('org.couchdb.user:ada'),
+          rev: const Value('3-abc'),
+          isUpdated: const Value(true),
+        ),
+      );
+
+      await runUpgrade(from: 44);
+
+      expect(
+        (await database.healthExaminationDao.getById(
+          'health-1725000000000001',
+        ))!.userId,
+        'org.couchdb.user:ada',
+      );
+    });
+
+    test('leaves a row carrying a profileId alone', () async {
+      // A row with a `profileId` is either recorded after Phase 105 or pulled
+      // from the server; neither is the shape being repaired.
+      await seedUser();
+      await database.healthExaminationDao.upsert(
+        HealthExaminationsCompanion.insert(
+          id: 'health-1725000000000002',
+          userId: const Value('org.couchdb.user:ada'),
+          profileId: const Value('user-key-1'),
+          isUpdated: const Value(true),
+        ),
+      );
+
+      await runUpgrade(from: 44);
+
+      expect(
+        (await database.healthExaminationDao.getById(
+          'health-1725000000000002',
+        ))!.userId,
+        'org.couchdb.user:ada',
+      );
+    });
+
+    test('leaves a clean row alone', () async {
+      // Nothing queues it, so it is not in the collision.
+      await seedUser();
+      await database.healthExaminationDao.upsert(
+        HealthExaminationsCompanion.insert(
+          id: 'health-1725000000000003',
+          userId: const Value('org.couchdb.user:ada'),
+        ),
+      );
+
+      await runUpgrade(from: 44);
+
+      expect(
+        (await database.healthExaminationDao.getById(
+          'health-1725000000000003',
+        ))!.userId,
+        'org.couchdb.user:ada',
+      );
+    });
+
+    test('the repair does not cost the record it repairs', () async {
+      // `health_examinations` is preserved, so the upgrade that carries the
+      // repair must not be the thing that discards the reading.
+      await seedUser();
+      await database.healthExaminationDao.upsert(
+        HealthExaminationsCompanion.insert(
+          id: 'health-1725000000000004',
+          userId: const Value('org.couchdb.user:ada'),
+          pulse: const Value(88),
+          data: const Value('ciphertext'),
+          isUpdated: const Value(true),
+        ),
+      );
+
+      await runUpgrade(from: 44);
+
+      final row = await database.healthExaminationDao.getById(
+        'health-1725000000000004',
+      );
+      expect(row!.pulse, 88);
+      expect(row.data, 'ciphertext');
+      expect(row.isUpdated, isTrue, reason: 'it still has to be uploaded');
+    });
+  });
+
   test('the health encryption key survives a schema upgrade', () async {
     // `key`/`iv` are generated on this device and never uploaded. Dropping
     // them would leave every health record already encrypted with them

--- a/flutter/test/repository/health_legacy_conflict_test.dart
+++ b/flutter/test/repository/health_legacy_conflict_test.dart
@@ -1,0 +1,261 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/repository/health_repository.dart';
+import 'package:myplanet/repository/health_uploader.dart';
+import 'package:myplanet/repository/outbox_drainer.dart';
+import 'package:myplanet/repository/outbox_repository.dart';
+
+/// Phase 107 found that a pre-Phase-105 examination row collides with the
+/// patient's profile document, and that the loser of that collision takes a
+/// 409 the outbox classifies as permanent. These tests hold the whole path —
+/// two rows, one queue, one drain against a CouchDB that enforces `_id`
+/// uniqueness — so the *record loss* is what is asserted, not the status code.
+void main() {
+  late AppDatabase database;
+  late _FakeCouchDb couch;
+  late HealthRepository repository;
+  late HealthUploader uploader;
+  late OutboxRepository outbox;
+  late OutboxDrainer drainer;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+
+  /// The signed-in health provider, synced, so their row key *is* their
+  /// CouchDB id — the ordinary case, and the one that collides.
+  const patientId = 'org.couchdb.user:ada';
+
+  setUp(() async {
+    database = AppDatabase.memory();
+    couch = _FakeCouchDb();
+    repository = HealthRepository(
+      couch,
+      database.healthExaminationDao,
+      database.userDao,
+    );
+    outbox = OutboxRepository(database.outboxDao);
+    uploader = HealthUploader(
+      couch,
+      repository,
+      database.healthExaminationDao,
+      outbox,
+    );
+    drainer = OutboxDrainer(
+      couch,
+      outbox,
+      handlers: {HealthUploader.type: uploader.handler},
+    );
+    await database.userDao.upsert(
+      UsersCompanion.insert(
+        id: patientId,
+        name: const Value('ada'),
+        couchId: const Value(patientId),
+      ),
+    );
+  });
+  tearDown(() => database.close());
+
+  /// The two rows a pre-Phase-105 device carries: the patient's profile row,
+  /// and an examination whose `userId` was set to the patient rather than to
+  /// its own id. Both serialize `_id` from `userId`, so both claim the same
+  /// CouchDB document.
+  Future<String> seedLegacyPair() async {
+    await repository.saveHealthProfileBlob(
+      patientId,
+      HealthRepository.initHealth(),
+    );
+    const legacyId = 'health-1725000000000000';
+    await database.healthExaminationDao.upsert(
+      HealthExaminationsCompanion.insert(
+        id: legacyId,
+        // The defect: the patient's id, not the row's own.
+        userId: const Value(patientId),
+        pulse: const Value(72),
+        temperature: const Value(36.6),
+        data: Value(jsonEncode({'diagnosis': 'asthma'})),
+        isUpdated: const Value(true),
+      ),
+    );
+    return legacyId;
+  }
+
+  Future<void> queueAndDrain() async {
+    await uploader.queuePending(config: config, userId: patientId);
+    await drainer.drain(authHeader: 'auth');
+  }
+
+  test(
+    'the legacy examination never reaches the server and nothing says so',
+    () async {
+      final legacyId = await seedLegacyPair();
+
+      await queueAndDrain();
+
+      // One document on the server, and it is the profile — the examination
+      // lost the race for the same `_id`.
+      expect(couch.documents.keys, [patientId]);
+      expect(couch.documents[patientId]!['pulse'], isNot(72));
+
+      // The row is still dirty, so the device believes it has work to do...
+      expect((await repository.getById(legacyId))!.isUpdated, isTrue);
+      // ...but the queue has given up on it permanently.
+      final entries = await database.outboxDao.forItem(
+        HealthUploader.type,
+        legacyId,
+      );
+      expect(entries.single.status, OutboxDao.statusAbandoned);
+      expect(entries.single.httpCode, 409);
+    },
+  );
+
+  test('after the v45 repair the same reading reaches the server', () async {
+    final legacyId = await seedLegacyPair();
+
+    await database.customStatement('SELECT 1');
+    await database.migration.onUpgrade(database.createMigrator(), 44, 45);
+
+    await queueAndDrain();
+
+    // Two documents now: the profile under the patient's id, and the
+    // examination under its own.
+    expect(couch.documents.keys, containsAll([patientId, legacyId]));
+    expect(couch.documents[legacyId]!['pulse'], 72);
+    // And the row is clean, so it is not queued again.
+    expect((await repository.getById(legacyId))!.isUpdated, isFalse);
+    expect(
+      await database.outboxDao.forItem(HealthUploader.type, legacyId),
+      isEmpty,
+    );
+  });
+
+  test('a refused record is countable instead of silent', () async {
+    final legacyId = await seedLegacyPair();
+
+    await queueAndDrain();
+
+    // What the health screen's caution banner reads. Before this there was no
+    // query that selected an abandoned row at all, so the refusal existed only
+    // as a status column nothing looked at.
+    final abandoned = await database.outboxDao.abandoned(HealthUploader.type);
+    expect(abandoned.map((row) => row.itemId), [legacyId]);
+    expect(abandoned.single.httpCode, 409);
+  });
+
+  test('a record refused twice is one stranded record, not two', () async {
+    // `enqueue` only looks for an *open* operation, so an abandoned row never
+    // blocks a fresh one — a save re-queues the same doomed record and earns a
+    // second abandoned row. Counting rows would tell the clinician the wrong
+    // number and keep growing.
+    final legacyId = await seedLegacyPair();
+
+    await queueAndDrain();
+    await queueAndDrain();
+
+    final abandoned = await database.outboxDao.abandoned(HealthUploader.type);
+    expect(abandoned.length, 2);
+    expect(abandoned.map((row) => row.itemId).toSet(), {legacyId});
+  });
+
+  test('creatorId is serialized from profileId, as Kotlin does', () async {
+    // `JsonUtils.addString(object, "creatorId", health.profileId)`
+    // (`HealthExamination.kt:110`). The columns are equal for anything either
+    // app authors, so this only bites on a document Planet wrote and this
+    // device edited — where the port used to send the server's `creatorId`
+    // back and Kotlin replaces it.
+    final row = HealthExaminationRow(
+      id: 'health-1',
+      userId: 'health-1',
+      temperature: 0,
+      pulse: 0,
+      height: 0,
+      weight: 0,
+      selfExamination: false,
+      hasInfo: false,
+      profileId: 'profile-key',
+      creatorId: 'someone-else',
+      age: 0,
+      date: 0,
+      isUpdated: true,
+    );
+
+    expect(HealthRepository.serialize(row)['creatorId'], 'profile-key');
+
+    // And a row with no `profileId` sends no `creatorId` at all, because
+    // `addString` skips a null.
+    final orphan = HealthExaminationRow(
+      id: 'health-2',
+      userId: 'health-2',
+      temperature: 0,
+      pulse: 0,
+      height: 0,
+      weight: 0,
+      selfExamination: false,
+      hasInfo: false,
+      creatorId: 'someone-else',
+      age: 0,
+      date: 0,
+      isUpdated: true,
+    );
+    expect(
+      HealthRepository.serialize(orphan).containsKey('creatorId'),
+      isFalse,
+    );
+  });
+
+  test('the repair leaves the patient profile row where it belongs', () async {
+    await seedLegacyPair();
+
+    await database.customStatement('SELECT 1');
+    await database.migration.onUpgrade(database.createMigrator(), 44, 45);
+
+    final profile = await repository.getById(patientId);
+    expect(
+      profile!.userId,
+      patientId,
+      reason: 'the profile document is keyed on the patient, not on a row id',
+    );
+  });
+}
+
+/// A CouchDB that enforces what the real one enforces: a POST naming an `_id`
+/// that already exists, without the current `_rev`, is a 409.
+class _FakeCouchDb extends Mock implements PlanetApi {
+  _FakeCouchDb() {
+    registerFallbackValue(<String, dynamic>{});
+    when(
+      () => postJsonObject(any(), any(), authHeader: any(named: 'authHeader')),
+    ).thenAnswer(
+      (invocation) async =>
+          _post(invocation.positionalArguments[1] as Map<String, dynamic>),
+    );
+  }
+
+  final Map<String, Map<String, dynamic>> documents = {};
+  var _rev = 0;
+
+  NetworkResult<Map<String, dynamic>> _post(Map<String, dynamic> body) {
+    final id = body['_id'] as String?;
+    if (id == null) {
+      final minted = 'minted-${documents.length}';
+      documents[minted] = {...body};
+      return NetworkSuccess({'id': minted, 'rev': '1-${++_rev}'});
+    }
+    final existing = documents[id];
+    if (existing != null && existing['_rev'] != body['_rev']) {
+      return const NetworkError(409, 'conflict');
+    }
+    final rev = '${++_rev}-x';
+    documents[id] = {...body, '_rev': rev};
+    return NetworkSuccess({'id': id, 'rev': rev});
+  }
+}

--- a/flutter/test/repository/health_legacy_conflict_test.dart
+++ b/flutter/test/repository/health_legacy_conflict_test.dart
@@ -166,9 +166,33 @@ void main() {
     expect(abandoned.map((row) => row.itemId).toSet(), {legacyId});
   });
 
+  test('a delivered record stops being reported as stranded', () async {
+    // The upgrade sequence a real device sees: the record is refused first, the
+    // repair lands later. Nothing sweeps an abandoned row — `enqueue` never
+    // reuses one and `cleanup()` has no caller — so without withdrawing them on
+    // success the screen would warn about a record that is on the server, for
+    // the life of the install, with no action to offer.
+    final legacyId = await seedLegacyPair();
+
+    await queueAndDrain();
+    expect(await database.outboxDao.abandoned(HealthUploader.type), isNotEmpty);
+
+    await database.customStatement('SELECT 1');
+    await database.migration.onUpgrade(database.createMigrator(), 44, 45);
+    await queueAndDrain();
+
+    expect(couch.documents.containsKey(legacyId), isTrue);
+    expect(
+      await database.outboxDao.abandoned(HealthUploader.type),
+      isEmpty,
+      reason:
+          'the record arrived, so the refusals that said it had not must go',
+    );
+  });
+
   test('creatorId is serialized from profileId, as Kotlin does', () async {
     // `JsonUtils.addString(object, "creatorId", health.profileId)`
-    // (`HealthExamination.kt:110`). The columns are equal for anything either
+    // (`HealthExamination.kt:111`). The columns are equal for anything either
     // app authors, so this only bites on a document Planet wrote and this
     // device edited — where the port used to send the server's `creatorId`
     // back and Kotlin replaces it.

--- a/flutter/test/ui/health/my_health_screen_test.dart
+++ b/flutter/test/ui/health/my_health_screen_test.dart
@@ -2,14 +2,21 @@ import 'dart:convert';
 
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
+import 'dart:io';
+
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/repository/health_repository.dart';
+import 'package:myplanet/repository/outbox_drainer.dart';
+import 'package:myplanet/repository/outbox_repository.dart';
 import 'package:myplanet/ui/components/profile_avatar.dart';
 import 'package:myplanet/ui/health/my_health_screen.dart';
 
@@ -31,6 +38,28 @@ class _TestSessionNotifier extends SessionNotifier {
 }
 
 class _NoopApi extends Mock implements PlanetApi {}
+
+/// Every send fails as a transport error, which the drainer treats as
+/// retryable — so a row it touches stays queued rather than being abandoned or
+/// deleted.
+class _UnreachableApi extends Mock implements PlanetApi {
+  @override
+  Future<NetworkResult<Map<String, dynamic>>> sendJsonObject(
+    String url, {
+    required Map<String, dynamic> body,
+    String method = 'POST',
+    String? authHeader,
+  }) async => const NetworkException(SocketException('offline'));
+}
+
+class _TestServerConfigNotifier extends ServerConfigNotifier {
+  @override
+  ServerConfig? build() => const ServerConfig(
+    serverUrl: 'https://planet.example',
+    couchDbUrl: 'https://satellite:1234@planet.example:443',
+    pin: '1234',
+  );
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -176,12 +205,14 @@ void main() {
     WidgetTester tester, {
     required UserRow? session,
     AppDatabase? database,
+    List<Override> overrides = const [],
   }) async {
     final db = database ?? AppDatabase.memory();
     await tester.pumpWidget(
       wrapScreen(
         const MyHealthScreen(),
         overrides: [
+          ...overrides,
           sessionProvider.overrideWith(() => _TestSessionNotifier(session)),
           appDatabaseProvider.overrideWith((ref) {
             ref.onDispose(db.close);
@@ -641,6 +672,72 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+    });
+
+    testWidgets('the caution shows even when no patient resolves', (
+      tester,
+    ) async {
+      // "No patient resolves" is exactly the state a clinician might be in
+      // while wondering where a reading went, and the refusal is a
+      // device-level fact rather than a property of the selected patient.
+      final db = AppDatabase.memory();
+      await abandon(db, 'health-1');
+      await pumpScreen(tester, session: null, database: db);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Health record not available'), findsOneWidget);
+      expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+    });
+
+    testWidgets('the caution offers a retry that re-queues the record', (
+      tester,
+    ) async {
+      // Kotlin re-attempts every failed health upload on each sync; the port
+      // re-queues only from the examination form's save, so without this the
+      // banner names a problem the clinician has no way to act on.
+      final db = AppDatabase.memory();
+      final user = await seedPatient(db);
+      await db.healthExaminationDao.upsert(
+        HealthExaminationsCompanion.insert(
+          id: 'health-1',
+          userId: const Value('health-1'),
+          pulse: const Value(72),
+          isUpdated: const Value(true),
+        ),
+      );
+      await abandon(db, 'health-1');
+      await pumpScreen(
+        tester,
+        session: user,
+        database: db,
+        // `serverConfigProvider` reaches `planetPrefsProvider`, which the
+        // widget-test harness leaves as `UnimplementedError` — the Phase 75
+        // trap. The retry reads it to decide whether it can drain.
+        overrides: [
+          serverConfigProvider.overrideWith(_TestServerConfigNotifier.new),
+          // `outboxDrainerProvider` builds every uploader, several of which
+          // reach `planetPrefsProvider` too. A drainer over an unreachable
+          // server exercises the same path: the send fails as a transport
+          // error, which is retryable, so the fresh operation stays queued.
+          outboxDrainerProvider.overrideWith(
+            (ref) => OutboxDrainer(
+              _UnreachableApi(),
+              OutboxRepository(db.outboxDao),
+            ),
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(TextButton, 'Retry'));
+      await tester.pumpAndSettle();
+
+      // A fresh operation alongside the abandoned one, because `enqueue`
+      // ignores an abandoned row rather than reusing it — which is what makes
+      // the retry a real re-attempt.
+      final open = await db.outboxDao.findOpen('health', 'health-1');
+      expect(open, isNotNull);
+      expect(open!.status, OutboxDao.statusPending);
     });
 
     testWidgets('the count is of records, not of attempts', (tester) async {

--- a/flutter/test/ui/health/my_health_screen_test.dart
+++ b/flutter/test/ui/health/my_health_screen_test.dart
@@ -577,4 +577,98 @@ void main() {
       expect(find.text('Alicia Smith'), findsOneWidget);
     });
   });
+
+  group('records the server refused', () {
+    // The outbox classifies a 409 as permanent, so a health record whose `_id`
+    // collides with another document is abandoned on its first attempt. Nothing
+    // read that state before — the reading stayed on the handset while the
+    // screen listed it as recorded.
+    Future<void> abandon(AppDatabase db, String itemId) async {
+      await db.outboxDao.upsert(
+        OutboxEntriesCompanion.insert(
+          id: 'op-$itemId',
+          uploadType: 'health',
+          itemId: itemId,
+          payload: '{}',
+          endpoint: 'https://planet.example/db/health',
+          createdAt: 1000,
+          status: const Value('abandoned'),
+          httpCode: const Value(409),
+        ),
+      );
+    }
+
+    testWidgets('nothing is said when every record was delivered', (
+      tester,
+    ) async {
+      final db = AppDatabase.memory();
+      final user = await seedPatient(db);
+      await pumpScreen(tester, session: user, database: db);
+
+      expect(find.byIcon(Icons.cloud_off), findsNothing);
+    });
+
+    testWidgets('a stranded record is reported on the screen', (tester) async {
+      final db = AppDatabase.memory();
+      final user = await seedPatient(db);
+      await abandon(db, 'health-1');
+      await pumpScreen(tester, session: user, database: db);
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+      expect(
+        find.textContaining('1 health record could not be sent'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('pull to refresh picks up a newly stranded record', (
+      tester,
+    ) async {
+      final db = AppDatabase.memory();
+      final user = await seedPatient(db);
+      await pumpScreen(tester, session: user, database: db);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.cloud_off), findsNothing);
+
+      // A drain finished behind the screen's back and gave up on a record.
+      await abandon(db, 'health-1');
+      await tester.fling(
+        find.byType(RefreshIndicator),
+        const Offset(0, 300),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+    });
+
+    testWidgets('the count is of records, not of attempts', (tester) async {
+      // A doomed record earns a fresh abandoned row on every save, because
+      // `enqueue` only looks for an *open* operation. Counting rows would show
+      // a number that climbs while nothing new is wrong.
+      final db = AppDatabase.memory();
+      final user = await seedPatient(db);
+      await abandon(db, 'health-1');
+      await db.outboxDao.upsert(
+        OutboxEntriesCompanion.insert(
+          id: 'op-retry',
+          uploadType: 'health',
+          itemId: 'health-1',
+          payload: '{}',
+          endpoint: 'https://planet.example/db/health',
+          createdAt: 2000,
+          status: const Value('abandoned'),
+          httpCode: const Value(409),
+        ),
+      );
+      await pumpScreen(tester, session: user, database: db);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('1 health record could not be sent'),
+        findsOneWidget,
+      );
+    });
+  });
 }


### PR DESCRIPTION
Lane C of the Phase 108–111 parallel round. Draft, open early so the lane has an inbound channel.

**Task:** Phase 107 (`flutter/PHASE_107_NOTES.md`, *"The gap this phase's own fix leaves open"*) found that a pre-Phase-105 examination row (`id = 'health-<micros>'`, `userId = <patientId>`) collides with the patient's profile document: whichever is POSTed second takes a **409**, which is not in the outbox's retryable class, so the record never reaches the server and nothing logs it. It handed the integrator two options; the integrator chose the one-time data repair and allocated `schemaVersion` **45** to this lane.

Scope:

1. Migration to schema 45 repairing legacy `health_examinations` rows, using the preserved-table pattern so a bump does not discard unsynced local writes.
2. An honest, narrow rule for identifying a legacy row — with its confidence stated rather than dressed up.
3. Making an unretryable outbox conflict observable independent of the repair.

Files owned by this lane: `lib/data/local/app_database.dart`, `lib/repository/health_repository.dart`, `lib/data/local/health_models.dart`, `lib/providers/health_provider.dart`, `lib/ui/health/`, the health DAOs and their tests. `lib/data/local/tables.dart` is shared; any diff there is confined to the `health_examinations` block and called out at merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_018VVHfofnLmTemAjNetR5aj)_