### PR TITLE
Phase 114: recover the human translations the Flutter port left on the table

### DIFF
--- a/flutter/PHASE_114_NOTES.md
+++ b/flutter/PHASE_114_NOTES.md
@@ -1,0 +1,3 @@
+# Phase 114 — recovering the human translations the port left on the table
+
+Work in progress. See the PR for the current state.

--- a/flutter/PHASE_114_NOTES.md
+++ b/flutter/PHASE_114_NOTES.md
@@ -1,3 +1,320 @@
 # Phase 114 — recovering the human translations the port left on the table
 
-Work in progress. See the PR for the current state.
+Lane B. `lib/l10n/*.arb`, `tool/arb_from_strings_xml.dart`, `test/l10n/`.
+
+## The premise, and why it was bigger than one string
+
+Phase 110 found that the exam retry snackbar used `incorrectAnswer` — "Incorrect
+answer" — where Kotlin's `incorrect_ans` says "Incorrect answer, please try
+again" and ships a real human translation of that sentence in all five locales.
+It handed the fix back because locale files were not its lane.
+
+That is not one string. It is a class, and the class has a mechanism behind it:
+**`tool/arb_from_strings_xml.dart` merges, and existing values win.** The rule is
+right for what it was written for — it stops a re-run deleting the 17 keys per
+locale that were translated by hand and have no Kotlin counterpart — but it also
+means the tool can only ever *add*. Once the external machine-translation pass
+filled ~560 keys per locale, every one of them was frozen, including the ones
+whose English the Kotlin app had been shipping a human translation of for years.
+The tool would never look at them again.
+
+So the recovery needed a mode that is allowed to overwrite, and a rule for what
+it may overwrite that cannot cost anybody their work.
+
+## `incorrect_ans`, before and after
+
+`app_en.arb` changes too: the port's English was its own wording, and the retry
+hint is the point of the string, not a flourish. Under Phase 110's gate this
+snackbar is the only thing telling a learner to try again.
+
+| | before | after |
+|---|---|---|
+| en | Incorrect answer | Incorrect answer, please try again |
+| ar | إجابة غير صحيحة *(x-mt)* | إجابة غير صحيحة، يرجى المحاولة مرة أخرى |
+| es | respuesta incorrecta *(x-mt)* | Respuesta incorrecta, por favor inténtalo de nuevo |
+| fr | Réponse incorrecte *(x-mt)* | Réponse incorrecte, veuillez réessayer |
+| ne | `[Nepali] Incorrect answer` *(x-mt)* | तपाईंले गलत उत्तर दिएका छन्, कृपया पुन: प्रयास गर्नुहोस् |
+| so | `[Somali] Incorrect answer` *(x-mt)* | Jawaab aan sax ahayn, fadlan isku day |
+
+Two of the five were not translations at all — they were the external tool's own
+"nothing here" marker sitting in the file as a value. All five are now human, and
+none carries `x-mt` any more.
+
+`test/ui/exam/take_exam_screen_test.dart` follows the English in two `find.text`
+literals. **That file is Lane A's**; the change is mechanical and is flagged for
+the integrator rather than done quietly.
+
+## The class
+
+`dart tool/arb_from_strings_xml.dart --candidates` reports; `--adopt` applies.
+Both are new. The report is the deliverable as much as the adoption is — 858 keys
+against 1050 Kotlin strings is not a thing to eyeball.
+
+**Matching is on English text, never on the key name.** The ARB key and the
+Kotlin name agree about a concept, not about a string: `achievements` ↔
+`myAchievements`, `teamLeader` ("You lead this team") ↔ `team_leader` ("Team
+Leader"), `taskNotification` ("Task") ↔ `task_notification` ("%1$s is due in
+%2$s"). A name-driven derivation would have swapped in translations of different
+words, silently, in five languages at once. Three tiers are adopted:
+
+| tier | rule | transformation |
+|---|---|---|
+| `exact` | identical after trimming | none |
+| `punctuation` | identical once a trailing `: . … !` run and its space are dropped from both | strip that run from the translation, give it the template's own trailing punctuation back |
+| `casing` | identical once case is ignored too | as above, plus align the first character to the template's case, upwards only |
+
+and two are reported and never applied: `nameOnly` (name matches, English does
+not) and `containment` (one English contains the other — the `incorrectAnswer`
+shape, where the port paraphrased a string Kotlin already had). Fixing one of
+those means changing `app_en.arb`, which is a judgement about what a screen
+should say, not a derivation. A tier's candidates must also be **unanimous**:
+`values/strings.xml` gives several names to one English phrase and they do not
+always agree in translation.
+
+**What may be overwritten** is only a value that is demonstrably not a human
+translation: absent, flagged `x-mt`, still carrying an `[Nepali] `-style marker,
+byte-identical to the English template, or the same translation differing only in
+surrounding whitespace. Anything else is somebody's work and is left alone **even
+when Kotlin disagrees with it** — 32 such disagreements are listed below rather
+than resolved, because this script has no way to tell a better rendering from a
+worse one.
+
+Three punctuation details are worth knowing, because two of them were caught by
+looking at output rather than by reasoning:
+
+* the template's trailing punctuation is only re-attached **onto a word**.
+  Nepali ends a sentence with the danda `।`, and appending a full stop produced
+  `CSV फाइल सुरक्षित गर्न असफल।.`;
+* a trailing space the template carries deliberately is preserved.
+  `selectResources` is `"Select resources: "` in both `app_en.arb` and the Kotlin
+  XML — Android's quoting exists precisely to protect that space, because the
+  value is drawn straight after it — and a `.trim()` would close the gap in every
+  language but English. Arabic had already lost it;
+* the first-character case alignment is **upwards only**. Lowercasing a
+  translation's first letter is not safe in general, and nothing here needs it.
+
+### Two things the audit found that were not what it was looking for
+
+**`app_es.arb` had never been through the derivation script at all.** A comment
+in the tool said the Kotlin app has no `values-es`. It has — 1050 strings, the
+same as every other locale. Spanish carried the most machine-translated strings
+of any locale (620) for exactly that reason, and gained the most human ones
+proportionally.
+
+**Fourteen French strings and one Somali one were rendering a literal
+backslash.** Android escapes an apostrophe in `strings.xml` as `\'`; the
+backslash is the platform's, not the sentence's. `_unquote` learned to strip it
+at some point, but values derived before that kept it, and nothing could see it:
+the value is well-formed JSON, `gen-l10n` compiles it, no analyzer looks inside a
+string. `Demandes d\'adhésion`, `Su\'aal`. `--adopt` repairs them wherever they
+survive, independently of any match.
+
+## Counts
+
+Examined: **858 template keys** against **1050 Kotlin strings**, in 5 locales.
+Matched at some tier: **445 keys** (268 `exact`, 10 `punctuation`, 85 `casing`,
+42 `nameOnly`, 85 `containment` — a key stops at the first tier that hits).
+Applied: **494 values** across the five locales, from the three adoptable tiers
+only.
+
+| locale | values | `x-mt` before → after | human before → after |
+|---|---|---|---|
+| ar | 816 → 821 | 557 → 496 (−61) | 259 → 325 |
+| es | 854 → 859 | 620 → 538 (−82) | 234 → 321 |
+| fr | 854 → 859 | 594 → 545 (−49) | 260 → 314 |
+| ne | 854 → 859 | 595 → 475 (−120) | 259 → 384 |
+| so | 854 → 859 | 595 → 476 (−119) | 259 → 383 |
+
+**431 machine-translated strings replaced by human ones**, and 25 keys that had
+no value at all now have one. `--adopt` is idempotent: a second run reports zero.
+
+## Residue — what was found and deliberately not applied
+
+Run `dart tool/arb_from_strings_xml.dart --candidates` for the live list with
+before/after values. In summary:
+
+**32 `keep-human`** — Kotlin has a different translation of the same English and
+the ARB's is unflagged, so it is somebody's work. es 22, so 4, fr 4, ne 1. Two
+recognisable groups: a genuine disagreement (`amount` Monto/Cantidad,
+`unselectAll` "Tout désélectionner"/"Désélectionner tout", `myProgress` "Mi
+Progreso" against the Spanish XML's camelCase artefact `miProgreso`), and a
+first-letter case difference where the ARB copied Kotlin's lowercase English
+(`view` → `ver`/`afficher`/`eeg`, `exportCancelled`, `failedToSaveCsvFile`).
+The second group is a presentation fix somebody could just make; it is not a
+translation question.
+
+**33 `no-unanimous`** — two or more Kotlin names share the English and disagree
+in translation, so there is nothing to prefer. so 12, ar 6, es 5, fr 5, ne 5.
+Some are worth a human's five minutes because the current value is the *English*:
+`so:settings` is still "Settings" and `ne:joinRequests` still
+`[Nepali] Join requests`, blocked only by `join_requests` and
+`notif_group_join_requests` disagreeing.
+
+**42 `nameOnly` + 85 `containment`** — the English differs, so recovering one
+means editing `app_en.arb`. This is the `incorrect_ans` shape and the list is
+where the next pass should start; `incorrect_ans` itself would have appeared
+under `containment`.
+
+### nameOnly
+
+| key | `app_en.arb` | Kotlin |
+|---|---|---|
+| `subjectLevel` | Subject | subject_level="Subject Level" |
+| `levels` | Levels | levels="Levels*" |
+| `invalidEmail` | Enter a valid email address | invalid_email="Invalid email." |
+| `taskNotification` | Task | task_notification="%1$s is due in %2$s" |
+| `achievements` | Achievements | achievements="myAchievements" |
+| `submission` | Submission | submission="mySubmissions" |
+| `editPersonal` | Edit personal item | edit_personal="Edit Personal" |
+| `noSurveys` | No surveys available | no_surveys="surveys not available" |
+| `surveyLoadFailed` | Survey could not be loaded | survey_load_failed="Couldn't load the survey. Please try again." |
+| `surveySubmitFailed` | Could not save your answers | survey_submit_failed="Couldn't submit the survey. Please try again." |
+| `sendSurveyTo` | Select users to send survey to | send_survey_to="Send Survey to:" |
+| `surveySentToUsers` | Survey sent to selected users | survey_sent_to_users="Survey sent to users" |
+| `noTeams` | No teams available | no_teams="teams not available" |
+| `teamLeader` | You lead this team | team_leader="Team Leader" |
+| `noTeamResources` | No resources linked to this team | no_team_resources="team resources not available" |
+| `privateResource` | Private resource | private_resource="Private resource (only visible to this team)" |
+| `selectOpenWith` | Select open with | select_open_with="Open" |
+| `selectMedia` | Select media | select_media="Media" |
+| `selectResourceType` | Select resource type | select_resource_type="Resource type" |
+| `noTeamCourses` | No courses linked to this team | no_team_courses="team courses not available" |
+| `noReports` | No financial reports yet | no_reports="No reports available" |
+| `profitLoss` | Profit / loss | profit_loss="Profit/Loss" |
+| `chatHistory` | Chat History | chat_history="chat history list" |
+| `noChats` | No chats yet | no_chats="no previous chats" |
+| `isUrgent` | Is this urgent? | is_urgent="Is your feedback Urgent? *" |
+| `feedbackType` | Feedback type | feedback_type="Feedback Type: *" |
+| `yourFeedback` | Your feedback | your_feedback="Your Feedback *" |
+| `pleaseEnterFeedback` | Please enter your feedback | please_enter_feedback="Please enter feedback." |
+| `takeTest` | Take test | take_test="take test [%d]" |
+| `error` | Error | error="Error: %1$s" |
+| `note` | Note | note="Note *", note_="notes" |
+| `height` | Height | height="Height (cm)" |
+| `weight` | Weight | weight="Weight (kg)" |
+| `bloodPressure` | Blood pressure | blood_pressure="Blood Pressure (Systolic/Diastolic)" |
+| `selfExamination` | Self-examination | self_examination="%s\nSelf Examination" |
+| `retypePassword` | Retype password | retype_password="Confirm Password" |
+| `courseNotStarted` | Course: Not started | course_not_started="%1$s not started" |
+| `resourceFor` | For | resource_for="Resource For" |
+| `subject` | Subject | subject="Subject(s)*:" |
+| `addedToMyLibrary` | Added to My Library | added_to_my_library="added to myLibrary" |
+| `myLibrary` | My Library | my_library="mylibrary" |
+| `dataCleared` | All data cleared | data_cleared="Data cleared" |
+
+### containment
+
+| key | `app_en.arb` | Kotlin |
+|---|---|---|
+| `serverUrlLabel` | Server URL | please_enter_server_url_first="Please enter server url first.", server_url_not_configured="Server URL not configured" |
+| `serverUrlHint` | https://planet.example.org | https_protocol="https://" |
+| `invalidCredentials` | Name or password is incorrect. | password="password" |
+| `missingAuthData` | Server response missing authentication data. | response="Response" |
+| `emptyCredentials` | Username and password are required. | hint_name="username", password="password" |
+| `backgroundSucceeded` | Completed successfully | completed="Completed", complete="complete", status_completed="Completed" |
+| `backgroundRetryRequested` | Incomplete — Android will retry | complete="complete" |
+| `syncForegroundNotice` | Keep myPlanet open until the sync finishes. Pending offline writes remain durable if the connection drops. | app_project_name="myPlanet", menu_myplanet="myPlanet", system_name="myPlanet" |
+| `syncVoicesDescription` | Refresh community discussions and replies | menu_community="Community", community="community" |
+| `syncFeedbackDescription` | Refresh feedback threads and responses | menu_feedback="Feedback", feedback="Feedback", response="Response" |
+| `joinCourse` | Add to my courses | my_courses="My Courses" |
+| `leaveCourse` | Remove from my courses | my_courses="My Courses" |
+| `serverUrl` | Server URL | please_enter_server_url_first="Please enter server url first.", server_url_not_configured="Server URL not configured" |
+| `notConfigured` | Not configured | server_not_configured_properly_connect_this_device_with_planet_server="Server not configured properly. Connect this device with Planet server", server_url_not_configured="Server URL not configured" |
+| `communityCode` | Community code | menu_community="Community", community="community" |
+| `dictionaryDescription` | Search downloaded definitions offline | download="Download", downloaded="Downloaded" |
+| `dictionaryUnavailable` | Dictionary unavailable | dictionary="Dictionary" |
+| `downloadDictionary` | Download dictionary | download="Download", dictionary="Dictionary" |
+| `retryDownload` | Retry download | download="Download" |
+| `dictionaryDownloadFailed` | The dictionary could not be downloaded. Your existing offline data was not changed. | download="Download", dictionary="Dictionary", downloaded="Downloaded" |
+| `wordNotFound` | Word not available in the offline dictionary | dictionary="Dictionary" |
+| `notifications` | Notifications | no_notifications="No notifications", no_unread_notifications="No unread notifications", no_read_notifications="No read notifications" |
+| `notification` | Notification | downloading_started_please_check_notification="Downloading started, please check notification…", downloading_started_please_check_notificati="Downloading started, please check notification…", no_notifications="No notifications", no_unread_notifications="No unread notifications", no_read_notifications="No read notifications", downloading_images_please_check_notification="Downloading images, please check notification…" |
+| `deleteNotificationConfirmation` | This notification will be removed from this device. | removed_from="removed from" |
+| `teamNotification` | Team update | notif_group_team_updates="Team Updates" |
+| `myHealth` | My health | my_health_saved_successfully="My health saved successfully" |
+| `submissions` | Submissions | submission="mySubmissions", no_survey_submissions="no survey submissions", no_exam_submissions="no exam submissions" |
+| `lastUpdated` | Last updated | disclaimer="\n    \n    <h1>Disclaimer</h1>\n    <p>Last updated: January 10, 2020</p>\n    <h1>Interpretation and Definitions</h1>\n    <h2>Interpretation</h2>\n    <p>The words of which the initial letter is capitalized have meanings defined under the following conditions.</p>\n    <p>The following definitions shall have the same meaning regardless of whether they appear in singular or in plural.</p>\n    <h2>Definitions</h2>\n    <p>For the purposes of this Disclaimer:</p>\n    <ul>\n        <li><strong>Company</strong> (referred to as either "the Company", "We", "Us" or "Our" in this Cookies Policy) refers to myPlanet.</li>\n        <li><strong>You</strong> means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.</li>\n        <li><strong>Application</strong> means the software program provided by the Company downloaded by You on any electronic device named myPlanet.</li>\n        <li><strong>Service</strong> refers to the Application.</li>\n    </ul>\n    <h1>Disclaimer</h1>\n    <p>The information contained on the Service is for general information purposes only.</p>\n    <p>The Company assumes no responsibility for errors or omissions in the contents of the Service.</p>\n    <p>In no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice.</p>\n    <p>The Company does not warrant that the Service is free of viruses or other harmful components.</p>\n    <h1>Medical Information Disclaimer</h1>\n    <p>The information about health provided by the Service is not intended to diagnose, treat, cure or prevent disease. Products, services, information and other content provided by the Service, including information linking to third-party websites are provided for informational purposes only.</p>\n    <p>Information offered by the Service is not comprehensive and does not cover all diseases, ailments, physical conditions or their treatment.</p>\n    <p>Individuals are different and may react differently to different products. Comments made on the Service by employees or other users are strictly their own personal views made in their own personal capacity and are not claims made by the Company nor do they represent the position or view of the Company.</p>\n    <p>The Company is not liable for any information provided by the Service with regard to recommendations regarding supplements for any health purposes.</p>\n    <p>The Company makes no guarantee or warranty with respect to any products or services sold. The Company is not responsible for any damages for information or services provided even if the Company has been advised of the possibility of damages.</p>\n    <h1>External Links Disclaimer</h1>\n    <p>The Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.</p>\n    <p>Please note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.</p>\n    <h1>Errors and Omissions Disclaimer</h1>\n    <p>The information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to ensure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules, and regulations, there may be delays, omissions, or inaccuracies in the information contained on the Service.</p>\n    <p>The Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.</p>\n    <h1>Fair Use Disclaimer</h1>\n    <p>The Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.</p>\n    <p>The Company believes this constitutes a "fair use" of any such copyrighted material as provided for in section 107 of the United States Copyright law.</p>\n    <p>If You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.</p>\n    <h1>Views Expressed Disclaimer</h1>\n    <p>The Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer, or company, including the Company.</p>\n    <p>Comments published by users are their sole responsibility and the users will take full responsibility, liability, and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.</p>\n    <h1>No Responsibility Disclaimer</h1>\n    <p>The information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal, or other competent advisers.</p>\n    <p>In no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.</p>\n    <h1>"Use at Your Own Risk" Disclaimer</h1>\n    <p>All information in the Service is provided "as is", with no guarantee of completeness, accuracy, timeliness, or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability, and fitness for a particular purpose.</p>\n    <p>The Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special, or similar damages, even if advised of the possibility of such damages.</p>\n    <h2>Contact Us</h2>\n    <p>If you have any questions about this Disclaimer, You can contact Us:</p>\n    <ul>\n        <li>By email: myplanet@ole.org</li>\n        <li>By visiting this page on our website: <a href="https://ole.org/contact">https://ole.org/contact</a></li>\n    </ul>\n    \n    " |
+| `uploaded` | Uploaded | about="\n    \n    <h3>MyPlanet</h3>\n    <p>myPlanet is a learning tool that is designed to work with Planet web application.\n        It has been used to improve early education, secondary schools, village health, youth workforce development,\n        and economic and community development.</p>\n    <p>Planet houses is a repository of free, open access and public domain resources to benefit all learners.</p>\n\n    <p>myPlanet is designed to be available to everyone, everywhere, all the time. It is portable, affordable, scalable and sustainable.\n        It runs on any android device such as tablets and mobile phones. It functions off, as well as on, the Internet.</p>\n\n    <p>This application enables schools and communities to have a complete multi-media library and learning system that periodically connects with Planet.\n        Configured devices can contain the learners' personal dashboard. This ensures learners can read books on their shelf and take courses offline - i.e\n        without connection to a central server. Learners are encouraged to rate from one to five stars the resources they use and the courses they take.\n        Periodically learners can sync with a server. Activity data are uploaded and new resources are downloaded in a matter of a few minutes unto myPlanet for offline use.</p>\n\n    <p>The dashboard also contains a record of achievements, a calendar of events, and an internal chat system for communicating with fellow members.</p>\n\n    <p>myPlanet has been proven highly effective in improving learning opportunities for over fifty thousand learners in more than 100 locations,\n        in schools throughout Nepal, Ghana, Kenya, and Rwanda, with Syrian refugees in Jordan, Somali refugees in Kenya, and village health workers in Uganda.</p>\n    \n    " |
+| `noPersonals` | No personal items yet. Add a private note to get started. | get_started="GET STARTED" |
+| `onboardingOfflineDescription` | Download resources for offline learning.\nAccess knowledge on the go. | download="Download", resources="Resources", download_resources="download Resources", ob_desc2_1="Download resources for offline learning." |
+| `onboardingOpenDescription` | Choose your interests and dive into interactive content.\nCraft your unique learning journey. | ob_desc3_1="Choose your interests and dive into interactive content." |
+| `onboardingPowerDescription` | Explore a world of knowledge at your fingertips.\n\n🌍 Offline Access: Learn without borders, anytime.\n🎯 Personalized: Tailor your learning path.\n📚 Interactive: Engage with videos, books, games.\n\nBegin your limitless learning journey with myPlanet! | app_project_name="myPlanet", menu_myplanet="myPlanet", system_name="myPlanet", ob_desc4_1="Explore a world of knowledge at your fingertips.", ob_desc4_2="🌍 Offline Access: Learn without borders, anytime.", ob_desc4_3="🎯 Personalized: Tailor your learning path.", ob_desc4_4="📚 Interactive: Engage with videos, books, games." |
+| `category` | Category | filter_by_category="Filter By Category" |
+| `sortResources` | Sort resources | resources="Resources" |
+| `surveyHasNoQuestions` | This survey has no questions | question="Question" |
+| `answerRequiredQuestions` | Answer all required questions | question="Question" |
+| `searchEnterprises` | Search enterprises | enterprises="Enterprises" |
+| `teamCourses` | Team courses | no_team_courses="team courses not available" |
+| `taskTitle` | Task title | task_title_is_required="Task title is required" |
+| `resourcesUnavailable` | Resources are unavailable | resources="Resources" |
+| `noResourcesToAdd` | All available resources are already linked | resources="Resources" |
+| `chatConversation` | Conversation | recycler_chat_label="conversations", full_conversation_response="Full conversation response" |
+| `aiProviders` | AI providers | fetching_ai_providers="Fetching AI providers…" |
+| `feedbackNotFound` | Feedback not found | menu_feedback="Feedback", feedback="Feedback" |
+| `feedbackTypeRequired` | Please select a feedback type | menu_feedback="Feedback", feedback="Feedback" |
+| `untitledFeedback` | Untitled feedback | menu_feedback="Feedback", feedback="Feedback" |
+| `comments` | Comments | disclaimer="\n    \n    <h1>Disclaimer</h1>\n    <p>Last updated: January 10, 2020</p>\n    <h1>Interpretation and Definitions</h1>\n    <h2>Interpretation</h2>\n    <p>The words of which the initial letter is capitalized have meanings defined under the following conditions.</p>\n    <p>The following definitions shall have the same meaning regardless of whether they appear in singular or in plural.</p>\n    <h2>Definitions</h2>\n    <p>For the purposes of this Disclaimer:</p>\n    <ul>\n        <li><strong>Company</strong> (referred to as either "the Company", "We", "Us" or "Our" in this Cookies Policy) refers to myPlanet.</li>\n        <li><strong>You</strong> means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.</li>\n        <li><strong>Application</strong> means the software program provided by the Company downloaded by You on any electronic device named myPlanet.</li>\n        <li><strong>Service</strong> refers to the Application.</li>\n    </ul>\n    <h1>Disclaimer</h1>\n    <p>The information contained on the Service is for general information purposes only.</p>\n    <p>The Company assumes no responsibility for errors or omissions in the contents of the Service.</p>\n    <p>In no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice.</p>\n    <p>The Company does not warrant that the Service is free of viruses or other harmful components.</p>\n    <h1>Medical Information Disclaimer</h1>\n    <p>The information about health provided by the Service is not intended to diagnose, treat, cure or prevent disease. Products, services, information and other content provided by the Service, including information linking to third-party websites are provided for informational purposes only.</p>\n    <p>Information offered by the Service is not comprehensive and does not cover all diseases, ailments, physical conditions or their treatment.</p>\n    <p>Individuals are different and may react differently to different products. Comments made on the Service by employees or other users are strictly their own personal views made in their own personal capacity and are not claims made by the Company nor do they represent the position or view of the Company.</p>\n    <p>The Company is not liable for any information provided by the Service with regard to recommendations regarding supplements for any health purposes.</p>\n    <p>The Company makes no guarantee or warranty with respect to any products or services sold. The Company is not responsible for any damages for information or services provided even if the Company has been advised of the possibility of damages.</p>\n    <h1>External Links Disclaimer</h1>\n    <p>The Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.</p>\n    <p>Please note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.</p>\n    <h1>Errors and Omissions Disclaimer</h1>\n    <p>The information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to ensure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules, and regulations, there may be delays, omissions, or inaccuracies in the information contained on the Service.</p>\n    <p>The Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.</p>\n    <h1>Fair Use Disclaimer</h1>\n    <p>The Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.</p>\n    <p>The Company believes this constitutes a "fair use" of any such copyrighted material as provided for in section 107 of the United States Copyright law.</p>\n    <p>If You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.</p>\n    <h1>Views Expressed Disclaimer</h1>\n    <p>The Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer, or company, including the Company.</p>\n    <p>Comments published by users are their sole responsibility and the users will take full responsibility, liability, and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.</p>\n    <h1>No Responsibility Disclaimer</h1>\n    <p>The information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal, or other competent advisers.</p>\n    <p>In no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.</p>\n    <h1>"Use at Your Own Risk" Disclaimer</h1>\n    <p>All information in the Service is provided "as is", with no guarantee of completeness, accuracy, timeliness, or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability, and fitness for a particular purpose.</p>\n    <p>The Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special, or similar damages, even if advised of the possibility of such damages.</p>\n    <h2>Contact Us</h2>\n    <p>If you have any questions about this Disclaimer, You can contact Us:</p>\n    <ul>\n        <li>By email: myplanet@ole.org</li>\n        <li>By visiting this page on our website: <a href="https://ole.org/contact">https://ole.org/contact</a></li>\n    </ul>\n    \n    " |
+| `unavailable` | unavailable | video_unavailable="Video unavailable — file not found and could not connect to server" |
+| `transaction` | Transaction | add_transaction="Add Transaction", transaction_added="Transaction added", finance_image="Transaction image" |
+| `noServicesAvailable` | No services available | services="Services" |
+| `examHasNoQuestions` | This exam has no questions | question="Question" |
+| `examComplete` | Exam Complete | complete="complete" |
+| `exitExamMessage` | Your progress will be lost. | progress="Progress" |
+| `fieldRequired` | Required | title_is_required="Title is required", description_is_required="Description is required", note_is_required="Note is required", amount_is_required="Amount is required", date_is_required="Date is required", feedback_priority_is_required="Feedback priority is required.", feedback_type_is_required="Feedback type is required.", level_is_required="Level is required", subject_is_required="Subject is required", pin_is_required="Pin is required.", task_title_is_required="Task title is required", deadline_is_required="Deadline is required", name_is_required="Name is required", compulsory_first_name="first name required", compulsory_last_name="last name is required", compulsory_email="email is required", compulsory_phone_number="phone number is required", compulsory_date_of_birth="date of birth is required", new_apk_version_required_but_not_found_on_server="New apk version required but not found on server. Contact admin.", permission_required="Permission Required", microphone_permission_required="Microphone permission is required to record audio. Please enable it in the app settings.", camera_permission_required="Camera permission is required. Please enable it in the app settings.", desc_is_required="Description is required" |
+| `yearOfBirthRequired` | Year of birth is required | year_of_birth="Year of birth" |
+| `invalidYear` | Please enter a valid year | please_enter_a_valid_year_of_birth="please enter a valid year of birth", please_enter_a_valid_year_between_1900_and="please enter a valid year between 1900 and %1$d" |
+| `unableToLoadVideo` | Unable to load video | unable_to_load="Unable to load " |
+| `unableToLoadAudio` | Unable to load audio | unable_to_load="Unable to load " |
+| `unableToLoadPdf` | Unable to load PDF | unable_to_load="Unable to load " |
+| `updateHealth` | Update health | update_health_record="Update Health Record" |
+| `addHealthRecord` | Add health record | unable_to_add_health_record="Unable to add health record." |
+| `temperature` | Temperature | body_temperature="Body Temperature (°C)", vitals_format="\n        Temperature: %1$s\n\n        Pulse: %2$s\n\n        Blood Pressure: %3$s\n\n        Height: %4$s\n\n        Weight: %5$s\n\n        Vision: %6$s\n\n        Hearing: %7$s\n\n    ", invalid_input_must_be_between_30_and_40="Body temperature, must be between 30 and 40" |
+| `observations` | Observations | observation="Observations and Notes", observations_notes_colon="\n        Observations and analysis: %1$s\n\n        %2$s\n\n        %3$s\n\n        %4$s\n\n        %5$s\n\n        Allergies: %6$s\n\n        X-ray: %7$s\n\n        Lab Tests: %8$s\n\n        Studies: %9$s\n\n    " |
+| `conditions` | Conditions | disclaimer="\n    \n    <h1>Disclaimer</h1>\n    <p>Last updated: January 10, 2020</p>\n    <h1>Interpretation and Definitions</h1>\n    <h2>Interpretation</h2>\n    <p>The words of which the initial letter is capitalized have meanings defined under the following conditions.</p>\n    <p>The following definitions shall have the same meaning regardless of whether they appear in singular or in plural.</p>\n    <h2>Definitions</h2>\n    <p>For the purposes of this Disclaimer:</p>\n    <ul>\n        <li><strong>Company</strong> (referred to as either "the Company", "We", "Us" or "Our" in this Cookies Policy) refers to myPlanet.</li>\n        <li><strong>You</strong> means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.</li>\n        <li><strong>Application</strong> means the software program provided by the Company downloaded by You on any electronic device named myPlanet.</li>\n        <li><strong>Service</strong> refers to the Application.</li>\n    </ul>\n    <h1>Disclaimer</h1>\n    <p>The information contained on the Service is for general information purposes only.</p>\n    <p>The Company assumes no responsibility for errors or omissions in the contents of the Service.</p>\n    <p>In no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice.</p>\n    <p>The Company does not warrant that the Service is free of viruses or other harmful components.</p>\n    <h1>Medical Information Disclaimer</h1>\n    <p>The information about health provided by the Service is not intended to diagnose, treat, cure or prevent disease. Products, services, information and other content provided by the Service, including information linking to third-party websites are provided for informational purposes only.</p>\n    <p>Information offered by the Service is not comprehensive and does not cover all diseases, ailments, physical conditions or their treatment.</p>\n    <p>Individuals are different and may react differently to different products. Comments made on the Service by employees or other users are strictly their own personal views made in their own personal capacity and are not claims made by the Company nor do they represent the position or view of the Company.</p>\n    <p>The Company is not liable for any information provided by the Service with regard to recommendations regarding supplements for any health purposes.</p>\n    <p>The Company makes no guarantee or warranty with respect to any products or services sold. The Company is not responsible for any damages for information or services provided even if the Company has been advised of the possibility of damages.</p>\n    <h1>External Links Disclaimer</h1>\n    <p>The Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.</p>\n    <p>Please note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.</p>\n    <h1>Errors and Omissions Disclaimer</h1>\n    <p>The information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to ensure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules, and regulations, there may be delays, omissions, or inaccuracies in the information contained on the Service.</p>\n    <p>The Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.</p>\n    <h1>Fair Use Disclaimer</h1>\n    <p>The Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.</p>\n    <p>The Company believes this constitutes a "fair use" of any such copyrighted material as provided for in section 107 of the United States Copyright law.</p>\n    <p>If You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.</p>\n    <h1>Views Expressed Disclaimer</h1>\n    <p>The Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer, or company, including the Company.</p>\n    <p>Comments published by users are their sole responsibility and the users will take full responsibility, liability, and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.</p>\n    <h1>No Responsibility Disclaimer</h1>\n    <p>The information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal, or other competent advisers.</p>\n    <p>In no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.</p>\n    <h1>"Use at Your Own Risk" Disclaimer</h1>\n    <p>All information in the Service is provided "as is", with no guarantee of completeness, accuracy, timeliness, or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability, and fitness for a particular purpose.</p>\n    <p>The Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special, or similar damages, even if advised of the possibility of such damages.</p>\n    <h2>Contact Us</h2>\n    <p>If you have any questions about this Disclaimer, You can contact Us:</p>\n    <ul>\n        <li>By email: myplanet@ole.org</li>\n        <li>By visiting this page on our website: <a href="https://ole.org/contact">https://ole.org/contact</a></li>\n    </ul>\n    \n    " |
+| `healthRecordAdded` | Health record added successfully | added_successfully="Added successfully" |
+| `centerOnDefault` | Center on default location | location="Location" |
+| `noStorageUsed` | No downloaded files found | download="Download", downloaded="Downloaded" |
+| `freeUpSpaceConfirm` | This will delete all downloaded resources to free up storage space. Continue? | download="Download", resources="Resources", continuation="continue", storage_delete_all="Delete All", downloaded="Downloaded" |
+| `enterPassword` | Enter password | password="password" |
+| `usernameAlreadyExists` | Username already exists | hint_name="username" |
+| `addedToCourse` | Added to your courses | added_to="added to", our_courses="Our Courses" |
+| `removedFromCourse` | Removed from your courses | removed_from="removed from", our_courses="Our Courses" |
+| `takeCourse` | Take Course | about="\n    \n    <h3>MyPlanet</h3>\n    <p>myPlanet is a learning tool that is designed to work with Planet web application.\n        It has been used to improve early education, secondary schools, village health, youth workforce development,\n        and economic and community development.</p>\n    <p>Planet houses is a repository of free, open access and public domain resources to benefit all learners.</p>\n\n    <p>myPlanet is designed to be available to everyone, everywhere, all the time. It is portable, affordable, scalable and sustainable.\n        It runs on any android device such as tablets and mobile phones. It functions off, as well as on, the Internet.</p>\n\n    <p>This application enables schools and communities to have a complete multi-media library and learning system that periodically connects with Planet.\n        Configured devices can contain the learners' personal dashboard. This ensures learners can read books on their shelf and take courses offline - i.e\n        without connection to a central server. Learners are encouraged to rate from one to five stars the resources they use and the courses they take.\n        Periodically learners can sync with a server. Activity data are uploaded and new resources are downloaded in a matter of a few minutes unto myPlanet for offline use.</p>\n\n    <p>The dashboard also contains a record of achievements, a calendar of events, and an internal chat system for communicating with fellow members.</p>\n\n    <p>myPlanet has been proven highly effective in improving learning opportunities for over fifty thousand learners in more than 100 locations,\n        in schools throughout Nepal, Ghana, Kenya, and Rwanda, with Syrian refugees in Jordan, Somali refugees in Kenya, and village health workers in Uganda.</p>\n    \n    " |
+| `teamCalendar` | Team Calendar | calendar="Calendar" |
+| `removedFromMyLibrary` | Removed from My Library | removed_from="removed from" |
+| `allResources` | All Resources | resources="Resources" |
+| `filterResources` | Filter Resources | resources="Resources" |
+| `surveyAdopted` | Survey adopted | survey_adopted_successfully="Survey adopted successfully!" |
+| `activitySummary` | Activity | my_activity="My Activity", about="\n    \n    <h3>MyPlanet</h3>\n    <p>myPlanet is a learning tool that is designed to work with Planet web application.\n        It has been used to improve early education, secondary schools, village health, youth workforce development,\n        and economic and community development.</p>\n    <p>Planet houses is a repository of free, open access and public domain resources to benefit all learners.</p>\n\n    <p>myPlanet is designed to be available to everyone, everywhere, all the time. It is portable, affordable, scalable and sustainable.\n        It runs on any android device such as tablets and mobile phones. It functions off, as well as on, the Internet.</p>\n\n    <p>This application enables schools and communities to have a complete multi-media library and learning system that periodically connects with Planet.\n        Configured devices can contain the learners' personal dashboard. This ensures learners can read books on their shelf and take courses offline - i.e\n        without connection to a central server. Learners are encouraged to rate from one to five stars the resources they use and the courses they take.\n        Periodically learners can sync with a server. Activity data are uploaded and new resources are downloaded in a matter of a few minutes unto myPlanet for offline use.</p>\n\n    <p>The dashboard also contains a record of achievements, a calendar of events, and an internal chat system for communicating with fellow members.</p>\n\n    <p>myPlanet has been proven highly effective in improving learning opportunities for over fifty thousand learners in more than 100 locations,\n        in schools throughout Nepal, Ghana, Kenya, and Rwanda, with Syrian refugees in Jordan, Somali refugees in Kenya, and village health workers in Uganda.</p>\n    \n    ", chart_description="Login Activity Chart", no_login_activity="No login activity recorded yet" |
+| `aboutContent` | ### MyPlanet\n\nmyPlanet is a learning tool that is designed to work with Planet web application. It has been used to improve early education, secondary schools, village health, youth workforce development, and economic and community development.\n\nPlanet houses is a repository of free, open access and public domain resources to benefit all learners.\n\nmyPlanet is designed to be available to everyone, everywhere, all the time. It is portable, affordable, scalable and sustainable. It runs on any android device such as tablets and mobile phones. It functions off, as well as on, the Internet.\n\nThis application enables schools and communities to have a complete multi-media library and learning system that periodically connects with Planet. Configured devices can contain the learners' personal dashboard. This ensures learners can read books on their shelf and take courses offline - i.e without connection to a central server. Learners are encouraged to rate from one to five stars the resources they use and the courses they take. Periodically learners can sync with a server. Activity data are uploaded and new resources are downloaded in a matter of a few minutes unto myPlanet for offline use.\n\nThe dashboard also contains a record of achievements, a calendar of events, and an internal chat system for communicating with fellow members.\n\nmyPlanet has been proven highly effective in improving learning opportunities for over fifty thousand learners in more than 100 locations, in schools throughout Nepal, Ghana, Kenya, and Rwanda, with Syrian refugees in Jordan, Somali refugees in Kenya, and village health workers in Uganda. | app_project_name="myPlanet", title_activity_dashboard="Dashboard", menu_myplanet="myPlanet", system_name="myPlanet", calendar="Calendar", download="Download", resources="Resources", location="Location", menu_community="Community", complete="complete", community="community", downloaded="Downloaded" |
+| `disclaimerContent` | # Disclaimer\n\nLast updated: January 10, 2020\n\n# Interpretation and Definitions\n\n## Interpretation\n\nThe words of which the initial letter is capitalized have meanings defined under the following conditions.\n\nThe following definitions shall have the same meaning regardless of whether they appear in singular or in plural.\n\n## Definitions\n\nFor the purposes of this Disclaimer:\n\n- **Company** (referred to as either "the Company", "We", "Us" or "Our" in this Cookies Policy) refers to myPlanet.\n- **You** means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.\n- **Application** means the software program provided by the Company downloaded by You on any electronic device named myPlanet.\n- **Service** refers to the Application.\n\n# Disclaimer\n\nThe information contained on the Service is for general information purposes only.\n\nThe Company assumes no responsibility for errors or omissions in the contents of the Service.\n\nIn no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice.\n\nThe Company does not warrant that the Service is free of viruses or other harmful components.\n\n# Medical Information Disclaimer\n\nThe information about health provided by the Service is not intended to diagnose, treat, cure or prevent disease. Products, services, information, and other content provided by the Service, including information linking to third-party websites are provided for informational purposes only.\n\nInformation offered by the Service is not comprehensive and does not cover all diseases, ailments, physical conditions or their treatment.\n\nIndividuals are different and may react differently to different products. Comments made on the Service by employees or other users are strictly their own personal views made in their own personal capacity and are not claims made by the Company nor do they represent the position or view of the Company.\n\nThe Company is not liable for any information provided by the Service with regard to recommendations regarding supplements for any health purposes.\n\nThe Company makes no guarantee or warranty with respect to any products or services sold. The Company is not responsible for any damages for information or services provided even if the Company has been advised of the possibility of damages.\n\n# External Links Disclaimer\n\nThe Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.\n\nPlease note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.\n\n# Errors and Omissions Disclaimer\n\nThe information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to ensure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules, and regulations, there may be delays, omissions, or inaccuracies in the information contained on the Service.\n\nThe Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.\n\n# Fair Use Disclaimer\n\nThe Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.\n\nThe Company believes this constitutes a "fair use" of any such copyrighted material as provided for in section 107 of the United States Copyright law.\n\nIf You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.\n\n# Views Expressed Disclaimer\n\nThe Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer, or company, including the Company.\n\nComments published by users are their sole responsibility and the users will take full responsibility, liability, and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.\n\n# No Responsibility Disclaimer\n\nThe information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal, or other competent advisers.\n\nIn no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.\n\n# "Use at Your Own Risk" Disclaimer\n\nAll information in the Service is provided "as is", with no guarantee of completeness, accuracy, timeliness, or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability, and fitness for a particular purpose.\n\nThe Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special, or similar damages, even if advised of the possibility of such damages.\n\n## Contact Us\n\nIf you have any questions about this Disclaimer, You can contact Us:\n\n- By email: myplanet@ole.org\n- By visiting this page on our website: [https://ole.org/contact](https://ole.org/contact) | app_project_name="myPlanet", menu_myplanet="myPlanet", system_name="myPlanet", question="Question", download="Download", https_protocol="https://", device_name="device name", action_disclaimer="Disclaimer", complete="complete", services="Services", downloaded="Downloaded" |
+| `voiceShared` | Post shared with community | menu_community="Community", community="community" |
+| `voiceUnshared` | Removed from community | removed_from="removed from", menu_community="Community", community="community" |
+| `thankYouForTakingExam` | Thank you for taking this exam! We wish you all the best. | thank_you_for_taking_this="Thank you for taking this " |
+
+## Wording for `CLAUDE.md`
+
+The l10n paragraph's "231–256 of 858 keys per locale" and the open decision about
+marking machine translations both move. Suggested replacement for the **Current
+l10n state** passage:
+
+> **Current l10n state, and one open decision.** The template `app_en.arb` has
+> 858 keys; the five locale files carry 821–859 values each, of which 314–384 are
+> human translations and 475–545 are machine output flagged `x-mt`. Phase 114
+> raised the human share by 431 strings without translating anything: it read the
+> Kotlin `values-*/strings.xml` — real human translations already shipping in the
+> Android app — and preferred them wherever the port had minted its own English
+> for a string Kotlin already had, or had let the machine pass fill a key whose
+> English the Kotlin app matches exactly.
+> `tool/arb_from_strings_xml.dart --candidates` reports the remaining
+> candidates and `--adopt` applies the confident ones; the residue it will not
+> touch (127 keys whose English differs, 33 where two Kotlin names disagree, 32
+> where the ARB already holds someone else's translation) is listed in
+> `flutter/PHASE_114_NOTES.md`. **Match on English text, never on the key name** —
+> `achievements` and Kotlin's `myAchievements` are the same concept and different
+> strings, and a name-driven derivation would swap words silently in five
+> languages.
+
+And a line for the Migration progress table's Localisation row, which was
+"231–256 of 858 keys per locale" at ~30: the measurable figure is now 314–384
+human of 858, with the rest present but machine-translated.

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -13,19 +13,13 @@
   "@serverUrlHint": {
     "x-mt": true
   },
-  "serverPinLabel": "رقم التعريف الشخصي للخادم",
-  "@serverPinLabel": {
-    "x-mt": true
-  },
+  "serverPinLabel": "رمز الخادم",
   "connect": "يتصل",
   "@connect": {
     "x-mt": true
   },
   "serverUrlNotConfigured": "لم يتم تكوين عنوان URL للخادم",
-  "deviceCouldNotReachLocalServer": "تعذر على الجهاز الوصول إلى الخادم. تحقق مما إذا كنت متصلاً بشبكة Wi-Fi الصحيحة للخادم المحلي (المجتمع).",
-  "@deviceCouldNotReachLocalServer": {
-    "x-mt": true
-  },
+  "deviceCouldNotReachLocalServer": "لم يتمكن الجهاز من الوصول إلى الخادم. تحقق مما إذا كنت متصلاً بشبكة Wi-Fi الصحيحة للخادم المحلي (المجتمع).",
   "deviceCouldNotReachNationServer": "لم يتمكن الجهاز من الوصول إلى الخادم. تحقق مما إذا كنت متصلاً بالإنترنت وحاول مرة أخرى.",
   "connectionFailed": "فشل الاتصال!",
   "changeServer": "تغيير الخادم",
@@ -146,14 +140,8 @@
   "@moreOptions": {
     "x-mt": true
   },
-  "appTheme": "موضوع التطبيق",
-  "@appTheme": {
-    "x-mt": true
-  },
-  "aiChat": "دردشة الذكاء الاصطناعي",
-  "@aiChat": {
-    "x-mt": true
-  },
+  "appTheme": "سمة التطبيق",
+  "aiChat": "AI Chat",
   "syncNow": "مزامنة الآن",
   "@syncNow": {
     "x-mt": true
@@ -386,10 +374,7 @@
   "@middleName": {
     "x-mt": true
   },
-  "lastName": "اسم العائلة",
-  "@lastName": {
-    "x-mt": true
-  },
+  "lastName": "الاسم الأخير",
   "save": "حفظ",
   "profileSaved": "تم حفظ الملف الشخصي على هذا الجهاز",
   "@profileSaved": {
@@ -597,10 +582,7 @@
   "@refresh": {
     "x-mt": true
   },
-  "complete": "مكتمل",
-  "@complete": {
-    "x-mt": true
-  },
+  "complete": "اكتمل",
   "noMatchingSubmissions": "لا توجد عمليات إرسال تتطابق مع هذا الفلتر",
   "@noMatchingSubmissions": {
     "x-mt": true
@@ -621,18 +603,9 @@
   "@unknown": {
     "x-mt": true
   },
-  "nA": "لا يوجد",
-  "@nA": {
-    "x-mt": true
-  },
-  "otherDiagnosis": "تشخيص آخر",
-  "@otherDiagnosis": {
-    "x-mt": true
-  },
-  "add": "يضيف",
-  "@add": {
-    "x-mt": true
-  },
+  "nA": "N/A",
+  "otherDiagnosis": "تشخيصات أخرى",
+  "add": "إضافة",
   "status": "الحالة",
   "lastUpdated": "آخر تحديث",
   "@lastUpdated": {
@@ -672,10 +645,7 @@
   "@newSubmission": {
     "x-mt": true
   },
-  "answer": "إجابة",
-  "@answer": {
-    "x-mt": true
-  },
+  "answer": "الإجابة",
   "availableChoices": "الاختيارات",
   "@availableChoices": {
     "x-mt": true
@@ -702,10 +672,7 @@
     "x-mt": true
   },
   "maps": "الخرائط",
-  "englishDictionary": "قاموس اللغة الإنجليزية",
-  "@englishDictionary": {
-    "x-mt": true
-  },
+  "englishDictionary": "قاموس الإنجليزية",
   "offlineMapsComingSoon": "لم يتم نقل الخرائط غير المتصلة بالإنترنت حتى الآن",
   "@offlineMapsComingSoon": {
     "x-mt": true
@@ -807,10 +774,7 @@
   "@onboardingPowerDescription": {
     "x-mt": true
   },
-  "onboardingServerPrepHint": "قبل تسجيل الدخول، ستحتاج إلى عنوان خادم Planet ورقم التعريف الشخصي (PIN). اسأل مسؤول مجتمعك إذا لم تكن لديك هذه الميزات بعد.",
-  "@onboardingServerPrepHint": {
-    "x-mt": true
-  },
+  "onboardingServerPrepHint": "قبل تسجيل الدخول، ستحتاج إلى عنوان خادم Planet ورقم التعريف الشخصي (PIN). اسأل مسؤول مجتمعك إذا لم تكن تملكهما بعد.",
   "meetups": "لقاءات",
   "@meetups": {
     "x-mt": true
@@ -847,24 +811,15 @@
   "@meetupNotFound": {
     "x-mt": true
   },
-  "createdBy": "تم إنشاؤها بواسطة",
-  "@createdBy": {
-    "x-mt": true
-  },
+  "createdBy": "تم إنشاؤه بواسطة",
   "category": "فئة",
   "@category": {
     "x-mt": true
   },
   "location": "الموقع",
   "link": "الرابط",
-  "recurring": "يتكرر",
-  "@recurring": {
-    "x-mt": true
-  },
-  "description": "وصف",
-  "@description": {
-    "x-mt": true
-  },
+  "recurring": "متكرر",
+  "description": "الوصف",
   "leaveMeetup": "مغادرة اللقاء",
   "@leaveMeetup": {
     "x-mt": true
@@ -873,10 +828,7 @@
   "@joinMeetup": {
     "x-mt": true
   },
-  "editMeetup": "تحرير اللقاء",
-  "@editMeetup": {
-    "x-mt": true
-  },
+  "editMeetup": "تعديل الاجتماع",
   "startTime": "وقت البدء",
   "@startTime": {
     "x-mt": true
@@ -956,10 +908,7 @@
   "@untitledSurvey": {
     "x-mt": true
   },
-  "takeSurvey": "خذ الاستطلاع",
-  "@takeSurvey": {
-    "x-mt": true
-  },
+  "takeSurvey": "أداء الاستبيان",
   "surveyLoadFailed": "لا يمكن تحميل الاستطلاع",
   "@surveyLoadFailed": {
     "x-mt": true
@@ -1043,10 +992,7 @@
   "@sendSurveyTo": {
     "x-mt": true
   },
-  "sendSurvey": "إرسال المسح",
-  "@sendSurvey": {
-    "x-mt": true
-  },
+  "sendSurvey": "إرسال الاستبيان",
   "surveySentToUsers": "Survey sent to selected users",
   "@surveySentToUsers": {
     "x-mt": true
@@ -1101,22 +1047,10 @@
   "@leader": {
     "x-mt": true
   },
-  "leave": "يترك",
-  "@leave": {
-    "x-mt": true
-  },
-  "remove": "يزيل",
-  "@remove": {
-    "x-mt": true
-  },
-  "makeLeader": "اصنع قائدا",
-  "@makeLeader": {
-    "x-mt": true
-  },
-  "leftTeam": "الفريق الأيسر",
-  "@leftTeam": {
-    "x-mt": true
-  },
+  "leave": "مغادرة",
+  "remove": "إزالة",
+  "makeLeader": "جعله قائدًا",
+  "leftTeam": "غادر الفريق",
   "memberRemoved": "تمت إزالة العضو",
   "@memberRemoved": {
     "x-mt": true
@@ -1167,10 +1101,7 @@
   "@untitledTask": {
     "x-mt": true
   },
-  "addTask": "أضف مهمة",
-  "@addTask": {
-    "x-mt": true
-  },
+  "addTask": "إضافة مهمة",
   "editTask": "تحرير المهمة",
   "@editTask": {
     "x-mt": true
@@ -1248,10 +1179,7 @@
   "@addResource": {
     "x-mt": true
   },
-  "editResource": "تحرير المورد",
-  "@editResource": {
-    "x-mt": true
-  },
+  "editResource": "تعديل المورد",
   "resourceUpdated": "تم تحديث المورد",
   "@resourceUpdated": {
     "x-mt": true
@@ -1349,10 +1277,7 @@
     "x-mt": true
   },
   "archiveReport": "الأرشيف",
-  "beginningBalance": "رصيد البداية",
-  "@beginningBalance": {
-    "x-mt": true
-  },
+  "beginningBalance": "الرصيد الافتتاحي",
   "sales": "المبيعات",
   "otherIncome": "دخل آخر",
   "@otherIncome": {
@@ -1370,31 +1295,19 @@
   "@totalIncome": {
     "x-mt": true
   },
-  "totalExpenses": "إجمالي النفقات",
-  "@totalExpenses": {
-    "x-mt": true
-  },
+  "totalExpenses": "إجمالي المصروفات",
   "profitLoss": "الربح / الخسارة",
   "@profitLoss": {
     "x-mt": true
   },
-  "endingBalance": "رصيد النهاية",
-  "@endingBalance": {
-    "x-mt": true
-  },
-  "negativeBalance": "الرصيد الحالي سلبي!",
-  "@negativeBalance": {
-    "x-mt": true
-  },
+  "endingBalance": "الرصيد النهائي",
+  "negativeBalance": "الرصيد الحالي سالب!",
   "chatHistory": "تاريخ الدردشة",
   "@chatHistory": {
     "x-mt": true
   },
   "chat": "الدردشة",
-  "newChat": "دردشة جديدة",
-  "@newChat": {
-    "x-mt": true
-  },
+  "newChat": "محادثة جديدة",
   "searchChats": "بحث في الدردشات",
   "@searchChats": {
     "x-mt": true
@@ -1411,14 +1324,8 @@
   "@untitledChat": {
     "x-mt": true
   },
-  "fullConversationResponse": "الرد الكامل على المحادثة",
-  "@fullConversationResponse": {
-    "x-mt": true
-  },
-  "response": "إجابة",
-  "@response": {
-    "x-mt": true
-  },
+  "fullConversationResponse": "استجابة المحادثة الكاملة",
+  "response": "استجابة",
   "chatConversation": "محادثة",
   "@chatConversation": {
     "x-mt": true
@@ -1476,10 +1383,7 @@
   "bug": "خطأ",
   "suggestion": "اقتراح",
   "priority": "الأولوية",
-  "openDate": "تاريخ مفتوح",
-  "@openDate": {
-    "x-mt": true
-  },
+  "openDate": "تاريخ الافتتاح",
   "replies": "الردود",
   "@replies": {
     "x-mt": true
@@ -1496,10 +1400,7 @@
   "@takeTest": {
     "x-mt": true
   },
-  "recordSurvey": "سجل المسح",
-  "@recordSurvey": {
-    "x-mt": true
-  },
+  "recordSurvey": "تسجيل الاستبيان",
   "react": "رد فعل",
   "@react": {
     "x-mt": true
@@ -1593,10 +1494,7 @@
   "@fromDate": {
     "x-mt": true
   },
-  "toDate": "حتى الآن",
-  "@toDate": {
-    "x-mt": true
-  },
+  "toDate": "إلى تاريخ",
   "reset": "إعادة ضبط",
   "@reset": {
     "x-mt": true
@@ -1709,26 +1607,17 @@
   "@yourInformation": {
     "x-mt": true
   },
-  "showAdditionalFields": "إظهار الحقول الإضافية",
-  "@showAdditionalFields": {
-    "x-mt": true
-  },
+  "showAdditionalFields": "عرض الحقول الإضافية",
   "hideAdditionalFields": "إخفاء الحقول الإضافية",
   "@hideAdditionalFields": {
     "x-mt": true
   },
-  "phoneNumber": "رقم التليفون",
-  "@phoneNumber": {
-    "x-mt": true
-  },
+  "phoneNumber": "رقم الهاتف",
   "birthDate": "تاريخ الميلاد",
   "@birthDate": {
     "x-mt": true
   },
-  "selectDate": "اختر التاريخ",
-  "@selectDate": {
-    "x-mt": true
-  },
+  "selectDate": "حدد التاريخ",
   "male": "ذكر",
   "@male": {
     "x-mt": true
@@ -1746,18 +1635,12 @@
   "@invalidYear": {
     "x-mt": true
   },
-  "thankYouForTakingSurvey": "شكرا لك على أخذ هذا الاستطلاع",
-  "@thankYouForTakingSurvey": {
-    "x-mt": true
-  },
+  "thankYouForTakingSurvey": "شكرًا لك على إجراء هذا الاستبيان",
   "errorSavingProfile": "حدث خطأ أثناء حفظ الملف الشخصي",
   "@errorSavingProfile": {
     "x-mt": true
   },
-  "videoPlayer": "مشغل فيديو",
-  "@videoPlayer": {
-    "x-mt": true
-  },
+  "videoPlayer": "مشغل الفيديو",
   "audioPlayer": "مشغل الصوت",
   "@audioPlayer": {
     "x-mt": true
@@ -1776,18 +1659,12 @@
   "htmlEntryNotFound": "ملف إدخال HTML غير موجود",
   "errorOccurred": "خطأ: {error}",
   "openingResource": "فتح: {title}",
-  "loadingMedia": "تحميل...",
-  "@loadingMedia": {
-    "x-mt": true
-  },
+  "loadingMedia": "جار التحميل...",
   "resourceUnavailable": "هذا المورد غير متاح للعرض في وضع عدم الاتصال",
   "@resourceUnavailable": {
     "x-mt": true
   },
-  "healthRecordNotAvailable": "السجل الصحي غير متوفر",
-  "@healthRecordNotAvailable": {
-    "x-mt": true
-  },
+  "healthRecordNotAvailable": "سجل الصحة غير متاح",
   "updateHealth": "تحديث الصحة",
   "@updateHealth": {
     "x-mt": true
@@ -1808,10 +1685,7 @@
   "@otherNeeds": {
     "x-mt": true
   },
-  "emergencyContact": "الاتصال في حالات الطوارئ",
-  "@emergencyContact": {
-    "x-mt": true
-  },
+  "emergencyContact": "جهة الاتصال في حالات الطوارئ",
   "contactNumber": "رقم الاتصال",
   "@contactNumber": {
     "x-mt": true
@@ -1891,10 +1765,7 @@
     "x-mt": true
   },
   "referrals": "الإحالات",
-  "labTests": "الاختبارات المعملية",
-  "@labTests": {
-    "x-mt": true
-  },
+  "labTests": "اختبارات المختبر",
   "xrays": "الأشعة السينية",
   "conditions": "شروط",
   "@conditions": {
@@ -1908,10 +1779,7 @@
   "@healthRecordAdded": {
     "x-mt": true
   },
-  "selectHealthMember": "اختر عضوا",
-  "@selectHealthMember": {
-    "x-mt": true
-  },
+  "selectHealthMember": "اختر عضو الفريق",
   "newPatient": "مريض جديد",
   "@newPatient": {
     "x-mt": true
@@ -1958,18 +1826,12 @@
   "@weightRangeError": {
     "x-mt": true
   },
-  "bloodPressureFormatError": "يجب أن يكون ضغط الدم الانقباضي / الانبساطي",
-  "@bloodPressureFormatError": {
-    "x-mt": true
-  },
+  "bloodPressureFormatError": "يجب أن يكون ضغط الدم عبارة عن نبضي/انبساطي",
   "bloodPressureRangeError": "يجب أن يكون ضغط الدم بين 60/40 و300/200",
   "@bloodPressureRangeError": {
     "x-mt": true
   },
-  "bloodPressureNotNumbers": "يجب أن يكون الضغط الانقباضي والانبساطي أرقامًا",
-  "@bloodPressureNotNumbers": {
-    "x-mt": true
-  },
+  "bloodPressureNotNumbers": "يجب أن تكون القيم النبضية والانبساطية أرقام",
   "temp": "درجة حرارة",
   "@temp": {
     "x-mt": true
@@ -2009,10 +1871,10 @@
     "x-mt": true
   },
   "areYouSure": "هل أنت متأكد؟",
-  "cancelAddingExamination": "Are you sure you want to cancel adding examination? The data will be lost.",
-  "yesIWantToExit": "Yes, I want to exit.",
-  "inactiveMessage": "User not activated, please contact administrator or manager to activate your account.",
-  "submitFeedback": "Submit Feedback",
+  "cancelAddingExamination": "هل أنت متأكد من إلغاء إضافة الامتحان؟ سيتم فقدان البيانات",
+  "yesIWantToExit": "نعم، أرغب في الخروج.",
+  "inactiveMessage": "المستخدم غير مفعل، يرجى التواصل مع المسؤول أو المدير لتفعيل حسابك.",
+  "submitFeedback": "إرسال ملاحظات",
   "storageDeleteSelectedConfirm": "Delete {count} selected items?",
   "@storageDeleteSelectedConfirm": {
     "x-mt": true
@@ -2063,10 +1925,7 @@
   },
   "becomeMember": "أصبح عضوًا",
   "toAccessThisFeatureBecomeAMember": "أنت حاليًا مستخدم ضيف. للوصول إلى هذه الميزة، كن عضوًا.",
-  "creatingMember": "جارٍ إنشاء حساب العضو...",
-  "@creatingMember": {
-    "x-mt": true
-  },
+  "creatingMember": "إنشاء حساب العضو...",
   "passwordsDoNotMatch": "كلمتا المرور غير متطابقتين",
   "pleaseSelectGender": "يرجى تحديد الجنس",
   "pleaseEnterPassword": "يرجى إدخال كلمة المرور",
@@ -2105,25 +1964,13 @@
   "@challengeDialogTitle": {
     "x-mt": true
   },
-  "start": "يبدأ",
-  "@start": {
-    "x-mt": true
-  },
-  "continuation": "يكمل",
-  "@continuation": {
-    "x-mt": true
-  },
+  "start": "ابدأ",
+  "continuation": "استمر",
   "plan": "خطة",
   "mission": "المهمة والخدمات",
   "editPlan": "تعديل الخطة",
-  "teamPlan": "ما هي خطة فريقك؟",
-  "@teamPlan": {
-    "x-mt": true
-  },
-  "entMission": "ما هي مهمة مؤسستك؟",
-  "@entMission": {
-    "x-mt": true
-  },
+  "teamPlan": "ما هو خطة فريقك؟",
+  "entMission": "ما هي مهمة المؤسسة الخاصة بك؟",
   "entServices": "ما هي الخدمات التي تقدمها المؤسسة الخاصة بك؟",
   "entRules": "ما هي قواعد المؤسسة الخاصة بك؟",
   "noMissionDefined": "لا يوجد لدى المؤسسة مهمة وخدمات.",
@@ -2154,10 +2001,7 @@
   "isPublic": "عام",
   "nameRequired": "الاسم مطلوب",
   "nameIsRequired": "يرجى إدخال الاسم",
-  "createdOn": "تم الإنشاء بتاريخ",
-  "@createdOn": {
-    "x-mt": true
-  },
+  "createdOn": "تم الإنشاء في",
   "courseDetails": "تفاصيل الدورة",
   "@courseDetails": {
     "x-mt": true
@@ -2211,19 +2055,10 @@
   "@untitledResourceTitle": {
     "x-mt": true
   },
-  "author": "مؤلف",
-  "@author": {
-    "x-mt": true
-  },
+  "author": "المؤلف",
   "publisher": "الناشر",
-  "license": "رخصة",
-  "@license": {
-    "x-mt": true
-  },
-  "addedBy": "تمت الإضافة بواسطة",
-  "@addedBy": {
-    "x-mt": true
-  },
+  "license": "الترخيص",
+  "addedBy": "أُضيف بواسطة",
   "resourceInformation": "معلومات الموارد",
   "@resourceInformation": {
     "x-mt": true
@@ -2360,10 +2195,7 @@
   "@totalVisits": {
     "x-mt": true
   },
-  "mostOpenedResource": "الموارد الأكثر فتحا",
-  "@mostOpenedResource": {
-    "x-mt": true
-  },
+  "mostOpenedResource": "أكثر مورد تم فتحه",
   "numberOfResourcesOpened": "عدد الموارد المفتوحة",
   "@numberOfResourcesOpened": {
     "x-mt": true
@@ -2384,10 +2216,7 @@
   "@serverUnreachable": {
     "x-mt": true
   },
-  "serverChecking": "فحص الخادم",
-  "@serverChecking": {
-    "x-mt": true
-  },
+  "serverChecking": "جارٍ فحص الخادم",
   "gridView": "عرض شبكي",
   "listView": "عرض قائمة",
   "disclaimer": "تنصل",
@@ -2423,7 +2252,7 @@
   "addAnAchievement": "إضافة إنجاز",
   "addReference": "إضافة مرجع",
   "addAReference": "إضافة مرجع",
-  "selectResources": "اختر الموارد:",
+  "selectResources": "اختر الموارد: ",
   "myGoals": "أهدافي",
   "myPurpose": "هدفي",
   "noGoalAdded": "لم يتم تحديد أي أهداف بعد",
@@ -2457,18 +2286,12 @@
   "@textSize": {
     "x-mt": true
   },
-  "selectTextSize": "حدد حجم النص",
-  "@selectTextSize": {
-    "x-mt": true
-  },
+  "selectTextSize": "اختر حجم النص",
   "textSizeSmall": "صغير",
   "@textSizeSmall": {
     "x-mt": true
   },
-  "textSizeMedium": "واسطة",
-  "@textSizeMedium": {
-    "x-mt": true
-  },
+  "textSizeMedium": "متوسط",
   "textSizeLarge": "كبير",
   "@textSizeLarge": {
     "x-mt": true
@@ -2477,10 +2300,7 @@
   "@resetApp": {
     "x-mt": true
   },
-  "clearAllDataConfirm": "هل أنت متأكد أنك تريد مسح كافة البيانات؟",
-  "@clearAllDataConfirm": {
-    "x-mt": true
-  },
+  "clearAllDataConfirm": "هل أنت متأكد أنك تريد مسح جميع البيانات؟",
   "dataCleared": "تم مسح كافة البيانات",
   "@dataCleared": {
     "x-mt": true
@@ -2490,5 +2310,10 @@
     "x-mt": true
   },
   "resourceTitleAlreadyExists": "يوجد مورد بهذا العنوان بالفعل",
-  "failedToUpdateResource": "فشل تحديث المورد"
+  "failedToUpdateResource": "فشل تحديث المورد",
+  "unableToAddHealthRecord": "غير قادر على إضافة سجل صحي",
+  "summaryOfAchievements": "ملخص الإنجازات - قم بتلخيص إنجازاتك بإيجاز وأضف المواد ذات الصلة أدناه",
+  "myGoalsDescription": "أهدافي - ما هي أهدافك للعشر سنوات القادمة؟",
+  "myPurposeDescription": "هدفي - ما هي طموحاتك التعليمية والمهنية؟",
+  "pleaseAnswerToContinue": "يرجى تحديد / كتابة إجابتك للمتابعة"
 }

--- a/flutter/lib/l10n/app_ar.arb
+++ b/flutter/lib/l10n/app_ar.arb
@@ -1660,10 +1660,7 @@
   "@submitExam": {
     "x-mt": true
   },
-  "incorrectAnswer": "إجابة غير صحيحة",
-  "@incorrectAnswer": {
-    "x-mt": true
-  },
+  "incorrectAnswer": "إجابة غير صحيحة، يرجى المحاولة مرة أخرى",
   "correctAnswers": "صحيح",
   "@correctAnswers": {
     "x-mt": true

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -875,7 +875,7 @@
   "examComplete": "Exam Complete",
   "examUnavailable": "Exam is unavailable",
   "submitExam": "Submit exam",
-  "incorrectAnswer": "Incorrect answer",
+  "incorrectAnswer": "Incorrect answer, please try again",
   "correctAnswers": "Correct",
   "yourAnswer": "Your answer",
   "previous": "Previous",

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -1,9 +1,6 @@
 {
   "@@locale": "es",
-  "appTitle": "miPlaneta",
-  "@appTitle": {
-    "x-mt": true
-  },
+  "appTitle": "myPlanet",
   "serverConfigurationTitle": "Conéctese a un servidor Planet",
   "@serverConfigurationTitle": {
     "x-mt": true
@@ -139,20 +136,14 @@
   },
   "logOut": "Cerrar sesión",
   "noDataAvailable": "No hay datos disponibles.",
-  "ok": "OK",
-  "home": "Hogar",
-  "@home": {
-    "x-mt": true
-  },
+  "ok": "De acuerdo",
+  "home": "Inicio",
   "moreOptions": "Más opciones",
   "@moreOptions": {
     "x-mt": true
   },
   "appTheme": "Tema de la aplicación",
-  "aiChat": "chat de IA",
-  "@aiChat": {
-    "x-mt": true
-  },
+  "aiChat": "Chat IA",
   "syncNow": "Sincronizar ahora",
   "syncCenter": "Centro de sincronización",
   "@syncCenter": {
@@ -258,14 +249,8 @@
   "subjectLabelTechnology": "Tecnología",
   "surveysToComplete": "Tienes {count, plural, =1{1 encuesta} other{{count} encuestas}} para completar",
   "lastSynced": "Última sincronización: {time}",
-  "neverSynced": "Nunca sincronizado",
-  "@neverSynced": {
-    "x-mt": true
-  },
-  "justNow": "En este momento",
-  "@justNow": {
-    "x-mt": true
-  },
+  "neverSynced": "nunca sincronizado",
+  "justNow": "Ahora mismo",
   "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
   "@minutesAgo": {
     "x-mt": true
@@ -321,10 +306,7 @@
   "@subjectLevel": {
     "x-mt": true
   },
-  "allLevels": "Todo",
-  "@allLevels": {
-    "x-mt": true
-  },
+  "allLevels": "Todos",
   "clearFilters": "Limpiar filtros",
   "@clearFilters": {
     "x-mt": true
@@ -509,10 +491,7 @@
     "x-mt": true
   },
   "markAllRead": "Marcar todo como leído",
-  "all": "Todo",
-  "@all": {
-    "x-mt": true
-  },
+  "all": "Todos",
   "read": "Leer",
   "@read": {
     "x-mt": true
@@ -537,10 +516,7 @@
   "@taskNotification": {
     "x-mt": true
   },
-  "chatNotification": "Charlar",
-  "@chatNotification": {
-    "x-mt": true
-  },
+  "chatNotification": "Chat",
   "replyNotification": "Nueva respuesta",
   "@replyNotification": {
     "x-mt": true
@@ -550,10 +526,7 @@
   "@storageNotification": {
     "x-mt": true
   },
-  "joinRequestNotification": "Solicitud de unión",
-  "@joinRequestNotification": {
-    "x-mt": true
-  },
+  "joinRequestNotification": "Solicitud de Unión",
   "teamNotification": "Actualización del equipo",
   "@teamNotification": {
     "x-mt": true
@@ -666,14 +639,8 @@
   "@unknown": {
     "x-mt": true
   },
-  "nA": "N / A",
-  "@nA": {
-    "x-mt": true
-  },
-  "otherDiagnosis": "Otro diagnóstico",
-  "@otherDiagnosis": {
-    "x-mt": true
-  },
+  "nA": "N/A",
+  "otherDiagnosis": "Otros diagnósticos",
   "add": "Agregar",
   "@add": {
     "x-mt": true
@@ -919,10 +886,7 @@
   "@link": {
     "x-mt": true
   },
-  "recurring": "Periódico",
-  "@recurring": {
-    "x-mt": true
-  },
+  "recurring": "Recurrente",
   "description": "Descripción",
   "leaveMeetup": "Salir de la reunión",
   "@leaveMeetup": {
@@ -948,14 +912,8 @@
   "@none": {
     "x-mt": true
   },
-  "daily": "A diario",
-  "@daily": {
-    "x-mt": true
-  },
-  "weekly": "Semanalmente",
-  "@weekly": {
-    "x-mt": true
-  },
+  "daily": "Diario",
+  "weekly": "Semanal",
   "syncMeetups": "Sincronizar reuniones",
   "@syncMeetups": {
     "x-mt": true
@@ -1024,10 +982,7 @@
   "@untitledSurvey": {
     "x-mt": true
   },
-  "takeSurvey": "Tomar encuesta",
-  "@takeSurvey": {
-    "x-mt": true
-  },
+  "takeSurvey": "Realizar encuesta",
   "surveyLoadFailed": "No se pudo cargar la encuesta",
   "@surveyLoadFailed": {
     "x-mt": true
@@ -1092,10 +1047,7 @@
   "@editVoice": {
     "x-mt": true
   },
-  "deleteVoice": "Borrar",
-  "@deleteVoice": {
-    "x-mt": true
-  },
+  "deleteVoice": "Eliminar",
   "deleteVoiceConfirm": "¿Eliminar esta publicación y todas sus respuestas?",
   "@deleteVoiceConfirm": {
     "x-mt": true
@@ -1120,10 +1072,7 @@
   "sendSurvey": "Enviar encuesta",
   "surveySentToUsers": "Encuesta enviada a usuarios seleccionados",
   "noUsersAvailable": "No hay usuarios disponibles",
-  "teams": "equipos",
-  "@teams": {
-    "x-mt": true
-  },
+  "teams": "Equipos",
   "syncTeams": "Sincronizar equipos",
   "@syncTeams": {
     "x-mt": true
@@ -1172,22 +1121,13 @@
   "@leader": {
     "x-mt": true
   },
-  "leave": "Dejar",
-  "@leave": {
-    "x-mt": true
-  },
+  "leave": "Salir",
   "remove": "Eliminar",
   "@remove": {
     "x-mt": true
   },
-  "makeLeader": "Hacer líder",
-  "@makeLeader": {
-    "x-mt": true
-  },
-  "leftTeam": "equipo izquierdo",
-  "@leftTeam": {
-    "x-mt": true
-  },
+  "makeLeader": "Asignar como líder",
+  "leftTeam": "Abandonó el equipo",
   "memberRemoved": "Miembro eliminado",
   "@memberRemoved": {
     "x-mt": true
@@ -1348,10 +1288,7 @@
   "@resourceUpdated": {
     "x-mt": true
   },
-  "resourceAddedToTeam": "Recurso agregado al equipo",
-  "@resourceAddedToTeam": {
-    "x-mt": true
-  },
+  "resourceAddedToTeam": "Recurso añadido al equipo",
   "descriptionIsRequired": "Se requiere descripción",
   "@descriptionIsRequired": {
     "x-mt": true
@@ -1360,10 +1297,7 @@
   "@levelIsRequired": {
     "x-mt": true
   },
-  "subjectIsRequired": "Se requiere sujeto",
-  "@subjectIsRequired": {
-    "x-mt": true
-  },
+  "subjectIsRequired": "Se requiere asignatura",
   "selectFile": "Seleccione un archivo",
   "@selectFile": {
     "x-mt": true
@@ -1492,10 +1426,7 @@
   "@chatHistory": {
     "x-mt": true
   },
-  "chat": "Charlar",
-  "@chat": {
-    "x-mt": true
-  },
+  "chat": "Chat",
   "newChat": "Nuevo chat",
   "@newChat": {
     "x-mt": true
@@ -1516,10 +1447,7 @@
   "@untitledChat": {
     "x-mt": true
   },
-  "fullConversationResponse": "Respuesta de conversación completa",
-  "@fullConversationResponse": {
-    "x-mt": true
-  },
+  "fullConversationResponse": "Respuesta completa de la conversación",
   "response": "Respuesta",
   "@response": {
     "x-mt": true
@@ -1564,10 +1492,7 @@
   "@feedbackNotFound": {
     "x-mt": true
   },
-  "feedbackSaved": "Comentarios guardados",
-  "@feedbackSaved": {
-    "x-mt": true
-  },
+  "feedbackSaved": "Comentario guardado",
   "isUrgent": "¿Es esto urgente?",
   "@isUrgent": {
     "x-mt": true
@@ -1592,10 +1517,7 @@
   "@question": {
     "x-mt": true
   },
-  "bug": "Bicho",
-  "@bug": {
-    "x-mt": true
-  },
+  "bug": "Error",
   "suggestion": "Sugerencia",
   "@suggestion": {
     "x-mt": true
@@ -1604,36 +1526,24 @@
   "@priority": {
     "x-mt": true
   },
-  "openDate": "fecha abierta",
-  "@openDate": {
-    "x-mt": true
-  },
+  "openDate": "Fecha de apertura",
   "replies": "Respuestas",
   "@replies": {
     "x-mt": true
   },
-  "pleaseEnterReply": "Por favor ingresa la respuesta",
-  "@pleaseEnterReply": {
-    "x-mt": true
-  },
+  "pleaseEnterReply": "Por favor, ingresa una respuesta",
   "untitledFeedback": "Comentarios sin título",
   "@untitledFeedback": {
     "x-mt": true
   },
   "yes": "Sí",
   "no": "No",
-  "submit": "Entregar",
-  "@submit": {
-    "x-mt": true
-  },
+  "submit": "Enviar",
   "takeTest": "hacer la prueba",
   "@takeTest": {
     "x-mt": true
   },
-  "recordSurvey": "Registro de encuesta",
-  "@recordSurvey": {
-    "x-mt": true
-  },
+  "recordSurvey": "Registrar encuesta",
   "react": "Reaccionar",
   "@react": {
     "x-mt": true
@@ -1682,10 +1592,7 @@
   "@error": {
     "x-mt": true
   },
-  "close": "Cerca",
-  "@close": {
-    "x-mt": true
-  },
+  "close": "Cerrar",
   "filter": "Filtrar",
   "@filter": {
     "x-mt": true
@@ -1714,14 +1621,8 @@
   "@communityLeaders": {
     "x-mt": true
   },
-  "nationLeaders": "Líderes de la nación",
-  "@nationLeaders": {
-    "x-mt": true
-  },
-  "ourVoices": "Nuestras Voces",
-  "@ourVoices": {
-    "x-mt": true
-  },
+  "nationLeaders": "Lideres de la nación",
+  "ourVoices": "Nuestras voces",
   "finances": "Finanzas",
   "reports": "Informes",
   "transaction": "Transacción",
@@ -1730,7 +1631,7 @@
   "noTransactions": "Aún no hay transacciones",
   "debit": "Débito",
   "credit": "Crédito",
-  "balance": "Balance",
+  "balance": "Saldo",
   "amount": "Monto",
   "note": "Nota",
   "date": "Fecha",
@@ -1800,22 +1701,13 @@
   "@exitExamMessage": {
     "x-mt": true
   },
-  "exit": "Salida",
-  "@exit": {
-    "x-mt": true
-  },
+  "exit": "Salir",
   "download": "Descargar",
   "@download": {
     "x-mt": true
   },
-  "downloading": "Descargando…",
-  "@downloading": {
-    "x-mt": true
-  },
-  "downloadFailed": "La descarga falló.",
-  "@downloadFailed": {
-    "x-mt": true
-  },
+  "downloading": "Descargando....",
+  "downloadFailed": "Descarga fallida.",
   "resourceNotDownloaded": "Este recurso aún no está en su dispositivo.",
   "@resourceNotDownloaded": {
     "x-mt": true
@@ -1864,10 +1756,7 @@
   "@female": {
     "x-mt": true
   },
-  "yearOfBirth": "año de nacimiento",
-  "@yearOfBirth": {
-    "x-mt": true
-  },
+  "yearOfBirth": "Año de nacimiento",
   "yearOfBirthRequired": "Se requiere año de nacimiento",
   "@yearOfBirthRequired": {
     "x-mt": true
@@ -1880,10 +1769,7 @@
   "@yearBetween": {
     "x-mt": true
   },
-  "thankYouForTakingSurvey": "Gracias por realizar esta encuesta.",
-  "@thankYouForTakingSurvey": {
-    "x-mt": true
-  },
+  "thankYouForTakingSurvey": "Gracias por completar esta encuesta",
   "errorSavingProfile": "Error al guardar perfil",
   "@errorSavingProfile": {
     "x-mt": true
@@ -1912,10 +1798,7 @@
   "openingResource": "Abriendo: {title}",
   "loadingMedia": "Cargando...",
   "resourceUnavailable": "Este recurso no está disponible para visualización sin conexión",
-  "healthRecordNotAvailable": "Historial de salud no disponible",
-  "@healthRecordNotAvailable": {
-    "x-mt": true
-  },
+  "healthRecordNotAvailable": "Registro de salud no disponible",
   "updateHealth": "Actualizar salud",
   "@updateHealth": {
     "x-mt": true
@@ -1972,10 +1855,7 @@
   "@vision": {
     "x-mt": true
   },
-  "hearing": "Audiencia",
-  "@hearing": {
-    "x-mt": true
-  },
+  "hearing": "Audición",
   "examinationHistory": "historial de exámenes",
   "@examinationHistory": {
     "x-mt": true
@@ -1984,10 +1864,7 @@
   "@personalInformation": {
     "x-mt": true
   },
-  "birthPlace": "lugar de nacimiento",
-  "@birthPlace": {
-    "x-mt": true
-  },
+  "birthPlace": "Lugar de nacimiento",
   "contactName": "Nombre de contacto",
   "@contactName": {
     "x-mt": true
@@ -2024,14 +1901,8 @@
   "@medications": {
     "x-mt": true
   },
-  "immunizations": "Vacunas",
-  "@immunizations": {
-    "x-mt": true
-  },
-  "treatments": "Tratos",
-  "@treatments": {
-    "x-mt": true
-  },
+  "immunizations": "Inmunizaciones",
+  "treatments": "Tratamientos",
   "observations": "Observaciones",
   "@observations": {
     "x-mt": true
@@ -2040,14 +1911,8 @@
   "@referrals": {
     "x-mt": true
   },
-  "labTests": "pruebas de laboratorio",
-  "@labTests": {
-    "x-mt": true
-  },
-  "xrays": "rayos x",
-  "@xrays": {
-    "x-mt": true
-  },
+  "labTests": "Pruebas de laboratorio",
+  "xrays": "Radiografías",
   "conditions": "Condiciones",
   "@conditions": {
     "x-mt": true
@@ -2088,10 +1953,7 @@
   "@searchMembers": {
     "x-mt": true
   },
-  "dismiss": "Despedir",
-  "@dismiss": {
-    "x-mt": true
-  },
+  "dismiss": "Descartar",
   "addMember": "Agregar miembro",
   "@addMember": {
     "x-mt": true
@@ -2116,18 +1978,12 @@
   "@weightRangeError": {
     "x-mt": true
   },
-  "bloodPressureFormatError": "La presión arterial debe ser sistólica/diastólica.",
-  "@bloodPressureFormatError": {
-    "x-mt": true
-  },
+  "bloodPressureFormatError": "La presión arterial debe ser sistólica/diastólica",
   "bloodPressureRangeError": "La presión arterial debe estar entre 60/40 y 300/200.",
   "@bloodPressureRangeError": {
     "x-mt": true
   },
-  "bloodPressureNotNumbers": "La sistólica y la diastólica deben ser números.",
-  "@bloodPressureNotNumbers": {
-    "x-mt": true
-  },
+  "bloodPressureNotNumbers": "Sistólica y diastólica deben ser números",
   "temp": "Temperatura",
   "@temp": {
     "x-mt": true
@@ -2150,18 +2006,12 @@
   "@storageTotalDownloaded": {
     "x-mt": true
   },
-  "storageVideos": "Vídeos",
-  "@storageVideos": {
-    "x-mt": true
-  },
+  "storageVideos": "Videos",
   "storageAudio": "Audio",
   "@storageAudio": {
     "x-mt": true
   },
-  "storagePdfs": "PDF",
-  "@storagePdfs": {
-    "x-mt": true
-  },
+  "storagePdfs": "PDFs",
   "storageImages": "Imágenes",
   "@storageImages": {
     "x-mt": true
@@ -2178,15 +2028,12 @@
   "@fileCountMany": {
     "x-mt": true
   },
-  "storageUnknownResource": "recurso desconocido",
-  "@storageUnknownResource": {
-    "x-mt": true
-  },
+  "storageUnknownResource": "Recurso desconocido",
   "areYouSure": "¿Estás seguro?",
-  "cancelAddingExamination": "Are you sure you want to cancel adding examination? The data will be lost.",
-  "yesIWantToExit": "Yes, I want to exit.",
-  "inactiveMessage": "User not activated, please contact administrator or manager to activate your account.",
-  "submitFeedback": "Submit Feedback",
+  "cancelAddingExamination": "¿Está seguro de que desea cancelar la adición del examen? Se perderán los datos.",
+  "yesIWantToExit": "Sí, quiero salir.",
+  "inactiveMessage": "El usuario no está activado. Por favor, ponte en contacto con el administrador o el responsable para activar tu cuenta.",
+  "submitFeedback": "Enviar comentarios",
   "failedToDelete": "No se pudo eliminar: {error}",
   "@failedToDelete": {
     "x-mt": true
@@ -2203,10 +2050,7 @@
   "@storageSelectedCount": {
     "x-mt": true
   },
-  "deleteSelected": "Eliminar seleccionado",
-  "@deleteSelected": {
-    "x-mt": true
-  },
+  "deleteSelected": "Eliminar seleccionados",
   "deleteAll": "Eliminar todo",
   "@deleteAll": {
     "x-mt": true
@@ -2215,10 +2059,7 @@
   "@selectAll": {
     "x-mt": true
   },
-  "unselectAll": "Unselect All",
-  "@unselectAll": {
-    "x-mt": true
-  },
+  "unselectAll": "Deseleccionar todo",
   "addedToMyCourses": "{count, plural, =1{1 course added} other{{count} courses added}}",
   "@addedToMyCourses": {
     "x-mt": true
@@ -2244,10 +2085,7 @@
   "freeUpSpaceConfirm": "Esto eliminará todos los recursos descargados para liberar espacio de almacenamiento. ¿Continuar?",
   "storageFreedSummary": "Liberado {bytes}. {count, plural, =0{No se eliminaron archivos} =1{1 archivo eliminado} other{{count} archivos eliminados}}.",
   "freeUpSpaceFailed": "No se pudo liberar espacio: {error}",
-  "enterUsername": "Ingrese el nombre de usuario",
-  "@enterUsername": {
-    "x-mt": true
-  },
+  "enterUsername": "Ingresa tu nombre de usuario",
   "enterPassword": "Introduce la contraseña",
   "@enterPassword": {
     "x-mt": true
@@ -2256,10 +2094,7 @@
   "@retypePassword": {
     "x-mt": true
   },
-  "becomeMember": "Hazte miembro",
-  "@becomeMember": {
-    "x-mt": true
-  },
+  "becomeMember": "convertirse en miembro",
   "toAccessThisFeatureBecomeAMember": "Actualmente eres un usuario invitado. Para acceder a esta función, hazte miembro.",
   "creatingMember": "Creando cuenta de miembro...",
   "@creatingMember": {
@@ -2269,14 +2104,8 @@
   "@passwordsDoNotMatch": {
     "x-mt": true
   },
-  "pleaseSelectGender": "Please select gender",
-  "@pleaseSelectGender": {
-    "x-mt": true
-  },
-  "pleaseEnterPassword": "Por favor ingrese una contraseña",
-  "@pleaseEnterPassword": {
-    "x-mt": true
-  },
+  "pleaseSelectGender": "Por favor selecciona el género",
+  "pleaseEnterPassword": "Por favor ingresa una contraseña",
   "usernameAlreadyExists": "El nombre de usuario ya existe",
   "@usernameAlreadyExists": {
     "x-mt": true
@@ -2294,14 +2123,8 @@
   "@memberCreatedOnline": {
     "x-mt": true
   },
-  "congratulations": "¡Felicidades! Desafío completado",
-  "@congratulations": {
-    "x-mt": true
-  },
-  "dailyVoices": "de 5 Voces Diarias",
-  "@dailyVoices": {
-    "x-mt": true
-  },
+  "congratulations": "¡Felicidades! Reto completado",
+  "dailyVoices": "de 5 Voces diarias",
   "voicesProgress": "{count} de 5 Voces Diarias",
   "@voicesProgress": {
     "x-mt": true
@@ -2318,18 +2141,12 @@
   "@syncCompletedChallenge": {
     "x-mt": true
   },
-  "rememberSync": "Recuerde sincronizar la aplicación móvil.",
-  "@rememberSync": {
-    "x-mt": true
-  },
+  "rememberSync": "Recuerda sincronizar la aplicación móvil.",
   "challengeDialogTitle": "Desafío diario",
   "@challengeDialogTitle": {
     "x-mt": true
   },
-  "start": "Comenzar",
-  "@start": {
-    "x-mt": true
-  },
+  "start": "Iniciar",
   "continuation": "Continuar",
   "@continuation": {
     "x-mt": true
@@ -2397,10 +2214,7 @@
   "@license": {
     "x-mt": true
   },
-  "addedBy": "Añadido por",
-  "@addedBy": {
-    "x-mt": true
-  },
+  "addedBy": "Agregado por",
   "resourceInformation": "Información de recursos",
   "@resourceInformation": {
     "x-mt": true
@@ -2550,10 +2364,7 @@
   "@serverUnreachable": {
     "x-mt": true
   },
-  "serverChecking": "Comprobando el servidor",
-  "@serverChecking": {
-    "x-mt": true
-  },
+  "serverChecking": "Verificando el servidor",
   "gridView": "Vista de cuadrícula",
   "@gridView": {
     "x-mt": true
@@ -2577,10 +2388,7 @@
   "filterCollections": "Filtrar colecciones",
   "selectManyCollections": "Seleccionar varias colecciones",
   "selected": "Seleccionado: ",
-  "myAchievements": "Mis logros",
-  "@myAchievements": {
-    "x-mt": true
-  },
+  "myAchievements": "misLogros",
   "editAchievement": "Editar logros",
   "@editAchievement": {
     "x-mt": true
@@ -2601,26 +2409,11 @@
   "@addAReference": {
     "x-mt": true
   },
-  "selectResources": "Seleccionar recursos:",
-  "@selectResources": {
-    "x-mt": true
-  },
-  "myGoals": "Mis metas",
-  "@myGoals": {
-    "x-mt": true
-  },
-  "myPurpose": "mi propósito",
-  "@myPurpose": {
-    "x-mt": true
-  },
-  "noGoalAdded": "Aún no se han fijado objetivos",
-  "@noGoalAdded": {
-    "x-mt": true
-  },
-  "noPurposeAdded": "No se agregó ningún propósito",
-  "@noPurposeAdded": {
-    "x-mt": true
-  },
+  "selectResources": "Seleccionar recursos: ",
+  "myGoals": "Mis Metas",
+  "myPurpose": "Mi Propósito",
+  "noGoalAdded": "Aún no se han establecido objetivos",
+  "noPurposeAdded": "No se agregó propósito",
   "noAchievementAdded": "Resumen de logros",
   "@noAchievementAdded": {
     "x-mt": true
@@ -2629,46 +2422,22 @@
   "@noReferencesAdded": {
     "x-mt": true
   },
-  "sendToNation": "Permita que sus logros sean compartidos con la nación.",
-  "@sendToNation": {
-    "x-mt": true
-  },
-  "saving": "Ahorro…",
-  "@saving": {
-    "x-mt": true
-  },
+  "sendToNation": "Permite que tus logros se compartan con la nación",
+  "saving": "Guardando…",
   "achievementSaved": "Logro actualizado",
   "@achievementSaved": {
     "x-mt": true
   },
-  "titleIsRequired": "Se requiere título",
-  "@titleIsRequired": {
-    "x-mt": true
-  },
-  "selectPdfOnly": "Please select a PDF file",
-  "@selectPdfOnly": {
-    "x-mt": true
-  },
-  "viewCv": "Ver CV/Currículum vitae",
-  "@viewCv": {
-    "x-mt": true
-  },
+  "titleIsRequired": "Se requiere un título.",
+  "selectPdfOnly": "Por favor selecciona un archivo PDF",
+  "viewCv": "Ver CV/Currículum",
   "deleteCv": "Eliminar CV",
   "@deleteCv": {
     "x-mt": true
   },
-  "uploadCvLabel": "Cargue su CV/Currículum vitae a continuación (solo PDF)",
-  "@uploadCvLabel": {
-    "x-mt": true
-  },
-  "addMaterials": "Agregue cualquier material que demuestre sus logros a continuación",
-  "@addMaterials": {
-    "x-mt": true
-  },
-  "labelAddReferences": "Agregue cualquier referencia a continuación",
-  "@labelAddReferences": {
-    "x-mt": true
-  },
+  "uploadCvLabel": "Sube tu CV/currículum a continuación (solo PDF)",
+  "addMaterials": "Agrega cualquier material que demuestre tus logros a continuación",
+  "labelAddReferences": "Añada referencias abajo",
   "cvResume": "CV / Currículum",
   "@cvResume": {
     "x-mt": true
@@ -2677,14 +2446,8 @@
   "@relationship": {
     "x-mt": true
   },
-  "noFileChosen": "Ningún archivo elegido",
-  "@noFileChosen": {
-    "x-mt": true
-  },
-  "chooseFile": "Elija archivo",
-  "@chooseFile": {
-    "x-mt": true
-  },
+  "noFileChosen": "Ningún archivo seleccionado",
+  "chooseFile": "Elegir archivo",
   "currentCv": "CV/Currículum vitae actual: {name}",
   "@currentCv": {
     "x-mt": true
@@ -2709,10 +2472,7 @@
   "@textSizeSmall": {
     "x-mt": true
   },
-  "textSizeMedium": "Medio",
-  "@textSizeMedium": {
-    "x-mt": true
-  },
+  "textSizeMedium": "Mediano",
   "textSizeLarge": "Grande",
   "@textSizeLarge": {
     "x-mt": true
@@ -2721,10 +2481,7 @@
   "@resetApp": {
     "x-mt": true
   },
-  "clearAllDataConfirm": "¿Está seguro de que desea borrar todos los datos?",
-  "@clearAllDataConfirm": {
-    "x-mt": true
-  },
+  "clearAllDataConfirm": "¿Estás seguro de que deseas borrar todos los datos?",
   "dataCleared": "Todos los datos borrados",
   "@dataCleared": {
     "x-mt": true
@@ -2734,5 +2491,10 @@
     "x-mt": true
   },
   "resourceTitleAlreadyExists": "Ya existe un recurso con este título",
-  "failedToUpdateResource": "Error al actualizar el recurso"
+  "failedToUpdateResource": "Error al actualizar el recurso",
+  "unableToAddHealthRecord": "No se puede agregar el registro de salud.",
+  "summaryOfAchievements": "Resumen de logros - Resume brevemente tu logro y añade los materiales relacionados a continuación",
+  "myGoalsDescription": "Mis Metas - ¿Cuáles son tus metas para los próximos 10 años?",
+  "myPurposeDescription": "Mi Propósito - ¿Cuáles son tus ambiciones educativas y profesionales?",
+  "pleaseAnswerToContinue": "Por favor, selecciona/escribe tu respuesta para continuar"
 }

--- a/flutter/lib/l10n/app_es.arb
+++ b/flutter/lib/l10n/app_es.arb
@@ -1775,10 +1775,7 @@
   "@submitExam": {
     "x-mt": true
   },
-  "incorrectAnswer": "respuesta incorrecta",
-  "@incorrectAnswer": {
-    "x-mt": true
-  },
+  "incorrectAnswer": "Respuesta incorrecta, por favor inténtalo de nuevo",
   "correctAnswers": "Correcto",
   "@correctAnswers": {
     "x-mt": true

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -1776,10 +1776,7 @@
   "@submitExam": {
     "x-mt": true
   },
-  "incorrectAnswer": "Réponse incorrecte",
-  "@incorrectAnswer": {
-    "x-mt": true
-  },
+  "incorrectAnswer": "Réponse incorrecte, veuillez réessayer",
   "correctAnswers": "Correct",
   "@correctAnswers": {
     "x-mt": true

--- a/flutter/lib/l10n/app_fr.arb
+++ b/flutter/lib/l10n/app_fr.arb
@@ -13,20 +13,14 @@
   "@serverUrlHint": {
     "x-mt": true
   },
-  "serverPinLabel": "Code PIN du serveur",
-  "@serverPinLabel": {
-    "x-mt": true
-  },
+  "serverPinLabel": "Code serveur",
   "connect": "Connecter",
   "@connect": {
     "x-mt": true
   },
   "serverUrlNotConfigured": "URL du serveur non configurée",
-  "deviceCouldNotReachLocalServer": "l'appareil n'a pas pu atteindre le serveur. vérifiez si vous êtes connecté au bon réseau Wi-Fi pour le serveur local (communauté).",
-  "@deviceCouldNotReachLocalServer": {
-    "x-mt": true
-  },
-  "deviceCouldNotReachNationServer": "l\\'appareil n\\'a pas pu atteindre le serveur. vérifiez si vous êtes connecté à Internet et réessayez.",
+  "deviceCouldNotReachLocalServer": "l'appareil n'a pas pu atteindre le serveur. vérifiez si vous êtes connecté au réseau Wi-Fi correct pour le serveur local (communauté).",
+  "deviceCouldNotReachNationServer": "l'appareil n'a pas pu atteindre le serveur. vérifiez si vous êtes connecté à Internet et réessayez.",
   "connectionFailed": "Échec de la connexion !",
   "connectedToCommunity": "Connecté à {code}",
   "@connectedToCommunity": {
@@ -158,14 +152,8 @@
   "@appTheme": {
     "x-mt": true
   },
-  "aiChat": "Chat IA",
-  "@aiChat": {
-    "x-mt": true
-  },
-  "syncNow": "Synchronisez maintenant",
-  "@syncNow": {
-    "x-mt": true
-  },
+  "aiChat": "AI Chat",
+  "syncNow": "Synchroniser maintenant",
   "syncCenter": "Centre de synchronisation",
   "@syncCenter": {
     "x-mt": true
@@ -277,7 +265,7 @@
     "x-mt": true
   },
   "neverSynced": "jamais synchronisé",
-  "justNow": "À l\\'instant",
+  "justNow": "À l'instant",
   "minutesAgo": "{count, plural, =1{1 minute ago} other{{count} minutes ago}}",
   "@minutesAgo": {
     "x-mt": true
@@ -587,8 +575,8 @@
     "x-mt": true
   },
   "tasks": "Tâches",
-  "notifGroupJoinRequests": "Demandes d\\'adhésion",
-  "notifGroupTeamUpdates": "Mises à jour de l\\'équipe",
+  "notifGroupJoinRequests": "Demandes d'adhésion",
+  "notifGroupTeamUpdates": "Mises à jour de l'équipe",
   "notifGroupNewVoices": "Nouvelles voix",
   "notifGroupVoiceReplies": "Réponses vocales",
   "notificationGroupSystem": "Système",
@@ -661,10 +649,7 @@
   "@refresh": {
     "x-mt": true
   },
-  "complete": "Complet",
-  "@complete": {
-    "x-mt": true
-  },
+  "complete": "Complète",
   "noMatchingSubmissions": "Aucune soumission ne correspond à ce filtre",
   "@noMatchingSubmissions": {
     "x-mt": true
@@ -685,14 +670,8 @@
   "@unknown": {
     "x-mt": true
   },
-  "nA": "N / A",
-  "@nA": {
-    "x-mt": true
-  },
-  "otherDiagnosis": "Autre diagnostic",
-  "@otherDiagnosis": {
-    "x-mt": true
-  },
+  "nA": "N/A",
+  "otherDiagnosis": "Autres diagnostics",
   "add": "Ajouter",
   "@add": {
     "x-mt": true
@@ -740,10 +719,7 @@
   "@newSubmission": {
     "x-mt": true
   },
-  "answer": "Répondre",
-  "@answer": {
-    "x-mt": true
-  },
+  "answer": "Réponse",
   "availableChoices": "Choix",
   "@availableChoices": {
     "x-mt": true
@@ -774,10 +750,7 @@
     "x-mt": true
   },
   "maps": "Cartes",
-  "englishDictionary": "dictionnaire anglais",
-  "@englishDictionary": {
-    "x-mt": true
-  },
+  "englishDictionary": "Dictionnaire anglais",
   "offlineMapsComingSoon": "Les cartes hors ligne ne sont pas encore portées",
   "@offlineMapsComingSoon": {
     "x-mt": true
@@ -885,7 +858,7 @@
   "welcomeToMyPlanet": "Bienvenue sur myPlanet",
   "learnOffline": "Apprendre hors ligne",
   "openLearning": "Apprentissage ouvert",
-  "unleashLearningPower": "Libérer le pouvoir d\\'apprendre",
+  "unleashLearningPower": "Libérer le pouvoir d'apprendre",
   "onboardingWelcomeDescription": "Votre passerelle vers un apprentissage illimité",
   "onboardingOfflineDescription": "Téléchargez des ressources pour l'apprentissage hors ligne.\nAccédez aux connaissances en déplacement.",
   "@onboardingOfflineDescription": {
@@ -899,10 +872,7 @@
   "@onboardingPowerDescription": {
     "x-mt": true
   },
-  "onboardingServerPrepHint": "Avant de vous connecter, vous aurez besoin de votre adresse de serveur Planet et de votre code PIN. Demandez à votre administrateur de communauté si vous ne les avez pas encore.",
-  "@onboardingServerPrepHint": {
-    "x-mt": true
-  },
+  "onboardingServerPrepHint": "Avant de vous connecter, vous aurez besoin de l'adresse du serveur Planet et du code PIN. Demandez à l'administrateur de votre communauté si vous ne les avez pas encore.",
   "pageProgress": "Page {current} de {total}",
   "@pageProgress": {
     "x-mt": true
@@ -969,10 +939,7 @@
   "@joinMeetup": {
     "x-mt": true
   },
-  "editMeetup": "Modifier la rencontre",
-  "@editMeetup": {
-    "x-mt": true
-  },
+  "editMeetup": "Modifier la réunion",
   "startTime": "Heure de début",
   "@startTime": {
     "x-mt": true
@@ -1139,10 +1106,7 @@
   "@sendSurveyTo": {
     "x-mt": true
   },
-  "sendSurvey": "Envoyer le sondage",
-  "@sendSurvey": {
-    "x-mt": true
-  },
+  "sendSurvey": "Envoyer l'enquête",
   "surveySentToUsers": "Survey sent to selected users",
   "@surveySentToUsers": {
     "x-mt": true
@@ -1197,22 +1161,10 @@
   "@leader": {
     "x-mt": true
   },
-  "leave": "Partir",
-  "@leave": {
-    "x-mt": true
-  },
-  "remove": "Retirer",
-  "@remove": {
-    "x-mt": true
-  },
-  "makeLeader": "Faire un leader",
-  "@makeLeader": {
-    "x-mt": true
-  },
-  "leftTeam": "Équipe de gauche",
-  "@leftTeam": {
-    "x-mt": true
-  },
+  "leave": "Quitter",
+  "remove": "Supprimer",
+  "makeLeader": "Faire de lui un leader",
+  "leftTeam": "A quitté l'équipe",
   "memberRemoved": "Membre supprimé",
   "@memberRemoved": {
     "x-mt": true
@@ -1364,10 +1316,7 @@
   "@levelIsRequired": {
     "x-mt": true
   },
-  "subjectIsRequired": "Le sujet est obligatoire",
-  "@subjectIsRequired": {
-    "x-mt": true
-  },
+  "subjectIsRequired": "Le sujet est requis",
   "selectFile": "Sélectionnez un fichier",
   "@selectFile": {
     "x-mt": true
@@ -1445,10 +1394,7 @@
     "x-mt": true
   },
   "archiveReport": "Archiver",
-  "beginningBalance": "Solde d'ouverture",
-  "@beginningBalance": {
-    "x-mt": true
-  },
+  "beginningBalance": "Solde de départ",
   "sales": "Ventes",
   "otherIncome": "Autres revenus",
   "@otherIncome": {
@@ -1491,10 +1437,7 @@
     "x-mt": true
   },
   "chat": "Discussion",
-  "newChat": "Nouvelle discussion",
-  "@newChat": {
-    "x-mt": true
-  },
+  "newChat": "Nouveau chat",
   "searchChats": "Rechercher des discussions",
   "@searchChats": {
     "x-mt": true
@@ -1511,10 +1454,7 @@
   "@untitledChat": {
     "x-mt": true
   },
-  "fullConversationResponse": "Réponse complète à la conversation",
-  "@fullConversationResponse": {
-    "x-mt": true
-  },
+  "fullConversationResponse": "Réponse complète de la conversation",
   "response": "Réponse",
   "@response": {
     "x-mt": true
@@ -1551,15 +1491,12 @@
   "@aiProviderUnavailable": {
     "x-mt": true
   },
-  "feedback": "Retour d\\'information",
+  "feedback": "Retour d'information",
   "feedbackNotFound": "Commentaires introuvables",
   "@feedbackNotFound": {
     "x-mt": true
   },
-  "feedbackSaved": "Commentaires enregistrés",
-  "@feedbackSaved": {
-    "x-mt": true
-  },
+  "feedbackSaved": "Commentaire enregistré",
   "isUrgent": "Est-ce urgent ?",
   "@isUrgent": {
     "x-mt": true
@@ -1604,10 +1541,7 @@
   "@takeTest": {
     "x-mt": true
   },
-  "recordSurvey": "Enquête record",
-  "@recordSurvey": {
-    "x-mt": true
-  },
+  "recordSurvey": "Enregistrer l'enquête",
   "react": "Réagir",
   "@react": {
     "x-mt": true
@@ -1705,14 +1639,8 @@
     "x-mt": true
   },
   "date": "Date",
-  "fromDate": "À partir du jour",
-  "@fromDate": {
-    "x-mt": true
-  },
-  "toDate": "À ce jour",
-  "@toDate": {
-    "x-mt": true
-  },
+  "fromDate": "Date de début",
+  "toDate": "Date de fin",
   "reset": "Réinitialiser",
   "@reset": {
     "x-mt": true
@@ -1781,10 +1709,7 @@
   "@correctAnswers": {
     "x-mt": true
   },
-  "yourAnswer": "Votre Réponse",
-  "@yourAnswer": {
-    "x-mt": true
-  },
+  "yourAnswer": "Votre réponse",
   "previous": "Précédent",
   "finish": "Terminer",
   "exitExam": "Examen de sortie ?",
@@ -1797,14 +1722,8 @@
   },
   "exit": "Quitter",
   "download": "Télécharger",
-  "downloading": "Téléchargement…",
-  "@downloading": {
-    "x-mt": true
-  },
-  "downloadFailed": "Le téléchargement a échoué.",
-  "@downloadFailed": {
-    "x-mt": true
-  },
+  "downloading": "Téléchargement....",
+  "downloadFailed": "Échec du téléchargement.",
   "resourceNotDownloaded": "Cette ressource n'est pas encore sur votre appareil.",
   "@resourceNotDownloaded": {
     "x-mt": true
@@ -1841,18 +1760,9 @@
   "@birthDate": {
     "x-mt": true
   },
-  "selectDate": "Sélectionnez une date",
-  "@selectDate": {
-    "x-mt": true
-  },
-  "male": "Mâle",
-  "@male": {
-    "x-mt": true
-  },
-  "female": "Femelle",
-  "@female": {
-    "x-mt": true
-  },
+  "selectDate": "Sélectionner une date",
+  "male": "Homme",
+  "female": "Femme",
   "yearOfBirth": "Année de naissance",
   "yearOfBirthRequired": "L'année de naissance est obligatoire",
   "@yearOfBirthRequired": {
@@ -1866,10 +1776,7 @@
   "@yearBetween": {
     "x-mt": true
   },
-  "thankYouForTakingSurvey": "Merci d'avoir répondu à cette enquête",
-  "@thankYouForTakingSurvey": {
-    "x-mt": true
-  },
+  "thankYouForTakingSurvey": "Merci d'avoir participé à cette enquête",
   "errorSavingProfile": "Erreur lors de l'enregistrement du profil",
   "@errorSavingProfile": {
     "x-mt": true
@@ -1904,10 +1811,7 @@
   "@resourceUnavailable": {
     "x-mt": true
   },
-  "healthRecordNotAvailable": "Carnet de santé non disponible",
-  "@healthRecordNotAvailable": {
-    "x-mt": true
-  },
+  "healthRecordNotAvailable": "Dossier de santé non disponible",
   "updateHealth": "Mettre à jour la santé",
   "@updateHealth": {
     "x-mt": true
@@ -1928,10 +1832,7 @@
   "@otherNeeds": {
     "x-mt": true
   },
-  "emergencyContact": "Personne à contacter en cas d'urgence",
-  "@emergencyContact": {
-    "x-mt": true
-  },
+  "emergencyContact": "Contact d'urgence",
   "contactNumber": "Numéro de contact",
   "@contactNumber": {
     "x-mt": true
@@ -2001,20 +1902,14 @@
   "allergies": "Allergies",
   "diagnosis": "Diagnostic",
   "medications": "Médicaments",
-  "immunizations": "Vaccinations",
-  "@immunizations": {
-    "x-mt": true
-  },
+  "immunizations": "Vaccins",
   "treatments": "Traitements",
   "observations": "Observations",
   "@observations": {
     "x-mt": true
   },
   "referrals": "Références",
-  "labTests": "Tests de laboratoire",
-  "@labTests": {
-    "x-mt": true
-  },
+  "labTests": "Analyses de laboratoire",
   "xrays": "Radiographies",
   "conditions": "Conditions",
   "@conditions": {
@@ -2086,10 +1981,7 @@
   "@bloodPressureRangeError": {
     "x-mt": true
   },
-  "bloodPressureNotNumbers": "Systolique et diastolique doivent être des nombres",
-  "@bloodPressureNotNumbers": {
-    "x-mt": true
-  },
+  "bloodPressureNotNumbers": "La systolique et la diastolique doivent être des nombres",
   "temp": "Température",
   "@temp": {
     "x-mt": true
@@ -2133,10 +2025,10 @@
     "x-mt": true
   },
   "areYouSure": "Êtes-vous sûr ?",
-  "cancelAddingExamination": "Are you sure you want to cancel adding examination? The data will be lost.",
-  "yesIWantToExit": "Yes, I want to exit.",
-  "inactiveMessage": "User not activated, please contact administrator or manager to activate your account.",
-  "submitFeedback": "Submit Feedback",
+  "cancelAddingExamination": "Voulez-vous vraiment annuler l'ajout de l'examen? Les données seront perdues.",
+  "yesIWantToExit": "Oui, je veux quitter.",
+  "inactiveMessage": "Utilisateur non activé, veuillez contacter l'administrateur ou le responsable pour activer votre compte.",
+  "submitFeedback": "Envoyer un commentaire",
   "failedToDelete": "Échec de la suppression : {error}",
   "@failedToDelete": {
     "x-mt": true
@@ -2185,10 +2077,7 @@
   "@freeUpSpaceFailed": {
     "x-mt": true
   },
-  "enterUsername": "Entrez le nom d'utilisateur",
-  "@enterUsername": {
-    "x-mt": true
-  },
+  "enterUsername": "Entrer le nom d'utilisateur",
   "enterPassword": "Entrez le mot de passe",
   "@enterPassword": {
     "x-mt": true
@@ -2199,10 +2088,7 @@
   },
   "becomeMember": "devenir membre",
   "toAccessThisFeatureBecomeAMember": "vous êtes actuellement un utilisateur invité. pour accéder à cette fonctionnalité, devenez membre.",
-  "creatingMember": "Création d'un compte membre...",
-  "@creatingMember": {
-    "x-mt": true
-  },
+  "creatingMember": "Création du compte membre...",
   "passwordsDoNotMatch": "Les mots de passe ne correspondent pas",
   "pleaseSelectGender": "Veuillez sélectionner le genre",
   "pleaseEnterPassword": "Veuillez entrer un mot de passe",
@@ -2210,14 +2096,14 @@
   "@usernameAlreadyExists": {
     "x-mt": true
   },
-  "usernameCannotBeEmpty": "Le nom d\\'utilisateur ne peut pas être vide",
-  "invalidUsername": "Nom d\\'utilisateur invalide",
+  "usernameCannotBeEmpty": "Le nom d'utilisateur ne peut pas être vide",
+  "invalidUsername": "Nom d'utilisateur invalide",
   "usernameMustStartWithLetterOrNumber": "Doit commencer par une lettre ou un chiffre",
   "usernameOnlyLettersNumbers": "Seules les lettres a à z, les chiffres et \"_\", \".\", \"-\" sont autorisés",
   "@usernameOnlyLettersNumbers": {
     "x-mt": true
   },
-  "usernameTaken": "Nom d\\'utilisateur déjà pris",
+  "usernameTaken": "Nom d'utilisateur déjà pris",
   "memberCreatedOffline": "Compte membre créé hors ligne",
   "@memberCreatedOffline": {
     "x-mt": true
@@ -2244,15 +2130,12 @@
   "@syncCompletedChallenge": {
     "x-mt": true
   },
-  "rememberSync": "N\\'oubliez pas de synchroniser l\\'application mobile.",
+  "rememberSync": "N'oubliez pas de synchroniser l'application mobile.",
   "challengeDialogTitle": "Défi quotidien",
   "@challengeDialogTitle": {
     "x-mt": true
   },
-  "start": "Commencer",
-  "@start": {
-    "x-mt": true
-  },
+  "start": "Démarrer",
   "continuation": "Continuer",
   "@continuation": {
     "x-mt": true
@@ -2260,25 +2143,16 @@
   "plan": "Plan",
   "mission": "Mission et Services",
   "editPlan": "Modifier le plan",
-  "teamPlan": "Quel est le projet de votre équipe ?",
-  "@teamPlan": {
-    "x-mt": true
-  },
-  "entMission": "Quelle est la Mission de votre entreprise ?",
-  "@entMission": {
-    "x-mt": true
-  },
+  "teamPlan": "Quel est le plan de votre équipe ?",
+  "entMission": "Quelle est la mission de votre entreprise ?",
   "entServices": "Quels sont les services fournis par votre entreprise ?",
   "entRules": "Quelles sont les règles de votre entreprise ?",
-  "noMissionDefined": "L\\'entreprise n\\'a pas de mission et de services.",
+  "noMissionDefined": "L'entreprise n'a pas de mission et de services.",
   "noPlanDefined": "Cette équipe n'a pas de plan défini.",
   "@noPlanDefined": {
     "x-mt": true
   },
-  "noDescriptionDefined": "Cette équipe n'a pas de description définie.",
-  "@noDescriptionDefined": {
-    "x-mt": true
-  },
+  "noDescriptionDefined": "Cette équipe n'a aucune description définie.",
   "enterpriseName": "Nom de l'entreprise",
   "@enterpriseName": {
     "x-mt": true
@@ -2440,7 +2314,7 @@
   "@filterResources": {
     "x-mt": true
   },
-  "teamSurveys": "Enquêtes d\\'équipe",
+  "teamSurveys": "Enquêtes d'équipe",
   "adoptableSurveys": "Enquêtes disponibles à adopter",
   "@adoptableSurveys": {
     "x-mt": true
@@ -2485,10 +2359,7 @@
   "@activitySummary": {
     "x-mt": true
   },
-  "lastLogin": "Dernière connexion",
-  "@lastLogin": {
-    "x-mt": true
-  },
+  "lastLogin": "Dernière Connexion",
   "memberDetail": "Détail du membre",
   "@memberDetail": {
     "x-mt": true
@@ -2501,18 +2372,9 @@
   "@noLogoutRecord": {
     "x-mt": true
   },
-  "totalVisits": "Visites totales",
-  "@totalVisits": {
-    "x-mt": true
-  },
-  "mostOpenedResource": "Ressource la plus ouverte",
-  "@mostOpenedResource": {
-    "x-mt": true
-  },
-  "numberOfResourcesOpened": "Nombre de ressources ouvertes",
-  "@numberOfResourcesOpened": {
-    "x-mt": true
-  },
+  "totalVisits": "Total des Visites",
+  "mostOpenedResource": "Ressource La Plus Consultée",
+  "numberOfResourcesOpened": "Nombre de Ressources Ouvertes",
   "resourceOpenedTimes": "{title} ouvert {count} fois",
   "@resourceOpenedTimes": {
     "x-mt": true
@@ -2571,8 +2433,8 @@
   "selectResources": "Sélectionner des ressources: ",
   "myGoals": "Mes Objectifs",
   "myPurpose": "Mon But",
-  "noGoalAdded": "Aucun objectif n\\'a encore été défini",
-  "noPurposeAdded": "Aucun objectif n\\'a été ajouté",
+  "noGoalAdded": "Aucun objectif n'a encore été défini",
+  "noPurposeAdded": "Aucun objectif n'a été ajouté",
   "noAchievementAdded": "Résumé des réalisations",
   "noReferencesAdded": "Aucune référence ajoutée",
   "sendToNation": "Autorisez la partage de vos réalisations avec la nation",
@@ -2606,10 +2468,7 @@
   "@textSize": {
     "x-mt": true
   },
-  "selectTextSize": "Sélectionnez la taille du texte",
-  "@selectTextSize": {
-    "x-mt": true
-  },
+  "selectTextSize": "Sélectionner la taille du texte",
   "textSizeSmall": "Petit",
   "@textSizeSmall": {
     "x-mt": true
@@ -2626,10 +2485,7 @@
   "@resetApp": {
     "x-mt": true
   },
-  "clearAllDataConfirm": "Êtes-vous sûr de vouloir effacer toutes les données ?",
-  "@clearAllDataConfirm": {
-    "x-mt": true
-  },
+  "clearAllDataConfirm": "Êtes-vous sûr de vouloir effacer toutes les données ?",
   "dataCleared": "Toutes les données effacées",
   "@dataCleared": {
     "x-mt": true
@@ -2639,5 +2495,10 @@
     "x-mt": true
   },
   "resourceTitleAlreadyExists": "Une ressource avec ce titre existe déjà",
-  "failedToUpdateResource": "Échec de la mise à jour de la ressource"
+  "failedToUpdateResource": "Échec de la mise à jour de la ressource",
+  "unableToAddHealthRecord": "Impossible d'ajouter un dossier de santé.",
+  "summaryOfAchievements": "Résumé des réalisations - Résumez brièvement votre réalisation et ajoutez les documents associés ci-dessous",
+  "myGoalsDescription": "Mes Objectifs - Quels sont vos objectifs pour les 10 prochaines années ?",
+  "myPurposeDescription": "Mon But - Quelles sont vos ambitions éducatives et professionnelles ?",
+  "pleaseAnswerToContinue": "Veuillez sélectionner/écrire votre réponse pour continuer"
 }

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -1776,10 +1776,7 @@
   "@submitExam": {
     "x-mt": true
   },
-  "incorrectAnswer": "[Nepali] Incorrect answer",
-  "@incorrectAnswer": {
-    "x-mt": true
-  },
+  "incorrectAnswer": "तपाईंले गलत उत्तर दिएका छन्, कृपया पुन: प्रयास गर्नुहोस्",
   "correctAnswers": "[Nepali] Correct",
   "@correctAnswers": {
     "x-mt": true

--- a/flutter/lib/l10n/app_ne.arb
+++ b/flutter/lib/l10n/app_ne.arb
@@ -13,19 +13,13 @@
   "@serverUrlHint": {
     "x-mt": true
   },
-  "serverPinLabel": "[Nepali] Server PIN",
-  "@serverPinLabel": {
-    "x-mt": true
-  },
+  "serverPinLabel": "सर्भर पिन",
   "connect": "[Nepali] Connect",
   "@connect": {
     "x-mt": true
   },
   "serverUrlNotConfigured": "सर्भर URL कन्फिगर गरिएको छैन",
-  "deviceCouldNotReachLocalServer": "[Nepali] device couldn't reach the server. check if you are connected to the correct Wi-Fi network for the local server (community).",
-  "@deviceCouldNotReachLocalServer": {
-    "x-mt": true
-  },
+  "deviceCouldNotReachLocalServer": "डिभाइसले सर्भरसम्म पुग्न सकेन। स्थानीय सर्भर (समुदाय) को लागि तपाईं सही Wi-Fi नेटवर्कमा जडित हुनुहुन्छ कि छैन जाँच गर्नुहोस्।",
   "deviceCouldNotReachNationServer": "डिभाइसले सर्भरसम्म पुग्न सकेन। इन्टरनेटमा जडित हुनुहुन्छ कि छैन जाँच गर्नुहोस् र पुन: प्रयास गर्नुहोस्।",
   "connectionFailed": "जडान असफल भयो!",
   "connectedToCommunity": "[Nepali] Connected to {code}",
@@ -77,10 +71,7 @@
   },
   "resources": "स्रोतहरू",
   "search": "खोज्नुहोस्",
-  "sync": "[Nepali] Sync",
-  "@sync": {
-    "x-mt": true
-  },
+  "sync": "सिंक",
   "cancel": "रद्द गर्नुहोस्",
   "settings": "सेटिङ्स",
   "backgroundSync": "[Nepali] Background sync",
@@ -154,18 +145,9 @@
   "@moreOptions": {
     "x-mt": true
   },
-  "appTheme": "[Nepali] App theme",
-  "@appTheme": {
-    "x-mt": true
-  },
-  "aiChat": "[Nepali] AI chat",
-  "@aiChat": {
-    "x-mt": true
-  },
-  "syncNow": "[Nepali] Sync now",
-  "@syncNow": {
-    "x-mt": true
-  },
+  "appTheme": "एप थिम",
+  "aiChat": "AI Chat",
+  "syncNow": "अहिले सिङ्क गर्नुहोस्",
   "syncCenter": "[Nepali] Sync center",
   "@syncCenter": {
     "x-mt": true
@@ -307,10 +289,7 @@
     "x-mt": true
   },
   "courses": "पाठ्यक्रमहरू",
-  "myCourses": "[Nepali] My courses",
-  "@myCourses": {
-    "x-mt": true
-  },
+  "myCourses": "मेरो पाठ्यक्रमहरू",
   "allCourses": "[Nepali] All courses",
   "@allCourses": {
     "x-mt": true
@@ -327,10 +306,7 @@
   "@resourcesInStep": {
     "x-mt": true
   },
-  "gradeLevel": "[Nepali] Grade level",
-  "@gradeLevel": {
-    "x-mt": true
-  },
+  "gradeLevel": "ग्रेड स्तर",
   "subjectLevel": "[Nepali] Subject",
   "@subjectLevel": {
     "x-mt": true
@@ -362,19 +338,13 @@
   "@profileUnavailable": {
     "x-mt": true
   },
-  "username": "[Nepali] Username",
-  "@username": {
-    "x-mt": true
-  },
+  "username": "प्रयोगकर्तानाम",
   "email": "ईमेल",
   "phone": "[Nepali] Phone",
   "@phone": {
     "x-mt": true
   },
-  "level": "[Nepali] Level",
-  "@level": {
-    "x-mt": true
-  },
+  "level": "स्तर",
   "levels": "[Nepali] Levels",
   "@levels": {
     "x-mt": true
@@ -382,10 +352,7 @@
   "language": "भाषा",
   "languages": "भाषाहरू",
   "gender": "लिङ्ग",
-  "dateOfBirth": "[Nepali] Date of birth",
-  "@dateOfBirth": {
-    "x-mt": true
-  },
+  "dateOfBirth": "जन्म मिति",
   "planetCode": "[Nepali] Planet code",
   "@planetCode": {
     "x-mt": true
@@ -402,10 +369,7 @@
   "@profilePhotoFor": {
     "x-mt": true
   },
-  "editProfile": "[Nepali] Edit profile",
-  "@editProfile": {
-    "x-mt": true
-  },
+  "editProfile": "प्रोफाइल सम्पादन गर्नुहोस्",
   "changePhoto": "[Nepali] Change profile photo",
   "@changePhoto": {
     "x-mt": true
@@ -418,18 +382,9 @@
   "@photoUpdateFailed": {
     "x-mt": true
   },
-  "firstName": "[Nepali] First name",
-  "@firstName": {
-    "x-mt": true
-  },
-  "middleName": "[Nepali] Middle name",
-  "@middleName": {
-    "x-mt": true
-  },
-  "lastName": "[Nepali] Last name",
-  "@lastName": {
-    "x-mt": true
-  },
+  "firstName": "नाम",
+  "middleName": "विचारको नाम",
+  "lastName": "थर",
   "save": "सुरक्षित गर्नुहोस्",
   "profileSaved": "[Nepali] Profile saved on this device",
   "@profileSaved": {
@@ -578,10 +533,7 @@
   "@storageNotification": {
     "x-mt": true
   },
-  "joinRequestNotification": "[Nepali] Join request",
-  "@joinRequestNotification": {
-    "x-mt": true
-  },
+  "joinRequestNotification": "सामेल हुने अनुरोध",
   "teamNotification": "[Nepali] Team update",
   "@teamNotification": {
     "x-mt": true
@@ -661,10 +613,7 @@
   "@refresh": {
     "x-mt": true
   },
-  "complete": "[Nepali] Complete",
-  "@complete": {
-    "x-mt": true
-  },
+  "complete": "समाप्त",
   "noMatchingSubmissions": "[Nepali] No submissions match this filter",
   "@noMatchingSubmissions": {
     "x-mt": true
@@ -685,18 +634,9 @@
   "@unknown": {
     "x-mt": true
   },
-  "nA": "[Nepali] N/A",
-  "@nA": {
-    "x-mt": true
-  },
-  "otherDiagnosis": "[Nepali] Other diagnosis",
-  "@otherDiagnosis": {
-    "x-mt": true
-  },
-  "add": "[Nepali] Add",
-  "@add": {
-    "x-mt": true
-  },
+  "nA": "N/A",
+  "otherDiagnosis": "अन्य निदानहरू",
+  "add": "थप्नुहोस्",
   "status": "स्थिति",
   "lastUpdated": "[Nepali] Last updated",
   "@lastUpdated": {
@@ -740,10 +680,7 @@
   "@newSubmission": {
     "x-mt": true
   },
-  "answer": "[Nepali] Answer",
-  "@answer": {
-    "x-mt": true
-  },
+  "answer": "उत्तर",
   "availableChoices": "[Nepali] Choices",
   "@availableChoices": {
     "x-mt": true
@@ -774,10 +711,7 @@
     "x-mt": true
   },
   "maps": "नक्सा",
-  "englishDictionary": "[Nepali] English dictionary",
-  "@englishDictionary": {
-    "x-mt": true
-  },
+  "englishDictionary": "अंग्रेजी शब्दकोश",
   "offlineMapsComingSoon": "[Nepali] Offline maps are not ported yet",
   "@offlineMapsComingSoon": {
     "x-mt": true
@@ -877,10 +811,7 @@
     "x-mt": true
   },
   "skip": "छोड्नुहोस्",
-  "next": "[Nepali] Next",
-  "@next": {
-    "x-mt": true
-  },
+  "next": "अर्को",
   "getStarted": "सुरु गर्नुहोस्",
   "welcomeToMyPlanet": "मेरो प्ल्यानेटमा स्वागत छ",
   "learnOffline": "अफलाइनमा सिक्नुहोस्",
@@ -899,10 +830,7 @@
   "@onboardingPowerDescription": {
     "x-mt": true
   },
-  "onboardingServerPrepHint": "[Nepali] Before you sign in, you'll need your Planet server address and PIN. Ask your community administrator if you don't have them yet.",
-  "@onboardingServerPrepHint": {
-    "x-mt": true
-  },
+  "onboardingServerPrepHint": "साइन इन गर्नु अघि, तपाईंलाई आफ्नो Planet सर्भर ठेगाना र PIN आवश्यक पर्नेछ। यदि तपाईंसँग अझै छैन भने आफ्नो सामुदायिक प्रशासकलाई सोध्नुहोस्।",
   "pageProgress": "[Nepali] Page {current} of {total}",
   "@pageProgress": {
     "x-mt": true
@@ -931,10 +859,7 @@
   "@untitledMeetup": {
     "x-mt": true
   },
-  "addMeetup": "[Nepali] Add meetup",
-  "@addMeetup": {
-    "x-mt": true
-  },
+  "addMeetup": "भेटघाट थप्नुहोस्",
   "meetupDetails": "[Nepali] Meetup details",
   "@meetupDetails": {
     "x-mt": true
@@ -943,24 +868,15 @@
   "@meetupNotFound": {
     "x-mt": true
   },
-  "createdBy": "[Nepali] Created by",
-  "@createdBy": {
-    "x-mt": true
-  },
+  "createdBy": "बनाएको",
   "category": "[Nepali] Category",
   "@category": {
     "x-mt": true
   },
   "location": "स्थान",
   "link": "लिङ्क",
-  "recurring": "[Nepali] Recurring",
-  "@recurring": {
-    "x-mt": true
-  },
-  "description": "[Nepali] Description",
-  "@description": {
-    "x-mt": true
-  },
+  "recurring": "आवर्तमान",
+  "description": "वर्णन",
   "leaveMeetup": "[Nepali] Leave meetup",
   "@leaveMeetup": {
     "x-mt": true
@@ -969,18 +885,9 @@
   "@joinMeetup": {
     "x-mt": true
   },
-  "editMeetup": "[Nepali] Edit meetup",
-  "@editMeetup": {
-    "x-mt": true
-  },
-  "startTime": "[Nepali] Start time",
-  "@startTime": {
-    "x-mt": true
-  },
-  "endTime": "[Nepali] End time",
-  "@endTime": {
-    "x-mt": true
-  },
+  "editMeetup": "भेटघाट सम्पादन गर्नुहोस्",
+  "startTime": "सुरु समय",
+  "endTime": "अन्त समय",
   "none": "कुनै पनि होइन",
   "daily": "दैनिक",
   "weekly": "साप्ताहिक",
@@ -1016,14 +923,8 @@
   "@titleDescending": {
     "x-mt": true
   },
-  "startDate": "[Nepali] Start date",
-  "@startDate": {
-    "x-mt": true
-  },
-  "endDate": "[Nepali] End date",
-  "@endDate": {
-    "x-mt": true
-  },
+  "startDate": "सुरु मिति",
+  "endDate": "अन्त मिति",
   "timeNotSet": "[Nepali] Time not set",
   "@timeNotSet": {
     "x-mt": true
@@ -1052,10 +953,7 @@
   "@untitledSurvey": {
     "x-mt": true
   },
-  "takeSurvey": "[Nepali] Take survey",
-  "@takeSurvey": {
-    "x-mt": true
-  },
+  "takeSurvey": "सर्वेक्षण लिनुहोस्",
   "surveyLoadFailed": "[Nepali] Survey could not be loaded",
   "@surveyLoadFailed": {
     "x-mt": true
@@ -1139,10 +1037,7 @@
   "@sendSurveyTo": {
     "x-mt": true
   },
-  "sendSurvey": "[Nepali] Send survey",
-  "@sendSurvey": {
-    "x-mt": true
-  },
+  "sendSurvey": "सर्वेक्षण पठाउनुहोस्",
   "surveySentToUsers": "Survey sent to selected users",
   "@surveySentToUsers": {
     "x-mt": true
@@ -1197,22 +1092,10 @@
   "@leader": {
     "x-mt": true
   },
-  "leave": "[Nepali] Leave",
-  "@leave": {
-    "x-mt": true
-  },
-  "remove": "[Nepali] Remove",
-  "@remove": {
-    "x-mt": true
-  },
-  "makeLeader": "[Nepali] Make leader",
-  "@makeLeader": {
-    "x-mt": true
-  },
-  "leftTeam": "[Nepali] Left team",
-  "@leftTeam": {
-    "x-mt": true
-  },
+  "leave": "छोड्नुहोस्",
+  "remove": "हटाउनुहोस्",
+  "makeLeader": "नेता बनाउनुहोस्",
+  "leftTeam": "टोलीबाट बाहिर गएको",
   "memberRemoved": "[Nepali] Member removed",
   "@memberRemoved": {
     "x-mt": true
@@ -1263,10 +1146,7 @@
   "@untitledTask": {
     "x-mt": true
   },
-  "addTask": "[Nepali] Add task",
-  "@addTask": {
-    "x-mt": true
-  },
+  "addTask": "काम थप्नुहोस्",
   "editTask": "[Nepali] Edit task",
   "@editTask": {
     "x-mt": true
@@ -1344,30 +1224,12 @@
   "@addResource": {
     "x-mt": true
   },
-  "editResource": "[Nepali] Edit resource",
-  "@editResource": {
-    "x-mt": true
-  },
-  "resourceUpdated": "[Nepali] Resource updated",
-  "@resourceUpdated": {
-    "x-mt": true
-  },
-  "resourceAddedToTeam": "[Nepali] Resource added to team",
-  "@resourceAddedToTeam": {
-    "x-mt": true
-  },
-  "descriptionIsRequired": "[Nepali] Description is required",
-  "@descriptionIsRequired": {
-    "x-mt": true
-  },
-  "levelIsRequired": "[Nepali] Level is required",
-  "@levelIsRequired": {
-    "x-mt": true
-  },
-  "subjectIsRequired": "[Nepali] Subject is required",
-  "@subjectIsRequired": {
-    "x-mt": true
-  },
+  "editResource": "स्रोत सम्पादन गर्नुहोस्",
+  "resourceUpdated": "स्रोत अद्यावधिक गरियो",
+  "resourceAddedToTeam": "स्रोत टोलीमा थपियो",
+  "descriptionIsRequired": "विवरण आवश्यक छ",
+  "levelIsRequired": "स्तर आवश्यक छ",
+  "subjectIsRequired": "विषय आवश्यक छ",
   "selectFile": "[Nepali] Select a file",
   "@selectFile": {
     "x-mt": true
@@ -1380,10 +1242,7 @@
   "@privateResource": {
     "x-mt": true
   },
-  "saveChanges": "[Nepali] Save changes",
-  "@saveChanges": {
-    "x-mt": true
-  },
+  "saveChanges": "परिवर्तनहरू सुरक्षित गर्नुहोस्",
   "selectOpenWith": "[Nepali] Select open with",
   "@selectOpenWith": {
     "x-mt": true
@@ -1396,10 +1255,7 @@
   "@selectResourceType": {
     "x-mt": true
   },
-  "linkToLicense": "[Nepali] Link to license",
-  "@linkToLicense": {
-    "x-mt": true
-  },
+  "linkToLicense": "लाइसेन्समा लिङ्क",
   "noResourcesToAdd": "[Nepali] All available resources are already linked",
   "@noResourcesToAdd": {
     "x-mt": true
@@ -1412,10 +1268,7 @@
   "@noTeamCourses": {
     "x-mt": true
   },
-  "untitledCourse": "[Nepali] Untitled course",
-  "@untitledCourse": {
-    "x-mt": true
-  },
+  "untitledCourse": "शीर्षक नभएको पाठ्यक्रम",
   "addCourse": "[Nepali] Add course",
   "@addCourse": {
     "x-mt": true
@@ -1436,24 +1289,15 @@
   "@noReports": {
     "x-mt": true
   },
-  "addReport": "[Nepali] Add report",
-  "@addReport": {
-    "x-mt": true
-  },
+  "addReport": "रिपोर्ट थप्नुहोस्",
   "editReport": "[Nepali] Edit report",
   "@editReport": {
     "x-mt": true
   },
   "archiveReport": "आर्काइभ",
-  "beginningBalance": "[Nepali] Beginning balance",
-  "@beginningBalance": {
-    "x-mt": true
-  },
+  "beginningBalance": "प्रारम्भिक मौज्दात",
   "sales": "बिक्री",
-  "otherIncome": "[Nepali] Other income",
-  "@otherIncome": {
-    "x-mt": true
-  },
+  "otherIncome": "अन्य आय",
   "wages": "[Nepali] Wages",
   "@wages": {
     "x-mt": true
@@ -1462,26 +1306,14 @@
   "@otherExpenses": {
     "x-mt": true
   },
-  "totalIncome": "[Nepali] Total income",
-  "@totalIncome": {
-    "x-mt": true
-  },
-  "totalExpenses": "[Nepali] Total expenses",
-  "@totalExpenses": {
-    "x-mt": true
-  },
+  "totalIncome": "कुल आय",
+  "totalExpenses": "कुल खर्च",
   "profitLoss": "[Nepali] Profit / loss",
   "@profitLoss": {
     "x-mt": true
   },
-  "endingBalance": "[Nepali] Ending balance",
-  "@endingBalance": {
-    "x-mt": true
-  },
-  "negativeBalance": "[Nepali] The current balance is negative!",
-  "@negativeBalance": {
-    "x-mt": true
-  },
+  "endingBalance": "अन्तिम मौज्दात",
+  "negativeBalance": "हालको शेष श्रेणी नकारात्मक छ!",
   "reportDateDetails": "[Nepali] Report created on: {created} | Updated on: {updated}",
   "@reportDateDetails": {
     "x-mt": true
@@ -1491,10 +1323,7 @@
     "x-mt": true
   },
   "chat": "च्याट",
-  "newChat": "[Nepali] New chat",
-  "@newChat": {
-    "x-mt": true
-  },
+  "newChat": "नयाँ च्याट",
   "searchChats": "[Nepali] Search chats",
   "@searchChats": {
     "x-mt": true
@@ -1511,14 +1340,8 @@
   "@untitledChat": {
     "x-mt": true
   },
-  "fullConversationResponse": "[Nepali] Full conversation response",
-  "@fullConversationResponse": {
-    "x-mt": true
-  },
-  "response": "[Nepali] Response",
-  "@response": {
-    "x-mt": true
-  },
+  "fullConversationResponse": "पूर्ण वार्तालाप उत्तर",
+  "response": "उत्तर",
   "chatConversation": "[Nepali] Conversation",
   "@chatConversation": {
     "x-mt": true
@@ -1556,10 +1379,7 @@
   "@feedbackNotFound": {
     "x-mt": true
   },
-  "feedbackSaved": "[Nepali] Feedback saved",
-  "@feedbackSaved": {
-    "x-mt": true
-  },
+  "feedbackSaved": "प्रतिक्रिया सुरक्षित गरियो",
   "isUrgent": "[Nepali] Is this urgent?",
   "@isUrgent": {
     "x-mt": true
@@ -1584,10 +1404,7 @@
   "bug": "बग",
   "suggestion": "सुझाव",
   "priority": "प्राथमिकता",
-  "openDate": "[Nepali] Open date",
-  "@openDate": {
-    "x-mt": true
-  },
+  "openDate": "खोल्ने मिति",
   "replies": "[Nepali] Replies",
   "@replies": {
     "x-mt": true
@@ -1604,10 +1421,7 @@
   "@takeTest": {
     "x-mt": true
   },
-  "recordSurvey": "[Nepali] Record survey",
-  "@recordSurvey": {
-    "x-mt": true
-  },
+  "recordSurvey": "सर्वेक्षण रेकर्ड गर्नुहोस्",
   "react": "[Nepali] React",
   "@react": {
     "x-mt": true
@@ -1673,14 +1487,8 @@
   },
   "community": "समुदाय",
   "communityLeaders": "सामुदायिक नेताहरू",
-  "nationLeaders": "[Nepali] Nation Leaders",
-  "@nationLeaders": {
-    "x-mt": true
-  },
-  "ourVoices": "[Nepali] Our Voices",
-  "@ourVoices": {
-    "x-mt": true
-  },
+  "nationLeaders": "राष्ट्रका नेता",
+  "ourVoices": "हाम्रो आवाजहरू",
   "finances": "वित्त",
   "reports": "रिपोर्टहरू",
   "transaction": "[Nepali] Transaction",
@@ -1705,14 +1513,8 @@
     "x-mt": true
   },
   "date": "मिति",
-  "fromDate": "[Nepali] From date",
-  "@fromDate": {
-    "x-mt": true
-  },
-  "toDate": "[Nepali] To date",
-  "@toDate": {
-    "x-mt": true
-  },
+  "fromDate": "मिति देखि",
+  "toDate": "मिति सम्म",
   "reset": "[Nepali] Reset",
   "@reset": {
     "x-mt": true
@@ -1781,10 +1583,7 @@
   "@correctAnswers": {
     "x-mt": true
   },
-  "yourAnswer": "[Nepali] Your answer",
-  "@yourAnswer": {
-    "x-mt": true
-  },
+  "yourAnswer": "तपाईंको उत्तर",
   "previous": "अघिल्लो",
   "finish": "समाप्त",
   "exitExam": "[Nepali] Exit exam?",
@@ -1797,14 +1596,8 @@
   },
   "exit": "बाहिर निस्कनुस्",
   "download": "डाउनलोड गर्नुहोस्",
-  "downloading": "[Nepali] Downloading…",
-  "@downloading": {
-    "x-mt": true
-  },
-  "downloadFailed": "[Nepali] Download failed.",
-  "@downloadFailed": {
-    "x-mt": true
-  },
+  "downloading": "डाउनलोड गर्दै…",
+  "downloadFailed": "डाउनलोड असफल भयो",
   "resourceNotDownloaded": "[Nepali] This resource is not on your device yet.",
   "@resourceNotDownloaded": {
     "x-mt": true
@@ -1825,34 +1618,13 @@
   "@yourInformation": {
     "x-mt": true
   },
-  "showAdditionalFields": "[Nepali] Show additional fields",
-  "@showAdditionalFields": {
-    "x-mt": true
-  },
-  "hideAdditionalFields": "[Nepali] Hide additional fields",
-  "@hideAdditionalFields": {
-    "x-mt": true
-  },
-  "phoneNumber": "[Nepali] Phone number",
-  "@phoneNumber": {
-    "x-mt": true
-  },
-  "birthDate": "[Nepali] Birth date",
-  "@birthDate": {
-    "x-mt": true
-  },
-  "selectDate": "[Nepali] Select date",
-  "@selectDate": {
-    "x-mt": true
-  },
-  "male": "[Nepali] Male",
-  "@male": {
-    "x-mt": true
-  },
-  "female": "[Nepali] Female",
-  "@female": {
-    "x-mt": true
-  },
+  "showAdditionalFields": "थप क्षेत्रहरू देखाउनुहोस्",
+  "hideAdditionalFields": "थप क्षेत्रहरू लुकाउनुहोस्",
+  "phoneNumber": "फोन नम्बर",
+  "birthDate": "जन्म मिति",
+  "selectDate": "मिति छान्नुहोस्",
+  "male": "पुरुष",
+  "female": "महिला",
   "yearOfBirth": "जन्म वर्ष",
   "yearOfBirthRequired": "[Nepali] Year of birth is required",
   "@yearOfBirthRequired": {
@@ -1866,18 +1638,12 @@
   "@yearBetween": {
     "x-mt": true
   },
-  "thankYouForTakingSurvey": "[Nepali] Thank you for taking this survey",
-  "@thankYouForTakingSurvey": {
-    "x-mt": true
-  },
+  "thankYouForTakingSurvey": "यो सर्वेक्षण लिनको लागि धन्यवाद।",
   "errorSavingProfile": "[Nepali] Error saving profile",
   "@errorSavingProfile": {
     "x-mt": true
   },
-  "videoPlayer": "[Nepali] Video player",
-  "@videoPlayer": {
-    "x-mt": true
-  },
+  "videoPlayer": "भिडियो प्लेयर",
   "audioPlayer": "[Nepali] Audio player",
   "@audioPlayer": {
     "x-mt": true
@@ -1896,18 +1662,12 @@
   "htmlEntryNotFound": "HTML प्रविष्टि फाइल फेला परेन",
   "errorOccurred": "त्रुटि: {error}",
   "openingResource": "खोल्दै: {title}",
-  "loadingMedia": "[Nepali] Loading...",
-  "@loadingMedia": {
-    "x-mt": true
-  },
+  "loadingMedia": "लोड हुँदैछ...",
   "resourceUnavailable": "[Nepali] This resource is not available for offline viewing",
   "@resourceUnavailable": {
     "x-mt": true
   },
-  "healthRecordNotAvailable": "[Nepali] Health record not available",
-  "@healthRecordNotAvailable": {
-    "x-mt": true
-  },
+  "healthRecordNotAvailable": "स्वास्थ्य रेकर्ड उपलब्ध छैन।",
   "updateHealth": "[Nepali] Update health",
   "@updateHealth": {
     "x-mt": true
@@ -1920,18 +1680,9 @@
   "@healthProfile": {
     "x-mt": true
   },
-  "specialNeeds": "[Nepali] Special needs",
-  "@specialNeeds": {
-    "x-mt": true
-  },
-  "otherNeeds": "[Nepali] Other needs",
-  "@otherNeeds": {
-    "x-mt": true
-  },
-  "emergencyContact": "[Nepali] Emergency contact",
-  "@emergencyContact": {
-    "x-mt": true
-  },
+  "specialNeeds": "विशेष आवश्यकता",
+  "otherNeeds": "अन्य आवश्यकता",
+  "emergencyContact": "आपतकालीन सम्पर्क",
   "contactNumber": "[Nepali] Contact number",
   "@contactNumber": {
     "x-mt": true
@@ -1970,10 +1721,7 @@
   "@personalInformation": {
     "x-mt": true
   },
-  "birthPlace": "[Nepali] Birth place",
-  "@birthPlace": {
-    "x-mt": true
-  },
+  "birthPlace": "जन्मस्थान",
   "contactName": "[Nepali] Contact name",
   "@contactName": {
     "x-mt": true
@@ -2001,20 +1749,14 @@
   "allergies": "एलर्जीहरू",
   "diagnosis": "निदान",
   "medications": "औषधि",
-  "immunizations": "[Nepali] Immunizations",
-  "@immunizations": {
-    "x-mt": true
-  },
+  "immunizations": "प्रतिरक्षात्मक टिकाकरण",
   "treatments": "उपचारहरू",
   "observations": "[Nepali] Observations",
   "@observations": {
     "x-mt": true
   },
   "referrals": "रेफरल",
-  "labTests": "[Nepali] Lab tests",
-  "@labTests": {
-    "x-mt": true
-  },
+  "labTests": "प्रयोगशालामा परीक्षण",
   "xrays": "एक्सरे",
   "conditions": "[Nepali] Conditions",
   "@conditions": {
@@ -2028,10 +1770,7 @@
   "@healthRecordAdded": {
     "x-mt": true
   },
-  "selectHealthMember": "[Nepali] Select member",
-  "@selectHealthMember": {
-    "x-mt": true
-  },
+  "selectHealthMember": "सदस्य छान्नुहोस्",
   "newPatient": "[Nepali] New patient",
   "@newPatient": {
     "x-mt": true
@@ -2078,18 +1817,12 @@
   "@weightRangeError": {
     "x-mt": true
   },
-  "bloodPressureFormatError": "[Nepali] Blood pressure should be systolic/diastolic",
-  "@bloodPressureFormatError": {
-    "x-mt": true
-  },
+  "bloodPressureFormatError": "रक्तचाप सिस्टोलिक/डायस्टोलिक हुनुपर्छ",
   "bloodPressureRangeError": "[Nepali] Blood pressure must be between 60/40 and 300/200",
   "@bloodPressureRangeError": {
     "x-mt": true
   },
-  "bloodPressureNotNumbers": "[Nepali] Systolic and diastolic must be numbers",
-  "@bloodPressureNotNumbers": {
-    "x-mt": true
-  },
+  "bloodPressureNotNumbers": "सिस्टोलिक र डायस्टोलिक अंशांकीय हुनुपर्छ",
   "temp": "[Nepali] Temp",
   "@temp": {
     "x-mt": true
@@ -2114,10 +1847,7 @@
   "@storageManagement": {
     "x-mt": true
   },
-  "storageTotalDownloaded": "[Nepali] Total Downloaded",
-  "@storageTotalDownloaded": {
-    "x-mt": true
-  },
+  "storageTotalDownloaded": "कुल डाउनलोड",
   "storageVideos": "भिडियोहरू",
   "storageAudio": "अडियो",
   "storagePdfs": "PDF हरू",
@@ -2128,15 +1858,12 @@
   "@fileCountMany": {
     "x-mt": true
   },
-  "storageUnknownResource": "[Nepali] Unknown resource",
-  "@storageUnknownResource": {
-    "x-mt": true
-  },
+  "storageUnknownResource": "अज्ञात स्रोत",
   "areYouSure": "के तपाईं निश्चित हुनुहुन्छ?",
-  "cancelAddingExamination": "Are you sure you want to cancel adding examination? The data will be lost.",
-  "yesIWantToExit": "Yes, I want to exit.",
-  "inactiveMessage": "User not activated, please contact administrator or manager to activate your account.",
-  "submitFeedback": "Submit Feedback",
+  "cancelAddingExamination": "के तपाईं स्वास्थ्य परीक्षण थप्ने कार्य रद्द गर्न चाहनुहुन्छ? डेटा हराउनेछ।",
+  "yesIWantToExit": "हो, म बाहिर निस्कन चाहन्छु।",
+  "inactiveMessage": "प्रयोगकर्ता सक्रिय गरिएको छैन, कृपया प्रशासक वा प्रबन्धकलाई सम्पर्क गर्नुहोस् तपाईंको खाता सक्रिय गर्नको लागि।",
+  "submitFeedback": "प्रतिक्रिया पेश गर्नुहोस्",
   "failedToDelete": "[Nepali] Failed to delete: {error}",
   "@failedToDelete": {
     "x-mt": true
@@ -2165,10 +1892,7 @@
   "@noStorageUsed": {
     "x-mt": true
   },
-  "availableSpace": "[Nepali] Available space",
-  "@availableSpace": {
-    "x-mt": true
-  },
+  "availableSpace": "उपलब्ध ठाउँ",
   "freeUpSpace": "[Nepali] Free up space",
   "@freeUpSpace": {
     "x-mt": true
@@ -2185,10 +1909,7 @@
   "@freeUpSpaceFailed": {
     "x-mt": true
   },
-  "enterUsername": "[Nepali] Enter username",
-  "@enterUsername": {
-    "x-mt": true
-  },
+  "enterUsername": "प्रयोगकर्तानाम प्रविष्ट गर्नुहोस्",
   "enterPassword": "[Nepali] Enter password",
   "@enterPassword": {
     "x-mt": true
@@ -2199,10 +1920,7 @@
   },
   "becomeMember": "सदस्य बन्नुहोस्",
   "toAccessThisFeatureBecomeAMember": "तपाईं हाल अतिथि प्रयोगकर्ता हुनुहुन्छ। यो सुविधा प्रयोग गर्न, सदस्य बन्नुहोस्।",
-  "creatingMember": "[Nepali] Creating member account...",
-  "@creatingMember": {
-    "x-mt": true
-  },
+  "creatingMember": "सदस्य खाता सिर्जना गर्दै",
   "passwordsDoNotMatch": "पासवर्डहरू मिलेनन्",
   "pleaseSelectGender": "कृपया लिङ्ग चयन गर्नुहोस्",
   "pleaseEnterPassword": "कृपया पासवर्ड लेख्नुहोस्",
@@ -2240,34 +1958,19 @@
   "@courseNotStarted": {
     "x-mt": true
   },
-  "syncCompletedChallenge": "[Nepali] Sync completed",
-  "@syncCompletedChallenge": {
-    "x-mt": true
-  },
+  "syncCompletedChallenge": "सिंक सम्पन्न भयो",
   "rememberSync": "मोबाइल एप्लिकेसनलाई समक्रमण गर्न सम्झनुहोस्।",
   "challengeDialogTitle": "[Nepali] Daily Challenge",
   "@challengeDialogTitle": {
     "x-mt": true
   },
-  "start": "[Nepali] Start",
-  "@start": {
-    "x-mt": true
-  },
-  "continuation": "[Nepali] Continue",
-  "@continuation": {
-    "x-mt": true
-  },
+  "start": "सुरु गर्नुहोस्",
+  "continuation": "जारी राख्नुहोस्",
   "plan": "योजना",
   "mission": "मिशन र सेवाहरू",
   "editPlan": "योजना सम्पादन गर्नुहोस्",
-  "teamPlan": "[Nepali] What is your team's plan?",
-  "@teamPlan": {
-    "x-mt": true
-  },
-  "entMission": "[Nepali] What is your enterprise's Mission?",
-  "@entMission": {
-    "x-mt": true
-  },
+  "teamPlan": "तपाईंको टोलीको योजना के हो?",
+  "entMission": "तपाईंको एन्टरप्राइजको मिशन के हो?",
   "entServices": "तपाईंको एन्टरप्राइजले के सेवाहरू प्रदान गर्दछ?",
   "entRules": "तपाईंको एन्टरप्राइजको नियमहरू के हुन्छन्?",
   "noMissionDefined": "एन्टरप्राइजमा मिशन र सेवाहरू छैनन्।",
@@ -2275,10 +1978,7 @@
   "@noPlanDefined": {
     "x-mt": true
   },
-  "noDescriptionDefined": "[Nepali] This team has no description defined.",
-  "@noDescriptionDefined": {
-    "x-mt": true
-  },
+  "noDescriptionDefined": "यस टिमको कुनै विवरण परिभाषित गरिएको छैन.",
   "enterpriseName": "[Nepali] Enterprise name",
   "@enterpriseName": {
     "x-mt": true
@@ -2298,10 +1998,7 @@
   "isPublic": "सार्वजनिक",
   "nameRequired": "नाम आवश्यक छ",
   "nameIsRequired": "कृपया नाम लेख्नुहोस्",
-  "createdOn": "[Nepali] Created on",
-  "@createdOn": {
-    "x-mt": true
-  },
+  "createdOn": "मा सिर्जना गरिएको",
   "courseDetails": "[Nepali] Course Details",
   "@courseDetails": {
     "x-mt": true
@@ -2347,27 +2044,15 @@
     "x-mt": true
   },
   "mistakes": "गल्तीहरू",
-  "step": "[Nepali] Step",
-  "@step": {
-    "x-mt": true
-  },
+  "step": "चरण",
   "untitledResourceTitle": "[Nepali] Untitled Resource",
   "@untitledResourceTitle": {
     "x-mt": true
   },
-  "author": "[Nepali] Author",
-  "@author": {
-    "x-mt": true
-  },
+  "author": "लेखक",
   "publisher": "प्रकाशक",
-  "license": "[Nepali] License",
-  "@license": {
-    "x-mt": true
-  },
-  "addedBy": "[Nepali] Added by",
-  "@addedBy": {
-    "x-mt": true
-  },
+  "license": "लाइसेन्स",
+  "addedBy": "थपिएको",
   "resourceInformation": "[Nepali] Resource Information",
   "@resourceInformation": {
     "x-mt": true
@@ -2380,10 +2065,7 @@
   "@mediaType": {
     "x-mt": true
   },
-  "resourceType": "[Nepali] Resource Type",
-  "@resourceType": {
-    "x-mt": true
-  },
+  "resourceType": "स्रोत प्रकार",
   "subject": "[Nepali] Subject",
   "@subject": {
     "x-mt": true
@@ -2488,34 +2170,19 @@
   "@activitySummary": {
     "x-mt": true
   },
-  "lastLogin": "[Nepali] Last login",
-  "@lastLogin": {
-    "x-mt": true
-  },
+  "lastLogin": "अन्तिम लगइन",
   "memberDetail": "[Nepali] Member detail",
   "@memberDetail": {
     "x-mt": true
   },
-  "numberOfVisits": "[Nepali] Number of visits",
-  "@numberOfVisits": {
-    "x-mt": true
-  },
+  "numberOfVisits": "भ्रमण संख्या",
   "noLogoutRecord": "[Nepali] No logout record found",
   "@noLogoutRecord": {
     "x-mt": true
   },
-  "totalVisits": "[Nepali] Total visits",
-  "@totalVisits": {
-    "x-mt": true
-  },
-  "mostOpenedResource": "[Nepali] Most opened resource",
-  "@mostOpenedResource": {
-    "x-mt": true
-  },
-  "numberOfResourcesOpened": "[Nepali] Number of resources opened",
-  "@numberOfResourcesOpened": {
-    "x-mt": true
-  },
+  "totalVisits": "कुल भ्रमण",
+  "mostOpenedResource": "सबैभन्दा धेरै खोलेको स्रोत",
+  "numberOfResourcesOpened": "खोलिएका स्रोतहरूको संख्या",
   "resourceOpenedTimes": "[Nepali] {title} opened {count} times",
   "@resourceOpenedTimes": {
     "x-mt": true
@@ -2532,10 +2199,7 @@
   "@serverUnreachable": {
     "x-mt": true
   },
-  "serverChecking": "[Nepali] Checking server",
-  "@serverChecking": {
-    "x-mt": true
-  },
+  "serverChecking": "सर्भर जाँच गर्दै",
   "gridView": "ग्रिड दृश्य",
   "listView": "सूची दृश्य",
   "disclaimer": "अस्वीकरण",
@@ -2605,34 +2269,13 @@
       }
     }
   },
-  "textSize": "[Nepali] Text size",
-  "@textSize": {
-    "x-mt": true
-  },
-  "selectTextSize": "[Nepali] Select text size",
-  "@selectTextSize": {
-    "x-mt": true
-  },
-  "textSizeSmall": "[Nepali] Small",
-  "@textSizeSmall": {
-    "x-mt": true
-  },
-  "textSizeMedium": "[Nepali] Medium",
-  "@textSizeMedium": {
-    "x-mt": true
-  },
-  "textSizeLarge": "[Nepali] Large",
-  "@textSizeLarge": {
-    "x-mt": true
-  },
-  "resetApp": "[Nepali] Reset app",
-  "@resetApp": {
-    "x-mt": true
-  },
-  "clearAllDataConfirm": "[Nepali] Are you sure you want to clear all data?",
-  "@clearAllDataConfirm": {
-    "x-mt": true
-  },
+  "textSize": "पाठको आकार",
+  "selectTextSize": "पाठको आकार छान्नुहोस्",
+  "textSizeSmall": "सानो",
+  "textSizeMedium": "मध्यम",
+  "textSizeLarge": "ठूलो",
+  "resetApp": "अनुप्रयोग रिसेट गर्नुहोस्",
+  "clearAllDataConfirm": "के तपाईं सबै डाटा हटाउन निश्चित हुनुहुन्छ?",
   "dataCleared": "[Nepali] All data cleared",
   "@dataCleared": {
     "x-mt": true
@@ -2642,5 +2285,10 @@
     "x-mt": true
   },
   "resourceTitleAlreadyExists": "यस शीर्षकको स्रोत पहिले नै अवस्थित छ",
-  "failedToUpdateResource": "स्रोत अद्यावधिक गर्न असफल भयो"
+  "failedToUpdateResource": "स्रोत अद्यावधिक गर्न असफल भयो",
+  "unableToAddHealthRecord": "स्वास्थ्य रेकर्ड थप्न सकिएन।",
+  "summaryOfAchievements": "उपलब्धिहरूको सारांश - आफ्नो उपलब्धि संक्षेपमा दिनुहोस् र सम्बन्धित सामग्री तल थप्नुहोस्",
+  "myGoalsDescription": "मेरा लक्ष्यहरू - आगामी १० वर्षका लागि तपाईँका लक्ष्यहरू के हुन्?",
+  "myPurposeDescription": "मेरो उद्देश्य - तपाईका शैक्षिक र व्यावसायिक महत्वाकांक्षा के हुन्?",
+  "pleaseAnswerToContinue": "कृपया जारी राख्नका लागि आफ्नो उत्तर चयन गर्नुहोस् / लेख्नुहोस्"
 }

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -1776,10 +1776,7 @@
   "@submitExam": {
     "x-mt": true
   },
-  "incorrectAnswer": "[Somali] Incorrect answer",
-  "@incorrectAnswer": {
-    "x-mt": true
-  },
+  "incorrectAnswer": "Jawaab aan sax ahayn, fadlan isku day",
   "correctAnswers": "[Somali] Correct",
   "@correctAnswers": {
     "x-mt": true

--- a/flutter/lib/l10n/app_so.arb
+++ b/flutter/lib/l10n/app_so.arb
@@ -13,19 +13,13 @@
   "@serverUrlHint": {
     "x-mt": true
   },
-  "serverPinLabel": "[Somali] Server PIN",
-  "@serverPinLabel": {
-    "x-mt": true
-  },
+  "serverPinLabel": "Pin-ka adeegsiga",
   "connect": "[Somali] Connect",
   "@connect": {
     "x-mt": true
   },
   "serverUrlNotConfigured": "URL-ka server-ka lama dejin",
-  "deviceCouldNotReachLocalServer": "[Somali] device couldn't reach the server. check if you are connected to the correct Wi-Fi network for the local server (community).",
-  "@deviceCouldNotReachLocalServer": {
-    "x-mt": true
-  },
+  "deviceCouldNotReachLocalServer": "qalabku ma uusan gaari karin server-ka. hubi inaad ku xiran tahay shabakadda Wi-Fi-ga saxda ah ee server-ka maxalliga ah (bulshada).",
   "deviceCouldNotReachNationServer": "qalabku ma uusan gaari karin server-ka. hubi inaad ku xiran tahay internetka oo dib isku day.",
   "connectionFailed": "Xiriirku wuu fashilmay!",
   "connectedToCommunity": "[Somali] Connected to {code}",
@@ -77,10 +71,7 @@
   },
   "resources": "Vifijo",
   "search": "Raadi",
-  "sync": "[Somali] Sync",
-  "@sync": {
-    "x-mt": true
-  },
+  "sync": "Dib u hagrees",
   "cancel": "burin",
   "settings": "Settings",
   "backgroundSync": "[Somali] Background sync",
@@ -154,18 +145,9 @@
   "@moreOptions": {
     "x-mt": true
   },
-  "appTheme": "[Somali] App theme",
-  "@appTheme": {
-    "x-mt": true
-  },
-  "aiChat": "[Somali] AI chat",
-  "@aiChat": {
-    "x-mt": true
-  },
-  "syncNow": "[Somali] Sync now",
-  "@syncNow": {
-    "x-mt": true
-  },
+  "appTheme": "Mawduuca app-ka",
+  "aiChat": "AI Chat",
+  "syncNow": "Isku-dar hadda",
   "syncCenter": "[Somali] Sync center",
   "@syncCenter": {
     "x-mt": true
@@ -307,10 +289,7 @@
     "x-mt": true
   },
   "courses": "Koorsooyin",
-  "myCourses": "[Somali] My courses",
-  "@myCourses": {
-    "x-mt": true
-  },
+  "myCourses": "Korasyadayda",
   "allCourses": "[Somali] All courses",
   "@allCourses": {
     "x-mt": true
@@ -327,10 +306,7 @@
   "@resourcesInStep": {
     "x-mt": true
   },
-  "gradeLevel": "[Somali] Grade level",
-  "@gradeLevel": {
-    "x-mt": true
-  },
+  "gradeLevel": "Darajo Loo qoondeeyey",
   "subjectLevel": "[Somali] Subject",
   "@subjectLevel": {
     "x-mt": true
@@ -362,19 +338,13 @@
   "@profileUnavailable": {
     "x-mt": true
   },
-  "username": "[Somali] Username",
-  "@username": {
-    "x-mt": true
-  },
+  "username": "Magaca isticmaalaha",
   "email": "iimayl",
   "phone": "[Somali] Phone",
   "@phone": {
     "x-mt": true
   },
-  "level": "[Somali] Level",
-  "@level": {
-    "x-mt": true
-  },
+  "level": "Heerka",
   "levels": "[Somali] Levels",
   "@levels": {
     "x-mt": true
@@ -382,10 +352,7 @@
   "language": "Luuqad",
   "languages": "Luqadaha",
   "gender": "Jinsi",
-  "dateOfBirth": "[Somali] Date of birth",
-  "@dateOfBirth": {
-    "x-mt": true
-  },
+  "dateOfBirth": "Taariikhda dhalashada",
   "planetCode": "[Somali] Planet code",
   "@planetCode": {
     "x-mt": true
@@ -402,10 +369,7 @@
   "@profilePhotoFor": {
     "x-mt": true
   },
-  "editProfile": "[Somali] Edit profile",
-  "@editProfile": {
-    "x-mt": true
-  },
+  "editProfile": "Wax ka beddel xogta",
   "changePhoto": "[Somali] Change profile photo",
   "@changePhoto": {
     "x-mt": true
@@ -418,18 +382,9 @@
   "@photoUpdateFailed": {
     "x-mt": true
   },
-  "firstName": "[Somali] First name",
-  "@firstName": {
-    "x-mt": true
-  },
-  "middleName": "[Somali] Middle name",
-  "@middleName": {
-    "x-mt": true
-  },
-  "lastName": "[Somali] Last name",
-  "@lastName": {
-    "x-mt": true
-  },
+  "firstName": "Magaca koowaad",
+  "middleName": "Magaca Dhexe",
+  "lastName": "Magaca Dambe",
   "save": "Keyd",
   "profileSaved": "[Somali] Profile saved on this device",
   "@profileSaved": {
@@ -578,10 +533,7 @@
   "@storageNotification": {
     "x-mt": true
   },
-  "joinRequestNotification": "[Somali] Join request",
-  "@joinRequestNotification": {
-    "x-mt": true
-  },
+  "joinRequestNotification": "Codsi ku biirid",
   "teamNotification": "[Somali] Team update",
   "@teamNotification": {
     "x-mt": true
@@ -661,10 +613,7 @@
   "@refresh": {
     "x-mt": true
   },
-  "complete": "[Somali] Complete",
-  "@complete": {
-    "x-mt": true
-  },
+  "complete": "Buuxi",
   "noMatchingSubmissions": "[Somali] No submissions match this filter",
   "@noMatchingSubmissions": {
     "x-mt": true
@@ -685,18 +634,9 @@
   "@unknown": {
     "x-mt": true
   },
-  "nA": "[Somali] N/A",
-  "@nA": {
-    "x-mt": true
-  },
-  "otherDiagnosis": "[Somali] Other diagnosis",
-  "@otherDiagnosis": {
-    "x-mt": true
-  },
-  "add": "[Somali] Add",
-  "@add": {
-    "x-mt": true
-  },
+  "nA": "N/A",
+  "otherDiagnosis": "Xeerka Kale",
+  "add": "Ku dar",
   "status": "xaalad",
   "lastUpdated": "[Somali] Last updated",
   "@lastUpdated": {
@@ -740,10 +680,7 @@
   "@newSubmission": {
     "x-mt": true
   },
-  "answer": "[Somali] Answer",
-  "@answer": {
-    "x-mt": true
-  },
+  "answer": "Jawaab",
   "availableChoices": "[Somali] Choices",
   "@availableChoices": {
     "x-mt": true
@@ -774,10 +711,7 @@
     "x-mt": true
   },
   "maps": "Maps",
-  "englishDictionary": "[Somali] English dictionary",
-  "@englishDictionary": {
-    "x-mt": true
-  },
+  "englishDictionary": "Qaamuuska Af Ingiriiska",
   "offlineMapsComingSoon": "[Somali] Offline maps are not ported yet",
   "@offlineMapsComingSoon": {
     "x-mt": true
@@ -877,10 +811,7 @@
     "x-mt": true
   },
   "skip": "Ka gudub",
-  "next": "[Somali] Next",
-  "@next": {
-    "x-mt": true
-  },
+  "next": "Ku Xus",
   "getStarted": "BILAAB",
   "welcomeToMyPlanet": "Soo dhawoow myPlanet",
   "learnOffline": "Baro horumarinta",
@@ -899,10 +830,7 @@
   "@onboardingPowerDescription": {
     "x-mt": true
   },
-  "onboardingServerPrepHint": "[Somali] Before you sign in, you'll need your Planet server address and PIN. Ask your community administrator if you don't have them yet.",
-  "@onboardingServerPrepHint": {
-    "x-mt": true
-  },
+  "onboardingServerPrepHint": "Ka hor inta aadan gelin, waxaad u baahan doontaa cinwaanka server-ka Planet iyo PIN-ka. Weydii maamulaha bulshadaada haddii aadan weli haysan.",
   "pageProgress": "[Somali] Page {current} of {total}",
   "@pageProgress": {
     "x-mt": true
@@ -931,10 +859,7 @@
   "@untitledMeetup": {
     "x-mt": true
   },
-  "addMeetup": "[Somali] Add meetup",
-  "@addMeetup": {
-    "x-mt": true
-  },
+  "addMeetup": "Ku dar kulan",
   "meetupDetails": "[Somali] Meetup details",
   "@meetupDetails": {
     "x-mt": true
@@ -943,24 +868,15 @@
   "@meetupNotFound": {
     "x-mt": true
   },
-  "createdBy": "[Somali] Created by",
-  "@createdBy": {
-    "x-mt": true
-  },
+  "createdBy": "Lagu sameeyay",
   "category": "[Somali] Category",
   "@category": {
     "x-mt": true
   },
   "location": "Goobta",
   "link": "Xiriirka",
-  "recurring": "[Somali] Recurring",
-  "@recurring": {
-    "x-mt": true
-  },
-  "description": "[Somali] Description",
-  "@description": {
-    "x-mt": true
-  },
+  "recurring": "Ku dhaqan",
+  "description": "Sharaxaad",
   "leaveMeetup": "[Somali] Leave meetup",
   "@leaveMeetup": {
     "x-mt": true
@@ -969,18 +885,9 @@
   "@joinMeetup": {
     "x-mt": true
   },
-  "editMeetup": "[Somali] Edit meetup",
-  "@editMeetup": {
-    "x-mt": true
-  },
-  "startTime": "[Somali] Start time",
-  "@startTime": {
-    "x-mt": true
-  },
-  "endTime": "[Somali] End time",
-  "@endTime": {
-    "x-mt": true
-  },
+  "editMeetup": "Wax ka beddel kulanka",
+  "startTime": "Bilowga Waqtiga",
+  "endTime": "Dhamaadka Waqtiga",
   "none": "Midna",
   "daily": "Maalinle",
   "weekly": "Toddobaad",
@@ -1016,14 +923,8 @@
   "@titleDescending": {
     "x-mt": true
   },
-  "startDate": "[Somali] Start date",
-  "@startDate": {
-    "x-mt": true
-  },
-  "endDate": "[Somali] End date",
-  "@endDate": {
-    "x-mt": true
-  },
+  "startDate": "Bilowga Dhibaatada",
+  "endDate": "Dhamaadka Dhibaatada",
   "timeNotSet": "[Somali] Time not set",
   "@timeNotSet": {
     "x-mt": true
@@ -1052,10 +953,7 @@
   "@untitledSurvey": {
     "x-mt": true
   },
-  "takeSurvey": "[Somali] Take survey",
-  "@takeSurvey": {
-    "x-mt": true
-  },
+  "takeSurvey": "Ku Dar Survey",
   "surveyLoadFailed": "[Somali] Survey could not be loaded",
   "@surveyLoadFailed": {
     "x-mt": true
@@ -1139,10 +1037,7 @@
   "@sendSurveyTo": {
     "x-mt": true
   },
-  "sendSurvey": "[Somali] Send survey",
-  "@sendSurvey": {
-    "x-mt": true
-  },
+  "sendSurvey": "Dir Survey",
   "surveySentToUsers": "Survey sent to selected users",
   "@surveySentToUsers": {
     "x-mt": true
@@ -1197,22 +1092,10 @@
   "@leader": {
     "x-mt": true
   },
-  "leave": "[Somali] Leave",
-  "@leave": {
-    "x-mt": true
-  },
-  "remove": "[Somali] Remove",
-  "@remove": {
-    "x-mt": true
-  },
-  "makeLeader": "[Somali] Make leader",
-  "@makeLeader": {
-    "x-mt": true
-  },
-  "leftTeam": "[Somali] Left team",
-  "@leftTeam": {
-    "x-mt": true
-  },
+  "leave": "Ka Dib",
+  "remove": "Ka saar",
+  "makeLeader": "Gacan-siin",
+  "leftTeam": "Kooxda iska saaray",
   "memberRemoved": "[Somali] Member removed",
   "@memberRemoved": {
     "x-mt": true
@@ -1263,10 +1146,7 @@
   "@untitledTask": {
     "x-mt": true
   },
-  "addTask": "[Somali] Add task",
-  "@addTask": {
-    "x-mt": true
-  },
+  "addTask": "Ku dar xog",
   "editTask": "[Somali] Edit task",
   "@editTask": {
     "x-mt": true
@@ -1344,30 +1224,15 @@
   "@addResource": {
     "x-mt": true
   },
-  "editResource": "[Somali] Edit resource",
-  "@editResource": {
-    "x-mt": true
-  },
-  "resourceUpdated": "[Somali] Resource updated",
-  "@resourceUpdated": {
-    "x-mt": true
-  },
-  "resourceAddedToTeam": "[Somali] Resource added to team",
-  "@resourceAddedToTeam": {
-    "x-mt": true
-  },
+  "editResource": "Wax ka beddel kheyraadka",
+  "resourceUpdated": "Kheyraadka waa la cusboonaysiiyay",
+  "resourceAddedToTeam": "Khayraadka waxaa lagu daray kooxda",
   "descriptionIsRequired": "[Somali] Description is required",
   "@descriptionIsRequired": {
     "x-mt": true
   },
-  "levelIsRequired": "[Somali] Level is required",
-  "@levelIsRequired": {
-    "x-mt": true
-  },
-  "subjectIsRequired": "[Somali] Subject is required",
-  "@subjectIsRequired": {
-    "x-mt": true
-  },
+  "levelIsRequired": "Heerka waa loo baahan yahay",
+  "subjectIsRequired": "Mawduuca waa loo baahan yahay",
   "selectFile": "[Somali] Select a file",
   "@selectFile": {
     "x-mt": true
@@ -1380,10 +1245,7 @@
   "@privateResource": {
     "x-mt": true
   },
-  "saveChanges": "[Somali] Save changes",
-  "@saveChanges": {
-    "x-mt": true
-  },
+  "saveChanges": "Kaydi isbedelada",
   "selectOpenWith": "[Somali] Select open with",
   "@selectOpenWith": {
     "x-mt": true
@@ -1396,10 +1258,7 @@
   "@selectResourceType": {
     "x-mt": true
   },
-  "linkToLicense": "[Somali] Link to license",
-  "@linkToLicense": {
-    "x-mt": true
-  },
+  "linkToLicense": "Link to shatiga",
   "noResourcesToAdd": "[Somali] All available resources are already linked",
   "@noResourcesToAdd": {
     "x-mt": true
@@ -1412,10 +1271,7 @@
   "@noTeamCourses": {
     "x-mt": true
   },
-  "untitledCourse": "[Somali] Untitled course",
-  "@untitledCourse": {
-    "x-mt": true
-  },
+  "untitledCourse": "Koorso Aan Magac Lahayn",
   "addCourse": "[Somali] Add course",
   "@addCourse": {
     "x-mt": true
@@ -1436,24 +1292,15 @@
   "@noReports": {
     "x-mt": true
   },
-  "addReport": "[Somali] Add report",
-  "@addReport": {
-    "x-mt": true
-  },
+  "addReport": "Ku dar warbixin",
   "editReport": "[Somali] Edit report",
   "@editReport": {
     "x-mt": true
   },
   "archiveReport": "Arsiif",
-  "beginningBalance": "[Somali] Beginning balance",
-  "@beginningBalance": {
-    "x-mt": true
-  },
+  "beginningBalance": "Hadhsiga bilowga",
   "sales": "Iibka",
-  "otherIncome": "[Somali] Other income",
-  "@otherIncome": {
-    "x-mt": true
-  },
+  "otherIncome": "Dakhliga kale",
   "wages": "[Somali] Wages",
   "@wages": {
     "x-mt": true
@@ -1462,26 +1309,14 @@
   "@otherExpenses": {
     "x-mt": true
   },
-  "totalIncome": "[Somali] Total income",
-  "@totalIncome": {
-    "x-mt": true
-  },
-  "totalExpenses": "[Somali] Total expenses",
-  "@totalExpenses": {
-    "x-mt": true
-  },
+  "totalIncome": "Dakhliga Guud",
+  "totalExpenses": "Kharashaadka Guud",
   "profitLoss": "[Somali] Profit / loss",
   "@profitLoss": {
     "x-mt": true
   },
-  "endingBalance": "[Somali] Ending balance",
-  "@endingBalance": {
-    "x-mt": true
-  },
-  "negativeBalance": "[Somali] The current balance is negative!",
-  "@negativeBalance": {
-    "x-mt": true
-  },
+  "endingBalance": "Hadhsiga dhammaadka",
+  "negativeBalance": "Xalinta hanaanka hadda waa ka baxa!",
   "reportDateDetails": "[Somali] Report created on: {created} | Updated on: {updated}",
   "@reportDateDetails": {
     "x-mt": true
@@ -1491,10 +1326,7 @@
     "x-mt": true
   },
   "chat": "Sawir",
-  "newChat": "[Somali] New chat",
-  "@newChat": {
-    "x-mt": true
-  },
+  "newChat": "Wadahadal cusub",
   "searchChats": "[Somali] Search chats",
   "@searchChats": {
     "x-mt": true
@@ -1511,14 +1343,8 @@
   "@untitledChat": {
     "x-mt": true
   },
-  "fullConversationResponse": "[Somali] Full conversation response",
-  "@fullConversationResponse": {
-    "x-mt": true
-  },
-  "response": "[Somali] Response",
-  "@response": {
-    "x-mt": true
-  },
+  "fullConversationResponse": "Jawaabta wada hadalka oo dhameystiran",
+  "response": "Jawaab",
   "chatConversation": "[Somali] Conversation",
   "@chatConversation": {
     "x-mt": true
@@ -1556,10 +1382,7 @@
   "@feedbackNotFound": {
     "x-mt": true
   },
-  "feedbackSaved": "[Somali] Feedback saved",
-  "@feedbackSaved": {
-    "x-mt": true
-  },
+  "feedbackSaved": "Warbixinta lagu kayd geliyay",
   "isUrgent": "[Somali] Is this urgent?",
   "@isUrgent": {
     "x-mt": true
@@ -1580,14 +1403,11 @@
   "@pleaseEnterFeedback": {
     "x-mt": true
   },
-  "question": "Su\\'aal",
+  "question": "Su'aal",
   "bug": "Bug",
   "suggestion": "talo soo jeedin",
   "priority": "mudnaanta",
-  "openDate": "[Somali] Open date",
-  "@openDate": {
-    "x-mt": true
-  },
+  "openDate": "Taariikhda Furan",
   "replies": "[Somali] Replies",
   "@replies": {
     "x-mt": true
@@ -1604,10 +1424,7 @@
   "@takeTest": {
     "x-mt": true
   },
-  "recordSurvey": "[Somali] Record survey",
-  "@recordSurvey": {
-    "x-mt": true
-  },
+  "recordSurvey": "Gali suuragal",
   "react": "[Somali] React",
   "@react": {
     "x-mt": true
@@ -1673,14 +1490,8 @@
   },
   "community": "Bulshada",
   "communityLeaders": "Hogaamiyayaasha bulshada",
-  "nationLeaders": "[Somali] Nation Leaders",
-  "@nationLeaders": {
-    "x-mt": true
-  },
-  "ourVoices": "[Somali] Our Voices",
-  "@ourVoices": {
-    "x-mt": true
-  },
+  "nationLeaders": "Hoggaamiyeyaasha qaranka",
+  "ourVoices": "Codadkeena",
   "finances": "Maaliyadda",
   "reports": "warbixino",
   "transaction": "[Somali] Transaction",
@@ -1705,14 +1516,8 @@
     "x-mt": true
   },
   "date": "Taariikhda",
-  "fromDate": "[Somali] From date",
-  "@fromDate": {
-    "x-mt": true
-  },
-  "toDate": "[Somali] To date",
-  "@toDate": {
-    "x-mt": true
-  },
+  "fromDate": "Ka bilaabata taariikhda",
+  "toDate": "Ku egtahay taariikhda",
   "reset": "[Somali] Reset",
   "@reset": {
     "x-mt": true
@@ -1781,10 +1586,7 @@
   "@correctAnswers": {
     "x-mt": true
   },
-  "yourAnswer": "[Somali] Your answer",
-  "@yourAnswer": {
-    "x-mt": true
-  },
+  "yourAnswer": "Jawaabtaada",
   "previous": "Hore",
   "finish": "Dhammaad",
   "exitExam": "[Somali] Exit exam?",
@@ -1797,14 +1599,8 @@
   },
   "exit": "Ka Bax",
   "download": "Download",
-  "downloading": "[Somali] Downloading…",
-  "@downloading": {
-    "x-mt": true
-  },
-  "downloadFailed": "[Somali] Download failed.",
-  "@downloadFailed": {
-    "x-mt": true
-  },
+  "downloading": "Soo degsado.... \"",
+  "downloadFailed": "Soo dejintu way fashilantay.",
   "resourceNotDownloaded": "[Somali] This resource is not on your device yet.",
   "@resourceNotDownloaded": {
     "x-mt": true
@@ -1825,34 +1621,13 @@
   "@yourInformation": {
     "x-mt": true
   },
-  "showAdditionalFields": "[Somali] Show additional fields",
-  "@showAdditionalFields": {
-    "x-mt": true
-  },
-  "hideAdditionalFields": "[Somali] Hide additional fields",
-  "@hideAdditionalFields": {
-    "x-mt": true
-  },
-  "phoneNumber": "[Somali] Phone number",
-  "@phoneNumber": {
-    "x-mt": true
-  },
-  "birthDate": "[Somali] Birth date",
-  "@birthDate": {
-    "x-mt": true
-  },
-  "selectDate": "[Somali] Select date",
-  "@selectDate": {
-    "x-mt": true
-  },
-  "male": "[Somali] Male",
-  "@male": {
-    "x-mt": true
-  },
-  "female": "[Somali] Female",
-  "@female": {
-    "x-mt": true
-  },
+  "showAdditionalFields": "Muuji beeraha dheeraadka ah",
+  "hideAdditionalFields": "Qari beeraha dheeraadka ah",
+  "phoneNumber": "Telefoon Number",
+  "birthDate": "Taariikhda Dhalashada",
+  "selectDate": "Xulo Taariikhda",
+  "male": "Lab",
+  "female": "Naag",
   "yearOfBirth": "Sannadka dhalashada",
   "yearOfBirthRequired": "[Somali] Year of birth is required",
   "@yearOfBirthRequired": {
@@ -1866,18 +1641,12 @@
   "@yearBetween": {
     "x-mt": true
   },
-  "thankYouForTakingSurvey": "[Somali] Thank you for taking this survey",
-  "@thankYouForTakingSurvey": {
-    "x-mt": true
-  },
+  "thankYouForTakingSurvey": "Mahadsanid in aad iska soo qaatay suuragal",
   "errorSavingProfile": "[Somali] Error saving profile",
   "@errorSavingProfile": {
     "x-mt": true
   },
-  "videoPlayer": "[Somali] Video player",
-  "@videoPlayer": {
-    "x-mt": true
-  },
+  "videoPlayer": "Qalabka fiidyowga",
   "audioPlayer": "[Somali] Audio player",
   "@audioPlayer": {
     "x-mt": true
@@ -1896,18 +1665,12 @@
   "htmlEntryNotFound": "Faylka gelinta HTML lama helin",
   "errorOccurred": "Khalad: {error}",
   "openingResource": "Furaya: {title}",
-  "loadingMedia": "[Somali] Loading...",
-  "@loadingMedia": {
-    "x-mt": true
-  },
+  "loadingMedia": "Soo dejinta...",
   "resourceUnavailable": "[Somali] This resource is not available for offline viewing",
   "@resourceUnavailable": {
     "x-mt": true
   },
-  "healthRecordNotAvailable": "[Somali] Health record not available",
-  "@healthRecordNotAvailable": {
-    "x-mt": true
-  },
+  "healthRecordNotAvailable": "Diiwaanada Caafimaadka ma helayo",
   "updateHealth": "[Somali] Update health",
   "@updateHealth": {
     "x-mt": true
@@ -1920,18 +1683,9 @@
   "@healthProfile": {
     "x-mt": true
   },
-  "specialNeeds": "[Somali] Special needs",
-  "@specialNeeds": {
-    "x-mt": true
-  },
-  "otherNeeds": "[Somali] Other needs",
-  "@otherNeeds": {
-    "x-mt": true
-  },
-  "emergencyContact": "[Somali] Emergency contact",
-  "@emergencyContact": {
-    "x-mt": true
-  },
+  "specialNeeds": "Dib-u-xuso",
+  "otherNeeds": "Dib-u-heshiisi kale",
+  "emergencyContact": "Xiriirka Degdegga ah",
   "contactNumber": "[Somali] Contact number",
   "@contactNumber": {
     "x-mt": true
@@ -1970,10 +1724,7 @@
   "@personalInformation": {
     "x-mt": true
   },
-  "birthPlace": "[Somali] Birth place",
-  "@birthPlace": {
-    "x-mt": true
-  },
+  "birthPlace": "Meesha dhalashada",
   "contactName": "[Somali] Contact name",
   "@contactName": {
     "x-mt": true
@@ -2001,20 +1752,14 @@
   "allergies": "Alargada",
   "diagnosis": "Baaris",
   "medications": "Daaweynaha",
-  "immunizations": "[Somali] Immunizations",
-  "@immunizations": {
-    "x-mt": true
-  },
+  "immunizations": "Xallinta daryeelka",
   "treatments": "Dib u dhiska",
   "observations": "[Somali] Observations",
   "@observations": {
     "x-mt": true
   },
   "referrals": "Dabaqyo",
-  "labTests": "[Somali] Lab tests",
-  "@labTests": {
-    "x-mt": true
-  },
+  "labTests": "Baarista labada",
   "xrays": "X-ray",
   "conditions": "[Somali] Conditions",
   "@conditions": {
@@ -2028,10 +1773,7 @@
   "@healthRecordAdded": {
     "x-mt": true
   },
-  "selectHealthMember": "[Somali] Select member",
-  "@selectHealthMember": {
-    "x-mt": true
-  },
+  "selectHealthMember": "Dooro Xubin",
   "newPatient": "[Somali] New patient",
   "@newPatient": {
     "x-mt": true
@@ -2078,18 +1820,12 @@
   "@weightRangeError": {
     "x-mt": true
   },
-  "bloodPressureFormatError": "[Somali] Blood pressure should be systolic/diastolic",
-  "@bloodPressureFormatError": {
-    "x-mt": true
-  },
+  "bloodPressureFormatError": "Dhacdo dheecaanka waa in uu noocan yahay (systolic/diastolic)",
   "bloodPressureRangeError": "[Somali] Blood pressure must be between 60/40 and 300/200",
   "@bloodPressureRangeError": {
     "x-mt": true
   },
-  "bloodPressureNotNumbers": "[Somali] Systolic and diastolic must be numbers",
-  "@bloodPressureNotNumbers": {
-    "x-mt": true
-  },
+  "bloodPressureNotNumbers": "Dhacdo dheecaanka iyo dheecaanku waa in ay yihiin lambarka",
   "temp": "[Somali] Temp",
   "@temp": {
     "x-mt": true
@@ -2114,10 +1850,7 @@
   "@storageManagement": {
     "x-mt": true
   },
-  "storageTotalDownloaded": "[Somali] Total Downloaded",
-  "@storageTotalDownloaded": {
-    "x-mt": true
-  },
+  "storageTotalDownloaded": "Wadarta la soo dejiyay",
   "storageVideos": "Fiidiyowyada",
   "storageAudio": "Codka",
   "storagePdfs": "Dukumentiyada PDF",
@@ -2128,15 +1861,12 @@
   "@fileCountMany": {
     "x-mt": true
   },
-  "storageUnknownResource": "[Somali] Unknown resource",
-  "@storageUnknownResource": {
-    "x-mt": true
-  },
+  "storageUnknownResource": "Agabka Aan La Garanayn",
   "areYouSure": "Ma hubtaa?",
-  "cancelAddingExamination": "Are you sure you want to cancel adding examination? The data will be lost.",
-  "yesIWantToExit": "Yes, I want to exit.",
-  "inactiveMessage": "User not activated, please contact administrator or manager to activate your account.",
-  "submitFeedback": "Submit Feedback",
+  "cancelAddingExamination": "Ma hubtaa inaad rabto inaad tirtirto ku-darka imtixaanka? Xogtu way lumin doontaa.",
+  "yesIWantToExit": "Haa, waxaan rabaa inaan ka cabsado.",
+  "inactiveMessage": "Isticmalahu ma hawlgelin, fadlan la xidhiidh maamulaha ama maareeyaha si aad u hawlgeliso akoonkaaga.",
+  "submitFeedback": "Rajayn Qoraalka",
   "failedToDelete": "[Somali] Failed to delete: {error}",
   "@failedToDelete": {
     "x-mt": true
@@ -2165,10 +1895,7 @@
   "@noStorageUsed": {
     "x-mt": true
   },
-  "availableSpace": "[Somali] Available space",
-  "@availableSpace": {
-    "x-mt": true
-  },
+  "availableSpace": "Boos la heli karo",
   "freeUpSpace": "[Somali] Free up space",
   "@freeUpSpace": {
     "x-mt": true
@@ -2185,10 +1912,7 @@
   "@freeUpSpaceFailed": {
     "x-mt": true
   },
-  "enterUsername": "[Somali] Enter username",
-  "@enterUsername": {
-    "x-mt": true
-  },
+  "enterUsername": "Geli Magaca isticmaalaha",
   "enterPassword": "[Somali] Enter password",
   "@enterPassword": {
     "x-mt": true
@@ -2199,10 +1923,7 @@
   },
   "becomeMember": "noqo xubin",
   "toAccessThisFeatureBecomeAMember": "hadda waxaad tahay isticmaale marti ah. si aad u hesho helitaanka astaamahan, noqo xubin.",
-  "creatingMember": "[Somali] Creating member account...",
-  "@creatingMember": {
-    "x-mt": true
-  },
+  "creatingMember": "Abuuraya akoonka xubnaha...",
   "passwordsDoNotMatch": "Furayaasha sirta isma waafaqsana",
   "pleaseSelectGender": "Fadlan xulo jinsiga",
   "pleaseEnterPassword": "Fadlan geli ereyga sirta ah",
@@ -2240,34 +1961,19 @@
   "@courseNotStarted": {
     "x-mt": true
   },
-  "syncCompletedChallenge": "[Somali] Sync completed",
-  "@syncCompletedChallenge": {
-    "x-mt": true
-  },
+  "syncCompletedChallenge": "Dib-u-hagreeska la kahadsanayaa",
   "rememberSync": "Xusuusnow inaad la socodsiiso codsiga mobilka.",
   "challengeDialogTitle": "[Somali] Daily Challenge",
   "@challengeDialogTitle": {
     "x-mt": true
   },
-  "start": "[Somali] Start",
-  "@start": {
-    "x-mt": true
-  },
-  "continuation": "[Somali] Continue",
-  "@continuation": {
-    "x-mt": true
-  },
+  "start": "Bilow",
+  "continuation": "Sii wad",
   "plan": "Qorshe",
   "mission": "Mission & Adeegyada",
   "editPlan": "Wax ka beddel qorshaha",
-  "teamPlan": "[Somali] What is your team's plan?",
-  "@teamPlan": {
-    "x-mt": true
-  },
-  "entMission": "[Somali] What is your enterprise's Mission?",
-  "@entMission": {
-    "x-mt": true
-  },
+  "teamPlan": "Ninka kooxdaada waa maxay qorsheheeda?",
+  "entMission": "Nabadgelyada Beelahaada waa maxay?",
   "entServices": "Xidhiidhka Beelahaada waxay bixisaa?",
   "entRules": "Qawaanada Beelahaada waa maxay?",
   "noMissionDefined": "Beelaha waa maxay & adeegyadooda ma jirto.",
@@ -2275,10 +1981,7 @@
   "@noPlanDefined": {
     "x-mt": true
   },
-  "noDescriptionDefined": "[Somali] This team has no description defined.",
-  "@noDescriptionDefined": {
-    "x-mt": true
-  },
+  "noDescriptionDefined": "Kooxdani ma laha sharaxaad la cayimay.",
   "enterpriseName": "[Somali] Enterprise name",
   "@enterpriseName": {
     "x-mt": true
@@ -2298,10 +2001,7 @@
   "isPublic": "Ciidamo",
   "nameRequired": "Magacu waa loo baahan yahay",
   "nameIsRequired": "Fadlan geli magac",
-  "createdOn": "[Somali] Created on",
-  "@createdOn": {
-    "x-mt": true
-  },
+  "createdOn": "Lagu sameeyey",
   "courseDetails": "[Somali] Course Details",
   "@courseDetails": {
     "x-mt": true
@@ -2347,27 +2047,15 @@
     "x-mt": true
   },
   "mistakes": "Khalad",
-  "step": "[Somali] Step",
-  "@step": {
-    "x-mt": true
-  },
+  "step": "Tallaabo",
   "untitledResourceTitle": "[Somali] Untitled Resource",
   "@untitledResourceTitle": {
     "x-mt": true
   },
-  "author": "[Somali] Author",
-  "@author": {
-    "x-mt": true
-  },
+  "author": "Qoraaga",
   "publisher": "Daabace",
-  "license": "[Somali] License",
-  "@license": {
-    "x-mt": true
-  },
-  "addedBy": "[Somali] Added by",
-  "@addedBy": {
-    "x-mt": true
-  },
+  "license": "Shatiga",
+  "addedBy": "Waxaa ku daray",
   "resourceInformation": "[Somali] Resource Information",
   "@resourceInformation": {
     "x-mt": true
@@ -2380,10 +2068,7 @@
   "@mediaType": {
     "x-mt": true
   },
-  "resourceType": "[Somali] Resource Type",
-  "@resourceType": {
-    "x-mt": true
-  },
+  "resourceType": "Nooca Kheyraadka",
   "subject": "[Somali] Subject",
   "@subject": {
     "x-mt": true
@@ -2488,34 +2173,19 @@
   "@activitySummary": {
     "x-mt": true
   },
-  "lastLogin": "[Somali] Last login",
-  "@lastLogin": {
-    "x-mt": true
-  },
+  "lastLogin": "Gelitaankii Ugu Dambeeyay",
   "memberDetail": "[Somali] Member detail",
   "@memberDetail": {
     "x-mt": true
   },
-  "numberOfVisits": "[Somali] Number of visits",
-  "@numberOfVisits": {
-    "x-mt": true
-  },
+  "numberOfVisits": "Tirada booqashooyinka",
   "noLogoutRecord": "[Somali] No logout record found",
   "@noLogoutRecord": {
     "x-mt": true
   },
-  "totalVisits": "[Somali] Total visits",
-  "@totalVisits": {
-    "x-mt": true
-  },
-  "mostOpenedResource": "[Somali] Most opened resource",
-  "@mostOpenedResource": {
-    "x-mt": true
-  },
-  "numberOfResourcesOpened": "[Somali] Number of resources opened",
-  "@numberOfResourcesOpened": {
-    "x-mt": true
-  },
+  "totalVisits": "Tirada Booqashooyinka",
+  "mostOpenedResource": "Kheyraadka Ugu Badan ee La Furay",
+  "numberOfResourcesOpened": "Tirada Kheyraadka La Furay",
   "resourceOpenedTimes": "[Somali] {title} opened {count} times",
   "@resourceOpenedTimes": {
     "x-mt": true
@@ -2532,10 +2202,7 @@
   "@serverUnreachable": {
     "x-mt": true
   },
-  "serverChecking": "[Somali] Checking server",
-  "@serverChecking": {
-    "x-mt": true
-  },
+  "serverChecking": "Hubinta server-ka",
   "gridView": "Muuqaal shabag",
   "listView": "Muuqaal liis",
   "disclaimer": "soo Celinta",
@@ -2605,34 +2272,13 @@
       }
     }
   },
-  "textSize": "[Somali] Text size",
-  "@textSize": {
-    "x-mt": true
-  },
-  "selectTextSize": "[Somali] Select text size",
-  "@selectTextSize": {
-    "x-mt": true
-  },
-  "textSizeSmall": "[Somali] Small",
-  "@textSizeSmall": {
-    "x-mt": true
-  },
-  "textSizeMedium": "[Somali] Medium",
-  "@textSizeMedium": {
-    "x-mt": true
-  },
-  "textSizeLarge": "[Somali] Large",
-  "@textSizeLarge": {
-    "x-mt": true
-  },
-  "resetApp": "[Somali] Reset app",
-  "@resetApp": {
-    "x-mt": true
-  },
-  "clearAllDataConfirm": "[Somali] Are you sure you want to clear all data?",
-  "@clearAllDataConfirm": {
-    "x-mt": true
-  },
+  "textSize": "Cabbirka qoraalka",
+  "selectTextSize": "Dooro Cabbirka Qoraalka",
+  "textSizeSmall": "Yar",
+  "textSizeMedium": "Dhexdhexaad",
+  "textSizeLarge": "Weyn",
+  "resetApp": "Isku day App-ka",
+  "clearAllDataConfirm": "Ma hubtaa inaad diiwaangelisid dhammaan xogta?",
   "dataCleared": "[Somali] All data cleared",
   "@dataCleared": {
     "x-mt": true
@@ -2642,5 +2288,10 @@
     "x-mt": true
   },
   "resourceTitleAlreadyExists": "Kheyraad leh cinwaankan hore ayuu u jiray",
-  "failedToUpdateResource": "Cusbooneysiin kheyraadka waxay ku guuldareysatay"
+  "failedToUpdateResource": "Cusbooneysiin kheyraadka waxay ku guuldareysatay",
+  "unableToAddHealthRecord": "Lama helayno diiwaan caafimaad",
+  "summaryOfAchievements": "Dulmar guulo - Si kooban u soo koob guushaada oo hoos ku dar agabka la xiriira",
+  "myGoalsDescription": "Hadafyadayda - Waa maxay yoolalkaaga 10-ka sano ee soo socda?",
+  "myPurposeDescription": "Ujeedadayda - Waa maxay himilooyinkaaga waxbarasho iyo kuwa xirfadeed?",
+  "pleaseAnswerToContinue": "Fadlan dooro / qor jawaabtaada si aad u sii wadato"
 }

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -162,11 +162,11 @@ void main() {
     // the map and say in the commit message who reviewed it. Adding an
     // unreviewed one means flagging it `x-mt`, which leaves them alone.
     const humanReviewed = {
-      'ar': 259,
-      'es': 234,
-      'fr': 260,
-      'ne': 259,
-      'so': 259,
+      'ar': 260,
+      'es': 235,
+      'fr': 261,
+      'ne': 260,
+      'so': 260,
     };
 
     for (final code in locales) {

--- a/flutter/test/l10n/placeholder_integrity_test.dart
+++ b/flutter/test/l10n/placeholder_integrity_test.dart
@@ -145,6 +145,65 @@ void main() {
     }
   });
 
+  test('no locale value carries an Android escape', () {
+    // Android escapes an apostrophe in `strings.xml` as `\'`, because the
+    // platform's own string reader would otherwise treat it as quoting. The
+    // backslash belongs to Android, not to the sentence — but XML parsing
+    // leaves it alone (it is not XML syntax) and JSON has no objection to it
+    // either, so `tool/arb_from_strings_xml.dart` carried it into the locale
+    // files before it learned to strip it.
+    //
+    // Fourteen French strings and one Somali one shipped that way, rendering a
+    // literal backslash on screen: `Demandes d\'adhésion`, `Su\'aal`. Nothing
+    // could see it — the value is well-formed JSON, `gen-l10n` compiles it, and
+    // no analyzer looks inside a string. Only a reader of French would notice.
+    final defects = <String>[];
+    for (final code in locales) {
+      final arb = _readArb(code);
+      for (final key in _messageKeys(arb)) {
+        final value = arb[key] as String;
+        if (RegExp("""\\\\['\\"]""").hasMatch(value)) {
+          defects.add('$code:$key — "$value"');
+        }
+      }
+    }
+
+    expect(
+      defects,
+      isEmpty,
+      reason:
+          '${defects.length} value(s) carry an Android escape that the Kotlin '
+          'XML needed and the ARB does not:\n${defects.join("\n")}\n'
+          'Run `dart tool/arb_from_strings_xml.dart --adopt`, which repairs '
+          'them.',
+    );
+  });
+
+  test('the incorrect-answer retry hint is the Kotlin string, everywhere', () {
+    // The instance this recovery pass started from, pinned so a regeneration
+    // cannot quietly take it back.
+    //
+    // The port minted its own "Incorrect answer" and had it machine-translated
+    // five ways, while Kotlin has shipped `incorrect_ans` — "Incorrect answer,
+    // please try again" — with a real translation in every locale for years.
+    // Under the exam retry gate this snackbar is the only thing telling a
+    // learner to try again, so the hint is the string, not a flourish.
+    //
+    // The Kotlin XML is read rather than the six strings copied here: the point
+    // is that the ARB tracks Kotlin, and a hardcoded expectation would pass
+    // just as happily against a stale value.
+    for (final code in [...locales, 'en']) {
+      final kotlin = _kotlinString(code == 'en' ? 'values' : 'values-$code');
+      expect(
+        _readArb(code)['incorrectAnswer'],
+        kotlin,
+        reason:
+            'app_$code.arb has drifted from `incorrect_ans` in '
+            'app/src/main/res/values${code == 'en' ? '' : '-$code'}/strings.xml',
+      );
+    }
+  });
+
   test('the template declares no review state of its own', () {
     // `app_en.arb` is the source text, not a translation of anything. An
     // `x-mt` flag there would mean the English itself is machine output.
@@ -162,11 +221,11 @@ void main() {
     // the map and say in the commit message who reviewed it. Adding an
     // unreviewed one means flagging it `x-mt`, which leaves them alone.
     const humanReviewed = {
-      'ar': 260,
-      'es': 235,
-      'fr': 261,
-      'ne': 260,
-      'so': 260,
+      'ar': 325,
+      'es': 321,
+      'fr': 314,
+      'ne': 384,
+      'so': 383,
     };
 
     for (final code in locales) {
@@ -246,3 +305,18 @@ Iterable<String> _machineTranslatedKeys(Map<String, Object?> arb) => arb.keys
 /// ICU and appears in the wild.
 bool _usesPlaceholder(String value, String name) =>
     RegExp('\\{\\s*${RegExp.escape(name)}\\s*[,}]').hasMatch(value);
+
+/// `incorrect_ans` as the Kotlin app ships it for one `values*` directory.
+///
+/// A regex rather than an XML parser: the test needs one string, `strings.xml`
+/// writes it on one line, and pulling a parser into the test tree to read it
+/// would be the larger dependency.
+String _kotlinString(String valuesDir) {
+  final xml = File(
+    '../app/src/main/res/$valuesDir/strings.xml',
+  ).readAsStringSync();
+  final match = RegExp(
+    r'<string name="incorrect_ans">(.*?)</string>',
+  ).firstMatch(xml);
+  return match!.group(1)!;
+}

--- a/flutter/test/ui/exam/take_exam_screen_test.dart
+++ b/flutter/test/ui/exam/take_exam_screen_test.dart
@@ -476,7 +476,7 @@ void main() {
       await tester.tap(find.text('Next'));
       await settleExam(tester);
 
-      expect(find.text('Incorrect answer'), findsOneWidget);
+      expect(find.text('Incorrect answer, please try again'), findsOneWidget);
       expect(
         find.text('Question 1 / 2'),
         findsOneWidget,
@@ -493,7 +493,7 @@ void main() {
       await tester.tap(find.text('Next'));
       await settleExam(tester);
 
-      expect(find.text('Incorrect answer'), findsNothing);
+      expect(find.text('Incorrect answer, please try again'), findsNothing);
       expect(find.text('Question 2 / 2'), findsOneWidget);
     });
 
@@ -555,7 +555,7 @@ void main() {
       await tester.tap(find.text('Submit exam'));
       await settleExam(tester);
 
-      expect(find.text('Incorrect answer'), findsNothing);
+      expect(find.text('Incorrect answer, please try again'), findsNothing);
       expect(find.text('Exam Complete'), findsOneWidget);
     });
 
@@ -632,7 +632,7 @@ void main() {
       await tester.tap(find.text('Submit exam'));
       await settleExam(tester);
 
-      expect(find.text('Incorrect answer'), findsOneWidget);
+      expect(find.text('Incorrect answer, please try again'), findsOneWidget);
       expect(find.text('Exam Complete'), findsNothing);
       final answers = await db.select(db.submissionAnswers).get();
       // Recorded, with its mistake — the attempt is not thrown away, it just
@@ -692,7 +692,7 @@ void main() {
       await tester.tap(find.text('Submit exam'));
       await settleExam(tester);
 
-      expect(find.text('Incorrect answer'), findsNothing);
+      expect(find.text('Incorrect answer, please try again'), findsNothing);
       expect(find.text('Exam Complete'), findsOneWidget);
       final answers = await db.select(db.submissionAnswers).get();
       expect(answers.single.mistakes, 0);
@@ -878,7 +878,7 @@ void main() {
         find.text('Could not save your exam. Please try again.'),
         findsOneWidget,
       );
-      expect(find.text('Incorrect answer'), findsNothing);
+      expect(find.text('Incorrect answer, please try again'), findsNothing);
       expect(find.text('Exam Complete'), findsNothing);
       // The submit button is live again rather than stuck on its spinner.
       expect(find.text('Question 1 / 1'), findsOneWidget);

--- a/flutter/tool/arb_from_strings_xml.dart
+++ b/flutter/tool/arb_from_strings_xml.dart
@@ -23,8 +23,13 @@
 // to text that says something else.
 //
 // Usage, from the `flutter/` directory:
-//   dart tool/arb_from_strings_xml.dart            # writes ar, fr, ne, so
+//   dart tool/arb_from_strings_xml.dart            # writes ar, es, fr, ne, so
 //   dart tool/arb_from_strings_xml.dart ar fr      # or named locales
+//
+// The merge below can only *add* a key, never correct one — see "Recovering
+// human translations the port left on the table" further down for `--candidates`
+// and `--adopt`, which are the modes that may overwrite, and for the rule that
+// says what they are allowed to overwrite.
 //
 // Re-running is safe: the script *merges* into the existing .arb rather than
 // replacing it. A key already present keeps its value, and only keys the .arb
@@ -63,12 +68,19 @@ import 'dart:io';
 
 import 'package:xml/xml.dart';
 
-/// Locales with a `values-<code>` directory in the Kotlin app.
-const defaultLocales = ['ar', 'fr', 'ne', 'so'];
+/// Every locale that ships an `.arb`, all five of which have a `values-<code>`
+/// directory in the Kotlin app and are therefore derivable.
+///
+/// `es` used to be missing from this list, with a comment here claiming the
+/// Kotlin app has no `values-es`. It does — 1050 strings, the same as every
+/// other locale — so `app_es.arb` had never been through this script at all.
+/// It carried the most machine-translated strings of any locale (619) for
+/// exactly that reason.
+const defaultLocales = ['ar', 'es', 'fr', 'ne', 'so'];
 
-/// Every locale that ships an `.arb`. `es` has no Kotlin `values-es`, so it is
-/// not derivable — but it does carry machine-translated strings to review.
-const allLocales = ['ar', 'es', 'fr', 'ne', 'so'];
+/// Retained under its old name for callers; identical to [defaultLocales] now
+/// that `es` is derivable too.
+const allLocales = defaultLocales;
 
 /// The ARB attribute marking a string as unreviewed machine translation.
 const machineTranslatedFlag = 'x-mt';
@@ -76,6 +88,11 @@ const machineTranslatedFlag = 'x-mt';
 void main(List<String> args) {
   if (args.isNotEmpty && args.first == '--unreviewed') {
     _reportUnreviewed(args.skip(1).toList());
+    return;
+  }
+  if (args.isNotEmpty &&
+      (args.first == '--candidates' || args.first == '--adopt')) {
+    _recover(args.skip(1).toList(), apply: args.first == '--adopt');
     return;
   }
   final locales = args.isEmpty ? defaultLocales : args;
@@ -273,6 +290,453 @@ void _reportUnreviewed(List<String> args) {
     );
     for (final key in unreviewed) {
       stdout.writeln('$key\t${arb[key]}');
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recovering human translations the port left on the table (Phase 114).
+//
+// The merge above can only *add* a key. It cannot correct one, so a key the
+// external machine-translation pass filled keeps its machine string forever,
+// even when the Kotlin app has been shipping a human translation of the very
+// same English all along. `incorrectAnswer` was the instance that started this:
+// port-minted English, machine-translated five ways, while Kotlin's
+// `incorrect_ans` ("Incorrect answer, please try again") carries five real
+// translations.
+//
+//   dart tool/arb_from_strings_xml.dart --candidates      # report, changes nothing
+//   dart tool/arb_from_strings_xml.dart --adopt           # apply the confident ones
+//   dart tool/arb_from_strings_xml.dart --candidates fr   # or named locales
+//
+// **How a match is made.** Never by key name alone — the ARB key and the Kotlin
+// name agree on a concept, not on a string, and `achievements`/`myAchievements`
+// or `teamLeader` ("You lead this team" vs "Team Leader") would silently swap in
+// a translation of different words. The English text is the evidence, in three
+// adoptable tiers:
+//
+//   [MatchTier.exact]       identical after trimming. No transformation at all.
+//   [MatchTier.punctuation] identical once a trailing `: . … !` run and its
+//                           surrounding space are removed from both. Kotlin
+//                           labels carry the colon the layout draws
+//                           (`author` → "Author:"); the ARB does not. The
+//                           translation is stripped the same way, then given the
+//                           template's own trailing punctuation back, so the
+//                           port's English and its translations agree on it.
+//   [MatchTier.casing]      identical once case is also ignored — title case
+//                           against sentence case ("Total Visits : " vs "Total
+//                           visits"). Only the first character is realigned, and
+//                           only upwards: lowercasing a foreign string's first
+//                           letter is not safe in general, and no rule here
+//                           needs it.
+//
+// and two that are reported and never applied:
+//
+//   [MatchTier.nameOnly]    the name matches, the English does not.
+//   [MatchTier.containment] one English is contained in the other — the
+//                           `incorrectAnswer` shape, where the port paraphrased
+//                           a string Kotlin already had. Fixing one means
+//                           changing `app_en.arb`, which is a judgement about
+//                           what the screen should say, not a derivation.
+//
+// **What may be overwritten.** Only a value that is demonstrably not a human
+// translation: absent, flagged `x-mt`, still carrying an `[Nepali] `-style
+// untranslated marker, or byte-identical to the English template. Anything else
+// is treated as a human translation and left alone even when Kotlin disagrees
+// with it — an unflagged value is somebody's work, and this script has no way to
+// tell a better rendering from a worse one.
+//
+// A tier's candidates must also be unanimous: `values/strings.xml` gives several
+// names to one English phrase and they do not always agree in translation.
+//
+// **The escape repair.** Separately from all of the above, `--adopt` undoes
+// Android's `\'` and `\"` escapes wherever they survive in a locale file. The
+// `_unquote` above learned to strip them, but values derived before it did kept
+// them, and JSON has no reason to object: `app_fr.arb` shipped fourteen strings
+// that render a literal backslash on a French screen (`Demandes d\'adhésion`).
+enum MatchTier {
+  exact,
+  punctuation,
+  casing,
+  nameOnly,
+  containment;
+
+  /// Whether `--adopt` may write this tier. The two text-differs tiers are
+  /// evidence for a human to read, not a derivation.
+  bool get isAdoptable =>
+      this == exact || this == punctuation || this == casing;
+}
+
+/// A Kotlin string (or several sharing one English text) matched to an ARB key.
+class _Match {
+  const _Match(this.tier, this.names);
+
+  final MatchTier tier;
+  final List<String> names;
+}
+
+/// One key/locale decision, ready to print or to write.
+class _Candidate {
+  const _Candidate({
+    required this.key,
+    required this.match,
+    required this.current,
+    required this.proposed,
+    required this.verdict,
+  });
+
+  final String key;
+  final _Match match;
+  final String? current;
+  final String? proposed;
+
+  /// `apply`, `already`, `keep-human`, `report`, or `no-unanimous`.
+  final String verdict;
+}
+
+void _recover(List<String> args, {required bool apply}) {
+  final resDir = Directory('../app/src/main/res');
+  if (!resDir.existsSync()) {
+    stderr.writeln('Run this from the flutter/ directory.');
+    exitCode = 1;
+    return;
+  }
+  final locales = args.isEmpty ? defaultLocales : args;
+  final template = _readArb('lib/l10n/app_en.arb');
+  final english = _readStringsXml('${resDir.path}/values/strings.xml');
+  final matches = _matchTemplateToKotlin(template, english);
+
+  final tally = <String, int>{};
+  for (final locale in locales) {
+    final xmlPath = '${resDir.path}/values-$locale/strings.xml';
+    if (!File(xmlPath).existsSync()) {
+      stderr.writeln('No strings.xml for "$locale" — skipped.');
+      continue;
+    }
+    final translated = _readStringsXml(xmlPath);
+    final file = File('lib/l10n/app_$locale.arb');
+    final arb = _readArb(file.path);
+    final machine = _machineTranslatedKeys(arb).toSet();
+
+    final candidates = <_Candidate>[];
+    for (final entry in matches.entries) {
+      final key = entry.key;
+      final templateValue = template[key];
+      if (templateValue is! String) continue;
+      final current = arb[key] is String ? arb[key] as String : null;
+      final proposals = <String>{};
+      for (final name in entry.value.names) {
+        final value = translated[name];
+        if (value == null || value.trim().isEmpty) continue;
+        final proposal = _proposal(entry.value.tier, value, templateValue);
+        // The template is placeholder-free by the time it gets here, but a
+        // translation is a separate string and could carry syntax of its own.
+        // A stray `{` in a locale value is an ICU parse error at build time;
+        // `%1$s` renders literally. Neither belongs in a value derived for a
+        // key whose English has no placeholders.
+        if (proposal.contains('{') ||
+            proposal.contains('}') ||
+            _printfSpecifier.hasMatch(proposal)) {
+          continue;
+        }
+        proposals.add(proposal);
+      }
+      String verdict;
+      if (!entry.value.tier.isAdoptable) {
+        // A tier that only ever produces reading material. Say so before
+        // judging its proposals: "the English differs" is the finding, and
+        // whether two Kotlin names happen to agree is beside the point.
+        verdict = 'report';
+      } else if (proposals.isEmpty) {
+        // The Kotlin name exists but this locale never translated it. Nothing
+        // to recover; not a disagreement either.
+        verdict = 'no-translation';
+      } else if (proposals.length != 1) {
+        verdict = 'no-unanimous';
+      } else if (current == proposals.single) {
+        verdict = 'already';
+      } else if (current != null && current.trim() == proposals.single.trim()) {
+        // Same translation, different surrounding whitespace. `selectResources`
+        // is `"Select resources: "` — a label the value is drawn after — and
+        // Arabic had lost the trailing space. Restoring it is not overwriting
+        // anybody's words.
+        verdict = 'apply';
+      } else if (_replaceable(current, templateValue, machine.contains(key))) {
+        verdict = 'apply';
+      } else {
+        verdict = 'keep-human';
+      }
+      candidates.add(
+        _Candidate(
+          key: key,
+          match: entry.value,
+          current: current,
+          proposed: proposals.isEmpty ? null : proposals.join(' | '),
+          verdict: verdict,
+        ),
+      );
+    }
+
+    for (final candidate in candidates) {
+      tally['$locale/${candidate.verdict}'] =
+          (tally['$locale/${candidate.verdict}'] ?? 0) + 1;
+    }
+
+    if (apply) {
+      final adopted = _adopt(file, arb, template, candidates);
+      stdout.writeln(
+        'app_$locale.arb: ${adopted.values} value(s) taken from the Kotlin '
+        'translations, ${adopted.escapes} escape artefact(s) repaired, '
+        '${adopted.flags} x-mt flag(s) cleared',
+      );
+    } else {
+      _printCandidates(locale, template, english, candidates, arb);
+    }
+  }
+
+  if (!apply) {
+    stdout.writeln('\n# summary');
+    for (final entry
+        in tally.entries.toList()..sort((a, b) => a.key.compareTo(b.key))) {
+      stdout.writeln('${entry.key}\t${entry.value}');
+    }
+  }
+}
+
+/// Matches every template key to the Kotlin strings whose English it shares,
+/// most confident tier first. A key stops at the first tier that hits.
+Map<String, _Match> _matchTemplateToKotlin(
+  Map<String, Object?> template,
+  Map<String, String> english,
+) {
+  final byCamelCase = <String, List<String>>{};
+  for (final name in english.keys) {
+    byCamelCase.putIfAbsent(_camelCase(name), () => []).add(name);
+  }
+
+  final matches = <String, _Match>{};
+  for (final key in template.keys) {
+    final value = template[key];
+    if (key.startsWith('@') || value is! String) continue;
+    // ICU and Kotlin's printf syntax are both out of scope — see the header.
+    if (value.contains('{') || _printfSpecifier.hasMatch(value)) continue;
+
+    final exact = <String>[];
+    final punctuation = <String>[];
+    final casing = <String>[];
+    final containment = <String>[];
+    final wanted = value.trim();
+    final wantedCore = _core(wanted);
+    for (final entry in english.entries) {
+      final other = entry.value.trim();
+      if (other.isEmpty) continue;
+      if (other == wanted) {
+        exact.add(entry.key);
+      } else if (_core(other) == wantedCore) {
+        punctuation.add(entry.key);
+      } else if (_core(other).toLowerCase() == wantedCore.toLowerCase()) {
+        casing.add(entry.key);
+      } else if (_contains(other, wantedCore)) {
+        containment.add(entry.key);
+      }
+    }
+    if (exact.isNotEmpty) {
+      matches[key] = _Match(MatchTier.exact, exact);
+    } else if (punctuation.isNotEmpty) {
+      matches[key] = _Match(MatchTier.punctuation, punctuation);
+    } else if (casing.isNotEmpty) {
+      matches[key] = _Match(MatchTier.casing, casing);
+    } else if (byCamelCase.containsKey(key)) {
+      matches[key] = _Match(MatchTier.nameOnly, byCamelCase[key]!);
+    } else if (containment.isNotEmpty) {
+      matches[key] = _Match(MatchTier.containment, containment);
+    }
+  }
+  return matches;
+}
+
+/// The value to write for [translation], given the tier it matched at.
+String _proposal(MatchTier tier, String translation, String templateEnglish) {
+  if (tier == MatchTier.exact) {
+    return _mirrorTrailingSpace(translation.trim(), templateEnglish);
+  }
+  var value = _core(translation);
+  // Give the template's own trailing punctuation back — but only onto a word.
+  // Nepali ends a sentence with the danda `।`, which `_core` does not strip and
+  // which must not be followed by a full stop: `CSV फाइल सुरक्षित गर्न असफल।.`
+  if (_endsWithWordCharacter.hasMatch(value)) {
+    value += _trailingPunctuation(templateEnglish);
+  }
+  return _mirrorTrailingSpace(
+    _alignInitialCase(value, templateEnglish),
+    templateEnglish,
+  );
+}
+
+final _endsWithWordCharacter = RegExp(r'[\p{L}\p{N}]$', unicode: true);
+
+/// Keeps a trailing space the template carries deliberately.
+///
+/// `selected` is `"Selected: "` in both `app_en.arb` and the Kotlin XML, where
+/// Android's quoting exists precisely to protect that space — it is a label
+/// prefix, and the value is drawn straight after it. Trimming the translation
+/// would close the gap in every language but English.
+String _mirrorTrailingSpace(String value, String templateEnglish) =>
+    templateEnglish.endsWith(' ') && !value.endsWith(' ') ? '$value ' : value;
+
+/// Whether [current] is something other than a human translation, and may
+/// therefore be replaced. See the header — this is the guard that keeps the
+/// script from undoing somebody's work.
+bool _replaceable(String? current, String templateEnglish, bool isMachine) {
+  if (current == null) return true;
+  if (isMachine) return true;
+  // `[Nepali] Incorrect answer` — the external pass's own "no translation here"
+  // marker, left in the file as a value.
+  if (_untranslatedMarker.hasMatch(current)) return true;
+  // The English text itself, sitting in a locale file. Not a translation.
+  if (current.trim() == templateEnglish.trim()) return true;
+  return false;
+}
+
+final _untranslatedMarker = RegExp(r'^\[[A-Z][A-Za-z]+\]\s');
+
+/// A trailing run of label punctuation, with the space Android puts around it.
+final _trailingLabelPunctuation = RegExp('[\\s ]*[:.…!]+[\\s ]*\$');
+
+/// The same run, unanchored to whitespace, as the template writes it.
+final _trailingPunctuationOnly = RegExp(r'[:.…!]+$');
+
+/// [text] with every trailing run of label punctuation removed.
+String _core(String text) {
+  var value = text.trim();
+  while (true) {
+    final next = value.replaceFirst(_trailingLabelPunctuation, '').trim();
+    if (next == value || next.isEmpty) return value;
+    value = next;
+  }
+}
+
+String _trailingPunctuation(String english) =>
+    _trailingPunctuationOnly.stringMatch(english.trimRight()) ?? '';
+
+/// Gives [value] the first-letter case the template's English has.
+///
+/// Only upwards. Lowercasing a translation's first letter would be wrong
+/// wherever the language capitalises for its own reasons, and nothing here
+/// needs it: the template is sentence case throughout.
+String _alignInitialCase(String value, String english) {
+  if (value.isEmpty || english.isEmpty) return value;
+  final first = english[0];
+  if (first.toUpperCase() != first || first.toLowerCase() == first) {
+    return value;
+  }
+  return value[0].toUpperCase() + value.substring(1);
+}
+
+/// Whether one English text contains the other as a whole phrase.
+///
+/// The `incorrectAnswer` shape: the port wrote "Incorrect answer" where Kotlin
+/// says "Incorrect answer, please try again". Reported, never adopted — the
+/// difference may be the whole point of the string.
+bool _contains(String a, String b) {
+  if (a.length < 8 || b.length < 8) return false; // too short to mean anything
+  final left = a.toLowerCase();
+  final right = b.toLowerCase();
+  return left != right && (left.contains(right) || right.contains(left));
+}
+
+/// Android's `\'` and `\"`, carried into an `.arb` before [_unquote] undid them.
+final _androidEscape = RegExp('\\\\([\'"])');
+
+class _AdoptCounts {
+  const _AdoptCounts(this.values, this.escapes, this.flags);
+  final int values;
+  final int escapes;
+  final int flags;
+}
+
+/// Writes the adoptable candidates into [file], in place.
+///
+/// Existing keys keep their position, so the diff is the values that changed
+/// rather than a reordered file; a key the locale did not have at all is
+/// appended in template order.
+_AdoptCounts _adopt(
+  File file,
+  Map<String, Object?> arb,
+  Map<String, Object?> template,
+  List<_Candidate> candidates,
+) {
+  final apply = {
+    for (final candidate in candidates)
+      if (candidate.verdict == 'apply') candidate.key: candidate.proposed!,
+  };
+
+  final merged = <String, Object?>{};
+  var values = 0;
+  var escapes = 0;
+  for (final entry in arb.entries) {
+    final value = entry.value;
+    if (value is! String || entry.key.startsWith('@')) {
+      merged[entry.key] = value;
+      continue;
+    }
+    final adopted = apply.remove(entry.key);
+    if (adopted != null) {
+      merged[entry.key] = adopted;
+      values++;
+      continue;
+    }
+    final repaired = value.replaceAllMapped(
+      _androidEscape,
+      (match) => match[1]!,
+    );
+    if (repaired != value) escapes++;
+    merged[entry.key] = repaired;
+  }
+  // Whatever is left was absent from this locale; append it in template order.
+  for (final key in template.keys) {
+    final adopted = apply[key];
+    if (adopted == null) continue;
+    merged[key] = adopted;
+    values++;
+  }
+
+  final flags = _reconcileMachineTranslationFlags(merged, {
+    for (final candidate in candidates)
+      if (candidate.verdict == 'apply') candidate.key,
+  });
+  file.writeAsStringSync('${_encodeArb(merged)}\n');
+  return _AdoptCounts(values, escapes, flags);
+}
+
+String _oneLine(String? value) =>
+    value == null ? 'null' : value.replaceAll('\n', r'\n');
+
+void _printCandidates(
+  String locale,
+  Map<String, Object?> template,
+  Map<String, String> english,
+  List<_Candidate> candidates,
+  Map<String, Object?> arb,
+) {
+  stdout.writeln('# $locale');
+  for (final verdict in ['apply', 'keep-human', 'report', 'no-unanimous']) {
+    final rows = candidates.where((c) => c.verdict == verdict).toList();
+    if (rows.isEmpty) continue;
+    stdout.writeln('## $verdict (${rows.length})');
+    for (final row in rows) {
+      final names = row.match.names
+          .map((n) => '$n="${_oneLine(english[n])}"')
+          .join(', ');
+      // Every field on one line. A value with a newline in it would otherwise
+      // split its own row in half, and this report is meant to be greppable.
+      stdout.writeln(
+        '${row.key}\t${row.match.tier.name}\n'
+        '  en   ${_oneLine(template[row.key] as String?)}\n'
+        '  xml  $names\n'
+        '  was  ${_oneLine(row.current)}\n'
+        '  now  ${_oneLine(row.proposed)}',
+      );
     }
   }
 }


### PR DESCRIPTION
**Lane B of the Phase 114 three-lane round.** Draft. Full write-up in `flutter/PHASE_114_NOTES.md`, including the residue tables.

## What this is

`incorrect_ans` was one instance of a class, and the class has a mechanism behind it: **`tool/arb_from_strings_xml.dart` merges, and existing values win.** That rule is right for what it was written for — it stops a re-run deleting the keys translated by hand that have no Kotlin counterpart — but it also means the tool can only ever *add*. Once the external machine-translation pass filled ~560 keys per locale, every one was frozen, including the ones whose English the Kotlin app has been shipping a human translation of for years.

So this adds `--candidates` (report) and `--adopt` (apply), which may overwrite, under a rule that cannot cost anybody their work.

## `incorrect_ans`, before and after

| | before | after |
|---|---|---|
| en | Incorrect answer | Incorrect answer, please try again |
| ar | إجابة غير صحيحة *(x-mt)* | إجابة غير صحيحة، يرجى المحاولة مرة أخرى |
| es | respuesta incorrecta *(x-mt)* | Respuesta incorrecta, por favor inténtalo de nuevo |
| fr | Réponse incorrecte *(x-mt)* | Réponse incorrecte, veuillez réessayer |
| ne | `[Nepali] Incorrect answer` *(x-mt)* | तपाईंले गलत उत्तर दिएका छन्, कृपया पुन: प्रयास गर्नुहोस् |
| so | `[Somali] Incorrect answer` *(x-mt)* | Jawaab aan sax ahayn, fadlan isku day |

Two of the five were not translations at all — they were the external tool's own "nothing here" marker sitting in the file as a value.

## The match method

**On English text, never on the key name.** The ARB key and the Kotlin name agree about a concept, not a string: `achievements` ↔ `myAchievements`, `teamLeader` ("You lead this team") ↔ `team_leader` ("Team Leader"), `taskNotification` ("Task") ↔ `task_notification` ("%1$s is due in %2$s"). Name-driven derivation would have swapped in translations of different words, silently, in five languages at once.

| tier | rule | adopted? |
|---|---|---|
| `exact` | identical after trimming | yes, verbatim |
| `punctuation` | identical once a trailing `: . … !` run and its space are dropped from both | yes, stripped + the template's own punctuation back |
| `casing` | identical once case is ignored too | yes, plus first-character case alignment, upwards only |
| `nameOnly` | name matches, English does not | **reported only** |
| `containment` | one English contains the other (the `incorrectAnswer` shape) | **reported only** |

Candidates must be unanimous across the Kotlin names sharing that English. Only a value that is demonstrably not a human translation may be replaced: absent, `x-mt`, an `[Nepali] `-style marker, identical to the English template, or the same translation differing only in whitespace.

## Counts

858 template keys examined against 1050 Kotlin strings; 445 matched at some tier; **494 values applied**, 431 of them replacing machine output.

| locale | `x-mt` before → after | human before → after |
|---|---|---|
| ar | 557 → 496 (−61) | 259 → 325 |
| es | 620 → 538 (−82) | 234 → 321 |
| fr | 594 → 545 (−49) | 260 → 314 |
| ne | 595 → 475 (−120) | 259 → 384 |
| so | 595 → 476 (−119) | 259 → 383 |

`--adopt` is idempotent: a second run reports zero.

## Two findings the audit was not looking for

- **`app_es.arb` had never been through the script at all.** A comment in the tool said the Kotlin app has no `values-es`. It has — 1050 strings, like every other locale. Spanish carried the most machine strings of any locale for exactly that reason.
- **Fourteen French strings and one Somali one were rendering a literal backslash** (`Demandes d\'adhésion`, `Su\'aal`) — an Android apostrophe escape carried in before `_unquote` learned to strip it. Well-formed JSON, compiles, analyzes clean; only a reader of French would ever have noticed.

## Residue (found, deliberately not applied)

- **32 `keep-human`** — Kotlin translates the same English differently and the ARB's value is unflagged, so it is someone's work.
- **33 `no-unanimous`** — two Kotlin names share the English and disagree. Some are worth five human minutes: `so:settings` is still literally "Settings".
- **42 `nameOnly` + 85 `containment`** — the English differs, so recovering one means editing `app_en.arb`. `incorrect_ans` itself would have appeared here.

Tables in the notes; `dart tool/arb_from_strings_xml.dart --candidates` prints the live list with before/after values.

## Gate

`dart format` clean, `flutter analyze` clean, **1803 tests pass** (1801 before; +2 new guards, each demonstrated failing on the pre-fix files).

## Files touched outside this lane's set

`test/ui/exam/take_exam_screen_test.dart` — two `find.text` literals following the English text change. Mechanical; flagged for the integrator since Lane A owns the exam surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Be1rs355KJhJh4QNSw9kXF