### PR TITLE
Phase 113 (flutter): make the exam/survey ↔ course-step join reachable

### DIFF
--- a/flutter/PHASE_113_NOTES.md
+++ b/flutter/PHASE_113_NOTES.md
@@ -172,11 +172,68 @@ absent join. Fixed in the same shape, and `stepSurveysProvider` now returns rows
    first and both go into one `upsertAll`. The port's two tables make the
    question unaskable.
 
+## A second audit, on the finished implementation
+
+Phase 110's harder-won lesson, repeated exactly: **an audit of the ground truth
+does not audit the implementation.** The first pass established the Kotlin and
+the fix was green — format clean, analyze clean, 1822 tests, CI green on
+`7a1b78a9`. A second pass pointed at my own diff found **twelve** findings, four
+of them serious, and one of my new tests then uncovered a thirteenth.
+
+The pattern worth recording: *every* one of the serious findings was hidden by
+the friendliest possible fixture. `step_assessment_sync_test.dart` embedded the
+**same map objects** in the course document that it served from the exams
+database, so the two copies were byte-identical, always had an `_id`, and always
+carried questions. That single shape hid four separate defects.
+
+| # | defect | pre-fix failure |
+|---|---|---|
+| A | **the exams walk deleted step assessments in the same sync pass.** I had reasoned that a course test is also an `exams` document so it is in that walk's keep set — true for the happy case, and false for four classes of row: a locally derived id (Kotlin's `ifBlank` fallback), an `_id` this satellite has not replicated, a step survey whose standalone document is not `type: "surveys"`, and `total_rows == 0` on the exams database, which runs `deleteNotIn([])` and empties both tables. `complete`/`hadBatchFailure` does not help: these ids are structurally absent from the keep set however complete the walk | `a derived-id step assessment survives the exams walk prune` — the row is written by the courses area and gone after the surveys area |
+| B | **nothing ever cleared a stale `stepId` again.** `Value.absent()` fixed the clobber and removed the only mechanism that ever *retired* a join. Kotlin can afford that: its step ids are a hash of the step's own JSON. The port's are positional (`'$courseId:$index'`), so deleting a step shifts every later id down one and the removed step's exam silently reappears under whatever step took its slot | `removing a step releases the exam it used to carry` — step `course-1:0` inherited `exam-1` |
+| C | **both step buttons navigated nowhere.** `'${Routes.exam}/${exam.id}'` concatenates the route *pattern*: `/courses/exam/:examId/exam-1`, which matches no route and lands on go_router's error page. The survey button was wrong twice over — same pattern bug, and it aimed at `PublicSurveyScreen` (anonymous, network-fetched) where Kotlin's `btnTakeSurvey` opens the signed-in user's own submission | `the step view offers Take test…` — `Found 0 widgets with text "EXAM_ROUTE exam-1"`; `Record survey opens the signed-in survey screen` — `Found 0 widgets with text "SURVEY_ROUTE survey-1"` |
+| D | **`stepExamProvider` cached a pre-sync `null` for the process lifetime.** A `FutureProvider.family` with no `autoDispose` and nothing invalidating it: open a course before the sync writes the join and the step never offers its test until restart. Latent before, because nothing ever wrote the join; now the sole gate on the feature. Kotlin re-reads in `CourseStepFragment.onViewCreated` | reasoning, then `.autoDispose` |
+| E | **a `steps[i].exam` typed `surveys` was dropped entirely.** My `accept` filter skipped it on the reasoning that "it is a survey there too" — but nothing then filed it as one, because `SurveyMapper.fromCourseDoc` only read the `survey` key. Kotlin writes it and its Take Survey button finds it. A test had pinned the loss as intended | `leaves a step exam that declares itself a survey to SurveyMapper` |
+| F | **a duplicate question id aborted the whole courses walk.** `batch.insertAll` raises `UNIQUE constraint failed` where Kotlin's `@Upsert` lets the later row win, and neither `sync` catches — so the remaining pages and the cleanup are skipped and the area fails. Reachable without adversarial data: the id falls back to a positional `$examId-$index`, which a later question may carry as its own `id` | `duplicate question ids do not produce a duplicate row` |
+| G | **the thirteenth, which the fix for A/B surfaced rather than the audit.** `exam_questions.id` is the question's own document id, unique only *within* an exam — so **two different exams carrying a question `q1` collide globally**. My new test hit it immediately. Kotlin has the same primary key and loses one question silently to `@Upsert`; the port threw. Fixed where Kotlin fixes it, at the DAO: `insertAllOnConflictUpdate` | `SqliteException(1555): UNIQUE constraint failed: exam_questions.id` out of `SurveysRepository.sync` |
+| H | **the courses walk wiped questions the exams walk wrote.** `ExamDao.upsertAll` deletes an exam's questions before reinserting the map entry, and I wrote an entry for every step exam including an empty list — so a course embedding an exam with no `questions` array emptied it. Kotlin's `questionDao` never deletes | `the courses walk does not wipe questions the exams walk wrote` |
+| I | **Take test appeared on a course the learner had not joined.** `CourseStepFragment.onViewCreated` hides *both* buttons when `!userHasCourse`, after `hideTestIfNoQuestion` has shown them. The port computed `isMyCourse` and passed it only to the navigation bar | `a course the learner has not joined offers neither` |
+| J | **`noOfQuestions` disagreed between the two walks.** Kotlin counts the raw array on both (`getJsonArray("questions", exam).size()`); `fromDoc` counted the parsed rows, so a non-object entry made the same row's count depend on which walk ran last | `noOfQuestions counts the raw array, as the Kotlin does` |
+
+**And one gap the join made fixable, which the diff had left on the table.**
+`CourseStepFragment.saveCourseProgress` passes
+`if (stepExams.isEmpty()) true else null` (`:97`): a step with no test is passed
+by reaching it. The port passed `null` unconditionally — because until this phase
+nothing could tell the two apart, `stepExams` being precisely the join that did
+not exist. **A course with no tests could therefore never complete.** Now
+ported.
+
+Fixes for A and B, and for G, are in `app_database.dart`: `deleteNotIn` on both
+tables spares rows with a non-null `stepId` (Kotlin has no prune here at all, so
+sparing is the closer behaviour), a new `releaseStepJoinsForCourse` on each DAO
+detaches the assessments a course document no longer claims — which hands the
+spared row back to the prune, so sparing is not immortality — and the question
+batches upsert instead of insert.
+
+Two findings were left as reported rather than fixed, both outside the join:
+Kotlin relabels the buttons `retake_test`/`redo_survey` from
+`hasSubmission(...)`, which the port does not; and `SurveyDao.getByCourseId` has
+no type filter where Kotlin's is `getByCourseIdAndType(courseId, "survey")` —
+singular, i.e. only type-less embedded step surveys — so the mandatory-survey
+block now fires for step surveys Kotlin's query would never match. That block is
+gated to one hardcoded onboarding course, so the blast radius is a single course.
+
 ## For the integrator
 
-- **Three files outside Lane A's set were touched, all minimally, all reported
-  rather than assumed.** None is owned by Lane B (`lib/l10n/`) or Lane C
-  (`lib/ui/teams/`, `teams_provider`, `teams_repository*`):
+- **Files outside Lane A's set were touched, all reported rather than assumed.**
+  None is owned by Lane B (`lib/l10n/`) or Lane C (`lib/ui/teams/`,
+  `teams_provider`, `teams_repository*`):
+  - **`lib/data/local/app_database.dart`** — the largest crossing, and not
+    optional: without it the feature loses data on every sync (defect A above).
+    `ExamDao.deleteNotIn` and `SurveyDao.deleteNotIn` gain a
+    `stepId IS NULL` restriction; each DAO gains `releaseStepJoinsForCourse`;
+    the two question batches move from `insertAll` to
+    `insertAllOnConflictUpdate`. No schema change — no column, no index, no
+    version bump.
   - `lib/providers/app_providers.dart` — two added arguments to
     `coursesRepositoryProvider`, because `CoursesRepository` now needs `ExamDao`
     and `SurveyDao` to write the rows the course document carries.
@@ -185,17 +242,11 @@ absent join. Fixed in the same shape, and `stepSurveysProvider` now returns rows
     passing on a fixture shape the server does not produce and read as if it
     covered the real path.
   - `test/support/` untouched.
-- **A note is owed to `SurveyDao.deleteNotIn` and `ExamDao.deleteNotIn` in
-  `app_database.dart`**, which this lane did not own: they now prune rows the
-  *courses* walk wrote, and are safe only because a step's exam and survey are
-  also documents of the `exams` database. **The one row that is not:** an
-  embedded exam or survey with no `_id` of its own, which takes Kotlin's
-  `ifBlank { "$courseId-$stepId-$examKey" }` fallback. That id can never be in
-  the exams walk's keep set, so such a row is written by the courses area and
-  deleted by the surveys area within the same sync pass. The clean fix is to
-  spare rows with a non-null `stepId` in both `deleteNotIn`s — one predicate
-  each, in a file this lane does not own. Kotlin has **no** delete-except-ids on
-  the exams table at all, so sparing them is if anything closer to it.
+- **The `exams`/`surveys` prune is now a two-writer question.** Both
+  `deleteNotIn`s belong to the `exams` database walk but the tables no longer
+  belong to it alone; the `stepId IS NULL` restriction and
+  `releaseStepJoinsForCourse` are a pair and neither is safe to remove without
+  the other. Both carry the reasoning at the code.
 - **`ProgressRepository.courseProgress` has no UI caller.** Worth a phase: the
   per-step question count and mistake total it computes are exactly what
   Kotlin's `ProgressGridAdapter` renders.

--- a/flutter/PHASE_113_NOTES.md
+++ b/flutter/PHASE_113_NOTES.md
@@ -1,0 +1,4 @@
+# Phase 113 — the exam/survey ↔ course-step join
+
+**In progress.** Phase 110 suspected `TakeExamScreen` is unreachable with real
+synced data. This phase settles that from the Kotlin and fixes it.

--- a/flutter/PHASE_113_NOTES.md
+++ b/flutter/PHASE_113_NOTES.md
@@ -1,4 +1,207 @@
 # Phase 113 — the exam/survey ↔ course-step join
 
