### PR TITLE
Phase 112 (Lane D): unify the guest-user predicate

### DIFF
--- a/flutter/PHASE_112_NOTES.md
+++ b/flutter/PHASE_112_NOTES.md
@@ -336,6 +336,22 @@ failing, which is most of the argument for taking it.
   half is missing, so a non-member cannot post on a public team.
 * **`team_members_screen.dart:203-225` omits `RequestsAdapter.kt:63-67`'s
   `isRequester` disable.**
+* **`take_exam_screen_test`'s verification-photo case is a wall-clock race with
+  a hardcoded round count**, and it is worth naming because it cost this lane
+  a full diagnostic cycle. `settleExam(tester, rounds: 40)` waits a fixed
+  number of `runAsync` rounds for `Directory.create` + `writeAsBytes` + the
+  drift row that follows — the count is hand-tuned, and its own comment says
+  so. It failed once here on a busy machine and passed on two subsequent full
+  runs, in isolation, and on the base tree; my diff shares no import with
+  `take_exam_screen.dart`. So it is not this lane's defect, but it is a real
+  fragility that any branch adding test files can trip. The fix is to poll
+  until the row exists (with a deadline) instead of counting rounds. Lane B's
+  file, so reported rather than edited.
+
+  Reducing the pressure *this* lane adds was in scope and is done:
+  `guest_predicate_parity_test` now reads asynchronously with a whole-file
+  pre-filter instead of `readAsLinesSync` over ~400 files, so its isolate no
+  longer starves its neighbours.
 
 ## For the integrator
 

--- a/flutter/PHASE_112_NOTES.md
+++ b/flutter/PHASE_112_NOTES.md
@@ -1,3 +1,359 @@
-# Phase 112 — the guest predicate: one rule, or three?
+# Phase 112 — one guest predicate, and the guest row that does not exist
 
