### PR TITLE
all: smoother file utils url resolving (fixes #16651)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.ole.planet.myplanet"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6930
-        versionName = "0.69.30"
+        versionCode = 6931
+        versionName = "0.69.31"
         ndkVersion = '26.3.11579264'
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/org/ole/planet/myplanet/base/BaseVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/base/BaseVoicesFragment.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -36,7 +35,6 @@ import org.ole.planet.myplanet.ui.voices.VoicesActions
 import org.ole.planet.myplanet.ui.voices.VoicesAdapter
 import org.ole.planet.myplanet.utils.FileUtils
 import org.ole.planet.myplanet.utils.FileUtils.getFileNameFromUrl
-import org.ole.planet.myplanet.utils.FileUtils.getRealPathFromURI
 import org.ole.planet.myplanet.utils.JsonUtils
 
 abstract class BaseVoicesFragment : BaseContainerFragment(), OnNewsItemClickListener {
@@ -143,10 +141,7 @@ abstract class BaseVoicesFragment : BaseContainerFragment(), OnNewsItemClickList
     private fun processImageUri(uri: Uri?, resultCode: Int) {
         if (uri == null) return
 
-        var path: String? = getRealPathFromURI(requireActivity(), uri)
-        if (TextUtils.isEmpty(path)) {
-            path = FileUtils.getPathFromURI(requireActivity(), uri)
-        }
+        val path: String? = FileUtils.resolveUriToPath(requireActivity(), uri)
 
         if (path.isNullOrEmpty()) return
 

--- a/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/resources/AddResourceFragment.kt
@@ -238,9 +238,8 @@ class AddResourceFragment : BottomSheetDialogFragment() {
 
     private fun handleUri(uri: Uri?, requestCode: Int) {
         val path = when (requestCode) {
-            REQUEST_CAPTURE_PICTURE, REQUEST_VIDEO_CAPTURE ->
-                FileUtils.getRealPathFromURI(requireContext(), uri)
-            REQUEST_FILE_SELECTION -> FileUtils.getPathFromURI(requireContext(), uri)
+            REQUEST_CAPTURE_PICTURE, REQUEST_VIDEO_CAPTURE, REQUEST_FILE_SELECTION ->
+                FileUtils.resolveUriToPath(requireContext(), uri)
             else -> null
         }
         processResource(path)

--- a/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/ui/voices/ReplyActivity.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
@@ -38,8 +37,7 @@ import org.ole.planet.myplanet.ui.components.FragmentNavigator
 import org.ole.planet.myplanet.utils.DispatcherProvider
 import org.ole.planet.myplanet.utils.EdgeToEdgeUtils
 import org.ole.planet.myplanet.utils.FileUtils.getFileNameFromUrl
-import org.ole.planet.myplanet.utils.FileUtils.getImagePath
-import org.ole.planet.myplanet.utils.FileUtils.getRealPathFromURI
+import org.ole.planet.myplanet.utils.FileUtils.resolveUriToPath
 import org.ole.planet.myplanet.utils.JsonUtils
 import org.ole.planet.myplanet.utils.JsonUtils.getString
 
@@ -217,10 +215,7 @@ open class ReplyActivity : AppCompatActivity(), OnNewsItemClickListener {
             return
         }
 
-        var path: String? = getRealPathFromURI(this, url)
-        if (TextUtils.isEmpty(path)) {
-            path = getImagePath(this, url)
-        }
+        val path: String? = resolveUriToPath(this, url)
 
         if (path == null) {
             return

--- a/app/src/main/java/org/ole/planet/myplanet/utils/FileUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/utils/FileUtils.kt
@@ -5,12 +5,10 @@ import android.app.usage.StorageStatsManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInstaller
-import android.database.Cursor
 import android.net.Uri
 import android.os.Environment
 import android.os.StatFs
 import android.os.storage.StorageManager
-import android.provider.MediaStore
 import android.provider.OpenableColumns
 import android.text.format.Formatter
 import android.util.Log
@@ -220,19 +218,6 @@ object FileUtils {
     }
 
 
-    fun getRealPathFromURI(context: Context, contentUri: Uri?): String? {
-        var cursor: Cursor? = null
-        return try {
-            val proj = arrayOf(MediaStore.Images.Media.DATA)
-            cursor = contentUri?.let { context.contentResolver.query(it, proj, null, null, null) }
-            val columnIndex = cursor?.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
-            cursor?.moveToFirst()
-            cursor?.getString(columnIndex ?: 0)
-        } finally {
-            cursor?.close()
-        }
-    }
-
     fun getMimeType(fileName: String?): String? {
         if (fileName.isNullOrBlank()) return null
         val ext = MimeTypeMap.getFileExtensionFromUrl(fileName)?.lowercase(Locale.getDefault())
@@ -268,26 +253,23 @@ object FileUtils {
         }
     }
 
-    fun getPathFromURI(context: Context, uri: Uri?): String? {
-        var filePath: String? = null
-        if (uri != null) {
-            when (uri.scheme) {
-                "content" -> {
-                    context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-                        if (cursor.moveToFirst()) {
-                            val columnIndex = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DISPLAY_NAME)
-                            val fileName = cursor.getString(columnIndex)
-                            val cacheDir = context.cacheDir
-                            val destinationFile = File(cacheDir, fileName)
-                            copyUriToFile(context, uri, destinationFile)
-                            filePath = destinationFile.absolutePath
-                        }
-                    }
-                }
-                "file" -> filePath = uri.path
+    fun resolveUriToPath(context: Context, uri: Uri?): String? {
+        uri ?: return null
+        if (uri.scheme == "file") return uri.path
+        return try {
+            val displayName = context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val columnIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (columnIndex >= 0) cursor.getString(columnIndex) else null
+                } else null
             }
+            val destinationFile = File(context.cacheDir, displayName ?: UUID.randomUUID().toString())
+            copyUriToFile(context, uri, destinationFile)
+            destinationFile.absolutePath
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
         }
-        return filePath
     }
 
     @Throws(Exception::class)
@@ -301,39 +283,6 @@ object FileUtils {
         intent.setDataAndType(uri, "*/*")
         intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
         return Intent.createChooser(intent, "Open folder")
-    }
-
-    fun getImagePath(context: Context, uri: Uri?): String? {
-        if (uri == null) return null
-        val projection = arrayOf(MediaStore.Images.Media._ID, MediaStore.Images.Media.DATA)
-        return try {
-            context.contentResolver.query(uri, projection, null, null, null)?.use { firstCursor ->
-                if (firstCursor.moveToFirst()) {
-                    val idIndex = firstCursor.getColumnIndex(MediaStore.Images.Media._ID)
-                    if (idIndex >= 0) {
-                        val documentId = firstCursor.getString(idIndex)
-                        val selection = "${MediaStore.Images.Media._ID} = ?"
-                        val args = arrayOf(documentId)
-                        context.contentResolver.query(
-                            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                            projection,
-                            selection,
-                            args,
-                            null
-                        )?.use { cursor ->
-                            if (cursor.moveToFirst()) {
-                                val dataIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
-                                if (dataIndex >= 0) return cursor.getString(dataIndex)
-                            }
-                        }
-                    }
-                }
-            }
-            null
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to get image path from uri", e)
-            null
-        }
     }
 
     fun externalMemoryAvailable(): Boolean {

--- a/app/src/test/java/org/ole/planet/myplanet/utils/FileUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/utils/FileUtilsTest.kt
@@ -1,10 +1,17 @@
 package org.ole.planet.myplanet.utils
 
 import android.app.Application
+import android.content.ContentProvider
+import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ProviderInfo
+import android.database.Cursor
+import android.database.MatrixCursor
 import android.net.Uri
 import android.os.Environment
+import android.os.ParcelFileDescriptor
+import android.provider.OpenableColumns
 import java.io.File
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -17,6 +24,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowContentResolver
 import org.robolectric.shadows.ShadowEnvironment
 
 @RunWith(RobolectricTestRunner::class)
@@ -232,6 +240,68 @@ class FileUtilsTest {
 
         assertTrue(destFile.exists())
         assertEquals(content, destFile.readText())
+    }
+
+    @Test
+    fun resolveUriToPath_returnsPathDirectlyForFileScheme() {
+        val sourceFile = File(tempDir, "source.txt")
+        sourceFile.writeText("Test Content")
+        val fileUri = Uri.fromFile(sourceFile)
+
+        val resolved = FileUtils.resolveUriToPath(context, fileUri)
+
+        assertEquals(sourceFile.absolutePath, resolved)
+    }
+
+    @Test
+    fun resolveUriToPath_returnsNullForNullUri() {
+        assertNull(FileUtils.resolveUriToPath(context, null))
+    }
+
+    @Test
+    fun resolveUriToPath_copiesContentUriUsingDisplayName() {
+        val authority = "org.ole.planet.myplanet.test.fileutils"
+        val displayName = "photo.jpg"
+        val sourceBytes = "fake image bytes".toByteArray()
+        val sourceFile = File(tempDir, "provider_source.jpg").apply { writeBytes(sourceBytes) }
+        val contentUri = Uri.parse("content://$authority/$displayName")
+
+        val provider = object : ContentProvider() {
+            override fun onCreate() = true
+
+            override fun query(
+                uri: Uri,
+                projection: Array<out String>?,
+                selection: String?,
+                selectionArgs: Array<out String>?,
+                sortOrder: String?
+            ): Cursor {
+                return MatrixCursor(arrayOf(OpenableColumns.DISPLAY_NAME)).apply {
+                    addRow(arrayOf(displayName))
+                }
+            }
+
+            override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor =
+                ParcelFileDescriptor.open(sourceFile, ParcelFileDescriptor.MODE_READ_ONLY)
+
+            override fun getType(uri: Uri): String? = null
+            override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+            override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?) = 0
+            override fun update(
+                uri: Uri,
+                values: ContentValues?,
+                selection: String?,
+                selectionArgs: Array<out String>?
+            ) = 0
+        }
+        val providerInfo = ProviderInfo().apply { this.authority = authority }
+        provider.attachInfo(context, providerInfo)
+        ShadowContentResolver.registerProviderInternal(authority, provider)
+
+        val resolved = FileUtils.resolveUriToPath(context, contentUri)
+
+        assertEquals(displayName, resolved?.let { File(it).name })
+        assertEquals("fake image bytes", resolved?.let { File(it).readText() })
     }
 
     @Test


### PR DESCRIPTION
fixes #16651
Replace getRealPathFromURI, getPathFromURI, and getImagePath with a single resolveUriToPath that handles both file and content URIs. Uses OpenableColumns.DISPLAY_NAME instead of deprecated MediaStore.Images.Media.DATA. Update all call sites and add unit tests.