-**In progress.** Phase 110 suspected `TakeExamScreen` is unreachable with real
-synced data. This phase settles that from the Kotlin and fixes it.
+Phase 110 finished porting Kotlin's exam retry model and then reported that the
+screen it had just hardened might be unreachable in production. **It was right,
+and the cause is worse than it recorded**: the port did not merely fail to *join*
+a course step to its exam — it never wrote the exam at all.
+
+## The verdict
+
+`TakeExamScreen` had two entries, `course_detail_screen.dart:190` and
+`take_course_screen.dart:326`, and both resolved the exam through
+`exams.stepId == course_steps.id`. Neither could ever match with real synced
+data, for two independent reasons.
+
+**1. A course step's test arrives embedded in the course document, and the port
+threw it away.** `CoursesRepositoryImpl.buildCoursePayload`
+(`CoursesRepositoryImpl.kt:670-698`) walks `doc["steps"]`, mints the step's own
+id, and calls `collectRoomExam(stepJson, "exam", …)` and
+`collectRoomExam(stepJson, "survey", …)` — which read `steps[i].exam` and
+`steps[i].survey` and write them into the `exams` table with **that step id**
+(`:745`) and the course id (`:746`). The port's `CourseMapper` parses steps and
+nothing else; its doc comment says the exam halves "arrive with the `ui/exam`
+package", and they never did. So the only writer of the port's `exams` table was
+the `exams`-database walk, which took `stepId` from the document's own `stepId`
+key.
+
+That key does not exist. `StepExam.serializeExam` (`StepExam.kt:70-94`) — the
+only exam serializer in the Kotlin app, and the payload of its only exam upload
+path — emits no `stepId` and no `courseId`. **`stepId` is a purely
+client-derived identifier with no server representation**, and the `exams` walk
+passes `""` for it (`SurveysRepositoryImpl.kt:387` →
+`StepExam.checkIdsAndInsert`, which skips a blank argument). The information
+exists only in the course document's `steps` array. The port was reading a key
+the Kotlin never writes and the server never sends.
+
+**2. The exams walk rejected every real course test anyway.**
+`ExamMapper.fromDoc` required `type == 'exam'`. That is the value
+`insertCourseStepsExams` uses only as a *fallback* for a document with no `type`
+key at all. **No Kotlin query anywhere filters the exams table on
+`type = "exam"`.** The complete set of type filters is `"courses"`
+(`CoursesRepositoryImpl.kt:196`, `:530`), `"surveys"` (nine sites), and one
+stray singular `"survey"` (`SubmissionsRepositoryImpl.kt:367`). A course test
+carries `type: "courses"` — `:530`, `getByStepIdAndType(stepId, "courses")`, is
+the sole thing that shows Kotlin's Take Test button — so the port's mapper
+returned `null` for it and `deleteNotIn` then deleted the row if anything else
+had written it.
+
+Phase 110 called half of this settled in-repo and half an inference. The
+inference is now as settled as it can be without a Planet server: the
+`"courses"` type filter is not a Room-era invention but verbatim from the Realm
+implementation (`91f63abd:CoursesRepositoryImpl.kt:543-552`) and has shipped for
+years; rows with `type = "surveys"` must exist for the individual-surveys screen
+and team survey adoption to work at all, and the only producers of either are
+the two walks copying the document's own `type`.
+
+**So both entries into `TakeExamScreen` were dead, and so was the step view's
+Take Survey button** — surveys share the whole path, `collectRoomExam` included.
+Phase 110's parting question ("check whether surveys are too") answers yes.
+
+Every port fixture had to hand-fake `'stepId': 'step-1'` because there was no
+other way to get a row the lookup could find.
+
+## What changed
+
+`ExamMapper.fromCourseDoc` and `SurveyMapper.fromCourseDoc` port
+`collectRoomExam` for the `"exam"` and `"survey"` keys, sharing one
+`ExamMapper.mapStepExams` step walk, and `CoursesRepository.sync` upserts their
+rows alongside the courses and steps — where Kotlin's `upsertRoomCoursesFromSync`
+does (`CoursesRepositoryImpl.kt:650-651`). The exam id is the embedded document's
+`_id`, falling back to `"$courseId-$stepId-$examKey"`; the step id is
+`CourseMapper.stepIdFor`, passed in rather than imported so the mappers stay
+independent.
+
+`ExamMapper.fromDoc`'s accept rule became **"anything that is not a survey"**,
+which is Kotlin's: `bulkInsertExamsFromSync` parses every document of the
+database and the survey/test split happens later, at query time. The port has no
+`type` column — it splits into two tables what Kotlin keeps in one — so the split
+has to happen at parse, and this is the only rule that reproduces the Kotlin's
+partition.
+
+`fromDoc` on both mappers now writes `stepId`/`courseId` as `Value.absent()`
+rather than `Value(null)` when the document omits the key. Same shape as the
+Phase 56 security-data fix and the Phase 74 reactions round trip: two writers,
+one column, and the one that knows nothing must not overwrite the one that does.
+
+`stepExamProvider` moved off `ExamDao.getByStepId` (whose `getSingleOrNull`
+throws on two rows) to `getByStepIds([id]).firstOrNull`, matching
+`ExamDao.getFirstByStepId`'s `LIMIT 1`. Not hypothetical: `adoptSurvey`
+(`SurveysRepositoryImpl.kt:181-182`) copies `stepId` and `courseId` onto a
+**new UUID row**, so a shareable course-step survey can legitimately produce two
+rows for one step. `course_detail_screen.dart`'s duplicate `examForStepProvider`
+— the same query under a second name — is gone in favour of it.
+
+No schema change (still v45), no table or converter touched, so no
+`build_runner` step. No new `app_en.arb` key.
+
+## Defects, each demonstrated failing first
+
+| # | defect | pre-fix failure |
+|---|---|---|
+| 1 | **the courses walk dropped the step's exam and survey entirely** | probe: after `CoursesRepository.sync` of a course whose step embeds an exam, `examDao.getByStepId('course-1:0')` → `Expected: not null / Actual: <null>`; same for `surveyDao.getByStepId` → `Expected: an object with length of <1> / Actual: <[]>` |
+| 2 | **the exams walk rejected a `type: "courses"` document** | probe: `ExamMapper.fromDoc({'_id': 'exam-1', 'type': 'courses', …})` → `Expected: not null / Actual: <null>` |
+| 3 | **the exams walk cleared the join on the next pull** | demonstrated by reverting only `_presentOrAbsent` back to `Value(...)`: `the exams walk keeps the step exam the courses walk wrote` fails on `the exams walk must not clear the join it has no way to know about` |
+| 4 | **a course test was deleted as an unknown type** | demonstrated by reverting only the accept rule to `type != 'exam'`: `a course test is not pruned as an unknown document type` fails with `Expected: not null / Actual: <null>` — the row the courses walk wrote is not in the exams walk's keep set, so `deleteNotIn` removes it in the same sync pass |
+
+Defects 3 and 4 are worth separating from 1 and 2 because they are not about
+getting the row written — they are about the row surviving the rest of one sync.
+The port syncs `DashboardSyncArea.courses` (index 1) **before** `.surveys`
+(index 4), and the surveys area owns `deleteNotIn` for both tables, so a step
+exam written at index 1 is offered for deletion at index 4 minutes later. It
+survives only because a course test is also a document of the `exams` database
+(the embedded object carries a CouchDB `_rev`, meaningless on anything unstored;
+and the Realm-era course walk prefetched the existing `exams` rows by those
+embedded ids) **and** because the mapper now accepts it. `step_assessment_sync_test.dart`
+pins that interaction, because it is exactly the kind of agreement between two
+files that a later tidy-up breaks silently.
+
+## Reachability, confirmed on the screens
+
+Two widget tests fill an in-memory database from a real-shaped course document
+through the real mappers and then assert the buttons appear, with
+`stepExamProvider`/`stepSurveysProvider` **not** overridden — so the join is the
+thing under test rather than the button:
+
+- `course_detail_screen_test.dart`: `a step carrying an embedded exam offers Take exam, from a real sync`
+- `take_course_screen_test.dart`: `the step view offers Take test and Take survey for an embedded pair`
+
+**The payoff, stated plainly: the graded-course-exam work of Phases 100 and 106
+is now reachable.** Certified-course verification photos, the retry gate,
+`mistakes`, the `"$examId@$courseId"` parent id — all of it sat behind a button
+that could not appear.
+
+## The three consequences Phase 110 asked about
+
+**Per-step mistake totals (`progress_repository.dart:72-75`) are now computed
+correctly — and still are not on screen, for a different reason.**
+`ProgressRepository.courseProgress`, which returns `CourseStepProgress` with
+`questionCount` and `totalMistakes`, has **no caller in `lib/` at all**; the only
+callers are its own tests. So Phase 110's defect 7 (the `parentId` fix) now
+joins correctly to an exam that exists, and `progress_repository_test.dart` has
+a test proving it, but nothing renders the result. That is a separate gap and
+this phase does not close it. What *is* on screen — the courses list's
+"My Progress" mistake counts (`courses_providers.dart:404-438`) — never used this
+join; it matches submissions to courses with `parentId.contains(courseId)`.
+
+**Surveys share the problem exactly.** Same `collectRoomExam`, same step id, same
+absent join. Fixed in the same shape, and `stepSurveysProvider` now returns rows.
+
+**Certified-course exams: reachable.** See above.
+
+## Deliberate divergences
+
+1. **A `steps[i].survey` with no `type` key is filed as a survey.** Kotlin types
+   it `"survey"` — singular — and then only ever queries for `"surveys"`
+   (`CoursesRepositoryImpl.kt:531`), so such a row is reachable from neither
+   button. (This is itself a Room-era regression: the Realm implementation
+   defaulted to the literal `"exam"` for both call sites, so `"survey"` could
+   never be produced and `SubmissionsRepositoryImpl.kt:367` was dead code;
+   `07b11362` changed the default to the key and made `:367` live and `:531`
+   dead for these rows. The two are mutually exclusive over the same rows and
+   both are live code — a contradiction the Kotlin has not noticed.)
+   Reproducing it would mean putting a survey in the exams table and offering it
+   as a graded test, which is worse than Kotlin's silence rather than equal to
+   it.
+2. **A `steps[i].exam` with no `type` key is filed as an exam.** Kotlin writes
+   `"exam"` and `:530` then returns nothing, so the Take Test button is hidden
+   for a test that exists — silently, with no error. The port shows it.
+3. **The port's step exam and step survey cannot be confused.** Kotlin's
+   `getFirstByStepId` (`ExamDao.kt:13`) has no type filter and no `ORDER BY`, so
+   on a step carrying both, which row the exam button opens is unspecified SQL —
+   it happens to be the exam because `collectRoomExam` is called for `"exam"`
+   first and both go into one `upsertAll`. The port's two tables make the
+   question unaskable.
+
+## For the integrator
+
+- **Three files outside Lane A's set were touched, all minimally, all reported
+  rather than assumed.** None is owned by Lane B (`lib/l10n/`) or Lane C
+  (`lib/ui/teams/`, `teams_provider`, `teams_repository*`):
+  - `lib/providers/app_providers.dart` — two added arguments to
+    `coursesRepositoryProvider`, because `CoursesRepository` now needs `ExamDao`
+    and `SurveyDao` to write the rows the course document carries.
+  - `test/repository/exam_flow_test.dart` — no behaviour change; one test
+    renamed and commented, because `an exam is reachable from its step` was
+    passing on a fixture shape the server does not produce and read as if it
+    covered the real path.
+  - `test/support/` untouched.
+- **A note is owed to `SurveyDao.deleteNotIn` and `ExamDao.deleteNotIn` in
+  `app_database.dart`**, which this lane did not own: they now prune rows the
+  *courses* walk wrote, and are safe only because a step's exam and survey are
+  also documents of the `exams` database. **The one row that is not:** an
+  embedded exam or survey with no `_id` of its own, which takes Kotlin's
+  `ifBlank { "$courseId-$stepId-$examKey" }` fallback. That id can never be in
+  the exams walk's keep set, so such a row is written by the courses area and
+  deleted by the surveys area within the same sync pass. The clean fix is to
+  spare rows with a non-null `stepId` in both `deleteNotIn`s — one predicate
+  each, in a file this lane does not own. Kotlin has **no** delete-except-ids on
+  the exams table at all, so sparing them is if anything closer to it.
+- **`ProgressRepository.courseProgress` has no UI caller.** Worth a phase: the
+  per-step question count and mistake total it computes are exactly what
+  Kotlin's `ProgressGridAdapter` renders.
+- **One Kotlin behaviour deliberately not chased**, recorded so a later phase
+  does not read it as a gap: `07b11362` dropped the Realm survey path's
+  `createdDate = courseCreatedDate` override
+  (`91f63abd:CoursesRepositoryImpl.kt:818-822`), so a course-step survey's
+  `createdDate` now comes from the survey document. `getSurveys` sorts on that
+  column. The port follows current master.

--- a/flutter/lib/data/local/app_database.dart
+++ b/flutter/lib/data/local/app_database.dart
@@ -2320,6 +2320,28 @@ class SurveyDao extends DatabaseAccessor<AppDatabase> with _$SurveyDaoMixin {
             ..orderBy([(row) => OrderingTerm(expression: row.position)]))
           .get();
 
+  /// The survey half of [ExamDao.releaseStepJoinsForCourse]; see it for why
+  /// positional step ids make this necessary.
+  Future<void> releaseStepJoinsForCourse(
+    String courseId,
+    Set<String> keepIds,
+  ) async {
+    final stale =
+        await (selectOnly(surveys)
+              ..addColumns([surveys.id])
+              ..where(
+                surveys.courseId.equals(courseId) & surveys.stepId.isNotNull(),
+              ))
+            .map((row) => row.read(surveys.id)!)
+            .get();
+    final drop = stale.where((id) => !keepIds.contains(id)).toList();
+    for (final chunk in _chunked(drop, _sqliteVariableChunk)) {
+      await (update(surveys)..where((row) => row.id.isIn(chunk))).write(
+        const SurveysCompanion(stepId: Value(null), courseId: Value(null)),
+      );
+    }
+  }
+
   Future<void> upsertAll(
     List<SurveysCompanion> rows,
     Map<String, List<SurveyQuestionsCompanion>> questions,
@@ -2332,18 +2354,30 @@ class SurveyDao extends DatabaseAccessor<AppDatabase> with _$SurveyDaoMixin {
         surveyQuestions,
       )..where((row) => row.surveyId.equals(entry.key))).go();
       if (entry.value.isNotEmpty) {
-        await batch((batch) => batch.insertAll(surveyQuestions, entry.value));
+        // See `ExamDao.upsertAll`. Survey question ids are namespaced by their
+        // survey (`'$surveyId:$remoteId'`) so they cannot collide across
+        // surveys, but the positional fallback can still collide within one —
+        // and matching Kotlin's `@Upsert` costs nothing.
+        await batch(
+          (batch) =>
+              batch.insertAllOnConflictUpdate(surveyQuestions, entry.value),
+        );
       }
     }
   });
 
   /// See [MeetupDao.deleteNotIn] for why the difference is taken in Dart and
-  /// the deletes are chunked.
+  /// the deletes are chunked. Rows with a `stepId` are spared for the reason
+  /// [ExamDao.deleteNotIn] gives: since Phase 113 a course step's survey is
+  /// written by the *courses* walk and cannot be in this walk's keep set.
   Future<int> deleteNotIn(List<String> ids) => transaction(() async {
     final keep = ids.toSet();
-    final all = await (selectOnly(
-      surveys,
-    )..addColumns([surveys.id])).map((row) => row.read(surveys.id)!).get();
+    final all =
+        await (selectOnly(surveys)
+              ..addColumns([surveys.id])
+              ..where(surveys.stepId.isNull()))
+            .map((row) => row.read(surveys.id)!)
+            .get();
     final stale = all.where((id) => !keep.contains(id)).toList(growable: false);
     var deleted = 0;
     for (final chunk in _chunked(stale, _sqliteVariableChunk)) {
@@ -2434,13 +2468,31 @@ class ExamDao extends DatabaseAccessor<AppDatabase> with _$ExamDaoMixin {
       into(examQuestions).insertOnConflictUpdate(row);
 
   /// See [MeetupDao.deleteNotIn] for why the difference is taken in Dart and
-  /// the deletes are chunked. Exams are a pure server cache — every row is
-  /// restorable by the next sync — so nothing here needs sparing.
+  /// the deletes are chunked.
+  ///
+  /// **Rows with a `stepId` are spared.** This prune belongs to the `exams`
+  /// database walk, but since Phase 113 it is no longer that walk's table
+  /// alone: a course step's test is written by the *courses* walk, from the
+  /// copy embedded in the course document, and that is the only walk that
+  /// knows the step. Ids it minted itself (Kotlin's
+  /// `ifBlank { "$courseId-$stepId-$examKey" }` fallback), or that name a
+  /// document this satellite has not replicated, are structurally absent from
+  /// the exams walk's keep set — so without this the courses area would write
+  /// a step exam and the surveys area would delete it minutes later, in the
+  /// same sync pass. Kotlin has no delete-except-ids on this table at all, so
+  /// sparing is if anything the closer behaviour.
+  ///
+  /// A spared row is not immortal: [releaseStepJoinsForCourse] nulls the
+  /// `stepId` of any row the course document no longer claims, which hands it
+  /// back to this prune.
   Future<int> deleteNotIn(List<String> ids) => transaction(() async {
     final keep = ids.toSet();
-    final all = await (selectOnly(
-      exams,
-    )..addColumns([exams.id])).map((row) => row.read(exams.id)!).get();
+    final all =
+        await (selectOnly(exams)
+              ..addColumns([exams.id])
+              ..where(exams.stepId.isNull()))
+            .map((row) => row.read(exams.id)!)
+            .get();
     final stale = all.where((id) => !keep.contains(id)).toList(growable: false);
     var deleted = 0;
     for (final chunk in _chunked(stale, _sqliteVariableChunk)) {
@@ -2451,6 +2503,36 @@ class ExamDao extends DatabaseAccessor<AppDatabase> with _$ExamDaoMixin {
     }
     return deleted;
   });
+
+  /// Detaches every exam of [courseId] that [keepIds] does not name.
+  ///
+  /// The courses walk owns the `stepId`/`courseId` join and is the only writer
+  /// that can retire it. It has to, because the port's step id is positional
+  /// (`CourseMapper.stepIdFor`, `'$courseId:$index'`): deleting a step shifts
+  /// every later step's id down one, so an exam left attached to `c1:0` would
+  /// silently reappear under whatever step took that slot. Kotlin cannot reach
+  /// that — its step ids are a hash of the step's own JSON — and its exams walk
+  /// nulls a stale `stepId` wholesale on the next pull anyway, which the port
+  /// deliberately no longer does.
+  Future<void> releaseStepJoinsForCourse(
+    String courseId,
+    Set<String> keepIds,
+  ) async {
+    final stale =
+        await (selectOnly(exams)
+              ..addColumns([exams.id])
+              ..where(
+                exams.courseId.equals(courseId) & exams.stepId.isNotNull(),
+              ))
+            .map((row) => row.read(exams.id)!)
+            .get();
+    final drop = stale.where((id) => !keepIds.contains(id)).toList();
+    for (final chunk in _chunked(drop, _sqliteVariableChunk)) {
+      await (update(exams)..where((row) => row.id.isIn(chunk))).write(
+        const ExamsCompanion(stepId: Value(null), courseId: Value(null)),
+      );
+    }
+  }
 
   Future<void> upsertAll(
     List<ExamsCompanion> rows,
@@ -2464,7 +2546,18 @@ class ExamDao extends DatabaseAccessor<AppDatabase> with _$ExamDaoMixin {
         examQuestions,
       )..where((row) => row.examId.equals(entry.key))).go();
       if (entry.value.isNotEmpty) {
-        await batch((batch) => batch.insertAll(examQuestions, entry.value));
+        // `insertAllOnConflictUpdate`, not `insertAll`: `exam_questions.id` is
+        // the question's own document id, which Planet only makes unique
+        // *within* an exam, so two exams in one batch can carry the same one.
+        // Kotlin's `questionDao.upsertAll` is `@Upsert` and lets the later row
+        // win; a plain insert raises `UNIQUE constraint failed` instead, and
+        // neither `CoursesRepository.sync` nor `SurveysRepository.sync` catches
+        // it — so one such pair aborted the whole walk, skipped its remaining
+        // pages and its cleanup, and failed the sync area.
+        await batch(
+          (batch) =>
+              batch.insertAllOnConflictUpdate(examQuestions, entry.value),
+        );
       }
     }
   });

--- a/flutter/lib/data/local/exam_mapper.dart
+++ b/flutter/lib/data/local/exam_mapper.dart
@@ -30,7 +30,7 @@ class ExamMapper {
   static ExamMapping? fromDoc(Map<String, dynamic> doc) {
     final id = JsonUtils.getString('_id', doc);
     final type = JsonUtils.getString('type', doc);
-    if (id.isEmpty || id.startsWith('_design/') || type == 'surveys') {
+    if (id.isEmpty || id.startsWith('_design') || type == 'surveys') {
       return null;
     }
     final questions = parseQuestions(id, doc['questions']);
@@ -65,10 +65,21 @@ class ExamMapper {
         teamId: Value(JsonUtils.getStringOrNull('teamId', doc)),
         teamShareAllowed: Value(JsonUtils.getBool('teamShareAllowed', doc)),
         sourceSurveyId: Value(JsonUtils.getStringOrNull('sourceSurveyId', doc)),
-        noOfQuestions: Value(questions.length),
+        // Kotlin counts the raw array on both walks
+        // (`StepExam.insertCourseStepsExams`:
+        // `getJsonArray("questions", exam).size()`), not the questions it
+        // managed to parse. Counting the parsed ones made the two walks
+        // disagree on the same row whenever an entry was not an object, and
+        // the last walk won.
+        noOfQuestions: Value(_rawQuestionCount(doc)),
       ),
       questions: questions,
     );
+  }
+
+  static int _rawQuestionCount(Map<String, dynamic> doc) {
+    final raw = doc['questions'];
+    return raw is List ? raw.length : 0;
   }
 
   /// The lowercased choice **ids** that count as correct.
@@ -168,7 +179,28 @@ class ExamMapper {
         ),
       );
     }
-    return questions;
+    return lastWinsById(questions, (q) => q.id.value);
+  }
+
+  /// Kotlin's `questionDao.upsertAll` is `@Upsert`, so a list carrying the same
+  /// primary key twice simply lets the later row win. The port inserts a
+  /// question batch with `batch.insertAll`, which raises
+  /// `UNIQUE constraint failed` instead — and because `CoursesRepository.sync`
+  /// has no `try`, that would abort the whole courses walk, skip its remaining
+  /// pages and its cleanup, and fail the sync area.
+  ///
+  /// It is reachable with ordinary data rather than adversarial data: the id
+  /// falls back to a positional `$examId-$index` / `$surveyId:$index`, so a
+  /// document mixing an unlabelled first question with a second whose own `id`
+  /// is `"0"` collides. Deduplicating here keeps the Kotlin's last-wins
+  /// semantics and takes the abort off the table.
+  static List<T> lastWinsById<T>(List<T> rows, String Function(T) id) {
+    if (rows.length < 2) return rows;
+    final byId = <String, T>{};
+    for (final row in rows) {
+      byId[id(row)] = row;
+    }
+    return byId.length == rows.length ? rows : byId.values.toList();
   }
 
   /// Port of `CoursesRepositoryImpl.collectRoomExam(stepJson, "exam", …)` —
