### PR TITLE
Phase 110 — port Kotlin's exam retry model (mistakes, grade, submission status)

### DIFF
--- a/flutter/PHASE_110_NOTES.md
+++ b/flutter/PHASE_110_NOTES.md
@@ -1,9 +1,306 @@
-# Phase 110 — the exam retry model (in progress)
+# Phase 110 — the exam retry model
 
-Slice: port Kotlin's cannot-advance-past-a-wrong-answer exam model, so
-`mistakes` accumulates and is uploaded, and a finished submission's answers are
-all `isPassed = true` as a consequence. Plus the two companion decisions Phase
-106 logged with it: per-answer `grade`, and the submission status
-(`requires grading`).
+Phase 106 logged three divergences with one shared caveat: they could not be
+closed individually because they are all consequences of an exam model the port
+did not have. This is that model.
 
-Notes to follow.
+Kotlin's exam **refuses to advance past a wrong answer**. `updateAnsDb` returns
+the verdict `saveExamAnswer` computed and both `btnNext`
+(`ExamTakingFragment.kt:196-204`) and `btnSubmit` (`:641-645`) bail with the
+`incorrect_ans` snackbar when it is false, so the learner retries until the
+answer is right. Everything else follows from that:
+
+- `mistakes` accumulates, `(existing?.mistakes ?: 0) + 1` per wrong attempt,
+  and is uploaded (`Answer.createObject` sends `"mistakes"`).
+- every answer in a *finished* submission is `isPassed = true`, because no
+  wrong one can be left behind — a consequence, not an assertion.
+- there is no score. `continueExam` shows a thank-you dialog
+  (`BaseExamFragment.kt:127-149`) and the submission goes up as
+  `requires grading` for Planet to mark.
+
+The port graded the whole attempt in widget state, wrote it once at the end,
+computed a percentage, and never wrote `mistakes` at all.
+
+## What changed
+
+**The attempt is now persisted before the answers, and each answer as it is
+given.** `createExamDraft` (one write at the end) is replaced by
+`startExamSession` + `saveExamAnswer`, which is where Kotlin has them. This is
+not a stylistic port: `mistakes` is `existing.mistakes + 1`, so there has to be
+an `existing` row on disk to add to. Reimplementing the accumulator in widget
+state would have been the "port the field without the model" half-measure
+Phase 106 warned against.
+
+| Kotlin | port |
+|---|---|
+| `startExamSession(recreate = true, deleteStale)` → `createExamSubmission` | `SubmissionsRepository.startExamSession` |
+| `deleteExamSubmissions(examId, courseId, userId)` | `_deleteExamSubmissions` |
+| `saveExamAnswer(ExamAnswerData)` → `Boolean` | `SubmissionsRepository.saveExamAnswer` → `Future<bool>` |
+| `ExamAnswerUtils.checkCorrectAnswer` + 3 helpers | `ExamGrading.isCorrect` / `isSelectionCorrect` / `isTextCorrect` |
+| `btnNext` / `btnSubmit` / `btnBack` | `_advance` / `_submitExam` / `_goBack` |
+| `isQuestionAnswered` | `_isAnswered` |
+| `continueExam`'s thank-you dialog | `_showResult` |
+
+No schema change (still v44); `mistakes`, `grade` and `isPassed` were already
+columns on `SubmissionAnswers`, and `serialize` was already uploading
+`mistakes` — it was just always 0.
+
+Two `app_en.arb` keys added, English only: `thankYouForTakingExam` and
+`pleaseAnswerToContinue`. `incorrect_ans` reuses the existing, already
+translated `incorrectAnswer` key rather than adding a sixth — see *For the
+integrator*.
+
+## The audit overturned my first reading, and it mattered
+
+I started from the belief that Kotlin's `select` grading can never return true:
+`saveExamAnswer` passes `ansForCheck = getChoiceTextById(question, ans)` — the
+choice's display **text** — into `checkSelectAnswer`, which compares it with
+`question.getCorrectChoice()`, and `ExamQuestion.insertCorrectChoice` looks
+like it stores ids. I wrote that into `exam_grading.dart` as the justification
+for the port's id-based comparison. **It was wrong twice over**, and a
+`parity-auditor` pass at `effort: max` caught both halves:
+
+1. `insertCorrectChoice`'s scalar branch does not store the id. It matches on
+   `id` and then stores the matched choice's **`res`** (`ExamQuestion.kt:96-108`)
+   — the legacy display-value key — so for a `{id, text}` choice it stores
+   `[""]`. Same verdict, different mechanism, and the mechanism says the intent
+   was text-vs-text all along.
+2. **`insertCorrectChoice` is not the parser a course exam goes through.**
+   There are two independent writers of `correctChoiceList`, and the one that
+   matters is `CoursesRepositoryImpl.extractCorrectChoices`
+   (`CoursesRepositoryImpl.kt:804-821`), on the `courses` walk, which resolves
+   each entry through `ExamAnswerUtils.choiceDisplayValue` and stores **display
+   text**. So `correctChoiceList` holds `["Water"]`, `ansForCheck` is
+   `"Water"`, and `checkSelectAnswer` lowercases both. **Kotlin's grading
+   works.**
+
+So the port's id comparison is a *representation choice*, not a rescue: Kotlin
+normalises the answer key to text, `ExamMapper._parseCorrectChoices` normalises
+it to ids, and each compares like with like. Ids are the more robust half —
+unique, where Kotlin's text comparison silently collapses two choices that
+share a label — and it is what the port has stored since Phase 106. The point
+that *is* load-bearing is that the mapper and the grader must agree: porting
+`checkCorrectAnswer` literally on top of an id-storing mapper would compare a
+label with an id, pass nothing, and under the gate produce an exam nobody can
+finish. The comment in `exam_grading.dart` now says that instead of the wrong
+thing.
+
+**A Kotlin citation is not a Kotlin reading.** I named the right functions and
+misread what they do, exactly as Phase 106 records happening to Phase 103.
+
+## Defects found and closed, each demonstrated failing first
+
+Eight of the nine new gate tests fail against the pre-fix `lib/`, and the two
+grading defects were demonstrated with a throwaway probe. Run: the five
+changed `lib/` files stashed, the new tests left in place.
+
+| # | defect | pre-fix failure |
+|---|---|---|
+| 1 | **the screen advanced past a wrong answer** | `a wrong answer does not advance and says so` — `Found 0 widgets with text "Incorrect answer"` |
+| 2 | **`mistakes` was never written** (column default 0, uploaded as if it meant something) | `each wrong attempt adds a mistake…` — `Found 0 widgets with text "Lyon"`: the second loop pass had nowhere to tap, because the un-gated screen had already moved to question 2 |
+| 3 | **pressing on with no answer** was accepted, so a blank press would have scored a mistake against an unanswered question | `pressing on with no answer asks for one…` — `Found 0 widgets with text "Please select / write your answer to continue"` |
+| 4 | **going back did not record the answer** — Kotlin's `btnBack` calls `updateAnsDb()` before moving (`:187-194`), so the mistake counts | `going back records the answer as it stands` — `Bad state: No element`: no answer row for q2 existed at all |
+| 5 | **the result dialog invented a score** and a pass/fail against `passingPercentage`, which has no Kotlin counterpart at all (`grep -rn passingPercentage app/src/main` finds only parse/store/re-serialize) | `a finished exam is sent for grading rather than scored` — `Found 0 widgets with text "Thank you for taking this exam!…"` |
+| 6 | **submission status was `complete`** where `saveExamAnswer` writes `requires grading` for an exam | same test — `status` was `'complete'`, `grade` was a device-computed percentage |
+| 7 | **`parentId` was the bare `courseId`** where `createExamSubmission` writes `"$examId@$courseId"`. `ProgressRepository._examIdFromParent` takes the leading `@`-segment to find the exam, so the per-step mistake counts could never have matched their exam even once `mistakes` was populated — defect 2 was hiding this one | same test — `parentId` was `'course-1'`, not `'exam-1@course-1'` |
+| 8 | **`isTextCorrect` was exact equality** where `checkTextAnswer` is `correctChoices.any { normalizedAns.contains(it) }` (`ExamAnswerUtils.kt:88-95`), asserted by Kotlin's own `testCheckCorrectAnswer_InputText`. Harmless under a percentage; under the gate it refuses a right answer carrying a stray word and traps the learner | probe: `isTextCorrect(q, 'It is Paris, I think')` → `Expected: true / Actual: <false>` |
+| 9 | **a keyless question could not be passed** (`isSelectionCorrect` returned false on an empty key by design, for a percentage model). Under the gate that is a question no answer satisfies — and every `ratingScale` question in an exam has no key | probe: `isTextCorrect(rating, '7')` → `Expected: true / Actual: <false>` |
+| 10 | **the per-answer `grade` badge** rendered `isCorrect ? 1 : 0` where Kotlin writes `1` for every answer and its adapter renders nothing | assertion, not a test: `answers.every((a) => a.grade == 1)` |
+
+Two of the nine gate tests pass pre-fix and are kept as companions rather than
+evidence: `a right answer advances` (the un-gated screen advanced too) and
+`a text answer passes by containment` (the un-gated screen finished the exam
+regardless of the verdict — its real evidence is defect 8's probe).
+
+## The three decisions Phase 106 asked for
+
+### Per-answer `grade`: take Kotlin's field, drop the badge
+
+`saveExamAnswer` writes `grade = if (type == "exam") 1` — **1 for every exam
+answer, right or wrong**. It is a "worth one mark" marker, not a score. The
+audit confirms it is read **nowhere** in `app/src/main` (only the write and a
+round-trip test) and is **not uploaded** — `Answer.createObject` emits only
+`value`, `mistakes`, `passed`, `questionId`.
+
+So the port writes `1`, and `submission_detail_screen`'s trailing badge is
+**removed**. Keeping the port's `isCorrect ? 1 : 0` would have been the only
+way to keep the badge meaningful, and that means inventing a field value to
+feed a widget Kotlin does not have (`QuestionAnswerAdapter.bind` never reads
+it, `item_question_answer.xml` has no view for it). The verdict is already on
+the tile as its leading icon; how many tries it took is `mistakes`, which the
+courses-progress screen shows per step, as Kotlin does.
+
+### Submission status: `requires grading`
+
+`complete` is the **survey** value. `saveExamAnswer`'s `when` is explicit:
+`complete` for a final explicit *survey* answer, `requires grading` for an
+exam's, `pending` otherwise. Adopted.
+
+What reads it, from the audit:
+
+- **Planet**: `requires grading` is what a teacher's grading queue selects on.
+  The in-repo corroboration is `SurveysRepositoryImpl.kt:310`, which treats
+  `complete` and `requires grading` as the same "finished" state.
+- **Kotlin locally**: functionally via `status != 'pending'` —
+  `SubmissionDao.kt:24` → `isStepCompleted` → `TakeCourseFragment.kt:323` step
+  unlocking. Nothing ever moves a submission off `requires grading` locally;
+  only a re-pull can.
+- **the port**: nothing breaks. `pendingUploads` has no status filter, the
+  exporter prints it verbatim, and the tile subtitle prints the raw string —
+  which is what `SubmissionsAdapter.kt:77` does too, so a learner seeing
+  "requires grading" is parity, not a regression.
+
+I had feared the opposite: `SubmissionDao.getPendingSubmissions` is
+`WHERE status = 'complete' AND …`, which would exclude a `requires grading`
+exam and mean Kotlin never uploads one. **The audit refuted that**: there is a
+second, exam-specific config, `UploadConfigs.ExamResults` (`:239-251`), feeding
+from `getPendingExamResults` — `WHERE type = 'exam' AND parentId IS NOT NULL
+AND userId IS NOT NULL AND (_id IS NULL OR _id = '')`, **no status filter**.
+Kotlin does upload exam submissions. The premise failed, so the "bug or intent"
+question does not arise: `requires grading` is intentional and `ExamResults`
+was written to carry it.
+
+The one thing that follows for the port: `SubmissionDao.pendingUploads`'
+missing status filter is now **load-bearing and deliberate**. Adding
+`status = 'complete'` to it, in a later tidy-up that reads
+`getPendingSubmissions` as the model, would silently strand every exam
+submission on the device. That note belongs on `pendingUploads` in
+`app_database.dart`, which another lane owns this round — see *For the
+integrator*.
+
+### Submission-level `grade`: 0, and left to Planet
+
+`createExamSubmission` sets no submission grade and neither does
+`saveExamAnswer`; the only writer in Kotlin is the sync-in
+(`JsonUtils.getLong("grade", submission)`). The port's device-computed
+percentage is gone. Under the gate it could only ever have read 100%.
+
+## Deliberate divergences
+
+Three, all recorded at the code:
+
+1. **A question with no answer key accepts any answer.** Kotlin fails it —
+   `extractCorrectChoices` returns `emptyList()` and every check helper is then
+   vacuously false. Under the gate that is a question no answer satisfies and
+   no route past but abandoning the exam, and it is not hypothetical: every
+   `ratingScale` question in an exam is in that position, as is any `input`
+   whose author supplied no key. **This is the one place I think Kotlin's
+   behaviour is wrong for this app**, and the integrator can overrule it. An
+   *unanswered* question still fails, so the gate keeps its other job.
+2. **A wrong press of Finish leaves the attempt `pending`.** Kotlin assigns
+   `isExplicitSubmission = true` at `:631` *before* calling `updateAnsDb`, so a
+   wrong final answer writes `requires grading` for an exam the learner has not
+   finished — and `isStepCompleted` (`status != 'pending'`) then unlocks the
+   next course step off a wrong answer. Pressing Back flips it back, which is
+   how the bug stays quiet. Not ported; here the status also decides
+   `isUpdated`, so it would additionally queue a half-finished attempt for
+   upload.
+3. **A half-finished attempt is not uploadable.** `getPendingExamResults` is
+   status-blind, so a Kotlin attempt abandoned mid-exam goes up as `pending` on
+   the next sync — and since `deleteExamSubmissions` then recreates the row
+   with an empty `_id`, the retake POSTs a *second* document. The port holds the
+   attempt until it is submitted (`isUpdated: false` until then). The port's
+   `queuePending` is also swept by unrelated callers (`submissions_screen`), so
+   without this an exam in progress would leak out on any other upload.
+
+And one structural difference: the port creates the session on the **first
+save** rather than before the first question is drawn, to keep `build` free of
+side effects. The only behavioural consequence is that abandoning an exam
+without answering anything leaves no row, where Kotlin leaves an empty
+`pending` attempt its next `deleteStale` clears.
+
+## Kotlin behaviours deliberately **not** ported
+
+Recorded so a later phase does not read them as gaps. All from the audit.
+
+- **`checkAnsAndContinue`'s `else` branch is dead code.** Its one caller is
+  reachable only with `cont == true` for an exam (the `!cont` path returned
+  already) and `cont` is unconditionally `true` for a survey. `isLastAnsvalid`
+  is written and read nowhere.
+- **Kotlin's free-text verdict reads stale state.** `updateAnsDb` passes `ans`,
+  and for `input`/`textarea` `ans` is never updated from the EditText —
+  `saveCurrentAnswer` and the text watcher both write `answerData.singleAnswer`
+  instead. So a free-text answer is graded against `""` on the first press and
+  marked wrong; navigating away and back re-renders, `loadSavedAnswer` assigns
+  `ans`, and the same answer then passes. **A Kotlin free-text exam question
+  can only be passed by leaving it and coming back.** The stored `value` is
+  correct throughout; only the verdict is computed from the stale field. The
+  port grades the answer it recorded, so this cannot arise.
+- **Two parsers race over `exam_questions`.** `"exams"` and `"courses"` sync
+  concurrently (`SyncManager.kt:145-169`), both produce the same row id, and
+  `QuestionDao.upsertAll` is `@Upsert` — a full-row replace. So whichever walk
+  lands last decides whether `correctChoiceList` holds labels or `[""]`,
+  per sync, nondeterministically. The same race nulls `exams.stepId`. A defect,
+  not a quirk: the same exam grades differently after two syncs. The port has
+  one writer.
+- **`ServerReachabilityWorker`'s upload gate disagrees with its selection.**
+  `countPendingExamResults` is `LOWER(status) = 'pending' AND …`, so on that
+  path a device whose only unsent work is a `requires grading` exam never opens
+  the gate — while the two ungated callers upload it fine. The port has one
+  queue.
+- **`btnSubmit` doubles as `btnNext`.** Kotlin's Submit button is never hidden
+  (no `android:visibility` in `fragment_exam_taking.xml`), reads "Submit"
+  mid-exam and "Finish" on the last question, and pressing it mid-exam runs the
+  same gate and then advances; `btnNext` is a shortcut that appears only once
+  the question is answered. The port keeps its one forward button per state
+  (Next, then Submit on the last question). The gating is identical; only the
+  button count differs.
+- **`hasOtherOption`** stays unported, as Phase 106 recorded, so
+  `handleChecked`'s `ans = "other"` — which `getChoiceTextById` cannot resolve
+  and which therefore traps the learner on any `select` where they pick
+  "Other" — has no counterpart either.
+
+## For the integrator
+
+- **Two `app_en.arb` keys appended** at the end of the file:
+  `thankYouForTakingExam`, `pleaseAnswerToContinue`. English only; the five
+  locale files are untouched. Lane A owns `lib/l10n/`, so expect a trivial
+  last-line conflict.
+- **`incorrect_ans` reuses the existing `incorrectAnswer` key** ("Incorrect
+  answer"), which was defined, translated in all six locales, and used nowhere.
+  Kotlin's string is "Incorrect answer, please try again", and its five
+  `values-*/strings.xml` translations are real human ones — better than the
+  `[Nepali] Incorrect answer` placeholders the ARB carries. A follow-up key
+  derived from `incorrect_ans` would be strictly better; I did not add one
+  because the locale files are not mine this round.
+- **No schema bump** (still v44) and no table or converter touched, so no
+  `build_runner` step is needed for this lane.
+- **One query lives in the wrong layer.** `_deleteExamSubmissions` builds its
+  `delete` statements in `submissions_repository.dart` because `SubmissionDao`
+  has no delete-by-parent and `app_database.dart` is Lane C's this round. It
+  should become `SubmissionDao.deleteExamSubmissions(parentId, userId)`.
+  Likewise `saveExamAnswer` reads the whole answer set and rewrites it, because
+  `upsertAll`'s `answers:` map replaces a submission's answers wholesale; a
+  `SubmissionDao.upsertAnswer` would drop that round trip. Neither is a
+  correctness problem — both are inside one `transaction` — and the rows are
+  one per question.
+- **A note is owed to `SubmissionDao.pendingUploads`** saying its missing
+  status filter is deliberate, because an exam is never `complete` and
+  `getPendingSubmissions`' `status = 'complete'` would strand every one. Same
+  file, same lane, not mine to write.
+- **Two reachability blockers the audit surfaced, both outside this slice, and
+  both meaning this gate may be guarding a screen nobody can open.** I did not
+  act on either: the premise is an inference from Kotlin's DAO queries rather
+  than a captured Planet document, and it is cheap to settle with one `curl`
+  against a Planet `exams` database. Worth a phase of its own.
+  1. **`TakeExamScreen` may be unreachable.** Its only entry is
+     `course_detail_screen.dart:190`, gated on `ExamDao.getByStepId`. But
+     `exam_mapper.dart:57` takes `stepId` from the exam document's own `stepId`
+     key — which the Kotlin never reads from there — while the port's step ids
+     are synthetic (`course_mapper.dart:117`, `'$courseId:$stepIndex'`). The
+     lookup can only match a document that literally carries
+     `"stepId": "<courseId>:<index>"`. The button may never render.
+  2. **Nothing may fill `exams`/`exam_questions` for a real course test.** The
+     only writer is `surveys_repository.dart:295` via `ExamMapper.fromDoc`,
+     which returns `null` unless `type == 'exam'` — while the in-repo Kotlin
+     evidence (`CoursesRepositoryImpl` reads exams as
+     `getByStepIdAndType(stepId, "courses")`) says a Planet course test carries
+     `type: "courses"` and arrives on the **courses** walk, which
+     `course_mapper.dart:9-10` explicitly excludes. Every port test builds on a
+     fixture (`'type': 'exam'`, `'stepId': 'step-1'`) that agrees with the
+     mapper and may agree with nothing on the server.
+
+  `exam_mapper.dart` is in this lane's file set and I left it alone
+  deliberately — changing which documents it accepts on an inference would be
+  reckless, and the fix, if it is one, belongs with the course-walk change in
+  `course_mapper.dart`, which is not mine.

--- a/flutter/PHASE_110_NOTES.md
+++ b/flutter/PHASE_110_NOTES.md
@@ -112,6 +112,39 @@ evidence: `a right answer advances` (the un-gated screen advanced too) and
 `a text answer passes by containment` (the un-gated screen finished the exam
 regardless of the verdict — its real evidence is defect 8's probe).
 
+## A second audit, on the finished implementation
+
+The first audit established the Kotlin. A second one attacked the port, and
+found four more defects in my own code plus one false claim in these notes.
+Worth recording as a pattern: **an audit of the ground truth does not audit the
+implementation**, and the implementation defects were the more dangerous half.
+
+| # | defect | pre-fix failure |
+|---|---|---|
+| 11 | **`_ensureSession` memoised a *rejected* future.** `_session ??= _createSession()` caches the failure, so after one transient error — a rejecting session, one failed write — no later press ever re-ran the body. The exam was over for the rest of the mount: every press replayed the same error, no submission row, no answers, the only way out to leave the screen. Kotlin is more forgiving twice over: `startExamSession` retries the local write three times (`SubmissionsRepositoryImpl.kt:420-435`) and a later press re-enters `saveExamAnswer`, whose `sub == null` chain re-finds a submission. The retry is now ported; `_ensureSession` clears a rejection | `a second press after a transient failure gets through` — `Expected: <2> / Actual: <1>`: `startExamSession` never called again |
+| 12 | **The renderer was case-sensitive where the grader and the shaper are not.** `_buildAnswerInput` matched `question.type` exactly; `ExamGrading.isCorrect` and `AnswerShape.forQuestion` both lowercase first, as Kotlin's `ignoreCase = true` comparisons do. A question typed `"Select"` therefore drew a **text field**, the typed answer went through `AnswerShape`'s select branch and was stored as the **empty string**, and the grader graded an empty selection against a non-empty key. The learner's answer discarded and the gate unable to open — where before the gate the same mismatch only cost a mark | `a capitalised select still renders its choices` — `Found 0 widgets with type "RadioGroup<String>"` |
+| 13 | **The retry snackbar sat on the retry button.** Flutter's 4-second default, `SnackBarBehavior.fixed`, over the bottom of the screen — which is where this screen's forward button is. Three wrong tries meant about twelve seconds of unusable button. Kotlin's overlap is narrower and I had asserted it was the same: `btnBack`/`btnNext` are `ImageButton`s in the **top** bar (`fragment_exam_taking.xml:30`, `:62`), so only its Submit is ever covered. Fixed with Kotlin's own `LENGTH_LONG` (2750 ms) and by dismissing the snackbar the moment the answer changes — the action that always precedes the next press | showed up *in the tests*: the second tap of the recovery test was absorbed by the snackbar's exit transition, which `pump(5s)` starts but does not finish |
+| 14 | **`user!` after re-awaiting the session.** A logout mid-exam threw into the failure branch and reported "Could not save your exam" for an attempt that was already written and already `requires grading`. Now the record stands and only the photo and the queueing are skipped | reasoning, not a test — the window needs a logout between the final save and the photo step |
+
+And one claim in these notes that was simply false: that the read-modify-write
+in `saveExamAnswer` was "inside one `transaction`". It was not; see *For the
+integrator*. It is now.
+
+The audit also caught a test that **passed while the screen was dead** — the
+pre-existing `a failed save reports it and keeps the user on the exam` asserts
+the button is live again and stops, so defect 11 sailed straight through it.
+The new test presses a second time. That is the failure mode to look for in
+this file: every assertion here is about what is on screen, and "the button
+looks usable" is not "the button works".
+
+Three tests were added for changes the audit found untested: `_isComplete`'s
+`requires grading` entry (the only change in this slice that alters an existing
+screen), the dropped `grade` badge, and `_goBack` on an unanswered question.
+The badge one needed `scrollUntilVisible` — the detail body is a
+`ListView(children: [...])`, so the answer card sits below the 600px test fold
+and a negative assertion would otherwise pass because nothing was mounted
+rather than because nothing was drawn. Same trap Phase 95 recorded.
+
 ## The three decisions Phase 106 asked for
 
 ### Per-answer `grade`: take Kotlin's field, drop the badge
@@ -185,16 +218,33 @@ Three, all recorded at the code:
    no route past but abandoning the exam, and it is not hypothetical: every
    `ratingScale` question in an exam is in that position, as is any `input`
    whose author supplied no key. **This is the one place I think Kotlin's
-   behaviour is wrong for this app**, and the integrator can overrule it. An
-   *unanswered* question still fails, so the gate keeps its other job.
+   behaviour is wrong for this app**, and the integrator can overrule it.
+
+   The cost, which the second audit made me state rather than leave implied: a
+   *malformed* exam — an author who forgot the key on a genuine
+   multiple-choice question — now silently accepts any answer and uploads
+   `passed: true`, where Kotlin fails loudly by trapping the learner. Under
+   `requires grading` a teacher marks it anyway, so what is lost is a
+   meaningless `passed` rather than a wrong grade. That still seems the better
+   trade against an exam nobody can finish, but it is a judgement about
+   learners, not a mechanical gap. An *unanswered* question still fails.
 2. **A wrong press of Finish leaves the attempt `pending`.** Kotlin assigns
    `isExplicitSubmission = true` at `:631` *before* calling `updateAnsDb`, so a
    wrong final answer writes `requires grading` for an exam the learner has not
-   finished — and `isStepCompleted` (`status != 'pending'`) then unlocks the
-   next course step off a wrong answer. Pressing Back flips it back, which is
-   how the bug stays quiet. Not ported; here the status also decides
-   `isUpdated`, so it would additionally queue a half-finished attempt for
-   upload.
+   finished. Not ported, and the port-specific reason is the strong one: here
+   the status also decides `isUpdated`, and `submissions_screen`'s draft flow
+   sweeps `queuePending` for the whole user, so reproducing it would leak a
+   half-finished attempt onto the wire on any unrelated upload.
+
+   Two corrections to what an earlier draft of this note claimed about the
+   Kotlin side, both from the second audit. `isStepCompleted` is not general
+   step unlocking: it is consulted from one place,
+   `TakeCourseFragment.changeNextButtonState`, whose whole body is wrapped in
+   `if (courseId == "4e6b78800b6ad18b4e8b0e1e38a98cac")` — one hardcoded
+   course. And the bug does **not** self-heal the way "pressing Back flips it
+   back" suggests: `btnBack` saves at the still-final index with the sticky
+   flag still set, so it re-writes `requires grading`; only the next save at a
+   non-final index returns it to `pending`.
 3. **A half-finished attempt is not uploadable.** `getPendingExamResults` is
    status-blind, so a Kotlin attempt abandoned mid-exam goes up as `pending` on
    the next sync — and since `deleteExamSubmissions` then recreates the row
@@ -203,11 +253,27 @@ Three, all recorded at the code:
    `queuePending` is also swept by unrelated callers (`submissions_screen`), so
    without this an exam in progress would leak out on any other upload.
 
+4. **Going back on an *unanswered* question records nothing.** Kotlin's
+   `btnBack` saves unconditionally, so an untouched question is written with
+   `mistakes + 1` and `isPassed = false` — and that row **uploads**, because
+   `getPendingExamResults` has no status filter and `Answer.createObject` sends
+   `mistakes`. Scoring a mistake against a question the learner never answered,
+   and reporting it to Planet, is a defect rather than a behaviour. The cost is
+   that the two apps report different mistake totals for identical learner
+   behaviour. (Added after the second audit, which caught that the guard was
+   already in the code and undocumented — a divergence that changes an uploaded
+   field, hiding behind a doc comment that described Kotlin's behaviour as if
+   it were the port's.)
+
 And one structural difference: the port creates the session on the **first
 save** rather than before the first question is drawn, to keep `build` free of
-side effects. The only behavioural consequence is that abandoning an exam
-without answering anything leaves no row, where Kotlin leaves an empty
-`pending` attempt its next `deleteStale` clears.
+side effects. Two behavioural consequences, the second of which is an
+improvement the first draft of this note missed: abandoning an exam without
+answering anything leaves no row (Kotlin leaves an empty `pending` attempt its
+next `deleteStale` clears), and **opening an exam and backing out no longer
+destroys the previous attempt** — Kotlin deletes stale attempts on screen open,
+before a single answer, so it has a wider window in which a queued-but-undrained
+upload can be lost.
 
 ## Kotlin behaviours deliberately **not** ported
 
@@ -217,15 +283,6 @@ Recorded so a later phase does not read them as gaps. All from the audit.
   reachable only with `cont == true` for an exam (the `!cont` path returned
   already) and `cont` is unconditionally `true` for a survey. `isLastAnsvalid`
   is written and read nowhere.
-- **Kotlin's free-text verdict reads stale state.** `updateAnsDb` passes `ans`,
-  and for `input`/`textarea` `ans` is never updated from the EditText —
-  `saveCurrentAnswer` and the text watcher both write `answerData.singleAnswer`
-  instead. So a free-text answer is graded against `""` on the first press and
-  marked wrong; navigating away and back re-renders, `loadSavedAnswer` assigns
-  `ans`, and the same answer then passes. **A Kotlin free-text exam question
-  can only be passed by leaving it and coming back.** The stored `value` is
-  correct throughout; only the verdict is computed from the stale field. The
-  port grades the answer it recorded, so this cannot arise.
 - **Two parsers race over `exam_questions`.** `"exams"` and `"courses"` sync
   concurrently (`SyncManager.kt:145-169`), both produce the same row id, and
   `QuestionDao.upsertAll` is `@Upsert` — a full-row replace. So whichever walk
@@ -245,6 +302,26 @@ Recorded so a later phase does not read them as gaps. All from the audit.
   the question is answered. The port keeps its one forward button per state
   (Next, then Submit on the last question). The gating is identical; only the
   button count differs.
+- **`continueExam`'s other half.** `BaseExamFragment.kt:133` does two things:
+  the thank-you dialog *and*
+  `saveCourseProgress(exam?.courseId, stepNumber, sub?.status == "graded")`.
+  `_showResult` ports only the dialog. Omitting it is nil-or-positive: `sub` is
+  the in-memory object `createExamSubmission` returned and `saveExamAnswer`
+  updates the row without mutating it, so `sub?.status == "graded"` is
+  **always false** and Kotlin's call writes `passed = false` — clearing a step
+  that had previously passed. Note that the port's own
+  `ProgressRepository.updateCourseProgress` has **no caller anywhere**, while
+  its doc comment and `app_database.dart:2929` both claim "used by the exam
+  path"; those two comments want correcting, in a file this lane does not own.
+- **Kotlin's free-text verdict reads stale state, and worse than first
+  recorded.** `updateAnsDb` passes `ans`, which for `input`/`textarea` is never
+  updated from the EditText — so the answer is graded against `""` on the first
+  press. Navigating away and back re-renders, `loadSavedAnswer` assigns `ans`,
+  and the same answer then passes. On the **first** question `btnBack` is
+  `GONE`, so there is nowhere to navigate to: **a Kotlin exam whose first
+  question is free-text and carries a key cannot be finished at all.** The
+  stored `value` is correct throughout (it arrives via the `otherText`
+  channel); only the verdict is wrong. The port grades the answer it recorded.
 - **`hasOtherOption`** stays unported, as Phase 106 recorded, so
   `handleChecked`'s `ans = "other"` — which `getChoiceTextById` cannot resolve
   and which therefore traps the learner on any `select` where they pick
@@ -271,9 +348,14 @@ Recorded so a later phase does not read them as gaps. All from the audit.
   should become `SubmissionDao.deleteExamSubmissions(parentId, userId)`.
   Likewise `saveExamAnswer` reads the whole answer set and rewrites it, because
   `upsertAll`'s `answers:` map replaces a submission's answers wholesale; a
-  `SubmissionDao.upsertAnswer` would drop that round trip. Neither is a
-  correctness problem — both are inside one `transaction` — and the rows are
-  one per question.
+  `SubmissionDao.upsertAnswer` would drop that round trip. The rows are one per
+  question, so the read is small. An earlier draft of this note claimed both
+  were "inside one `transaction`" and therefore harmless; **that was false** —
+  the read sat outside, so two concurrent saves could interleave
+  read/read/write/write and revert the first, losing a `mistakes` increment.
+  `saveExamAnswer` now wraps the read and the write in one `_dao.transaction`
+  (drift nests it as a savepoint inside `upsertAll`'s own). The round trip in
+  `_deleteExamSubmissions` has the same shape but no interleaving caller.
 - **A note is owed to `SubmissionDao.pendingUploads`** saying its missing
   status filter is deliberate, because an exam is never `complete` and
   `getPendingSubmissions`' `status = 'complete'` would strand every one. Same
@@ -283,14 +365,23 @@ Recorded so a later phase does not read them as gaps. All from the audit.
   act on either: the premise is an inference from Kotlin's DAO queries rather
   than a captured Planet document, and it is cheap to settle with one `curl`
   against a Planet `exams` database. Worth a phase of its own.
-  1. **`TakeExamScreen` may be unreachable.** Its only entry is
-     `course_detail_screen.dart:190`, gated on `ExamDao.getByStepId`. But
-     `exam_mapper.dart:57` takes `stepId` from the exam document's own `stepId`
-     key — which the Kotlin never reads from there — while the port's step ids
-     are synthetic (`course_mapper.dart:117`, `'$courseId:$stepIndex'`). The
-     lookup can only match a document that literally carries
-     `"stepId": "<courseId>:<index>"`. The button may never render.
-  2. **Nothing may fill `exams`/`exam_questions` for a real course test.** The
+  1. **`TakeExamScreen` is unreachable with real synced data, and this half is
+     settled in-repo — no `curl` needed.** Both entries —
+     `course_detail_screen.dart:190` and `take_course_screen.dart:373` (the
+     first draft of this note named only the former) — resolve the exam through
+     `ExamDao.getByStepId`. But `exam_mapper.dart:57` takes `stepId` from the
+     exam document's own `stepId` key, which the Kotlin never reads from there
+     (`CoursesRepositoryImpl.kt:679` mints the step's own id and `:745` assigns
+     it to the exam), while the port's step ids are synthetic
+     (`course_mapper.dart:118`, `'$courseId:$stepIndex'`). **Nothing in the port
+     ever writes an `exams.stepId` equal to a `course_steps.id`**, so the two
+     ends of its own join cannot meet except by coincidence — which is why every
+     fixture has to hand-fake it. The same lookup gates the payoff of defect 7:
+     `progress_repository.dart:72-75` builds `examByStep` from
+     `getByStepIds(...)`, so the per-step mistake totals the fixed `parentId`
+     restores are still unobservable.
+  2. **Nothing may fill `exams`/`exam_questions` for a real course test.**
+     This half *is* the inference — it is the one a `curl` would settle. The
      only writer is `surveys_repository.dart:295` via `ExamMapper.fromDoc`,
      which returns `null` unless `type == 'exam'` — while the in-repo Kotlin
      evidence (`CoursesRepositoryImpl` reads exams as

--- a/flutter/PHASE_110_NOTES.md
+++ b/flutter/PHASE_110_NOTES.md
@@ -1,0 +1,9 @@
+# Phase 110 — the exam retry model (in progress)
+
+Slice: port Kotlin's cannot-advance-past-a-wrong-answer exam model, so
+`mistakes` accumulates and is uploaded, and a finished submission's answers are
+all `isPassed = true` as a consequence. Plus the two companion decisions Phase
+106 logged with it: per-answer `grade`, and the submission status
+(`requires grading`).
+
+Notes to follow.

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -1407,5 +1407,7 @@
   "dataCleared": "All data cleared",
   "dataManagement": "Data management",
   "resourceTitleAlreadyExists": "A resource with this title already exists",
-  "failedToUpdateResource": "Failed to update resource"
+  "failedToUpdateResource": "Failed to update resource",
+  "thankYouForTakingExam": "Thank you for taking this exam! We wish you all the best.",
+  "pleaseAnswerToContinue": "Please select / write your answer to continue"
 }

--- a/flutter/lib/repository/exam_grading.dart
+++ b/flutter/lib/repository/exam_grading.dart
@@ -1,18 +1,73 @@
 import '../data/local/app_database.dart';
 
-/// Marking rules for a graded exam, ported from `ExamTakingFragment`'s
-/// answer checks.
+/// Marking rules for a graded exam — the port of `ExamAnswerUtils
+/// .checkCorrectAnswer` and its three helpers.
 ///
-/// This lives outside the widget because it is the part that has to be right:
-/// an exam is scored on the device and the verdict is what gets uploaded.
+/// This lives outside the widget because it is the part that has to be right.
+/// Under Kotlin's exam model the verdict is not a score at the end: it is the
+/// gate on every question. `saveExamAnswer` returns it, and `btnNext` /
+/// `btnSubmit` refuse to advance when it is false
+/// (`ExamTakingFragment.kt:196-204`, `:641-645`). So a rule that answers
+/// "false" where Kotlin's author meant "true" does not cost a mark — it leaves
+/// the learner on question one with no way forward.
 class ExamGrading {
   const ExamGrading._();
+
+  /// The verdict for one answer, dispatched on the question type the way
+  /// `checkCorrectAnswer` dispatches (`ExamAnswerUtils.kt:54-68`).
+  ///
+  /// Kotlin reads `select`/`selectMultiple` and sends everything else —
+  /// `input`, `textarea`, `ratingScale`, and any unrecognised type — through
+  /// `checkTextAnswer`. The extra clause here is for a question whose document
+  /// names no type but does offer choices: `take_exam_screen` renders a text
+  /// field for an unknown type, so it cannot produce a selection, but
+  /// [AnswerShape] treats choices-plus-a-pick as a choice question and it
+  /// would be incoherent to store an answer as a choice and grade it as text.
+  static bool isCorrect({
+    required ExamQuestionRow question,
+    List<String> choiceIds = const [],
+    String? text,
+  }) {
+    final type = question.type?.toLowerCase();
+    if (type == 'select' || type == 'selectmultiple' || choiceIds.isNotEmpty) {
+      return isSelectionCorrect(question, choiceIds);
+    }
+    return isTextCorrect(question, text ?? '');
+  }
 
   /// Grades a choice question.
   ///
   /// A selection and `correctChoices` are both choice **ids**, so this is a set
   /// comparison. `selectMultiple` requires the exact set — a subset does not
-  /// pass, matching the Kotlin's all-or-nothing marking.
+  /// pass, matching `checkMultipleSelectAnswer`'s sorted-list equality.
+  ///
+  /// The port normalises the answer key to choice **ids** where Kotlin
+  /// normalises it to display **text**, and both are self-consistent.
+  /// `CoursesRepositoryImpl.extractCorrectChoices` — the parser a course
+  /// exam's questions actually go through, `CoursesRepositoryImpl.kt:804-821`
+  /// — resolves each `correctChoice` entry to
+  /// `ExamAnswerUtils.choiceDisplayValue(matched)`, so `correctChoiceList`
+  /// holds labels; `saveExamAnswer` then passes
+  /// `ansForCheck = getChoiceTextById(question, ans)` into `checkSelectAnswer`
+  /// and compares label with label, and `listAnsForCheck = listAns.keys
+  /// .associateWith { it }` does the same for `selectMultiple`. Kotlin's
+  /// grading works; the two representations are mirror images.
+  ///
+  /// `ExamMapper._parseCorrectChoices` reduces the same entries to ids
+  /// instead, so this compares ids. That is the more robust half of the
+  /// mirror — an id is unique where two choices can share a label, which
+  /// Kotlin's comparison silently collapses — and it is what the port has
+  /// stored since Phase 106. What matters is that the mapper and this
+  /// function agree: porting `checkCorrectAnswer` literally on top of an
+  /// id-storing mapper would compare a label with an id and pass nothing,
+  /// which under the gate means an exam nobody can finish.
+  ///
+  /// (`ExamQuestion.insertCorrectChoice` — the *other* Kotlin writer, on the
+  /// `exams` walk — really does produce garbage for a `{id, text}` choice: it
+  /// matches on `id` and then stores the matched choice's `res`, which such a
+  /// document does not have, so the list is `[""]`. That walk is not how a
+  /// course exam arrives, and the two writers racing over the same
+  /// `exam_questions.id` is a Kotlin defect the port has no counterpart to.)
   static bool isSelectionCorrect(
     ExamQuestionRow question,
     List<String> choiceIds,
@@ -20,19 +75,48 @@ class ExamGrading {
     final correct = question.correctChoices
         .map((id) => id.toLowerCase())
         .toSet();
-    // A question whose document carried no answer key cannot be passed;
-    // treating "no key" as "anything goes" would score blank exams full marks.
-    if (correct.isEmpty) return false;
+    if (correct.isEmpty) return _unkeyed(choiceIds.isNotEmpty);
     final chosen = choiceIds.map((id) => id.toLowerCase()).toSet();
     return chosen.length == correct.length && chosen.containsAll(correct);
   }
 
   /// Grades a text or rating answer against the recorded correct values.
+  ///
+  /// Containment, not equality: `checkTextAnswer` is
+  /// `correctChoices.any { normalizedAns.contains(it.lowercase(locale)) }`
+  /// (`ExamAnswerUtils.kt:88-95`), so "the expected word is here" passes a key
+  /// of "expected word" — its own test asserts exactly that
+  /// (`ExamAnswerUtilsTest.testCheckCorrectAnswer_InputText`). The port had
+  /// exact equality, which under the gate would refuse a right answer that
+  /// carried a stray word.
   static bool isTextCorrect(ExamQuestionRow question, String value) {
-    final trimmed = value.trim().toLowerCase();
-    if (trimmed.isEmpty) return false;
-    return question.correctChoices
+    final correct = question.correctChoices
         .map((id) => id.toLowerCase())
-        .contains(trimmed);
+        .toList();
+    final trimmed = value.trim().toLowerCase();
+    if (correct.isEmpty) return _unkeyed(trimmed.isNotEmpty);
+    if (trimmed.isEmpty) return false;
+    return correct.any(trimmed.contains);
   }
+
+  /// A question whose document carried no answer key.
+  ///
+  /// Kotlin fails it. `extractCorrectChoices` returns `emptyList()` when
+  /// `correctChoice` is absent or blank, and every one of the three check
+  /// helpers is then vacuously false — `checkTextAnswer` is
+  /// `correctChoices.any { ... }` over an empty list, and the `null` guard
+  /// above it never fires. Combined with the gate that traps the learner:
+  /// every `ratingScale` question in an exam has no key (Planet's rating
+  /// questions carry no `correctChoice`), and so does any `input` or
+  /// `textarea` question whose author did not supply one. There is no answer
+  /// that satisfies such a question and no way out of the exam but to abandon
+  /// it.
+  ///
+  /// The port answers "any answer will do". This is the only deliberate
+  /// divergence in this file that is not a correction: the gate presupposes
+  /// that a right answer exists, and when the document names none the honest
+  /// reading is that there is nothing to get wrong. An *unanswered* question
+  /// still fails, so the gate keeps its other job of making the learner
+  /// respond.
+  static bool _unkeyed(bool answered) => answered;
 }

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -11,6 +11,7 @@ import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
 import '../data/local/converters.dart';
+import 'exam_grading.dart';
 
 /// Offline list portion of `repository/SubmissionsRepositoryImpl.kt`.
 class SubmissionsRepository {
@@ -210,34 +211,45 @@ class SubmissionsRepository {
   static String _rawQuestionId(SurveyQuestionRow question) =>
       question.questionId ?? question.id;
 
-  /// Records a completed exam attempt, with its grade, as an uploadable
-  /// submission.
+  /// Opens an exam attempt, the port of `SubmissionsRepositoryImpl
+  /// .startExamSession` + `createExamSubmission` as `ExamTakingFragment
+  /// .initializeExamData` calls them for `type == "exam"`.
   ///
-  /// Kotlin's `ExamTakingFragment` writes a `RealmSubmission` per attempt and
-  /// `UploadManager` sends it. Without this the port graded an exam into a
-  /// dialog and dropped the result when the dialog closed — the attempt never
-  /// reached the device, let alone the server.
-  Future<String> createExamDraft({
+  /// Kotlin creates the submission **before** the first question is shown and
+  /// writes each answer as the learner passes it ([saveExamAnswer]), because
+  /// `mistakes` is an accumulator: it is `(existing?.mistakes ?: 0) + 1` per
+  /// wrong attempt, and there is no "existing" to add to unless the row is
+  /// already on disk. The port used to grade the whole attempt in widget state
+  /// and write it once at the end, which is why `mistakes` was structurally
+  /// stuck at its column default.
+  ///
+  /// The exam branch passes `recreate = true` with `deleteStale`, so a second
+  /// entry to the same exam discards the previous local attempt rather than
+  /// resuming it — the survey branch is the one that offers resume. The
+  /// `pending` status plus `isUpdated: false` is what keeps a half-finished
+  /// attempt out of `pendingUploads`; Kotlin gets the same effect from
+  /// `getPendingSubmissions`' `WHERE status = 'complete'` filter.
+  Future<String> startExamSession({
     required ExamRow exam,
     required List<ExamQuestionRow> questions,
     required String userId,
-    required Map<String, ExamDraftAnswer> answers,
     String? courseId,
     DateTime? now,
   }) async {
+    final resolvedCourseId = (courseId?.isNotEmpty ?? false)
+        ? courseId
+        : exam.courseId;
+    final parentId = examParentId(examId: exam.id, courseId: resolvedCourseId);
+    await _deleteExamSubmissions(parentId: parentId, userId: userId);
     final timestamp = (now ?? DateTime.now()).millisecondsSinceEpoch;
     final id = sha1
         .convert(utf8.encode('$userId:$timestamp:${exam.id}'))
         .toString();
-    final correct = questions
-        .where((question) => answers[question.id]?.isCorrect ?? false)
-        .length;
-    final grade = questions.isEmpty ? 0 : (correct * 100) ~/ questions.length;
     await _dao.upsertAll(
       [
         SubmissionsCompanion.insert(
           id: id,
-          parentId: Value(courseId ?? exam.courseId),
+          parentId: Value(parentId),
           parent: Value(
             jsonEncode({
               '_id': exam.id,
@@ -251,10 +263,17 @@ class SubmissionsRepository {
           type: const Value('exam'),
           startTime: Value(timestamp),
           lastUpdateTime: Value(timestamp),
-          grade: Value(grade),
-          status: const Value('complete'),
+          // Deliberately left at 0. `createExamSubmission` never sets a
+          // submission-level grade for an exam and neither does
+          // `saveExamAnswer`: the attempt goes up as `requires grading` and
+          // Planet's grading queue writes the mark, which the sync-in reads
+          // back into this column. The port used to compute a percentage here
+          // on the device, which under the retry gate would be 100% every
+          // time — every answer in a finished attempt is correct by
+          // construction.
+          status: const Value('pending'),
           uploaded: const Value(false),
-          isUpdated: const Value(true),
+          isUpdated: const Value(false),
         ),
       ],
       questions: {
@@ -266,6 +285,9 @@ class SubmissionsRepository {
               header: Value(question.header),
               body: Value(question.body),
               type: Value(question.type),
+              // The labels only: this column is a display list
+              // (`availableChoices`), and `SubmissionQuestions` is a preserved
+              // table whose converter cannot change here.
               choices: Value(
                 question.choices.map((choice) => choice.text).toList(),
               ),
@@ -273,54 +295,155 @@ class SubmissionsRepository {
             ),
         ],
       },
-      answers: {
-        id: [
-          for (final question in questions)
-            _examAnswer(
-              submissionId: id,
-              examId: exam.id,
-              question: question,
-              draft: answers[question.id],
-            ),
-        ],
-      },
     );
     return id;
   }
 
-  /// One graded exam answer row.
+  /// `"$examId@$courseId"`, or the bare exam id when the exam belongs to no
+  /// course — the shape `createExamSubmission` writes
+  /// (`SubmissionsRepositoryImpl.kt:449-456`) and `deleteExamSubmissions`
+  /// searches by (`:344-350`).
   ///
-  /// The screen hands over choice **ids** — that is what a radio/checkbox
-  /// records and what grading compares against — and [AnswerShape] turns them
-  /// into the `{id, text}` objects `saveExamAnswer` stores, resolving each
-  /// label from the question the way `getChoiceTextById` does. The port used to
-  /// store the bare ids, so a choice answer reached Planet as a list of ids
-  /// where Kotlin sends objects (or, for a single choice, the display text).
-  SubmissionAnswersCompanion _examAnswer({
+  /// The port used to store the bare `courseId` here, which
+  /// `ProgressRepository._examIdFromParent` reads as the exam id — it takes
+  /// the leading `@`-delimited segment — so the per-step mistake counts could
+  /// never find their exam even once `mistakes` was populated.
+  static String examParentId({required String examId, String? courseId}) =>
+      (courseId?.isNotEmpty ?? false) ? '$examId@$courseId' : examId;
+
+  /// Records one answer and returns whether it was **correct** — the verdict
+  /// `updateAnsDb` hands back to `btnNext`/`btnSubmit`, which is what makes a
+  /// wrong answer refuse to advance.
+  ///
+  /// Port of the exam half of `SubmissionsRepositoryImpl.saveExamAnswer`
+  /// (`:491-579`). Every field it writes is Kotlin's:
+  ///
+  ///  * `mistakes` — `(existing?.mistakes ?: 0) + 1` when this attempt is
+  ///    wrong, otherwise the count so far. It accumulates across retries of
+  ///    the same question within one attempt, is uploaded by
+  ///    [serialize] (`Answer.createObject` sends `"mistakes"`), and is what
+  ///    the courses-progress screen totals per step.
+  ///  * `isPassed` — the verdict for this attempt. In a *finished* attempt
+  ///    every answer is `true`, but as a consequence rather than an
+  ///    assertion: the learner cannot leave a question until it is right.
+  ///  * `grade` — `1` for every exam answer, right or wrong. It is a
+  ///    "worth one mark" marker, not a score, and `createObject` does not
+  ///    upload it. See `submission_detail_screen` for why nothing renders it.
+  ///  * the submission's `status` — `requires grading` on the final answer of
+  ///    an explicit submission, `pending` otherwise. `complete` is the survey
+  ///    value; an exam is not complete until somebody marks it.
+  Future<bool> saveExamAnswer({
     required String submissionId,
-    required String examId,
     required ExamQuestionRow question,
-    required ExamDraftAnswer? draft,
-  }) {
+    required ExamDraftAnswer answer,
+    required bool isFinal,
+    required bool isExplicitSubmission,
+    DateTime? now,
+  }) async {
+    final isCorrect = ExamGrading.isCorrect(
+      question: question,
+      choiceIds: answer.choiceIds,
+      text: answer.value,
+    );
     final shape = AnswerShape.forQuestion(
       type: question.type,
       choices: question.choices,
-      selected: (draft?.choiceIds ?? const <String>[]).map(
-        (id) => ExamChoice(id: id, text: ''),
+      selected: answer.choiceIds.map((id) => ExamChoice(id: id, text: '')),
+      text: answer.value,
+    );
+    final answerId = '$submissionId:${question.id}';
+    // `answersFor` + a full rewrite rather than a targeted update: the DAO's
+    // `upsertAll` replaces a submission's whole answer set, and adding a
+    // `SubmissionDao` method to touch one row would mean editing
+    // `app_database.dart`, which another lane owns this round. The rows are
+    // one per question, so the read is small; a follow-up should move this to
+    // `SubmissionDao.upsertAnswer` and drop the round trip.
+    final existing = await _dao.answersFor(submissionId);
+    final previous = existing.where((row) => row.id == answerId).firstOrNull;
+    final companions = [
+      for (final row in existing)
+        if (row.id != answerId) row.toCompanion(false),
+      SubmissionAnswersCompanion.insert(
+        id: answerId,
+        submissionId: submissionId,
+        examId: Value(question.examId),
+        questionId: Value(question.id),
+        value: Value(shape.value),
+        valueChoices: Value(shape.valueChoices),
+        mistakes: Value((previous?.mistakes ?? 0) + (isCorrect ? 0 : 1)),
+        isPassed: Value(isCorrect),
+        grade: const Value(1),
       ),
-      text: draft?.value,
+    ];
+    // `isCorrect` is part of the condition, which Kotlin's is not: `onClick`
+    // assigns `isExplicitSubmission = true` at `ExamTakingFragment.kt:631`
+    // *before* it calls `updateAnsDb`, so a **wrong** press of Finish writes
+    // `requires grading` for an exam the learner has not finished — and
+    // `isStepCompleted` (`status != 'pending'`) then unlocks the next course
+    // step off the back of a wrong answer. Pressing Back flips it to
+    // `pending` again, which is how the bug stays quiet. Here the status
+    // would additionally decide `isUpdated`, so reproducing it would queue a
+    // half-finished attempt for upload.
+    final status = isFinal && isExplicitSubmission && isCorrect
+        ? 'requires grading'
+        : 'pending';
+    await _dao.upsertAll(
+      [
+        SubmissionsCompanion(
+          id: Value(submissionId),
+          status: Value(status),
+          lastUpdateTime: Value((now ?? DateTime.now()).millisecondsSinceEpoch),
+          // Kotlin's `updateStatusAndLastUpdate` sets `isUpdated = 1` on every
+          // save, and its exam-specific upload config
+          // (`UploadConfigs.ExamResults` -> `getPendingExamResults`) has no
+          // status filter at all — so a half-finished Kotlin attempt goes up
+          // as `pending` on the next sync, and `deleteExamSubmissions` then
+          // POSTs a second document for the retake. The port's
+          // `pendingUploads` is likewise status-blind (`isUpdated == true`,
+          // deliberately: filtering on `status = 'complete'` the way
+          // `getPendingSubmissions` does would strand every exam, since an
+          // exam is never `complete`), so this flag is the gate instead: an
+          // attempt becomes uploadable exactly when it is submitted.
+          isUpdated: Value(status == 'requires grading'),
+        ),
+      ],
+      answers: {submissionId: companions},
     );
-    final isCorrect = draft?.isCorrect ?? false;
-    return SubmissionAnswersCompanion.insert(
-      id: '$submissionId:${question.id}',
-      submissionId: submissionId,
-      examId: Value(examId),
-      questionId: Value(question.id),
-      value: Value(shape.value),
-      valueChoices: Value(shape.valueChoices),
-      isPassed: Value(isCorrect),
-      grade: Value(isCorrect ? 1 : 0),
-    );
+    return isCorrect;
+  }
+
+  /// Port of `SubmissionsRepositoryImpl.deleteExamSubmissions` — every local
+  /// attempt at this exam for this user, answers and questions included.
+  ///
+  /// Kotlin's `deleteByParentAndUser` has no status filter, so an already
+  /// uploaded attempt goes too: the server keeps its document and the device
+  /// keeps only the attempt in progress.
+  ///
+  /// The query is built here rather than in `SubmissionDao` because
+  /// `app_database.dart` belongs to another lane this round and the DAO has no
+  /// delete-by-parent. It should move there — it is the only place in this
+  /// repository that reaches for a table directly.
+  Future<void> _deleteExamSubmissions({
+    required String parentId,
+    required String userId,
+  }) async {
+    final stale = await _dao.getExamSubmissionsByUser(userId);
+    final ids = stale
+        .where((row) => row.parentId == parentId)
+        .map((row) => row.id)
+        .toList();
+    if (ids.isEmpty) return;
+    await _dao.transaction(() async {
+      await (_dao.delete(
+        _dao.submissionAnswers,
+      )..where((row) => row.submissionId.isIn(ids))).go();
+      await (_dao.delete(
+        _dao.submissionQuestions,
+      )..where((row) => row.submissionId.isIn(ids))).go();
+      await (_dao.delete(
+        _dao.submissions,
+      )..where((row) => row.id.isIn(ids))).go();
+    });
   }
 
   /// Attaches the profile collected by `UserInformationFragment` to an attempt.
@@ -970,14 +1093,12 @@ class AnswerShape {
 
 /// One question's answer on an exam attempt.
 ///
-/// Unlike a survey answer this carries a verdict: exams are graded on the
-/// device against the correct-choice ids that came down with the question.
+/// It carries no verdict. `saveExamAnswer` grades the answer itself, from the
+/// question's own `correctChoices`, exactly as Kotlin does — the value written
+/// to the row and the value returned to the gate are then one computation
+/// rather than two that can disagree.
 class ExamDraftAnswer {
-  const ExamDraftAnswer({
-    this.value,
-    this.choiceIds = const [],
-    this.isCorrect = false,
-  });
+  const ExamDraftAnswer({this.value, this.choiceIds = const []});
 
   /// Free text, or the selected rating rendered as a string.
   final String? value;
@@ -989,8 +1110,6 @@ class ExamDraftAnswer {
   /// is the `{id, text}` object a stored answer and an uploaded document
   /// actually carry.
   final List<String> choiceIds;
-
-  final bool isCorrect;
 
   bool get isEmpty => (value == null || value!.isEmpty) && choiceIds.isEmpty;
 }

--- a/flutter/lib/repository/submissions_repository.dart
+++ b/flutter/lib/repository/submissions_repository.dart
@@ -240,6 +240,37 @@ class SubmissionsRepository {
         ? courseId
         : exam.courseId;
     final parentId = examParentId(examId: exam.id, courseId: resolvedCourseId);
+    // Retried three times like `startExamSession`'s own loop
+    // (`SubmissionsRepositoryImpl.kt:420-435`, whose comment names transient
+    // SQLite constraints during rapid operations). Without it a single failed
+    // write ends the exam: the screen has one caller and nothing else opens an
+    // attempt.
+    Object? lastError;
+    for (var attempt = 0; attempt < 3; attempt++) {
+      try {
+        return await _openExamSession(
+          exam: exam,
+          questions: questions,
+          userId: userId,
+          parentId: parentId,
+          now: now,
+        );
+      } on Exception catch (error) {
+        lastError = error;
+      }
+    }
+    throw StateError(
+      'Failed to start exam session after 3 attempts: $lastError',
+    );
+  }
+
+  Future<String> _openExamSession({
+    required ExamRow exam,
+    required List<ExamQuestionRow> questions,
+    required String userId,
+    required String parentId,
+    DateTime? now,
+  }) async {
     await _deleteExamSubmissions(parentId: parentId, userId: userId);
     final timestamp = (now ?? DateTime.now()).millisecondsSinceEpoch;
     final id = sha1
@@ -352,63 +383,78 @@ class SubmissionsRepository {
       text: answer.value,
     );
     final answerId = '$submissionId:${question.id}';
-    // `answersFor` + a full rewrite rather than a targeted update: the DAO's
-    // `upsertAll` replaces a submission's whole answer set, and adding a
-    // `SubmissionDao` method to touch one row would mean editing
-    // `app_database.dart`, which another lane owns this round. The rows are
-    // one per question, so the read is small; a follow-up should move this to
-    // `SubmissionDao.upsertAnswer` and drop the round trip.
-    final existing = await _dao.answersFor(submissionId);
-    final previous = existing.where((row) => row.id == answerId).firstOrNull;
-    final companions = [
-      for (final row in existing)
-        if (row.id != answerId) row.toCompanion(false),
-      SubmissionAnswersCompanion.insert(
-        id: answerId,
-        submissionId: submissionId,
-        examId: Value(question.examId),
-        questionId: Value(question.id),
-        value: Value(shape.value),
-        valueChoices: Value(shape.valueChoices),
-        mistakes: Value((previous?.mistakes ?? 0) + (isCorrect ? 0 : 1)),
-        isPassed: Value(isCorrect),
-        grade: const Value(1),
-      ),
-    ];
-    // `isCorrect` is part of the condition, which Kotlin's is not: `onClick`
-    // assigns `isExplicitSubmission = true` at `ExamTakingFragment.kt:631`
-    // *before* it calls `updateAnsDb`, so a **wrong** press of Finish writes
-    // `requires grading` for an exam the learner has not finished — and
-    // `isStepCompleted` (`status != 'pending'`) then unlocks the next course
-    // step off the back of a wrong answer. Pressing Back flips it to
-    // `pending` again, which is how the bug stays quiet. Here the status
-    // would additionally decide `isUpdated`, so reproducing it would queue a
-    // half-finished attempt for upload.
+    // `isCorrect` is part of the status condition, which Kotlin's is not:
+    // `onClick` assigns `isExplicitSubmission = true`
+    // (`ExamTakingFragment.kt:630-632`) *before* it calls `updateAnsDb`, so a
+    // **wrong** press of Finish writes `requires grading` for an exam the
+    // learner has not finished. Not ported, and the port-specific reason is
+    // the strong one: here the status also decides `isUpdated`, and
+    // `submissions_screen`'s draft flow sweeps `queuePending` for the whole
+    // user, so reproducing it would leak a half-finished attempt onto the wire
+    // on any unrelated upload. (Kotlin's own consequence is narrower than it
+    // looks — `isStepCompleted` is read from one place,
+    // `TakeCourseFragment.changeNextButtonState`, whose body is wrapped in a
+    // single hardcoded `courseId` — and it does not self-heal the way a first
+    // reading suggests: `btnBack` saves at the still-final index with the
+    // sticky flag still set, so it re-writes `requires grading`; only the next
+    // save at a non-final index returns it to `pending`.)
     final status = isFinal && isExplicitSubmission && isCorrect
         ? 'requires grading'
         : 'pending';
-    await _dao.upsertAll(
-      [
-        SubmissionsCompanion(
-          id: Value(submissionId),
-          status: Value(status),
-          lastUpdateTime: Value((now ?? DateTime.now()).millisecondsSinceEpoch),
-          // Kotlin's `updateStatusAndLastUpdate` sets `isUpdated = 1` on every
-          // save, and its exam-specific upload config
-          // (`UploadConfigs.ExamResults` -> `getPendingExamResults`) has no
-          // status filter at all — so a half-finished Kotlin attempt goes up
-          // as `pending` on the next sync, and `deleteExamSubmissions` then
-          // POSTs a second document for the retake. The port's
-          // `pendingUploads` is likewise status-blind (`isUpdated == true`,
-          // deliberately: filtering on `status = 'complete'` the way
-          // `getPendingSubmissions` does would strand every exam, since an
-          // exam is never `complete`), so this flag is the gate instead: an
-          // attempt becomes uploadable exactly when it is submitted.
-          isUpdated: Value(status == 'requires grading'),
+    // One transaction around the read *and* the write, because `upsertAll`
+    // replaces a submission's whole answer set: a read outside it lets two
+    // concurrent saves interleave read/read/write/write and revert the first,
+    // losing a `mistakes` increment. Drift nests this as a savepoint inside
+    // `upsertAll`'s own transaction.
+    //
+    // Reading the set and rewriting it is itself a workaround: `SubmissionDao`
+    // has no way to touch one answer row, and adding one would mean editing
+    // `app_database.dart`, which another lane owns this round. The rows are one
+    // per question, so the read is small; a follow-up should add
+    // `SubmissionDao.upsertAnswer` and drop the rewrite.
+    await _dao.transaction(() async {
+      final existing = await _dao.answersFor(submissionId);
+      final previous = existing.where((row) => row.id == answerId).firstOrNull;
+      final companions = [
+        for (final row in existing)
+          if (row.id != answerId) row.toCompanion(false),
+        SubmissionAnswersCompanion.insert(
+          id: answerId,
+          submissionId: submissionId,
+          examId: Value(question.examId),
+          questionId: Value(question.id),
+          value: Value(shape.value),
+          valueChoices: Value(shape.valueChoices),
+          mistakes: Value((previous?.mistakes ?? 0) + (isCorrect ? 0 : 1)),
+          isPassed: Value(isCorrect),
+          grade: const Value(1),
         ),
-      ],
-      answers: {submissionId: companions},
-    );
+      ];
+      await _dao.upsertAll(
+        [
+          SubmissionsCompanion(
+            id: Value(submissionId),
+            status: Value(status),
+            lastUpdateTime: Value(
+              (now ?? DateTime.now()).millisecondsSinceEpoch,
+            ),
+            // Kotlin's `updateStatusAndLastUpdate` sets `isUpdated = 1` on
+            // every save, and its exam-specific upload config
+            // (`UploadConfigs.ExamResults` -> `getPendingExamResults`) has no
+            // status filter at all — so a half-finished Kotlin attempt goes up
+            // as `pending` on the next sync, and `deleteExamSubmissions` then
+            // POSTs a second document for the retake. The port's
+            // `pendingUploads` is likewise status-blind (`isUpdated == true`,
+            // deliberately: filtering on `status = 'complete'` the way
+            // `getPendingSubmissions` does would strand every exam, since an
+            // exam is never `complete`), so this flag is the gate instead: an
+            // attempt becomes uploadable exactly when it is submitted.
+            isUpdated: Value(status == 'requires grading'),
+          ),
+        ],
+        answers: {submissionId: companions},
+      );
+    });
     return isCorrect;
   }
 

--- a/flutter/lib/ui/exam/take_exam_screen.dart
+++ b/flutter/lib/ui/exam/take_exam_screen.dart
@@ -8,10 +8,21 @@ import '../../data/local/app_database.dart';
 import '../../l10n/app_localizations.dart';
 import '../../providers/app_providers.dart';
 import '../../providers/session_provider.dart';
-import '../../repository/exam_grading.dart';
 import '../../repository/submissions_repository.dart';
 
-/// Port of `ExamTakingFragment.kt` for course exams with grading.
+/// Port of `ExamTakingFragment.kt` / `BaseExamFragment.kt` for course exams.
+///
+/// Kotlin's exam model is a **retry** model, not a score model. The attempt is
+/// persisted before the first question is shown (`startExamSession`), each
+/// answer is written as the learner passes it (`updateAnsDb` ->
+/// `saveExamAnswer`), and the verdict that call returns is a gate: `btnNext`
+/// and `btnSubmit` both bail with the `incorrect_ans` snackbar when it is
+/// false (`ExamTakingFragment.kt:196-204`, `:641-645`), so the learner stays
+/// on the question and retries until it is right. That is why `mistakes`
+/// accumulates and why every answer in a finished attempt is `isPassed` — a
+/// consequence of the gate, not an assertion. There is no score at the end:
+/// `continueExam` shows a thank-you dialog (`BaseExamFragment.kt:127-148`) and
+/// the submission goes up as `requires grading` for Planet to mark.
 ///
 /// Supports multiple question types:
 /// - `select`: Single choice (radio buttons)
@@ -48,7 +59,12 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
   final Map<String, TextEditingController> _controllers = {};
 
   bool _isSubmitting = false;
+  bool _isSaving = false;
   List<ExamQuestionRow> _questions = const [];
+
+  /// The attempt this exam is being answered into, created once per mount.
+  String? _submissionId;
+  Future<String>? _session;
 
   @override
   void dispose() {
@@ -240,6 +256,7 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
   Widget _buildNavigationButtons(BuildContext context, int totalQuestions) {
     final l10n = AppLocalizations.of(context);
     final isLast = _currentIndex >= totalQuestions - 1;
+    final busy = _isSaving || _isSubmitting;
 
     return Padding(
       padding: const EdgeInsets.all(16),
@@ -248,7 +265,7 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
         children: [
           if (_currentIndex > 0)
             OutlinedButton.icon(
-              onPressed: () => setState(() => _currentIndex--),
+              onPressed: busy ? null : _goBack,
               icon: const Icon(Icons.arrow_back),
               label: Text(l10n.previous),
             )
@@ -256,7 +273,7 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
             const SizedBox.shrink(),
           if (isLast)
             FilledButton.icon(
-              onPressed: _isSubmitting ? null : () => _submitExam(context),
+              onPressed: busy ? null : () => _submitExam(context),
               icon: _isSubmitting
                   ? const SizedBox.square(
                       dimension: 18,
@@ -267,7 +284,7 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
             )
           else
             FilledButton.icon(
-              onPressed: () => setState(() => _currentIndex++),
+              onPressed: busy ? null : () => _advance(context),
               icon: const Icon(Icons.arrow_forward),
               label: Text(l10n.next),
             ),
@@ -276,23 +293,100 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
     );
   }
 
-  void _recordChoices(ExamQuestionRow question, List<String> choiceIds) {
-    _answers[question.id] = ExamDraftAnswer(
-      choiceIds: List.unmodifiable(choiceIds),
-      isCorrect: ExamGrading.isSelectionCorrect(question, choiceIds),
-    );
+  /// Whether the current question has an answer to submit at all.
+  ///
+  /// Port of `isQuestionAnswered` (`ExamTakingFragment.kt:290-322`), minus its
+  /// `hasOtherOption` clause, which the port has no "Other" choice to reach.
+  /// Kotlin returns `false` for an unrecognised type because `startExam`
+  /// renders no input for one; the port renders a text field, so the rule
+  /// follows what the widget can actually hold rather than the type name.
+  bool _isAnswered(ExamQuestionRow question) {
+    final answer = _answers[question.id];
+    return answer != null && !answer.isEmpty;
   }
 
-  void _recordText(ExamQuestionRow question, String value) {
-    _answers[question.id] = ExamDraftAnswer(
-      value: value,
-      isCorrect: ExamGrading.isTextCorrect(question, value),
-    );
+  /// `btnBack`. Kotlin saves the current answer before moving
+  /// (`ExamTakingFragment.kt:187-194`) and then moves regardless of the
+  /// verdict — going back is the one way to leave a question wrong, and it
+  /// still records the mistake.
+  Future<void> _goBack() async {
+    if (_currentIndex == 0) return;
+    final question = _questions[_currentIndex];
+    if (_isAnswered(question)) {
+      await _saveCurrentAnswer(question, isFinal: false, isExplicit: false);
+    }
+    if (mounted) setState(() => _currentIndex--);
   }
 
-  Future<void> _submitExam(BuildContext context) async {
+  /// `btnNext`: save, and advance only if the answer was right.
+  Future<void> _advance(BuildContext context) async {
     final l10n = AppLocalizations.of(context);
     final messenger = ScaffoldMessenger.of(context);
+    final question = _questions[_currentIndex];
+    if (!_isAnswered(question)) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.pleaseAnswerToContinue)),
+      );
+      return;
+    }
+    final correct = await _saveCurrentAnswer(
+      question,
+      isFinal: false,
+      isExplicit: false,
+    );
+    if (!mounted) return;
+    if (correct != true) {
+      if (correct == false) {
+        messenger.showSnackBar(SnackBar(content: Text(l10n.incorrectAnswer)));
+      }
+      return;
+    }
+    setState(() => _currentIndex++);
+  }
+
+  /// Writes the current answer through `saveExamAnswer` and returns its
+  /// verdict, or `null` when the save itself failed — the caller must not read
+  /// a failed save as a wrong answer, or the learner would be told their
+  /// answer was incorrect when the truth is that nothing was recorded.
+  Future<bool?> _saveCurrentAnswer(
+    ExamQuestionRow question, {
+    required bool isFinal,
+    required bool isExplicit,
+  }) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final l10n = AppLocalizations.of(context);
+    setState(() => _isSaving = true);
+    try {
+      final submissionId = await _ensureSession();
+      return await ref
+          .read(submissionsRepositoryProvider)
+          .saveExamAnswer(
+            submissionId: submissionId,
+            question: question,
+            answer: _answers[question.id] ?? const ExamDraftAnswer(),
+            isFinal: isFinal,
+            isExplicitSubmission: isExplicit,
+          );
+    } catch (_) {
+      if (mounted) {
+        messenger.showSnackBar(SnackBar(content: Text(l10n.examSubmitFailed)));
+      }
+      return null;
+    } finally {
+      if (mounted) setState(() => _isSaving = false);
+    }
+  }
+
+  /// The attempt every answer is written into, created on first use.
+  ///
+  /// Kotlin opens the session in `initializeExamData`, before the first
+  /// question is drawn. Creating it here instead keeps `build` free of side
+  /// effects, and the only difference it makes is that abandoning an exam
+  /// without answering anything leaves no row behind — where Kotlin leaves an
+  /// empty `pending` attempt that its next `deleteStale` clears.
+  Future<String> _ensureSession() => _session ??= _createSession();
+
+  Future<String> _createSession() async {
     // Awaited rather than read off the current `AsyncValue`. Kotlin's
     // `initializeExamData` resolves its own user (`userSessionManager
     // .getUserModel()`) before the exam is usable; a bare
@@ -301,38 +395,77 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
     // watches it. That silently dropped the whole attempt: no dialog, no
     // snackbar, the graded answers discarded. It only stays hidden in the
     // shipping app because the router holds a `ref.listen` on the session.
-    final UserRow? user;
-    try {
-      user = await ref.read(sessionProvider.future);
-    } catch (_) {
-      // Awaiting a future means it can also reject, which `ref.read(...)
-      // .valueOrNull` could not. Leaving that uncaught would reproduce the
-      // very silence this await was introduced to remove — the attempt lost
-      // with nothing on screen — so it reports the same failure the save path
-      // does.
-      if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text(l10n.examSubmitFailed)));
+    final user = await ref.read(sessionProvider.future);
+    final exam = await ref.read(examProvider(widget.examId).future);
+    if (user == null || exam == null) {
+      // Cleared so a retry can try again rather than replaying this failure
+      // for the rest of the mount.
+      _session = null;
+      throw StateError('An exam attempt needs a signed-in user and an exam');
+    }
+    final id = await ref
+        .read(submissionsRepositoryProvider)
+        .startExamSession(
+          exam: exam,
+          questions: _questions,
+          userId: user.id,
+          courseId: widget.courseId,
+        );
+    _submissionId = id;
+    return id;
+  }
+
+  void _recordChoices(ExamQuestionRow question, List<String> choiceIds) {
+    _answers[question.id] = ExamDraftAnswer(
+      choiceIds: List.unmodifiable(choiceIds),
+    );
+  }
+
+  void _recordText(ExamQuestionRow question, String value) {
+    _answers[question.id] = ExamDraftAnswer(value: value);
+  }
+
+  /// `btn_submit` on the last question — `onClick`
+  /// (`ExamTakingFragment.kt:626-653`).
+  ///
+  /// The order is Kotlin's and it matters: save, gate on the verdict, and only
+  /// then capture the verification photo and finish. A wrong final answer
+  /// takes the `incorrect_ans` branch before `capturePhoto()` is reached, so
+  /// the camera never opens for an attempt that is not finished.
+  Future<void> _submitExam(BuildContext context) async {
+    final l10n = AppLocalizations.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final question = _questions[_currentIndex];
+    if (!_isAnswered(question)) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.pleaseAnswerToContinue)),
+      );
       return;
     }
-    if (!mounted) return;
-    final exam = ref.read(examProvider(widget.examId)).valueOrNull;
-    if (user == null || exam == null) return;
-
-    setState(() => _isSubmitting = true);
 
     // Persist before showing anything. The attempt is the deliverable — a
     // dialog the user dismisses is not a record of it.
+    final correct = await _saveCurrentAnswer(
+      question,
+      isFinal: true,
+      isExplicit: true,
+    );
+    if (!mounted) return;
+    if (correct != true) {
+      if (correct == false) {
+        messenger.showSnackBar(SnackBar(content: Text(l10n.incorrectAnswer)));
+      }
+      return;
+    }
+
+    final exam = ref.read(examProvider(widget.examId)).valueOrNull;
+    final submissionId = _submissionId;
+    if (exam == null || submissionId == null) return;
+
+    setState(() => _isSubmitting = true);
     try {
-      final submissionId = await ref
-          .read(submissionsRepositoryProvider)
-          .createExamDraft(
-            exam: exam,
-            questions: _questions,
-            userId: user.id,
-            answers: _answers,
-            courseId: widget.courseId,
-          );
-      await _captureVerificationPhoto(submissionId, exam, user.id);
+      final user = await ref.read(sessionProvider.future);
+      await _captureVerificationPhoto(submissionId, exam, user!.id);
       final config = ref.read(serverConfigProvider);
       if (config != null) {
         await ref
@@ -343,7 +476,7 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
             .queuePending(config: config);
       }
       if (!mounted) return;
-      await _showResult(exam);
+      await _showResult();
     } catch (_) {
       if (!mounted) return;
       setState(() => _isSubmitting = false);
@@ -413,17 +546,20 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
     }
   }
 
-  Future<void> _showResult(ExamRow exam) async {
+  /// `continueExam`'s end-of-exam dialog (`BaseExamFragment.kt:132-147`):
+  /// "Thank you for taking this exam! We wish you all the best." and a
+  /// `Finish` button that pops the screen.
+  ///
+  /// There is no score here, and that is the point. The port used to compute a
+  /// percentage and compare it with `passingPercentage`, which the retry gate
+  /// makes meaningless — every answer in a finished attempt is correct, so the
+  /// dialog would congratulate every learner with 100% however many times they
+  /// got a question wrong. The record of that is `mistakes`, which the
+  /// courses-progress screen shows per step, and the mark is Planet's to
+  /// write: the attempt uploads as `requires grading`.
+  Future<void> _showResult() async {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final correctCount = _questions
-        .where((question) => _answers[question.id]?.isCorrect ?? false)
-        .length;
-    final total = _questions.length;
-    final score = total > 0 ? (correctCount * 100) ~/ total : 0;
-    // The exam carries its own bar; only fall back to 70 when it names none.
-    final passMark = int.tryParse(exam.passingPercentage ?? '') ?? 70;
-    final passed = score >= passMark;
 
     await showDialog<void>(
       context: context,
@@ -433,14 +569,13 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              passed ? Icons.celebration : Icons.emoji_events,
-              size: 64,
-              color: passed ? Colors.green : Colors.orange,
-            ),
+            const Icon(Icons.celebration, size: 64, color: Colors.green),
             const SizedBox(height: 16),
-            Text('$score%', style: theme.textTheme.headlineLarge),
-            Text('${l10n.correctAnswers}: $correctCount / $total'),
+            Text(
+              l10n.thankYouForTakingExam,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleMedium,
+            ),
             const SizedBox(height: 8),
             Text(l10n.savedOffline, style: theme.textTheme.bodySmall),
           ],

--- a/flutter/lib/ui/exam/take_exam_screen.dart
+++ b/flutter/lib/ui/exam/take_exam_screen.dart
@@ -158,12 +158,21 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
   }
 
   Widget _buildAnswerInput(BuildContext context, ExamQuestionRow question) {
-    switch (question.type ?? 'input') {
+    // Lowercased, because `ExamGrading.isCorrect` and `AnswerShape.forQuestion`
+    // both are — `startExam` and `saveExamAnswer` compare the type with
+    // `ignoreCase = true`. Matching exactly here while they normalise made a
+    // question typed `"Select"` render a **text field**: the learner's typed
+    // answer then went through `AnswerShape`'s select branch, which looks for a
+    // pick, finds none, and stores the empty string, while the grader graded an
+    // empty selection against a non-empty key. The answer was discarded and the
+    // gate could never open — a dead end where before the gate it only cost a
+    // mark.
+    switch (question.type?.toLowerCase() ?? 'input') {
       case 'select':
         return _buildRadioGroup(question);
-      case 'selectMultiple':
+      case 'selectmultiple':
         return _buildCheckboxGroup(question);
-      case 'ratingScale':
+      case 'ratingscale':
         return _buildRatingScale(question);
       case 'textarea':
         return _buildTextField(context, question, maxLines: 5);
@@ -295,7 +304,7 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
 
   /// Whether the current question has an answer to submit at all.
   ///
-  /// Port of `isQuestionAnswered` (`ExamTakingFragment.kt:290-322`), minus its
+  /// Port of `isQuestionAnswered` (`ExamTakingFragment.kt:289-322`), minus its
   /// `hasOtherOption` clause, which the port has no "Other" choice to reach.
   /// Kotlin returns `false` for an unrecognised type because `startExam`
   /// renders no input for one; the port renders a text field, so the rule
@@ -305,10 +314,21 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
     return answer != null && !answer.isEmpty;
   }
 
-  /// `btnBack`. Kotlin saves the current answer before moving
-  /// (`ExamTakingFragment.kt:187-194`) and then moves regardless of the
-  /// verdict — going back is the one way to leave a question wrong, and it
-  /// still records the mistake.
+  /// `btnBack` (`ExamTakingFragment.kt:189-194`). Kotlin saves the current
+  /// answer before moving and then moves regardless of the verdict — going
+  /// back is the one route out of a question left wrong, and it still records
+  /// the mistake.
+  ///
+  /// **One deliberate divergence**: the save is guarded on the question being
+  /// answered, where Kotlin's is unconditional. For an untouched question
+  /// Kotlin's `ans` is `""`, every check helper fails it, and it writes a row
+  /// with `mistakes + 1` and `isPassed = false` — which then **uploads**,
+  /// because `getPendingExamResults` has no status filter and
+  /// `Answer.createObject` sends `mistakes`. Scoring a mistake against a
+  /// question the learner never answered, and reporting it to Planet, is a
+  /// defect rather than a behaviour. The cost of not porting it is that the
+  /// two apps report different mistake totals for identical learner
+  /// behaviour.
   Future<void> _goBack() async {
     if (_currentIndex == 0) return;
     final question = _questions[_currentIndex];
@@ -324,9 +344,7 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
     final messenger = ScaffoldMessenger.of(context);
     final question = _questions[_currentIndex];
     if (!_isAnswered(question)) {
-      messenger.showSnackBar(
-        SnackBar(content: Text(l10n.pleaseAnswerToContinue)),
-      );
+      _showRetryPrompt(messenger, l10n.pleaseAnswerToContinue);
       return;
     }
     final correct = await _saveCurrentAnswer(
@@ -337,7 +355,7 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
     if (!mounted) return;
     if (correct != true) {
       if (correct == false) {
-        messenger.showSnackBar(SnackBar(content: Text(l10n.incorrectAnswer)));
+        _showRetryPrompt(messenger, l10n.incorrectAnswer);
       }
       return;
     }
@@ -384,7 +402,31 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
   /// effects, and the only difference it makes is that abandoning an exam
   /// without answering anything leaves no row behind — where Kotlin leaves an
   /// empty `pending` attempt that its next `deleteStale` clears.
-  Future<String> _ensureSession() => _session ??= _createSession();
+  ///
+  /// Memoised so every answer lands in one attempt, but **only on success**. A
+  /// rejected future left in `_session` is one `??=` never re-runs, so a single
+  /// transient failure — a rejecting session, one failed write — would end the
+  /// exam for the rest of the mount: every later press would replay the same
+  /// error, with no submission row and no answers, and the only way out would
+  /// be to leave the screen. Kotlin is more forgiving still: `startExamSession`
+  /// retries the local write three times
+  /// (`SubmissionsRepositoryImpl.kt:420-435`) and, having only toasted on
+  /// failure, lets the next press re-enter `saveExamAnswer`, whose
+  /// `sub == null` fallback chain re-finds a submission. The retry is ported;
+  /// the fallback chain is not, because the port has one caller and it can just
+  /// try again.
+  Future<String> _ensureSession() async {
+    final pending = _session;
+    if (pending != null) return pending;
+    final attempt = _createSession();
+    _session = attempt;
+    try {
+      return await attempt;
+    } catch (_) {
+      _session = null;
+      rethrow;
+    }
+  }
 
   Future<String> _createSession() async {
     // Awaited rather than read off the current `AsyncValue`. Kotlin's
@@ -398,9 +440,6 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
     final user = await ref.read(sessionProvider.future);
     final exam = await ref.read(examProvider(widget.examId).future);
     if (user == null || exam == null) {
-      // Cleared so a retry can try again rather than replaying this failure
-      // for the rest of the mount.
-      _session = null;
       throw StateError('An exam attempt needs a signed-in user and an exam');
     }
     final id = await ref
@@ -416,13 +455,42 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
   }
 
   void _recordChoices(ExamQuestionRow question, List<String> choiceIds) {
+    _clearFeedback();
     _answers[question.id] = ExamDraftAnswer(
       choiceIds: List.unmodifiable(choiceIds),
     );
   }
 
   void _recordText(ExamQuestionRow question, String value) {
+    _clearFeedback();
     _answers[question.id] = ExamDraftAnswer(value: value);
+  }
+
+  /// Tells the learner their answer was wrong, without sitting on the button
+  /// they need next.
+  ///
+  /// Kotlin's `incorrect_ans` snackbar overlaps only its **Submit** button:
+  /// `btnBack` and `btnNext` are `ImageButton`s in the *top* bar
+  /// (`fragment_exam_taking.xml:30`, `:62`), so its retry path is never
+  /// blocked. This screen's forward button is at the bottom, under the
+  /// snackbar, so three wrong tries meant about twelve seconds of unusable
+  /// button. Two things fix that without redrawing the layout: Kotlin's own
+  /// `LENGTH_LONG` (2750 ms, not Flutter's 4 s), and dismissing the snackbar
+  /// the moment the learner changes their answer — which is the action that
+  /// always precedes the next press.
+  void _showRetryPrompt(ScaffoldMessengerState messenger, String message) {
+    messenger.clearSnackBars();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: const Duration(milliseconds: 2750),
+      ),
+    );
+  }
+
+  void _clearFeedback() {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).clearSnackBars();
   }
 
   /// `btn_submit` on the last question — `onClick`
@@ -437,9 +505,7 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
     final messenger = ScaffoldMessenger.of(context);
     final question = _questions[_currentIndex];
     if (!_isAnswered(question)) {
-      messenger.showSnackBar(
-        SnackBar(content: Text(l10n.pleaseAnswerToContinue)),
-      );
+      _showRetryPrompt(messenger, l10n.pleaseAnswerToContinue);
       return;
     }
 
@@ -453,7 +519,7 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
     if (!mounted) return;
     if (correct != true) {
       if (correct == false) {
-        messenger.showSnackBar(SnackBar(content: Text(l10n.incorrectAnswer)));
+        _showRetryPrompt(messenger, l10n.incorrectAnswer);
       }
       return;
     }
@@ -464,16 +530,22 @@ class _TakeExamScreenState extends ConsumerState<TakeExamScreen> {
 
     setState(() => _isSubmitting = true);
     try {
+      // The attempt is already written and already `requires grading` by this
+      // point, so a session that has since resolved to null (a logout mid-exam)
+      // must not be reported as a failed save. The photo and the queueing are
+      // what need a user; the record does not.
       final user = await ref.read(sessionProvider.future);
-      await _captureVerificationPhoto(submissionId, exam, user!.id);
       final config = ref.read(serverConfigProvider);
-      if (config != null) {
-        await ref
-            .read(submissionsUploaderProvider)
-            .queuePending(config: config, userId: user.id);
-        await ref
-            .read(submitPhotosUploaderProvider)
-            .queuePending(config: config);
+      if (user != null) {
+        await _captureVerificationPhoto(submissionId, exam, user.id);
+        if (config != null) {
+          await ref
+              .read(submissionsUploaderProvider)
+              .queuePending(config: config, userId: user.id);
+          await ref
+              .read(submitPhotosUploaderProvider)
+              .queuePending(config: config);
+        }
       }
       if (!mounted) return;
       await _showResult();

--- a/flutter/lib/ui/submissions/submission_detail_screen.dart
+++ b/flutter/lib/ui/submissions/submission_detail_screen.dart
@@ -184,7 +184,13 @@ class _AnswerTile extends StatelessWidget {
               ? '$value\n${l10n.availableChoices}: ${question!.choices.join(', ')}'
               : value,
         ),
-        trailing: answer.grade > 0 ? Text('${answer.grade}') : null,
+        // No trailing mark. `saveExamAnswer` writes `grade = 1` for **every**
+        // exam answer, right or wrong — a "worth one mark" marker rather than
+        // a score — so a badge reading it would say "1" on every row and mean
+        // nothing. `QuestionAnswerAdapter.bind` renders it nowhere either.
+        // The leading icon carries the verdict; `mistakes` carries how many
+        // tries it took, and the courses-progress screen is where Kotlin
+        // shows that.
       ),
     );
   }

--- a/flutter/lib/ui/submissions/submissions_screen.dart
+++ b/flutter/lib/ui/submissions/submissions_screen.dart
@@ -191,12 +191,22 @@ class _SubmissionsScreenState extends ConsumerState<SubmissionsScreen> {
   }
 }
 
+/// Whether a submission is finished from the learner's side.
+///
+/// `requires grading` is on the list because that is the status
+/// `saveExamAnswer` gives a **finished exam** — `complete` is the survey
+/// value, and an exam is not complete until somebody marks it. Without it a
+/// submitted exam would sit under Pending until its upload landed, which is
+/// the opposite of what the learner just did.
+/// `SurveysRepositoryImpl.kt:310` treats the two the same way
+/// (`status == "complete" || status == "requires grading"`).
 bool _isComplete(SubmissionRow row) =>
     row.uploaded ||
     const {
       'complete',
       'completed',
       'graded',
+      'requires grading',
     }.contains(row.status?.trim().toLowerCase());
 
 class _SubmissionTile extends StatelessWidget {

--- a/flutter/test/repository/exam_flow_test.dart
+++ b/flutter/test/repository/exam_flow_test.dart
@@ -156,26 +156,71 @@ void main() {
       expect(ExamGrading.isSelectionCorrect(q, const ['c1']), isFalse);
     });
 
-    test('a question with no recorded answer key never scores', () {
-      final q = question(type: 'select', correct: const []);
-      expect(ExamGrading.isSelectionCorrect(q, const ['c1']), isFalse);
-    });
-
-    test('text answers are compared case- and space-insensitively', () {
+    /// `checkTextAnswer` is `correctChoices.any { normalizedAns.contains(it) }`
+    /// — containment, not equality, and its own Kotlin test asserts exactly
+    /// that ("the expected word is here" passes a key of "expected word",
+    /// `ExamAnswerUtilsTest.testCheckCorrectAnswer_InputText`). The port had
+    /// exact equality, which under the retry gate refuses a right answer with
+    /// a stray word and leaves the learner stuck on the question.
+    test('a text answer passes by containment, as Kotlin marks it', () {
       final q = question(type: 'input', correct: const ['paris']);
       expect(ExamGrading.isTextCorrect(q, '  Paris '), isTrue);
+      expect(ExamGrading.isTextCorrect(q, 'It is Paris, I think'), isTrue);
       expect(ExamGrading.isTextCorrect(q, 'Lyon'), isFalse);
       expect(ExamGrading.isTextCorrect(q, '   '), isFalse);
+    });
+
+    /// The one deliberate divergence. Kotlin fails a keyless question —
+    /// `extractCorrectChoices` returns `emptyList()` and every check helper is
+    /// vacuously false — which under the gate is a question no answer can
+    /// satisfy and no route past. Every `ratingScale` question in an exam is
+    /// in that position.
+    test('a question with no answer key accepts any answer, but not none', () {
+      final choiceQuestion = question(type: 'select', correct: const []);
+      expect(
+        ExamGrading.isSelectionCorrect(choiceQuestion, const ['c1']),
+        isTrue,
+      );
+      expect(ExamGrading.isSelectionCorrect(choiceQuestion, const []), isFalse);
+
+      final rating = question(type: 'ratingScale', correct: const []);
+      expect(ExamGrading.isTextCorrect(rating, '7'), isTrue);
+      expect(ExamGrading.isTextCorrect(rating, ''), isFalse);
+    });
+
+    /// `checkCorrectAnswer` dispatches on the type; the port adds one clause
+    /// for a question that names no type but carries a pick, because
+    /// `AnswerShape` stores such an answer as a choice and grading it as text
+    /// would contradict that.
+    test('the dispatcher follows the answer when the type says nothing', () {
+      final untyped = ExamQuestionRow(
+        id: 'q1',
+        examId: 'exam-1',
+        correctChoices: const ['c1'],
+        choices: const [ExamChoice(id: 'c1', text: 'Paris')],
+        hasOtherOption: false,
+        scaleMax: 9,
+        position: 0,
+      );
+      expect(
+        ExamGrading.isCorrect(question: untyped, choiceIds: const ['c1']),
+        isTrue,
+      );
+      expect(
+        ExamGrading.isCorrect(question: untyped, text: 'Paris'),
+        isFalse,
+        reason: 'the key holds an id, and a text answer is not one',
+      );
     });
   });
 
   group('the attempt', () {
-    Future<ExamRow> seedExam() async {
+    Future<ExamRow> seedExam({String? courseId = 'course-1'}) async {
       await database.examDao.upsertExam(
         ExamsCompanion.insert(
           id: 'exam-1',
           name: const Value('Unit 1'),
-          courseId: const Value('course-1'),
+          courseId: Value(courseId),
           passingPercentage: const Value('80'),
         ),
       );
@@ -205,168 +250,414 @@ void main() {
       ),
     ];
 
-    test('is persisted as an uploadable submission', () async {
+    /// Answers a whole attempt the way the screen does — save each question in
+    /// order, the last one as the explicit submission — and hands back the
+    /// verdicts.
+    Future<List<bool>> answerAll(
+      String id,
+      List<ExamQuestionRow> questions,
+      Map<String, ExamDraftAnswer> answers,
+    ) async {
+      final verdicts = <bool>[];
+      for (var index = 0; index < questions.length; index++) {
+        final isFinal = index == questions.length - 1;
+        verdicts.add(
+          await submissions.saveExamAnswer(
+            submissionId: id,
+            question: questions[index],
+            answer: answers[questions[index].id] ?? const ExamDraftAnswer(),
+            isFinal: isFinal,
+            isExplicitSubmission: isFinal,
+          ),
+        );
+      }
+      return verdicts;
+    }
+
+    test('opens as a pending attempt that is not yet uploadable', () async {
       final exam = await seedExam();
-      final id = await submissions.createExamDraft(
+      final id = await submissions.startExamSession(
         exam: exam,
         questions: twoQuestions(),
         userId: 'ada',
-        answers: const {
-          'q1': ExamDraftAnswer(choiceIds: ['c1'], isCorrect: true),
-          'q2': ExamDraftAnswer(value: 'red'),
-        },
       );
 
       final row = await database.submissionDao.getById(id);
       expect(row, isNotNull);
       expect(row!.type, 'exam');
-      // Half right, so 50 — and it is on disk, not in a dismissed dialog.
-      expect(row.grade, 50);
+      expect(row.status, 'pending');
+      expect(row.grade, 0);
       expect(row.uploaded, isFalse);
-      expect(await submissions.pendingUploads('ada'), hasLength(1));
       expect(jsonDecode(row.parent!)['_id'], 'exam-1');
+      // `"$examId@$courseId"` — the shape `createExamSubmission` writes and
+      // `ProgressRepository._examIdFromParent` splits back to the exam id. The
+      // port stored the bare course id, so the per-step mistake counts could
+      // never find their exam.
+      expect(row.parentId, 'exam-1@course-1');
+      // The question rows the detail screen renders are written up front.
+      expect(
+        await database.submissionDao.watchQuestions(id).first,
+        hasLength(2),
+      );
+      expect(
+        await submissions.pendingUploads('ada'),
+        isEmpty,
+        reason: 'a half-finished attempt must not go up',
+      );
     });
 
-    test('records each answer with its verdict', () async {
-      final exam = await seedExam();
-      final id = await submissions.createExamDraft(
+    test('an exam with no course is parented by the exam alone', () async {
+      final exam = await seedExam(courseId: null);
+      final id = await submissions.startExamSession(
         exam: exam,
         questions: twoQuestions(),
         userId: 'ada',
-        answers: const {
-          'q1': ExamDraftAnswer(choiceIds: ['c1'], isCorrect: true),
-          'q2': ExamDraftAnswer(value: 'blue', isCorrect: true),
-        },
       );
-
-      final answers = await database.submissionDao.answersFor(id);
-      expect(answers, hasLength(2));
-      final byQuestion = {for (final a in answers) a.questionId: a};
-      expect(byQuestion['q1']!.valueChoices, ['{"id":"c1","text":"Paris"}']);
-      expect(byQuestion['q1']!.isPassed, isTrue);
-      expect(byQuestion['q2']!.value, 'blue');
-      expect(byQuestion['q2']!.examId, 'exam-1');
+      expect((await database.submissionDao.getById(id))!.parentId, 'exam-1');
     });
 
-    test(
-      'a select answer is stored as the choice object, not its id',
-      () async {
-        // `SubmissionsRepositoryImpl.saveExamAnswer` writes
-        // `listOf("""{"id":"$ans","text":"$ansForCheck"}""")` for a `select`
-        // question and sets `value` to `ansForCheck`, the choice's display text
-        // via `ExamAnswerUtils.getChoiceTextById`. The port stored the bare id
-        // and left `value` null.
-        final exam = await seedExam();
-        final id = await submissions.createExamDraft(
-          exam: exam,
-          questions: twoQuestions(),
-          userId: 'ada',
-          answers: const {
-            'q1': ExamDraftAnswer(choiceIds: ['c1'], isCorrect: true),
-          },
-        );
-        final answers = await database.submissionDao.answersFor(id);
-        final q1 = answers.firstWhere((a) => a.questionId == 'q1');
-        expect(q1.valueChoices, ['{"id":"c1","text":"Paris"}']);
-        expect(q1.value, 'Paris');
-      },
-    );
-
-    test('a selectMultiple answer stores objects and an empty value', () async {
-      // Kotlin's `selectMultiple` branch sets `value = ""` and maps `listAns`
-      // (text -> id) to `{"id":"$id","text":"$text"}` per entry.
+    /// `startExamSession(recreate = true)` with `deleteStale`, which
+    /// `deleteExamSubmissions` implements without a status filter: re-entering
+    /// an exam discards the previous local attempt, answers and all, so
+    /// `mistakes` accumulates within one sitting and never across two.
+    test('re-entering the exam discards the previous attempt', () async {
       final exam = await seedExam();
-      final questions = [
-        ExamQuestionRow(
-          id: 'q1',
-          examId: 'exam-1',
-          type: 'selectMultiple',
-          correctChoices: const ['c1', 'c2'],
-          choices: const [
-            ExamChoice(id: 'c1', text: 'Paris'),
-            ExamChoice(id: 'c2', text: 'Lyon'),
-          ],
-          hasOtherOption: false,
-          scaleMax: 9,
-          position: 0,
-        ),
-      ];
-      final id = await submissions.createExamDraft(
+      final questions = twoQuestions();
+      final first = await submissions.startExamSession(
         exam: exam,
         questions: questions,
         userId: 'ada',
-        answers: const {
-          'q1': ExamDraftAnswer(choiceIds: ['c1', 'c2'], isCorrect: true),
-        },
       );
-      final answers = await database.submissionDao.answersFor(id);
-      expect(answers.single.valueChoices, [
-        '{"id":"c1","text":"Paris"}',
-        '{"id":"c2","text":"Lyon"}',
-      ]);
-      expect(answers.single.value, '');
+      await submissions.saveExamAnswer(
+        submissionId: first,
+        question: questions.first,
+        answer: const ExamDraftAnswer(choiceIds: ['c9']),
+        isFinal: false,
+        isExplicitSubmission: false,
+      );
+      expect(await database.submissionDao.answersFor(first), hasLength(1));
+
+      final second = await submissions.startExamSession(
+        exam: exam,
+        questions: questions,
+        userId: 'ada',
+      );
+
+      expect(second, isNot(first));
+      expect(await database.submissionDao.getById(first), isNull);
+      expect(await database.submissionDao.answersFor(first), isEmpty);
+      expect(await database.submissionDao.watchQuestions(first).first, isEmpty);
+      // Another user's attempt at the same exam is untouched.
+      expect(await database.submissionDao.getById(second), isNotNull);
     });
 
-    test('an unknown choice id falls back to the id as its text', () async {
-      // `getChoiceTextById` returns `map[id] ?: id`.
+    test('another user\'s attempt at the same exam survives', () async {
       final exam = await seedExam();
-      final id = await submissions.createExamDraft(
+      final questions = twoQuestions();
+      final theirs = await submissions.startExamSession(
         exam: exam,
-        questions: twoQuestions(),
-        userId: 'ada',
-        answers: const {
-          'q1': ExamDraftAnswer(choiceIds: ['ghost']),
-        },
+        questions: questions,
+        userId: 'bob',
       );
-      final answers = await database.submissionDao.answersFor(id);
-      final q1 = answers.firstWhere((a) => a.questionId == 'q1');
-      expect(q1.valueChoices, ['{"id":"ghost","text":"ghost"}']);
-      expect(q1.value, 'ghost');
+      await submissions.startExamSession(
+        exam: exam,
+        questions: questions,
+        userId: 'ada',
+      );
+      expect(await database.submissionDao.getById(theirs), isNotNull);
     });
 
-    test('a select answer uploads its display text, as Kotlin does', () async {
-      // `Answer.createObject` sends `value` whenever it is non-empty and only
-      // falls back to `valueChoicesArray` when it is not — so a `select`
-      // answer reaches Planet as a bare string, and `valueChoicesArray` is
-      // reached only for `selectMultiple` (and an unanswered select).
+    /// The accumulator, and the reason this had to become an incremental
+    /// write: `mistakes` is `(existing?.mistakes ?: 0) + 1`, so there has to
+    /// be an `existing` row to add to. The port graded the whole attempt in
+    /// widget state and wrote it once at the end, which left the column
+    /// structurally stuck at its default of 0 — and `serialize` was uploading
+    /// that 0 as if it meant something.
+    test('a wrong answer counts a mistake and does not pass', () async {
       final exam = await seedExam();
-      final id = await submissions.createExamDraft(
+      final questions = twoQuestions();
+      final id = await submissions.startExamSession(
         exam: exam,
-        questions: twoQuestions(),
+        questions: questions,
         userId: 'ada',
-        answers: const {
-          'q1': ExamDraftAnswer(choiceIds: ['c1'], isCorrect: true),
-        },
       );
+
+      for (var attempt = 1; attempt <= 3; attempt++) {
+        final correct = await submissions.saveExamAnswer(
+          submissionId: id,
+          question: questions.first,
+          answer: const ExamDraftAnswer(choiceIds: ['c9']),
+          isFinal: false,
+          isExplicitSubmission: false,
+        );
+        expect(correct, isFalse);
+        final row = (await database.submissionDao.answersFor(id)).single;
+        expect(row.mistakes, attempt);
+        expect(row.isPassed, isFalse);
+      }
+
+      // Getting it right keeps the count rather than clearing it — the
+      // finished row carries the whole retry history.
+      final correct = await submissions.saveExamAnswer(
+        submissionId: id,
+        question: questions.first,
+        answer: const ExamDraftAnswer(choiceIds: ['c1']),
+        isFinal: false,
+        isExplicitSubmission: false,
+      );
+      expect(correct, isTrue);
+      final row = (await database.submissionDao.answersFor(id)).single;
+      expect(row.mistakes, 3);
+      expect(row.isPassed, isTrue);
+      // `grade = if (type == "exam") 1` — every exam answer, right or wrong.
+      expect(row.grade, 1);
+    });
+
+    test('one question\'s mistakes do not touch another\'s', () async {
+      final exam = await seedExam();
+      final questions = twoQuestions();
+      final id = await submissions.startExamSession(
+        exam: exam,
+        questions: questions,
+        userId: 'ada',
+      );
+      await submissions.saveExamAnswer(
+        submissionId: id,
+        question: questions.first,
+        answer: const ExamDraftAnswer(choiceIds: ['c9']),
+        isFinal: false,
+        isExplicitSubmission: false,
+      );
+      await submissions.saveExamAnswer(
+        submissionId: id,
+        question: questions[1],
+        answer: const ExamDraftAnswer(value: 'red'),
+        isFinal: true,
+        isExplicitSubmission: false,
+      );
+
+      final byQuestion = {
+        for (final row in await database.submissionDao.answersFor(id))
+          row.questionId: row,
+      };
+      expect(byQuestion['q1']!.mistakes, 1);
+      expect(byQuestion['q2']!.mistakes, 1);
+      expect(byQuestion, hasLength(2));
+    });
+
+    test('a finished attempt is sent for grading and uploads', () async {
+      final exam = await seedExam();
+      final questions = twoQuestions();
+      final id = await submissions.startExamSession(
+        exam: exam,
+        questions: questions,
+        userId: 'ada',
+      );
+      final verdicts = await answerAll(id, questions, const {
+        'q1': ExamDraftAnswer(choiceIds: ['c1']),
+        'q2': ExamDraftAnswer(value: 'blue'),
+      });
+
+      expect(verdicts, [true, true]);
+      final row = (await database.submissionDao.getById(id))!;
+      // `saveExamAnswer`'s `when`: `complete` is the *survey* value; an exam's
+      // final answer is `requires grading`, which is what Planet's grading
+      // queue selects on.
+      expect(row.status, 'requires grading');
+      expect(row.grade, 0, reason: 'Planet marks it, not the device');
+      expect(await submissions.pendingUploads('ada'), hasLength(1));
+
+      final answers = await database.submissionDao.answersFor(id);
+      expect(answers.every((answer) => answer.isPassed), isTrue);
+      expect(answers.every((answer) => answer.grade == 1), isTrue);
+    });
+
+    /// `onClick` assigns `isExplicitSubmission = true` **before** calling
+    /// `updateAnsDb` (`ExamTakingFragment.kt:630-632`), so a wrong press of
+    /// Finish writes `requires grading` for an exam the learner has not
+    /// finished — and `isStepCompleted` (`status != 'pending'`) then unlocks
+    /// the next course step. Not ported: here the status also decides
+    /// `isUpdated`, so it would queue a half-finished attempt for upload too.
+    test('a wrong final answer leaves the attempt pending', () async {
+      final exam = await seedExam();
+      final questions = twoQuestions();
+      final id = await submissions.startExamSession(
+        exam: exam,
+        questions: questions,
+        userId: 'ada',
+      );
+      final verdicts = await answerAll(id, questions, const {
+        'q1': ExamDraftAnswer(choiceIds: ['c1']),
+        'q2': ExamDraftAnswer(value: 'red'),
+      });
+
+      expect(verdicts, [true, false]);
+      expect((await database.submissionDao.getById(id))!.status, 'pending');
+      expect(await submissions.pendingUploads('ada'), isEmpty);
+    });
+
+    test('the mistake counts and verdicts reach the upload payload', () async {
+      final exam = await seedExam();
+      final questions = twoQuestions();
+      final id = await submissions.startExamSession(
+        exam: exam,
+        questions: questions,
+        userId: 'ada',
+      );
+      await submissions.saveExamAnswer(
+        submissionId: id,
+        question: questions.first,
+        answer: const ExamDraftAnswer(choiceIds: ['c9']),
+        isFinal: false,
+        isExplicitSubmission: false,
+      );
+      await answerAll(id, questions, const {
+        'q1': ExamDraftAnswer(choiceIds: ['c1']),
+        'q2': ExamDraftAnswer(value: 'blue'),
+      });
+
       final payload = await submissions.serialize(
         (await submissions.getById(id))!,
       );
       final byQuestion = {
         for (final answer in payload['answers'] as List)
-          (answer as Map)['questionId']: answer['value'],
+          (answer as Map)['questionId']: answer,
       };
-      expect(byQuestion['q1'], 'Paris');
+      // `Answer.createObject` sends `mistakes` and `passed` per answer. The
+      // field was always being sent; before the gate it was always 0.
+      expect(byQuestion['q1']!['mistakes'], 1);
+      expect(byQuestion['q1']!['passed'], isTrue);
+      expect(byQuestion['q2']!['mistakes'], 0);
+      expect(payload['status'], 'requires grading');
+      // `grade` is not in the per-answer object at all — `createObject` emits
+      // only value/mistakes/passed/questionId.
+      expect(byQuestion['q1']!.containsKey('grade'), isFalse);
     });
 
-    test('an unanswered exam scores zero rather than failing', () async {
-      final exam = await seedExam();
-      final id = await submissions.createExamDraft(
-        exam: exam,
-        questions: twoQuestions(),
-        userId: 'ada',
-        answers: const {},
+    /// Phase 106's answer-shape findings, re-expressed against the
+    /// incremental writer. `saveExamAnswer` records the answer whether or not
+    /// it is right, so the shape assertions hold on a wrong answer too.
+    group('answer shape', () {
+      Future<SubmissionAnswerRow> saveOne(
+        ExamQuestionRow question,
+        ExamDraftAnswer answer,
+      ) async {
+        final exam = await seedExam();
+        final id = await submissions.startExamSession(
+          exam: exam,
+          questions: [question],
+          userId: 'ada',
+        );
+        await submissions.saveExamAnswer(
+          submissionId: id,
+          question: question,
+          answer: answer,
+          isFinal: true,
+          isExplicitSubmission: true,
+        );
+        return (await database.submissionDao.answersFor(id)).single;
+      }
+
+      test(
+        'a select answer is stored as the choice object, not its id',
+        () async {
+          // `saveExamAnswer` writes
+          // `listOf("""{"id":"$ans","text":"$ansForCheck"}""")` for a `select`
+          // question and sets `value` to `ansForCheck`, the choice's display
+          // text via `ExamAnswerUtils.getChoiceTextById`. The port stored the
+          // bare id and left `value` null.
+          final row = await saveOne(
+            twoQuestions().first,
+            const ExamDraftAnswer(choiceIds: ['c1']),
+          );
+          expect(row.valueChoices, ['{"id":"c1","text":"Paris"}']);
+          expect(row.value, 'Paris');
+          expect(row.examId, 'exam-1');
+        },
       );
-      expect((await database.submissionDao.getById(id))!.grade, 0);
+
+      test(
+        'a selectMultiple answer stores objects and an empty value',
+        () async {
+          // Kotlin's `selectMultiple` branch sets `value = ""` and maps
+          // `listAns` (text -> id) to `{"id":"$id","text":"$text"}` per entry.
+          final row = await saveOne(
+            ExamQuestionRow(
+              id: 'q1',
+              examId: 'exam-1',
+              type: 'selectMultiple',
+              correctChoices: const ['c1', 'c2'],
+              choices: const [
+                ExamChoice(id: 'c1', text: 'Paris'),
+                ExamChoice(id: 'c2', text: 'Lyon'),
+              ],
+              hasOtherOption: false,
+              scaleMax: 9,
+              position: 0,
+            ),
+            const ExamDraftAnswer(choiceIds: ['c1', 'c2']),
+          );
+          expect(row.valueChoices, [
+            '{"id":"c1","text":"Paris"}',
+            '{"id":"c2","text":"Lyon"}',
+          ]);
+          expect(row.value, '');
+        },
+      );
+
+      test('an unknown choice id falls back to the id as its text', () async {
+        // `getChoiceTextById` returns `map[id] ?: id`.
+        final row = await saveOne(
+          twoQuestions().first,
+          const ExamDraftAnswer(choiceIds: ['ghost']),
+        );
+        expect(row.valueChoices, ['{"id":"ghost","text":"ghost"}']);
+        expect(row.value, 'ghost');
+      });
+
+      test(
+        'a select answer uploads its display text, as Kotlin does',
+        () async {
+          // `Answer.createObject` sends `value` whenever it is non-empty and
+          // only falls back to `valueChoicesArray` when it is not — so a
+          // `select` answer reaches Planet as a bare string, and
+          // `valueChoicesArray` is reached only for `selectMultiple` (and an
+          // unanswered select).
+          final exam = await seedExam();
+          final questions = twoQuestions();
+          final id = await submissions.startExamSession(
+            exam: exam,
+            questions: questions,
+            userId: 'ada',
+          );
+          await answerAll(id, questions, const {
+            'q1': ExamDraftAnswer(choiceIds: ['c1']),
+            'q2': ExamDraftAnswer(value: 'blue'),
+          });
+          final payload = await submissions.serialize(
+            (await submissions.getById(id))!,
+          );
+          final byQuestion = {
+            for (final answer in payload['answers'] as List)
+              (answer as Map)['questionId']: answer['value'],
+          };
+          expect(byQuestion['q1'], 'Paris');
+        },
+      );
     });
 
     test('the profile screen attaches its answers to the attempt', () async {
       final exam = await seedExam();
-      final id = await submissions.createExamDraft(
+      final questions = twoQuestions();
+      final id = await submissions.startExamSession(
         exam: exam,
-        questions: twoQuestions(),
+        questions: questions,
         userId: 'ada',
-        answers: const {},
       );
+      await answerAll(id, questions, const {
+        'q1': ExamDraftAnswer(choiceIds: ['c1']),
+        'q2': ExamDraftAnswer(value: 'blue'),
+      });
       await database.submissionDao.markUploaded(id, 'couch-1', '1-a');
 
       await submissions.markSubmissionComplete(id, {'gender': 'female'});

--- a/flutter/test/ui/exam/take_exam_screen_test.dart
+++ b/flutter/test/ui/exam/take_exam_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/core/files/submit_photos_files.dart';
 import 'package:myplanet/core/system/device_identity.dart';
 import 'package:myplanet/core/system/photo_capture.dart';
+import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/data/local/converters.dart';
 import 'package:myplanet/providers/app_providers.dart';
@@ -82,10 +83,54 @@ class _FakePhotoCapture implements PhotoCapture {
   }
 }
 
-/// Fails the persist step the way a full disk or a closed database would, so
-/// the screen's failure branch can be exercised. A [Fake] rather than a mock
-/// because `createExamDraft` takes an `ExamRow`, and mocktail's `any()` would
-/// need a registered fallback for it.
+/// Fails the first [startExamSession] and then delegates, so a retry can be
+/// shown to recover rather than replaying the same error. A [Fake] rather than
+/// a mock because `startExamSession` takes an `ExamRow`, and mocktail's `any()`
+/// would need a registered fallback for it.
+class _FlakySubmissionsRepository extends Fake
+    implements SubmissionsRepository {
+  _FlakySubmissionsRepository(this._inner);
+
+  final SubmissionsRepository _inner;
+  int calls = 0;
+
+  @override
+  Future<String> startExamSession({
+    required ExamRow exam,
+    required List<ExamQuestionRow> questions,
+    required String userId,
+    String? courseId,
+    DateTime? now,
+  }) async {
+    calls++;
+    if (calls == 1) throw Exception('transient');
+    return _inner.startExamSession(
+      exam: exam,
+      questions: questions,
+      userId: userId,
+      courseId: courseId,
+      now: now,
+    );
+  }
+
+  @override
+  Future<bool> saveExamAnswer({
+    required String submissionId,
+    required ExamQuestionRow question,
+    required ExamDraftAnswer answer,
+    required bool isFinal,
+    required bool isExplicitSubmission,
+    DateTime? now,
+  }) => _inner.saveExamAnswer(
+    submissionId: submissionId,
+    question: question,
+    answer: answer,
+    isFinal: isFinal,
+    isExplicitSubmission: isExplicitSubmission,
+    now: now,
+  );
+}
+
 class _ThrowingSubmissionsRepository extends Fake
     implements SubmissionsRepository {
   @override
@@ -212,14 +257,23 @@ void main() {
 
   /// Waits out a snackbar.
   ///
-  /// The `incorrect_ans` / "please answer" snackbars float over the bottom of
-  /// the screen, which is exactly where the Next and Submit buttons live, so a
-  /// tap that follows one lands on the snackbar instead of the button. Kotlin
-  /// has the same overlap (`Snackbar.make(binding.root, ...)`); the tests just
-  /// have to let it go away first.
+  /// The `incorrect_ans` / "please answer" snackbars sit over the bottom of
+  /// the screen, which is where this screen's Next and Submit buttons live, so
+  /// a tap that follows one lands on the snackbar instead of the button.
+  ///
+  /// Kotlin's overlap is narrower, not the same: `btnBack` and `btnNext` are
+  /// `ImageButton`s in the **top** bar (`fragment_exam_taking.xml:30`, `:62`),
+  /// so only its Submit is covered. The screen answers that by using Kotlin's
+  /// own 2750 ms `LENGTH_LONG` and by dismissing the snackbar as soon as the
+  /// answer changes — so in practice a learner who edits their answer before
+  /// pressing again is never blocked. These tests press again *without*
+  /// editing, which is the one path that still has to wait.
   Future<void> clearSnackBar(WidgetTester tester) async {
     await tester.pump(const Duration(seconds: 5));
-    await tester.pump();
+    // And settle, not just pump: jumping time past the duration starts the
+    // exit transition but does not finish it, and a half-faded snackbar still
+    // absorbs a tap aimed at the button underneath it.
+    await tester.pumpAndSettle();
   }
 
   Future<void> pumpExam(
@@ -600,12 +654,27 @@ void main() {
     });
 
     /// A question whose document carries no answer key is the one place the
-    /// port deliberately parts from Kotlin. Kotlin's three check helpers all
-    /// open with `if (correctChoices == null) return false`, and
-    /// `insertCorrectChoice` is only called for `select*` types with choices —
-    /// so a Kotlin exam containing one free-text question cannot be finished
-    /// at all. The gate presupposes a right answer exists; when the document
-    /// names none, any answer will do.
+    /// port deliberately parts from Kotlin. `extractCorrectChoices` returns
+    /// `emptyList()` when `correctChoice` is absent or blank, and every check
+    /// helper is then vacuously false — so no answer can satisfy the question
+    /// and there is no route past it but abandoning the exam. Every
+    /// `ratingScale` question in an exam is in that position, as is any
+    /// `input`/`textarea` whose author supplied no key. The gate presupposes a
+    /// right answer exists; when the document names none, any answer will do.
+    ///
+    /// (An earlier draft of this comment said `insertCorrectChoice` is only
+    /// called for `select*` types "so a Kotlin exam containing one free-text
+    /// question cannot be finished at all". That is the reading Phase 110's
+    /// audit overturned: `CoursesRepositoryImpl.extractCorrectChoices` — the
+    /// parser a course exam actually goes through — runs for **every**
+    /// question regardless of type, so a keyed free-text question is
+    /// gradeable. The trap is the missing key, not the type.)
+    ///
+    /// The cost, stated because it is real: a *malformed* exam — an author who
+    /// forgot the key on a genuine multiple-choice question — now accepts any
+    /// answer and uploads `passed: true`, where Kotlin fails loudly by
+    /// trapping the learner. Under `requires grading` a teacher marks it
+    /// anyway, so what is lost is a meaningless `passed`, not a wrong grade.
     testWidgets('a question with no answer key accepts any answer', (
       tester,
     ) async {
@@ -982,4 +1051,149 @@ void main() {
       expect(find.text('Exam Complete'), findsOneWidget);
     });
   });
+
+  group('recovering from a failed save', () {
+    /// The defect: `_ensureSession` memoised the session future with `??=`, so
+    /// a **rejected** future stayed cached and no later press ever re-ran the
+    /// body. One transient failure ended the exam for the rest of the mount —
+    /// every press replayed the same error, with no submission row and no
+    /// answers, and the only way out was to leave the screen.
+    ///
+    /// The pre-existing `a failed save reports it…` test could not catch this:
+    /// it asserts the button is live again and stops, so it passed while the
+    /// screen was dead. This one presses a second time.
+    testWidgets('a second press after a transient failure gets through', (
+      tester,
+    ) async {
+      final real = SubmissionsRepository(
+        _UnusedApi(),
+        db.submissionDao,
+        db.submitPhotosDao,
+        db.surveyDao,
+      );
+      final flaky = _FlakySubmissionsRepository(real);
+
+      await seedTwoQuestionExam();
+      await pumpExam(
+        tester,
+        overrides: [submissionsRepositoryProvider.overrideWithValue(flaky)],
+      );
+
+      await tester.tap(find.text('Paris'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+
+      expect(
+        find.text('Could not save your exam. Please try again.'),
+        findsOneWidget,
+      );
+      expect(find.text('Question 1 / 2'), findsOneWidget);
+      await clearSnackBar(tester);
+
+      // Same answer, pressed again. Nothing else changed.
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+
+      expect(
+        flaky.calls,
+        2,
+        reason: 'the rejected session must not be memoised',
+      );
+      expect(find.text('Question 2 / 2'), findsOneWidget);
+      final answers = await db.select(db.submissionAnswers).get();
+      expect(answers.single.questionId, 'q1');
+      expect(answers.single.isPassed, isTrue);
+    });
+  });
+
+  group('question types the server did not lowercase', () {
+    /// `ExamGrading.isCorrect` and `AnswerShape.forQuestion` both normalise the
+    /// type (Kotlin compares with `ignoreCase = true`); the renderer matched
+    /// exactly. So a question typed `"Select"` drew a **text field**, the typed
+    /// answer went through `AnswerShape`'s select branch and was stored as the
+    /// empty string, and the grader graded an empty selection against a
+    /// non-empty key — the answer discarded and the gate unable to open.
+    testWidgets('a capitalised select still renders its choices', (
+      tester,
+    ) async {
+      await seedExam();
+      await seedQuestion(
+        id: 'q1',
+        position: 0,
+        type: 'Select',
+        header: 'Capital city',
+        choices: const [
+          ExamChoice(id: 'c1', text: 'Lyon'),
+          ExamChoice(id: 'c2', text: 'Paris'),
+        ],
+        correctChoices: const ['c2'],
+      );
+      await pumpExam(tester);
+
+      expect(find.byType(RadioGroup<String>), findsOneWidget);
+      expect(find.byType(TextField), findsNothing);
+
+      await tester.tap(find.text('Paris'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Submit exam'));
+      await settleExam(tester);
+
+      expect(find.text('Exam Complete'), findsOneWidget);
+      final answers = await db.select(db.submissionAnswers).get();
+      expect(answers.single.valueChoices, ['{"id":"c2","text":"Paris"}']);
+      expect(answers.single.isPassed, isTrue);
+    });
+
+    testWidgets('a capitalised selectMultiple still renders its checkboxes', (
+      tester,
+    ) async {
+      await seedExam();
+      await seedQuestion(
+        id: 'q1',
+        position: 0,
+        type: 'SelectMultiple',
+        header: 'Pick two',
+        choices: const [
+          ExamChoice(id: 'c1', text: 'Red'),
+          ExamChoice(id: 'c2', text: 'Blue'),
+        ],
+        correctChoices: const ['c1', 'c2'],
+      );
+      await pumpExam(tester);
+
+      expect(find.byType(CheckboxListTile), findsNWidgets(2));
+      expect(find.byType(TextField), findsNothing);
+    });
+  });
+
+  group('going back on an unanswered question', () {
+    /// A deliberate divergence: Kotlin's `btnBack` saves unconditionally, so an
+    /// untouched question is written with `mistakes + 1` and `isPassed = false`
+    /// — and that row uploads, because `getPendingExamResults` has no status
+    /// filter. Scoring a mistake against a question the learner never answered
+    /// is a defect, not a behaviour.
+    testWidgets('records nothing rather than a mistake', (tester) async {
+      await seedTwoQuestionExam();
+      await pumpExam(tester);
+
+      await tester.tap(find.text('Paris'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+
+      // Question two is untouched.
+      await tester.tap(find.text('Previous'));
+      await settleExam(tester);
+
+      expect(find.text('Question 1 / 2'), findsOneWidget);
+      final answers = await db.select(db.submissionAnswers).get();
+      expect(answers, hasLength(1));
+      expect(answers.single.questionId, 'q1');
+    });
+  });
 }
+
+/// Only ever handed to a [SubmissionsRepository] that the test drives through
+/// its local DAOs; no method on it is called.
+class _UnusedApi extends Fake implements PlanetApi {}

--- a/flutter/test/ui/exam/take_exam_screen_test.dart
+++ b/flutter/test/ui/exam/take_exam_screen_test.dart
@@ -89,11 +89,10 @@ class _FakePhotoCapture implements PhotoCapture {
 class _ThrowingSubmissionsRepository extends Fake
     implements SubmissionsRepository {
   @override
-  Future<String> createExamDraft({
+  Future<String> startExamSession({
     required ExamRow exam,
     required List<ExamQuestionRow> questions,
     required String userId,
-    required Map<String, ExamDraftAnswer> answers,
     String? courseId,
     DateTime? now,
   }) async => throw Exception('disk full');
@@ -209,6 +208,18 @@ void main() {
       );
       await tester.pump(const Duration(milliseconds: 100));
     }
+  }
+
+  /// Waits out a snackbar.
+  ///
+  /// The `incorrect_ans` / "please answer" snackbars float over the bottom of
+  /// the screen, which is exactly where the Next and Submit buttons live, so a
+  /// tap that follows one lands on the snackbar instead of the button. Kotlin
+  /// has the same overlap (`Snackbar.make(binding.root, ...)`); the tests just
+  /// have to let it go away first.
+  Future<void> clearSnackBar(WidgetTester tester) async {
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pump();
   }
 
   Future<void> pumpExam(
@@ -344,8 +355,12 @@ void main() {
       await pumpExam(tester);
 
       expect(find.text('Previous'), findsNothing, reason: 'first question');
-      await tester.tap(find.text('Next'));
+      // Answering first, and answering correctly, is now the precondition for
+      // moving on at all — see the retry gate group.
+      await tester.tap(find.text('Paris'));
       await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
 
       expect(find.text('Question 2 / 2'), findsOneWidget);
       expect(find.text('Spell it'), findsOneWidget);
@@ -354,7 +369,7 @@ void main() {
       expect(find.text('Submit exam'), findsOneWidget);
 
       await tester.tap(find.text('Previous'));
-      await tester.pumpAndSettle();
+      await settleExam(tester);
       expect(find.text('Question 1 / 2'), findsOneWidget);
     });
 
@@ -371,7 +386,7 @@ void main() {
       await tester.tap(find.text('Paris'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Next'));
-      await tester.pumpAndSettle();
+      await settleExam(tester);
 
       // The second question's field is its own, not seeded from question one.
       expect(find.widgetWithText(TextField, 'Paris'), findsNothing);
@@ -379,79 +394,170 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('Previous'));
-      await tester.pumpAndSettle();
+      await settleExam(tester);
       final radio = tester.widget<RadioGroup<String>>(
         find.byType(RadioGroup<String>),
       );
       expect(radio.groupValue, 'c2', reason: 'the choice is still selected');
 
       await tester.tap(find.text('Next'));
-      await tester.pumpAndSettle();
+      await settleExam(tester);
       expect(find.widgetWithText(TextField, 'Paris'), findsOneWidget);
     });
   });
 
-  group('submitting', () {
-    testWidgets('a fully correct attempt is persisted and scored 100%', (
-      tester,
-    ) async {
-      await seedTwoQuestionExam();
-      await pumpExam(tester);
-
-      await tester.tap(find.text('Paris'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Next'));
-      await tester.pumpAndSettle();
-      await tester.enterText(find.byType(TextField), 'Paris');
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Submit exam'));
-      await settleExam(tester);
-
-      expect(find.text('Exam Complete'), findsOneWidget);
-      expect(find.text('100%'), findsOneWidget);
-      expect(find.text('Correct: 2 / 2'), findsOneWidget);
-      expect(find.text('Saved offline — pending upload'), findsOneWidget);
-
-      // The attempt reached the database, which is the whole point: a graded
-      // exam that lives only in a dialog is lost when the dialog closes.
-      final saved = await db.select(db.submissions).get();
-      expect(saved, hasLength(1));
-      expect(saved.single.grade, 100);
-      expect(saved.single.status, 'complete');
-      expect(saved.single.userId, 'user-1');
-      expect(saved.single.uploaded, isFalse);
-
-      final answers = await db.select(db.submissionAnswers).get();
-      expect(answers, hasLength(2));
-      expect(answers.every((answer) => answer.isPassed), isTrue);
-    });
-
-    testWidgets('a wrong choice scores zero and is still recorded', (
-      tester,
-    ) async {
+  /// Kotlin's exam is a retry model: `updateAnsDb` returns the verdict and
+  /// both `btnNext` and `btnSubmit` bail with the `incorrect_ans` snackbar
+  /// when it is false, so the learner cannot leave a question until the answer
+  /// is right. Every test in this group failed before the gate was ported —
+  /// the screen advanced on any answer, graded once at the end, and never
+  /// wrote `mistakes` at all.
+  group('the retry gate', () {
+    testWidgets('a wrong answer does not advance and says so', (tester) async {
       await seedTwoQuestionExam();
       await pumpExam(tester);
 
       await tester.tap(find.text('Lyon'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Next'));
-      await tester.pumpAndSettle();
-      await tester.enterText(find.byType(TextField), 'Lyon');
-      await tester.pumpAndSettle();
+      await settleExam(tester);
 
+      expect(find.text('Incorrect answer'), findsOneWidget);
+      expect(
+        find.text('Question 1 / 2'),
+        findsOneWidget,
+        reason: 'a wrong answer keeps the learner on its question',
+      );
+    });
+
+    testWidgets('a right answer advances', (tester) async {
+      await seedTwoQuestionExam();
+      await pumpExam(tester);
+
+      await tester.tap(find.text('Paris'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+
+      expect(find.text('Incorrect answer'), findsNothing);
+      expect(find.text('Question 2 / 2'), findsOneWidget);
+    });
+
+    /// The accumulator. `mistakes` is `(existing?.mistakes ?: 0) + 1` per
+    /// wrong attempt, which only works because the row is already on disk —
+    /// the whole reason the attempt is persisted before the first question
+    /// rather than graded in widget state at the end.
+    testWidgets('each wrong attempt adds a mistake, and the right one does '
+        'not clear them', (tester) async {
+      await seedTwoQuestionExam();
+      await pumpExam(tester);
+
+      // Two wrong tries.
+      for (var attempt = 0; attempt < 2; attempt++) {
+        await tester.tap(find.text('Lyon'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Next'));
+        await settleExam(tester);
+        await clearSnackBar(tester);
+      }
+      expect(find.text('Question 1 / 2'), findsOneWidget);
+
+      await tester.tap(find.text('Paris'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+
+      expect(find.text('Question 2 / 2'), findsOneWidget);
+      final answers = await db.select(db.submissionAnswers).get();
+      final q1 = answers.firstWhere((answer) => answer.questionId == 'q1');
+      expect(q1.mistakes, 2);
+      expect(q1.isPassed, isTrue, reason: 'the answer that got through');
+      expect(q1.value, 'Paris');
+      // `grade = 1` for every exam answer, right or wrong — a "worth one
+      // mark" marker, not a score.
+      expect(q1.grade, 1);
+    });
+
+    /// `checkTextAnswer` is `correctChoices.any { ans.contains(it) }`, not
+    /// equality — `ExamAnswerUtilsTest.testCheckCorrectAnswer_InputText`
+    /// asserts "the expected word is here" passes a key of "expected word".
+    /// The port had exact equality, which under the gate refuses a right
+    /// answer that carries a stray word and leaves the learner stuck.
+    testWidgets('a text answer passes by containment, as Kotlin marks it', (
+      tester,
+    ) async {
+      await seedExam();
+      await seedQuestion(
+        id: 'q1',
+        position: 0,
+        type: 'input',
+        header: 'Spell it',
+        correctChoices: const ['paris'],
+      );
+      await pumpExam(tester);
+
+      await tester.enterText(find.byType(TextField), 'It is Paris, I think');
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Submit exam'));
       await settleExam(tester);
 
-      expect(find.text('0%'), findsOneWidget);
-      expect(find.text('Correct: 0 / 2'), findsOneWidget);
-      final saved = await db.select(db.submissions).get();
-      expect(saved.single.grade, 0);
+      expect(find.text('Incorrect answer'), findsNothing);
+      expect(find.text('Exam Complete'), findsOneWidget);
     });
 
-    /// `selectMultiple` is all-or-nothing in `ExamGrading.isSelectionCorrect`,
-    /// matching the Kotlin's marking: a subset of the answer key does not pass.
-    testWidgets('a partial multi-select answer does not pass', (tester) async {
+    /// `isQuestionAnswered` gates the press before any answer is written:
+    /// Kotlin toasts `please_select_write_your_answer_to_continue` and
+    /// returns. Without this an empty press would score a mistake against a
+    /// question the learner had not answered yet.
+    testWidgets('pressing on with no answer asks for one instead of scoring '
+        'a mistake', (tester) async {
+      await seedTwoQuestionExam();
+      await pumpExam(tester);
+
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+
+      expect(
+        find.text('Please select / write your answer to continue'),
+        findsOneWidget,
+      );
+      expect(find.text('Question 1 / 2'), findsOneWidget);
+      expect(
+        await db.select(db.submissionAnswers).get(),
+        isEmpty,
+        reason: 'nothing was answered, so nothing is a mistake',
+      );
+    });
+
+    /// `btnBack` calls `updateAnsDb()` and then moves regardless of the
+    /// verdict (`ExamTakingFragment.kt:187-194`) — going back is the one route
+    /// out of a question left wrong, and it still records the mistake.
+    testWidgets('going back records the answer as it stands', (tester) async {
+      await seedTwoQuestionExam();
+      await pumpExam(tester);
+
+      await tester.tap(find.text('Paris'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+      await tester.enterText(find.byType(TextField), 'Lyon');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Previous'));
+      await settleExam(tester);
+
+      expect(find.text('Question 1 / 2'), findsOneWidget);
+      final answers = await db.select(db.submissionAnswers).get();
+      final q2 = answers.firstWhere((answer) => answer.questionId == 'q2');
+      expect(q2.mistakes, 1);
+      expect(q2.isPassed, isFalse);
+    });
+
+    /// `checkMultipleSelectAnswer` compares the whole sorted set, so a subset
+    /// is wrong — and under the gate that means it does not advance.
+    testWidgets('a partial multi-select answer does not get through', (
+      tester,
+    ) async {
       await seedExam();
       await seedQuestion(
         id: 'q1',
@@ -472,13 +578,148 @@ void main() {
       await tester.tap(find.text('Submit exam'));
       await settleExam(tester);
 
-      expect(find.text('0%'), findsOneWidget);
-
-      // Adding the second correct choice would have passed it.
+      expect(find.text('Incorrect answer'), findsOneWidget);
+      expect(find.text('Exam Complete'), findsNothing);
       final answers = await db.select(db.submissionAnswers).get();
-      // Stored as the choice object `saveExamAnswer` writes, not the bare id.
+      // Recorded, with its mistake — the attempt is not thrown away, it just
+      // does not finish the exam.
       expect(answers.single.valueChoices, ['{"id":"c1","text":"Red"}']);
       expect(answers.single.isPassed, isFalse);
+      expect(answers.single.mistakes, 1);
+
+      await clearSnackBar(tester);
+      await tester.tap(find.text('Blue'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Submit exam'));
+      await settleExam(tester);
+
+      expect(find.text('Exam Complete'), findsOneWidget);
+      final passed = await db.select(db.submissionAnswers).get();
+      expect(passed.single.isPassed, isTrue);
+      expect(passed.single.mistakes, 1, reason: 'the earlier try still counts');
+    });
+
+    /// A question whose document carries no answer key is the one place the
+    /// port deliberately parts from Kotlin. Kotlin's three check helpers all
+    /// open with `if (correctChoices == null) return false`, and
+    /// `insertCorrectChoice` is only called for `select*` types with choices —
+    /// so a Kotlin exam containing one free-text question cannot be finished
+    /// at all. The gate presupposes a right answer exists; when the document
+    /// names none, any answer will do.
+    testWidgets('a question with no answer key accepts any answer', (
+      tester,
+    ) async {
+      await seedExam();
+      await seedQuestion(
+        id: 'q1',
+        position: 0,
+        type: 'textarea',
+        header: 'Tell us what you thought',
+      );
+      await pumpExam(tester);
+
+      await tester.enterText(find.byType(TextField), 'It was fine');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Submit exam'));
+      await settleExam(tester);
+
+      expect(find.text('Incorrect answer'), findsNothing);
+      expect(find.text('Exam Complete'), findsOneWidget);
+      final answers = await db.select(db.submissionAnswers).get();
+      expect(answers.single.mistakes, 0);
+      expect(answers.single.isPassed, isTrue);
+    });
+  });
+
+  group('submitting', () {
+    testWidgets('a finished exam is sent for grading rather than scored', (
+      tester,
+    ) async {
+      await seedTwoQuestionExam(courseId: 'course-1');
+      await pumpExam(tester, courseId: 'course-1');
+
+      await tester.tap(find.text('Paris'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+      await tester.enterText(find.byType(TextField), 'Paris');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Submit exam'));
+      await settleExam(tester);
+
+      expect(find.text('Exam Complete'), findsOneWidget);
+      expect(
+        find.text('Thank you for taking this exam! We wish you all the best.'),
+        findsOneWidget,
+      );
+      expect(find.text('Saved offline — pending upload'), findsOneWidget);
+      // `continueExam` shows no score, and under the gate a percentage could
+      // only ever read 100%.
+      expect(find.text('100%'), findsNothing);
+      expect(find.textContaining('Correct:'), findsNothing);
+
+      final saved = await db.select(db.submissions).get();
+      expect(saved, hasLength(1));
+      expect(saved.single.status, 'requires grading');
+      // `createExamSubmission` sets no submission-level grade for an exam and
+      // neither does `saveExamAnswer`: Planet marks it and the sync-in reads
+      // the mark back into this column.
+      expect(saved.single.grade, 0);
+      expect(saved.single.userId, 'user-1');
+      expect(saved.single.uploaded, isFalse);
+      // `"$examId@$courseId"`, the shape `createExamSubmission` writes and
+      // `ProgressRepository._examIdFromParent` splits to find the exam — the
+      // port stored the bare course id, so the per-step mistake counts could
+      // never match their exam.
+      expect(saved.single.parentId, 'exam-1@course-1');
+      expect(await db.submissionDao.pendingUploads('user-1'), hasLength(1));
+
+      final answers = await db.select(db.submissionAnswers).get();
+      expect(answers, hasLength(2));
+      expect(answers.every((answer) => answer.isPassed), isTrue);
+      expect(answers.every((answer) => answer.grade == 1), isTrue);
+      expect(answers.every((answer) => answer.examId == 'exam-1'), isTrue);
+    });
+
+    /// The invariant Phase 106 could only state as an assertion, now a
+    /// consequence: every answer in a finished attempt is `isPassed`, because
+    /// no wrong one can be left behind — and `mistakes` is what records that
+    /// it took three tries.
+    testWidgets('a finished attempt passes every answer and keeps the '
+        'mistake count', (tester) async {
+      await seedTwoQuestionExam();
+      await pumpExam(tester);
+
+      await tester.tap(find.text('Lyon'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+      await clearSnackBar(tester);
+      await tester.tap(find.text('Paris'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await settleExam(tester);
+
+      await tester.enterText(find.byType(TextField), 'Lyon');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Submit exam'));
+      await settleExam(tester);
+      expect(find.text('Exam Complete'), findsNothing);
+      await clearSnackBar(tester);
+
+      await tester.enterText(find.byType(TextField), 'Paris');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Submit exam'));
+      await settleExam(tester);
+
+      expect(find.text('Exam Complete'), findsOneWidget);
+      final answers = await db.select(db.submissionAnswers).get();
+      expect(answers.every((answer) => answer.isPassed), isTrue);
+      expect(
+        {for (final answer in answers) answer.questionId: answer.mistakes},
+        {'q1': 1, 'q2': 1},
+      );
     });
 
     testWidgets('Finish closes the result dialog and leaves the exam', (
@@ -493,6 +734,8 @@ void main() {
       );
       await pumpExam(tester);
 
+      await tester.enterText(find.byType(TextField), 'anything at all');
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Submit exam'));
       await settleExam(tester);
       expect(find.text('Exam Complete'), findsOneWidget);
@@ -504,10 +747,10 @@ void main() {
       expect(find.text('Exam Complete'), findsNothing);
     });
 
-    /// The submit path awaits `sessionProvider.future` — which, unlike the
+    /// The exam session awaits `sessionProvider.future` — which, unlike the
     /// `ref.read(...).valueOrNull` it replaced, can also *reject*. Left
     /// uncaught that reproduces the silence the await was introduced to
-    /// remove: the graded attempt gone with nothing on screen.
+    /// remove: the attempt gone with nothing on screen.
     testWidgets('a rejecting session reports the failure instead of silence', (
       tester,
     ) async {
@@ -523,6 +766,8 @@ void main() {
         overrides: [sessionProvider.overrideWith(_FailingSessionNotifier.new)],
       );
 
+      await tester.enterText(find.byType(TextField), 'anything at all');
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Submit exam'));
       await settleExam(tester);
 
@@ -533,6 +778,9 @@ void main() {
       expect(find.text('Exam Complete'), findsNothing);
     });
 
+    /// A failed *save* must not be reported as a wrong answer: the learner
+    /// would be told their answer was incorrect when the truth is that
+    /// nothing was written.
     testWidgets('a failed save reports it and keeps the user on the exam', (
       tester,
     ) async {
@@ -552,6 +800,8 @@ void main() {
         ],
       );
 
+      await tester.enterText(find.byType(TextField), 'anything at all');
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Submit exam'));
       await settleExam(tester);
 
@@ -559,6 +809,7 @@ void main() {
         find.text('Could not save your exam. Please try again.'),
         findsOneWidget,
       );
+      expect(find.text('Incorrect answer'), findsNothing);
       expect(find.text('Exam Complete'), findsNothing);
       // The submit button is live again rather than stuck on its spinner.
       expect(find.text('Question 1 / 1'), findsOneWidget);
@@ -624,6 +875,8 @@ void main() {
       );
       await pumpExam(tester, courseId: 'course-1');
 
+      await tester.enterText(find.byType(TextField), 'anything at all');
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Submit exam'));
       await settleExam(tester);
 
@@ -663,6 +916,8 @@ void main() {
       );
       await pumpExam(tester, courseId: 'course-1');
 
+      await tester.enterText(find.byType(TextField), 'anything at all');
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Submit exam'));
       // The only test that waits on a real file write, so it needs the most
       // wall-clock time: eight rounds is enough for drift, not for
@@ -716,6 +971,8 @@ void main() {
       );
       await pumpExam(tester, courseId: 'course-1');
 
+      await tester.enterText(find.byType(TextField), 'anything at all');
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Submit exam'));
       await settleExam(tester);
 

--- a/flutter/test/ui/submissions_screen_test.dart
+++ b/flutter/test/ui/submissions_screen_test.dart
@@ -77,6 +77,130 @@ void main() {
     expect(find.text('exam'), findsNothing);
   });
 
+  /// `saveExamAnswer` gives a **finished exam** the status `requires grading`
+  /// — `complete` is the survey value, and an exam is not complete until
+  /// somebody marks it. Without it on `_isComplete`'s list a just-submitted
+  /// exam would file under Pending until its upload landed, which is the
+  /// opposite of what the learner just did.
+  testWidgets('a submitted exam awaiting grading counts as complete', (
+    tester,
+  ) async {
+    const submitted = SubmissionRow(
+      id: 'awaiting',
+      type: 'exam',
+      startTime: 0,
+      lastUpdateTime: 2,
+      grade: 0,
+      status: 'requires grading',
+      // Not yet on the wire, so `uploaded` cannot be what carries it.
+      uploaded: false,
+      isUpdated: true,
+    );
+    const pending = SubmissionRow(
+      id: 'in-progress',
+      type: 'exam',
+      startTime: 0,
+      lastUpdateTime: 1,
+      grade: 0,
+      status: 'pending',
+      uploaded: false,
+      isUpdated: false,
+    );
+    await tester.pumpWidget(
+      wrapScreen(
+        const SubmissionsScreen(),
+        overrides: [
+          submissionsProvider.overrideWith(
+            (ref) => Stream.value([submitted, pending]),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Complete'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('requires grading'), findsOneWidget);
+    expect(find.textContaining('pending'), findsNothing);
+
+    await tester.tap(find.text('Pending'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('pending'), findsOneWidget);
+    expect(find.textContaining('requires grading'), findsNothing);
+  });
+
+  /// The per-answer `grade` is `1` for **every** exam answer, right or wrong —
+  /// `saveExamAnswer`'s "worth one mark" marker, not a score. A badge reading
+  /// it would say "1" on every row and mean nothing, and
+  /// `QuestionAnswerAdapter.bind` renders it nowhere. This pins the absence,
+  /// because the temptation to restore the mark later is real and a comment
+  /// alone will not stop it.
+  testWidgets('an answer shows no mark of its own', (tester) async {
+    const row = SubmissionRow(
+      id: 'submission-5',
+      userId: 'user-1',
+      type: 'exam',
+      startTime: 0,
+      lastUpdateTime: 0,
+      grade: 0,
+      status: 'requires grading',
+      uploaded: false,
+      isUpdated: true,
+    );
+    await tester.pumpWidget(
+      wrapScreen(
+        const SubmissionDetailScreen(submissionId: 'submission-5'),
+        overrides: [
+          submissionProvider(
+            'submission-5',
+          ).overrideWith((ref) => Stream.value(row)),
+          submissionAnswersProvider('submission-5').overrideWith(
+            (ref) => Stream.value([
+              const SubmissionAnswerRow(
+                id: 'submission-5:q-1',
+                submissionId: 'submission-5',
+                questionId: 'q-1',
+                value: 'Paris',
+                valueChoices: [],
+                mistakes: 3,
+                isPassed: true,
+                grade: 1,
+              ),
+            ]),
+          ),
+          submissionQuestionsProvider('submission-5').overrideWith(
+            (ref) => Stream.value([
+              const SubmissionQuestionRow(
+                id: 'submission-5:q-1',
+                submissionId: 'submission-5',
+                header: 'Capital city',
+                correctChoices: ['paris'],
+                choices: [],
+                position: 0,
+              ),
+            ]),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The body is a `ListView(children: [...])`: it builds its children
+    // eagerly but only *mounts* those in the viewport, and `find.text` walks
+    // the element tree — so the answer card sits below the 600px test fold
+    // until it is scrolled to. Asserting the badge's absence without scrolling
+    // would pass because nothing is mounted, not because nothing is drawn.
+    await tester.scrollUntilVisible(find.text('Capital city'), 200);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Paris'), findsOneWidget);
+    expect(
+      find.text('1'),
+      findsNothing,
+      reason: 'the marker is not a score and is not rendered',
+    );
+  });
+
   testWidgets('renders submission details from the offline cache', (
     tester,
   ) async {


### PR DESCRIPTION
Lane B of the Phase 107–110 parallel round. **Phase 110.** Head: `3d6201a`.

Closes the three divergences `flutter/PHASE_106_NOTES.md` logged with one shared caveat — they are all consequences of an exam model the port did not have.

Kotlin's exam **refuses to advance past a wrong answer**: `updateAnsDb` returns the verdict `saveExamAnswer` computed, and both `btnNext` (`ExamTakingFragment.kt:196-204`) and `btnSubmit` (`:641-645`) bail with the `incorrect_ans` snackbar when it is false. Everything else follows — `mistakes` accumulates and is uploaded, every answer in a finished submission is `isPassed` as a *consequence*, and there is no score: a thank-you dialog, and the submission goes up as `requires grading`.

So the attempt is now persisted before the answers and each answer as it is given: `createExamDraft`'s single end-of-exam write becomes `startExamSession` + `saveExamAnswer`, where Kotlin has them. `mistakes` is `existing.mistakes + 1` — there has to be an `existing` row to add to.

## Ten defects, eight demonstrated failing on the pre-fix code

| defect | pre-fix failure |
|---|---|
| the screen advanced past a wrong answer | `Found 0 widgets with text "Incorrect answer"` |
| `mistakes` was never written, and `serialize` uploaded the 0 | the second retry had no radio to tap — the un-gated screen had already moved on |
| pressing on with no answer was accepted | `Found 0 widgets with text "Please select / write your answer to continue"` |
| going back did not record the answer (`btnBack` calls `updateAnsDb` first) | `Bad state: No element` — no answer row existed |
| the result dialog invented a score and a pass mark against `passingPercentage`, which Kotlin never reads for any decision | `Found 0 widgets with text "Thank you for taking this exam!…"` |
| status was `complete`, the *survey* value | `status` was `'complete'`; `grade` a device-computed percentage |
| `parentId` was the bare `courseId`, so `ProgressRepository._examIdFromParent` could never match an attempt to its exam | `parentId` was `'course-1'`, not `'exam-1@course-1'` |
| `isTextCorrect` was exact equality where `checkTextAnswer` is containment | probe: `Expected: true / Actual: <false>` |
| a keyless question could not be passed — under the gate that traps the learner, and every `ratingScale` question in an exam has no key | probe: `Expected: true / Actual: <false>` |
| the per-answer `grade` badge rendered a score where Kotlin writes `1` for every answer and renders it nowhere | assertion |

## The two decisions Phase 106 asked for

- **Per-answer `grade`** — take Kotlin's value (`1` for every exam answer, right or wrong; not uploaded, read nowhere in `app/src/main`) and **drop the badge**. Keeping the port's `isCorrect ? 1 : 0` would mean inventing a field value to feed a widget Kotlin does not have.
- **Status** — `requires grading`. `complete` is the survey value. It is what Planet's grading queue selects on, and the port's status-blind `pendingUploads` carries it fine.

## A parity audit overturned my first reading

I had concluded Kotlin's `select` grading can never pass, citing `ExamQuestion.insertCorrectChoice`. Wrong twice: that function stores the matched choice's `res`, not its id — and it is **not** the parser a course exam goes through. `CoursesRepositoryImpl.extractCorrectChoices` (`:804-821`) is, and it stores display **text**. So Kotlin's grading works, and the port's id comparison is the more robust half of a mirror rather than a rescue. The comment says that now instead of the wrong thing.

Three deliberate divergences and six unported Kotlin behaviours are recorded in `flutter/PHASE_110_NOTES.md`, along with two reachability blockers the audit surfaced that belong to a later phase.

## Notes for the integrator

- **No schema change** (still v44); no table or converter touched, so no `build_runner` step for this lane.
- **Two `app_en.arb` keys**, English only, appended at the end of the file — Lane A owns `lib/l10n/`, so expect a trivial last-line conflict.
- Two queries live in the repository rather than `SubmissionDao` because `app_database.dart` is Lane C's this round; both are flagged in the notes with the DAO methods they should become.
- Gate: `dart format` clean, `flutter analyze` clean, **1754 tests pass** (was 1740).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkyXMKc1tBK5TTZqVPHBy6