-Picking up Phase 107's first "Found and left" item. In progress.
+Picking up Phase 107's first *Found and left* item. Its finding was that the
+port spells the guest check three ways — `user.id.startsWith('guest')` in the
+screens, `couchId?.startsWith('guest')` in `validateUsername`, and Kotlin's
+`_id?.startsWith("guest_")` unported — and called that "three spellings of one
+predicate".
+
+**That framing is partly a misreading, and the correction matters more than the
+unification.** Kotlin does not have one spelling. It has eleven, and each port
+site is a faithful transcription of the *particular* Kotlin spelling at the site
+it ports. A `parity-auditor` pass at `effort: max` enumerated them; the two the
+phase brief singled out as suspect are the two that were already right.
+
+The real finding underneath is larger, and it is item 2's answer.
+
+---
+
+## 1. Kotlin's rule, and why it needs no unifying there
+
+`createGuestUser(username)` → `saveUser(buildGuestUserJson(username))`, the
+three-arg overload (`UserSyncRepository.kt:15`, `UserRepositoryImpl.kt:348`) →
+`buildUserFromJson` → `applyJsonToUser` → `upsertUser`. Traced end to end, the
+row it writes is:
+
+```
+id   == "guest_ada"      // the fresh entity's id is blank, so `_id` fills it
+_id  == "guest_ada"
+name == "ada",  firstName == "ada",  rolesList == ["guest"]
+password == null
+```
+
+**That equality is the whole answer.** `id == _id == "guest_<username>"`, so
+these all agree:
+
+| | Spelling | Column | Prefix |
+|---|---|---|---|
+| K1 | `user.id.startsWith("guest")` | `id` | 5 |
+| K2 | `_id?.startsWith("guest_")` | `_id` | 6 |
+| K3 | `_id.orEmpty().startsWith("guest")` | `_id` | 5 |
+| K4 | `_id?.contains("guest")` | `_id` | substring |
+| K6 | `SUBSTR(id,1,5) != 'guest'` | `id` | 5 |
+| K7 | `SUBSTR(_id,1,6) = 'guest_'` | `_id` | 6 |
+| K8/K9/K10 | `NOT LIKE 'guest%'` / `userId?.startsWith("guest")` | a row's `userId` | 5 |
+| K11 | `it._id?.isEmpty() == true` | `_id` | — **not a guest check** |
+
+K1 has ~30 sites, K2 six, and the rest one to three each. Kotlin gets away with
+this because nothing can write an id that starts `guest` without starting
+`guest_`: the only ids either app mints are `guest_<username>` (the username is
+validated non-empty), `org.couchdb.user:<name>`, and a millisecond timestamp.
+
+**One Kotlin spelling genuinely disagrees with the rest.** `UserEntity.isGuest()`
+(`UserEntity.kt:177-181`) is K2 **or** (a `guest` role without a `learner` role).
+The role clause is reachable: `TransactionSyncManager.kt:230` walks
+`tablet_users/_all_docs` into `insertUsersFromSync`, which filters only
+`_design` docs and lets `applyJsonToUser` set `rolesList` unconditionally. A
+server document `{"_id":"org.couchdb.user:zoe","name":"zoe","roles":["guest"]}`
+therefore produces a row where `isGuest()` is **true** and
+`id.startsWith("guest")` is **false** — and Kotlin then contradicts itself
+inside a single fragment: `ResourcesFragment:487` hides the checkboxes (K5)
+while `:534` runs `addToMyList` (K1). That is Kotlin's quirk, not a port bug,
+and it is why the role clause must stay a **second** predicate if it is ever
+ported — folding it into the id rule would silently widen the settings and
+voices gates past their originals.
+
+## 2. Does the port create guest rows? No — and that is the honest answer
+
+`grep -rn "createGuest\|guestLogin\|GuestLogin\|btnGuest" lib test` finds only
+`guest_dialog.dart` imports and comments. `login_screen.dart:11` says so in its
+own header. Nothing pushes a guest-login route; every guest fixture in `test/`
+is hand-built. **Every guest gate in the port is dead code today**, and
+`buildUserFromJson`'s guest-adoption branch (item 3) stays unportable: there is
+nothing to adopt.
+
+So the unified predicate is still the deliverable, and item 3 is deferred. But
+the audit turned the "next lane needs a target" line into an actual target, and
+it is bigger than a login button. **The port is missing 15+ of Kotlin's guest
+gates**, which is the finding Phase 107's framing obscured:
+
+*Would have to be built, in order:*
+
+1. `buildGuestUserJson(username)` — `{"_id": "guest_$username", "name":
+   username, "firstName": username, "roles": ["guest"]}`. The `roles` entry is
+   load-bearing: without it `home_screen.dart:351-355`'s
+   `rolesList.isEmpty && !userAdmin` branch fires and a guest lands on
+   `InactiveDashboardScreen`.
+2. `createGuestUser(username)` → `_cacheUserDoc(buildGuestUserJson(username))`.
+   Two lines: `_cacheUserDoc` already produces `id == couchId ==
+   'guest_<username>'` for a doc with a non-empty `_id`. **It must not be
+   routed through a become-member-shaped insert** — see §4.
+3. `UserDao.getGuestUserByName` / `getGuestUsersByNames` / `getSyncedUsers` /
+   `getSyncedUserByName` / `getDuplicateUsers` + `deleteByIds`, none of which
+   the port has. `getSyncedUsers` is `couchId` non-blank **and** `id NOT LIKE
+   'guest%'` — without it a guest's shelf is not excluded from upload.
+4. `migrateGuestUser` (`UserRepositoryImpl.kt:278-290`) wired into
+   `_cacheUserDoc`'s missing middle branch, plus `cleanupDuplicateUsers`
+   (`:837-856`), whose caller is `become_member_screen.dart` — Phase 107
+   deferred both for the same reason.
+5. The guest-login dialog (`GuestLoginExtensions.kt`: lowercase-forcing field,
+   300 ms debounced `validateUsername`, then the three-way `findUserByName`
+   branch), `showGuestDialog`/`showUserAlreadyMemberDialog`, a `source` field on
+   the saved-accounts picker (`UserDao.getSavedUsers` reads the `users` table;
+   Kotlin reads a `SharedPreferences` list of DTOs carrying
+   `source: "guest"|"member"`), and `resetGuestAsMember`.
+6. **The gates.** `lib/ui/teams/`, `lib/ui/courses/`, `lib/ui/resources/`,
+   `lib/ui/surveys/` and `lib/ui/user/` contain no guest check of any kind.
+   Missing, with counterparts: team join/leave (`TeamDetailFragment:255`),
+   course multi-select and add-to-shelf (`CoursesFragment:135/141/250/531`,
+   `CourseSelectionController:35/81`, `CoursesAdapter:339`), the Join button
+   (`TakeCourseFragment:212`), resources batch selection, add-resource and
+   long-press edit (`ResourcesFragment:169/178/457/476/487/501/534`), the
+   shelf button (`ResourceDetailFragment:215`), Edit profile
+   (`UserProfileFragment:436`), start/adopt survey (`SurveysAdapter:105`),
+   the new-voice FAB (`VoicesFragment:94`), every settings switch
+   (`blockGuestSwitches`, `SettingsActivity:220-242` — the port's
+   background-sync toggle is ungated), the toolbar sync action
+   (`DashboardElementActivity:109`), the rating click listener
+   (`BaseContainerFragment:154`), and the whole guest trial-limit UX
+   (`DashboardActivity:744-748`). Several are subsumed rather than missing:
+   the port has no add-team or add-meetup affordance at all, and
+   `team_members_screen` gates its whole tab on `isLeader`.
+
+Not a task but a decision the next lane owes: **whether to port
+`isGuest()`'s role clause.** Its only producer is a server-authored
+`tablet_users` document and the port has no `tablet_users` walk, so porting it
+alone adds an unreachable branch while porting the walk without it lets a
+`roles:["guest"]` account through gates Kotlin closes.
+
+## 3. The unification
+
+`UserMapper` gains three members, and `lib/` now contains **no** other guest
+literal (`test/guest_predicate_parity_test.dart` enforces it by scanning the
+source, because a review of one file cannot).
+
+* `guestIdPrefix` = `'guest_'`
+* `isGuestId(String?)` — the rule on a bare id
+* `isGuest(UserRow)` — `isGuestId(id) || isGuestId(couchId)`
+
+Call sites moved (7 Dart-level predicates, all of them):
+
+| Site | Was | Now |
+|---|---|---|
+| `home_screen.dart:81` health key/iv | `user.id.startsWith('guest')` | `UserMapper.isGuest` |
+| `home_screen.dart:149` challenge | same | same |
+| `home_screen.dart:195` pending surveys | same | same |
+| `home_screen.dart:345` `isGuest` (chat, feedback, library/courses headers, tiles) | same | same |
+| `dashboard_drawer.dart:23` | `session?.id.startsWith('guest')` | same |
+| `settings_screen.dart:175` storage | `session.id.startsWith('guest')` | same |
+| `settings_screen.dart:334` reset app | same | same |
+| `voices_screen.dart:117` share | `!user.id.startsWith('guest')` | same |
+| `voices_screen.dart:192` reactions | same | same |
+| `user_repository.dart:246` `validateUsername` | `couchId?.startsWith('guest')` | same |
+| `activities_provider.dart:119` | `user.id.startsWith('guest')` | same |
+| `activities_repository.dart:443` `_isGuest` | `userId.startsWith('guest')` | `UserMapper.isGuestId` |
+| `voices_repository.dart:537` | `(row.userId ?? '').startsWith('guest')` | `UserMapper.isGuestId` |
+
+**Two deviations, stated rather than buried.** The audit flagged both, and
+both are kept:
+
+* **Five characters to six.** Every site above tested `guest`; the helper tests
+  `guest_`. No producible id distinguishes them, and the error directions are
+  not symmetric: a false positive gates a real member out of features they are
+  entitled to, while a false negative needs an id starting `guest` and not
+  `guest_`, which only a guest-creator ignoring `guestIdPrefix` could mint —
+  which is what exporting the constant prevents.
+* **One column to two.** `validateUsername` was an exact port of K3 (`_id`
+  only) and the screens were exact ports of K1 (`id` only). Reading both is
+  what makes the helper impossible to disagree with itself, and Kotlin's own
+  interchangeability rests on an equality **the port cannot yet enforce**,
+  because nothing creates a guest row. On every row Kotlin produces the two
+  columns are equal, so no answer changes; where they differ the helper errs
+  towards "guest", withholding a privilege rather than granting one. The one
+  direction to watch: if a future `migrateGuestUser` re-keys `_id` and leaves
+  `id`, that row reads as a guest and its name becomes re-takeable. Kotlin's
+  `migrateGuestUser` sets both — keep it that way.
+
+**Deliberately not folded in**: `isGuest()`'s role clause, pinned by a test
+named after the omission so it is visible rather than forgotten.
+
+### Four Drift query bodies stay as they are
+
+`app_database.dart` carries `like('guest%')` in four DAO predicates
+(`RatingDao`, `CourseProgressDao`, `pendingLoginUploads`, `AchievementDao`).
+Those are **faithful transcriptions of Kotlin's own SQL** — `AchievementDao.kt:19`,
+`CourseProgressDao.kt:28` and `RatingDao.kt:35` all write `NOT LIKE 'guest%'`
+verbatim — and a SQL `WHERE` cannot call a Dart predicate, so pinning them to
+the Kotlin query text is the closest thing to one source of truth available
+there. The guard test exempts that file and says why. They were also not this
+lane's to edit.
+
+## 4. Defects, each demonstrated failing first
+
+### 4.1 Both settings guest gates read a provider the screen never watches
+
+`settings_screen.dart` referenced `sessionProvider` exactly twice, both
+`ref.read(...).valueOrNull` inside an `onTap`, with no `watch` and no `listen`
+anywhere in the file. So the session was `null`, `session != null` was false,
+the gate fell through — and a guest reached **`clearAllData()`, the only
+destructive action in the app**, plus the storage tools. Neither gate had ever
+had a test, which is how it survived.
+
+The **fifth** instance of this shape (`take_exam_screen` Phase 100,
+`add_resource_screen` 102, `public_survey_screen` and `take_survey_screen`
+104/105). Latent in the shipping app for the usual reason — `router.dart:644`
+holds a lifetime `ref.listen(sessionProvider)` and `:201` holds the redirect
+while the session is loading — and live for any harness that does not install
+the router, which is exactly why it was untestable.
+
+Fixed by **watching** at build and passing the row down, rather than awaiting
+`.future` in each callback: the value is read by two widgets on every rebuild,
+so watching is both cheaper and the shape that cannot regress.
+
+Kotlin has no equivalent hazard: `SettingsActivity.kt:183` resolves the user in
+`onCreatePreferences` and `:247`/`:284` each re-resolve it inside the handler.
+
+*Failing-first:* both guest tests find 0 guest dialogs; the member test passes.
+
+### 4.2 An author lost their own voices the moment their account uploaded
+
+`voices_screen.dart:115` was `row.userId == (user.couchId ?? user.id)` — a
+*preference* between the two id columns. `VoicesAdapter.matchesCurrentUser`
+(`VoicesAdapter.kt:666-669`) is an **or**:
+
+```kotlin
+if (id.isNullOrEmpty()) return false
+return id == currentUser?._id || id == currentUser?.id
+```
+
+Same rule as `UserDao.getById`'s `WHERE id = :id OR _id = :id`, and the same
+reason Phase 107 gave for it: a member registered on this device authors rows
+under the locally-minted `'<millis>'` key and gains a `couchId` only once the
+upload lands. Under the preference, every voice they had already posted stopped
+being theirs — no edit, no delete — at the moment their account got a server
+identity.
+
+Ported as `UserMapper.matchesUser`, including the empty-or-null guard that
+comes first in the Kotlin and is load-bearing: without it a row with no author
+matches a session with no `couchId`.
+
+*Failing-first:* exactly one of four new cases fails — the local-id post finds
+no edit action.
+
+### 4.3 The `password` column's documentation stated a false Kotlin fact
+
+`tables.dart:42` said "Only ever set for guest users, which have an empty
+`_id`", echoed in `user_mapper.dart:122` ("which is the guest shape") and
+`user_repository.dart:178`. **A guest row's `_id` is `guest_ada`.**
+`applyJsonToUser:261` reads `_id` *after* `_id = newId`, so the guest branch is
+never taken and a guest's password stays null; guests are never authenticated
+by comparison at all, because guest re-entry goes back through
+`showGuestLoginDialog` (`GuestLoginExtensions.kt:64`), not `authenticateUser`.
+The rows that do carry a plaintext password come from the **offline
+become-member** path, whose `createMember` document has no `_id`
+(`UserRepositoryImpl.kt:570-579`).
+
+Not a comment nit: it is the specification the next lane will build
+`createGuestUser` against, and following it would mint `couchId = null`, which
+lands the row in `UserDao.pendingSyncUsers` (`couchId IS NULL | '' | isUpdated`)
+and gets it POSTed to `_users` by `user_uploader.dart:91`. Kotlin never uploads
+a guest, and the thing stopping it is precisely that `_id` is non-empty.
+
+All three comments corrected, and `tables.dart` now names the constraint a
+guest-creator has to honour. (Comment-only; no schema effect.)
+
+### 4.4 `loginOffline`'s `isGuest` was true for exactly the rows that are not guests
+
+Same misreading in code. The local was named `isGuest` and the branch it
+selects is Kotlin's `if (it._id?.isEmpty() == true)` (`:862`) — accounts with
+**no server identity**. A real guest row (`couchId = 'guest_ada'`) takes the
+*other* branch and fails against a null `derived_key`, which is correct. Renamed
+to `hasNoServerIdentity`, doc comment rewritten.
+
+And its test had absorbed the same error: *"authenticates a guest against the
+plaintext password"* seeded `id: 'guest-1'` with no `couchId` — a row
+`createGuestUser` cannot produce. Renamed to what it tests, re-seeded to a
+`'<millis>'` member, and a second case added pinning that a real guest row is
+**not** authenticated by the plaintext branch. That case matters: a guest row
+has no password, so had the branch been taken, `null == null` would sign a guest
+in on an empty password.
+
+The port's `couchId == null || couchId.isEmpty` remains equivalent to Kotlin's
+`_id?.isEmpty()`, because `UserMapper.fromDoc` normalises the absent `_id` to
+`null` rather than `''`. That is now written down.
+
+### 4.5 Two fixtures spelled the prefix a fourth way
+
+`home_screen_test.dart:676` seeded `_user('guest-ada')` — a **hyphen** — while
+the same file's three other guest fixtures use `guest_ada`. The
+five-character rule could not tell them apart, so a row `createGuestUser` can
+never write had been standing in for a guest. Under `guest_` the test fails
+loudly (the key/iv sync fires for what is now a member), which is the point.
+
+`inactive_dashboard_screen_test.dart:166` had the same hyphen, and was wrong on
+a second count: `rolesList: const []`, where `buildGuestUserJson` sends
+`roles: ["guest"]`. Both corrected. The empty roles list is *kept* there, with
+a comment saying why: a real guest row's `["guest"]` would hold
+`rolesList.isEmpty` false and shut the inactive branch on its own, so the empty
+list is what makes that test about the `!isGuest` clause rather than about the
+roles.
+
+Neither fixture had to be hunted for — the tighter prefix surfaced both by
+failing, which is most of the argument for taking it.
+
+## Found and left
+
+* **`logCourseVisit` carries a guest gate Kotlin has nowhere.**
+  `activities_repository.dart:230`. Kotlin's chain is ungated at every layer —
+  `TakeCourseFragment:246` → `TakeCourseViewModel:55` →
+  `CoursesRepositoryImpl:569` → `ActivitiesRepositoryImpl:88-108` — and
+  `CourseActivityDao.getPendingUploads` does not filter guests either (the
+  port's counterpart faithfully doesn't). So a guest opening a course logs a
+  visit in Kotlin and nothing in the port. The other two `_isGuest` calls in
+  that file do have counterparts (`UserSessionManager:102`,
+  `ActivitiesRepositoryImpl:234`). Left: the file is outside this lane, and
+  which way to resolve it is a judgement (Kotlin's own upload config filters
+  guests elsewhere, so the gate may be the better behaviour).
+* **Exam submissions from a guest are not filtered.**
+  `SubmissionDao.pendingUploads` is `userId = ? AND isUpdated = 1`;
+  `UploadConfigs.kt:239-251` sets `filterGuests = true` on `ExamResults` (only
+  — the `Submissions` config at `:253` does not). Latent. Lane B's file.
+* **`RatingDao.pendingUploads` drops Kotlin's `userId IS NULL OR` disjunct.**
+  `RatingDao.kt:35` is `isUpdated = 1 AND (userId IS NULL OR userId NOT LIKE
+  'guest%')`; the port has only the second half, and in SQL a `NOT LIKE`
+  against NULL is NULL, so a null-`userId` row would be withheld. Inert today:
+  the port's `Ratings.userId` is non-nullable (`tables.dart:372`) and
+  `saveRating` requires it. Recorded because the disjunct's absence would
+  become live if that column were ever relaxed.
+* **`activities_provider.dart:119` reads `sessionProvider` without watching
+  it** — the same shape as §4.1, in a file outside this lane. Its Kotlin
+  counterpart (`recordSyncUserChallengeAction`) has no guest check at all, so
+  the gate is a port addition either way; the `.valueOrNull` is the part worth
+  fixing.
+* **`team_voices_screen.dart:48` gates posting on `membership != null`** where
+  `TeamsRepository.kt:19` is `!isGuest && (isMember || isPublic)`. The
+  `!isGuest` half is subsumed (a guest is never a member); the `|| isPublic`
+  half is missing, so a non-member cannot post on a public team.
+* **`team_members_screen.dart:203-225` omits `RequestsAdapter.kt:63-67`'s
+  `isRequester` disable.**
+
+## For the integrator
+
+* **No schema change.** Drift stays at v44. `app_database.dart` is **not
+  touched at all** (see §3 on the four query bodies). `tables.dart` is touched,
+  but only a doc comment — no column, type, converter or index — so no codegen
+  and no migration.
+* **No new `app_en.arb` keys.** Nothing user-facing changed.
+* **Outside the named lane set**, and worth a targeted look: `tables.dart`
+  (comment only), `lib/ui/dashboard/dashboard_drawer.dart`,
+  `lib/providers/activities_provider.dart`,
+  `lib/repository/activities_repository.dart`,
+  `lib/repository/voices_repository.dart` — one predicate line each, taken
+  because leaving a raw literal behind would defeat the guard test. No sibling
+  lane owns any of them.
+* Files touched: `lib/data/local/user_mapper.dart`, `lib/data/local/tables.dart`,
+  `lib/repository/{user,activities,voices}_repository.dart`,
+  `lib/providers/activities_provider.dart`,
+  `lib/ui/dashboard/{home_screen,dashboard_drawer}.dart`,
+  `lib/ui/settings/settings_screen.dart`, `lib/ui/voices/voices_screen.dart`,
+  and `test/{guest_predicate_parity_test,data/local/user_mapper_test,repository/user_repository_test,ui/home_screen_test,ui/inactive_dashboard_screen_test,ui/settings_screen_test,ui/voices_screen_test}.dart`.