@@ -183,6 +215,16 @@ class ExamMapper {
   ///
   /// [stepIdFor] is [CourseMapper.stepIdFor], passed in rather than imported so
   /// the two mappers stay independent.
+  ///
+  /// **One deliberate divergence.** Kotlin types a `steps[i].exam` with no
+  /// `type` key as `"exam"` (`collectRoomExam`'s `else examKey`) and then only
+  /// ever looks for `"courses"` (`CoursesRepositoryImpl.kt:530`), so its Take
+  /// Test button stays hidden for a test that exists — silently, with no
+  /// error. The port has no `type` column and finds the exam by `stepId`
+  /// alone, so it shows the button. This is the mirror image of the
+  /// type-less-survey divergence recorded on `SurveyMapper.fromCourseDoc`, and
+  /// the same judgement: a test the learner cannot reach is a worse outcome
+  /// than one they can.
   static List<ExamMapping> fromCourseDoc(
     Map<String, dynamic> doc, {
     required String Function(String courseId, int stepIndex) stepIdFor,
@@ -193,8 +235,12 @@ class ExamMapper {
     // Kotlin files an embedded document by its own `type` when it has one
     // (`type = if (examJson.has("type")) … else examKey`), so a `steps[i].exam`
     // that declares itself a survey is a survey there too and
-    // `getByStepIdAndType(stepId, "courses")` would not return it.
-    accept: (examJson) => JsonUtils.getString('type', examJson) != 'surveys',
+    // `getByStepIdAndType(stepId, "courses")` would not return it. It is not
+    // *lost* there, though — it lands in the one table as a survey and the
+    // Take Survey button finds it — so `SurveyMapper.fromCourseDoc` picks the
+    // same object up off the `exam` key. Filtering here without that would
+    // have dropped it on the floor.
+    accept: (examJson) => !isSurveyType(examJson),
     build: (examId, stepId, courseId, examJson) => ExamMapping(
       exam: ExamsCompanion.insert(
         id: examId,
@@ -221,11 +267,7 @@ class ExamMapper {
         sourceSurveyId: Value(
           JsonUtils.getStringOrNull('sourceSurveyId', examJson),
         ),
-        noOfQuestions: Value(
-          examJson['questions'] is List
-              ? (examJson['questions']! as List).length
-              : 0,
-        ),
+        noOfQuestions: Value(_rawQuestionCount(examJson)),
       ),
       questions: parseQuestions(
         examId,
@@ -272,6 +314,15 @@ class ExamMapper {
     }
     return mapped;
   }
+
+  /// Whether an embedded assessment belongs in the `surveys` table.
+  ///
+  /// Kotlin has one table and decides at query time on `type`; the port has to
+  /// decide here. Both `steps[i].exam` and `steps[i].survey` are routed by this
+  /// so neither key can strand a document in the wrong table — or, worse, in
+  /// neither.
+  static bool isSurveyType(Map<String, dynamic> json) =>
+      JsonUtils.getString('type', json) == 'surveys';
 
   /// `Value(doc[key])` when the document carries the key, `Value.absent()` when
   /// it does not — so an upsert leaves a column another writer owns alone.

--- a/flutter/lib/data/local/exam_mapper.dart
+++ b/flutter/lib/data/local/exam_mapper.dart
@@ -4,58 +4,52 @@ import '../../core/utils/json_utils.dart';
 import 'app_database.dart';
 import 'converters.dart';
 
-/// Port of `StepExam.insertCourseStepsExams` and `ExamQuestion.insertExamQuestions`.
+/// Port of `StepExam.insertCourseStepsExams` / `ExamQuestion.insertExamQuestions`
+/// (the `exams` database walk) and of `CoursesRepositoryImpl.collectRoomExam`
+/// (the `courses` walk's embedded step tests).
 class ExamMapper {
   const ExamMapper._();
 
-  /// Parses exam documents with questions from CouchDB.
-  /// Exam documents have type='exam' (not 'surveys').
+  /// Parses one document of the `exams` database.
+  ///
+  /// **The port splits into two tables what the Kotlin keeps in one.** Kotlin's
+  /// `bulkInsertExamsFromSync` runs `StepExam.insertCourseStepsExams` over
+  /// *every* document of that database and never filters on `type`; the split
+  /// between a survey and a test happens later, at query time
+  /// (`ExamDao.getByType("surveys")`, `getByStepIdAndType(stepId, "courses")`).
+  /// The port has no `type` column, so the split has to happen here instead —
+  /// and the rule is therefore `type == 'surveys'` goes to [SurveyMapper],
+  /// **everything else is an exam**.
+  ///
+  /// It used to require `type == 'exam'`, which is the value
+  /// `insertCourseStepsExams` only ever uses as a *fallback* for a document
+  /// with no `type` key at all. No Kotlin query anywhere selects the exams
+  /// table on `type = "exam"`; a course test carries `type: "courses"`
+  /// (`CoursesRepositoryImpl.kt:196`, `:530`), so every real one was dropped on
+  /// the floor here.
   static ExamMapping? fromDoc(Map<String, dynamic> doc) {
     final id = JsonUtils.getString('_id', doc);
     final type = JsonUtils.getString('type', doc);
-    // Exams have type='exam', surveys have type='surveys'
-    if (id.isEmpty || id.startsWith('_design/') || type != 'exam') {
+    if (id.isEmpty || id.startsWith('_design/') || type == 'surveys') {
       return null;
     }
-    final rawQuestions = doc['questions'];
-    final questions = <ExamQuestionsCompanion>[];
-    if (rawQuestions is List) {
-      for (var index = 0; index < rawQuestions.length; index++) {
-        final question = rawQuestions[index];
-        if (question is! Map<String, dynamic>) continue;
-        final questionId = JsonUtils.getString('id', question);
-        // `$examId-$index`, matching `ExamQuestion.insertExamQuestions`.
-        final questionIdValue = questionId.isEmpty ? '$id-$index' : questionId;
-        final choices = ExamChoice.listFromJson(question['choices']);
-        questions.add(
-          ExamQuestionsCompanion.insert(
-            id: questionIdValue,
-            examId: id,
-            // The Kotlin reads `title` here, not `header`; a document has no
-            // `header` key, so reading one left every question unlabelled.
-            header: Value(JsonUtils.getStringOrNull('title', question)),
-            body: Value(JsonUtils.getStringOrNull('body', question)),
-            type: Value(JsonUtils.getStringOrNull('type', question)),
-            choices: Value(choices),
-            correctChoices: Value(_parseCorrectChoices(choices, question)),
-            marks: Value(JsonUtils.getStringOrNull('marks', question)),
-            hasOtherOption: Value(
-              JsonUtils.getBool('hasOtherOption', question),
-            ),
-            scaleMax: Value(
-              JsonUtils.getInt('scaleMax', question).let((v) => v <= 0 ? 9 : v),
-            ),
-            position: index,
-          ),
-        );
-      }
-    }
+    final questions = parseQuestions(id, doc['questions']);
     return ExamMapping(
       exam: ExamsCompanion.insert(
         id: id,
         rev: Value(JsonUtils.getStringOrNull('_rev', doc)),
-        stepId: Value(JsonUtils.getStringOrNull('stepId', doc)),
-        courseId: Value(JsonUtils.getStringOrNull('courseId', doc)),
+        // **Absent, not `Value(null)`, when the document does not carry them.**
+        // This walk knows nothing about course steps: `insertCourseStepsExams`
+        // is called with `("", "", doc, "")` from `bulkInsertExamsFromSync`
+        // (`SurveysRepositoryImpl.kt:387`) and `checkIdsAndInsert` skips a
+        // blank id, so the Kotlin leaves both null — and because `@Upsert` is a
+        // full-row replace, whichever of the two walks lands last decides
+        // whether a course test still knows its step. Phase 110 recorded that
+        // race as a Kotlin defect. Writing the columns absent means a re-pull
+        // of the standalone document cannot wipe the join the `courses` walk
+        // owns; same shape as the Phase 56 security-data fix.
+        stepId: _presentOrAbsent('stepId', doc),
+        courseId: _presentOrAbsent('courseId', doc),
         name: Value(JsonUtils.getStringOrNull('name', doc)),
         description: Value(JsonUtils.getStringOrNull('description', doc)),
         createdDate: Value(JsonUtils.getLong('createdDate', doc)),
@@ -120,6 +114,173 @@ class ExamMapper {
     }
     return raw.toLowerCase();
   }
+
+  /// Port of `ExamQuestion.insertExamQuestions` and of the question half of
+  /// `CoursesRepositoryImpl.collectRoomExam` — one parser, because the port
+  /// stores one representation.
+  ///
+  /// The two Kotlin parsers differ in two places, and only the first is
+  /// portable. `collectRoomExam` falls back to the question's `title` when
+  /// `body` is blank ([bodyFallsBackToTitle]); `insertExamQuestions` does not.
+  /// They also disagree about the answer key — `collectRoomExam` resolves it to
+  /// display **text** and `insertExamQuestions` to a choice's `res` — and the
+  /// port deliberately normalises both to **ids**, which is what
+  /// [ExamGrading] compares. See [_parseCorrectChoices].
+  static List<ExamQuestionsCompanion> parseQuestions(
+    String examId,
+    Object? rawQuestions, {
+    bool bodyFallsBackToTitle = false,
+  }) {
+    final questions = <ExamQuestionsCompanion>[];
+    if (rawQuestions is! List) return questions;
+    for (var index = 0; index < rawQuestions.length; index++) {
+      final question = rawQuestions[index];
+      if (question is! Map<String, dynamic>) continue;
+      final questionId = JsonUtils.getString('id', question);
+      // `$examId-$index`, matching `ExamQuestion.insertExamQuestions`.
+      final questionIdValue = questionId.isEmpty
+          ? '$examId-$index'
+          : questionId;
+      final choices = ExamChoice.listFromJson(question['choices']);
+      // The Kotlin reads `title` here, not `header`; a document has no
+      // `header` key, so reading one left every question unlabelled.
+      final title = JsonUtils.getStringOrNull('title', question);
+      final body = JsonUtils.getStringOrNull('body', question);
+      questions.add(
+        ExamQuestionsCompanion.insert(
+          id: questionIdValue,
+          examId: examId,
+          header: Value(title),
+          body: Value(
+            bodyFallsBackToTitle && (body == null || body.isEmpty)
+                ? title
+                : body,
+          ),
+          type: Value(JsonUtils.getStringOrNull('type', question)),
+          choices: Value(choices),
+          correctChoices: Value(_parseCorrectChoices(choices, question)),
+          marks: Value(JsonUtils.getStringOrNull('marks', question)),
+          hasOtherOption: Value(JsonUtils.getBool('hasOtherOption', question)),
+          scaleMax: Value(
+            JsonUtils.getInt('scaleMax', question).let((v) => v <= 0 ? 9 : v),
+          ),
+          position: index,
+        ),
+      );
+    }
+    return questions;
+  }
+
+  /// Port of `CoursesRepositoryImpl.collectRoomExam(stepJson, "exam", …)` —
+  /// the tests embedded in a course document under `steps[i].exam`.
+  ///
+  /// **This is how a course test actually reaches the exams table.** The
+  /// `exams` database walk never learns which step a test belongs to; the
+  /// `courses` walk does, because it mints the step's own id and hands it
+  /// straight to the exam (`CoursesRepositoryImpl.kt:679`, `:745`). The port
+  /// had no counterpart at all, so nothing ever wrote an `exams.stepId` equal
+  /// to a `course_steps.id` and both entries into the exam screen were dead.
+  ///
+  /// [stepIdFor] is [CourseMapper.stepIdFor], passed in rather than imported so
+  /// the two mappers stay independent.
+  static List<ExamMapping> fromCourseDoc(
+    Map<String, dynamic> doc, {
+    required String Function(String courseId, int stepIndex) stepIdFor,
+  }) => mapStepExams(
+    doc,
+    stepIdFor: stepIdFor,
+    examKey: 'exam',
+    // Kotlin files an embedded document by its own `type` when it has one
+    // (`type = if (examJson.has("type")) … else examKey`), so a `steps[i].exam`
+    // that declares itself a survey is a survey there too and
+    // `getByStepIdAndType(stepId, "courses")` would not return it.
+    accept: (examJson) => JsonUtils.getString('type', examJson) != 'surveys',
+    build: (examId, stepId, courseId, examJson) => ExamMapping(
+      exam: ExamsCompanion.insert(
+        id: examId,
+        rev: Value(JsonUtils.getStringOrNull('_rev', examJson)),
+        stepId: Value(stepId),
+        courseId: Value(courseId),
+        name: Value(JsonUtils.getStringOrNull('name', examJson)),
+        description: Value(JsonUtils.getStringOrNull('description', examJson)),
+        createdDate: Value(JsonUtils.getLong('createdDate', examJson)),
+        updatedDate: Value(JsonUtils.getLong('updatedDate', examJson)),
+        adoptionDate: Value(JsonUtils.getLong('adoptionDate', examJson)),
+        createdBy: Value(JsonUtils.getStringOrNull('createdBy', examJson)),
+        totalMarks: Value(JsonUtils.getInt('totalMarks', examJson)),
+        passingPercentage: Value(
+          JsonUtils.getStringOrNull('passingPercentage', examJson),
+        ),
+        sourcePlanet: Value(
+          JsonUtils.getStringOrNull('sourcePlanet', examJson),
+        ),
+        teamId: Value(JsonUtils.getStringOrNull('teamId', examJson)),
+        teamShareAllowed: Value(
+          JsonUtils.getBool('teamShareAllowed', examJson),
+        ),
+        sourceSurveyId: Value(
+          JsonUtils.getStringOrNull('sourceSurveyId', examJson),
+        ),
+        noOfQuestions: Value(
+          examJson['questions'] is List
+              ? (examJson['questions']! as List).length
+              : 0,
+        ),
+      ),
+      questions: parseQuestions(
+        examId,
+        examJson['questions'],
+        bodyFallsBackToTitle: true,
+      ),
+    ),
+  );
+
+  /// The shared `steps[i].<examKey>` walk, used by [fromCourseDoc] and by
+  /// `SurveyMapper.fromCourseDoc` — the Kotlin runs one `collectRoomExam` for
+  /// each of `"exam"` and `"survey"` and puts both in the same table, which the
+  /// port has to split across its two.
+  static List<T> mapStepExams<T>(
+    Map<String, dynamic> doc, {
+    required String Function(String courseId, int stepIndex) stepIdFor,
+    required String examKey,
+    bool Function(Map<String, dynamic> examJson)? accept,
+    required T Function(
+      String examId,
+      String stepId,
+      String courseId,
+      Map<String, dynamic> examJson,
+    )
+    build,
+  }) {
+    final courseId = JsonUtils.getString('_id', doc);
+    if (courseId.isEmpty || courseId.startsWith('_design')) return const [];
+    final rawSteps = doc['steps'];
+    if (rawSteps is! List) return const [];
+
+    final mapped = <T>[];
+    for (var index = 0; index < rawSteps.length; index++) {
+      final step = rawSteps[index];
+      if (step is! Map<String, dynamic>) continue;
+      final examJson = step[examKey];
+      if (examJson is! Map<String, dynamic>) continue;
+      if (accept != null && !accept(examJson)) continue;
+      final stepId = stepIdFor(courseId, index);
+      // `getString("_id", examJson).ifBlank { "$courseId-$stepId-$examKey" }`.
+      final docId = JsonUtils.getString('_id', examJson);
+      final examId = docId.isEmpty ? '$courseId-$stepId-$examKey' : docId;
+      mapped.add(build(examId, stepId, courseId, examJson));
+    }
+    return mapped;
+  }
+
+  /// `Value(doc[key])` when the document carries the key, `Value.absent()` when
+  /// it does not — so an upsert leaves a column another writer owns alone.
+  static Value<String?> _presentOrAbsent(
+    String key,
+    Map<String, dynamic> doc,
+  ) => doc.containsKey(key)
+      ? Value(JsonUtils.getStringOrNull(key, doc))
+      : const Value.absent();
 }
 
 class ExamMapping {

--- a/flutter/lib/data/local/survey_mapper.dart
+++ b/flutter/lib/data/local/survey_mapper.dart
@@ -3,19 +3,19 @@ import 'package:drift/drift.dart';
 import '../../core/utils/json_utils.dart';
 import 'app_database.dart';
 import 'converters.dart';
+import 'exam_mapper.dart';
 
 /// Port of `StepExam.insertCourseStepsExams` and
 /// `ExamQuestion.insertExamQuestions` for survey documents.
 class SurveyMapper {
   const SurveyMapper._();
 
-  static SurveyMapping? fromDoc(Map<String, dynamic> doc) {
-    final id = JsonUtils.getString('_id', doc);
-    final type = JsonUtils.getString('type', doc);
-    if (id.isEmpty || id.startsWith('_design/') || type != 'surveys') {
-      return null;
-    }
-    final rawQuestions = doc['questions'];
+  /// Port of `ExamQuestion.insertExamQuestions` for a survey document — shared
+  /// by the `exams` database walk and by the `steps[i].survey` walk.
+  static List<SurveyQuestionsCompanion> _parseQuestions(
+    String surveyId,
+    Object? rawQuestions,
+  ) {
     final questions = <SurveyQuestionsCompanion>[];
     if (rawQuestions is List) {
       for (var index = 0; index < rawQuestions.length; index++) {
@@ -26,8 +26,8 @@ class SurveyMapper {
             : JsonUtils.getString('_id', question);
         questions.add(
           SurveyQuestionsCompanion.insert(
-            id: remoteId.isEmpty ? '$id:$index' : '$id:$remoteId',
-            surveyId: id,
+            id: remoteId.isEmpty ? '$surveyId:$index' : '$surveyId:$remoteId',
+            surveyId: surveyId,
             questionId: Value(remoteId.isEmpty ? null : remoteId),
             // `ExamQuestion.insertExamQuestions` — which is what
             // `StepExam.insertCourseStepsExams` runs for a survey document too
@@ -54,6 +54,16 @@ class SurveyMapper {
         );
       }
     }
+    return questions;
+  }
+
+  static SurveyMapping? fromDoc(Map<String, dynamic> doc) {
+    final id = JsonUtils.getString('_id', doc);
+    final type = JsonUtils.getString('type', doc);
+    if (id.isEmpty || id.startsWith('_design/') || type != 'surveys') {
+      return null;
+    }
+    final questions = _parseQuestions(id, doc['questions']);
     return SurveyMapping(
       survey: SurveysCompanion.insert(
         id: id,
@@ -73,12 +83,79 @@ class SurveyMapper {
         teamId: Value(JsonUtils.getStringOrNull('teamId', doc)),
         teamShareAllowed: Value(JsonUtils.getBool('teamShareAllowed', doc)),
         sourceSurveyId: Value(JsonUtils.getStringOrNull('sourceSurveyId', doc)),
-        courseId: Value(JsonUtils.getStringOrNull('courseId', doc)),
-        stepId: Value(JsonUtils.getStringOrNull('stepId', doc)),
+        // Absent, not `Value(null)`, when the document omits them — see the
+        // note on `ExamMapper.fromDoc`. The `exams` database walk is called
+        // with a blank course and step id, so it must not overwrite the join
+        // the `courses` walk owns.
+        courseId: _presentOrAbsent('courseId', doc),
+        stepId: _presentOrAbsent('stepId', doc),
       ),
       questions: questions,
     );
   }
+
+  /// Port of `CoursesRepositoryImpl.collectRoomExam(stepJson, "survey", …)` —
+  /// the surveys embedded in a course document under `steps[i].survey`.
+  ///
+  /// Kotlin keeps these in the same `exams` table as the tests and separates
+  /// them at query time (`getByStepIdAndType(stepId, "surveys")`); the port has
+  /// a separate `surveys` table, so the split happens here.
+  ///
+  /// **One deliberate divergence.** Kotlin types a `steps[i].survey` with no
+  /// `type` key as `"survey"` — singular — and then only ever queries for
+  /// `"surveys"`, so such a row is unreachable from both the Take Test and the
+  /// Take Survey button. The port files every `steps[i].survey` as a survey.
+  /// Reproducing the quirk would mean putting a survey in the exams table and
+  /// offering it as a graded test, which is worse than Kotlin's silence rather
+  /// than equal to it.
+  static List<SurveyMapping> fromCourseDoc(
+    Map<String, dynamic> doc, {
+    required String Function(String courseId, int stepIndex) stepIdFor,
+  }) => ExamMapper.mapStepExams(
+    doc,
+    stepIdFor: stepIdFor,
+    examKey: 'survey',
+    build: (surveyId, stepId, courseId, surveyJson) => SurveyMapping(
+      survey: SurveysCompanion.insert(
+        id: surveyId,
+        rev: Value(JsonUtils.getStringOrNull('_rev', surveyJson)),
+        name: Value(JsonUtils.getStringOrNull('name', surveyJson)),
+        description: Value(
+          JsonUtils.getStringOrNull('description', surveyJson),
+        ),
+        createdDate: Value(JsonUtils.getLong('createdDate', surveyJson)),
+        updatedDate: Value(JsonUtils.getLong('updatedDate', surveyJson)),
+        adoptionDate: Value(JsonUtils.getLong('adoptionDate', surveyJson)),
+        createdBy: Value(JsonUtils.getStringOrNull('createdBy', surveyJson)),
+        totalMarks: Value(JsonUtils.getInt('totalMarks', surveyJson)),
+        passingPercentage: Value(
+          JsonUtils.getStringOrNull('passingPercentage', surveyJson),
+        ),
+        sourcePlanet: Value(
+          JsonUtils.getStringOrNull('sourcePlanet', surveyJson),
+        ),
+        teamId: Value(JsonUtils.getStringOrNull('teamId', surveyJson)),
+        teamShareAllowed: Value(
+          JsonUtils.getBool('teamShareAllowed', surveyJson),
+        ),
+        sourceSurveyId: Value(
+          JsonUtils.getStringOrNull('sourceSurveyId', surveyJson),
+        ),
+        courseId: Value(courseId),
+        stepId: Value(stepId),
+      ),
+      questions: _parseQuestions(surveyId, surveyJson['questions']),
+    ),
+  );
+
+  /// `Value(doc[key])` when the document carries the key, `Value.absent()`
+  /// otherwise, so an upsert leaves a column another writer owns alone.
+  static Value<String?> _presentOrAbsent(
+    String key,
+    Map<String, dynamic> doc,
+  ) => doc.containsKey(key)
+      ? Value(JsonUtils.getStringOrNull(key, doc))
+      : const Value.absent();
 }
 
 class SurveyMapping {

--- a/flutter/lib/data/local/survey_mapper.dart
+++ b/flutter/lib/data/local/survey_mapper.dart
@@ -54,13 +54,16 @@ class SurveyMapper {
         );
       }
     }
-    return questions;
+    // See `ExamMapper.lastWinsById`: the port's `batch.insertAll` raises on a
+    // duplicate id where Kotlin's `@Upsert` lets the later row win, and the
+    // positional id fallback here makes that reachable.
+    return ExamMapper.lastWinsById(questions, (q) => q.id.value);
   }
 
   static SurveyMapping? fromDoc(Map<String, dynamic> doc) {
     final id = JsonUtils.getString('_id', doc);
     final type = JsonUtils.getString('type', doc);
-    if (id.isEmpty || id.startsWith('_design/') || type != 'surveys') {
+    if (id.isEmpty || id.startsWith('_design') || type != 'surveys') {
       return null;
     }
     final questions = _parseQuestions(id, doc['questions']);
@@ -111,41 +114,59 @@ class SurveyMapper {
   static List<SurveyMapping> fromCourseDoc(
     Map<String, dynamic> doc, {
     required String Function(String courseId, int stepIndex) stepIdFor,
-  }) => ExamMapper.mapStepExams(
-    doc,
-    stepIdFor: stepIdFor,
-    examKey: 'survey',
-    build: (surveyId, stepId, courseId, surveyJson) => SurveyMapping(
-      survey: SurveysCompanion.insert(
-        id: surveyId,
-        rev: Value(JsonUtils.getStringOrNull('_rev', surveyJson)),
-        name: Value(JsonUtils.getStringOrNull('name', surveyJson)),
-        description: Value(
-          JsonUtils.getStringOrNull('description', surveyJson),
-        ),
-        createdDate: Value(JsonUtils.getLong('createdDate', surveyJson)),
-        updatedDate: Value(JsonUtils.getLong('updatedDate', surveyJson)),
-        adoptionDate: Value(JsonUtils.getLong('adoptionDate', surveyJson)),
-        createdBy: Value(JsonUtils.getStringOrNull('createdBy', surveyJson)),
-        totalMarks: Value(JsonUtils.getInt('totalMarks', surveyJson)),
-        passingPercentage: Value(
-          JsonUtils.getStringOrNull('passingPercentage', surveyJson),
-        ),
-        sourcePlanet: Value(
-          JsonUtils.getStringOrNull('sourcePlanet', surveyJson),
-        ),
-        teamId: Value(JsonUtils.getStringOrNull('teamId', surveyJson)),
-        teamShareAllowed: Value(
-          JsonUtils.getBool('teamShareAllowed', surveyJson),
-        ),
-        sourceSurveyId: Value(
-          JsonUtils.getStringOrNull('sourceSurveyId', surveyJson),
-        ),
-        courseId: Value(courseId),
-        stepId: Value(stepId),
-      ),
-      questions: _parseQuestions(surveyId, surveyJson['questions']),
+  }) => [
+    // Both keys, because Kotlin has one table and files by `type`: a
+    // `steps[i].exam` that declares itself `type: "surveys"` is a survey there
+    // and its Take Survey button works. `ExamMapper.fromCourseDoc` skips those,
+    // so without this pass they would be written nowhere at all.
+    ...ExamMapper.mapStepExams(
+      doc,
+      stepIdFor: stepIdFor,
+      examKey: 'exam',
+      accept: ExamMapper.isSurveyType,
+      build: _build,
     ),
+    ...ExamMapper.mapStepExams(
+      doc,
+      stepIdFor: stepIdFor,
+      examKey: 'survey',
+      build: _build,
+    ),
+  ];
+
+  static SurveyMapping _build(
+    String surveyId,
+    String stepId,
+    String courseId,
+    Map<String, dynamic> surveyJson,
+  ) => SurveyMapping(
+    survey: SurveysCompanion.insert(
+      id: surveyId,
+      rev: Value(JsonUtils.getStringOrNull('_rev', surveyJson)),
+      name: Value(JsonUtils.getStringOrNull('name', surveyJson)),
+      description: Value(JsonUtils.getStringOrNull('description', surveyJson)),
+      createdDate: Value(JsonUtils.getLong('createdDate', surveyJson)),
+      updatedDate: Value(JsonUtils.getLong('updatedDate', surveyJson)),
+      adoptionDate: Value(JsonUtils.getLong('adoptionDate', surveyJson)),
+      createdBy: Value(JsonUtils.getStringOrNull('createdBy', surveyJson)),
+      totalMarks: Value(JsonUtils.getInt('totalMarks', surveyJson)),
+      passingPercentage: Value(
+        JsonUtils.getStringOrNull('passingPercentage', surveyJson),
+      ),
+      sourcePlanet: Value(
+        JsonUtils.getStringOrNull('sourcePlanet', surveyJson),
+      ),
+      teamId: Value(JsonUtils.getStringOrNull('teamId', surveyJson)),
+      teamShareAllowed: Value(
+        JsonUtils.getBool('teamShareAllowed', surveyJson),
+      ),
+      sourceSurveyId: Value(
+        JsonUtils.getStringOrNull('sourceSurveyId', surveyJson),
+      ),
+      courseId: Value(courseId),
+      stepId: Value(stepId),
+    ),
+    questions: _parseQuestions(surveyId, surveyJson['questions']),
   );
 
   /// `Value(doc[key])` when the document carries the key, `Value.absent()`

--- a/flutter/lib/providers/app_providers.dart
+++ b/flutter/lib/providers/app_providers.dart
@@ -559,6 +559,8 @@ final coursesRepositoryProvider = Provider<CoursesRepository>(
     ref.watch(planetApiProvider),
     ref.watch(courseDaoProvider),
     ref.watch(removedLogDaoProvider),
+    ref.watch(examDaoProvider),
+    ref.watch(surveyDaoProvider),
   ),
 );
 

--- a/flutter/lib/providers/courses_providers.dart
+++ b/flutter/lib/providers/courses_providers.dart
@@ -265,13 +265,22 @@ final courseStepsProvider = StreamProvider.family<List<CourseStepRow>, String>((
 });
 
 /// The exam attached to a course step, or null if the step has none. Drives
-/// the "Take test" button on the step content view.
+/// the "Take test" button on the step content view and on the course detail
+/// screen — both entries into `TakeExamScreen`.
+///
+/// Port of `ExamDao.getFirstByStepId`, which is `… WHERE stepId = :stepId
+/// LIMIT 1`. Deliberately **not** `ExamDao.getByStepId`, whose
+/// `getSingleOrNull` throws when two rows share a step id: the `courses` walk
+/// writes one exam per step, but a standalone `exams` document is free to carry
+/// a `stepId` key naming the same step, and a screen that throws out of `build`
+/// is worse than one that takes the first row, which is what the Kotlin does.
 final stepExamProvider = FutureProvider.family<ExamRow?, String>((
   ref,
   stepId,
 ) async {
   final db = ref.watch(appDatabaseProvider);
-  return db.examDao.getByStepId(stepId);
+  final rows = await db.examDao.getByStepIds([stepId]);
+  return rows.isEmpty ? null : rows.first;
 });
 
 /// The surveys attached to a course step. Drives the "Take survey" button.

--- a/flutter/lib/providers/courses_providers.dart
+++ b/flutter/lib/providers/courses_providers.dart
@@ -268,13 +268,21 @@ final courseStepsProvider = StreamProvider.family<List<CourseStepRow>, String>((
 /// the "Take test" button on the step content view and on the course detail
 /// screen — both entries into `TakeExamScreen`.
 ///
+/// **`autoDispose`, and that is load-bearing.** A plain `FutureProvider.family`
+/// is cached for the container's lifetime and nothing invalidates these, so a
+/// step opened before the sync wrote its exam answered `null` for the rest of
+/// the process — the one gate on a feature that had just been made to work.
+/// Kotlin re-reads in `CourseStepFragment.onViewCreated`, i.e. on every
+/// fragment creation; disposing when the last listener goes is the closest
+/// equivalent.
+///
 /// Port of `ExamDao.getFirstByStepId`, which is `… WHERE stepId = :stepId
 /// LIMIT 1`. Deliberately **not** `ExamDao.getByStepId`, whose
 /// `getSingleOrNull` throws when two rows share a step id: the `courses` walk
 /// writes one exam per step, but a standalone `exams` document is free to carry
 /// a `stepId` key naming the same step, and a screen that throws out of `build`
 /// is worse than one that takes the first row, which is what the Kotlin does.
-final stepExamProvider = FutureProvider.family<ExamRow?, String>((
+final stepExamProvider = FutureProvider.autoDispose.family<ExamRow?, String>((
   ref,
   stepId,
 ) async {
@@ -284,13 +292,11 @@ final stepExamProvider = FutureProvider.family<ExamRow?, String>((
 });
 
 /// The surveys attached to a course step. Drives the "Take survey" button.
-final stepSurveysProvider = FutureProvider.family<List<SurveyRow>, String>((
-  ref,
-  stepId,
-) async {
-  final db = ref.watch(appDatabaseProvider);
-  return db.surveyDao.getByStepId(stepId);
-});
+final stepSurveysProvider = FutureProvider.autoDispose
+    .family<List<SurveyRow>, String>((ref, stepId) async {
+      final db = ref.watch(appDatabaseProvider);
+      return db.surveyDao.getByStepId(stepId);
+    });
 
 /// Distinct grade levels present locally, for the filter spinner.
 ///

--- a/flutter/lib/repository/courses_repository.dart
+++ b/flutter/lib/repository/courses_repository.dart
@@ -7,6 +7,8 @@ import '../core/utils/url_utils.dart';
 import '../data/api/planet_api.dart';
 import '../data/local/app_database.dart';
 import '../data/local/course_mapper.dart';
+import '../data/local/exam_mapper.dart';
+import '../data/local/survey_mapper.dart';
 import 'shelf_repository.dart';
 
 /// Port of the courses read/sync surface of
@@ -22,7 +24,13 @@ import 'shelf_repository.dart';
 /// SQLite and never touch the network; [sync] refills the table and Drift pushes
 /// the change into any open stream.
 class CoursesRepository {
-  CoursesRepository(this._api, this._dao, this._removedLogDao);
+  CoursesRepository(
+    this._api,
+    this._dao,
+    this._removedLogDao,
+    this._examDao,
+    this._surveyDao,
+  );
 
   /// Courses carry embedded steps, so documents are much larger than resource
   /// documents — a smaller starting page keeps the first batch responsive on a
@@ -32,6 +40,13 @@ class CoursesRepository {
   final PlanetApi _api;
   final CourseDao _dao;
   final RemovedLogDao _removedLogDao;
+
+  /// A course document carries its steps' tests and surveys inline, so the
+  /// `courses` walk writes the exams and surveys tables too — see
+  /// [ExamMapper.fromCourseDoc]. Kotlin's `upsertRoomCoursesFromSync` does the
+  /// same, through `examDao`/`questionDao` (`CoursesRepositoryImpl.kt:650-651`).
+  final ExamDao _examDao;
+  final SurveyDao _surveyDao;
 
   /// Reactive, offline-first course list.
   Stream<List<CourseRow>> watchCourses({
@@ -171,6 +186,10 @@ class CoursesRepository {
 
       final courseRows = <CoursesCompanion>[];
       final stepRows = <CourseStepsCompanion>[];
+      final examRows = <ExamsCompanion>[];
+      final examQuestionRows = <String, List<ExamQuestionsCompanion>>{};
+      final surveyRows = <SurveysCompanion>[];
+      final surveyQuestionRows = <String, List<SurveyQuestionsCompanion>>{};
 
       // Preserve shelf membership already recorded for these courses. Fetched
       // once per page rather than once per row — a large sync would otherwise
@@ -203,10 +222,35 @@ class CoursesRepository {
         courseRows.add(parsed.course);
         stepRows.addAll(parsed.steps);
         savedIds.add(parsed.course.id.value);
+
+        for (final mapping in ExamMapper.fromCourseDoc(
+          doc,
+          stepIdFor: CourseMapper.stepIdFor,
+        )) {
+          examRows.add(mapping.exam);
+          examQuestionRows[mapping.exam.id.value] = mapping.questions;
+        }
+        for (final mapping in SurveyMapper.fromCourseDoc(
+          doc,
+          stepIdFor: CourseMapper.stepIdFor,
+        )) {
+          surveyRows.add(mapping.survey);
+          surveyQuestionRows[mapping.survey.id.value] = mapping.questions;
+        }
       }
 
       if (courseRows.isNotEmpty) {
         await _dao.upsertAll(courseRows, stepRows);
+      }
+      // Written after the courses, so a step row always exists by the time an
+      // exam claims to belong to it. Neither table is pruned here: the `exams`
+      // database walk owns their `deleteNotIn`, and a course test is a document
+      // of that database too, so it is in that walk's keep set.
+      if (examRows.isNotEmpty) {
+        await _examDao.upsertAll(examRows, examQuestionRows);
+      }
+      if (surveyRows.isNotEmpty) {
+        await _surveyDao.upsertAll(surveyRows, surveyQuestionRows);
       }
 
       skip += rows.length;

--- a/flutter/lib/repository/courses_repository.dart
+++ b/flutter/lib/repository/courses_repository.dart
@@ -190,6 +190,10 @@ class CoursesRepository {
       final examQuestionRows = <String, List<ExamQuestionsCompanion>>{};
       final surveyRows = <SurveysCompanion>[];
       final surveyQuestionRows = <String, List<SurveyQuestionsCompanion>>{};
+      // Per course, the assessments its document still claims — anything else
+      // attached to it is a step the author has removed.
+      final examIdsByCourse = <String, Set<String>>{};
+      final surveyIdsByCourse = <String, Set<String>>{};
 
       // Preserve shelf membership already recorded for these courses. Fetched
       // once per page rather than once per row — a large sync would otherwise
@@ -223,19 +227,36 @@ class CoursesRepository {
         stepRows.addAll(parsed.steps);
         savedIds.add(parsed.course.id.value);
 
+        // A question map entry is written only when the embedded object
+        // actually carried questions. `ExamDao.upsertAll` deletes an exam's
+        // questions before reinserting the entry's list, so passing an empty
+        // one for an embedded object with no `questions` array would wipe the
+        // questions the `exams` database walk had written for the same exam —
+        // leaving it openable with nothing in it. Kotlin's `questionDao` never
+        // deletes, so skipping is the faithful half as well as the safe one.
         for (final mapping in ExamMapper.fromCourseDoc(
           doc,
           stepIdFor: CourseMapper.stepIdFor,
         )) {
           examRows.add(mapping.exam);
-          examQuestionRows[mapping.exam.id.value] = mapping.questions;
+          examIdsByCourse
+              .putIfAbsent(courseId, () => <String>{})
+              .add(mapping.exam.id.value);
+          if (mapping.questions.isNotEmpty) {
+            examQuestionRows[mapping.exam.id.value] = mapping.questions;
+          }
         }
         for (final mapping in SurveyMapper.fromCourseDoc(
           doc,
           stepIdFor: CourseMapper.stepIdFor,
         )) {
           surveyRows.add(mapping.survey);
-          surveyQuestionRows[mapping.survey.id.value] = mapping.questions;
+          surveyIdsByCourse
+              .putIfAbsent(courseId, () => <String>{})
+              .add(mapping.survey.id.value);
+          if (mapping.questions.isNotEmpty) {
+            surveyQuestionRows[mapping.survey.id.value] = mapping.questions;
+          }
         }
       }
 
@@ -251,6 +272,21 @@ class CoursesRepository {
       }
       if (surveyRows.isNotEmpty) {
         await _surveyDao.upsertAll(surveyRows, surveyQuestionRows);
+      }
+      // Retire the joins this page's course documents no longer claim. Runs
+      // for every course on the page, not only those that still have an
+      // assessment, so removing the last test from a course clears it too.
+      for (final doc in docs) {
+        final courseId = JsonUtils.getString('_id', doc);
+        if (courseId.isEmpty) continue;
+        await _examDao.releaseStepJoinsForCourse(
+          courseId,
+          examIdsByCourse[courseId] ?? const <String>{},
+        );
+        await _surveyDao.releaseStepJoinsForCourse(
+          courseId,
+          surveyIdsByCourse[courseId] ?? const <String>{},
+        );
       }
 
       skip += rows.length;

--- a/flutter/lib/ui/courses/course_detail_screen.dart
+++ b/flutter/lib/ui/courses/course_detail_screen.dart
@@ -187,7 +187,7 @@ class _StepTile extends ConsumerWidget {
     // A step's exam is the only way into `TakeExamScreen`, exactly as
     // `TakeCourseFragment` is in the Kotlin. Without this the exam screen was
     // routable but unreachable.
-    final exam = ref.watch(examForStepProvider(step.id));
+    final exam = ref.watch(stepExamProvider(step.id));
 
     return Card(
       margin: const EdgeInsets.only(bottom: 8),
@@ -222,14 +222,6 @@ class _StepTile extends ConsumerWidget {
     );
   }
 }
-
-/// The graded exam attached to a course step, if the sync brought one down.
-final examForStepProvider = FutureProvider.family<ExamRow?, String>((
-  ref,
-  stepId,
-) async {
-  return ref.watch(examDaoProvider).getByStepId(stepId);
-});
 
 /// The cover banner on the course detail screen — port of
 /// `CourseDetailFragment.setCourseCover`.

--- a/flutter/lib/ui/courses/course_detail_screen.dart
+++ b/flutter/lib/ui/courses/course_detail_screen.dart
@@ -184,9 +184,16 @@ class _StepTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    // A step's exam is the only way into `TakeExamScreen`, exactly as
-    // `TakeCourseFragment` is in the Kotlin. Without this the exam screen was
-    // routable but unreachable.
+    // **A port addition, not a port of anything.** Kotlin's
+    // `CourseDetailFragment` has no per-step exam button — page 0 of its pager
+    // shows an exam *count* (`CourseDetailFragment.kt:86-88`,
+    // `countByCourseIdAndType(courseId, "courses")`) and the button itself
+    // lives on `CourseStepFragment`, which the port reaches through
+    // `take_course_screen`. An earlier comment here claimed this was "exactly
+    // as `TakeCourseFragment` is in the Kotlin"; it is a second, more direct
+    // entry the port offers. Note it therefore carries none of
+    // `CourseStepFragment`'s gating — no `userHasCourse`, no already-submitted
+    // relabelling.
     final exam = ref.watch(stepExamProvider(step.id));
 
     return Card(

--- a/flutter/lib/ui/courses/take_course_screen.dart
+++ b/flutter/lib/ui/courses/take_course_screen.dart
@@ -147,6 +147,7 @@ class _CourseContent extends ConsumerWidget {
               step: steps[index],
               stepNumber: index + 1,
               totalSteps: steps.length,
+              isMyCourse: isMyCourse,
             ),
           ),
         ),
@@ -166,13 +167,24 @@ class _CourseContent extends ConsumerWidget {
     );
   }
 
-  /// Port of `TakeCourseFragment.onPageSelected` — landing on a step records a
-  /// `course_progress` row (passed=null: an exam grades it later) and queues
-  /// it for upload. The row is keyed by `(courseId, userId, stepNum)`, so a
-  /// re-visit upserts in place rather than creating duplicates.
+  /// Port of `CourseStepFragment.saveCourseProgress` — landing on a step
+  /// records a `course_progress` row and queues it for upload. The row is keyed
+  /// by `(courseId, userId, stepNum)`, so a re-visit upserts in place rather
+  /// than creating duplicates.
+  ///
+  /// `passed` is `if (stepExams.isEmpty()) true else null`
+  /// (`CourseStepFragment.kt:97`): a step with no test is passed by reaching
+  /// it, and a step with one waits for the exam to grade it. The port passed
+  /// `null` unconditionally, because until Phase 113 nothing could tell the two
+  /// apart — `stepExams` is `getByStepIdAndType(stepId, "courses")`, the join
+  /// that did not exist. A course with no tests could therefore never complete.
+  /// Surveys are deliberately not consulted: Kotlin reads `stepExams` here, not
+  /// `stepSurvey`.
   Future<void> _recordProgress(WidgetRef ref, int index) async {
     final userId = this.userId;
     if (userId == null) return;
+
+    final exam = await ref.read(stepExamProvider(steps[index].id).future);
 
     await ref
         .read(progressRepositoryProvider)
@@ -181,6 +193,7 @@ class _CourseContent extends ConsumerWidget {
           courseId: course.id,
           userId: userId,
           stepNum: index + 1,
+          passed: exam == null ? true : null,
         );
     final config = ref.read(serverConfigProvider);
     if (config != null) {
@@ -313,18 +326,29 @@ class _StepContent extends ConsumerWidget {
     required this.step,
     required this.stepNumber,
     required this.totalSteps,
+    required this.isMyCourse,
   });
 
   final CourseStepRow step;
   final int stepNumber;
   final int totalSteps;
 
+  /// `CourseStepFragment.onViewCreated` hides **both** assessment buttons when
+  /// the user has not joined the course, after `hideTestIfNoQuestion` has shown
+  /// them. Without this the port offered a test on a course the learner is only
+  /// browsing.
+  final bool isMyCourse;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final exam = ref.watch(stepExamProvider(step.id)).valueOrNull;
-    final surveys = ref.watch(stepSurveysProvider(step.id)).valueOrNull;
+    final exam = isMyCourse
+        ? ref.watch(stepExamProvider(step.id)).valueOrNull
+        : null;
+    final surveys = isMyCourse
+        ? ref.watch(stepSurveysProvider(step.id)).valueOrNull
+        : null;
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
@@ -370,7 +394,16 @@ class _StepContent extends ConsumerWidget {
                 leading: const Icon(Icons.quiz_outlined),
                 title: Text(l10n.takeTest),
                 trailing: const Icon(Icons.chevron_right),
-                onTap: () => context.push('${Routes.exam}/${exam.id}'),
+                // `Routes.exam` is the *pattern* `/courses/exam/:examId`;
+                // appending the id to it produced
+                // `/courses/exam/:examId/<id>`, which matches no route and
+                // dropped the learner on go_router's error page. The exam
+                // screen wants the step and course as query parameters, as
+                // `CourseStepFragment` passes `stepId`/`stepNum`.
+                onTap: () => context.push(
+                  '/courses/exam/${exam.id}'
+                  '?stepId=${step.id}&courseId=${step.courseId ?? ''}',
+                ),
               ),
             ),
             const SizedBox(height: 8),
@@ -382,9 +415,16 @@ class _StepContent extends ConsumerWidget {
                 leading: const Icon(Icons.assignment_outlined),
                 title: Text(l10n.recordSurvey),
                 trailing: const Icon(Icons.chevron_right),
-                onTap: () => context.push(
-                  '${Routes.publicSurvey}/${surveys.first.teamId ?? ''}/${surveys.first.id}',
-                ),
+                // Kotlin's `btnTakeSurvey` calls
+                // `SubmissionsAdapter.openSurvey(…, stepSurvey[0].id, …)`,
+                // which opens `ExamTakingFragment` against the signed-in
+                // user's own submission — not the anonymous public-survey
+                // path. `Routes.publicSurvey` was both the wrong screen and,
+                // being a pattern rather than a base, an unmatchable route: a
+                // course-step survey has no `teamId`, so the interpolation
+                // left an empty segment too.
+                onTap: () =>
+                    context.push('${Routes.surveys}/${surveys.first.id}'),
               ),
             ),
           ],

--- a/flutter/test/data/local/exam_mapper_test.dart
+++ b/flutter/test/data/local/exam_mapper_test.dart
@@ -154,4 +154,120 @@ void main() {
     expect(converter.fromSql(converter.toSql(choices)), choices);
     expect(converter.fromSql(''), isEmpty);
   });
+
+  group('the exams-database walk', () {
+    // Phase 113. The rule is Kotlin's: `bulkInsertExamsFromSync` parses every
+    // document of that database, and the split between a survey and a test is
+    // made later by `type`. Requiring `type == 'exam'` dropped every real
+    // course test, which carries `type: "courses"`
+    // (`CoursesRepositoryImpl.kt:196`, `:530`).
+    test('accepts a course test, which is typed "courses" and not "exam"', () {
+      final mapped = ExamMapper.fromDoc({
+        '_id': 'exam-1',
+        'type': 'courses',
+        'name': 'Unit 1 test',
+      });
+      expect(mapped, isNotNull);
+      expect(mapped!.exam.id.value, 'exam-1');
+    });
+
+    test('accepts a document with no type at all', () {
+      expect(ExamMapper.fromDoc({'_id': 'exam-1'}), isNotNull);
+    });
+
+    test('leaves stepId and courseId absent when the document omits them', () {
+      // Not `Value(null)`: this walk is called with a blank step and course id
+      // (`SurveysRepositoryImpl.kt:387`), so writing null would erase the join
+      // the `courses` walk owns on the next re-pull.
+      final mapped = ExamMapper.fromDoc({'_id': 'exam-1', 'type': 'courses'})!;
+      expect(mapped.exam.stepId.present, isFalse);
+      expect(mapped.exam.courseId.present, isFalse);
+    });
+
+    test('still records stepId and courseId when the document has them', () {
+      final mapped = ExamMapper.fromDoc(examDoc())!;
+      expect(mapped.exam.stepId.value, 'step-1');
+      expect(mapped.exam.courseId.value, 'course-1');
+    });
+  });
+
+  group('ExamMapper.fromCourseDoc', () {
+    String stepIdFor(String courseId, int index) => '$courseId:$index';
+
+    Map<String, dynamic> courseDoc({
+      Map<String, dynamic>? exam,
+      int steps = 1,
+    }) => {
+      '_id': 'course-1',
+      'courseTitle': 'Water',
+      'steps': [
+        for (var i = 0; i < steps; i++)
+          {'stepTitle': 'Step $i', if (i == 0 && exam != null) 'exam': exam},
+      ],
+    };
+
+    test('attaches the step exam to the step id the course mapper mints', () {
+      final mapped = ExamMapper.fromCourseDoc(
+        courseDoc(
+          exam: {
+            '_id': 'exam-1',
+            'type': 'courses',
+            'name': 'Step test',
+            'questions': [
+              {'id': 'q1', 'title': 'Which is wet?', 'type': 'input'},
+            ],
+          },
+        ),
+        stepIdFor: stepIdFor,
+      );
+
+      expect(mapped, hasLength(1));
+      expect(mapped.single.exam.id.value, 'exam-1');
+      expect(mapped.single.exam.stepId.value, 'course-1:0');
+      expect(mapped.single.exam.courseId.value, 'course-1');
+      expect(mapped.single.exam.noOfQuestions.value, 1);
+      expect(mapped.single.questions.single.examId.value, 'exam-1');
+    });
+
+    test('falls back to a derived id when the embedded exam has none', () {
+      final mapped = ExamMapper.fromCourseDoc(
+        courseDoc(exam: {'name': 'Step test'}),
+        stepIdFor: stepIdFor,
+      );
+      expect(mapped.single.exam.id.value, 'course-1-course-1:0-exam');
+    });
+
+    test("a question's body falls back to its title", () {
+      // `collectRoomExam` does this; `insertExamQuestions` does not.
+      final mapped = ExamMapper.fromCourseDoc(
+        courseDoc(
+          exam: {
+            '_id': 'exam-1',
+            'questions': [
+              {'id': 'q1', 'title': 'Which is wet?', 'type': 'input'},
+            ],
+          },
+        ),
+        stepIdFor: stepIdFor,
+      );
+      expect(mapped.single.questions.single.body.value, 'Which is wet?');
+    });
+
+    test('leaves a step exam that declares itself a survey alone', () {
+      expect(
+        ExamMapper.fromCourseDoc(
+          courseDoc(exam: {'_id': 's-1', 'type': 'surveys'}),
+          stepIdFor: stepIdFor,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('a step with no exam produces nothing', () {
+      expect(
+        ExamMapper.fromCourseDoc(courseDoc(steps: 3), stepIdFor: stepIdFor),
+        isEmpty,
+      );
+    });
+  });
 }

--- a/flutter/test/data/local/exam_mapper_test.dart
+++ b/flutter/test/data/local/exam_mapper_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/data/local/converters.dart';
 import 'package:myplanet/data/local/exam_mapper.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
 
 void main() {
   Map<String, dynamic> examDoc({
@@ -253,13 +254,66 @@ void main() {
       expect(mapped.single.questions.single.body.value, 'Which is wet?');
     });
 
-    test('leaves a step exam that declares itself a survey alone', () {
-      expect(
-        ExamMapper.fromCourseDoc(
-          courseDoc(exam: {'_id': 's-1', 'type': 'surveys'}),
-          stepIdFor: stepIdFor,
+    test('leaves a step exam that declares itself a survey to SurveyMapper', () {
+      // Not dropped: Kotlin files it by its own `type`, so it lands in the one
+      // table as a survey and the Take Survey button finds it.
+      // `SurveyMapper.fromCourseDoc` reads the `exam` key for exactly these.
+      final doc = courseDoc(exam: {'_id': 's-1', 'type': 'surveys'});
+      expect(ExamMapper.fromCourseDoc(doc, stepIdFor: stepIdFor), isEmpty);
+      final asSurvey = SurveyMapper.fromCourseDoc(doc, stepIdFor: stepIdFor);
+      expect(asSurvey.single.survey.id.value, 's-1');
+      expect(asSurvey.single.survey.stepId.value, 'course-1:0');
+    });
+
+    test('duplicate question ids do not produce a duplicate row', () {
+      // `batch.insertAll` raises `UNIQUE constraint failed` where Kotlin's
+      // `@Upsert` lets the later row win, and `CoursesRepository.sync` has no
+      // `try` — so this would abort the whole courses walk. Reachable without
+      // adversarial data: an unlabelled first question takes the positional id
+      // `exam-1-0`, which a second question may carry as its own `id`.
+      final mapped = ExamMapper.fromCourseDoc(
+        courseDoc(
+          exam: {
+            '_id': 'exam-1',
+            'questions': [
+              {'title': 'First'},
+              {'id': 'exam-1-0', 'title': 'Second'},
+            ],
+          },
         ),
-        isEmpty,
+        stepIdFor: stepIdFor,
+      );
+      final ids = mapped.single.questions.map((q) => q.id.value).toList();
+      expect(ids.toSet(), hasLength(ids.length));
+      expect(mapped.single.questions.single.header.value, 'Second');
+    });
+
+    test('noOfQuestions counts the raw array, as the Kotlin does', () {
+      // `getJsonArray("questions", exam).size()` on both walks. Counting the
+      // parsed rows instead made the two walks disagree on the same row.
+      final mapped = ExamMapper.fromCourseDoc(
+        courseDoc(
+          exam: {
+            '_id': 'exam-1',
+            'questions': [
+              {'id': 'q1', 'title': 'Real'},
+              'not an object',
+            ],
+          },
+        ),
+        stepIdFor: stepIdFor,
+      );
+      expect(mapped.single.exam.noOfQuestions.value, 2);
+      expect(mapped.single.questions, hasLength(1));
+      expect(
+        ExamMapper.fromDoc({
+          '_id': 'exam-1',
+          'questions': [
+            {'id': 'q1', 'title': 'Real'},
+            'not an object',
+          ],
+        })!.exam.noOfQuestions.value,
+        2,
       );
     });
 

--- a/flutter/test/data/local/survey_mapper_test.dart
+++ b/flutter/test/data/local/survey_mapper_test.dart
@@ -17,15 +17,17 @@ void main() {
       expect(mapping.survey.stepId.value, 'step-2');
     });
 
-    test('leaves courseId null when absent', () {
+    test('leaves courseId and stepId out of the write when absent', () {
       final mapping = SurveyMapper.fromDoc({
         '_id': 'survey-1',
         'type': 'surveys',
         'name': 'Standalone survey',
       });
       expect(mapping, isNotNull);
-      expect(mapping!.survey.courseId.value, isNull);
-      expect(mapping.survey.stepId.value, isNull);
+      // `Value.absent()`, so an upsert of the standalone document does not
+      // clear a join written by the `courses` walk — see the fromDoc note.
+      expect(mapping!.survey.courseId.present, isFalse);
+      expect(mapping.survey.stepId.present, isFalse);
     });
 
     test('returns null for non-survey documents', () {
@@ -96,6 +98,69 @@ void main() {
       });
 
       expect(mapping!.questions.single.header.value, 'Which service?');
+    });
+  });
+
+  group('SurveyMapper.fromCourseDoc', () {
+    String stepIdFor(String courseId, int index) => '$courseId:$index';
+
+    // Phase 113. A survey attached to a course step arrives embedded in the
+    // course document, exactly as a test does — `collectRoomExam(stepJson,
+    // "survey", …)`. The port had no counterpart, so `SurveyDao.getByStepId`
+    // could never match and the step view's Take Survey button was dead.
+    test('attaches the step survey to the step id the course mapper mints', () {
+      final mapped = SurveyMapper.fromCourseDoc({
+        '_id': 'course-1',
+        'steps': [
+          {
+            'stepTitle': 'Step one',
+            'survey': {
+              '_id': 'survey-1',
+              'type': 'surveys',
+              'name': 'How was it?',
+              'questions': [
+                {'id': 's1', 'title': 'Rate the step', 'type': 'input'},
+              ],
+            },
+          },
+        ],
+      }, stepIdFor: stepIdFor);
+
+      expect(mapped, hasLength(1));
+      expect(mapped.single.survey.id.value, 'survey-1');
+      expect(mapped.single.survey.stepId.value, 'course-1:0');
+      expect(mapped.single.survey.courseId.value, 'course-1');
+      expect(mapped.single.questions.single.surveyId.value, 'survey-1');
+      expect(mapped.single.questions.single.header.value, 'Rate the step');
+    });
+
+    test('files a type-less step survey as a survey', () {
+      // Kotlin types it `"survey"` — singular — and then only queries for
+      // `"surveys"`, so such a row is reachable from neither button. See the
+      // divergence note on `fromCourseDoc`.
+      final mapped = SurveyMapper.fromCourseDoc({
+        '_id': 'course-1',
+        'steps': [
+          {
+            'survey': {'_id': 'survey-1', 'name': 'How was it?'},
+          },
+        ],
+      }, stepIdFor: stepIdFor);
+      expect(mapped, hasLength(1));
+      expect(mapped.single.survey.stepId.value, 'course-1:0');
+    });
+  });
+
+  group('SurveyMapper.fromDoc, step columns', () {
+    test('records stepId and courseId when the document has them', () {
+      final mapped = SurveyMapper.fromDoc({
+        '_id': 'survey-1',
+        'type': 'surveys',
+        'courseId': 'course-1',
+        'stepId': 'step-1',
+      })!;
+      expect(mapped.survey.stepId.value, 'step-1');
+      expect(mapped.survey.courseId.value, 'course-1');
     });
   });
 }

--- a/flutter/test/repository/courses_repository_test.dart
+++ b/flutter/test/repository/courses_repository_test.dart
@@ -5,6 +5,8 @@ import 'package:myplanet/core/network/network_result.dart';
 import 'package:myplanet/core/sync/sync_result.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/exam_mapper.dart';
 import 'package:myplanet/repository/courses_repository.dart';
 
 class MockPlanetApi extends Mock implements PlanetApi {}
@@ -25,7 +27,13 @@ void main() {
   setUp(() {
     db = AppDatabase.memory();
     api = MockPlanetApi();
-    repository = CoursesRepository(api, db.courseDao, db.removedLogDao);
+    repository = CoursesRepository(
+      api,
+      db.courseDao,
+      db.removedLogDao,
+      db.examDao,
+      db.surveyDao,
+    );
   });
 
   tearDown(() => db.close());
@@ -455,6 +463,139 @@ void main() {
       await repository.sync(config: config);
 
       expect(await repository.gradeLevels(), ['Primary']);
+    });
+  });
+
+  group('step exams and surveys (Phase 113)', () {
+    // A course document shaped the way Planet writes one: the step's test and
+    // survey are embedded under `steps[i].exam` / `steps[i].survey`, and the
+    // test carries `type: "courses"`. Nothing in the port used to read them,
+    // so nothing ever wrote an `exams.stepId` equal to a `course_steps.id` and
+    // both entries into the exam screen were dead.
+    Map<String, dynamic> courseWithStepAssessments() => {
+      '_id': 'course-1',
+      'courseTitle': 'Water',
+      'steps': [
+        {'stepTitle': 'Intro'},
+        {
+          'stepTitle': 'Assessment',
+          'exam': {
+            '_id': 'exam-1',
+            'type': 'courses',
+            'name': 'Step two test',
+            'totalMarks': 10,
+            'questions': [
+              {
+                'id': 'q1',
+                'title': 'Which is wet?',
+                'type': 'select',
+                'choices': [
+                  {'id': 'water', 'text': 'Water'},
+                  {'id': 'sand', 'text': 'Sand'},
+                ],
+                'correctChoice': 'water',
+              },
+            ],
+          },
+          'survey': {
+            '_id': 'survey-1',
+            'type': 'surveys',
+            'name': 'Step two survey',
+            'questions': [
+              {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+            ],
+          },
+        },
+      ],
+    };
+
+    test('the courses walk makes the step exam reachable by step id', () async {
+      stubCount(1);
+      stubPage(0, 50, [
+        {'id': 'course-1', 'doc': courseWithStepAssessments()},
+      ]);
+
+      final result = await repository.sync(config: config);
+      expect(result, isA<SyncComplete>());
+
+      final stepId = CourseMapper.stepIdFor('course-1', 1);
+      final exam = await db.examDao.getByStepId(stepId);
+      expect(exam, isNotNull);
+      expect(exam!.id, 'exam-1');
+      expect(exam.courseId, 'course-1');
+      expect(exam.totalMarks, 10);
+      expect(await db.examDao.questionsFor('exam-1'), hasLength(1));
+
+      // The join `ProgressRepository.courseProgress` builds is the same one.
+      final byStepIds = await db.examDao.getByStepIds([
+        for (final step in await db.courseDao.getSteps('course-1')) step.id,
+      ]);
+      expect(byStepIds.single.id, 'exam-1');
+    });
+
+    test('the courses walk makes the step survey reachable too', () async {
+      stubCount(1);
+      stubPage(0, 50, [
+        {'id': 'course-1', 'doc': courseWithStepAssessments()},
+      ]);
+
+      await repository.sync(config: config);
+
+      final stepId = CourseMapper.stepIdFor('course-1', 1);
+      final surveys = await db.surveyDao.getByStepId(stepId);
+      expect(surveys, hasLength(1));
+      expect(surveys.single.id, 'survey-1');
+      expect(await db.surveyDao.questionsFor('survey-1'), hasLength(1));
+      // The step's test must not have landed in the surveys table.
+      expect(await db.surveyDao.getById('exam-1'), isNull);
+      expect(await db.examDao.getById('survey-1'), isNull);
+    });
+
+    test(
+      're-pulling the standalone exam document keeps the step join',
+      () async {
+        // The two walks write the same row: the `courses` walk knows the step,
+        // the `exams` walk does not. Kotlin's `@Upsert` is a full-row replace,
+        // so whichever landed last decided whether the exam still knew its
+        // step. Writing the columns absent removes the race.
+        stubCount(1);
+        stubPage(0, 50, [
+          {'id': 'course-1', 'doc': courseWithStepAssessments()},
+        ]);
+        await repository.sync(config: config);
+
+        final mapped = ExamMapper.fromDoc({
+          '_id': 'exam-1',
+          '_rev': '2-b',
+          'type': 'courses',
+          'name': 'Step two test',
+        })!;
+        await db.examDao.upsertAll([mapped.exam], {'exam-1': mapped.questions});
+
+        final exam = await db.examDao.getByStepId(
+          CourseMapper.stepIdFor('course-1', 1),
+        );
+        expect(exam, isNotNull);
+        expect(exam!.rev, '2-b', reason: 'the re-pull still updates the row');
+      },
+    );
+
+    test('a step with no assessments writes no exam or survey', () async {
+      stubCount(1);
+      stubPage(0, 50, [
+        row(
+          'course-1',
+          'Water',
+          steps: [
+            {'stepTitle': 'Intro'},
+          ],
+        ),
+      ]);
+
+      await repository.sync(config: config);
+
+      expect(await db.examDao.getByStepIds(['course-1:0']), isEmpty);
+      expect(await db.surveyDao.getByStepId('course-1:0'), isEmpty);
     });
   });
 }

--- a/flutter/test/repository/exam_flow_test.dart
+++ b/flutter/test/repository/exam_flow_test.dart
@@ -61,7 +61,10 @@ void main() {
     });
   }
 
-  Map<String, dynamic> examDoc(String id, {String? stepId}) => {
+  Map<String, dynamic> examDoc(
+    String id, {
+    String? stepId,
+  }) => <String, dynamic>{
     '_id': id,
     // `'exam'` is the type `insertCourseStepsExams` falls back to for a
     // document with no `type` key at all; a real course test is `'courses'`.
@@ -124,10 +127,14 @@ void main() {
     });
 
     test('a stale exam and its questions are evicted', () async {
-      stubExamsDatabase([examDoc('exam-1')]);
+      // No `stepId`: the real shape of a standalone `exams` document, and the
+      // shape this prune is for. A row that *does* carry one belongs to the
+      // courses walk and is deliberately spared — see `ExamDao.deleteNotIn`.
+      final noStep = examDoc('exam-1')..remove('stepId');
+      stubExamsDatabase([noStep]);
       await surveys.sync(config: config);
 
-      stubExamsDatabase([examDoc('exam-2')]);
+      stubExamsDatabase([examDoc('exam-2')..remove('stepId')]);
       await surveys.sync(config: config);
 
       expect(await database.examDao.getById('exam-1'), isNull);

--- a/flutter/test/repository/exam_flow_test.dart
+++ b/flutter/test/repository/exam_flow_test.dart
@@ -63,6 +63,10 @@ void main() {
 
   Map<String, dynamic> examDoc(String id, {String? stepId}) => {
     '_id': id,
+    // `'exam'` is the type `insertCourseStepsExams` falls back to for a
+    // document with no `type` key at all; a real course test is `'courses'`.
+    // Both reach the exams table now — the mapper's rule is "anything that is
+    // not a survey" — so this fixture stays valid.
     'type': 'exam',
     'name': 'Exam $id',
     'courseId': 'course-1',
@@ -105,7 +109,15 @@ void main() {
       expect(await database.examDao.questionsFor('exam-1'), hasLength(1));
     });
 
-    test('an exam is reachable from its step', () async {
+    test('a document-carried stepId is still honoured', () async {
+      // **Not the path a course test takes**, and the fixture is not a shape
+      // Planet produces: `StepExam.serializeExam` emits no `stepId`, so an
+      // `exams`-database document has no step id to carry, and the Kotlin's
+      // exams walk passes `""` for it (`SurveysRepositoryImpl.kt:387`). Phase
+      // 113 moved the real join onto the `courses` walk — see
+      // `step_assessment_sync_test.dart`. This only pins that a document that
+      // *does* carry the key is still written with it, which is what keeps
+      // `_presentOrAbsent` honest.
       stubExamsDatabase([examDoc('exam-1', stepId: 'step-7')]);
       await surveys.sync(config: config);
       expect((await database.examDao.getByStepId('step-7'))?.id, 'exam-1');

--- a/flutter/test/repository/progress_repository_test.dart
+++ b/flutter/test/repository/progress_repository_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:myplanet/data/api/planet_api.dart';
 import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/exam_mapper.dart';
 import 'package:myplanet/repository/progress_repository.dart';
 
 class _MockPlanetApi extends Mock implements PlanetApi {}
@@ -221,6 +223,70 @@ void main() {
       expect(gap['course-gap']?.current, 0);
     },
   );
+
+  test('a step exam written by the courses walk carries its question count and '
+      'mistakes into the progress grid', () async {
+    // Phase 113. `courseProgress` joins `exams.stepId` to `course_steps.id`.
+    // Nothing in the port used to write that join, so `questionCount` was 0
+    // and `totalMistakes` 0 for every step regardless of what the learner
+    // had done. The exam row here comes from the mapper the `courses` walk
+    // now runs, not from a hand-faked `stepId`.
+    final mapped = ExamMapper.fromCourseDoc({
+      '_id': 'course-1',
+      'steps': [
+        {'stepTitle': 'Intro'},
+        {
+          'stepTitle': 'Assessment',
+          'exam': {
+            '_id': 'exam-1',
+            'type': 'courses',
+            'questions': [
+              {'id': 'q1', 'title': 'One?', 'type': 'input'},
+              {'id': 'q2', 'title': 'Two?', 'type': 'input'},
+            ],
+          },
+        },
+      ],
+    }, stepIdFor: CourseMapper.stepIdFor);
+    expect(mapped.single.exam.stepId.value, 'course-1:1');
+    await database.examDao.upsertAll(
+      [mapped.single.exam],
+      {'exam-1': mapped.single.questions},
+    );
+
+    // One attempt with two mistakes. `parentId` is `"$examId@$courseId"`,
+    // the shape Phase 110 restored.
+    await database.submissionDao.upsertAll(
+      [
+        SubmissionsCompanion.insert(
+          id: 'sub-1',
+          parentId: const Value('exam-1@course-1'),
+          userId: const Value('user-1'),
+          type: const Value('exam'),
+          status: const Value('requires grading'),
+        ),
+      ],
+      answers: {
+        'sub-1': [
+          SubmissionAnswersCompanion.insert(
+            id: 'sub-1:q1',
+            submissionId: 'sub-1',
+            examId: const Value('exam-1'),
+            questionId: const Value('q1'),
+            mistakes: const Value(2),
+          ),
+        ],
+      },
+    );
+
+    final grid = await repository.courseProgress('course-1', 'user-1');
+    expect(grid, hasLength(3));
+    expect(grid[1].questionCount, 2);
+    expect(grid[1].totalMistakes, 2);
+    // A step with no exam is untouched.
+    expect(grid[0].questionCount, 0);
+    expect(grid[0].totalMistakes, 0);
+  });
 }
 
 /// Seeds a course with [stepCount] steps, mirroring the `course_steps` shape

--- a/flutter/test/repository/step_assessment_sync_test.dart
+++ b/flutter/test/repository/step_assessment_sync_test.dart
@@ -1,0 +1,179 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:myplanet/core/config/server_config.dart';
+import 'package:myplanet/core/network/network_result.dart';
+import 'package:myplanet/core/sync/sync_result.dart';
+import 'package:myplanet/data/api/planet_api.dart';
+import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/repository/courses_repository.dart';
+import 'package:myplanet/repository/submissions_repository.dart';
+import 'package:myplanet/repository/surveys_repository.dart';
+
+class MockPlanetApi extends Mock implements PlanetApi {}
+
+/// Phase 113. A course step's test and survey are written by the **courses**
+/// walk, which is the only walk that knows the step id; the **exams** walk
+/// writes the same documents from the `exams` database and owns the
+/// `deleteNotIn` prune for both tables.
+///
+/// The two therefore have to agree, and the port syncs them in that order
+/// (`DashboardSyncArea.courses` before `.surveys`). These tests pin the
+/// agreement, because a change to either mapper's accept rule would break it
+/// silently: the step exam would be written, pruned minutes later in the same
+/// sync pass, and the Take Test button would go back to never appearing.
+void main() {
+  late AppDatabase db;
+  late MockPlanetApi api;
+  late CoursesRepository courses;
+  late SurveysRepository surveys;
+
+  const config = ServerConfig(
+    serverUrl: 'https://planet.example.org',
+    pin: '1234',
+    couchDbUrl: 'https://satellite:1234@planet.example.org:443',
+  );
+  const dbUrl = 'https://satellite:1234@planet.example.org:443/db';
+
+  setUp(() {
+    db = AppDatabase.memory();
+    api = MockPlanetApi();
+    courses = CoursesRepository(
+      api,
+      db.courseDao,
+      db.removedLogDao,
+      db.examDao,
+      db.surveyDao,
+    );
+    surveys = SurveysRepository(
+      api,
+      db.surveyDao,
+      db.examDao,
+      SubmissionsRepository(
+        api,
+        db.submissionDao,
+        db.submitPhotosDao,
+        db.surveyDao,
+      ),
+    );
+  });
+  tearDown(() => db.close());
+
+  // The exam and survey the course document embeds are also documents of the
+  // `exams` database — the embedded objects carry a CouchDB `_rev`, which is
+  // meaningless on anything unstored, and Kotlin's course walk used to prefetch
+  // the existing rows by those ids before writing them.
+  final examDoc = {
+    '_id': 'exam-1',
+    '_rev': '3-abc',
+    'type': 'courses',
+    'name': 'Step two test',
+    'questions': [
+      {'id': 'q1', 'title': 'Which is wet?', 'type': 'input'},
+    ],
+  };
+  final surveyDoc = {
+    '_id': 'survey-1',
+    '_rev': '2-def',
+    'type': 'surveys',
+    'name': 'Step two survey',
+    'questions': [
+      {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+    ],
+  };
+  final courseDoc = {
+    '_id': 'course-1',
+    'courseTitle': 'Water',
+    'steps': [
+      {'stepTitle': 'Intro'},
+      {'stepTitle': 'Assessment', 'exam': examDoc, 'survey': surveyDoc},
+    ],
+  };
+
+  void stubCourses() {
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/courses/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({'total_rows': 1}),
+    );
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/courses/_all_docs?include_docs=true&limit=50&skip=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          {'id': 'course-1', 'doc': courseDoc},
+        ],
+      }),
+    );
+  }
+
+  void stubExamsDatabase(List<Map<String, dynamic>> docs) {
+    when(
+      () => api.getJsonObject(
+        any(that: contains('/exams/_all_docs?limit=0')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          NetworkSuccess<Map<String, dynamic>>({'total_rows': docs.length}),
+    );
+    when(
+      () => api.getJsonObject(
+        any(that: contains('include_docs=true')),
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          for (final doc in docs) {'id': doc['_id'], 'doc': doc},
+        ],
+      }),
+    );
+  }
+
+  test('the exams walk keeps the step exam the courses walk wrote', () async {
+    stubCourses();
+    await courses.sync(config: config);
+
+    final stepId = CourseMapper.stepIdFor('course-1', 1);
+    expect((await db.examDao.getByStepIds([stepId])).single.id, 'exam-1');
+
+    // Now the exams-database walk, which prunes everything it did not see.
+    stubExamsDatabase([examDoc, surveyDoc]);
+    expect(await surveys.sync(config: config), isA<SyncComplete>());
+
+    final exam = (await db.examDao.getByStepIds([stepId])).single;
+    expect(exam.id, 'exam-1');
+    expect(
+      exam.stepId,
+      stepId,
+      reason:
+          'the exams walk must not clear the join it has no way to know about',
+    );
+    expect(exam.courseId, 'course-1');
+    expect(
+      (await db.surveyDao.getByStepId(stepId)).single.id,
+      'survey-1',
+      reason: 'the step survey survives the same prune',
+    );
+  });
+
+  test('a course test is not pruned as an unknown document type', () async {
+    // The regression this guards: while `ExamMapper.fromDoc` required
+    // `type == "exam"`, a `type: "courses"` document was skipped, so its id
+    // never entered the walk's keep set and `deleteNotIn` deleted the row.
+    stubCourses();
+    await courses.sync(config: config);
+    stubExamsDatabase([examDoc, surveyDoc]);
+    await surveys.sync(config: config);
+
+    expect(await db.examDao.getById('exam-1'), isNotNull);
+    expect(await db.examDao.questionsFor('exam-1'), hasLength(1));
+  });
+}

--- a/flutter/test/repository/step_assessment_sync_test.dart
+++ b/flutter/test/repository/step_assessment_sync_test.dart
@@ -176,4 +176,169 @@ void main() {
     expect(await db.examDao.getById('exam-1'), isNotNull);
     expect(await db.examDao.questionsFor('exam-1'), hasLength(1));
   });
+
+  test('a derived-id step assessment survives the exams walk prune', () async {
+    // The friendly fixture above hides this: there, the embedded copy and
+    // the standalone document are the same object, so the id is always in
+    // the exams walk's keep set. An embedded exam with no `_id` of its own
+    // takes Kotlin's `ifBlank { "$courseId-$stepId-$examKey" }` fallback,
+    // which by construction can never be an `_all_docs` id — so the courses
+    // area wrote the row and the surveys area deleted it in the same pass.
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/courses/_all_docs?limit=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({'total_rows': 1}),
+    );
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/courses/_all_docs?include_docs=true&limit=50&skip=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          {
+            'id': 'course-2',
+            'doc': {
+              '_id': 'course-2',
+              'courseTitle': 'Local',
+              'steps': [
+                {
+                  'stepTitle': 'Assessment',
+                  'exam': {
+                    'name': 'Unpublished test',
+                    'questions': [
+                      {'id': 'q1', 'title': 'One?', 'type': 'input'},
+                    ],
+                  },
+                  'survey': {
+                    'name': 'Unpublished survey',
+                    'questions': [
+                      {'id': 's1', 'title': 'How?', 'type': 'input'},
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+    await courses.sync(config: config);
+
+    final stepId = CourseMapper.stepIdFor('course-2', 0);
+    expect(
+      (await db.examDao.getByStepIds([stepId])).single.id,
+      'course-2-course-2:0-exam',
+    );
+
+    // An exams database that has never heard of either.
+    stubExamsDatabase([examDoc]);
+    await surveys.sync(config: config);
+
+    expect(
+      (await db.examDao.getByStepIds([stepId])).single.id,
+      'course-2-course-2:0-exam',
+      reason: 'a locally derived id can never be in the exams walk keep set',
+    );
+    expect(await db.surveyDao.getByStepId(stepId), hasLength(1));
+  });
+
+  test('removing a step releases the exam it used to carry', () async {
+    // The port's step id is positional, so deleting a step shifts every later
+    // step down one slot. Without the release the old exam would reappear
+    // under whatever step inherited `course-1:1`.
+    stubCourses();
+    await courses.sync(config: config);
+    expect(
+      (await db.examDao.getByStepIds([
+        CourseMapper.stepIdFor('course-1', 1),
+      ])).single.id,
+      'exam-1',
+    );
+
+    when(
+      () => api.getJsonObject(
+        '$dbUrl/courses/_all_docs?include_docs=true&limit=50&skip=0',
+        authHeader: any(named: 'authHeader'),
+      ),
+    ).thenAnswer(
+      (_) async => NetworkSuccess<Map<String, dynamic>>({
+        'rows': [
+          {
+            'id': 'course-1',
+            'doc': {
+              '_id': 'course-1',
+              'courseTitle': 'Water',
+              'steps': [
+                {'stepTitle': 'Intro'},
+              ],
+            },
+          },
+        ],
+      }),
+    );
+    await courses.sync(config: config);
+
+    expect(
+      await db.examDao.getByStepIds([CourseMapper.stepIdFor('course-1', 0)]),
+      isEmpty,
+      reason: 'the surviving step must not inherit the removed step exam',
+    );
+    expect(await db.surveyDao.getByStepId('course-1:0'), isEmpty);
+    // The row itself is kept, detached, so the exams walk can prune it.
+    expect((await db.examDao.getById('exam-1'))?.stepId, isNull);
+  });
+
+  test(
+    'the courses walk does not wipe questions the exams walk wrote',
+    () async {
+      // `ExamDao.upsertAll` deletes an exam's questions before reinserting the
+      // map entry, so an embedded copy carrying no `questions` array would
+      // empty an exam the other walk had filled.
+      stubExamsDatabase([examDoc, surveyDoc]);
+      await surveys.sync(config: config);
+      expect(await db.examDao.questionsFor('exam-1'), hasLength(1));
+
+      when(
+        () => api.getJsonObject(
+          '$dbUrl/courses/_all_docs?limit=0',
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({'total_rows': 1}),
+      );
+      when(
+        () => api.getJsonObject(
+          '$dbUrl/courses/_all_docs?include_docs=true&limit=50&skip=0',
+          authHeader: any(named: 'authHeader'),
+        ),
+      ).thenAnswer(
+        (_) async => NetworkSuccess<Map<String, dynamic>>({
+          'rows': [
+            {
+              'id': 'course-1',
+              'doc': {
+                '_id': 'course-1',
+                'courseTitle': 'Water',
+                'steps': [
+                  {'stepTitle': 'Intro'},
+                  {
+                    'stepTitle': 'Assessment',
+                    'exam': {'_id': 'exam-1', 'type': 'courses'},
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      );
+      await courses.sync(config: config);
+
+      expect(await db.examDao.questionsFor('exam-1'), hasLength(1));
+    },
+  );
 }

--- a/flutter/test/ui/courses/course_detail_screen_test.dart
+++ b/flutter/test/ui/courses/course_detail_screen_test.dart
@@ -4,6 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/exam_mapper.dart';
+import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/courses_providers.dart';
 import 'package:myplanet/providers/ratings_provider.dart';
 import 'package:myplanet/providers/session_provider.dart';
@@ -223,4 +226,60 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Step A'), findsOneWidget);
   });
+
+  testWidgets(
+    'a step carrying an embedded exam offers Take exam, from a real sync',
+    (tester) async {
+      // Phase 113. The reachability proof, and the reason it is written this
+      // way: the join is `exams.stepId == course_steps.id`, and until this
+      // phase nothing in the port ever wrote one. Overriding `stepExamProvider`
+      // here would prove only that the button renders when handed an exam —
+      // which it always did. So the database is filled by the real courses
+      // walk from a real-shaped course document, and the provider does its own
+      // lookup.
+      final db = AppDatabase.memory();
+      addTearDown(db.close);
+
+      const doc = {
+        '_id': 'c1',
+        'courseTitle': 'Water',
+        'steps': [
+          {
+            'stepTitle': 'Assessment',
+            'exam': {
+              '_id': 'exam-1',
+              'type': 'courses',
+              'name': 'Step test',
+              'questions': [
+                {'id': 'q1', 'title': 'Which is wet?', 'type': 'input'},
+              ],
+            },
+          },
+        ],
+      };
+      final parsed = CourseMapper.fromDoc(doc)!;
+      await db.courseDao.upsertAll([parsed.course], parsed.steps);
+      for (final mapping in ExamMapper.fromCourseDoc(
+        doc,
+        stepIdFor: CourseMapper.stepIdFor,
+      )) {
+        await db.examDao.upsertAll(
+          [mapping.exam],
+          {mapping.exam.id.value: mapping.questions},
+        );
+      }
+
+      final steps = await db.courseDao.getSteps('c1');
+      await pumpScreen(
+        tester,
+        course: buildCourseRow(id: 'c1', courseTitle: 'Water'),
+        steps: steps,
+        overrides: [appDatabaseProvider.overrideWithValue(db)],
+      );
+
+      await tester.tap(find.text('Assessment'));
+      await tester.pumpAndSettle();
+      expect(find.widgetWithText(FilledButton, 'Take exam'), findsOneWidget);
+    },
+  );
 }

--- a/flutter/test/ui/courses/take_course_screen_test.dart
+++ b/flutter/test/ui/courses/take_course_screen_test.dart
@@ -45,6 +45,7 @@ void main() {
   Future<void> pumpScreen(
     WidgetTester tester, {
     List<Override> overrides = const [],
+    Map<String, WidgetBuilder> extraTargets = const {},
   }) async {
     await tester.pumpWidget(
       wrapScreen(
@@ -66,6 +67,7 @@ void main() {
         ),
         pushTargets: {
           '/take': (context) => const TakeCourseScreen(courseId: 'course-1'),
+          ...extraTargets,
         },
         overrides: [
           sessionProvider.overrideWith(() => _TestSessionNotifier(_user())),
@@ -273,76 +275,144 @@ void main() {
     expect(find.byType(AlertDialog), findsNothing);
   });
 
+  /// Fills an in-memory database from a real-shaped course document through
+  /// the real mappers, so the `exams.stepId == course_steps.id` join is what
+  /// the test exercises rather than a hand-faked row.
+  Future<AppDatabase> seedStepAssessments() async {
+    final db = AppDatabase.memory();
+    const doc = {
+      '_id': 'course-1',
+      'courseTitle': 'Algebra',
+      'steps': [
+        {
+          'stepTitle': 'First',
+          'exam': {
+            '_id': 'exam-1',
+            'type': 'courses',
+            'name': 'Step test',
+            'questions': [
+              {'id': 'q1', 'title': 'One?', 'type': 'input'},
+            ],
+          },
+          'survey': {
+            '_id': 'survey-1',
+            'type': 'surveys',
+            'name': 'Step survey',
+            'questions': [
+              {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+            ],
+          },
+        },
+      ],
+    };
+    final parsed = CourseMapper.fromDoc(doc)!;
+    await db.courseDao.upsertAll([parsed.course], parsed.steps);
+    for (final mapping in ExamMapper.fromCourseDoc(
+      doc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await db.examDao.upsertAll(
+        [mapping.exam],
+        {mapping.exam.id.value: mapping.questions},
+      );
+    }
+    for (final mapping in SurveyMapper.fromCourseDoc(
+      doc,
+      stepIdFor: CourseMapper.stepIdFor,
+    )) {
+      await db.surveyDao.upsertAll(
+        [mapping.survey],
+        {mapping.survey.id.value: mapping.questions},
+      );
+    }
+    return db;
+  }
+
+  Future<void> pumpSeededStep(
+    WidgetTester tester, {
+    required bool joined,
+  }) async {
+    final db = await seedStepAssessments();
+    addTearDown(db.close);
+    final steps = await db.courseDao.getSteps('course-1');
+    await pumpScreen(
+      tester,
+      // Sentinels rather than the real screens: what is under test is that the
+      // push matches a route at all, and both destinations need a provider
+      // graph of their own.
+      extraTargets: {
+        '/courses/exam/:examId': (context) => Scaffold(
+          body: Text(
+            'EXAM_ROUTE ${GoRouterState.of(context).pathParameters['examId']}',
+          ),
+        ),
+        '/life/surveys/:surveyId': (context) => Scaffold(
+          body: Text(
+            'SURVEY_ROUTE '
+            '${GoRouterState.of(context).pathParameters['surveyId']}',
+          ),
+        ),
+      },
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        courseProvider('course-1').overrideWith(
+          (ref) => Stream.value(
+            buildCourseRow(
+              id: 'course-1',
+              courseTitle: 'Algebra',
+              userId: joined ? const ['user-1'] : const [],
+            ),
+          ),
+        ),
+        courseStepsProvider(
+          'course-1',
+        ).overrideWith((ref) => Stream.value(steps)),
+      ],
+    );
+  }
+
   testWidgets(
     'the step view offers Take test and Take survey for an embedded pair',
     (tester) async {
       // Phase 113. Same reachability proof as `course_detail_screen_test`, on
       // the other entry into `TakeExamScreen`. Neither `stepExamProvider` nor
       // `stepSurveysProvider` is overridden: both do their own lookup against
-      // a database filled by the mappers the courses walk now runs, so the
-      // `exams.stepId == course_steps.id` join is the thing under test.
-      final db = AppDatabase.memory();
-      addTearDown(db.close);
-
-      const doc = {
-        '_id': 'course-1',
-        'courseTitle': 'Algebra',
-        'steps': [
-          {
-            'stepTitle': 'First',
-            'exam': {
-              '_id': 'exam-1',
-              'type': 'courses',
-              'name': 'Step test',
-              'questions': [
-                {'id': 'q1', 'title': 'One?', 'type': 'input'},
-              ],
-            },
-            'survey': {
-              '_id': 'survey-1',
-              'type': 'surveys',
-              'name': 'Step survey',
-              'questions': [
-                {'id': 's1', 'title': 'How was it?', 'type': 'input'},
-              ],
-            },
-          },
-        ],
-      };
-      final parsed = CourseMapper.fromDoc(doc)!;
-      await db.courseDao.upsertAll([parsed.course], parsed.steps);
-      for (final mapping in ExamMapper.fromCourseDoc(
-        doc,
-        stepIdFor: CourseMapper.stepIdFor,
-      )) {
-        await db.examDao.upsertAll(
-          [mapping.exam],
-          {mapping.exam.id.value: mapping.questions},
-        );
-      }
-      for (final mapping in SurveyMapper.fromCourseDoc(
-        doc,
-        stepIdFor: CourseMapper.stepIdFor,
-      )) {
-        await db.surveyDao.upsertAll(
-          [mapping.survey],
-          {mapping.survey.id.value: mapping.questions},
-        );
-      }
-      final steps = await db.courseDao.getSteps('course-1');
-
-      await pumpScreen(
-        tester,
-        overrides: [
-          appDatabaseProvider.overrideWithValue(db),
-          courseStepsProvider(
-            'course-1',
-          ).overrideWith((ref) => Stream.value(steps)),
-        ],
-      );
+      // a database filled by the mappers the courses walk now runs.
+      await pumpSeededStep(tester, joined: true);
 
       expect(find.text('Take test'), findsOneWidget);
       expect(find.text('Record survey'), findsOneWidget);
+
+      // **Rendering is not reachability**, which is what the first cut of this
+      // test asserted and all it asserted. Both buttons concatenated the route
+      // *pattern* — `Routes.exam` is `/courses/exam/:examId`, so the push was
+      // `/courses/exam/:examId/exam-1` — which matches no route and drops the
+      // learner on go_router's error page.
+      await tester.tap(find.text('Take test'));
+      await tester.pumpAndSettle();
+      expect(find.text('EXAM_ROUTE exam-1'), findsOneWidget);
     },
   );
+
+  testWidgets('Record survey opens the signed-in survey screen', (
+    tester,
+  ) async {
+    // Kotlin's `btnTakeSurvey` opens `ExamTakingFragment` against the user's
+    // own submission (`SubmissionsAdapter.openSurvey`). The port aimed at the
+    // anonymous public-survey screen, on a route that could not match anyway.
+    await pumpSeededStep(tester, joined: true);
+    await tester.tap(find.text('Record survey'));
+    await tester.pumpAndSettle();
+    expect(find.text('SURVEY_ROUTE survey-1'), findsOneWidget);
+  });
+
+  testWidgets('a course the learner has not joined offers neither', (
+    tester,
+  ) async {
+    // `CourseStepFragment.onViewCreated` hides both after
+    // `hideTestIfNoQuestion` has shown them, when `!userHasCourse`.
+    await pumpSeededStep(tester, joined: false);
+    expect(find.text('Take test'), findsNothing);
+    expect(find.text('Record survey'), findsNothing);
+  });
 }

--- a/flutter/test/ui/courses/take_course_screen_test.dart
+++ b/flutter/test/ui/courses/take_course_screen_test.dart
@@ -4,6 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:drift/drift.dart' show Value;
 import 'package:myplanet/data/local/app_database.dart';
+import 'package:myplanet/data/local/course_mapper.dart';
+import 'package:myplanet/data/local/exam_mapper.dart';
+import 'package:myplanet/data/local/survey_mapper.dart';
 import 'package:myplanet/providers/app_providers.dart';
 import 'package:myplanet/providers/courses_providers.dart';
 import 'package:myplanet/providers/ratings_provider.dart';
@@ -269,4 +272,77 @@ void main() {
     );
     expect(find.byType(AlertDialog), findsNothing);
   });
+
+  testWidgets(
+    'the step view offers Take test and Take survey for an embedded pair',
+    (tester) async {
+      // Phase 113. Same reachability proof as `course_detail_screen_test`, on
+      // the other entry into `TakeExamScreen`. Neither `stepExamProvider` nor
+      // `stepSurveysProvider` is overridden: both do their own lookup against
+      // a database filled by the mappers the courses walk now runs, so the
+      // `exams.stepId == course_steps.id` join is the thing under test.
+      final db = AppDatabase.memory();
+      addTearDown(db.close);
+
+      const doc = {
+        '_id': 'course-1',
+        'courseTitle': 'Algebra',
+        'steps': [
+          {
+            'stepTitle': 'First',
+            'exam': {
+              '_id': 'exam-1',
+              'type': 'courses',
+              'name': 'Step test',
+              'questions': [
+                {'id': 'q1', 'title': 'One?', 'type': 'input'},
+              ],
+            },
+            'survey': {
+              '_id': 'survey-1',
+              'type': 'surveys',
+              'name': 'Step survey',
+              'questions': [
+                {'id': 's1', 'title': 'How was it?', 'type': 'input'},
+              ],
+            },
+          },
+        ],
+      };
+      final parsed = CourseMapper.fromDoc(doc)!;
+      await db.courseDao.upsertAll([parsed.course], parsed.steps);
+      for (final mapping in ExamMapper.fromCourseDoc(
+        doc,
+        stepIdFor: CourseMapper.stepIdFor,
+      )) {
+        await db.examDao.upsertAll(
+          [mapping.exam],
+          {mapping.exam.id.value: mapping.questions},
+        );
+      }
+      for (final mapping in SurveyMapper.fromCourseDoc(
+        doc,
+        stepIdFor: CourseMapper.stepIdFor,
+      )) {
+        await db.surveyDao.upsertAll(
+          [mapping.survey],
+          {mapping.survey.id.value: mapping.questions},
+        );
+      }
+      final steps = await db.courseDao.getSteps('course-1');
+
+      await pumpScreen(
+        tester,
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          courseStepsProvider(
+            'course-1',
+          ).overrideWith((ref) => Stream.value(steps)),
+        ],
+      );
+
+      expect(find.text('Take test'), findsOneWidget);
+      expect(find.text('Record survey'), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION
Lane A of the Phase 111–113 round. Full write-up in `flutter/PHASE_113_NOTES.md`.

## Verdict

Phase 110 was right that `TakeExamScreen` was unreachable, and the cause is worse than it recorded: **the port never wrote the exam at all.**

1. **A course step's test and survey arrive embedded in the course document** (`steps[i].exam` / `steps[i].survey`) and are written by the *courses* walk, which mints the step id and hands it straight to the exam (`CoursesRepositoryImpl.collectRoomExam`). The port's `CourseMapper` dropped both halves and its exam mapper took `stepId` from a document key that does not exist — `StepExam.serializeExam` emits no `stepId` and no `courseId`, so the step id is purely client-derived with no server representation.
2. **`ExamMapper.fromDoc` required `type == 'exam'`**, a value `insertCourseStepsExams` uses only as a fallback for a document with no type. No Kotlin query anywhere filters the exams table on `type = "exam"`; a course test carries `type: "courses"`.

**Surveys share the problem exactly.** The Take Survey button was equally dead.

**Payoff: the graded-course-exam work of Phases 100 and 106 is now reachable.**

## What changed

- `ExamMapper.fromCourseDoc` / `SurveyMapper.fromCourseDoc` port `collectRoomExam` for both step keys; `CoursesRepository.sync` writes their rows.
- The exams-database walk accepts anything that is not a survey — Kotlin's own partition — and writes `stepId`/`courseId` absent rather than null so a re-pull cannot erase the join.
- `ExamDao`/`SurveyDao` `deleteNotIn` spare rows carrying a `stepId`; `releaseStepJoinsForCourse` retires the ones a course no longer claims; question batches upsert instead of insert.
- A step with no test records `passed = true`, as `CourseStepFragment` does — so a course with no tests can complete.

No schema change (still v45), no new `app_en.arb` key, no codegen needed.

## Method

Two `parity-auditor` passes at max effort. The first established the Kotlin. **The second, pointed at the finished and already-green implementation, found twelve more defects** — among them: the exams walk deleting step assessments in the same sync pass, a stale `stepId` that nothing retired, both step buttons navigating to an unmatchable route, and a provider caching a pre-sync `null` for the process lifetime. A thirteenth surfaced from the fix. Every one is demonstrated failing-first.

## Files outside Lane A's set

Reported rather than assumed; none owned by Lane B or C.

- `lib/data/local/app_database.dart` — the prune predicates, `releaseStepJoinsForCourse`, and the question-batch upsert. Not optional: without it the feature loses data on every sync. No schema change.
- `lib/providers/app_providers.dart` — two arguments added to `coursesRepositoryProvider`.

## Gate

Format clean, `flutter analyze` clean, **1829 tests pass** (1801 at branch point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZPaWdTjgcubV4Vq9wRrdB