--- a/flutter/PHASE_112_NOTES.md
+++ b/flutter/PHASE_112_NOTES.md
@@ -1,0 +1,3 @@
+# Phase 112 — the guest predicate: one rule, or three?
+
+Picking up Phase 107's first "Found and left" item. In progress.

--- a/flutter/lib/data/local/tables.dart
+++ b/flutter/lib/data/local/tables.dart
@@ -39,8 +39,20 @@ class Users extends Table {
   TextColumn get birthPlace => text().nullable()();
   TextColumn get userImage => text().nullable()();
 
-  /// Only ever set for guest users, which have an empty `_id` and are compared
-  /// in plaintext (see `UserRepositoryImpl.authenticateUser`).
+  /// Set for an account with **no server identity** — a member registered
+  /// offline, whose `createMember` document carries no `_id`, so
+  /// `applyJsonToUser` takes the plaintext password it typed
+  /// (`UserRepositoryImpl.kt:261`, read after `_id = newId`) and
+  /// `authenticateUser` compares it directly (`:862`).
+  ///
+  /// Not guests, which this comment used to say: `buildGuestUserJson` keys a
+  /// guest row `guest_<username>`, so its `_id` is non-empty, its password
+  /// stays null, and it is never authenticated here at all — guest re-entry
+  /// goes back through `showGuestLoginDialog`. Anything that creates a guest
+  /// row must leave this column alone and set `couchId` to
+  /// `UserMapper.guestIdPrefix + username`, or the row lands in
+  /// `UserDao.pendingSyncUsers` and gets POSTed to `_users`, which Kotlin
+  /// never does.
   TextColumn get password => text().nullable()();
 
   BoolColumn get isArchived => boolean().withDefault(const Constant(false))();

--- a/flutter/lib/data/local/user_mapper.dart
+++ b/flutter/lib/data/local/user_mapper.dart
@@ -121,8 +121,14 @@ class UserMapper {
       salt: Value(JsonUtils.getStringOrNull('salt', doc)),
       // `if (_id?.isEmpty() == true) password = getString("password", jsonDoc)`
       // — and that reads `_id` *after* `_id = newId`, so the plaintext
-      // password is taken only for a document with no `_id`, which is the
-      // guest shape. Everyone else is verified against `derived_key`/`salt`.
+      // password is taken only for a document with no `_id`. That is **not**
+      // the guest shape, which this comment used to claim: `createGuestUser`
+      // supplies `_id = "guest_<username>"` (`buildGuestUserJson`), so a guest
+      // row's password stays null and a guest is never verified by comparison.
+      // The shape it is for is a member registered **offline**, whose
+      // `createMember` document carries no `_id` at all
+      // (`UserRepositoryImpl.kt:570-579`). Everyone else is verified against
+      // `derived_key`/`salt`.
       password: couchId.isEmpty
           ? Value(JsonUtils.getStringOrNull('password', doc))
           : const Value.absent(),
@@ -276,4 +282,92 @@ class UserMapper {
   static bool isManager(UserRow user) =>
       user.userAdmin ||
       user.rolesList.any((role) => role.toLowerCase() == 'manager');
+
+  /// The prefix `createGuestUser` keys a guest row on.
+  ///
+  /// `buildGuestUserJson` (`UserRepositoryImpl.kt:146-153`) mints
+  /// `{"_id": "guest_$username", "name": username, "firstName": username,
+  /// "roles": ["guest"]}` and hands it to `saveUser(jsonDoc)`, so
+  /// `applyJsonToUser` writes **both** the row key (`id`, from `_id` because
+  /// the fresh entity's is blank) and the `_id` column as `guest_<username>`.
+  /// That equality is why Kotlin can spell the check five different ways —
+  /// `_id?.startsWith("guest_")` (`UserEntity.isGuest`, `migrateGuestUser`,
+  /// `cleanupDuplicateUsers`, `insertUsersFromSync`),
+  /// `SUBSTR(_id, 1, 6) = 'guest_'` (`UserDao.getGuestUserByName`),
+  /// `_id.orEmpty().startsWith("guest")` (`validateUsername`),
+  /// `id.startsWith("guest")` (every UI gate, `getSyncedUserByName`) and
+  /// `SUBSTR(id, 1, 5) != 'guest'` (`UserDao.getSyncedUsers`) — and still get
+  /// one answer.
+  ///
+  /// Anything a guest row is created by must use this constant, so the
+  /// equality holds here too.
+  static const String guestIdPrefix = 'guest_';
+
+  /// The guest rule, applied to one id string.
+  ///
+  /// **A deliberate deviation, recorded rather than hidden.** Six characters,
+  /// not five — and five is what the Kotlin sites this replaced use
+  /// (`user.id.startsWith("guest")` at every UI gate,
+  /// `_id.orEmpty().startsWith("guest")` in `validateUsername`). `guest_` is
+  /// what Kotlin's *authoritative* spellings use (the list above), and the
+  /// five-character ones cannot disagree with it for any id either app
+  /// writes: those are `guest_<username>` (the username is validated
+  /// non-empty), `org.couchdb.user:<name>`, and a millisecond timestamp, so
+  /// no id starts `guest` without starting `guest_`.
+  ///
+  /// The two error directions are not symmetric, which is why the tighter
+  /// rule wins. A false positive — some future id that merely begins `guest`,
+  /// a server document called `guestbook` — would gate a real member out of
+  /// features they are entitled to. A false negative needs an id that starts
+  /// `guest` and not `guest_`, which only a guest-creator that ignores this
+  /// constant could mint; that is what exporting the constant prevents.
+  static bool isGuestId(String? id) => id?.startsWith(guestIdPrefix) ?? false;
+
+  /// Whether [user] is the local guest row — the single predicate every guest
+  /// gate in the port reads.
+  ///
+  /// Both id columns are tested, and that is a deliberate widening of any one
+  /// Kotlin spelling. Kotlin's spellings are interchangeable only because of
+  /// the `id == _id` equality [guestIdPrefix] describes, and the port cannot
+  /// yet enforce that equality: **nothing in the port creates a guest row at
+  /// all** (see `PHASE_112_NOTES.md`). Reading one column would leave a future
+  /// `createGuestUser` free to satisfy this predicate at some call sites and
+  /// not others — which is exactly the state Phase 107 found and this helper
+  /// exists to make unrepresentable. On every row Kotlin can produce the two
+  /// columns agree, so the widening changes no answer; where they disagree it
+  /// errs towards "guest", which withholds a privilege rather than granting
+  /// one.
+  ///
+  /// **Not** a port of `UserEntity.isGuest()`, which is this rule *or* a
+  /// `guest` role without a `learner` role. That role clause is unported
+  /// because every gate the port has is a counterpart of Kotlin's narrower
+  /// `user.id.startsWith("guest")` family; the gates that read the role clause
+  /// (`TeamFragment:235`, `CoursesFragment:135`, `TakeCourseFragment:212`)
+  /// have no port counterpart yet. When they land, the role clause belongs
+  /// here as a second predicate beside this one — not folded into it, or the
+  /// settings and voices gates silently widen past their Kotlin counterparts.
+  static bool isGuest(UserRow user) =>
+      isGuestId(user.id) || isGuestId(user.couchId);
+
+  /// Port of `VoicesAdapter.matchesCurrentUser` (`VoicesAdapter.kt:666-669`):
+  ///
+  /// ```kotlin
+  /// if (id.isNullOrEmpty()) return false
+  /// return id == currentUser?._id || id == currentUser?.id
+  /// ```
+  ///
+  /// An **or** over both id columns, and the same rule as
+  /// `UserDao.getById`'s `WHERE id = :id OR _id = :id`, for the reason
+  /// Phase 107 established: a member registered on this device authors rows
+  /// under the locally-minted `'<millis>'` key and gains a `couchId` only once
+  /// the upload lands. Preferring one column over the other makes the
+  /// account's own earlier rows stop being its own the moment it uploads.
+  ///
+  /// The empty-or-null guard comes first in the Kotlin and is load-bearing:
+  /// without it a row with no author would match a session that has no
+  /// `couchId`.
+  static bool matchesUser(UserRow user, String? id) {
+    if (id == null || id.isEmpty) return false;
+    return id == user.couchId || id == user.id;
+  }
 }

--- a/flutter/lib/providers/activities_provider.dart
+++ b/flutter/lib/providers/activities_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../core/config/server_config.dart';
 import '../core/sync/sync_result.dart';
 import '../data/local/app_database.dart';
+import '../data/local/user_mapper.dart';
 import '../repository/activities_repository.dart';
 import 'app_providers.dart';
 import 'session_provider.dart';
@@ -116,7 +117,7 @@ class ActivityLog {
   /// swallows it — a lost row costs a checkbox, not a sync.
   Future<void> recordSyncChallengeAction() async {
     final user = ref.read(sessionProvider).valueOrNull;
-    if (user == null || user.id.startsWith('guest')) return;
+    if (user == null || UserMapper.isGuest(user)) return;
     try {
       await ref
           .read(activitiesRepositoryProvider)

--- a/flutter/lib/repository/activities_repository.dart
+++ b/flutter/lib/repository/activities_repository.dart
@@ -9,6 +9,7 @@ import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
 import '../data/local/offline_activity_mapper.dart';
+import '../data/local/user_mapper.dart';
 
 /// One resource and how many times it was opened — the pair
 /// `getMostOpenedResource` returns.
@@ -439,6 +440,5 @@ class ActivitiesRepository {
   }
 
   /// `UserSessionManager`'s test: a `guest`-prefixed id, case-sensitively.
-  static bool _isGuest(String? userId) =>
-      userId != null && userId.startsWith('guest');
+  static bool _isGuest(String? userId) => UserMapper.isGuestId(userId);
 }

--- a/flutter/lib/repository/user_repository.dart
+++ b/flutter/lib/repository/user_repository.dart
@@ -175,9 +175,21 @@ class UserRepository {
 
   /// Port of `UserRepositoryImpl.authenticateUser`.
   ///
-  /// Guest accounts have an empty `_id` and store their password in plaintext;
-  /// everyone else is checked with the same PBKDF2 comparison as the online
-  /// path.
+  /// The branch is `if (it._id?.isEmpty() == true)`
+  /// (`UserRepositoryImpl.kt:862`), and despite how it reads it is **not** a
+  /// guest check — a guest row's `_id` is `guest_<username>`, not empty
+  /// (`buildGuestUserJson`), so a guest takes the *other* branch and fails
+  /// against a null `derived_key`. That is correct: guest re-entry never comes
+  /// through here, it goes back through `showGuestLoginDialog`, which
+  /// recognises the stored row and re-offers it without a password
+  /// (`GuestLoginExtensions.kt:64`).
+  ///
+  /// What the branch actually selects is an account with **no server
+  /// identity** — a member registered offline, whose document had no `_id`, so
+  /// `applyJsonToUser` wrote `""` and the plaintext password it typed. The
+  /// port stores that absent id as `null` rather than `''`, so both are
+  /// tested. Everyone with a server identity is checked with the same PBKDF2
+  /// comparison as the online path.
   Future<LoginResult> loginOffline({
     required String username,
     required String password,
@@ -192,8 +204,8 @@ class UserRepository {
       return const LoginFailure(LoginFailureReason.userNotFound);
     }
 
-    final isGuest = user.couchId == null || user.couchId!.isEmpty;
-    final authenticated = isGuest
+    final hasNoServerIdentity = user.couchId == null || user.couchId!.isEmpty;
+    final authenticated = hasNoServerIdentity
         ? user.password == password
         : AndroidDecrypter.androidDecrypter(
             username,
@@ -242,8 +254,12 @@ class UserRepository {
     }
 
     final existing = await _userDao.getByName(username);
-    final taken =
-        existing != null && !(existing.couchId?.startsWith('guest') ?? false);
+    // Kotlin reads `_id.orEmpty().startsWith("guest")` here
+    // (`UserRepositoryImpl.kt:832`) — a guest may re-take their own name,
+    // because becoming a member *reuses* that row (`migrateGuestUser`) rather
+    // than adding one. `UserMapper.isGuest` is the same rule read off both id
+    // columns; see its doc comment for why both.
+    final taken = existing != null && !UserMapper.isGuest(existing);
     return taken ? messages.taken : null;
   }
 

--- a/flutter/lib/repository/voices_repository.dart
+++ b/flutter/lib/repository/voices_repository.dart
@@ -11,6 +11,7 @@ import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
 import '../data/local/news_mapper.dart';
+import '../data/local/user_mapper.dart';
 
 /// Port of `repository/VoicesRepositoryImpl.kt` — the voices/discussion feed.
 class VoicesRepository {
@@ -534,7 +535,7 @@ class VoicesRepository {
   Future<List<NewsRow>> pendingUploads() async {
     final rows = await _dao.getAll();
     return rows
-        .where((row) => !(row.userId ?? '').startsWith('guest'))
+        .where((row) => !UserMapper.isGuestId(row.userId))
         .where((row) => row.docId == null || row.docId!.isEmpty || row.isEdited)
         .toList(growable: false);
   }

--- a/flutter/lib/ui/dashboard/dashboard_drawer.dart
+++ b/flutter/lib/ui/dashboard/dashboard_drawer.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../data/local/app_database.dart';
+import '../../data/local/user_mapper.dart';
 import '../../l10n/app_localizations.dart';
 import '../../providers/session_provider.dart';
 import '../components/guest_dialog.dart';
@@ -20,7 +21,7 @@ class DashboardDrawer extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final session = ref.watch(sessionProvider).valueOrNull;
-    final isGuest = session?.id.startsWith('guest') ?? false;
+    final isGuest = session != null && UserMapper.isGuest(session);
 
     return NavigationDrawer(
       children: [

--- a/flutter/lib/ui/dashboard/home_screen.dart
+++ b/flutter/lib/ui/dashboard/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../data/local/app_database.dart';
+import '../../data/local/user_mapper.dart';
 import '../../l10n/app_localizations.dart';
 import '../../providers/app_providers.dart';
 import '../../providers/challenge_provider.dart';
@@ -78,7 +79,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         // account published to its `userdb-*` database. The Kotlin gates on
         // `TextUtils.isEmpty(user.key)`; the notifier's SyncRunning check is
         // the `syncJob?.isActive` re-entrancy guard.
-        if (!user.id.startsWith('guest') && (user.key?.isEmpty ?? true)) {
+        if (!UserMapper.isGuest(user) && (user.key?.isEmpty ?? true)) {
           ref
               .read(healthKeyIvSyncProvider.notifier)
               .sync(user.rolesList.join(','));
@@ -146,7 +147,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final evaluator = ref.read(challengeEvaluatorProvider);
     final data = await evaluator.evaluate(
       userId: session.id,
-      isGuest: session.id.startsWith('guest'),
+      isGuest: UserMapper.isGuest(session),
       serverUrl: config.serverUrl,
     );
     if (data == null || !mounted) return;
@@ -192,7 +193,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     _surveyCheckDone = true;
 
     // Guests never see the dialog, exactly as the Kotlin guards it.
-    if (session.id.startsWith('guest')) return;
+    if (UserMapper.isGuest(session)) return;
 
     final prefs = ref.read(planetPrefsProvider);
     final now = DateTime.now().millisecondsSinceEpoch;
@@ -342,7 +343,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               ? 'Planet ${prefs.communityName}'
               : l10n.appTitle);
 
-    final isGuest = session != null && session.id.startsWith('guest');
+    final isGuest = session != null && UserMapper.isGuest(session);
 
     // `DashboardActivity.handleGuestAccess`: a logged-in user with no roles
     // and no admin flag sees the inactive dashboard instead of the full

--- a/flutter/lib/ui/settings/settings_screen.dart
+++ b/flutter/lib/ui/settings/settings_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../data/local/app_database.dart';
+import '../../data/local/user_mapper.dart';
 import '../../l10n/app_localizations.dart';
 import '../../providers/app_providers.dart';
 import '../../providers/session_provider.dart';
@@ -27,6 +29,14 @@ class SettingsScreen extends ConsumerWidget {
     final versionInfo = ref.watch(appVersionInfoProvider).valueOrNull;
     final textScale = ref.watch(textScaleProvider);
     final clearState = ref.watch(clearDataProvider);
+    // Watched, not read. Both guest gates below used to call
+    // `ref.read(sessionProvider).valueOrNull` from inside their `onTap`, and
+    // this screen watches `sessionProvider` nowhere else — so the session was
+    // `null` until something outside the screen resolved it, the gate fell
+    // through, and a guest reached the reset-app confirmation. Latent in the
+    // shipping app only because the router holds a `ref.listen` on the same
+    // provider; the fifth instance of that shape in this port.
+    final session = ref.watch(sessionProvider).valueOrNull;
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.settings)),
@@ -171,8 +181,7 @@ class SettingsScreen extends ConsumerWidget {
             // Guest-gated, matching `SettingsActivity`: a guest is offered
             // membership instead of the storage tools.
             onTap: () {
-              final session = ref.read(sessionProvider).valueOrNull;
-              if (session != null && session.id.startsWith('guest')) {
+              if (session != null && UserMapper.isGuest(session)) {
                 showGuestDialog(context);
                 return;
               }
@@ -198,7 +207,7 @@ class SettingsScreen extends ConsumerWidget {
             title: Text(l10n.resetApp),
             subtitle: Text(l10n.clearAllDataConfirm),
             enabled: !clearState.isLoading,
-            onTap: () => _confirmClearData(context, l10n, ref),
+            onTap: () => _confirmClearData(context, l10n, ref, session),
           ),
         ],
       ),
@@ -329,9 +338,9 @@ Future<void> _confirmClearData(
   BuildContext context,
   AppLocalizations l10n,
   WidgetRef ref,
+  UserRow? session,
 ) async {
-  final session = ref.read(sessionProvider).valueOrNull;
-  if (session != null && session.id.startsWith('guest')) {
+  if (session != null && UserMapper.isGuest(session)) {
     showGuestDialog(context);
     return;
   }

--- a/flutter/lib/ui/voices/voices_screen.dart
+++ b/flutter/lib/ui/voices/voices_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../core/utils/json_utils.dart';
 import '../../data/local/app_database.dart';
+import '../../data/local/user_mapper.dart';
 import '../../l10n/app_localizations.dart';
 import '../../providers/app_providers.dart';
 import '../../providers/session_provider.dart';
@@ -110,11 +111,13 @@ class VoiceCard extends ConsumerWidget {
 
     // The Kotlin gates run on `VoicesAdapter.canEdit/canDelete/canShare`; the
     // moderator and shared-by widenings it allows are not ported, so an author
-    // check is the honest subset.
-    final isAuthor = user != null && row.userId == (user.couchId ?? user.id);
+    // check is the honest subset. The check itself is
+    // `matchesCurrentUser` — an *or* over both id columns, not a preference
+    // between them; see `UserMapper.matchesUser`.
+    final isAuthor = user != null && UserMapper.matchesUser(user, row.userId);
     final canShare =
         user != null &&
-        !user.id.startsWith('guest') &&
+        !UserMapper.isGuest(user) &&
         !VoicesRepository.isCommunityNews(row);
 
     return Card(
@@ -189,7 +192,7 @@ class VoiceCard extends ConsumerWidget {
                   ],
                 ),
               ],
-              if (user != null && !user.id.startsWith('guest'))
+              if (user != null && !UserMapper.isGuest(user))
                 _ReactionRow(row: row, userId: user.id),
               const SizedBox(height: 4),
               Align(

--- a/flutter/test/data/local/user_mapper_test.dart
+++ b/flutter/test/data/local/user_mapper_test.dart
@@ -471,4 +471,118 @@ void main() {
       expect(UserMapper.docIsManager({'name': 'ada'}), isFalse);
     });
   });
+
+  /// Phase 112. `UserEntity.isGuest()`, `UserDao.getGuestUserByName`,
+  /// `validateUsername` and every Kotlin UI gate spell this check differently
+  /// and still agree, because `createGuestUser` writes the same string to both
+  /// id columns. The port had three of those spellings and no path that
+  /// creates a guest row, so nothing held them together.
+  group('UserMapper.isGuest', () {
+    UserRow user({
+      String id = '1700000000000',
+      String? couchId,
+      List<String> roles = const ['learner'],
+    }) => UserRow(
+      id: id,
+      couchId: couchId,
+      name: 'ada',
+      rolesList: roles,
+      userAdmin: false,
+      joinDate: 0,
+      isArchived: false,
+      isUpdated: false,
+    );
+
+    /// The row `createGuestUser('ada')` actually produces.
+    test('the row createGuestUser writes reads as a guest', () {
+      // Built through the production mapper from Kotlin's own
+      // `buildGuestUserJson` output, so the shape is not asserted by hand.
+      final companion = UserMapper.fromDoc({
+        '_id': 'guest_ada',
+        'name': 'ada',
+        'firstName': 'ada',
+        'roles': ['guest'],
+      });
+      expect(companion.id.value, 'guest_ada');
+      expect(companion.couchId.value, 'guest_ada');
+      expect(
+        UserMapper.isGuest(user(id: 'guest_ada', couchId: 'guest_ada')),
+        isTrue,
+      );
+    });
+
+    test('a member is not a guest by either column', () {
+      expect(
+        UserMapper.isGuest(user(couchId: 'org.couchdb.user:ada')),
+        isFalse,
+      );
+      // A member registered on this device, before their upload lands.
+      expect(UserMapper.isGuest(user()), isFalse);
+    });
+
+    /// This is the row the three pre-unification spellings disagreed on, and
+    /// the port's *own* code produces it: `_cacheUserDoc` resolves the row a
+    /// document belongs to and `fromDoc` keeps that row's `id`, so caching a
+    /// guest document against a member registered offline on this device
+    /// leaves the guest prefix in `_id` alone.
+    test('a row with the prefix in only one column still reads as a guest', () {
+      final companion = UserMapper.fromDoc({
+        '_id': 'guest_ada',
+        'name': 'ada',
+        'roles': ['guest'],
+      }, existing: user(id: '1700000000000'));
+      // Produced, not asserted: the key stays local, the couch id is the
+      // guest one.
+      expect(companion.id.value, '1700000000000');
+      expect(companion.couchId.value, 'guest_ada');
+
+      // The two spellings this phase replaced would split on it — the screens
+      // read `id` ("not a guest", so reset-app and voice posting are open),
+      // `validateUsername` reads `_id` ("a guest", so the name is
+      // re-takeable). One row, two answers.
+      const row = ('1700000000000', 'guest_ada');
+      expect(row.$1.startsWith('guest'), isFalse);
+      expect(row.$2.startsWith('guest'), isTrue);
+
+      // The unified rule gives one answer, and it is the safe one: a
+      // privilege withheld, never granted.
+      expect(UserMapper.isGuest(user(id: row.$1, couchId: row.$2)), isTrue);
+      expect(UserMapper.isGuest(user(id: 'guest_ada', couchId: null)), isTrue);
+    });
+
+    /// Six characters, not five. Every id either app writes is
+    /// `guest_<username>`, `org.couchdb.user:<name>` or a millisecond
+    /// timestamp, so this narrowing changes no producible row — but it does
+    /// mean a fixture has to spell the prefix the way `createGuestUser` does.
+    test('the prefix is guest_, not guest', () {
+      expect(UserMapper.guestIdPrefix, 'guest_');
+      expect(UserMapper.isGuestId('guest_ada'), isTrue);
+      expect(UserMapper.isGuestId('guest-ada'), isFalse);
+      expect(UserMapper.isGuestId('guestbook'), isFalse);
+      expect(UserMapper.isGuestId(null), isFalse);
+      expect(UserMapper.isGuestId(''), isFalse);
+    });
+
+    /// The half of `UserEntity.isGuest()` this helper deliberately does not
+    /// carry. Kotlin returns true for a `guest` role without a `learner` role
+    /// (`UserEntity.kt:177-181`), and the gates that read it — `TeamFragment`,
+    /// `CoursesFragment`, `TakeCourseFragment` — have no port counterpart, so
+    /// porting the clause here would widen the settings and voices gates past
+    /// their Kotlin originals. Pinned so the omission is visible rather than
+    /// forgotten.
+    test('a role-only guest is not caught: isGuest() role clause unported', () {
+      final roleOnly = user(
+        id: 'org.couchdb.user:ada',
+        couchId: 'org.couchdb.user:ada',
+        roles: const ['guest'],
+      );
+      expect(UserMapper.isGuest(roleOnly), isFalse);
+      // What Kotlin's `isGuest()` would answer for the same row.
+      expect(
+        roleOnly.rolesList.any((r) => r.toLowerCase() == 'guest') &&
+            !roleOnly.rolesList.any((r) => r.toLowerCase() == 'learner'),
+        isTrue,
+      );
+    });
+  });
 }

--- a/flutter/test/guest_predicate_parity_test.dart
+++ b/flutter/test/guest_predicate_parity_test.dart
@@ -23,13 +23,20 @@ import 'package:flutter_test/flutter_test.dart';
 /// `UserMapper.isGuest(row)` for a `UserRow`, or `UserMapper.isGuestId(id)`
 /// for a bare id string.
 void main() {
-  test('the guest prefix is written down exactly once in lib/', () {
+  test('the guest prefix is written down exactly once in lib/', () async {
     // `UserMapper` is the one definition, so the literal lives there.
     const owner = 'lib/data/local/user_mapper.dart';
     final pattern = RegExp(r'''["']guest''');
 
     final offenders = <String>[];
-    for (final entity in Directory('lib').listSync(recursive: true)) {
+    // Async reads with a cheap whole-file pre-filter, rather than
+    // `readAsLinesSync` over ~400 files: `flutter test` runs each test file in
+    // its own isolate concurrently, and one isolate blocking on several
+    // hundred synchronous reads starves the others. At least one neighbouring
+    // test waits on a real `dart:io` write against a hand-tuned round count
+    // (`take_exam_screen_test`'s verification photo), so this file makes a
+    // point of not competing with it.
+    await for (final entity in Directory('lib').list(recursive: true)) {
       if (entity is! File || !entity.path.endsWith('.dart')) continue;
       // Generated sources are gitignored and rebuilt; they carry no rules.
       if (entity.path.endsWith('.g.dart')) continue;
@@ -45,7 +52,10 @@ void main() {
       // `UserMapper.isGuestId`.
       if (entity.path == 'lib/data/local/app_database.dart') continue;
 
-      final lines = entity.readAsLinesSync();
+      final text = await entity.readAsString();
+      if (!pattern.hasMatch(text)) continue;
+
+      final lines = text.split('\n');
       for (var i = 0; i < lines.length; i++) {
         final line = lines[i];
         // Comments and doc comments may quote the Kotlin freely.

--- a/flutter/test/guest_predicate_parity_test.dart
+++ b/flutter/test/guest_predicate_parity_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins Phase 112's unification: **one** guest predicate, in one place.
+///
+/// **Why this exists.** Kotlin spells "is this user a guest?" five ways —
+/// `_id?.startsWith("guest_")` (`UserEntity.isGuest`, `migrateGuestUser`,
+/// `cleanupDuplicateUsers`, `insertUsersFromSync`),
+/// `SUBSTR(_id, 1, 6) = 'guest_'` (`UserDao.getGuestUserByName`),
+/// `_id.orEmpty().startsWith("guest")` (`validateUsername`),
+/// `id.startsWith("guest")` (every UI gate, `getSyncedUserByName`) and
+/// `SUBSTR(id, 1, 5) != 'guest'` (`UserDao.getSyncedUsers`) — and they always
+/// agree, because `createGuestUser` writes the same `guest_<username>` string
+/// to both id columns (`buildGuestUserJson` -> `applyJsonToUser`).
+///
+/// The port inherited three of those spellings across unrelated files and has
+/// **no path that creates a guest row**, so nothing enforced the equality that
+/// makes them interchangeable. Phase 107 found the divergence; this test stops
+/// a fourth spelling reappearing, which a code review of one file cannot.
+///
+/// If this fails: do not add another `startsWith('guest…')`. Call
+/// `UserMapper.isGuest(row)` for a `UserRow`, or `UserMapper.isGuestId(id)`
+/// for a bare id string.
+void main() {
+  test('the guest prefix is written down exactly once in lib/', () {
+    // `UserMapper` is the one definition, so the literal lives there.
+    const owner = 'lib/data/local/user_mapper.dart';
+    final pattern = RegExp(r'''["']guest''');
+
+    final offenders = <String>[];
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      // Generated sources are gitignored and rebuilt; they carry no rules.
+      if (entity.path.endsWith('.g.dart')) continue;
+      if (entity.path == owner) continue;
+      // Drift DAO query bodies are exempt, and deliberately so. Three Kotlin
+      // DAOs spell the rule in SQL as `NOT LIKE 'guest%'`
+      // (`AchievementDao.kt:19`, `CourseProgressDao.kt:28`,
+      // `RatingDao.kt:35`) and the port's four `like('guest%')` predicates are
+      // faithful transcriptions of that text. A SQL `WHERE` cannot call a Dart
+      // predicate, so pinning those to the Kotlin query text is the closest
+      // thing to one source of truth available there. They cannot disagree
+      // with `guestIdPrefix` on any id either app writes — see
+      // `UserMapper.isGuestId`.
+      if (entity.path == 'lib/data/local/app_database.dart') continue;
+
+      final lines = entity.readAsLinesSync();
+      for (var i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        // Comments and doc comments may quote the Kotlin freely.
+        final code = line.trimLeft();
+        if (code.startsWith('//') || code.startsWith('///')) continue;
+        if (pattern.hasMatch(line)) {
+          offenders.add('${entity.path}:${i + 1}: ${line.trim()}');
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'A guest id prefix appears outside $owner. Use '
+          'UserMapper.isGuest / UserMapper.isGuestId instead:\n'
+          '${offenders.join('\n')}',
+    );
+  });
+}

--- a/flutter/test/repository/user_repository_test.dart
+++ b/flutter/test/repository/user_repository_test.dart
@@ -326,22 +326,53 @@ void main() {
       expect((result as LoginFailure).reason, LoginFailureReason.userNotFound);
     });
 
-    /// Guest accounts have an empty `_id` and a plaintext password.
-    test('authenticates a guest against the plaintext password', () async {
+    /// This case was called "authenticates a guest" and seeded
+    /// `id: 'guest-1'` with no `couchId` — a row `createGuestUser` cannot
+    /// produce, because it writes `guest_<username>` to *both* id columns. The
+    /// branch it exercises is `if (it._id?.isEmpty() == true)`
+    /// (`UserRepositoryImpl.kt:862`), which selects an account with no server
+    /// identity, not a guest. Renamed and re-seeded to the row that branch is
+    /// actually for; the guest row gets its own case below.
+    test('authenticates an offline-registered member against the plaintext '
+        'password', () async {
       await db.userDao.upsert(
         UsersCompanion.insert(
-          id: 'guest-1',
-          name: const Value('guest'),
+          id: '1700000000000',
+          name: const Value('ada'),
           password: const Value('letmein'),
         ),
       );
 
       expect(
-        await repository.loginOffline(username: 'guest', password: 'letmein'),
+        await repository.loginOffline(username: 'ada', password: 'letmein'),
         isA<LoginSuccess>(),
       );
       expect(
-        await repository.loginOffline(username: 'guest', password: 'nope'),
+        await repository.loginOffline(username: 'ada', password: 'nope'),
+        isA<LoginFailure>(),
+      );
+    });
+
+    /// And the row that *is* a guest does not take that branch, matching
+    /// Kotlin. A guest row carries no password — `applyJsonToUser` reads one
+    /// only for a document with no `_id`, and `buildGuestUserJson` supplies
+    /// `guest_<username>` — so were the plaintext branch taken, `null ==
+    /// null` would sign a guest in on an empty password.
+    test('a guest row is not authenticated by the plaintext branch', () async {
+      await db.userDao.upsert(
+        UsersCompanion.insert(
+          id: 'guest_ada',
+          couchId: const Value('guest_ada'),
+          name: const Value('ada'),
+        ),
+      );
+
+      expect(
+        await repository.loginOffline(username: 'ada', password: ''),
+        isA<LoginFailure>(),
+      );
+      expect(
+        await repository.loginOffline(username: 'ada', password: 'anything'),
         isA<LoginFailure>(),
       );
     });

--- a/flutter/test/ui/home_screen_test.dart
+++ b/flutter/test/ui/home_screen_test.dart
@@ -673,7 +673,13 @@ void main() {
         wrapScreen(
           const HomeScreen(),
           overrides: await homeOverrides(
-            user: _user('guest-ada'),
+            // `guest_ada`, not `guest-ada`. This fixture used to carry a
+            // hyphen while the three other guest fixtures in this file used
+            // the underscore, and the pre-Phase-112 five-character
+            // `startsWith('guest')` could not tell them apart — so a row
+            // `createGuestUser` can never write was standing in for a guest.
+            // `UserMapper.guestIdPrefix` is `guest_`.
+            user: _user('guest_ada'),
             keyIvSync: keyIvSync,
           ),
         ),

--- a/flutter/test/ui/inactive_dashboard_screen_test.dart
+++ b/flutter/test/ui/inactive_dashboard_screen_test.dart
@@ -162,8 +162,19 @@ void main() {
   testWidgets('guest user sees the full dashboard, not inactive', (
     tester,
   ) async {
+    // `guest_123`, not `guest-123`. The hyphen spelled the prefix a fourth
+    // way and the pre-Phase-112 five-character `startsWith('guest')` could
+    // not tell it from `UserMapper.guestIdPrefix`, so this fixture was a row
+    // `createGuestUser` can never write.
+    //
+    // `rolesList` stays empty on purpose, and that too is not a real guest
+    // row: `buildGuestUserJson` sends `roles: ["guest"]`, which would keep
+    // `rolesList.isEmpty` false and the inactive branch shut on its own. The
+    // empty list is what makes this test about the `!isGuest` clause rather
+    // than about the roles.
     final user = UserRow(
-      id: 'guest-123',
+      id: 'guest_123',
+      couchId: 'guest_123',
       name: 'guest',
       rolesList: const [],
       userAdmin: false,

--- a/flutter/test/ui/settings_screen_test.dart
+++ b/flutter/test/ui/settings_screen_test.dart
@@ -5,7 +5,9 @@ import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/core/config/server_config.dart';
 import 'package:myplanet/core/background/background_scheduler.dart';
 import 'package:myplanet/core/prefs/planet_prefs.dart';
+import 'package:myplanet/data/local/app_database.dart';
 import 'package:myplanet/providers/app_providers.dart';
+import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/ui/settings/settings_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -203,6 +205,146 @@ void main() {
     expect(find.text('Version 0.62.98'), findsOneWidget);
     expect(find.text('Build 6298'), findsOneWidget);
   });
+
+  /// `SettingsActivity.SettingFragment` gates the destructive and the storage
+  /// actions on `user?.id?.startsWith("guest") == true` and offers
+  /// `DialogUtils.guestDialog` instead (`SettingsActivity.kt:221`, `:249`,
+  /// `:286`). Neither gate had a test, and both read
+  /// `ref.read(sessionProvider).valueOrNull` on a screen that never watches
+  /// `sessionProvider` — so the session resolved to `null`, the gate fell
+  /// through, and a guest reached the only destructive action in the app.
+  group('guest gates', () {
+    testWidgets('a guest tapping Reset app is offered membership', (
+      tester,
+    ) async {
+      final prefs = await _prefs();
+      await tester.pumpWidget(
+        wrapScreen(
+          const SettingsScreen(),
+          overrides: [
+            planetPrefsProvider.overrideWithValue(prefs),
+            sessionProvider.overrideWith(
+              () => _TestSessionNotifier(_guestRow()),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.text('Reset app'),
+        300,
+        scrollable: _settingsScrollable(),
+      );
+      await tester.tap(find.text('Reset app'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'You are currently a guest user. To access this feature, become a member.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Are you sure?'), findsNothing);
+    });
+
+    testWidgets('a guest tapping Storage Management is offered membership', (
+      tester,
+    ) async {
+      final prefs = await _prefs();
+      await tester.pumpWidget(
+        wrapScreen(
+          const SettingsScreen(),
+          overrides: [
+            planetPrefsProvider.overrideWithValue(prefs),
+            sessionProvider.overrideWith(
+              () => _TestSessionNotifier(_guestRow()),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.text('Storage Management'),
+        300,
+        scrollable: _settingsScrollable(),
+      );
+      await tester.tap(find.text('Storage Management'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'You are currently a guest user. To access this feature, become a member.',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    /// The other half of the gate: a member still reaches the confirmation.
+    testWidgets('a member tapping Reset app gets the confirmation', (
+      tester,
+    ) async {
+      final prefs = await _prefs();
+      await tester.pumpWidget(
+        wrapScreen(
+          const SettingsScreen(),
+          overrides: [
+            planetPrefsProvider.overrideWithValue(prefs),
+            sessionProvider.overrideWith(
+              () => _TestSessionNotifier(_memberRow()),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.text('Reset app'),
+        300,
+        scrollable: _settingsScrollable(),
+      );
+      await tester.tap(find.text('Reset app'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Are you sure?'), findsOneWidget);
+    });
+  });
+}
+
+/// The row `createGuestUser('ada')` produces: `buildGuestUserJson`
+/// (`UserRepositoryImpl.kt:146-153`) keys the document `guest_ada`, and
+/// `applyJsonToUser` writes that to both the row key and the `_id` column.
+UserRow _guestRow() => UserRow(
+  id: 'guest_ada',
+  couchId: 'guest_ada',
+  name: 'ada',
+  rolesList: const ['guest'],
+  userAdmin: false,
+  joinDate: 0,
+  isArchived: false,
+  isUpdated: false,
+);
+
+/// A member registered on this device whose upload has landed.
+UserRow _memberRow() => UserRow(
+  id: '1699999999999',
+  couchId: 'org.couchdb.user:ada',
+  name: 'ada',
+  rolesList: const ['learner'],
+  userAdmin: false,
+  joinDate: 0,
+  isArchived: false,
+  isUpdated: false,
+);
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+
+  final UserRow? user;
+
+  @override
+  Future<UserRow?> build() async => user;
 }
 
 Finder _settingsScrollable() => find

--- a/flutter/test/ui/voices_screen_test.dart
+++ b/flutter/test/ui/voices_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/providers/session_provider.dart';
 import 'package:myplanet/providers/voices_provider.dart';
 import 'package:myplanet/ui/voices/voices_screen.dart';
 
@@ -11,6 +12,7 @@ void main() {
     required String id,
     String? message,
     String? userName,
+    String? userId,
     String? docId,
     bool isEdited = false,
     List<String> labels = const [],
@@ -19,6 +21,7 @@ void main() {
     docId: docId,
     message: message,
     userName: userName,
+    userId: userId,
     time: 1735689600000,
     updatedDate: 0,
     imageUrls: const [],
@@ -92,4 +95,102 @@ void main() {
 
     expect(find.text('No voices yet'), findsOneWidget);
   });
+
+  /// `VoicesAdapter.matchesCurrentUser` (`VoicesAdapter.kt:666-669`) is
+  /// `id == currentUser?._id || id == currentUser?.id` — an **or** over both
+  /// id columns, the same rule as `UserDao.getById`'s
+  /// `WHERE id = :id OR _id = :id`, and for the same reason Phase 107
+  /// established: a member registered on this device authors rows under the
+  /// locally-minted `'<millis>'` key and gains a `couchId` only when the
+  /// upload lands. The port preferred one column over the other, so the
+  /// account's own earlier posts stopped being its own the moment it uploaded.
+  group('author actions', () {
+    UserRow user({required String id, String? couchId}) => UserRow(
+      id: id,
+      couchId: couchId,
+      name: 'ada',
+      rolesList: const ['learner'],
+      userAdmin: false,
+      joinDate: 0,
+      isArchived: false,
+      isUpdated: false,
+    );
+
+    Future<void> pumpFeed(
+      WidgetTester tester,
+      UserRow session,
+      String? author,
+    ) async {
+      await tester.pumpWidget(
+        wrapScreen(
+          const VoicesScreen(),
+          overrides: [
+            sessionProvider.overrideWith(() => _TestSessionNotifier(session)),
+            communityFeedProvider.overrideWith(
+              (ref) => Stream.value([
+                post(id: 'n1', message: 'Water pump is fixed', userId: author),
+              ]),
+            ),
+            voiceReplyCountProvider('n1').overrideWith((ref) async => 0),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('a post keyed on the local id is still the author\'s once '
+        'the account has uploaded', (tester) async {
+      // The row was authored before the upload landed, so it carries the
+      // local key; the session now also carries the server id.
+      await pumpFeed(
+        tester,
+        user(id: '1700000000000', couchId: 'org.couchdb.user:ada'),
+        '1700000000000',
+      );
+
+      expect(find.byTooltip('Edit'), findsOneWidget);
+    });
+
+    testWidgets('a post keyed on the couch id is the author\'s too', (
+      tester,
+    ) async {
+      await pumpFeed(
+        tester,
+        user(id: '1700000000000', couchId: 'org.couchdb.user:ada'),
+        'org.couchdb.user:ada',
+      );
+
+      expect(find.byTooltip('Edit'), findsOneWidget);
+    });
+
+    testWidgets('someone else\'s post offers no author actions', (
+      tester,
+    ) async {
+      await pumpFeed(
+        tester,
+        user(id: '1700000000000', couchId: 'org.couchdb.user:ada'),
+        'org.couchdb.user:zoe',
+      );
+
+      expect(find.byTooltip('Edit'), findsNothing);
+    });
+
+    /// `matchesCurrentUser` returns false for a null or empty id before it
+    /// compares anything (`:667`) — otherwise a row with no author would
+    /// match a session with no couch id.
+    testWidgets('a post with no author id matches nobody', (tester) async {
+      await pumpFeed(tester, user(id: '1700000000000'), null);
+
+      expect(find.byTooltip('Edit'), findsNothing);
+    });
+  });
+}
+
+class _TestSessionNotifier extends SessionNotifier {
+  _TestSessionNotifier(this.user);
+
+  final UserRow? user;
+
+  @override
+  Future<UserRow?> build() async => user;
 }


### PR DESCRIPTION
Lane D of the Phase 112 four-lane round. Picks up Phase 107's first *Found and left* item.

Full write-up in `flutter/PHASE_112_NOTES.md`.

## The headline is a correction

Phase 107 called the port's guest check "three spellings of one predicate" and read that as a port defect. A `parity-auditor` pass at `effort: max` says the framing is **partly a misreading**: Kotlin has **eleven** spellings, and each port site faithfully transcribes the particular Kotlin spelling at the site it ports — including both sites the phase brief flagged as suspect. `validateUsername` reading `couchId` was correct; it ports `_id.orEmpty().startsWith("guest")` (`UserRepositoryImpl.kt:832`), not a drift from the UI's `id.startsWith("guest")`.

Kotlin's spellings agree because `createGuestUser` writes `id == _id == "guest_<username>"` — an equality the **port cannot enforce, because nothing in the port creates a guest row at all.** That is what left the spellings unheld-together, and it is the real reason to unify.

Kotlin's one genuine internal disagreement is `UserEntity.isGuest()`'s role clause (a `guest` role without a `learner` role), and it *is* reachable: `TransactionSyncManager.kt:230` walks `tablet_users` into `insertUsersFromSync` unfiltered, so a `roles:["guest"]` document makes Kotlin contradict itself inside a single fragment (`ResourcesFragment:487` hides the checkboxes while `:534` runs `addToMyList`). The port has no `tablet_users` walk, so the clause is deliberately **not** ported — and deliberately not folded into the id rule, which would widen the settings and voices gates past their originals. Pinned by a test named after the omission.

## Item 2, answered with evidence

**No — the port has no guest login and this stays dormant.** But the finding underneath is bigger than a login button: the port is missing **15+ of Kotlin's guest gates**. `lib/ui/teams/`, `courses/`, `resources/`, `surveys/` and `user/` contain no guest check of any kind. The notes carry an ordered 6-item target list with Kotlin line references, so the next lane has a target rather than a mood. **Item 3** (`buildUserFromJson`'s guest-adoption branch) stays deferred: there is nothing to adopt.

## The unification

`UserMapper.guestIdPrefix` / `isGuestId(String?)` / `isGuest(UserRow)`. 13 call sites moved; **no raw guest literal remains in `lib/`**, enforced by a source-scanning test (verified against a planted violation). Two deviations, documented in the code rather than buried: five characters to six (the error directions are not symmetric), and one id column to two (Kotlin's interchangeability rests on that unenforceable equality).

The four `like('guest%')` predicates in `app_database.dart` are left alone — they are verbatim transcriptions of Kotlin's own SQL (`AchievementDao.kt:19`, `CourseProgressDao.kt:28`, `RatingDao.kt:35`) and a SQL `WHERE` cannot call a Dart predicate. The guard test exempts that file and says why.

## Five defects, each demonstrated failing first

1. **Both settings guest gates read `sessionProvider` without ever watching it** — so the session was null, the gate fell through, and a guest reached `clearAllData()`, the only destructive action in the app. Neither gate had ever had a test. The fifth instance of that shape in this port.
2. **An author lost their own voices the moment their account uploaded** — `row.userId == (user.couchId ?? user.id)` is a *preference*, where `VoicesAdapter.matchesCurrentUser` is an **or** over both id columns.
3. **`tables.dart`, `user_mapper` and `user_repository` all stated that guests have an empty `_id`.** They do not. That comment is the specification the next lane would build `createGuestUser` against, and following it would land the row in `pendingSyncUsers` and POST a guest to `_users`, which Kotlin never does.
4. **`loginOffline`'s `isGuest` local was true for exactly the rows that are not guests**, and its test had absorbed the same error.
5. **Two fixtures spelled the prefix a fourth way** (`guest-ada`, `guest-123`); the tighter prefix surfaced both by failing.

## Verification

`dart format --set-exit-if-changed` clean, `flutter analyze` clean, **1754/1754 tests pass**. No schema change (Drift stays at v44) and no new `app_en.arb` keys.

Touched outside the named lane set, and worth a targeted look — one predicate line each, taken because a leftover literal would defeat the guard test, and no sibling lane owns any of them: `tables.dart` (doc comment only), `lib/ui/dashboard/dashboard_drawer.dart`, `lib/providers/activities_provider.dart`, `lib/repository/activities_repository.dart`, `lib/repository/voices_repository.dart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GeUX4tWXmqyPa55y4maMN